### PR TITLE
Add CI for Linux Arm64 and fix minor bug

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,3 +23,21 @@ jobs:
       run: cargo test --verbose
     - name: Run testprog checks
       run: bash ./testprog_check.sh
+
+  build-linux-arm64:
+
+    runs-on: ubuntu-24.04-arm
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Temporarily modify the rust toolchain version
+      run: rustup override set nightly-2025-04-25
+    - name: Output rust version for educational purposes
+      run: rustup --version
+
+    - name: Build
+      run: cargo build --verbose
+    - name: Run tests
+      run: cargo test --verbose
+    - name: Run testprog checks
+      run: bash ./testprog_check.sh

--- a/src/wrappers.rs
+++ b/src/wrappers.rs
@@ -807,27 +807,23 @@ mod tests {
 
         let ru = unsafe { libc::strcmp(s1.as_ptr(), s2.as_ptr()) };
         let rs = strcmp_safe(s1, s2);
-        assert_eq!(ru, rs);
+        assert_eq!(ru.signum(), rs.signum());
 
         let ru = unsafe { libc::strcmp(s1.as_ptr(), s3.as_ptr()) };
         let rs = strcmp_safe(s1, s3);
-        assert_eq!(ru, rs);
+        assert_eq!(ru.signum(), rs.signum());
 
         let ru = unsafe { libc::strcmp(s3.as_ptr(), s1.as_ptr()) };
         let rs = strcmp_safe(s3, s1);
-        assert_eq!(ru, rs);
+        assert_eq!(ru.signum(), rs.signum());
 
         let ru = unsafe { libc::strcmp(s1.as_ptr(), s2.as_ptr()) };
         let rs = strcmp_safe(s1, s2);
-        assert_eq!(ru, rs);
-
-        let ru = unsafe { libc::strcmp(s1.as_ptr(), s3.as_ptr()) };
-        let rs = strcmp_safe(s1, s3);
-        assert_eq!(ru, rs);
+        assert_eq!(ru.signum(), rs.signum());
 
         let ru = unsafe { libc::strcmp(s3.as_ptr(), s4.as_ptr()) };
         let rs = strcmp_safe(s3, s4);
-        assert_eq!(ru, rs);
+        assert_eq!(ru.signum(), rs.signum());
     }
 
     #[test]


### PR DESCRIPTION
- CI for Linux ARM 64
- Fix `strcmp` test case to check for sign instead of value