### PR TITLE
Implement eval_* files

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,3 +53,4 @@ hcompress = "0.3"
 chrono = ">=0.4.20"
 cbitset = "0.2"
 memchr = { version = "2.7.5", default-features = false }
+errno = "0.3.13"

--- a/TODO.md
+++ b/TODO.md
@@ -17,3 +17,4 @@
 - [X] Mark all extern functions as deprecated so that we can detect usage
 - [ ] Feature "bzip2" doesn't work
 - [X] Feature "shared_mem" doesn't work
+- [ ] fits_parser_yytokentype refactor to enum

--- a/examples/iter_a/main.rs
+++ b/examples/iter_a/main.rs
@@ -25,7 +25,7 @@ use rsfitsio::putcol::{fits_iter_get_array, fits_iter_get_datatype, fits_iter_se
 */
 pub fn main() -> ExitCode {
     let mut fptr: Option<Box<fitsfile>> = None;
-    let mut cols: [iteratorCol; 3] = unsafe { std::mem::zeroed() }; /* structure used by the iterator function */
+    let mut cols: [iteratorCol; 3] = Default::default(); /* structure used by the iterator function */
     let n_cols: c_int = 3; /* number of columns */
     let rows_per_loop: c_long = 0; /* use default optimum number of rows */
     let offset: c_long = 0; /* process all the rows */

--- a/examples/iter_b/main.rs
+++ b/examples/iter_b/main.rs
@@ -25,7 +25,7 @@ use rsfitsio::putcol::{fits_iter_get_array, fits_iter_get_datatype, fits_iter_se
 */
 pub fn main() -> ExitCode {
     let mut fptr: Option<Box<fitsfile>> = None;
-    let mut cols: [iteratorCol; 2] = unsafe { std::mem::zeroed() };
+    let mut cols: [iteratorCol; 2] = Default::default();
     let n_cols: c_int = 2; /* number of columns */
     let rows_per_loop: c_long = 0; /* use default optimum number of rows */
     let offset: c_long = 0; /* process all the rows */

--- a/examples/iter_c/main.rs
+++ b/examples/iter_c/main.rs
@@ -36,7 +36,7 @@ static YBINSIZE: c_long = 32;
 
 pub fn main() -> ExitCode {
     let mut fptr: Option<Box<fitsfile>> = None;
-    let mut cols: [iteratorCol; 1] = unsafe { std::mem::zeroed() };
+    let mut cols: [iteratorCol; 1] = Default::default();
     let n_cols: c_int = 1; /* number of columns */
     let mut status: c_int = 0;
     let n_per_loop: c_long = -1; /* force whole array to be passed at one time */
@@ -126,7 +126,7 @@ extern "C" fn writehisto(
     _user_pointer: *mut std::os::raw::c_void,
 ) -> c_int {
     let mut tblptr: Option<Box<fitsfile>> = None;
-    let mut cols: [iteratorCol; 2] = unsafe { std::mem::zeroed() };
+    let mut cols: [iteratorCol; 2] = Default::default();
     let n_cols: c_int = 2; /* number of columns */
     let mut status: c_int = 0;
     let rows_per_loop: c_long = 0; /* take default number of rows per iteration */

--- a/examples/iter_image/main.rs
+++ b/examples/iter_image/main.rs
@@ -19,7 +19,7 @@ use rsfitsio::putcol::{
 */
 pub fn main() -> ExitCode {
     let mut fptr: Option<Box<fitsfile>> = None;
-    let mut cols: [iteratorCol; 3] = unsafe { std::mem::zeroed() }; /* structure used by the iterator function */
+    let mut cols: [iteratorCol; 3] = Default::default(); /* structure used by the iterator function */
     let n_cols: c_int = 1;
     let rows_per_loop: c_long = 0; /* use default optimum number of rows */
     let offset: c_long = 0; /* process all the rows */

--- a/examples/iter_var/main.rs
+++ b/examples/iter_var/main.rs
@@ -19,7 +19,7 @@ use rsfitsio::putcol::{
 */
 pub fn main() -> ExitCode {
     let mut fptr: Option<Box<fitsfile>> = None;
-    let mut cols: [iteratorCol; 3] = unsafe { std::mem::zeroed() }; /* structure used by the iterator function */
+    let mut cols: [iteratorCol; 3] = Default::default(); /* structure used by the iterator function */
     let n_cols: c_int = 1; /* number of columns */
     let rows_per_loop: c_long = 0; /* use default optimum number of rows */
     let offset: c_long = 0; /* process all the rows */

--- a/src/bin/imcopy/main.rs
+++ b/src/bin/imcopy/main.rs
@@ -233,9 +233,7 @@ pub fn main() -> ExitCode {
                     if tstatus != 0 {
                         strcpy_safe(
                             &mut card,
-                            cs!(
-                                c"EXTNAME = 'COMPRESSED_IMAGE'   / name of this binary table extension"
-                            ),
+                            cs!(c"EXTNAME = 'COMPRESSED_IMAGE'   / name of this binary table extension"),
                         );
                         fits_write_record(outfptr.as_mut(), card.as_ptr(), &mut status);
                     }

--- a/src/cfileio.rs
+++ b/src/cfileio.rs
@@ -7,7 +7,7 @@
 use core::slice;
 use std::ffi::CStr;
 use std::fs::File;
-use std::io::{Read, Write};
+use std::io::Write;
 use std::sync::{Mutex, OnceLock};
 use std::{cmp, mem, ptr};
 
@@ -1604,10 +1604,10 @@ pub unsafe fn ffopen_safer(
 
                     /* write history records */
                     ffphis_safe(
-                    f,
-                    cs!(c"CFITSIO used the following filtering expression to create this table:"),
-                    status,
-                );
+                        f,
+                        cs!(c"CFITSIO used the following filtering expression to create this table:"),
+                        status,
+                    );
                     ffphis_safe(f, name, status);
                 } /* end of no binspec case */
             } /* end of table HDU case */
@@ -5315,9 +5315,7 @@ pub unsafe fn ffifile2_safer(
             };
         }
 
-        if ptr1.is_some() {
-            let p1: usize = ptr1.unwrap();
-
+        if let Some(p1) = ptr1 {
             /* found the binning string */
             if !binspec.is_null() {
                 if strlen_safe(&rowfilter[(p1 + 1)..]) > FLEN_FILENAME - 1 {

--- a/src/drvrfile.rs
+++ b/src/drvrfile.rs
@@ -491,15 +491,21 @@ pub(crate) fn file_close(handle: c_int) -> c_int {
     //let mut h = handleTable.lock().unwrap();
     let mut h = HANDLE_TABLE.lock().unwrap();
 
-    if let Some(f) = &mut h[handle as usize].fileptr
-        && f.sync_all().is_err()
-    {
-        return FILE_NOT_CLOSED;
+    match &mut h[handle as usize].fileptr {
+        Some(f) => {
+            let e = f.sync_all();
+            if e.is_err() {
+                // return WRITE_ERROR;
+            }
+        }
+        None => {
+        }
     }
 
     (h[handle as usize]).fileptr = None; // Implicitly drop the file
 
     0
+
 }
 
 /*--------------------------------------------------------------------------*/

--- a/src/drvrmem.rs
+++ b/src/drvrmem.rs
@@ -1230,7 +1230,7 @@ pub(crate) unsafe fn mem_uncompress2mem<T: Read + AsRawHandle>(
 
     if strstr_safe(filename, cs!(c".Z")).is_some() {
         let raw_file_handle = unsafe {
-            use libc::{open_osfhandle, fdopen};
+            use libc::{fdopen, open_osfhandle};
 
             let handle = diskfile.as_raw_handle();
             let fd = open_osfhandle(handle as isize, 0);
@@ -1250,7 +1250,7 @@ pub(crate) unsafe fn mem_uncompress2mem<T: Read + AsRawHandle>(
         #[cfg(feature = "bzip2")]
         {
             let raw_file_handle = unsafe {
-                use libc::{open_osfhandle, fdopen};
+                use libc::{fdopen, open_osfhandle};
 
                 let handle = diskfile.as_raw_handle();
                 let fd = open_osfhandle(handle as isize, 0);
@@ -1540,25 +1540,23 @@ pub(crate) unsafe fn bzip2uncompress2mem(
                     return;
                 }
                 total_read += nread as usize;
-            } else {
-                if bzerror == BZ_IO_ERROR {
-                    strcpy_safe(&mut errormsg, cs!(c"failed to read bzip2 file: I/O error"));
-                } else if bzerror == BZ_UNEXPECTED_EOF {
-                    strcpy_safe(
-                        &mut errormsg,
-                        cs!(c"failed to read bzip2 file: unexpected end-of-file"),
-                    );
-                } else if bzerror == BZ_DATA_ERROR {
-                    strcpy_safe(
-                        &mut errormsg,
-                        cs!(c"failed to read bzip2 file: data integrity error"),
-                    );
-                } else if bzerror == BZ_MEM_ERROR {
-                    strcpy_safe(
-                        &mut errormsg,
-                        cs!(c"failed to read bzip2 file: insufficient memory"),
-                    );
-                }
+            } else if bzerror == BZ_IO_ERROR {
+                strcpy_safe(&mut errormsg, cs!(c"failed to read bzip2 file: I/O error"));
+            } else if bzerror == BZ_UNEXPECTED_EOF {
+                strcpy_safe(
+                    &mut errormsg,
+                    cs!(c"failed to read bzip2 file: unexpected end-of-file"),
+                );
+            } else if bzerror == BZ_DATA_ERROR {
+                strcpy_safe(
+                    &mut errormsg,
+                    cs!(c"failed to read bzip2 file: data integrity error"),
+                );
+            } else if bzerror == BZ_MEM_ERROR {
+                strcpy_safe(
+                    &mut errormsg,
+                    cs!(c"failed to read bzip2 file: insufficient memory"),
+                );
             }
         }
         BZ2_bzReadClose(&mut bzerror, b);

--- a/src/edithdu.rs
+++ b/src/edithdu.rs
@@ -365,16 +365,12 @@ pub unsafe fn ffcphd_safer(
             /* write standard block of self-documentating comments */
             ffprec_safe(
                 outfptr,
-                cs!(
-                    c"COMMENT   FITS (Flexible Image Transport System) format is defined in 'Astronomy"
-                ),
+                cs!(c"COMMENT   FITS (Flexible Image Transport System) format is defined in 'Astronomy"),
                 status,
             );
             ffprec_safe(
                 outfptr,
-                cs!(
-                    c"COMMENT   and Astrophysics', volume 376, page 359; bibcode: 2001A&A...376..359H"
-                ),
+                cs!(c"COMMENT   and Astrophysics', volume 376, page 359; bibcode: 2001A&A...376..359H"),
                 status,
             );
 

--- a/src/eval_defs.rs
+++ b/src/eval_defs.rs
@@ -26,6 +26,20 @@ pub struct DataInfo {
     pub data: *mut c_void,
 }
 
+impl Default for DataInfo {
+    fn default() -> Self {
+        DataInfo {
+            name: [0; MAXVARNAME + 1],
+            dtype: 0,
+            nelem: 0,
+            naxis: 0,
+            naxes: [0; MAXDIMS as usize],
+            undef: std::ptr::null_mut(),
+            data: std::ptr::null_mut(),
+        }
+    }
+}
+
 #[derive(Copy, Clone)]
 pub union data_union {
     pub dbl: f64,

--- a/src/eval_defs.rs
+++ b/src/eval_defs.rs
@@ -6,14 +6,16 @@ use crate::fitsio::{LONGLONG, PixelFilter, fitsfile, iteratorCol};
 
 pub const MAXDIMS: c_int = 5;
 pub const MAXSUBS: c_int = 10;
-pub const MAXVARNAME: c_int = 80;
+pub const MAXVARNAME: usize = 80;
 pub const CONST_OP: c_int = -1000;
-pub const P_ERROR: c_int = -1;
+pub const pERROR: c_int = -1;
 pub const MAX_STRLEN: c_int = 256;
 pub const MAX_STRLEN_S: &str = "255";
 
+pub(crate) type yyscan_t = *mut c_void;
+
 pub struct DataInfo {
-    pub name: [c_char; MAXVARNAME as usize + 1],
+    pub name: [c_char; MAXVARNAME + 1],
     pub dtype: c_int,
     pub nelem: c_long,
     pub naxis: c_int,
@@ -52,22 +54,24 @@ pub struct lval {
     pub data: data_union,
 }
 
+#[derive(Default, Copy, Clone)]
 pub struct Node {
     pub operation: c_int,
-    pub DoOp: Option<unsafe fn(p: *mut ParseData, this: *mut Node)>,
+    pub DoOp: Option<unsafe fn(p: &mut ParseData, this: *mut Node)>,
     pub nSubNodes: c_int,
     pub SubNodes: [c_int; MAXSUBS as usize],
     pub ntype: c_int,
     pub value: lval,
 }
 
+#[derive(Default)]
 pub struct ParseData {
     pub def_fptr: *mut fitsfile,
     pub getData:
-        Option<fn(p: *mut ParseData, dataName: *mut c_char, dataValue: *mut c_void) -> c_int>,
+        Option<fn(p: &mut ParseData, dataName: &[c_char], dataValue: *mut c_void) -> c_int>,
     pub loadData: Option<
         fn(
-            p: *mut ParseData,
+            p: &mut ParseData,
             varNum: c_int,
             fRow: c_long,
             nRows: c_long,
@@ -82,7 +86,7 @@ pub struct ParseData {
     pub expr: *mut c_char,
     pub index: c_int,
     pub is_eobuf: c_int,
-    pub Nodes: *mut Node,
+    pub Nodes: Vec<Node>,
     pub nNodes: c_int,
     pub nNodesAlloc: c_int,
     pub resultNode: c_int,
@@ -102,6 +106,42 @@ pub struct ParseData {
     pub datatype: c_int,
     pub hdutype: c_int,
     pub status: c_int,
+}
+
+impl ParseData {
+    pub(crate) fn reset(&mut self) {
+        // Reset all fields
+        self.def_fptr = Default::default();
+        self.getData = Default::default();
+        self.loadData = Default::default();
+        self.compressed = Default::default();
+        self.timeCol = Default::default();
+        self.parCol = Default::default();
+        self.valCol = Default::default();
+        self.expr = Default::default();
+        self.index = Default::default();
+        self.is_eobuf = Default::default();
+        self.Nodes = Default::default();
+        self.nNodes = Default::default();
+        self.nNodesAlloc = Default::default();
+        self.resultNode = Default::default();
+        self.firstRow = Default::default();
+        self.nRows = Default::default();
+        self.nCols = Default::default();
+        self.nElements = Default::default();
+        self.nAxis = Default::default();
+        self.nAxes = Default::default();
+        self.colData = Default::default();
+        self.varData = Default::default();
+        self.pixFilter = Default::default();
+        self.firstDataRow = Default::default();
+        self.nDataRows = Default::default();
+        self.totalRows = Default::default();
+        self.nPrevDataRows = Default::default();
+        self.datatype = Default::default();
+        self.hdutype = Default::default();
+        self.status = Default::default();
+    }
 }
 
 enum funcOp {
@@ -158,27 +198,29 @@ enum funcOp {
     array_fct,
 }
 
-pub struct ParseStatusVariables<'a> {
+#[derive(Default)]
+pub(crate) struct ParseStatusVariables {
     /* These variables were 'static' in fits_parse_workfn() */
-    Data: &'a c_void,
-    Null: &'a c_void,
-    datasize: c_int,
-    lastRow: c_long,
-    repeat: c_long,
-    resDataSize: c_long,
-    jnull: LONGLONG,
-    userInfo: &'a parseInfo<'a>,
-    zeros: [c_long; 4],
+    pub(crate) Data: *mut c_void,
+    pub(crate) Null: *mut c_void,
+    pub(crate) datasize: c_int,
+    pub(crate) lastRow: c_long,
+    pub(crate) repeat: c_long,
+    pub(crate) resDataSize: c_long,
+    pub(crate) jnull: LONGLONG,
+    pub(crate) userInfo: *mut parseInfo,
+    pub(crate) zeros: [c_long; 4],
 }
 
-pub struct parseInfo<'a> {
-    datatype: c_int,           /* Data type to cast parse results into for user       */
-    dataPtr: &'a c_void,       /* Pointer to array of results, NULL if to use iterCol */
-    nullPtr: &'a c_void,       /* Pointer to nulval, use zero if NULL                 */
-    maxRows: c_long,           /* Max No. of rows to process, -1=all, 0=1 iteration   */
-    anyNull: c_int,            /* Flag indicating at least 1 undef value encountered  */
-    parseData: *mut ParseData, /* Pointer to parser configuration */
-    parseVariables: ParseStatusVariables<'a>,
+#[derive(Default)]
+pub(crate) struct parseInfo {
+    pub(crate) datatype: c_int, /* Data type to cast parse results into for user       */
+    pub(crate) dataPtr: *mut c_void, /* Pointer to array of results, NULL if to use iterCol */
+    pub(crate) nullPtr: *mut c_void, /* Pointer to nulval, use zero if NULL                 */
+    pub(crate) maxRows: c_long, /* Max No. of rows to process, -1=all, 0=1 iteration   */
+    pub(crate) anyNull: c_int,  /* Flag indicating at least 1 undef value encountered  */
+    pub(crate) parseData: *mut ParseData, /* Pointer to parser configuration */
+    pub(crate) parseVariables: ParseStatusVariables,
 }
 
 /* Not sure why this is needed but it is */

--- a/src/eval_defs.rs
+++ b/src/eval_defs.rs
@@ -2,6 +2,7 @@ use std::ffi::c_void;
 
 use crate::c_types::{c_char, c_int, c_long};
 
+use crate::eval_l::yyguts_t;
 use crate::fitsio::{LONGLONG, PixelFilter, fitsfile, iteratorCol};
 
 pub const MAXDIMS: c_int = 5;
@@ -12,8 +13,9 @@ pub const pERROR: c_int = -1;
 pub const MAX_STRLEN: c_int = 256;
 pub const MAX_STRLEN_S: &str = "255";
 
-pub(crate) type yyscan_t = *mut c_void;
+pub(crate) type yyscan_t<'a> = &'a mut yyguts_t;
 
+#[derive(Debug, Copy, Clone)]
 pub struct DataInfo {
     pub name: [c_char; MAXVARNAME + 1],
     pub dtype: c_int,
@@ -96,8 +98,8 @@ pub struct ParseData {
     pub nElements: c_long,
     pub nAxis: c_int,
     pub nAxes: [c_long; MAXDIMS as usize],
-    pub colData: *mut iteratorCol, // This is a list
-    pub varData: *mut DataInfo,
+    pub colData: Vec<iteratorCol>, // This is a list
+    pub varData: Vec<DataInfo>,
     pub pixFilter: *mut PixelFilter,
     pub firstDataRow: c_long,
     pub nDataRows: c_long,

--- a/src/eval_defs.rs
+++ b/src/eval_defs.rs
@@ -9,7 +9,7 @@ pub const MAXDIMS: c_int = 5;
 pub const MAXSUBS: c_int = 10;
 pub const MAXVARNAME: usize = 80;
 pub const CONST_OP: c_int = -1000;
-pub const pERROR: c_int = -1;
+pub const P_ERROR: c_int = -1;
 pub const MAX_STRLEN: c_int = 256;
 pub const MAX_STRLEN_S: &str = "255";
 
@@ -59,9 +59,9 @@ pub struct lval {
 #[derive(Default, Copy, Clone)]
 pub struct Node {
     pub operation: c_int,
-    pub DoOp: Option<unsafe fn(p: &mut ParseData, this: *mut Node)>,
+    pub DoOp: Option<fn(p: &mut ParseData, this_node_idx: usize)>,
     pub nSubNodes: c_int,
-    pub SubNodes: [c_int; MAXSUBS as usize],
+    pub SubNodes: [usize; MAXSUBS as usize],
     pub ntype: c_int,
     pub value: lval,
 }

--- a/src/eval_defs.rs
+++ b/src/eval_defs.rs
@@ -40,7 +40,7 @@ impl Default for DataInfo {
     }
 }
 
-#[derive(Copy, Clone)]
+#[derive( Copy, Clone)]
 pub union data_union {
     pub dbl: f64,
     pub lng: c_long,
@@ -53,6 +53,12 @@ pub union data_union {
     pub ptr: *mut c_void,
 }
 
+impl std::fmt::Debug for data_union {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "data_union {{ long: {:?} }}", unsafe { self.lng } )
+    }
+}
+
 impl Default for data_union {
     fn default() -> Self {
         data_union {
@@ -61,7 +67,7 @@ impl Default for data_union {
     }
 }
 
-#[derive(Default, Copy, Clone)]
+#[derive(Default, Debug, Copy, Clone)]
 pub struct lval {
     pub nelem: c_long,
     pub naxis: c_int,
@@ -70,7 +76,7 @@ pub struct lval {
     pub data: data_union,
 }
 
-#[derive(Default, Copy, Clone)]
+#[derive(Default, Debug, Copy, Clone)]
 pub struct Node {
     pub operation: c_int,
     pub DoOp: Option<fn(p: &mut ParseData, this_node_idx: usize)>,

--- a/src/eval_defs.rs
+++ b/src/eval_defs.rs
@@ -12,83 +12,96 @@ pub const P_ERROR: c_int = -1;
 pub const MAX_STRLEN: c_int = 256;
 pub const MAX_STRLEN_S: &str = "255";
 
-pub struct DataInfo<'a> {
-    name: [c_char; MAXVARNAME as usize + 1],
-    r#type: c_int,
-    nelem: c_long,
-    naxis: c_int,
-    naxes: [c_long; MAXDIMS as usize],
-    undef: &'a c_char,
-    data: &'a c_void,
+pub struct DataInfo {
+    pub name: [c_char; MAXVARNAME as usize + 1],
+    pub dtype: c_int,
+    pub nelem: c_long,
+    pub naxis: c_int,
+    pub naxes: [c_long; MAXDIMS as usize],
+    pub undef: *mut c_char,
+    pub data: *mut c_void,
 }
 
-union data_union {
-    dbl: f64,
-    lng: c_long,
-    log: c_char,
-    str: [c_char; MAX_STRLEN as usize],
-    dblptr: *mut f64,
-    lngptr: *mut c_long,
-    logptr: *mut c_char,
-    strptr: *mut c_char,
-    ptr: *mut c_void,
+#[derive(Copy, Clone)]
+pub union data_union {
+    pub dbl: f64,
+    pub lng: c_long,
+    pub log: c_char,
+    pub astr: [c_char; MAX_STRLEN as usize],
+    pub dblptr: *mut f64,
+    pub lngptr: *mut c_long,
+    pub logptr: *mut c_char,
+    pub strptr: *mut *mut c_char,
+    pub ptr: *mut c_void,
 }
 
-pub struct lval<'a> {
-    nelem: c_long,
-    naxis: c_int,
-    naxes: [c_long; MAXDIMS as usize],
-    undef: &'a c_char,
-    data: data_union,
+impl Default for data_union {
+    fn default() -> Self {
+        data_union {
+            ptr: std::ptr::null_mut(),
+        }
+    }
 }
 
-pub struct Node<'a> {
-    operation: c_int,
-    DoOp: fn(p: ParseData, this: Node) -> c_void,
-    nSubNodes: c_int,
-    SubNodes: [c_int; MAXSUBS as usize],
-    r#type: c_int,
-    value: &'a lval<'a>,
+#[derive(Default, Copy, Clone)]
+pub struct lval {
+    pub nelem: c_long,
+    pub naxis: c_int,
+    pub naxes: [c_long; MAXDIMS as usize],
+    pub undef: *mut c_char,
+    pub data: data_union,
 }
 
-pub struct ParseData<'a> {
-    def_fptr: &'a fitsfile,
-    getData: fn(p: ParseData, dataName: c_char, dataValue: c_void) -> c_int,
-    loadData: fn(
-        p: ParseData,
-        varNum: c_int,
-        fRow: c_long,
-        nRows: c_long,
-        data: c_void,
-        undef: c_char,
-    ) -> c_int,
-    compressed: c_int,
-    timeCol: c_int,
-    parCol: c_int,
-    valCol: c_int,
-    expr: c_char,
-    index: c_int,
-    is_eobuf: c_int,
-    Nodes: &'a Node<'a>,
-    nNodes: c_int,
-    nNodesAlloc: c_int,
-    resultNode: c_int,
-    firstRow: c_long,
-    nRows: c_long,
-    nCols: c_int,
-    nElements: c_long,
-    nAxis: c_int,
-    nAxes: [c_long; MAXDIMS as usize],
-    colData: &'a iteratorCol,
-    varData: &'a DataInfo<'a>,
-    pixFilter: &'a PixelFilter,
-    firstDataRow: c_long,
-    nDataRows: c_long,
-    totalRows: c_long,
-    nPrevDataRows: c_long,
-    datatype: c_int,
-    hdutype: c_int,
-    status: c_int,
+pub struct Node {
+    pub operation: c_int,
+    pub DoOp: Option<unsafe fn(p: *mut ParseData, this: *mut Node)>,
+    pub nSubNodes: c_int,
+    pub SubNodes: [c_int; MAXSUBS as usize],
+    pub ntype: c_int,
+    pub value: lval,
+}
+
+pub struct ParseData {
+    pub def_fptr: *mut fitsfile,
+    pub getData:
+        Option<fn(p: *mut ParseData, dataName: *mut c_char, dataValue: *mut c_void) -> c_int>,
+    pub loadData: Option<
+        fn(
+            p: *mut ParseData,
+            varNum: c_int,
+            fRow: c_long,
+            nRows: c_long,
+            data: *mut c_void,
+            undef: *mut c_char,
+        ) -> c_int,
+    >,
+    pub compressed: c_int,
+    pub timeCol: c_int,
+    pub parCol: c_int,
+    pub valCol: c_int,
+    pub expr: *mut c_char,
+    pub index: c_int,
+    pub is_eobuf: c_int,
+    pub Nodes: *mut Node,
+    pub nNodes: c_int,
+    pub nNodesAlloc: c_int,
+    pub resultNode: c_int,
+    pub firstRow: c_long,
+    pub nRows: c_long,
+    pub nCols: c_int,
+    pub nElements: c_long,
+    pub nAxis: c_int,
+    pub nAxes: [c_long; MAXDIMS as usize],
+    pub colData: *mut iteratorCol, // This is a list
+    pub varData: *mut DataInfo,
+    pub pixFilter: *mut PixelFilter,
+    pub firstDataRow: c_long,
+    pub nDataRows: c_long,
+    pub totalRows: c_long,
+    pub nPrevDataRows: c_long,
+    pub datatype: c_int,
+    pub hdutype: c_int,
+    pub status: c_int,
 }
 
 enum funcOp {
@@ -159,12 +172,12 @@ pub struct ParseStatusVariables<'a> {
 }
 
 pub struct parseInfo<'a> {
-    datatype: c_int,     /* Data type to cast parse results into for user       */
-    dataPtr: &'a c_void, /* Pointer to array of results, NULL if to use iterCol */
-    nullPtr: &'a c_void, /* Pointer to nulval, use zero if NULL                 */
-    maxRows: c_long,     /* Max No. of rows to process, -1=all, 0=1 iteration   */
-    anyNull: c_int,      /* Flag indicating at least 1 undef value encountered  */
-    parseData: &'a ParseData<'a>, /* Pointer to parser configuration */
+    datatype: c_int,           /* Data type to cast parse results into for user       */
+    dataPtr: &'a c_void,       /* Pointer to array of results, NULL if to use iterCol */
+    nullPtr: &'a c_void,       /* Pointer to nulval, use zero if NULL                 */
+    maxRows: c_long,           /* Max No. of rows to process, -1=all, 0=1 iteration   */
+    anyNull: c_int,            /* Flag indicating at least 1 undef value encountered  */
+    parseData: *mut ParseData, /* Pointer to parser configuration */
     parseVariables: ParseStatusVariables<'a>,
 }
 

--- a/src/eval_defs.rs
+++ b/src/eval_defs.rs
@@ -40,7 +40,7 @@ impl Default for DataInfo {
     }
 }
 
-#[derive( Copy, Clone)]
+#[derive(Copy, Clone)]
 pub union data_union {
     pub dbl: f64,
     pub lng: c_long,
@@ -55,7 +55,7 @@ pub union data_union {
 
 impl std::fmt::Debug for data_union {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "data_union {{ long: {:?} }}", unsafe { self.lng } )
+        write!(f, "data_union {{ long: {:?} }}", unsafe { self.lng })
     }
 }
 

--- a/src/eval_f.rs
+++ b/src/eval_f.rs
@@ -60,9 +60,9 @@ use crate::{fitsio::*, raw_to_slice};
 use bytemuck::cast_slice;
 use core::ffi::CStr;
 
-pub(crate) struct ffffrw_workdata<'a> {
+pub(crate) struct ffffrw_workdata {
     prownum: Vec<c_long>,
-    lParse: Vec<ParseData<'a>>,
+    lParse: Vec<ParseData>,
 }
 
 /*---------------------------------------------------------------------------*/

--- a/src/eval_f.rs
+++ b/src/eval_f.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 /************************************************************************/
 /*                                                                      */
 /*                       CFITSIO Lexical Parser                         */
@@ -51,18 +53,79 @@
 /************************************************************************/
 
 use std::ffi::c_void;
+use std::{cmp, mem, ptr};
 
+use crate::buffers::{ffgbyt, ffgtbb_safe, ffmbyt_safe, ffpbyt, ffptbb_safe};
 use crate::c_types::{c_char, c_int, c_long};
 
-use crate::eval_defs::{MAXDIMS, ParseData};
-use crate::fitscore::ffpmsg_str;
-use crate::{fitsio::*, raw_to_slice};
-use bytemuck::cast_slice;
+use crate::aliases::rust_api::{fits_binary_tform, fits_set_atblnull, fits_set_btblnull};
+use crate::aliases::rust_api::{
+    fits_create_img, fits_get_colnum, fits_get_coltype, fits_get_hdrspace, fits_get_hdu_type,
+    fits_get_img_param, fits_get_keyclass, fits_get_keytype, fits_read_imgnull, fits_read_key_dbl,
+    fits_read_key_lng, fits_read_key_log, fits_read_key_str, fits_read_keyword, fits_read_record,
+    fits_read_tdim, fits_set_imgnull, fits_update_key_lng, fits_write_record,
+};
+use crate::cfileio::ffimport_file_safer;
+use crate::editcol::{ffdrow_safe, fficol_safe, ffirow_safe};
+use crate::eval_defs::{
+    CONST_OP, DataInfo, MAX_STRLEN, MAXDIMS, MAXVARNAME, Node, ParseData, pERROR, parseInfo,
+    yyscan_t,
+};
+use crate::eval_l::{
+    fits_parser_yylex_destroy, fits_parser_yylex_init_extra, fits_parser_yyrestart,
+};
+use crate::eval_tab::{FITS_PARSER_YYSTYPE, fits_parser_yytokentype};
+use crate::eval_y::{Evaluate_Parser, fits_parser_yyparse, gtifilt_fct, regfilt_fct};
+use crate::fitscore::{
+    ffcmph_safer, ffcmsg_safe, ffgcno_safe, ffgdesll_safe, ffgncl_safe, ffgnrw_safe, ffiblk,
+    ffkeyn_safe, ffmahd_safe, ffpdes_safe, ffpmrk, fits_strcasecmp,
+};
+use crate::fitscore::{ffpmsg_slice, ffpmsg_str, ffrdef_safe, fits_recalloc};
+use crate::fitsio2::{IGNORE_EOF, REPORT_EOF};
+use crate::getcolb::ffgcvb_safe;
+use crate::getcold::{ffgcfd_safe, ffgcvd_safe};
+use crate::getcolj::{ffgcfj_safe, ffgcvj_safe};
+use crate::getcoll::ffgcfl_safe;
+use crate::getcols::{ffgcfs_safe, ffgcvs_safe};
+use crate::getkey::ffgcrd_safe;
+use crate::getkey::ffgkyj_safe;
+use crate::modkey::{ffdkey_safe, ffukyd_safe, ffukyj_safe, ffukyl_safe, ffukys_safe};
+use crate::putcol::{ffiter_safe, fits_iter_set_by_num};
+use crate::putkey::{ffpcom_safe, ffphis_safe, ffpkyj_safe, ffpkys_safe, ffptdm_safe};
+use crate::region::{SAORegion, fits_free_region};
+use crate::wrappers::{strcat, strcpy, strlen, strlen_safe, strncpy};
+use crate::{BL, cs, fitsio::*, int_snprintf, raw_to_slice};
+use bytemuck::{cast_slice, cast_slice_mut};
 use core::ffi::CStr;
+use libc::{c_double, c_uchar, free, malloc, memset, printf, snprintf};
+use std::os::raw::c_short;
+
+// Constants needed for the function
+const UCHAR_MAX: LONGLONG = 255;
+const SHRT_MIN: LONGLONG = c_short::MIN as LONGLONG;
+const INT_MIN: LONGLONG = c_int::MIN as LONGLONG;
+const LONG_MIN: LONGLONG = c_long::MIN as LONGLONG;
+use std::mem::size_of;
 
 pub(crate) struct ffffrw_workdata {
-    prownum: Vec<c_long>,
-    lParse: Vec<ParseData>,
+    prownum: *mut c_long,
+    lParse: *mut ParseData,
+}
+
+static DEBUG_PIXFILTER: c_int = 0;
+
+// Free macro for raw pointers
+macro_rules! FREE {
+    ($x:expr) => {
+        if !$x.is_null() {
+            unsafe {
+                libc::free($x as *mut libc::c_void);
+            }
+            $x = std::ptr::null_mut();
+        } else {
+            println!("invalid free at {}:{}", file!(), line!());
+        }
+    };
 }
 
 /*---------------------------------------------------------------------------*/
@@ -95,15 +158,111 @@ pub unsafe extern "C" fn fffrow(
 /// Evaluate a boolean expression using the indicated rows, returning an
 /// array of flags indicating which rows evaluated to TRUE/FALSE
 pub fn fffrow_safe(
-    _fptr: &mut fitsfile,       /* I - Input FITS file                   */
-    _expr: &[c_char],           /* I - Boolean expression                */
-    _firstrow: c_long,          /* I - First row of table to eval        */
-    _nrows: c_long,             /* I - Number of rows to evaluate        */
-    _n_good_rows: &mut c_long,  /* O - Number of rows eval to True       */
-    _row_status: &mut [c_char], /* O - Array of boolean results          */
-    _status: &mut c_int,        /* O - Error status                      */
+    fptr: &mut fitsfile,       /* I - Input FITS file                   */
+    expr: &[c_char],           /* I - Boolean expression                */
+    firstrow: c_long,          /* I - First row of table to eval        */
+    nrows: c_long,             /* I - Number of rows to evaluate        */
+    n_good_rows: &mut c_long,  /* O - Number of rows eval to True       */
+    row_status: &mut [c_char], /* O - Array of boolean results          */
+    status: &mut c_int,        /* O - Error status                      */
 ) -> c_int {
-    todo!()
+    let mut naxis: c_int = 0;
+    let constant: bool;
+    let mut nelem: c_long = 0;
+    let mut naxes: [c_long; MAXDIMS as usize] = [0; MAXDIMS as usize];
+    let mut elem: c_long;
+    let result: c_char;
+    let mut lParse: ParseData = ParseData::default();
+
+    if *status != 0 {
+        return *status;
+    }
+
+    let mut Info: parseInfo = Default::default();
+
+    if ffiprs(
+        fptr,
+        0,
+        expr,
+        MAXDIMS,
+        &mut Info.datatype,
+        &mut nelem,
+        &mut naxis,
+        &mut naxes,
+        &mut lParse,
+        status,
+    ) != 0
+    {
+        ffcprs(&mut lParse);
+        return *status;
+    }
+
+    if nelem < 0 {
+        constant = true;
+        nelem = -nelem;
+    } else {
+        constant = false;
+    }
+
+    if Info.datatype != TLOGICAL || nelem != 1 {
+        ffcprs(&mut lParse);
+        ffpmsg_str("Expression does not evaluate to a logical scalar.");
+        *status = PARSE_BAD_TYPE;
+        return *status;
+    }
+
+    if constant {
+        /* No need to call parser... have result from ffiprs */
+        result = unsafe { (lParse.Nodes[lParse.resultNode as usize]).value.data.log };
+        *n_good_rows = nrows;
+
+        for elem in 0..nrows {
+            row_status[elem as usize] = result;
+        }
+    } else {
+        let firstrow = if firstrow > 1 { firstrow } else { 1 };
+        Info.dataPtr = row_status.as_mut_ptr() as *mut c_void;
+        Info.nullPtr = ptr::null_mut();
+        Info.maxRows = nrows;
+        Info.parseData = &mut lParse;
+
+        let colData_slice =
+            unsafe { std::slice::from_raw_parts_mut(lParse.colData, lParse.nCols as usize) };
+        if ffiter_safe(
+            lParse.nCols,
+            colData_slice,
+            firstrow - 1,
+            0,
+            fits_parser_workfn,
+            &Info as *const _ as *mut c_void,
+            status,
+        ) == -1
+        {
+            *status = 0; /* -1 indicates exitted without error before end... OK */
+        }
+
+        if *status != 0 {
+
+            /***********************/
+            /* Error... Do nothing */
+            /***********************/
+        } else {
+            /***********************************/
+            /* Count number of good rows found */
+            /***********************************/
+
+            *n_good_rows = 0;
+
+            for elem in 0..Info.maxRows {
+                if row_status[elem as usize] == 1 {
+                    *n_good_rows += 1;
+                }
+            }
+        }
+    }
+
+    ffcprs(&mut lParse);
+    *status
 }
 
 /*--------------------------------------------------------------------------*/
@@ -139,12 +298,341 @@ pub unsafe extern "C" fn ffsrow(
 /// extension is before the input extension, the second extension *MUST* be
 /// opened using ffreopen, so that CFITSIO can handle changing file lengths
 pub fn ffsrow_safe(
-    _infptr: &mut fitsfile,  /* I - Input FITS file                      */
-    _outfptr: &mut fitsfile, /* I - Output FITS file                     */
-    _expr: &[c_char],        /* I - Boolean expression                   */
-    _status: &mut c_int,     /* O - Error status                         */
+    infptr: &mut fitsfile,  /* I - Input FITS file                      */
+    outfptr: &mut fitsfile, /* I - Output FITS file                     */
+    expr: &[c_char],        /* I - Boolean expression                   */
+    status: &mut c_int,     /* O - Error status                         */
 ) -> c_int {
-    todo!()
+    let mut Info: parseInfo = Default::default();
+    let mut naxis: c_int = 0;
+    let mut constant: c_int = 0;
+    let mut nelem: c_long = 0;
+    let mut rdlen: c_long = 0;
+    let mut naxes: [c_long; MAXDIMS as usize] = [0; MAXDIMS as usize];
+    let mut maxrows: c_long = 0;
+    let mut nbuff: c_long = 0;
+    let mut nGood: c_long = 0;
+    let mut inloc: c_long = 0;
+    let mut outloc: c_long = 0;
+    let mut ntodo: LONGLONG = 0;
+    let mut inbyteloc: LONGLONG = 0;
+    let mut outbyteloc: LONGLONG = 0;
+    let mut hsize: LONGLONG = 0;
+    let mut freespace: c_long = 0;
+    let mut buffer: *mut c_uchar = std::ptr::null_mut();
+    let mut result: c_char = 0;
+
+    #[derive(Default)]
+    struct in_out_ext {
+        rowLength: LONGLONG,
+        numRows: LONGLONG,
+        heapSize: LONGLONG,
+        dataStart: LONGLONG,
+        heapStart: LONGLONG,
+    }
+
+    let mut inExt: in_out_ext = in_out_ext::default();
+    let mut outExt: in_out_ext = in_out_ext::default();
+
+    let mut lParse: ParseData = ParseData::default();
+
+    unsafe {
+        if *status != 0 {
+            return *status;
+        }
+
+        if ffiprs(
+            infptr,
+            0,
+            expr,
+            MAXDIMS,
+            &mut Info.datatype,
+            &mut nelem,
+            &mut naxis,
+            &mut naxes,
+            &mut lParse,
+            status,
+        ) != 0
+        {
+            ffcprs(&mut lParse);
+            return *status;
+        }
+
+        if nelem < 0 {
+            constant = 1;
+            nelem = -nelem;
+        } else {
+            constant = 0;
+        }
+
+        /**********************************************************************/
+        /* Make sure expression evaluates to the right type... logical scalar */
+        /**********************************************************************/
+
+        if Info.datatype != TLOGICAL || nelem != 1 {
+            ffcprs(&mut lParse);
+            ffpmsg_str("Expression does not evaluate to a logical scalar.");
+            *status = PARSE_BAD_TYPE;
+            return *status;
+        }
+
+        /***********************************************************/
+        /*  Extract various table information from each extension  */
+        /***********************************************************/
+
+        if infptr.HDUposition != (infptr.Fptr).curhdu {
+            ffmahd_safe(infptr, (infptr.HDUposition) + 1, None, status);
+        }
+        if *status != 0 {
+            ffcprs(&mut lParse);
+            return *status;
+        }
+        inExt.rowLength = (infptr.Fptr).rowlength as c_long;
+        inExt.numRows = (infptr.Fptr).numrows;
+        inExt.heapSize = (infptr.Fptr).heapsize;
+        if inExt.numRows == 0 {
+            /* Nothing to copy */
+            ffcprs(&mut lParse);
+            return *status;
+        }
+
+        if outfptr.HDUposition != (outfptr.Fptr).curhdu {
+            ffmahd_safe(outfptr, (outfptr.HDUposition) + 1, None, status);
+        }
+        if (outfptr.Fptr).datastart < 0 {
+            ffrdef_safe(outfptr, status);
+        }
+        if *status != 0 {
+            ffcprs(&mut lParse);
+            return *status;
+        }
+        outExt.rowLength = (outfptr.Fptr).rowlength as c_long;
+        outExt.numRows = (outfptr.Fptr).numrows;
+        if outExt.numRows == 0 {
+            (outfptr.Fptr).heapsize = 0;
+        }
+        outExt.heapSize = (outfptr.Fptr).heapsize;
+
+        if inExt.rowLength != outExt.rowLength {
+            ffpmsg_str("Output table has different row length from input");
+            ffcprs(&mut lParse);
+            *status = PARSE_BAD_OUTPUT;
+            return *status;
+        }
+
+        /***********************************/
+        /*  Fill out Info data for parser  */
+        /***********************************/
+
+        Info.dataPtr =
+            malloc((inExt.numRows + 1) as usize * mem::size_of::<c_char>()) as *mut c_void;
+        Info.nullPtr = ptr::null_mut();
+        Info.maxRows = inExt.numRows as c_long;
+        Info.parseData = &mut lParse as *mut ParseData;
+        if Info.dataPtr.is_null() {
+            ffpmsg_str("Unable to allocate memory for row selection");
+            ffcprs(&mut lParse);
+            *status = MEMORY_ALLOCATION;
+            return *status;
+        }
+
+        /* make sure array is zero terminated */
+        *(Info.dataPtr as *mut c_char).add(inExt.numRows as usize) = 0;
+
+        if constant != 0 {
+            /*  Set all rows to the same value from constant result  */
+
+            result = (lParse.Nodes[lParse.resultNode as usize]).value.data.log;
+
+            for ntodo in 0..inExt.numRows {
+                *(Info.dataPtr as *mut c_char).add(ntodo as usize) = result;
+            }
+            nGood = if result != 0 { inExt.numRows } else { 0 } as c_long;
+        } else {
+            let col_slice = std::slice::from_raw_parts_mut(lParse.colData, lParse.nCols as usize);
+            ffiter_safe(
+                lParse.nCols,
+                col_slice,
+                0,
+                0,
+                fits_parser_workfn,
+                &mut Info as *mut parseInfo as *mut c_void,
+                status,
+            );
+
+            nGood = 0;
+
+            for ntodo in 0..inExt.numRows {
+                if (*(Info.dataPtr as *mut c_char).add(ntodo as usize)) != 0 {
+                    nGood += 1;
+                }
+            }
+        }
+
+        if *status != 0 {
+            /* Error... Do nothing */
+        } else {
+            rdlen = inExt.rowLength as c_long;
+            buffer = malloc(
+                (cmp::max(500000, rdlen) as usize * mem::size_of::<c_char>())
+                    .try_into()
+                    .unwrap(),
+            ) as *mut c_uchar;
+            if buffer.is_null() {
+                FREE!(Info.dataPtr);
+                ffcprs(&mut lParse);
+                *status = MEMORY_ALLOCATION;
+                return *status;
+            }
+            maxrows = cmp::max(500000 / rdlen, 1);
+            nbuff = 0;
+            inloc = 1;
+            if std::ptr::eq(infptr, outfptr) {
+                /* Skip initial good rows if input==output file */
+                while *(Info.dataPtr as *mut c_char).add((inloc - 1) as usize) != 0 {
+                    inloc += 1;
+                }
+                outloc = inloc;
+            } else {
+                outloc = (outExt.numRows + 1) as c_long;
+                if outloc > 1 {
+                    ffirow_safe(outfptr, outExt.numRows, nGood, status);
+                }
+            }
+
+            loop {
+                if *(Info.dataPtr as *mut c_char).add((inloc - 1) as usize) != 0 {
+                    let buffer_part = std::slice::from_raw_parts_mut(
+                        buffer.add((rdlen * nbuff) as usize),
+                        rdlen as usize,
+                    );
+                    ffgtbb_safe(infptr, inloc, 1, rdlen, buffer_part, status);
+                    nbuff += 1;
+                    if nbuff == maxrows {
+                        let buffer_slice =
+                            std::slice::from_raw_parts(buffer, (rdlen * nbuff) as usize);
+                        ffptbb_safe(outfptr, outloc, 1, rdlen * nbuff, buffer_slice, status);
+                        outloc += nbuff;
+                        nbuff = 0;
+                    }
+                }
+                inloc += 1;
+                if *status != 0 || inloc > inExt.numRows {
+                    break;
+                }
+            }
+
+            if nbuff != 0 {
+                let buffer_slice = std::slice::from_raw_parts(buffer, (rdlen * nbuff) as usize);
+                ffptbb_safe(outfptr, outloc, 1, rdlen * nbuff, buffer_slice, status);
+                outloc += nbuff;
+            }
+
+            if std::ptr::eq(infptr, outfptr) {
+                if outloc <= inExt.numRows {
+                    ffdrow_safe(infptr, outloc, inExt.numRows - outloc + 1, status);
+                }
+            } else if inExt.heapSize != 0 && nGood != 0 {
+                /* Copy heap, if it exists and at least one row copied */
+
+                /********************************************************/
+                /*  Get location information from the output extension  */
+                /********************************************************/
+
+                if outfptr.HDUposition != (outfptr.Fptr).curhdu {
+                    ffmahd_safe(outfptr, (outfptr.HDUposition) + 1, None, status);
+                }
+                outExt.dataStart = (outfptr.Fptr).datastart;
+                outExt.heapStart = (outfptr.Fptr).heapstart;
+
+                /*************************************************/
+                /*  Insert more space into outfptr if necessary  */
+                /*************************************************/
+
+                hsize = outExt.heapStart + outExt.heapSize;
+                freespace = ((((hsize + (BL!() - 1)) / BL!()) * BL!()) - hsize) as c_long;
+                ntodo = inExt.heapSize;
+
+                if (freespace - ntodo) < 0 {
+                    /* not enough existing space? */
+                    ntodo = (ntodo - freespace + (BL!() - 1)) / BL!(); /* number of blocks  */
+                    ffiblk(outfptr, ntodo as c_long, 1, status); /* insert the blocks */
+                }
+                ffukyj_safe(
+                    outfptr,
+                    cs!(c"PCOUNT"),
+                    inExt.heapSize + outExt.heapSize,
+                    None,
+                    status,
+                );
+
+                /*******************************************************/
+                /*  Get location information from the input extension  */
+                /*******************************************************/
+
+                if infptr.HDUposition != (infptr.Fptr).curhdu {
+                    ffmahd_safe(infptr, (infptr.HDUposition) + 1, None, status);
+                }
+                inExt.dataStart = (infptr.Fptr).datastart;
+                inExt.heapStart = (infptr.Fptr).heapstart;
+
+                /**********************************/
+                /*  Finally copy heap to outfptr  */
+                /**********************************/
+
+                ntodo = inExt.heapSize;
+                inbyteloc = inExt.heapStart + inExt.dataStart;
+                outbyteloc = outExt.heapStart + outExt.dataStart + outExt.heapSize;
+
+                while ntodo != 0 && *status == 0 {
+                    rdlen = cmp::min(ntodo, 500000) as c_long;
+                    ffmbyt_safe(infptr, inbyteloc, REPORT_EOF, status);
+                    let buffer_slice = std::slice::from_raw_parts_mut(buffer, rdlen as usize);
+                    ffgbyt(infptr, rdlen, buffer_slice, status);
+                    ffmbyt_safe(outfptr, outbyteloc, IGNORE_EOF, status);
+                    let buffer_slice = std::slice::from_raw_parts(buffer, rdlen as usize);
+                    ffpbyt(outfptr, rdlen, buffer_slice, status);
+                    inbyteloc += rdlen;
+                    outbyteloc += rdlen;
+                    ntodo -= rdlen;
+                }
+
+                /***********************************************************/
+                /*  But must update DES if data is being appended to a     */
+                /*  pre-existing heap space.  Edit each new entry in file  */
+                /***********************************************************/
+
+                if outExt.heapSize != 0 {
+                    let mut repeat: LONGLONG = 0;
+                    let mut offset: LONGLONG = 0;
+                    for i in 1..=(outfptr.Fptr).tfield {
+                        if (*(outfptr.Fptr).tableptr.add((i - 1) as usize)).tdatatype < 0 {
+                            for j in (outExt.numRows + 1)..=(outExt.numRows + nGood) {
+                                ffgdesll_safe(
+                                    outfptr,
+                                    i,
+                                    j,
+                                    Some(&mut repeat),
+                                    Some(&mut offset),
+                                    status,
+                                );
+                                offset += outExt.heapSize;
+                                ffpdes_safe(outfptr, i, j, repeat, offset, status);
+                            }
+                        }
+                    }
+                }
+            } /*  End of HEAP copy  */
+
+            FREE!(buffer);
+        }
+
+        FREE!(Info.dataPtr);
+        ffcprs(&mut lParse);
+
+        ffcmph_safer(outfptr, status); /* compress heap, deleting any orphaned data */
+        *status
+    }
 }
 
 /*---------------------------------------------------------------------------*/
@@ -173,10 +661,6 @@ pub unsafe extern "C" fn ffcrow(
 
         let array = std::slice::from_raw_parts_mut(array as *mut u8, nelements as usize);
 
-        todo!(
-            "Need to handle nulval and the slice of array above is not correct due to data type size"
-        );
-
         raw_to_slice!(expr);
 
         ffcrow_safe(
@@ -193,17 +677,82 @@ pub unsafe extern "C" fn ffcrow(
 /// even multiple of the result dimension.  Call fftexp to obtain the
 /// dimensions of the results.
 pub fn ffcrow_safe(
-    _fptr: &mut fitsfile,   /* I - Input FITS file                      */
-    _datatype: c_int,       /* I - Datatype to return results as        */
-    _expr: &[c_char],       /* I - Arithmetic expression                */
-    _firstrow: c_long,      /* I - First row to evaluate                */
-    _nelements: c_long,     /* I - Number of elements to return         */
-    _nulval: *const c_void, /* I - Ptr to value to use as UNDEF         */
-    _array: &mut [u8],      /* O - Array of results                     */
-    _anynul: &mut c_int,    /* O - Were any UNDEFs encountered?         */
-    _status: &mut c_int,    /* O - Error status                         */
+    fptr: &mut fitsfile,   /* I - Input FITS file                      */
+    datatype: c_int,       /* I - Datatype to return results as        */
+    expr: &[c_char],       /* I - Arithmetic expression                */
+    firstrow: c_long,      /* I - First row to evaluate                */
+    nelements: c_long,     /* I - Number of elements to return         */
+    nulval: *const c_void, /* I - Ptr to value to use as UNDEF         */
+    array: &mut [u8],      /* O - Array of results                     */
+    anynul: &mut c_int,    /* O - Were any UNDEFs encountered?         */
+    status: &mut c_int,    /* O - Error status                         */
 ) -> c_int {
-    todo!()
+    let mut Info: parseInfo = Default::default();
+    let mut naxis: c_int = 0;
+    let mut nelem1: c_long = 0;
+    let mut naxes: [c_long; MAXDIMS as usize] = [0; MAXDIMS as usize];
+    let mut lParse: ParseData = ParseData::default();
+
+    if *status != 0 {
+        return *status;
+    }
+
+    if ffiprs(
+        fptr,
+        0,
+        expr,
+        MAXDIMS,
+        &mut Info.datatype,
+        &mut nelem1,
+        &mut naxis,
+        &mut naxes,
+        &mut lParse,
+        status,
+    ) != 0
+    {
+        ffcprs(&mut lParse);
+        return *status;
+    }
+    if nelem1 < 0 {
+        nelem1 = -nelem1;
+    }
+
+    if nelements < nelem1 {
+        ffcprs(&mut lParse);
+        ffpmsg_str("Array not large enough to hold at least one row of data.");
+        *status = PARSE_LRG_VECTOR;
+        return *status;
+    }
+
+    let firstrow = if firstrow > 1 { firstrow } else { 1 };
+
+    if datatype != 0 {
+        Info.datatype = datatype;
+    }
+
+    Info.dataPtr = array.as_mut_ptr() as *mut c_void;
+    Info.nullPtr = nulval as *mut c_void;
+    Info.maxRows = nelements / nelem1;
+    Info.parseData = &mut lParse;
+
+    let colData_slice =
+        unsafe { std::slice::from_raw_parts_mut(lParse.colData, lParse.nCols as usize) };
+    if ffiter_safe(
+        lParse.nCols,
+        colData_slice,
+        firstrow - 1,
+        0,
+        fits_parser_workfn,
+        (&mut Info) as *mut parseInfo as *mut c_void,
+        status,
+    ) == -1
+    {
+        *status = 0; /* -1 indicates exitted without error before end... OK */
+    }
+
+    *anynul = Info.anyNull;
+    ffcprs(&mut lParse);
+    *status
 }
 
 /*--------------------------------------------------------------------------*/
@@ -266,17 +815,32 @@ pub fn ffcalc_safe(
 ///        If parInfo is NULL, use a default data type for the column.      
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffcalc_rng(
-    _infptr: *mut fitsfile,  /* I - Input FITS file                  */
-    _expr: *const c_char,    /* I - Arithmetic expression            */
-    _outfptr: *mut fitsfile, /* I - Output fits file                 */
-    _parName: *const c_char, /* I - Name of output parameter         */
-    _parInfo: *const c_char, /* I - Extra information on parameter   */
-    _nRngs: c_int,           /* I - Row range info                   */
-    _start: *mut c_long,     /* I - Row range info                   */
-    _end: *mut c_long,       /* I - Row range info                   */
-    _status: *mut c_int,     /* O - Error status                     */
+    infptr: *mut fitsfile,  /* I - Input FITS file                  */
+    expr: *const c_char,    /* I - Arithmetic expression            */
+    outfptr: *mut fitsfile, /* I - Output fits file                 */
+    parName: *const c_char, /* I - Name of output parameter         */
+    parInfo: *const c_char, /* I - Extra information on parameter   */
+    nRngs: c_int,           /* I - Row range info                   */
+    start: *mut c_long,     /* I - Row range info                   */
+    end: *mut c_long,       /* I - Row range info                   */
+    status: *mut c_int,     /* O - Error status                     */
 ) -> c_int {
-    todo!();
+    unsafe {
+        raw_to_slice!(expr);
+        raw_to_slice!(parName);
+        raw_to_slice!(parInfo);
+        unsafe {
+            let infptr = infptr.as_mut().expect(NULL_MSG);
+            let outfptr = outfptr.as_mut().expect(NULL_MSG);
+            let status = status.as_mut().expect(NULL_MSG);
+            let start = start.as_mut().expect(NULL_MSG);
+            let end = end.as_mut().expect(NULL_MSG);
+
+            ffcalc_rng_safe(
+                infptr, expr, outfptr, parName, parInfo, nRngs, start, end, status,
+            )
+        }
+    }
 }
 
 /*--------------------------------------------------------------------------*/
@@ -294,21 +858,408 @@ pub unsafe extern "C" fn ffcalc_rng(
 ///    (4) Else, create a new column with name parName and TFORM parInfo.   
 ///        If parInfo is NULL, use a default data type for the column.      
 pub fn ffcalc_rng_safe(
-    _infptr: &mut fitsfile,  /* I - Input FITS file                  */
-    _expr: &[c_char],        /* I - Arithmetic expression            */
-    _outfptr: &mut fitsfile, /* I - Output fits file                 */
-    _parName: &[c_char],     /* I - Name of output parameter         */
-    _parInfo: &[c_char],     /* I - Extra information on parameter   */
-    _nRngs: c_int,           /* I - Row range info                   */
-    _start: &mut c_long,     /* I - Row range info                   */
-    _end: &mut c_long,       /* I - Row range info                   */
-    _status: &mut c_int,     /* O - Error status                     */
+    infptr: &mut fitsfile,  /* I - Input FITS file                  */
+    expr: &[c_char],        /* I - Arithmetic expression            */
+    outfptr: &mut fitsfile, /* I - Output fits file                 */
+    parName: &[c_char],     /* I - Name of output parameter         */
+    parInfo: &[c_char],     /* I - Extra information on parameter   */
+    nRngs: c_int,           /* I - Row range info                   */
+    start: &mut c_long,     /* I - Row range info                   */
+    end: &mut c_long,       /* I - Row range info                   */
+    status: &mut c_int,     /* O - Error status                     */
 ) -> c_int {
-    todo!();
+    unsafe {
+        let mut Info: parseInfo = Default::default();
+        let mut naxis: c_int = 0;
+        let constant: c_int;
+        let mut typecode: c_int = 0;
+        let mut newNullKwd: c_int = 0;
+        let mut nelem: c_long = 0;
+        let mut naxes: [c_long; MAXDIMS as usize] = [0; MAXDIMS as usize];
+        let mut repeat: c_long = 0;
+        let mut width: c_long = 0;
+        let col_cnt: c_int;
+        let mut colNo: c_int;
+        let result: *mut Node;
+        let mut card: [c_char; FLEN_CARD] = [0; FLEN_CARD];
+        let mut tform: [c_char; 16] = [0; 16];
+        let mut nullKwd: [c_char; 9] = [0; 9];
+        let mut tdimKwd: [c_char; 9] = [0; 9];
+        let mut lParse: ParseData = ParseData::default();
+
+        let mut parInfo = parInfo;
+
+        if *status != 0 {
+            return *status;
+        }
+
+        if ffiprs(
+            infptr,
+            0,
+            expr,
+            MAXDIMS,
+            &mut Info.datatype,
+            &mut nelem,
+            &mut naxis,
+            &mut naxes,
+            &mut lParse,
+            status,
+        ) != 0
+        {
+            ffcprs(&mut lParse);
+            return *status;
+        }
+        if nelem < 0 {
+            constant = 1;
+            nelem = -nelem;
+        } else {
+            constant = 0;
+        }
+
+        Info.parseData = &mut lParse;
+        /*  Case (1): If column exists put it there  */
+
+        colNo = 0;
+        ffpmrk(); /* prevent lack of column name from sullying the stack */
+        ffgcno_safe(outfptr, CASEINSEN as c_int, parName, &mut colNo, status);
+        ffcmsg_safe();
+        if *status == 0 {
+            /*  Output column doesn't exist.  Test for keyword. */
+
+            /* Case (2): Does parName indicate result should be put into keyword */
+
+            *status = 0;
+            if parName[0] == b'#' as i8 {
+                if constant == 0 {
+                    ffcprs(&mut lParse);
+                    ffpmsg_str("Cannot put tabular result into keyword (ffcalc)");
+                    *status = PARSE_BAD_TYPE;
+                    return *status;
+                }
+                let parName = &parName[1..]; /* Advance past '#' */
+                if (fits_strcasecmp(parName, cs!(c"HISTORY")) == 0
+                    || fits_strcasecmp(parName, cs!(c"COMMENT")) == 0)
+                    && Info.datatype != TSTRING
+                {
+                    ffcprs(&mut lParse);
+                    ffpmsg_str("HISTORY and COMMENT values must be strings (ffcalc)");
+                    *status = PARSE_BAD_TYPE;
+                    return *status;
+                }
+            } else if constant != 0 {
+                /* Case (3): Does a keyword named parName already exist */
+
+                if ffgcrd_safe(outfptr, parName, &mut card, status) == KEY_NO_EXIST {
+                    colNo = -1;
+                } else if *status != 0 {
+                    ffcprs(&mut lParse);
+                    return *status;
+                }
+            } else {
+                colNo = -1;
+            }
+
+            if colNo < 0 {
+                /* Case (4): Create new column */
+
+                *status = 0;
+                ffgncl_safe(outfptr, &mut colNo, status);
+                colNo += 1;
+                if parInfo.is_empty() || parInfo[0] == 0 {
+                    /*  Figure out best default column type  */
+                    if lParse.hdutype == BINARY_TBL {
+                        int_snprintf!(&mut tform, 15, "{}", nelem);
+                        match Info.datatype {
+                            TLOGICAL => {
+                                strcat(tform.as_mut_ptr(), (c"L").as_ptr());
+                            }
+                            TLONG => {
+                                strcat(tform.as_mut_ptr(), (c"J").as_ptr());
+                            }
+                            TDOUBLE => {
+                                strcat(tform.as_mut_ptr(), (c"D").as_ptr());
+                            }
+                            TSTRING => {
+                                strcat(tform.as_mut_ptr(), (c"A").as_ptr());
+                            }
+                            TBIT => {
+                                strcat(tform.as_mut_ptr(), (c"X").as_ptr());
+                            }
+                            TLONGLONG => {
+                                strcat(tform.as_mut_ptr(), (c"K").as_ptr());
+                            }
+                            _ => {}
+                        }
+                    } else {
+                        match Info.datatype {
+                            TLOGICAL => {
+                                ffcprs(&mut lParse);
+                                ffpmsg_str("Cannot create LOGICAL column in ASCII table");
+                                *status = NOT_BTABLE;
+                                return *status;
+                            }
+                            TLONG => {
+                                strcpy(tform.as_mut_ptr(), (c"I11").as_ptr());
+                            }
+                            TDOUBLE => {
+                                strcpy(tform.as_mut_ptr(), (c"D23.15").as_ptr());
+                            }
+                            TSTRING | TBIT => {
+                                int_snprintf!(&mut tform, 16, "A{}", nelem);
+                            }
+                            _ => {}
+                        }
+                    }
+                    parInfo = &tform;
+                } else if !(parInfo[0] as u8 as char).is_ascii_digit()
+                    && lParse.hdutype == BINARY_TBL
+                {
+                    if Info.datatype == TBIT && parInfo[0] == b'B' as i8 {
+                        nelem = (nelem + 7) / 8;
+                    }
+                    int_snprintf!(
+                        &mut tform,
+                        16,
+                        "{}{}",
+                        nelem,
+                        std::str::from_utf8(unsafe {
+                            std::slice::from_raw_parts(parInfo.as_ptr() as *const u8, parInfo.len())
+                        })
+                        .unwrap_or("")
+                    );
+                    parInfo = &tform;
+                }
+                fficol_safe(outfptr, colNo, parName, parInfo, status);
+
+                if naxis > 1 {
+                    ffptdm_safe(outfptr, colNo, naxis, &naxes[..naxis as usize], status);
+                }
+
+                /*  Setup TNULLn keyword in case NULLs are encountered  */
+
+                ffkeyn_safe(cs!(c"TNULL"), colNo, &mut nullKwd, status);
+                if ffgcrd_safe(outfptr, &nullKwd, &mut card, status) == KEY_NO_EXIST {
+                    *status = 0;
+                    if lParse.hdutype == BINARY_TBL {
+                        let mut nullVal: LONGLONG = 0;
+                        fits_binary_tform(
+                            parInfo,
+                            Some(&mut typecode),
+                            Some(&mut repeat),
+                            Some(&mut width),
+                            status,
+                        );
+                        if typecode == TBYTE {
+                            nullVal = UCHAR_MAX;
+                        } else if typecode == TSHORT {
+                            nullVal = SHRT_MIN;
+                        } else if typecode == TINT {
+                            nullVal = INT_MIN;
+                        } else if typecode == TLONG {
+                            if std::mem::size_of::<c_long>() == 8
+                                && std::mem::size_of::<c_int>() == 4
+                            {
+                                nullVal = INT_MIN;
+                            } else {
+                                nullVal = LONG_MIN;
+                            }
+                        } else if typecode == TLONGLONG {
+                            nullVal = LONGLONG_MIN;
+                        }
+
+                        if nullVal != 0 {
+                            ffpkyj_safe(
+                                outfptr,
+                                &nullKwd,
+                                nullVal,
+                                Some(cs!(c"Null value")),
+                                status,
+                            );
+                            fits_set_btblnull(outfptr, colNo, nullVal, status);
+                            newNullKwd = 1;
+                        }
+                    } else if lParse.hdutype == ASCII_TBL {
+                        ffpkys_safe(
+                            outfptr,
+                            &nullKwd,
+                            cs!(c"NULL"),
+                            Some(cs!(c"Null value string")),
+                            status,
+                        );
+                        fits_set_atblnull(outfptr, colNo, cs!(c"NULL"), status);
+                        newNullKwd = 1;
+                    }
+                }
+            }
+        } else if *status != 0 {
+            ffcprs(&mut lParse);
+            return *status;
+        } else {
+            /********************************************************/
+            /*  Check if a TDIM keyword should be written/updated.  */
+            /********************************************************/
+
+            ffkeyn_safe(cs!(c"TDIM"), colNo, &mut tdimKwd, status);
+            ffgcrd_safe(outfptr, &tdimKwd, &mut card, status);
+            if *status == 0 {
+                /*  TDIM exists, so update it with result's dimension  */
+                ffptdm_safe(outfptr, colNo, naxis, &naxes[..naxis as usize], status);
+            } else if *status == KEY_NO_EXIST {
+                /*  TDIM does not exist, so clear error stack and     */
+                /*  write a TDIM only if result is multi-dimensional  */
+                *status = 0;
+                ffcmsg_safe();
+                if naxis > 1 {
+                    ffptdm_safe(outfptr, colNo, naxis, &naxes[..naxis as usize], status);
+                }
+            }
+            if *status != 0 {
+                /*  Either some other error happened in ffgcrd   */
+                /*  or one happened in ffptdm                    */
+                ffcprs(&mut lParse);
+                return *status;
+            }
+        }
+
+        if colNo > 0 {
+            /*  Output column exists (now)... put results into it  */
+
+            let mut anyNull: c_int = 0;
+            let mut nPerLp: c_int;
+            let mut i: c_int;
+            let mut totaln: c_long = 0;
+
+            ffgkyj_safe(infptr, cs!(c"NAXIS2"), &mut totaln, None, status);
+
+            /*************************************/
+            /* Create new iterator Output Column */
+            /*************************************/
+
+            col_cnt = lParse.nCols;
+            if fits_parser_allocateCol(&mut lParse, col_cnt, status) != 0 {
+                ffcprs(&mut lParse);
+                return *status;
+            }
+
+            fits_iter_set_by_num(
+                lParse.colData.wrapping_add(col_cnt as usize),
+                outfptr,
+                colNo,
+                0,
+                OutputCol,
+            );
+            lParse.nCols += 1;
+
+            for i in 0..nRngs {
+                Info.dataPtr = std::ptr::null_mut();
+                let start_slice =
+                    unsafe { std::slice::from_raw_parts(start as *const c_long, nRngs as usize) };
+                let end_slice =
+                    unsafe { std::slice::from_raw_parts(end as *const c_long, nRngs as usize) };
+                Info.maxRows = end_slice[i as usize] - start_slice[i as usize] + 1;
+
+                /*
+                   If there is only 1 range, and it includes all the rows,
+                   and there are 10 or more rows, then set nPerLp = 0 so
+                   that the iterator function will dynamically choose the
+                   most efficient number of rows to process in each loop.
+                   Otherwise, set nPerLp to the number of rows in this range.
+                */
+
+                if (Info.maxRows >= 10)
+                    && (nRngs == 1)
+                    && (start_slice[0] == 1)
+                    && (end_slice[0] == totaln)
+                {
+                    nPerLp = 0;
+                } else {
+                    nPerLp = Info.maxRows as c_int;
+                }
+
+                let colData_slice =
+                    std::slice::from_raw_parts_mut(lParse.colData, lParse.nCols as usize);
+                if ffiter_safe(
+                    lParse.nCols,
+                    colData_slice,
+                    start_slice[i as usize] - 1,
+                    nPerLp as c_long,
+                    fits_parser_workfn,
+                    &Info as *const _ as *mut c_void,
+                    status,
+                ) == -1
+                {
+                    *status = 0;
+                } else if *status != 0 {
+                    ffcprs(&mut lParse);
+                    return *status;
+                }
+                if Info.anyNull != 0 {
+                    anyNull = 1;
+                }
+            }
+
+            if newNullKwd != 0 && anyNull == 0 {
+                ffdkey_safe(outfptr, &nullKwd, status);
+            }
+        } else {
+            /* Put constant result into keyword */
+
+            result = &mut lParse.Nodes[lParse.resultNode as usize];
+            match Info.datatype {
+                TDOUBLE => {
+                    ffukyd_safe(
+                        outfptr,
+                        parName,
+                        unsafe { (*result).value.data.dbl },
+                        15,
+                        Some(parInfo),
+                        status,
+                    );
+                }
+                TLONG => {
+                    ffukyj_safe(
+                        outfptr,
+                        parName,
+                        unsafe { (*result).value.data.lng },
+                        Some(parInfo),
+                        status,
+                    );
+                }
+                TLOGICAL => {
+                    ffukyl_safe(
+                        outfptr,
+                        parName,
+                        unsafe { (*result).value.data.log } as i32,
+                        Some(parInfo),
+                        status,
+                    );
+                }
+                TBIT | TSTRING => {
+                    if fits_strcasecmp(parName, cs!(c"HISTORY")) == 0 {
+                        ffphis_safe(outfptr, unsafe { &(*result).value.data.astr }, status);
+                    } else if fits_strcasecmp(parName, cs!(c"COMMENT")) == 0 {
+                        ffpcom_safe(outfptr, unsafe { &(*result).value.data.astr }, status);
+                    } else {
+                        ffukys_safe(
+                            outfptr,
+                            parName,
+                            unsafe { &(*result).value.data.astr },
+                            Some(parInfo),
+                            status,
+                        );
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        ffcprs(&mut lParse);
+        *status
+    }
 }
 
 /*--------------------------------------------------------------------------*/
-/// Evaluate the given expression and return information on the result.
+/// Evaluate the given expression and return information on the (*result).
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn fftexp(
     fptr: *mut fitsfile,  /* I - Input FITS file                     */
@@ -335,49 +1286,302 @@ pub unsafe extern "C" fn fftexp(
 }
 
 /*--------------------------------------------------------------------------*/
-/// Evaluate the given expression and return information on the result.
+/// Evaluate the given expression and return information on the (*result).
 pub fn fftexp_safe(
-    _fptr: &mut fitsfile,  /* I - Input FITS file                     */
-    _expr: &[c_char],      /* I - Arithmetic expression               */
-    _maxdim: c_int,        /* I - Max Dimension of naxes              */
-    _datatype: &mut c_int, /* O - Data type of result                 */
-    _nelem: &mut c_long,   /* O - Vector length of result             */
-    _naxis: &mut c_int,    /* O - # of dimensions of result           */
-    _naxes: &mut [c_long], /* O - Size of each dimension              */
-    _status: &mut c_int,   /* O - Error status                        */
+    fptr: &mut fitsfile,  /* I - Input FITS file                     */
+    expr: &[c_char],      /* I - Arithmetic expression               */
+    maxdim: c_int,        /* I - Max Dimension of naxes              */
+    datatype: &mut c_int, /* O - Data type of result                 */
+    nelem: &mut c_long,   /* O - Vector length of result             */
+    naxis: &mut c_int,    /* O - # of dimensions of result           */
+    naxes: &mut [c_long], /* O - Size of each dimension              */
+    status: &mut c_int,   /* O - Error status                        */
 ) -> c_int {
-    todo!();
+    let mut lParse: ParseData = ParseData::default();
+
+    ffiprs(
+        fptr,
+        0,
+        expr,
+        maxdim,
+        datatype,
+        nelem,
+        naxis,
+        naxes,
+        &mut lParse,
+        status,
+    );
+    ffcprs(&mut lParse);
+    *status
 }
 
 /*--------------------------------------------------------------------------*/
 /// Initialize the parser and determine what type of result the expression
 /// produces.
 pub(crate) fn ffiprs(
-    _fptr: &mut fitsfile,     /* I - Input FITS file                     */
-    _arg: c_int,              /* I - Is FITS file hkunexpanded?          */
-    _expr: *const c_char,     /* I - Arithmetic expression               */
-    _maxdim: c_int,           /* I - Max Dimension of naxes              */
-    _datatype: *mut c_int,    /* O - Data type of result                 */
-    _nelem: &mut c_long,      /* O - Vector length of result             */
-    _naxis: &mut c_long,      /* O - # of dimensions of result           */
-    _naxes: &mut [c_long],    /* O - Size of each dimension              */
-    _l_parse: &mut ParseData, /* O - parser status                       */
-    _status: &mut c_int,      /* O - Error status                        */
+    fptr: &mut fitsfile,    /* I - Input FITS file                     */
+    compressed: c_int,      /* I - Is FITS file hkunexpanded?          */
+    expr: &[c_char],        /* I - Arithmetic expression               */
+    maxdim: c_int,          /* I - Max Dimension of naxes              */
+    datatype: &mut c_int,   /* O - Data type of result                 */
+    nelem: &mut c_long,     /* O - Vector length of result             */
+    naxis: &mut c_int,      /* O - # of dimensions of result           */
+    naxes: &mut [c_long],   /* O - Size of each dimension              */
+    lParse: &mut ParseData, /* O - parser status                       */
+    status: &mut c_int,     /* O - Error status                        */
 ) -> c_int {
-    todo!()
+    unsafe {
+        let mut result: *mut Node = ptr::null_mut();
+        let i: c_int = 0;
+        let mut lexpr: c_int = 0;
+        let mut tstatus: c_int = 0;
+        let mut xaxis: c_int = 0;
+        let mut bitpix: c_int = 0;
+        let mut xaxes: [c_long; 9] = [0; 9];
+        let mut yylex_scanner: yyscan_t = ptr::null_mut(); /* Used internally by FLEX lexer */
+        let mut pixFilter: *mut PixelFilter = ptr::null_mut();
+
+        if *status != 0 {
+            return *status;
+        }
+
+        /* make sure all internal structures for this HDU are current */
+        if ffrdef_safe(fptr, status) != 0 {
+            return *status;
+        }
+
+        /*  Initialize the Parser structure  */
+
+        /* Unfortunately we need to preserve the pixFilter value since it
+        is pre-set when ffiprs() is called */
+        pixFilter = lParse.pixFilter;
+
+        lParse.reset();
+
+        lParse.pixFilter = pixFilter;
+
+        lParse.def_fptr = fptr;
+        lParse.compressed = compressed;
+        lParse.nCols = 0;
+        lParse.colData = ptr::null_mut();
+        lParse.varData = ptr::null_mut();
+        lParse.getData = Some(find_column);
+        lParse.loadData = Some(load_column);
+        lParse.Nodes = Vec::new();
+        lParse.nNodesAlloc = 0;
+        lParse.nNodes = 0;
+        lParse.hdutype = 0;
+        lParse.status = 0;
+
+        fits_get_hdu_type(fptr, &mut (lParse.hdutype), status);
+
+        if lParse.hdutype == IMAGE_HDU {
+            fits_get_img_param(
+                fptr,
+                9,
+                Some(&mut bitpix),
+                Some(&mut xaxis),
+                Some(&mut xaxes[..]),
+                status,
+            );
+            if *status != 0 {
+                ffpmsg_str("ffiprs: unable to get image dimensions");
+                return *status;
+            }
+
+            lParse.totalRows = if xaxis > 0 { 1 } else { 0 };
+
+            for i in 0..(xaxis as usize) {
+                lParse.totalRows *= xaxes[i];
+            }
+
+            if DEBUG_PIXFILTER != 0 {
+                println!("naxis={}, (*lParse).totalRows={}", xaxis, lParse.totalRows,);
+            }
+        } else if ffgkyj_safe(
+            fptr,
+            cs!(c"NAXIS2"),
+            &mut lParse.totalRows,
+            None,
+            &mut tstatus,
+        ) != 0
+        {
+            /* this might be a 1D or null image with no NAXIS2 keyword */
+            lParse.totalRows = 0;
+        }
+
+        /*  Copy expression into parser... read from file if necessary  */
+
+        if expr[0] == b'@' as i8 {
+            if ffimport_file_safer(&expr[1..], &mut lParse.expr, status) != 0 {
+                return *status;
+            }
+            lexpr = strlen(lParse.expr) as c_int;
+        } else {
+            lexpr = strlen_safe(expr) as c_int;
+            lParse.expr =
+                malloc(((2 + lexpr as usize) * mem::size_of::<c_char>()) as usize) as *mut c_char;
+            strcpy(lParse.expr, expr.as_ptr());
+        }
+        strcat(
+            (lParse.expr as *mut c_char).wrapping_add(lexpr as usize),
+            c"\n".as_ptr(),
+        );
+        lParse.index = 0;
+        lParse.is_eobuf = 0;
+
+        /*  Parse the expression, building the Nodes and determing  */
+        /*  which columns are needed and what data type is returned  */
+
+        fits_parser_yylex_init_extra(lParse, &mut yylex_scanner);
+        fits_parser_yyrestart(ptr::null_mut(), yylex_scanner);
+        *status = fits_parser_yyparse(yylex_scanner, lParse);
+        fits_parser_yylex_destroy(yylex_scanner);
+
+        if *status != 0 {
+            *status = PARSE_SYNTAX_ERR;
+            return *status;
+        }
+
+        /*  Check results  */
+        *status = lParse.status;
+        if *status != 0 {
+            return *status;
+        }
+
+        if lParse.nNodes == 0 {
+            ffpmsg_str("Blank expression");
+            *status = PARSE_SYNTAX_ERR;
+            return *status;
+        }
+        if lParse.nCols == 0 {
+            lParse.colData = malloc(size_of::<iteratorCol>()) as *mut iteratorCol;
+            if lParse.colData.is_null() {
+                ffpmsg_str("memory allocation failed (ffiprs)");
+                *status = MEMORY_ALLOCATION;
+                return *status;
+            }
+            /* This allows iterator to know value of */
+            /* fptr when no columns are referenced   */
+            memset(lParse.colData as *mut c_void, 0, size_of::<iteratorCol>());
+            unsafe {
+                (*lParse.colData.wrapping_add(0)).fptr = fptr;
+            }
+        }
+
+        result = &mut lParse.Nodes[lParse.resultNode as usize];
+
+        lParse.nAxis = (*result).value.naxis;
+        *naxis = lParse.nAxis;
+        lParse.nElements = (*result).value.nelem;
+        *nelem = lParse.nElements;
+
+        for i in 0..cmp::max(*naxis, maxdim) {
+            lParse.nAxes[i as usize] = (*result).value.naxes[i as usize];
+            naxes[i as usize] = lParse.nAxes[i as usize];
+        }
+
+        match (*result).ntype {
+            val if val == fits_parser_yytokentype::BOOLEAN as c_int => *datatype = TLOGICAL,
+
+            val if val == fits_parser_yytokentype::LONG as c_int => *datatype = TLONG,
+
+            val if val == fits_parser_yytokentype::DOUBLE as c_int => *datatype = TDOUBLE,
+
+            val if val == fits_parser_yytokentype::BITSTR as c_int => *datatype = TBIT,
+
+            val if val == fits_parser_yytokentype::STRING as c_int => *datatype = TSTRING,
+
+            _ => {
+                *datatype = 0;
+                ffpmsg_str("Bad return data type");
+                lParse.status = PARSE_BAD_TYPE;
+                *status = lParse.status;
+            }
+        }
+        lParse.datatype = *datatype;
+        FREE!(lParse.expr);
+
+        if (*result).operation == CONST_OP {
+            *nelem = -*nelem;
+        }
+        *status
+    }
 }
 
 /*---------------------------------------------------------------------------*/
 /// Clear the parser, making it ready to accept a new expression.
-fn ffcprs(_l_parse: &mut ParseData) -> c_int {
-    todo!()
+fn ffcprs(lParse: &mut ParseData) {
+    unsafe {
+        let col: c_int = 0;
+        let mut node: c_int = 0;
+        let mut i: c_int = 0;
+
+        if lParse.nCols > 0 {
+            FREE!(lParse.colData);
+            for col in 0..lParse.nCols {
+                if unsafe { (*lParse.varData.wrapping_add(col as usize)).undef.is_null() } {
+                    continue;
+                }
+                if unsafe {
+                    (*lParse.varData.wrapping_add(col as usize)).dtype
+                        == fits_parser_yytokentype::BITSTR as c_int
+                } {
+                    unsafe {
+                        let data_ptr =
+                            (*lParse.varData.wrapping_add(col as usize)).data as *mut *mut c_char;
+                        let mut first_ptr = *data_ptr;
+                        FREE!(first_ptr);
+                    }
+                }
+                free(unsafe { (*lParse.varData.wrapping_add(col as usize)).undef } as *mut c_void);
+            }
+            FREE!(lParse.varData);
+            lParse.nCols = 0;
+        } else if !lParse.colData.is_null() {
+            /* Special case if colData needed to be created with no columns */
+            FREE!(lParse.colData);
+        }
+
+        if lParse.nNodes > 0 {
+            node = lParse.nNodes;
+            while node != 0 {
+                node -= 1;
+                if unsafe { (lParse.Nodes[node as usize]).operation == gtifilt_fct as c_int } {
+                    i = unsafe { lParse.Nodes[node as usize].SubNodes[0] };
+                    if unsafe { !(lParse.Nodes[i as usize]).value.data.ptr.is_null() } {
+                        unsafe {
+                            let mut data_ptr = (lParse.Nodes[i as usize]).value.data.ptr;
+                            FREE!(data_ptr);
+                        }
+                    }
+                } else if unsafe { (lParse.Nodes[node as usize]).operation == regfilt_fct as c_int }
+                {
+                    i = unsafe { (lParse.Nodes[node as usize]).SubNodes[0] };
+                    unsafe {
+                        fits_free_region(Box::from_raw(
+                            (lParse.Nodes[i as usize]).value.data.ptr as *mut SAORegion,
+                        ));
+                    }
+                }
+            }
+            lParse.nNodes = 0;
+        }
+
+        lParse.Nodes = Vec::new(); // Frees
+
+        lParse.hdutype = ANY_HDU;
+        lParse.pixFilter = std::ptr::null_mut();
+        lParse.nDataRows = 0;
+        lParse.nPrevDataRows = 0;
+    }
 }
 
 /*---------------------------------------------------------------------------*/
 /// Iterator work function which calls the parser and copies the results
 /// into either an OutputCol or a data pointer supplied in the userPtr
 /// structure.
-fn fits_parser_workfn(
+extern "C" fn fits_parser_workfn(
     _totalrows: c_long,         /* I - Total rows to be processed     */
     _offset: c_long,            /* I - Number of rows skipped at start*/
     _firstrow: c_long,          /* I - First row of this iteration    */
@@ -434,17 +1638,230 @@ pub unsafe extern "C" fn fffrwc(
 /// Evaluate a boolean expression for each time in a compressed file,
 /// returning an array of flags indicating which times evaluated to TRUE/FALSE
 pub fn fffrwc_safe(
-    _fptr: &mut fitsfile,        /* I - Input FITS file                    */
-    _expr: &[c_char],            /* I - Boolean expression                 */
-    _timeCol: &[c_char],         /* I - Name of time column                */
-    _parCol: &[c_char],          /* I - Name of parameter column           */
-    _valCol: &[c_char],          /* I - Name of value column               */
-    _ntimes: c_long,             /* I - Number of distinct times in file   */
-    _times: &mut [f64],          /* O - Array of times in file             */
-    _time_status: &mut [c_char], /* O - Array of boolean results           */
-    _status: &mut c_int,         /* O - Error status                       */
+    fptr: &mut fitsfile,        /* I - Input FITS file                    */
+    expr: &[c_char],            /* I - Boolean expression                 */
+    timeCol: &[c_char],         /* I - Name of time column                */
+    parCol: &[c_char],          /* I - Name of parameter column           */
+    valCol: &[c_char],          /* I - Name of value column               */
+    ntimes: c_long,             /* I - Number of distinct times in file   */
+    times: &mut [f64],          /* O - Array of times in file             */
+    time_status: &mut [c_char], /* O - Array of boolean results           */
+    status: &mut c_int,         /* O - Error status                       */
 ) -> c_int {
-    todo!()
+    unsafe {
+        let mut Info: parseInfo = Default::default();
+        let mut alen: c_long = 0;
+        let mut width: c_long = 0;
+        let mut parNo: c_int = 0;
+        let mut typecode: c_int = 0;
+        let mut naxis: c_int = 0;
+        let mut constant: c_int = 0;
+        let mut nCol: c_int = 0;
+        let mut nelem: c_long = 0;
+        let mut naxes: [c_long; MAXDIMS as usize] = [0; MAXDIMS as usize];
+        let mut result: c_char = 0;
+        let mut lParse: ParseData = ParseData::default();
+
+        if *status != 0 {
+            return *status;
+        }
+
+        if ffiprs(
+            fptr,
+            1,
+            expr,
+            MAXDIMS,
+            &mut Info.datatype,
+            &mut nelem,
+            &mut naxis,
+            &mut naxes,
+            &mut lParse,
+            status,
+        ) != 0
+        {
+            ffcprs(&mut lParse);
+            return *status;
+        }
+
+        fits_get_colnum(
+            fptr,
+            CASEINSEN.try_into().unwrap(),
+            timeCol,
+            &mut lParse.timeCol,
+            status,
+        );
+        fits_get_colnum(
+            fptr,
+            CASEINSEN.try_into().unwrap(),
+            parCol,
+            &mut lParse.parCol,
+            status,
+        );
+        fits_get_colnum(
+            fptr,
+            CASEINSEN.try_into().unwrap(),
+            valCol,
+            &mut lParse.valCol,
+            status,
+        );
+        if *status != 0 {
+            return *status;
+        }
+
+        if nelem < 0 {
+            constant = 1;
+            nelem = -nelem;
+            nCol = lParse.nCols;
+            lParse.nCols = 0; /*  Ignore all column references  */
+        } else {
+            constant = 0;
+        }
+
+        if Info.datatype != TLOGICAL || nelem != 1 {
+            ffcprs(&mut lParse);
+            ffpmsg_str("Expression does not evaluate to a logical scalar.");
+            *status = PARSE_BAD_TYPE;
+            return *status;
+        }
+
+        /*******************************************/
+        /* Allocate data arrays for each parameter */
+        /*******************************************/
+
+        parNo = lParse.nCols;
+        while parNo > 0 {
+            parNo -= 1;
+            let col_data = lParse.colData.wrapping_add(parNo as usize);
+            match (*col_data).datatype {
+                TLONG => {
+                    (*col_data).array =
+                        malloc(((ntimes + 1) as usize) * size_of::<c_long>()) as *mut c_void;
+                    if !(*col_data).array.is_null() {
+                        let array_ptr = (*col_data).array as *mut c_long;
+                        *array_ptr.wrapping_add(0) = 1234554321;
+                    } else {
+                        *status = MEMORY_ALLOCATION;
+                    }
+                }
+                TDOUBLE => {
+                    (*col_data).array =
+                        malloc(((ntimes + 1) as usize) * size_of::<c_double>()) as *mut c_void;
+                    if !(*col_data).array.is_null() {
+                        let array_ptr = (*col_data).array as *mut c_double;
+                        *array_ptr.wrapping_add(0) = DOUBLENULLVALUE;
+                    } else {
+                        *status = MEMORY_ALLOCATION;
+                    }
+                }
+                TSTRING => {
+                    if fits_get_coltype(
+                        fptr,
+                        lParse.valCol,
+                        Some(&mut typecode),
+                        Some(&mut alen),
+                        Some(&mut width),
+                        status,
+                    ) == 0
+                    {
+                        alen += 1;
+                        (*col_data).array =
+                            malloc(((ntimes + 1) as usize) * size_of::<*mut c_char>())
+                                as *mut c_void;
+                        if !(*col_data).array.is_null() {
+                            let str_array = (*col_data).array as *mut *mut c_char;
+                            let first_str = malloc(((ntimes + 1) * alen) as usize) as *mut c_char;
+                            *str_array.wrapping_add(0) = first_str;
+                            if !first_str.is_null() {
+                                for elem in 1..=(ntimes as usize) {
+                                    *str_array.wrapping_add(elem) = (*str_array
+                                        .wrapping_add(elem - 1))
+                                    .wrapping_add(alen as usize);
+                                }
+                                *(*str_array.wrapping_add(0)).wrapping_add(0) = 0;
+                            } else {
+                                free((*col_data).array);
+                                *status = MEMORY_ALLOCATION;
+                            }
+                        } else {
+                            *status = MEMORY_ALLOCATION;
+                        }
+                    }
+                }
+                _ => {}
+            }
+            if *status != 0 {
+                while parNo > 0 {
+                    parNo -= 1;
+                    let col_data2 = lParse.colData.wrapping_add(parNo as usize);
+                    if (*col_data2).datatype == TSTRING {
+                        let str_array = (*col_data2).array as *mut *mut c_char;
+                        if !str_array.is_null() {
+                            let mut first_str = *str_array.wrapping_add(0);
+                            FREE!(first_str);
+                        }
+                    }
+                    let mut array_ptr = (*col_data2).array;
+                    FREE!(array_ptr);
+                }
+                return *status;
+            }
+        }
+
+        /**********************************************************************/
+        /* Read data from columns needed for the expression and then parse it */
+        /**********************************************************************/
+
+        if fits_uncompress_hkdata(&mut lParse, fptr, ntimes, times, status) == 0 {
+            if constant != 0 {
+                let result_node = lParse.Nodes[lParse.resultNode as usize];
+                result = (result_node).value.data.log;
+                let mut elem = ntimes;
+                while elem > 0 {
+                    elem -= 1;
+                    time_status[elem as usize] = result;
+                }
+            } else {
+                Info.dataPtr = time_status.as_mut_ptr() as *mut c_void;
+                Info.nullPtr = ptr::null_mut();
+                Info.maxRows = ntimes;
+                *status = fits_parser_workfn(
+                    ntimes,
+                    0,
+                    1,
+                    ntimes,
+                    lParse.nCols,
+                    lParse.colData,
+                    (&mut Info) as *mut parseInfo as *mut c_void,
+                );
+            }
+        }
+
+        /************/
+        /* Clean up */
+        /************/
+
+        parNo = lParse.nCols;
+        while parNo > 0 {
+            parNo -= 1;
+            let col_data = lParse.colData.wrapping_add(parNo as usize);
+            if (*col_data).datatype == TSTRING {
+                let str_array = (*col_data).array as *mut *mut c_char;
+                if !str_array.is_null() {
+                    let mut first_str = *str_array.wrapping_add(0);
+                    FREE!(first_str);
+                }
+            }
+            let mut array_ptr = (*col_data).array;
+            FREE!(array_ptr);
+        }
+
+        if constant != 0 {
+            lParse.nCols = nCol;
+        }
+
+        ffcprs(&mut lParse);
+        *status
+    }
 }
 
 /*---------------------------------------------------------------------------*/
@@ -477,16 +1894,14 @@ pub fn ffffrw_safer(
     rownum: &mut c_long, /* O - First row of table to eval to T   */
     status: &mut c_int,  /* O - Error status                      */
 ) -> c_int {
-    let naxis = 0; /* No need to call parser... have result from ffiprs */
-    let constant = 0; /*  Make sure there is at least 1 row in table  */
-    let dtype = 0; /* -1 indicates exitted without error before end... OK */
-    let nelem: c_long = 0;
-    let naxes: [c_long; 5] = [0; 5];
-    let result: c_char = 0;
+    let mut naxis = 0; /* No need to call parser... have result from ffiprs */
+    let mut constant = 0; /*  Make sure there is at least 1 row in table  */
+    let mut dtype = 0; /* -1 indicates exitted without error before end... OK */
+    let mut nelem: c_long = 0;
+    let mut naxes: [c_long; 5] = [0; 5];
+    let mut result: c_char = 0;
 
-    let mut lParse: ParseData;
-
-    todo!();
+    let mut lParse: ParseData = ParseData::default();
 
     if *status != 0 {
         return *status;
@@ -494,7 +1909,7 @@ pub fn ffffrw_safer(
     if ffiprs(
         fptr,
         0,
-        expr.as_ptr(),
+        expr,
         MAXDIMS,
         &mut dtype,
         &mut nelem,
@@ -524,52 +1939,352 @@ pub fn ffffrw_safer(
     }
     *rownum = 0;
     {
-        todo!("Haven't implemented");
-        /*
         if constant != 0 {
-            result = (*lParse.Nodes.offset(lParse.resultNode)).value.data.log;
+            result = unsafe { (lParse.Nodes[lParse.resultNode as usize]).value.data.log };
             if result != 0 {
-                ffgnrw(fptr, &mut nelem, status);
+                ffgnrw_safe(fptr, &mut nelem, status);
                 if nelem != 0 {
                     *rownum = 1;
                 };
             };
         } else {
-            let mut workData: ffffrw_workdata;
-            workData.prownum = rownum;
-            workData.lParse = &mut lParse;
-            if ffiter(
-                lParse.nCols,
-                lParse.colData,
+            let mut workData = ffffrw_workdata {
+                prownum: rownum,
+                lParse: &mut lParse as *mut ParseData,
+            };
+            let colData_slice =
+                unsafe { std::slice::from_raw_parts_mut(lParse.colData, lParse.nCols as usize) };
+            if ffiter_safe(
+                (lParse).nCols,
+                colData_slice,
                 0,
                 0,
                 ffffrw_work,
-                &mut workData as *mut c_void,
+                (&mut workData as *mut ffffrw_workdata) as *mut c_void,
                 status,
             ) == -1
             {
                 *status = 0;
             };
         }
-        */
     }
     ffcprs(&mut lParse);
     *status
 }
 
 /*---------------------------------------------------------------------------*/
+fn fits_parser_set_temporary_col(
+    lParse: &mut ParseData,
+    Info: &mut parseInfo,
+    nrows: c_long,
+    nulval: *mut c_void,
+    status: &mut c_int,
+) -> c_int {
+    unsafe {
+        /* Setup iterator column and parser information to be ready to compute
+        temporary calculator expression */
+
+        if *status != 0 {
+            return *status;
+        }
+
+        let col_cnt: c_int = lParse.nCols;
+
+        if fits_parser_allocateCol(lParse, col_cnt, unsafe { &mut *status }) != 0 {
+            return *status;
+        }
+
+        /* Set important variables for TemporaryCol where calculated results end up */
+        unsafe {
+            fits_iter_set_by_num(
+                lParse.colData.wrapping_add(col_cnt as usize),
+                ptr::null_mut(),
+                0,
+                TDOUBLE,
+                TemporaryCol,
+            );
+        }
+        unsafe {
+            (*lParse.colData.wrapping_add(col_cnt as usize)).repeat = lParse.nElements;
+        }
+        Info.dataPtr = ptr::null_mut();
+        Info.nullPtr = nulval;
+        Info.maxRows = nrows;
+        Info.parseData = lParse;
+        lParse.nCols += 1;
+
+        0
+    }
+}
+
+/*---------------------------------------------------------------------------*/
+/// Uncompress housekeeping data from a compressed FITS table
+fn fits_uncompress_hkdata(
+    lParse: &mut ParseData,
+    fptr: &mut fitsfile,
+    ntimes: c_long,
+    times: &mut [f64],
+    status: &mut c_int,
+) -> c_int {
+    unsafe {
+        let mut parName: [c_char; 256] = [0; 256];
+        let sPtr: [*mut c_char; 1] = [parName.as_mut_ptr()];
+        let mut found: [c_char; 1000] = [0; 1000];
+        let mut parNo: c_int;
+        let mut anynul: c_int = 0;
+        let mut naxis2: c_long = 0;
+        let mut row: c_long;
+        let mut currelem: c_long;
+        let mut currtime: f64;
+        let mut newtime: f64 = 0.0;
+
+        currelem = 0;
+        currtime = -1e38;
+
+        parNo = lParse.nCols;
+        while parNo > 0 {
+            parNo -= 1;
+            found[parNo as usize] = 0;
+        }
+
+        if ffgkyj_safe(fptr, cs!(c"NAXIS2"), &mut naxis2, None, status) != 0 {
+            return *status;
+        }
+
+        for row in 1..=naxis2 {
+            if ffgcvd_safe(
+                fptr,
+                lParse.timeCol,
+                row,
+                1,
+                1,
+                0.0,
+                std::slice::from_mut(&mut newtime),
+                Some(&mut anynul),
+                status,
+            ) != 0
+            {
+                return *status;
+            }
+
+            if newtime != currtime {
+                /*  New time encountered... propogate parameters to next row  */
+                if currelem == ntimes {
+                    ffpmsg_str("Found more unique time stamps than caller indicated");
+                    *status = PARSE_BAD_COL;
+                    return *status;
+                }
+
+                times[currelem as usize] = newtime;
+                currtime = newtime;
+                currelem += 1;
+
+                parNo = lParse.nCols;
+                while parNo > 0 {
+                    parNo -= 1;
+                    let col_data = lParse.colData.wrapping_add(parNo as usize);
+                    match (*col_data).datatype {
+                        TLONG => {
+                            let array = (*col_data).array as *mut c_long;
+                            *array.wrapping_add(currelem as usize) =
+                                *array.wrapping_add((currelem - 1) as usize);
+                        }
+                        TDOUBLE => {
+                            let array = (*col_data).array as *mut f64;
+                            *array.wrapping_add(currelem as usize) =
+                                *array.wrapping_add((currelem - 1) as usize);
+                        }
+                        TSTRING => {
+                            let str_array = (*col_data).array as *mut *mut c_char;
+                            strcpy(
+                                *str_array.wrapping_add(currelem as usize),
+                                *str_array.wrapping_add((currelem - 1) as usize),
+                            );
+                        }
+                        _ => {}
+                    }
+                }
+            }
+
+            if ffgcvs_safe(
+                fptr,
+                lParse.parCol,
+                row,
+                1,
+                1,
+                Some(cs!(c"")),
+                &mut [std::slice::from_raw_parts_mut(sPtr[0], 256)],
+                Some(&mut anynul),
+                status,
+            ) != 0
+            {
+                return *status;
+            }
+
+            parNo = lParse.nCols;
+            while parNo > 0 {
+                parNo -= 1;
+                let var_data = lParse.varData.wrapping_add(parNo as usize);
+                if fits_strcasecmp(
+                    std::slice::from_raw_parts(parName.as_ptr(), strlen(parName.as_ptr())),
+                    std::slice::from_raw_parts(
+                        (*var_data).name.as_ptr(),
+                        strlen((*var_data).name.as_ptr()),
+                    ),
+                ) == 0
+                {
+                    break;
+                }
+            }
+
+            if parNo >= 0 {
+                found[parNo as usize] = 1; /* Flag this parameter as found */
+                let col_data = lParse.colData.wrapping_add(parNo as usize);
+                match (*col_data).datatype {
+                    TLONG => {
+                        let array = (*col_data).array as *mut c_long;
+                        ffgcvj_safe(
+                            fptr,
+                            lParse.valCol,
+                            row,
+                            1,
+                            1,
+                            *array.wrapping_add(0),
+                            std::slice::from_raw_parts_mut(
+                                array.wrapping_add(currelem as usize),
+                                1,
+                            ),
+                            Some(&mut anynul),
+                            status,
+                        );
+                    }
+                    TDOUBLE => {
+                        let array = (*col_data).array as *mut f64;
+                        ffgcvd_safe(
+                            fptr,
+                            lParse.valCol,
+                            row,
+                            1,
+                            1,
+                            *array.wrapping_add(0),
+                            std::slice::from_raw_parts_mut(
+                                array.wrapping_add(currelem as usize),
+                                1,
+                            ),
+                            Some(&mut anynul),
+                            status,
+                        );
+                    }
+                    TSTRING => {
+                        let str_array = (*col_data).array as *mut *mut c_char;
+                        ffgcvs_safe(
+                            fptr,
+                            lParse.valCol,
+                            row,
+                            1,
+                            1,
+                            Some(std::slice::from_raw_parts(
+                                *str_array.wrapping_add(0),
+                                strlen(*str_array.wrapping_add(0)) as usize,
+                            )),
+                            &mut [std::slice::from_raw_parts_mut(
+                                *str_array.wrapping_add(currelem as usize),
+                                256,
+                            )],
+                            Some(&mut anynul),
+                            status,
+                        );
+                    }
+                    _ => {}
+                }
+                if *status != 0 {
+                    return *status;
+                }
+            }
+        }
+
+        if currelem < ntimes {
+            ffpmsg_str("Found fewer unique time stamps than caller indicated");
+            *status = PARSE_BAD_COL;
+            return *status;
+        }
+
+        /*  Check for any parameters which were not located in the table  */
+        parNo = lParse.nCols;
+        while parNo > 0 {
+            parNo -= 1;
+            if found[parNo as usize] == 0 {
+                let var_data = lParse.varData.wrapping_add(parNo as usize);
+                snprintf(
+                    parName.as_mut_ptr(),
+                    256,
+                    c"Parameter not found: %-30s".as_ptr() as *const c_char,
+                    (*var_data).name.as_ptr(),
+                );
+                ffpmsg_slice(&parName);
+                *status = PARSE_SYNTAX_ERR;
+            }
+        }
+
+        *status
+    }
+}
+
+/*---------------------------------------------------------------------------*/
 /// Iterator work function which calls the parser and searches for the
 /// first row which evaluates to TRUE.
-pub(crate) fn ffffrw_work(
-    _totalrows: c_long,     /* I - Total rows to be processed     */
-    _offset: c_long,        /* I - Number of rows skipped at start*/
-    _firstrow: c_long,      /* I - First row of this iteration    */
-    _nrows: c_long,         /* I - Number of rows in this iter    */
-    _nCols: c_int,          /* I - Number of columns in use       */
-    _colData: &iteratorCol, /* IO- Column information/data        */
-    _userPtr: *const c_void,
+pub(crate) extern "C" fn ffffrw_work(
+    totalrows: c_long,         /* I - Total rows to be processed     */
+    offset: c_long,            /* I - Number of rows skipped at start*/
+    firstrow: c_long,          /* I - First row of this iteration    */
+    nrows: c_long,             /* I - Number of rows in this iter    */
+    nCols: c_int,              /* I - Number of columns in use       */
+    colData: *mut iteratorCol, /* IO- Column information/data        */
+    userPtr: *mut c_void,
 ) -> c_int {
-    todo!()
+    ffffrw_work_safe(totalrows, offset, firstrow, nrows, nCols, colData, userPtr)
+}
+
+/*---------------------------------------------------------------------------*/
+/// Iterator work function which calls the parser and searches for the
+/// first row which evaluates to TRUE.
+pub(crate) fn ffffrw_work_safe(
+    totalrows: c_long,         /* I - Total rows to be processed     */
+    offset: c_long,            /* I - Number of rows skipped at start*/
+    firstrow: c_long,          /* I - First row of this iteration    */
+    nrows: c_long,             /* I - Number of rows in this iter    */
+    nCols: c_int,              /* I - Number of columns in use       */
+    colData: *mut iteratorCol, /* IO- Column information/data        */
+    userPtr: *mut c_void,
+) -> c_int {
+    unsafe {
+        let result: *mut Node;
+        let workData: *mut ffffrw_workdata = userPtr as *mut ffffrw_workdata;
+        let lParse: &mut ParseData = &mut *(*workData).lParse;
+
+        Evaluate_Parser(lParse, firstrow, nrows);
+
+        if (lParse.status) == 0 {
+            result = &mut lParse.Nodes[lParse.resultNode as usize];
+            if (*result).operation == CONST_OP {
+                if (*result).value.data.log != 0 {
+                    *((*workData).prownum) = firstrow;
+                    return -1;
+                }
+            } else {
+                for idx in 0..(nrows as usize) {
+                    if *((*result).value.data.logptr.add(idx)) != 0
+                        && *((*result).value.undef.add(idx)) == 0
+                    {
+                        *((*workData).prownum) = firstrow + idx as c_long;
+                        return -1;
+                    }
+                }
+            }
+        }
+
+        lParse.status
+    }
 }
 
 /*--------------------------------------------------------------------------*/
@@ -589,8 +2304,1143 @@ pub unsafe extern "C" fn fits_pixel_filter(
 
 /// Apply pixel filtering operations (safe version)
 pub fn fits_pixel_filter_safer(
-    _filter: &mut PixelFilter, /* I - pixel filter structure */
-    _status: &mut c_int,       /* IO - error status */
+    filter: &mut PixelFilter, /* I - pixel filter structure */
+    status: &mut c_int,       /* IO - error status */
 ) -> c_int {
-    todo!("fits_pixel_filter: Apply pixel filtering operations")
+    unsafe {
+        let mut info: parseInfo = parseInfo::default();
+        let mut naxis: c_int = 0;
+        let mut bitpix: c_int = 0;
+        let mut nelem: c_long = 0;
+        let mut naxes: [c_long; MAXDIMS as usize] = [0; MAXDIMS as usize];
+        let mut col_cnt: c_int = 0;
+        let mut result: *mut Node = std::ptr::null_mut();
+        let mut datatype: c_int = 0;
+
+        let default_tags: [c_char; 2] = ['X' as c_char, 0];
+        let mut msg: [c_char; 256] = [0; 256];
+        let mut write_blank_kwd: c_int = 0; /* write BLANK if any output nulls? */
+        let mut lParse: ParseData = ParseData::default();
+
+        let debug_pixfilter = if std::env::var("DEBUG_PIXFILTER").is_ok() {
+            1
+        } else {
+            0
+        };
+
+        if *status != 0 {
+            return *status;
+        }
+
+        unsafe {
+            if filter.tag.is_null() || (*filter.tag).is_null() || **filter.tag == 0 {
+                filter.tag = default_tags.as_ptr() as *mut *mut c_char;
+                if debug_pixfilter != 0 {
+                    println!("using default tag '{}'", **filter.tag);
+                }
+            }
+        }
+
+        let infptr: *mut fitsfile = unsafe { *filter.ifptr };
+        let outfptr: *mut fitsfile = filter.ofptr;
+        lParse.pixFilter = filter;
+
+        let filter_expr = cast_slice(CStr::from_ptr(filter.expression).to_bytes_with_nul());
+        if ffiprs(
+            unsafe { infptr.as_mut().unwrap() },
+            0,
+            filter_expr,
+            MAXDIMS,
+            &mut info.datatype,
+            &mut nelem,
+            &mut naxis,
+            &mut naxes,
+            &mut lParse,
+            status,
+        ) != 0
+        {
+            ffcprs(&mut lParse);
+            return *status;
+        }
+
+        if nelem < 0 {
+            nelem = -nelem;
+        }
+
+        {
+            /* validate result type */
+            let rtype: &str;
+            match info.datatype {
+                TLOGICAL => {
+                    rtype = "LOGICAL";
+                }
+                TLONG => {
+                    rtype = "LONG";
+                }
+                TDOUBLE => {
+                    rtype = "DOUBLE";
+                }
+                TSTRING => {
+                    rtype = "STRING";
+                    *status = pERROR;
+                    ffpmsg_str("pixel_filter: cannot have string image");
+                }
+                TBIT => {
+                    rtype = "BIT";
+                    if debug_pixfilter != 0 {
+                        println!("hmm, image from bits?");
+                    }
+                }
+                _ => {
+                    rtype = "UNKNOWN?!";
+                    *status = pERROR;
+                    ffpmsg_str("pixel_filter: unexpected result datatype");
+                }
+            }
+            if debug_pixfilter != 0 {
+                println!("result type is {} [{}]", rtype, info.datatype);
+            }
+            if *status != 0 {
+                ffcprs(&mut lParse);
+                return *status;
+            }
+        }
+
+        if fits_get_img_param(
+            unsafe { infptr.as_mut().unwrap() },
+            MAXDIMS,
+            Some(&mut bitpix),
+            Some(&mut naxis),
+            Some(&mut naxes),
+            status,
+        ) != 0
+        {
+            ffpmsg_str("pixel_filter: unable to read input image parameters");
+            ffcprs(&mut lParse);
+            return *status;
+        }
+
+        if debug_pixfilter != 0 {
+            println!("input bitpix {}", bitpix);
+        }
+
+        if info.datatype == TDOUBLE {
+            // for floating point expressions, set the default output image to
+            // bitpix = -32 (float) unless the default is already a double
+            if bitpix != DOUBLE_IMG {
+                bitpix = FLOAT_IMG;
+            }
+        }
+
+        // override output image bitpix if specified by caller
+        if filter.bitpix != 0 {
+            bitpix = filter.bitpix;
+        }
+        if debug_pixfilter != 0 {
+            println!("output bitpix {}", bitpix);
+        }
+
+        if unsafe {
+            fits_create_img(
+                outfptr.as_mut().unwrap(),
+                bitpix,
+                naxis,
+                &naxes[..naxis as usize],
+                status,
+            )
+        } != 0
+        {
+            ffpmsg_str("pixel_filter: unable to create output image");
+            ffcprs(&mut lParse);
+            return *status;
+        }
+
+        // transfer keycards
+        {
+            let mut ncards: c_int = 0;
+            let mut more: c_int = 0;
+            if fits_get_hdrspace(
+                unsafe { infptr.as_mut().unwrap() },
+                Some(&mut ncards),
+                Some(&mut more),
+                status,
+            ) != 0
+            {
+                ffpmsg_str("pixel_filter: unable to determine number of keycards");
+                ffcprs(&mut lParse);
+                return *status;
+            }
+
+            for i in 1..=ncards {
+                let mut keyclass: c_int = 0;
+                let mut card: [c_char; FLEN_CARD] = [0; FLEN_CARD];
+
+                if fits_read_record(
+                    unsafe { infptr.as_mut().unwrap() },
+                    i,
+                    Some(&mut card),
+                    status,
+                ) != 0
+                {
+                    unsafe {
+                        snprintf(
+                            msg.as_mut_ptr(),
+                            256,
+                            c"pixel_filter: unable to read keycard %d".as_ptr() as *const c_char,
+                            i,
+                        );
+                    }
+                    ffpmsg_slice(&msg);
+                    ffcprs(&mut lParse);
+                    return *status;
+                }
+
+                keyclass = fits_get_keyclass(&card);
+                if keyclass == TYP_STRUC_KEY {
+                    // output structure defined by fits_create_img
+                } else if keyclass == TYP_COMM_KEY && i < 12 {
+                    // assume this is one of the FITS standard comments
+                } else if keyclass == TYP_NULL_KEY && bitpix < 0 {
+                    // do not transfer BLANK to real output image
+                } else if keyclass == TYP_SCAL_KEY && bitpix < 0 {
+                    // do not transfer BZERO, BSCALE to real output image
+                } else if fits_write_record(unsafe { outfptr.as_mut().unwrap() }, &card, status)
+                    != 0
+                {
+                    unsafe {
+                        snprintf(
+                            msg.as_mut_ptr(),
+                            256,
+                            c"pixel_filter: unable to write keycard [%d]".as_ptr() as *const c_char,
+                            *status,
+                        );
+                    }
+                    ffpmsg_slice(&msg);
+                    ffcprs(&mut lParse);
+                    return *status;
+                }
+            }
+        }
+
+        match bitpix {
+            BYTE_IMG => {
+                datatype = TLONG;
+                info.datatype = TBYTE;
+            }
+            SHORT_IMG => {
+                datatype = TLONG;
+                info.datatype = TSHORT;
+            }
+            LONG_IMG => {
+                datatype = TLONG;
+                info.datatype = TLONG;
+            }
+            FLOAT_IMG => {
+                datatype = TDOUBLE;
+                info.datatype = TFLOAT;
+            }
+            DOUBLE_IMG => {
+                datatype = TDOUBLE;
+                info.datatype = TDOUBLE;
+            }
+
+            _ => {
+                unsafe {
+                    int_snprintf!(
+                        &mut msg,
+                        256,
+                        "pixel_filter: unexpected output bitpix {}",
+                        bitpix,
+                    );
+                }
+                ffpmsg_slice(&msg);
+                *status = pERROR;
+                ffcprs(&mut lParse);
+                return *status;
+            }
+        }
+
+        if bitpix > 0 {
+            // arrange for NULLs in output
+            let mut null_val: c_long = filter.blank;
+            if filter.blank == 0 {
+                let mut tstatus: c_int = 0;
+                if fits_read_key_lng(
+                    unsafe { infptr.as_mut().unwrap() },
+                    unsafe { cs!(c"BLANK") },
+                    &mut null_val,
+                    None,
+                    &mut tstatus,
+                ) != 0
+                {
+                    write_blank_kwd = 1;
+
+                    if bitpix == BYTE_IMG {
+                        null_val = UCHAR_MAX as c_long;
+                    } else if bitpix == SHORT_IMG {
+                        null_val = SHRT_MIN as c_long;
+                    } else if bitpix == LONG_IMG {
+                        if std::mem::size_of::<c_long>() == 8 && std::mem::size_of::<c_int>() == 4 {
+                            null_val = INT_MIN as c_long;
+                        } else {
+                            null_val = LONG_MIN;
+                        }
+                    } else {
+                        println!("unhandled positive output BITPIX {}", bitpix);
+                    }
+                }
+
+                filter.blank = null_val;
+            }
+
+            fits_set_imgnull(unsafe { outfptr.as_mut().unwrap() }, filter.blank, status);
+            if debug_pixfilter != 0 {
+                println!("using blank {}", null_val);
+            }
+        }
+
+        if unsafe { *filter.keyword.as_ptr() } == 0 {
+            let mut colIter: *mut iteratorCol = std::ptr::null_mut();
+            let mut varInfo: *mut DataInfo = std::ptr::null_mut();
+
+            /*************************************/
+            /* Create new iterator Output Column */
+            /*************************************/
+            col_cnt = lParse.nCols;
+            if fits_parser_allocateCol(&mut lParse, col_cnt, status) != 0 {
+                ffcprs(&mut lParse);
+                return *status;
+            }
+            lParse.nCols += 1;
+
+            colIter = unsafe { lParse.colData.add(col_cnt as usize) };
+            unsafe { (*colIter).fptr = filter.ofptr };
+            unsafe { (*colIter).iotype = OutputCol };
+            varInfo = unsafe { lParse.varData.add(col_cnt as usize) };
+            set_image_col_types(
+                &mut lParse,
+                unsafe { (*colIter).fptr.as_mut().unwrap() },
+                cs!(c"CREATED"),
+                bitpix,
+                &mut *varInfo,
+                colIter,
+            );
+
+            info.maxRows = -1;
+            info.parseData = &mut lParse;
+
+            if unsafe {
+                ffiter_safe(
+                    lParse.nCols,
+                    unsafe {
+                        std::slice::from_raw_parts_mut((lParse).colData, (lParse).nCols as usize)
+                    },
+                    0,
+                    0,
+                    fits_parser_workfn,
+                    (&mut info as *mut parseInfo) as *mut c_void,
+                    status,
+                )
+            } == -1
+            {
+                *status = 0;
+            } else if *status != 0 {
+                ffcprs(&mut lParse);
+                return *status;
+            }
+
+            if info.anyNull != 0 {
+                if write_blank_kwd != 0 {
+                    fits_update_key_lng(
+                        unsafe { outfptr.as_mut().unwrap() },
+                        unsafe { cs!(c"BLANK") },
+                        filter.blank,
+                        Some(unsafe { cs!(c"NULL pixel value") }),
+                        status,
+                    );
+                    if *status != 0 {
+                        ffpmsg_str("pixel_filter: unable to write BLANK keyword");
+                    }
+                    if debug_pixfilter != 0 {
+                        println!("output has NULLs");
+                        println!("wrote blank [{}]", *status);
+                    }
+                }
+            } else if bitpix > 0 {
+                // never used a null
+                if fits_set_imgnull(unsafe { outfptr.as_mut().unwrap() }, -1234554321, status) != 0
+                {
+                    ffpmsg_str("pixel_filter: unable to reset imgnull");
+                }
+            }
+        } else {
+            // Put constant result into keyword
+            let par_name = unsafe { &filter.keyword };
+            let par_info: Option<&[i8]> = if filter.comment[0] == 0 {
+                None
+            } else {
+                Some(unsafe { &filter.comment })
+            };
+
+            result = &mut lParse.Nodes[lParse.resultNode as usize];
+            match info.datatype {
+                TDOUBLE => {
+                    ffukyd_safe(
+                        unsafe { outfptr.as_mut().unwrap() },
+                        par_name,
+                        unsafe { (*result).value.data.dbl },
+                        15,
+                        par_info,
+                        status,
+                    );
+                }
+                TLONG => {
+                    ffukyj_safe(
+                        unsafe { outfptr.as_mut().unwrap() },
+                        par_name,
+                        unsafe { (*result).value.data.lng },
+                        par_info,
+                        status,
+                    );
+                }
+                TLOGICAL => {
+                    ffukyl_safe(
+                        unsafe { outfptr.as_mut().unwrap() },
+                        par_name,
+                        unsafe { (*result).value.data.log.into() },
+                        par_info,
+                        status,
+                    );
+                }
+                TBIT | TSTRING => {
+                    let str_val = unsafe {
+                        std::slice::from_raw_parts(
+                            (*result).value.data.astr.as_ptr(),
+                            strlen((*result).value.data.astr.as_ptr()),
+                        )
+                    };
+                    ffukys_safe(
+                        unsafe { outfptr.as_mut().unwrap() },
+                        par_name,
+                        str_val,
+                        par_info,
+                        status,
+                    );
+                }
+                _ => {
+                    unsafe {
+                        int_snprintf!(
+                            &mut msg,
+                            256,
+                            "pixel_filter: unexpected constant result type [{}]",
+                            info.datatype,
+                        );
+                    }
+                    ffpmsg_slice(&msg);
+                }
+            }
+        }
+
+        ffcprs(&mut lParse);
+        *status
+    }
+}
+
+fn set_image_col_types(
+    lParse: &mut ParseData,
+    fptr: &mut fitsfile,
+    name: &[c_char],
+    bitpix: c_int,
+    varInfo: &mut DataInfo,
+    colIter: *mut iteratorCol,
+) -> c_int {
+    unsafe {
+        let mut istatus: c_int = 0;
+        let mut tscale: f64 = 0.0;
+        let mut tzero: f64 = 0.0;
+        let mut temp: [c_char; 80] = [0; 80];
+
+        match bitpix {
+            BYTE_IMG | SHORT_IMG | LONG_IMG => {
+                istatus = 0;
+                if fits_read_key_dbl(fptr, cs!(c"BZERO"), &mut tzero, None, &mut istatus) != 0 {
+                    tzero = 0.0;
+                }
+
+                istatus = 0;
+                if fits_read_key_dbl(fptr, cs!(c"BSCALE"), &mut tscale, None, &mut istatus) != 0 {
+                    tscale = 1.0;
+                }
+
+                if tscale == 1.0 && (tzero == 0.0 || tzero == 32768.0) {
+                    varInfo.dtype = fits_parser_yytokentype::LONG as c_int;
+                    (*colIter).datatype = TLONG;
+                } else {
+                    varInfo.dtype = fits_parser_yytokentype::DOUBLE as c_int;
+                    (*colIter).datatype = TDOUBLE;
+                    if DEBUG_PIXFILTER != 0 {
+                        printf(
+                            c"usefits_parser_yytokentype::DOUBLE as c_int for %s with BSCALE=%g/BZERO=%g\n".as_ptr() as *const c_char,
+                            name,
+                            tscale,
+                            tzero,
+                        );
+                    }
+                }
+            }
+            LONGLONG_IMG | FLOAT_IMG | DOUBLE_IMG => {
+                varInfo.dtype = fits_parser_yytokentype::DOUBLE as c_int;
+                (*colIter).datatype = TDOUBLE;
+            }
+            _ => {
+                int_snprintf!(
+                    &mut temp,
+                    80,
+                    "set_image_col_types: unrecognized image bitpix [{}]\n",
+                    bitpix
+                );
+                ffpmsg_slice(&temp);
+                lParse.status = PARSE_BAD_TYPE;
+                return lParse.status;
+            }
+        }
+        0
+    }
+}
+
+/*************************************************************************
+
+       Functions used by the evaluator to access FITS data
+           (find_column, find_keywd, fits_parser_allocateCol, load_column)
+
+*************************************************************************/
+
+fn find_column(lParse: &mut ParseData, colName: &[c_char], itslval: *mut c_void) -> c_int {
+    unsafe {
+        let thelval: *mut FITS_PARSER_YYSTYPE = itslval as *mut FITS_PARSER_YYSTYPE;
+
+        let mut status: c_int;
+        let mut colnum: c_int = 0;
+        let mut typecode: c_int = 0;
+        let mut ktype: c_int = 0;
+        let mut repeat: c_long = 0;
+        let mut width: c_long = 0;
+        let mut fptr: *mut fitsfile;
+        let mut temp: [c_char; 80] = [0; 80];
+        let mut tzero: f64 = 0.0;
+        let mut tscale: f64 = 1.0;
+        let mut istatus: c_int;
+        let varInfo: *mut DataInfo;
+        let colIter: *mut iteratorCol;
+
+        if DEBUG_PIXFILTER != 0 {
+            printf(c"find_column(%s)\n".as_ptr() as *const c_char, colName);
+        }
+
+        if colName[0] == b'#' as i8 {
+            return find_keywd(lParse, &colName[1..], itslval);
+        }
+
+        fptr = lParse.def_fptr;
+
+        status = 0;
+        let col_cnt: c_int = lParse.nCols;
+
+        if lParse.hdutype == IMAGE_HDU {
+            let i: c_int = 0;
+            if lParse.pixFilter.is_null() {
+                lParse.status = COL_NOT_FOUND;
+                ffpmsg_str("find_column: IMAGE_HDU but no PixelFilter");
+                return pERROR;
+            }
+
+            colnum = -1;
+            for i in 0..unsafe { (*lParse.pixFilter).count } {
+                if fits_strcasecmp(colName, unsafe {
+                    std::slice::from_raw_parts(
+                        (*lParse.pixFilter).tag.wrapping_add(i as usize).read(),
+                        strlen((*lParse.pixFilter).tag.wrapping_add(i as usize).read()),
+                    )
+                }) == 0
+                {
+                    colnum = i;
+                }
+            }
+            if colnum < 0 {
+                snprintf(
+                    temp.as_mut_ptr(),
+                    80,
+                    c"find_column: PixelFilter tag %s not found".as_ptr() as *const c_char,
+                    colName,
+                );
+                ffpmsg_slice(&temp);
+                lParse.status = COL_NOT_FOUND;
+                return pERROR;
+            }
+
+            let mut tstatus = 0;
+            if fits_parser_allocateCol(lParse, col_cnt, &mut tstatus) != 0 {
+                lParse.status = tstatus;
+                return pERROR;
+            }
+            lParse.status = tstatus;
+
+            varInfo = lParse.varData.wrapping_add(col_cnt as usize);
+            colIter = lParse.colData.wrapping_add(col_cnt as usize);
+
+            fptr = unsafe {
+                (*lParse.pixFilter)
+                    .ifptr
+                    .wrapping_add(colnum as usize)
+                    .read()
+            };
+            fits_get_img_param(
+                unsafe { &mut *fptr },
+                MAXDIMS,
+                Some(&mut typecode), /* actually bitpix */
+                Some(unsafe { &mut (*varInfo).naxis }),
+                Some(unsafe { &mut (*varInfo).naxes }),
+                &mut status,
+            );
+            (*varInfo).nelem = 1;
+            ktype = fits_parser_yytokentype::COLUMN as c_int;
+            if set_image_col_types(
+                lParse,
+                unsafe { &mut *fptr },
+                colName,
+                typecode,
+                &mut *varInfo,
+                colIter,
+            ) != 0
+            {
+                return pERROR;
+            }
+            (*colIter).fptr = fptr;
+            (*colIter).iotype = InputCol;
+        } else {
+            /* HDU holds a table */
+            if lParse.compressed != 0 {
+                colnum = lParse.valCol;
+            } else if fits_get_colnum(
+                unsafe { &mut *fptr },
+                CASEINSEN.try_into().unwrap(),
+                colName,
+                &mut colnum,
+                &mut status,
+            ) != 0
+            {
+                if status == COL_NOT_FOUND {
+                    ktype = find_keywd(lParse, colName, itslval);
+                    if ktype != pERROR {
+                        ffcmsg_safe();
+                    }
+                    return ktype;
+                }
+                lParse.status = status;
+                return pERROR;
+            }
+
+            if fits_get_coltype(
+                unsafe { &mut *fptr },
+                colnum,
+                Some(&mut typecode),
+                Some(&mut repeat),
+                Some(&mut width),
+                &mut status,
+            ) != 0
+            {
+                lParse.status = status;
+                return pERROR;
+            }
+
+            let mut tstatus = 0;
+            if fits_parser_allocateCol(lParse, col_cnt, &mut tstatus) != 0 {
+                lParse.status = tstatus;
+                return pERROR;
+            }
+            lParse.status = tstatus;
+
+            varInfo = lParse.varData.wrapping_add(col_cnt as usize);
+            colIter = lParse.colData.wrapping_add(col_cnt as usize);
+
+            fits_iter_set_by_num(colIter, fptr, colnum, 0, InputCol);
+        }
+
+        /*  Make sure we don't overflow variable name array  */
+        strncpy((*varInfo).name.as_mut_ptr(), colName.as_ptr(), MAXVARNAME);
+        (*varInfo).name[MAXVARNAME] = 0;
+
+        if lParse.hdutype != IMAGE_HDU {
+            match typecode {
+                TBIT => {
+                    (*varInfo).dtype = fits_parser_yytokentype::BITSTR as c_int;
+                    (*colIter).datatype = TBYTE;
+                    ktype = fits_parser_yytokentype::BITCOL as c_int;
+                }
+                TBYTE | TSHORT | TLONG => {
+                    /* The datatype of column with TZERO and TSCALE keywords might be
+                       float or double.
+                    */
+                    snprintf(
+                        temp.as_mut_ptr(),
+                        80,
+                        c"TZERO%d".as_ptr() as *const c_char,
+                        colnum,
+                    );
+                    istatus = 0;
+                    if fits_read_key_dbl(
+                        unsafe { &mut *fptr },
+                        &temp,
+                        &mut tzero,
+                        None,
+                        &mut istatus,
+                    ) != 0
+                    {
+                        tzero = 0.0;
+                    }
+                    snprintf(
+                        temp.as_mut_ptr(),
+                        80,
+                        c"TSCAL%d".as_ptr() as *const c_char,
+                        colnum,
+                    );
+                    istatus = 0;
+                    if fits_read_key_dbl(
+                        unsafe { &mut *fptr },
+                        &temp,
+                        &mut tscale,
+                        None,
+                        &mut istatus,
+                    ) != 0
+                    {
+                        tscale = 1.0;
+                    }
+                    if tscale == 1.0 && (tzero == 0.0 || tzero == 32768.0) {
+                        (*varInfo).dtype = fits_parser_yytokentype::LONG as c_int;
+                        (*colIter).datatype = TLONG;
+                    /*    Reading an unsigned long column as a long can cause overflow errors.
+                         Treat the column as a double instead.
+                         } else if (tscale == 1.0 &&  tzero == 2147483648.0 ) {
+                             (*varInfo).dtype     =fits_parser_yytokentype::LONG as c_int;
+                             (*colIter).datatype = TULONG;
+                    */
+                    } else {
+                        (*varInfo).dtype = fits_parser_yytokentype::DOUBLE as c_int;
+                        (*colIter).datatype = TDOUBLE;
+                    }
+                    ktype = fits_parser_yytokentype::COLUMN as c_int;
+                }
+                /*
+                  For now, treat 8-byte integer columns as type double.
+                  This can lose precision, so the better long term solution
+                  will be to add support for TLONGLONG as a separate datatype.
+                */
+                TLONGLONG | TFLOAT | TDOUBLE => {
+                    (*varInfo).dtype = fits_parser_yytokentype::DOUBLE as c_int;
+                    (*colIter).datatype = TDOUBLE;
+                    ktype = fits_parser_yytokentype::COLUMN as c_int;
+                }
+                TLOGICAL => {
+                    (*varInfo).dtype = fits_parser_yytokentype::BOOLEAN as c_int;
+                    (*colIter).datatype = TLOGICAL;
+                    ktype = fits_parser_yytokentype::BCOLUMN as c_int;
+                }
+                TSTRING => {
+                    (*varInfo).dtype = fits_parser_yytokentype::STRING as c_int;
+                    (*colIter).datatype = TSTRING;
+                    ktype = fits_parser_yytokentype::SCOLUMN as c_int;
+                    if width >= MAX_STRLEN.into() {
+                        snprintf(
+                            temp.as_mut_ptr(),
+                            80,
+                            c"column %d is wider than maximum %d characters".as_ptr()
+                                as *const c_char,
+                            colnum,
+                            MAX_STRLEN - 1,
+                        );
+                        ffpmsg_slice(&temp);
+                        lParse.status = PARSE_LRG_VECTOR;
+                        return pERROR;
+                    }
+                    if lParse.hdutype == ASCII_TBL {
+                        repeat = width;
+                    }
+                }
+                _ => {
+                    if typecode < 0 {
+                        snprintf(
+                            temp.as_mut_ptr(),
+                            80,
+                            c"variable-length array columns are not supported. typecode = %d"
+                                .as_ptr() as *const c_char,
+                            typecode,
+                        );
+                        ffpmsg_slice(&temp);
+                    }
+                    lParse.status = PARSE_BAD_TYPE;
+                    return pERROR;
+                }
+            }
+            (*varInfo).nelem = repeat;
+            (*colIter).repeat = 0; /* ffiter() will fill in this value */
+            if repeat > 1 && typecode != TSTRING {
+                if fits_read_tdim(
+                    unsafe { &mut *fptr },
+                    colnum,
+                    MAXDIMS,
+                    unsafe { &mut (*varInfo).naxis },
+                    unsafe { &mut (*varInfo).naxes },
+                    &mut status,
+                ) != 0
+                {
+                    lParse.status = status;
+                    return pERROR;
+                }
+            } else {
+                (*varInfo).naxis = 1;
+                (*varInfo).naxes[0] = 1;
+            }
+        }
+        lParse.nCols += 1;
+        (*thelval).lng = col_cnt as c_long;
+
+        ktype
+    }
+}
+
+fn find_keywd(lParse: &mut ParseData, keyname: &[c_char], itslval: *mut c_void) -> c_int {
+    unsafe {
+        let thelval: *mut FITS_PARSER_YYSTYPE = itslval as *mut FITS_PARSER_YYSTYPE;
+
+        let mut status: c_int = 0;
+        let mut ktype: c_int = 0;
+
+        let mut keyvalue: [c_char; FLEN_VALUE] = [0; FLEN_VALUE];
+        let mut dtype: c_char = 0;
+
+        let mut rval: c_double = 0.0;
+        let mut bval: c_int = 0;
+        let mut ival: c_long = 0;
+
+        status = 0;
+        let fptr: *mut fitsfile = lParse.def_fptr;
+        if fits_read_keyword(
+            unsafe { &mut *fptr },
+            keyname,
+            &mut keyvalue,
+            None,
+            &mut status,
+        ) != 0
+        {
+            if status == KEY_NO_EXIST {
+                /*  Do this since ffgkey doesn't put an error message on stack  */
+                int_snprintf!(
+                    &mut keyvalue,
+                    FLEN_VALUE,
+                    "ffgkey could not find keyword: {}",
+                    CStr::from_bytes_until_nul(cast_slice(keyname))
+                        .unwrap()
+                        .to_str()
+                        .unwrap(),
+                );
+                ffpmsg_slice(&keyvalue);
+            }
+            lParse.status = status;
+            return pERROR;
+        }
+
+        if fits_get_keytype(&keyvalue, &mut dtype, &mut status) != 0 {
+            lParse.status = status;
+            return pERROR;
+        }
+
+        /* Read appropriate value type and set to CONST_OP */
+        match dtype as u8 {
+            b'C' => {
+                // 'C' as i8
+                fits_read_key_str(
+                    unsafe { &mut *fptr },
+                    keyname,
+                    &mut keyvalue,
+                    None,
+                    &mut status,
+                );
+                ktype = fits_parser_yytokentype::STRING as c_int;
+                strcpy(unsafe { (*thelval).astr.as_mut_ptr() }, keyvalue.as_ptr());
+            }
+            b'L' => {
+                // 'L' as i8
+                fits_read_key_log(unsafe { &mut *fptr }, keyname, &mut bval, None, &mut status);
+                ktype = fits_parser_yytokentype::BOOLEAN as c_int;
+                unsafe {
+                    (*thelval).log = bval as c_char;
+                }
+            }
+            b'I' => {
+                // 'I' as i8
+                fits_read_key_lng(unsafe { &mut *fptr }, keyname, &mut ival, None, &mut status);
+                ktype = fits_parser_yytokentype::LONG as c_int;
+                unsafe {
+                    (*thelval).lng = ival;
+                }
+            }
+            b'F' => {
+                // 'F' as i8
+                fits_read_key_dbl(unsafe { &mut *fptr }, keyname, &mut rval, None, &mut status);
+                ktype = fits_parser_yytokentype::DOUBLE as c_int;
+                unsafe {
+                    (*thelval).dbl = rval;
+                }
+            }
+            _ => {
+                ktype = pERROR;
+            }
+        }
+
+        if status != 0 {
+            lParse.status = status;
+            return pERROR;
+        }
+
+        ktype
+    }
+}
+
+/* Allocates parser iterator column storage for 25 columns *more* than
+nCols */
+fn fits_parser_allocateCol(lParse: &mut ParseData, nCol: c_int, status: &mut c_int) -> c_int {
+    unsafe {
+        if (nCol % 25) == 0 {
+            lParse.colData = fits_recalloc(
+                lParse.colData as *mut c_void,
+                nCol.try_into().unwrap(),
+                (nCol + 25).try_into().unwrap(),
+                size_of::<iteratorCol>(),
+            ) as *mut iteratorCol;
+            lParse.varData = fits_recalloc(
+                lParse.varData as *mut c_void,
+                nCol.try_into().unwrap(),
+                (nCol + 25).try_into().unwrap(),
+                size_of::<DataInfo>(),
+            ) as *mut DataInfo;
+
+            memset(
+                (lParse.colData as *mut c_void).add(nCol as usize * size_of::<iteratorCol>()),
+                0x00,
+                size_of::<iteratorCol>() * 25,
+            );
+            memset(
+                (lParse.varData as *mut c_void).add(nCol as usize * size_of::<DataInfo>()),
+                0x00,
+                size_of::<DataInfo>() * 25,
+            );
+
+            if lParse.colData.is_null() || lParse.varData.is_null() {
+                if !lParse.colData.is_null() {
+                    free(lParse.colData as *mut c_void);
+                }
+                if !lParse.varData.is_null() {
+                    free(lParse.varData as *mut c_void);
+                }
+                lParse.colData = ptr::null_mut();
+                lParse.varData = ptr::null_mut();
+                *status = MEMORY_ALLOCATION;
+                return *status;
+            }
+        }
+        unsafe {
+            (*lParse.varData.wrapping_add(nCol as usize)).data = ptr::null_mut();
+            (*lParse.varData.wrapping_add(nCol as usize)).undef = ptr::null_mut();
+        }
+        0
+    }
+}
+
+fn load_column(
+    lParse: &mut ParseData,
+    varNum: c_int,
+    fRow: c_long,
+    nRows: c_long,
+    data: *mut c_void,
+    undef: *mut c_char,
+) -> c_int {
+    unsafe {
+        let mut nelem: c_long = 0;
+        let mut nbytes: c_long = 0;
+        let row: c_long = 0;
+        let len: c_long = 0;
+        let mut idx: c_long = 0;
+        let bitStrs: *mut *mut c_char;
+        let mut msg: [c_char; 80] = [0; 80];
+        let mut bytes: *mut u8;
+        let mut status: c_int = 0;
+        let mut anynul: c_int = 0;
+
+        let var: *mut iteratorCol = lParse.colData.wrapping_add(varNum as usize);
+        if lParse.hdutype == IMAGE_HDU {
+            /* This test would need to be on a per varNum basis to support
+             * cross HDU operations */
+            fits_read_imgnull(
+                unsafe { &mut *(*var).fptr },
+                (*var).datatype,
+                fRow,
+                nRows,
+                unsafe { std::slice::from_raw_parts_mut(data as *mut u8, (nRows * 8) as usize) }, // Assuming 8 bytes per element
+                unsafe { std::slice::from_raw_parts_mut(undef, nRows as usize) },
+                Some(&mut anynul),
+                &mut status,
+            );
+            if DEBUG_PIXFILTER != 0 {
+                printf(
+                    c"load_column: IMAGE_HDU fRow=%ld, nRows=%ld => %d\n".as_ptr() as *const c_char,
+                    fRow,
+                    nRows,
+                    status,
+                );
+            }
+        } else {
+            nelem = nRows * (*var).repeat;
+
+            match (*var).datatype {
+                TBYTE => {
+                    nbytes = (((*var).repeat + 7) / 8) * nRows;
+                    bytes = malloc((nbytes as usize) * size_of::<c_char>()) as *mut c_uchar;
+
+                    ffgcvb_safe(
+                        unsafe { &mut *(*var).fptr },
+                        (*var).colnum,
+                        fRow,
+                        1,
+                        nbytes,
+                        0,
+                        unsafe { std::slice::from_raw_parts_mut(bytes, nbytes as usize) },
+                        Some(&mut anynul),
+                        &mut status,
+                    );
+
+                    nelem = (*var).repeat;
+                    bitStrs = data as *mut *mut c_char;
+                    for row in 0..nRows {
+                        idx = (row) * ((nelem + 7) / 8) + 1;
+                        for len in 0..nelem {
+                            if unsafe { *bytes.wrapping_add(idx as usize) } & (1 << (7 - len % 8))
+                                != 0
+                            {
+                                unsafe {
+                                    *(*bitStrs.wrapping_add(row as usize))
+                                        .wrapping_add(len as usize) = b'1' as i8;
+                                }
+                            } else {
+                                unsafe {
+                                    *(*bitStrs.wrapping_add(row as usize))
+                                        .wrapping_add(len as usize) = b'0' as i8;
+                                }
+                            }
+                            if len % 8 == 7 {
+                                idx += 1;
+                            }
+                        }
+                        unsafe {
+                            *(*bitStrs.wrapping_add(row as usize)).wrapping_add(len as usize) = 0;
+                        }
+                    }
+
+                    FREE!(bytes);
+                }
+                TSTRING => {
+                    // Convert data to Vec<&mut [c_char]> and undef to &mut [c_char]
+                    let data_ptr_array = data as *mut *mut c_char;
+                    let mut string_vec = Vec::new();
+                    for i in 0..nRows {
+                        let str_ptr = unsafe { *data_ptr_array.wrapping_add(i as usize) };
+                        let str_len = unsafe { strlen(str_ptr as *const c_char) };
+                        let str_slice =
+                            unsafe { std::slice::from_raw_parts_mut(str_ptr, str_len + 1) };
+                        string_vec.push(str_slice);
+                    }
+                    let undef_slice =
+                        unsafe { std::slice::from_raw_parts_mut(undef, nRows as usize) };
+
+                    ffgcfs_safe(
+                        unsafe { &mut *(*var).fptr },
+                        (*var).colnum,
+                        fRow,
+                        1,
+                        nRows,
+                        &mut string_vec,
+                        undef_slice,
+                        Some(&mut anynul),
+                        &mut status,
+                    );
+                }
+                TLOGICAL => {
+                    let data_slice = unsafe {
+                        std::slice::from_raw_parts_mut(data as *mut c_char, nelem as usize)
+                    };
+                    let undef_slice =
+                        unsafe { std::slice::from_raw_parts_mut(undef, nelem as usize) };
+
+                    ffgcfl_safe(
+                        unsafe { &mut *(*var).fptr },
+                        (*var).colnum,
+                        fRow,
+                        1,
+                        nelem,
+                        data_slice,
+                        undef_slice,
+                        Some(&mut anynul),
+                        &mut status,
+                    );
+                }
+                TLONG => {
+                    ffgcfj_safe(
+                        &mut *(*var).fptr,
+                        (*var).colnum,
+                        fRow,
+                        1,
+                        nelem,
+                        unsafe {
+                            std::slice::from_raw_parts_mut(data as *mut c_long, nelem as usize)
+                        },
+                        unsafe { std::slice::from_raw_parts_mut(undef, nelem as usize) },
+                        Some(&mut anynul),
+                        &mut status,
+                    );
+                }
+                TDOUBLE => {
+                    let data_slice =
+                        unsafe { std::slice::from_raw_parts_mut(data as *mut f64, nelem as usize) };
+                    let undef_slice =
+                        unsafe { std::slice::from_raw_parts_mut(undef, nelem as usize) };
+
+                    ffgcfd_safe(
+                        unsafe { &mut *(*var).fptr },
+                        (*var).colnum,
+                        fRow,
+                        1,
+                        nelem,
+                        data_slice,
+                        undef_slice,
+                        Some(&mut anynul),
+                        &mut status,
+                    );
+                }
+                _ => {
+                    snprintf(
+                        msg.as_mut_ptr(),
+                        80,
+                        b"load_column: unexpected datatype %d\0".as_ptr() as *const c_char,
+                        (*var).datatype,
+                    );
+                    ffpmsg_slice(&msg);
+                }
+            }
+        }
+        if status != 0 {
+            lParse.status = status;
+            return pERROR;
+        }
+
+        0
+    }
 }

--- a/src/eval_f.rs
+++ b/src/eval_f.rs
@@ -50,7 +50,7 @@
 /*                                                                      */
 /************************************************************************/
 
-use libc::{memcpy, memset};
+use libc::{c_float, memcpy, memset};
 use std::{cmp, ptr};
 
 use crate::buffers::{ffgbyt, ffgtbb_safe, ffmbyt_safe, ffpbyt, ffptbb_safe};
@@ -80,9 +80,12 @@ use crate::fitscore::{
 };
 use crate::fitscore::{ffpmsg_slice, ffpmsg_str, ffrdef_safe};
 use crate::fitsio2::{FSTRCMP, IGNORE_EOF, REPORT_EOF};
-use crate::getcolb::ffgcvb_safe;
+use crate::getcolb::{fffi2i1, fffr4i1, fffr8i1, ffgcvb_safe};
 use crate::getcold::{ffgcfd_safe, ffgcvd_safe};
-use crate::getcolj::{ffgcfj_safe, ffgcvj_safe};
+use crate::getcole::fffr8r4;
+use crate::getcoli::{fffr4i2, fffr8i2};
+use crate::getcolj::{fffr4i4, fffr4i8, fffr8i4, fffr8i8, ffgcfj_safe, ffgcvj_safe};
+use crate::getcolk::{fffr4int, fffr8int};
 use crate::getcoll::ffgcfl_safe;
 use crate::getcols::{ffgcfs_safe, ffgcvs_safe};
 use crate::getkey::ffgkyj_safe;
@@ -92,7 +95,7 @@ use crate::putcol::{ffiter_safe, fits_iter_set_by_num_safe};
 use crate::putkey::{ffpcom_safe, ffphis_safe, ffpkyj_safe, ffpkys_safe, ffptdm_safe};
 use crate::region::{SAORegion, fits_free_region};
 use crate::wrappers::{strcat, strcpy, strlen, strlen_safe, strncpy_safe};
-use crate::{BL, cs, fitsio::*, int_snprintf, raw_to_slice};
+use crate::{BL, NullCheckType, cs, fitsio::*, int_snprintf, raw_to_slice};
 use bytemuck::{cast_slice, cast_slice_mut};
 use core::ffi::CStr;
 use libc::{free, malloc};
@@ -100,6 +103,7 @@ use libc::{free, malloc};
 // Constants needed for the function
 const UCHAR_MAX: LONGLONG = 255;
 const SHRT_MIN: LONGLONG = c_short::MIN as LONGLONG;
+const SHRT_MAX: LONGLONG = c_short::MAX as LONGLONG;
 const INT_MIN: LONGLONG = c_int::MIN as LONGLONG;
 const LONG_MIN: LONGLONG = c_long::MIN as LONGLONG;
 use std::mem::size_of;
@@ -2051,7 +2055,6 @@ fn fits_parser_workfn_safe(
                         FREE!(*(result.value.data.strptr));
                         FREE!(result.value.data.strptr);
                     }
-                    break;
                 }
                 fits_parser_yytokentype::STRING => {
                     if (*(pv.userInfo)).datatype == TSTRING {
@@ -2413,7 +2416,689 @@ fn ffcvtn(
     anynull: &mut c_int,   /* O - Any nulls flagged?                     */
     status: &mut c_int,    /* O - Error status                           */
 ) -> c_int {
-    todo!();
+    unsafe {
+        let i: c_long = 0;
+        let mut dummy_nullarray: [c_char; 0] = [0; 0];
+
+        match outputType {
+            TLOGICAL => {
+                match inputType {
+                    TLOGICAL | TBYTE => {
+                        for i in 0..ntodo {
+                            if (*((input as *const c_uchar).add(i.try_into().unwrap()))) != 0 {
+                                *((output as *mut c_uchar).add(i.try_into().unwrap())) = 1;
+                            } else {
+                                *((output as *mut c_uchar).add(i.try_into().unwrap())) = 0;
+                            }
+                        }
+                    }
+                    TSHORT => {
+                        for i in 0..ntodo {
+                            if (*((input as *const c_short).add(i.try_into().unwrap()))) != 0 {
+                                *((output as *mut c_uchar).add(i.try_into().unwrap())) = 1;
+                            } else {
+                                *((output as *mut c_uchar).add(i.try_into().unwrap())) = 0;
+                            }
+                        }
+                    }
+                    TLONG => {
+                        for i in 0..ntodo {
+                            if (*((input as *const c_long).add(i.try_into().unwrap()))) != 0 {
+                                *((output as *mut c_uchar).add(i.try_into().unwrap())) = 1;
+                            } else {
+                                *((output as *mut c_uchar).add(i.try_into().unwrap())) = 0;
+                            }
+                        }
+                    }
+                    TFLOAT => {
+                        for i in 0..ntodo {
+                            if (*((input as *const c_float).add(i.try_into().unwrap()))) != 0.0 {
+                                *((output as *mut c_uchar).add(i.try_into().unwrap())) = 1;
+                            } else {
+                                *((output as *mut c_uchar).add(i.try_into().unwrap())) = 0;
+                            }
+                        }
+                    }
+                    TDOUBLE => {
+                        for i in 0..ntodo {
+                            if (*((input as *const c_double).add(i.try_into().unwrap()))) != 0.0 {
+                                *((output as *mut c_uchar).add(i.try_into().unwrap())) = 1;
+                            } else {
+                                *((output as *mut c_uchar).add(i.try_into().unwrap())) = 0;
+                            }
+                        }
+                    }
+                    _ => {
+                        *status = BAD_DATATYPE;
+                    }
+                }
+                for i in 0..ntodo {
+                    if *((undef).add(i.try_into().unwrap())) != 0 {
+                        *((output as *mut c_uchar).add(i.try_into().unwrap())) =
+                            *(nulval as *const c_uchar);
+                        *anynull = 1;
+                    }
+                }
+            }
+            TBYTE => {
+                match inputType {
+                    TLOGICAL | TBYTE => {
+                        for i in 0..ntodo {
+                            *((output as *mut c_uchar).add(i.try_into().unwrap())) =
+                                *((input as *const c_uchar).add(i.try_into().unwrap()));
+                        }
+                    }
+                    TSHORT => {
+                        let input_slice = unsafe {
+                            std::slice::from_raw_parts(
+                                input as *const c_short,
+                                ntodo.try_into().unwrap(),
+                            )
+                        };
+
+                        let output_slice = unsafe {
+                            std::slice::from_raw_parts_mut(
+                                output as *mut c_uchar,
+                                ntodo.try_into().unwrap(),
+                            )
+                        };
+
+                        fffi2i1(
+                            input_slice,
+                            ntodo,
+                            1.,
+                            0.,
+                            NullCheckType::None,
+                            0,
+                            0,
+                            &mut dummy_nullarray,
+                            None,
+                            output_slice,
+                            status,
+                        );
+                    }
+                    TLONG => {
+                        for i in 0..ntodo {
+                            if *((undef).add(i.try_into().unwrap())) != 0 {
+                                *((output as *mut c_uchar).add(i.try_into().unwrap())) =
+                                    *(nulval as *const c_uchar);
+                                *anynull = 1;
+                            } else if *((input as *const c_long).add(i.try_into().unwrap())) < 0 {
+                                *status = OVERFLOW_ERR;
+                                *((output as *mut c_uchar).add(i.try_into().unwrap())) = 0;
+                            } else if *((input as *const c_long).add(i.try_into().unwrap()))
+                                > UCHAR_MAX
+                            {
+                                *status = OVERFLOW_ERR;
+                                *((output as *mut c_uchar).add(i.try_into().unwrap())) =
+                                    UCHAR_MAX as c_uchar;
+                            } else {
+                                *((output as *mut c_uchar).add(i.try_into().unwrap())) =
+                                    *((input as *const c_long).add(i.try_into().unwrap()))
+                                        as c_uchar;
+                            }
+                        }
+                        return *status;
+                    }
+                    TFLOAT => {
+                        let input_slice = unsafe {
+                            std::slice::from_raw_parts(
+                                input as *const f32,
+                                ntodo.try_into().unwrap(),
+                            )
+                        };
+
+                        let output_slice = unsafe {
+                            std::slice::from_raw_parts_mut(
+                                output as *mut c_uchar,
+                                ntodo.try_into().unwrap(),
+                            )
+                        };
+
+                        fffr4i1(
+                            input_slice,
+                            ntodo,
+                            1.,
+                            0.,
+                            NullCheckType::None,
+                            0,
+                            &mut dummy_nullarray,
+                            None,
+                            output_slice,
+                            status,
+                        );
+                    }
+                    TDOUBLE => {
+                        let input_slice = unsafe {
+                            std::slice::from_raw_parts(
+                                input as *const f64,
+                                ntodo.try_into().unwrap(),
+                            )
+                        };
+
+                        let output_slice = unsafe {
+                            std::slice::from_raw_parts_mut(
+                                output as *mut c_uchar,
+                                ntodo.try_into().unwrap(),
+                            )
+                        };
+
+                        fffr8i1(
+                            input_slice,
+                            ntodo,
+                            1.,
+                            0.,
+                            NullCheckType::None,
+                            0,
+                            &mut dummy_nullarray,
+                            None,
+                            output_slice,
+                            status,
+                        );
+                    }
+                    _ => {
+                        *status = BAD_DATATYPE;
+                    }
+                }
+
+                for i in 0..ntodo {
+                    if *((undef).add(i.try_into().unwrap())) != 0 {
+                        *((output as *mut c_uchar).add(i.try_into().unwrap())) =
+                            *(nulval as *const c_uchar);
+                        *anynull = 1;
+                    }
+                }
+            }
+            TSHORT => {
+                match inputType {
+                    TLOGICAL | TBYTE => {
+                        for i in 0..ntodo {
+                            *((output as *mut c_short).add(i.try_into().unwrap())) =
+                                *((input as *const c_uchar).add(i.try_into().unwrap())) as c_short;
+                        }
+                    }
+                    TSHORT => {
+                        for i in 0..ntodo {
+                            *((output as *mut c_short).add(i.try_into().unwrap())) =
+                                *((input as *const c_short).add(i.try_into().unwrap()));
+                        }
+                    }
+                    TLONG => {
+                        for i in 0..ntodo {
+                            if *((undef).add(i.try_into().unwrap())) != 0 {
+                                *((output as *mut c_short).add(i.try_into().unwrap())) =
+                                    *(nulval as *const c_short);
+                                *anynull = 1;
+                            } else if *((input as *const c_long).add(i.try_into().unwrap()))
+                                < SHRT_MIN
+                            {
+                                *status = OVERFLOW_ERR;
+                                *((output as *mut c_short).add(i.try_into().unwrap())) =
+                                    SHRT_MIN as c_short;
+                            } else if *((input as *const c_long).add(i.try_into().unwrap()))
+                                > SHRT_MAX as c_long
+                            {
+                                *status = OVERFLOW_ERR;
+                                *((output as *mut c_short).add(i.try_into().unwrap())) =
+                                    SHRT_MAX as c_short;
+                            } else {
+                                *((output as *mut c_short).add(i.try_into().unwrap())) =
+                                    *((input as *const c_long).add(i.try_into().unwrap()))
+                                        as c_short;
+                            }
+                        }
+                        return *status;
+                    }
+                    TFLOAT => {
+                        let input_slice = unsafe {
+                            std::slice::from_raw_parts(
+                                input as *const f32,
+                                ntodo.try_into().unwrap(),
+                            )
+                        };
+
+                        let output_slice = unsafe {
+                            std::slice::from_raw_parts_mut(
+                                output as *mut c_short,
+                                ntodo.try_into().unwrap(),
+                            )
+                        };
+
+                        fffr4i2(
+                            input_slice,
+                            ntodo,
+                            1.,
+                            0.,
+                            NullCheckType::None,
+                            0,
+                            &mut dummy_nullarray,
+                            None,
+                            output_slice,
+                            status,
+                        );
+                    }
+                    TDOUBLE => {
+                        let input_slice = unsafe {
+                            std::slice::from_raw_parts(
+                                input as *const f64,
+                                ntodo.try_into().unwrap(),
+                            )
+                        };
+
+                        let output_slice = unsafe {
+                            std::slice::from_raw_parts_mut(
+                                output as *mut c_short,
+                                ntodo.try_into().unwrap(),
+                            )
+                        };
+
+                        fffr8i2(
+                            input_slice,
+                            ntodo,
+                            1.,
+                            0.,
+                            NullCheckType::None,
+                            0,
+                            &mut dummy_nullarray,
+                            None,
+                            output_slice,
+                            status,
+                        );
+                    }
+                    _ => {
+                        *status = BAD_DATATYPE;
+                    }
+                }
+                for i in 0..ntodo {
+                    if *((undef).add(i.try_into().unwrap())) != 0 {
+                        *((output as *mut c_short).add(i.try_into().unwrap())) =
+                            *(nulval as *const c_short);
+                        *anynull = 1;
+                    }
+                }
+            }
+            TINT => {
+                match inputType {
+                    TLOGICAL | TBYTE => {
+                        for i in 0..ntodo {
+                            *((output as *mut c_int).add(i.try_into().unwrap())) =
+                                *((input as *const c_uchar).add(i.try_into().unwrap())) as c_int;
+                        }
+                    }
+                    TSHORT => {
+                        for i in 0..ntodo {
+                            *((output as *mut c_int).add(i.try_into().unwrap())) =
+                                *((input as *const c_short).add(i.try_into().unwrap())) as c_int;
+                        }
+                    }
+                    TLONG => {
+                        for i in 0..ntodo {
+                            *((output as *mut c_int).add(i.try_into().unwrap())) =
+                                *((input as *const c_long).add(i.try_into().unwrap())) as c_int;
+                        }
+                    }
+                    TFLOAT => {
+                        let input_slice = unsafe {
+                            std::slice::from_raw_parts(
+                                input as *const f32,
+                                ntodo.try_into().unwrap(),
+                            )
+                        };
+
+                        let output_slice = unsafe {
+                            std::slice::from_raw_parts_mut(
+                                output as *mut c_int,
+                                ntodo.try_into().unwrap(),
+                            )
+                        };
+
+                        fffr4int(
+                            input_slice,
+                            ntodo,
+                            1.,
+                            0.,
+                            NullCheckType::None,
+                            0,
+                            &mut dummy_nullarray,
+                            None,
+                            output_slice,
+                            status,
+                        );
+                    }
+                    TDOUBLE => {
+                        let input_slice = unsafe {
+                            std::slice::from_raw_parts(
+                                input as *const f64,
+                                ntodo.try_into().unwrap(),
+                            )
+                        };
+
+                        let output_slice = unsafe {
+                            std::slice::from_raw_parts_mut(
+                                output as *mut c_int,
+                                ntodo.try_into().unwrap(),
+                            )
+                        };
+
+                        fffr8int(
+                            input_slice,
+                            ntodo,
+                            1.,
+                            0.,
+                            NullCheckType::None,
+                            0,
+                            &mut dummy_nullarray,
+                            None,
+                            output_slice,
+                            status,
+                        );
+                    }
+                    _ => {
+                        *status = BAD_DATATYPE;
+                    }
+                }
+                for i in 0..ntodo {
+                    if *((undef).add(i.try_into().unwrap())) != 0 {
+                        *((output as *mut c_int).add(i.try_into().unwrap())) =
+                            *(nulval as *const c_int);
+                        *anynull = 1;
+                    }
+                }
+            }
+            TLONG => {
+                match inputType {
+                    TLOGICAL | TBYTE => {
+                        for i in 0..ntodo {
+                            *((output as *mut c_long).add(i.try_into().unwrap())) =
+                                *((input as *const c_uchar).add(i.try_into().unwrap())) as c_long;
+                        }
+                    }
+                    TSHORT => {
+                        for i in 0..ntodo {
+                            *((output as *mut c_long).add(i.try_into().unwrap())) =
+                                *((input as *const c_short).add(i.try_into().unwrap())) as c_long;
+                        }
+                    }
+                    TLONG => {
+                        for i in 0..ntodo {
+                            *((output as *mut c_long).add(i.try_into().unwrap())) =
+                                *((input as *const c_long).add(i.try_into().unwrap()));
+                        }
+                    }
+                    TFLOAT => {
+                        let input_slice = unsafe {
+                            std::slice::from_raw_parts(
+                                input as *const f32,
+                                ntodo.try_into().unwrap(),
+                            )
+                        };
+
+                        let output_slice = unsafe {
+                            std::slice::from_raw_parts_mut(
+                                output as *mut c_long,
+                                ntodo.try_into().unwrap(),
+                            )
+                        };
+
+                        fffr4i4(
+                            input_slice,
+                            ntodo,
+                            1.,
+                            0.,
+                            NullCheckType::None,
+                            0,
+                            &mut dummy_nullarray,
+                            None,
+                            output_slice,
+                            status,
+                        );
+                    }
+                    TDOUBLE => {
+                        let input_slice = unsafe {
+                            std::slice::from_raw_parts(
+                                input as *const f64,
+                                ntodo.try_into().unwrap(),
+                            )
+                        };
+
+                        let output_slice = unsafe {
+                            std::slice::from_raw_parts_mut(
+                                output as *mut c_long,
+                                ntodo.try_into().unwrap(),
+                            )
+                        };
+
+                        fffr8i4(
+                            input_slice,
+                            ntodo,
+                            1.,
+                            0.,
+                            NullCheckType::None,
+                            0,
+                            &mut dummy_nullarray,
+                            None,
+                            output_slice,
+                            status,
+                        );
+                    }
+                    _ => {
+                        *status = BAD_DATATYPE;
+                    }
+                }
+                for i in 0..ntodo {
+                    if *((undef).add(i.try_into().unwrap())) != 0 {
+                        *((output as *mut c_long).add(i.try_into().unwrap())) =
+                            *(nulval as *const c_long);
+                        *anynull = 1;
+                    }
+                }
+            }
+            TLONGLONG => {
+                match inputType {
+                    TLOGICAL | TBYTE => {
+                        for i in 0..ntodo {
+                            *((output as *mut LONGLONG).add(i.try_into().unwrap())) =
+                                *((input as *const c_uchar).add(i.try_into().unwrap())) as LONGLONG;
+                        }
+                    }
+                    TSHORT => {
+                        for i in 0..ntodo {
+                            *((output as *mut LONGLONG).add(i.try_into().unwrap())) =
+                                *((input as *const c_short).add(i.try_into().unwrap())) as LONGLONG;
+                        }
+                    }
+                    TLONG => {
+                        for i in 0..ntodo {
+                            *((output as *mut LONGLONG).add(i.try_into().unwrap())) =
+                                *((input as *const c_long).add(i.try_into().unwrap()));
+                        }
+                    }
+                    TFLOAT => {
+                        let input_slice = unsafe {
+                            std::slice::from_raw_parts(
+                                input as *const f32,
+                                ntodo.try_into().unwrap(),
+                            )
+                        };
+
+                        let output_slice = unsafe {
+                            std::slice::from_raw_parts_mut(
+                                output as *mut LONGLONG,
+                                ntodo.try_into().unwrap(),
+                            )
+                        };
+
+                        fffr4i8(
+                            input_slice,
+                            ntodo,
+                            1.,
+                            0.,
+                            NullCheckType::None,
+                            0,
+                            &mut dummy_nullarray,
+                            None,
+                            output_slice,
+                            status,
+                        );
+                    }
+                    TDOUBLE => {
+                        let input_slice = unsafe {
+                            std::slice::from_raw_parts(
+                                input as *const f64,
+                                ntodo.try_into().unwrap(),
+                            )
+                        };
+
+                        let output_slice = unsafe {
+                            std::slice::from_raw_parts_mut(
+                                output as *mut LONGLONG,
+                                ntodo.try_into().unwrap(),
+                            )
+                        };
+
+                        fffr8i8(
+                            input_slice,
+                            ntodo,
+                            1.,
+                            0.,
+                            NullCheckType::None,
+                            0,
+                            &mut dummy_nullarray,
+                            None,
+                            output_slice,
+                            status,
+                        );
+                    }
+                    _ => {
+                        *status = BAD_DATATYPE;
+                    }
+                }
+                for i in 0..ntodo {
+                    if *((undef).add(i.try_into().unwrap())) != 0 {
+                        *((output as *mut LONGLONG).add(i.try_into().unwrap())) =
+                            *(nulval as *const LONGLONG);
+                        *anynull = 1;
+                    }
+                }
+            }
+            TFLOAT => {
+                match inputType {
+                    TLOGICAL | TBYTE => {
+                        for i in 0..ntodo {
+                            *((output as *mut c_float).add(i.try_into().unwrap())) =
+                                *((input as *const c_uchar).add(i.try_into().unwrap())) as c_float;
+                        }
+                    }
+                    TSHORT => {
+                        for i in 0..ntodo {
+                            *((output as *mut c_float).add(i.try_into().unwrap())) =
+                                *((input as *const c_short).add(i.try_into().unwrap())) as c_float;
+                        }
+                    }
+                    TLONG => {
+                        for i in 0..ntodo {
+                            *((output as *mut c_float).add(i.try_into().unwrap())) =
+                                *((input as *const c_long).add(i.try_into().unwrap())) as c_float;
+                        }
+                    }
+                    TFLOAT => {
+                        for i in 0..ntodo {
+                            *((output as *mut c_float).add(i.try_into().unwrap())) =
+                                *((input as *const c_float).add(i.try_into().unwrap()));
+                        }
+                    }
+                    TDOUBLE => {
+                        let input_slice = unsafe {
+                            std::slice::from_raw_parts(
+                                input as *const f64,
+                                ntodo.try_into().unwrap(),
+                            )
+                        };
+
+                        let output_slice = unsafe {
+                            std::slice::from_raw_parts_mut(
+                                output as *mut f32,
+                                ntodo.try_into().unwrap(),
+                            )
+                        };
+
+                        fffr8r4(
+                            input_slice,
+                            ntodo,
+                            1.,
+                            0.,
+                            NullCheckType::None,
+                            0.0,
+                            &mut dummy_nullarray,
+                            None,
+                            output_slice,
+                            status,
+                        );
+                    }
+                    _ => {
+                        *status = BAD_DATATYPE;
+                    }
+                }
+                for i in 0..ntodo {
+                    if *((undef).add(i.try_into().unwrap())) != 0 {
+                        *((output as *mut c_float).add(i.try_into().unwrap())) =
+                            *(nulval as *const c_float);
+                        *anynull = 1;
+                    }
+                }
+            }
+            TDOUBLE => {
+                match inputType {
+                    TLOGICAL | TBYTE => {
+                        for i in 0..ntodo {
+                            *((output as *mut c_double).add(i.try_into().unwrap())) =
+                                *((input as *const c_uchar).add(i.try_into().unwrap())) as c_double;
+                        }
+                    }
+                    TSHORT => {
+                        for i in 0..ntodo {
+                            *((output as *mut c_double).add(i.try_into().unwrap())) =
+                                *((input as *const c_short).add(i.try_into().unwrap())) as c_double;
+                        }
+                    }
+                    TLONG => {
+                        for i in 0..ntodo {
+                            *((output as *mut c_double).add(i.try_into().unwrap())) =
+                                *((input as *const c_long).add(i.try_into().unwrap())) as c_double;
+                        }
+                    }
+                    TFLOAT => {
+                        for i in 0..ntodo {
+                            *((output as *mut c_double).add(i.try_into().unwrap())) =
+                                *((input as *const c_float).add(i.try_into().unwrap())) as c_double;
+                        }
+                    }
+                    TDOUBLE => {
+                        for i in 0..ntodo {
+                            *((output as *mut c_double).add(i.try_into().unwrap())) =
+                                *((input as *const c_double).add(i.try_into().unwrap()))
+                                    as c_double;
+                        }
+                    }
+                    _ => {
+                        *status = BAD_DATATYPE;
+                    }
+                }
+                for i in 0..ntodo {
+                    if *((undef).add(i.try_into().unwrap())) != 0 {
+                        *((output as *mut c_double).add(i.try_into().unwrap())) =
+                            *(nulval as *const c_double);
+                        *anynull = 1;
+                    }
+                }
+            }
+            _ => {
+                *status = BAD_DATATYPE;
+            }
+        }
+
+        *status
+    }
 }
 
 /*---------------------------------------------------------------------------*/

--- a/src/eval_f.rs
+++ b/src/eval_f.rs
@@ -387,7 +387,7 @@ pub fn ffsrow_safe(
             ffcprs(&mut lParse);
             return *status;
         }
-        inExt.rowLength = (infptr.Fptr).rowlength as c_long;
+        inExt.rowLength = (infptr.Fptr).rowlength as LONGLONG;
         inExt.numRows = (infptr.Fptr).numrows;
         inExt.heapSize = (infptr.Fptr).heapsize;
         if inExt.numRows == 0 {
@@ -406,7 +406,7 @@ pub fn ffsrow_safe(
             ffcprs(&mut lParse);
             return *status;
         }
-        outExt.rowLength = (outfptr.Fptr).rowlength as c_long;
+        outExt.rowLength = (outfptr.Fptr).rowlength as LONGLONG;
         outExt.numRows = (outfptr.Fptr).numrows;
         if outExt.numRows == 0 {
             (outfptr.Fptr).heapsize = 0;
@@ -497,7 +497,7 @@ pub fn ffsrow_safe(
             } else {
                 outloc = (outExt.numRows + 1) as c_long;
                 if outloc > 1 {
-                    ffirow_safe(outfptr, outExt.numRows, nGood, status);
+                    ffirow_safe(outfptr, outExt.numRows, nGood as LONGLONG, status);
                 }
             }
 
@@ -505,16 +505,30 @@ pub fn ffsrow_safe(
                 if *(Info.dataPtr as *mut c_char).add((inloc - 1) as usize) != 0 {
                     let buffer_part = &mut buffer[((rdlen * nbuff) as usize)..];
 
-                    ffgtbb_safe(infptr, inloc, 1, rdlen, buffer_part, status);
+                    ffgtbb_safe(
+                        infptr,
+                        inloc as LONGLONG,
+                        1,
+                        rdlen as LONGLONG,
+                        buffer_part,
+                        status,
+                    );
                     nbuff += 1;
                     if nbuff == maxrows {
-                        ffptbb_safe(outfptr, outloc, 1, rdlen * nbuff, &buffer, status);
+                        ffptbb_safe(
+                            outfptr,
+                            outloc as LONGLONG,
+                            1,
+                            (rdlen * nbuff) as LONGLONG,
+                            &buffer,
+                            status,
+                        );
                         outloc += nbuff;
                         nbuff = 0;
                     }
                 }
                 inloc += 1;
-                if *status != 0 || inloc > inExt.numRows {
+                if *status != 0 || (inloc as LONGLONG) > inExt.numRows {
                     break;
                 }
             }
@@ -522,13 +536,25 @@ pub fn ffsrow_safe(
             if nbuff != 0 {
                 let buffer_part = &buffer[((rdlen * nbuff) as usize)..];
 
-                ffptbb_safe(outfptr, outloc, 1, rdlen * nbuff, buffer_part, status);
+                ffptbb_safe(
+                    outfptr,
+                    outloc as LONGLONG,
+                    1,
+                    (rdlen * nbuff) as LONGLONG,
+                    buffer_part,
+                    status,
+                );
                 outloc += nbuff;
             }
 
             if std::ptr::eq(infptr, outfptr) {
-                if outloc <= inExt.numRows {
-                    ffdrow_safe(infptr, outloc, inExt.numRows - outloc + 1, status);
+                if (outloc as LONGLONG) <= inExt.numRows {
+                    ffdrow_safe(
+                        infptr,
+                        outloc as LONGLONG,
+                        inExt.numRows - outloc as LONGLONG + 1,
+                        status,
+                    );
                 }
             } else if inExt.heapSize != 0 && nGood != 0 {
                 /* Copy heap, if it exists and at least one row copied */
@@ -551,9 +577,9 @@ pub fn ffsrow_safe(
                 freespace = ((((hsize + (BL!() - 1)) / BL!()) * BL!()) - hsize) as c_long;
                 ntodo = inExt.heapSize;
 
-                if (freespace - ntodo) < 0 {
+                if (freespace as LONGLONG - ntodo) < 0 {
                     /* not enough existing space? */
-                    ntodo = (ntodo - freespace + (BL!() - 1)) / BL!(); /* number of blocks  */
+                    ntodo = (ntodo - (freespace as LONGLONG) + (BL!() - 1)) / BL!(); /* number of blocks  */
                     ffiblk(outfptr, ntodo as c_long, 1, status); /* insert the blocks */
                 }
                 ffukyj_safe(
@@ -585,12 +611,22 @@ pub fn ffsrow_safe(
                 while ntodo != 0 && *status == 0 {
                     rdlen = cmp::min(ntodo, 500000) as c_long;
                     ffmbyt_safe(infptr, inbyteloc, REPORT_EOF, status);
-                    ffgbyt(infptr, rdlen, &mut buffer[..rdlen as usize], status);
+                    ffgbyt(
+                        infptr,
+                        rdlen as LONGLONG,
+                        &mut buffer[..rdlen as usize],
+                        status,
+                    );
                     ffmbyt_safe(outfptr, outbyteloc, IGNORE_EOF, status);
-                    ffpbyt(outfptr, rdlen, &buffer[..rdlen as usize], status);
-                    inbyteloc += rdlen;
-                    outbyteloc += rdlen;
-                    ntodo -= rdlen;
+                    ffpbyt(
+                        outfptr,
+                        rdlen as LONGLONG,
+                        &buffer[..rdlen as usize],
+                        status,
+                    );
+                    inbyteloc += rdlen as LONGLONG;
+                    outbyteloc += rdlen as LONGLONG;
+                    ntodo -= rdlen as LONGLONG;
                 }
 
                 /***********************************************************/
@@ -603,7 +639,7 @@ pub fn ffsrow_safe(
                     let mut offset: LONGLONG = 0;
                     for i in 1..=(outfptr.Fptr).tfield {
                         if (*(outfptr.Fptr).tableptr.add((i - 1) as usize)).tdatatype < 0 {
-                            for j in (outExt.numRows + 1)..=(outExt.numRows + nGood) {
+                            for j in (outExt.numRows + 1)..=(outExt.numRows + nGood as LONGLONG) {
                                 ffgdesll_safe(
                                     outfptr,
                                     i,
@@ -1208,7 +1244,7 @@ pub fn ffcalc_rng_safe(
                     ffukyj_safe(
                         outfptr,
                         parName,
-                        unsafe { result.value.data.lng },
+                        unsafe { result.value.data.lng } as LONGLONG,
                         Some(parInfo),
                         status,
                     );
@@ -1994,7 +2030,7 @@ fn fits_parser_workfn_safe(
                                 for kk in 0..ntodo {
                                     for jj in 0..result.value.nelem {
                                         let r = if (result.value.data.astr
-                                            [<i64 as TryInto<usize>>::try_into(jj).unwrap()])
+                                            [jj as usize])
                                             == b'1' as c_char
                                         {
                                             1
@@ -2536,7 +2572,7 @@ fn ffcvtn(
                                 *status = OVERFLOW_ERR;
                                 *((output as *mut c_uchar).add(i.try_into().unwrap())) = 0;
                             } else if *((input as *const c_long).add(i.try_into().unwrap()))
-                                > UCHAR_MAX
+                                > UCHAR_MAX as c_long
                             {
                                 *status = OVERFLOW_ERR;
                                 *((output as *mut c_uchar).add(i.try_into().unwrap())) =
@@ -2639,7 +2675,7 @@ fn ffcvtn(
                                     *(nulval as *const c_short);
                                 *anynull = 1;
                             } else if *((input as *const c_long).add(i.try_into().unwrap()))
-                                < SHRT_MIN
+                                < SHRT_MIN as c_long
                             {
                                 *status = OVERFLOW_ERR;
                                 *((output as *mut c_short).add(i.try_into().unwrap())) =
@@ -2919,7 +2955,7 @@ fn ffcvtn(
                     TLONG => {
                         for i in 0..ntodo {
                             *((output as *mut LONGLONG).add(i.try_into().unwrap())) =
-                                *((input as *const c_long).add(i.try_into().unwrap()));
+                                *((input as *const c_long).add(i.try_into().unwrap())) as LONGLONG;
                         }
                     }
                     TFLOAT => {
@@ -3570,7 +3606,7 @@ fn fits_uncompress_hkdata(
             if ffgcvd_safe(
                 fptr,
                 lParse.timeCol,
-                row,
+                row as LONGLONG,
                 1,
                 1,
                 0.0,
@@ -3624,7 +3660,7 @@ fn fits_uncompress_hkdata(
             if ffgcvs_safe(
                 fptr,
                 lParse.parCol,
-                row,
+                row as LONGLONG,
                 1,
                 1,
                 Some(cs!(c"")),
@@ -3661,7 +3697,7 @@ fn fits_uncompress_hkdata(
                         ffgcvj_safe(
                             fptr,
                             lParse.valCol,
-                            row,
+                            row as LONGLONG,
                             1,
                             1,
                             *array.wrapping_add(0),
@@ -3678,7 +3714,7 @@ fn fits_uncompress_hkdata(
                         ffgcvd_safe(
                             fptr,
                             lParse.valCol,
-                            row,
+                            row as LONGLONG,
                             1,
                             1,
                             *array.wrapping_add(0),
@@ -3695,7 +3731,7 @@ fn fits_uncompress_hkdata(
                         ffgcvs_safe(
                             fptr,
                             lParse.valCol,
-                            row,
+                            row as LONGLONG,
                             1,
                             1,
                             Some(std::slice::from_raw_parts(
@@ -4093,7 +4129,7 @@ pub fn fits_pixel_filter_safer(
                         if std::mem::size_of::<c_long>() == 8 && std::mem::size_of::<c_int>() == 4 {
                             null_val = INT_MIN as c_long;
                         } else {
-                            null_val = LONG_MIN;
+                            null_val = LONG_MIN as c_long;
                         }
                     } else {
                         println!("unhandled positive output BITPIX {}", bitpix);
@@ -4103,7 +4139,11 @@ pub fn fits_pixel_filter_safer(
                 filter.blank = null_val;
             }
 
-            fits_set_imgnull(unsafe { outfptr.as_mut().unwrap() }, filter.blank, status);
+            fits_set_imgnull(
+                unsafe { outfptr.as_mut().unwrap() },
+                filter.blank as LONGLONG,
+                status,
+            );
             if debug_pixfilter != 0 {
                 println!("using blank {}", null_val);
             }
@@ -4160,7 +4200,7 @@ pub fn fits_pixel_filter_safer(
                     fits_update_key_lng(
                         unsafe { outfptr.as_mut().unwrap() },
                         unsafe { cs!(c"BLANK") },
-                        filter.blank,
+                        filter.blank as LONGLONG,
                         Some(unsafe { cs!(c"NULL pixel value") }),
                         status,
                     );
@@ -4203,7 +4243,7 @@ pub fn fits_pixel_filter_safer(
                     ffukyj_safe(
                         outfptr.as_mut().unwrap(),
                         par_name,
-                        result.value.data.lng,
+                        result.value.data.lng as LONGLONG,
                         par_info,
                         status,
                     );
@@ -4766,8 +4806,8 @@ fn load_column(
             fits_read_imgnull(
                 unsafe { &mut *var.fptr },
                 var.datatype,
-                fRow,
-                nRows,
+                fRow as LONGLONG,
+                nRows as LONGLONG,
                 unsafe { std::slice::from_raw_parts_mut(data as *mut u8, (nRows * 8) as usize) }, // Assuming 8 bytes per element
                 unsafe { std::slice::from_raw_parts_mut(undef, nRows as usize) },
                 Some(&mut anynul),
@@ -4790,9 +4830,9 @@ fn load_column(
                     ffgcvb_safe(
                         unsafe { &mut *var.fptr },
                         var.colnum,
-                        fRow,
+                        fRow as LONGLONG,
                         1,
-                        nbytes,
+                        nbytes as LONGLONG,
                         0,
                         unsafe { std::slice::from_raw_parts_mut(bytes, nbytes as usize) },
                         Some(&mut anynul),
@@ -4845,9 +4885,9 @@ fn load_column(
                     ffgcfs_safe(
                         unsafe { &mut *var.fptr },
                         var.colnum,
-                        fRow,
+                        fRow as LONGLONG,
                         1,
-                        nRows,
+                        nRows as LONGLONG,
                         &mut string_vec,
                         undef_slice,
                         Some(&mut anynul),
@@ -4864,9 +4904,9 @@ fn load_column(
                     ffgcfl_safe(
                         unsafe { &mut *var.fptr },
                         var.colnum,
-                        fRow,
+                        fRow as LONGLONG,
                         1,
-                        nelem,
+                        nelem as LONGLONG,
                         data_slice,
                         undef_slice,
                         Some(&mut anynul),
@@ -4877,9 +4917,9 @@ fn load_column(
                     ffgcfj_safe(
                         &mut *var.fptr,
                         var.colnum,
-                        fRow,
+                        fRow as LONGLONG,
                         1,
-                        nelem,
+                        nelem as LONGLONG,
                         unsafe {
                             std::slice::from_raw_parts_mut(data as *mut c_long, nelem as usize)
                         },
@@ -4897,9 +4937,9 @@ fn load_column(
                     ffgcfd_safe(
                         unsafe { &mut *var.fptr },
                         var.colnum,
-                        fRow,
+                        fRow as LONGLONG,
                         1,
-                        nelem,
+                        nelem as LONGLONG,
                         data_slice,
                         undef_slice,
                         Some(&mut anynul),

--- a/src/eval_f.rs
+++ b/src/eval_f.rs
@@ -51,7 +51,7 @@
 /************************************************************************/
 
 use libc::{memcpy, memset};
-use std::{cmp, mem, ptr};
+use std::{cmp, ptr};
 
 use crate::buffers::{ffgbyt, ffgtbb_safe, ffmbyt_safe, ffpbyt, ffptbb_safe};
 use crate::c_types::{c_char, c_double, c_int, c_long, c_short, c_uchar, c_void};
@@ -79,7 +79,7 @@ use crate::fitscore::{
     ffkeyn_safe, ffmahd_safe, ffpdes_safe, ffpmrk_safe, fits_strcasecmp,
 };
 use crate::fitscore::{ffpmsg_slice, ffpmsg_str, ffrdef_safe};
-use crate::fitsio2::{IGNORE_EOF, REPORT_EOF};
+use crate::fitsio2::{FSTRCMP, IGNORE_EOF, REPORT_EOF};
 use crate::getcolb::ffgcvb_safe;
 use crate::getcold::{ffgcfd_safe, ffgcvd_safe};
 use crate::getcolj::{ffgcfj_safe, ffgcvj_safe};
@@ -583,7 +583,7 @@ pub fn ffsrow_safe(
                     ffmbyt_safe(infptr, inbyteloc, REPORT_EOF, status);
                     ffgbyt(infptr, rdlen, &mut buffer[..rdlen as usize], status);
                     ffmbyt_safe(outfptr, outbyteloc, IGNORE_EOF, status);
-                    ffpbyt(outfptr, rdlen, &mut buffer[..rdlen as usize], status);
+                    ffpbyt(outfptr, rdlen, &buffer[..rdlen as usize], status);
                     inbyteloc += rdlen;
                     outbyteloc += rdlen;
                     ntodo -= rdlen;
@@ -1583,13 +1583,13 @@ fn fits_parser_workfn_safe(
         let mut constant: c_int = 0;
         let mut anyNullThisTime: c_int = 0;
         let mut jj: c_long = 0;
-        let mut kk: c_long = 0;
+        let kk: c_long = 0;
         let mut idx: c_long = 0;
         let mut remain: c_long = 0;
         let mut ntodo: c_long = 0;
         let mut result: &mut Node;
         let mut outcol: &mut iteratorCol;
-        let mut lParse: &mut ParseData = unsafe {
+        let lParse: &mut ParseData = unsafe {
             (userPtr as *mut parseInfo)
                 .as_mut()
                 .unwrap()
@@ -1599,12 +1599,11 @@ fn fits_parser_workfn_safe(
         };
         let pv: &mut ParseStatusVariables =
             unsafe { &mut (userPtr as *mut parseInfo).as_mut().unwrap().parseVariables };
-        let Data0: *mut c_void;
 
         /* declare variables static to preserve their values between calls */
         let mut zeros: [c_long; 4] = [0, 0, 0, 0];
 
-        if (DEBUG_PIXFILTER != 0) {
+        if DEBUG_PIXFILTER != 0 {
             println!(
                 "fits_parser_workfn(total={}, offset={}, first={}, rows={}, cols={})",
                 totalrows, offset, firstrow, nrows, nCols
@@ -1614,7 +1613,7 @@ fn fits_parser_workfn_safe(
         /*  Initialization procedures: execute on the first call  */
         /*--------------------------------------------------------*/
         outcol = &mut colData[(nCols - 1) as usize];
-        if (firstrow == offset + 1) {
+        if firstrow == offset + 1 {
             (pv.userInfo) = userPtr as *mut parseInfo;
             (*(pv.userInfo)).anyNull = 0;
 
@@ -1630,9 +1629,9 @@ fn fits_parser_workfn_safe(
 
             outcol = &mut colData[(nCols - 1) as usize]; // Re-bind
 
-            if ((*(pv.userInfo)).maxRows > 0) {
+            if (*(pv.userInfo)).maxRows > 0 {
                 (*(pv.userInfo)).maxRows = cmp::min(totalrows, (*(pv.userInfo)).maxRows);
-            } else if ((*(pv.userInfo)).maxRows < 0) {
+            } else if (*(pv.userInfo)).maxRows < 0 {
                 (*(pv.userInfo)).maxRows = totalrows;
             } else {
                 (*(pv.userInfo)).maxRows = nrows;
@@ -1643,10 +1642,10 @@ fn fits_parser_workfn_safe(
             /* dataPtr == NULL indicates an iterator-derived column, which
             means that the first value will be a null value and the remaining
             values will be the where the outputs are placed */
-            if ((*(pv.userInfo)).dataPtr.is_null()) {
-                if (outcol.iotype == InputCol) {
+            if (*(pv.userInfo)).dataPtr.is_null() {
+                if outcol.iotype == InputCol {
                     ffpmsg_str("Output column for parser results not found!");
-                    return (PARSE_NO_OUTPUT);
+                    return PARSE_NO_OUTPUT;
                 }
                 /* Data gets set later */
                 (pv.Null) = outcol.array;
@@ -1656,12 +1655,12 @@ fn fits_parser_workfn_safe(
 
                 status = 0;
                 (pv.jnull) = 0;
-                if (lParse.hdutype == IMAGE_HDU) {
+                if lParse.hdutype == IMAGE_HDU {
                     if (*(lParse.pixFilter)).blank != 0 {
                         (pv.jnull) = (*(lParse.pixFilter)).blank as LONGLONG;
                     }
                 } else {
-                    if (outcol.iotype != TemporaryCol) {
+                    if outcol.iotype != TemporaryCol {
                         let mut jj_tmp: c_int = 0;
                         ffgknjj_safe(
                             outcol.fptr.as_mut().unwrap(),
@@ -1675,9 +1674,9 @@ fn fits_parser_workfn_safe(
                         jj = jj_tmp as c_long;
                     }
 
-                    if (status == BAD_INTKEY || outcol.iotype == TemporaryCol) {
+                    if status == BAD_INTKEY || outcol.iotype == TemporaryCol {
                         /*  Probably ASCII table with text TNULL keyword  */
-                        match ((*(pv.userInfo)).datatype) {
+                        match (*(pv.userInfo)).datatype {
                             TSHORT => {
                                 (pv.jnull) = SHRT_MIN as LONGLONG;
                             }
@@ -1711,7 +1710,7 @@ fn fits_parser_workfn_safe(
 
             /* Determine the size of each element of the returned result */
 
-            match ((*(pv.userInfo)).datatype) {
+            match (*(pv.userInfo)).datatype {
                 TBIT | TLOGICAL | TBYTE => {
                     (pv.datasize) = size_of::<c_char>() as c_int;
                 }
@@ -1742,7 +1741,7 @@ fn fits_parser_workfn_safe(
             /* Determine the size of each element of the calculated result */
             /*   (only matters for numeric/logical data)                   */
 
-            match (lParse.Nodes[lParse.resultNode as usize].ntype) {
+            match lParse.Nodes[lParse.resultNode as usize].ntype {
                 BOOLEAN => {
                     (pv.resDataSize) = size_of::<c_char>() as c_long;
                 }
@@ -1766,7 +1765,7 @@ fn fits_parser_workfn_safe(
                     printf("fits_parser_workfn: using null value %ld\n", (pv.jnull));
         */
 
-        if ((*(pv.userInfo)).dataPtr.is_null()) {
+        if (*(pv.userInfo)).dataPtr.is_null() {
             /* First, reset Data pointer to start of output array, plus 1
             because the 0th element is the null value (cute undocumented
             feature of the iterator!) */
@@ -1774,28 +1773,28 @@ fn fits_parser_workfn_safe(
                 (outcol.array as *mut c_char).add(pv.datasize.try_into().unwrap()) as *mut c_void;
 
             /* A TemporaryCol with null value specified explicitly */
-            if (outcol.iotype == TemporaryCol && !(*(pv.userInfo)).nullPtr.is_null()) {
+            if outcol.iotype == TemporaryCol && !(*(pv.userInfo)).nullPtr.is_null() {
                 pv.Null = (*(pv.userInfo)).nullPtr;
             } else {
                 /* ... or an OutputCol or TemporaryCol with no explicit null */
-                match ((*(pv.userInfo)).datatype) {
+                match (*(pv.userInfo)).datatype {
                     TLOGICAL => {
                         *(pv.Null as *mut c_char) = b'U' as c_char;
                     }
                     TBYTE => {
-                        *(pv.Null as *mut c_char) = (pv.jnull) as (c_char);
+                        *(pv.Null as *mut c_char) = (pv.jnull) as c_char;
                     }
                     TSHORT => {
-                        *(pv.Null as *mut c_short) = (pv.jnull) as (c_short);
+                        *(pv.Null as *mut c_short) = (pv.jnull) as c_short;
                     }
                     TINT => {
-                        *(pv.Null as *mut c_int) = (pv.jnull) as (c_int);
+                        *(pv.Null as *mut c_int) = (pv.jnull) as c_int;
                     }
                     TLONG => {
-                        *(pv.Null as *mut c_long) = (pv.jnull) as (c_long);
+                        *(pv.Null as *mut c_long) = (pv.jnull) as c_long;
                     }
                     TLONGLONG => {
-                        *(pv.Null as *mut LONGLONG) = (pv.jnull) as (LONGLONG);
+                        *(pv.Null as *mut LONGLONG) = (pv.jnull) as LONGLONG;
                     }
                     TFLOAT => {
                         *(pv.Null as *mut f32) = FLOATNULLVALUE;
@@ -1814,7 +1813,7 @@ fn fits_parser_workfn_safe(
 
         /* Alter nrows in case calling routine didn't want to do all rows */
 
-        Data0 = pv.Data; /* Record starting point */
+        let Data0: *mut c_void = pv.Data; /* Record starting point */
         nrows = cmp::min(nrows, (pv.lastRow) - firstrow + 1);
 
         Setup_DataArrays(lParse, nCols, colData, firstrow, nrows);
@@ -1827,10 +1826,10 @@ fn fits_parser_workfn_safe(
         /* whole to fits_parser_workfn in a single iteration.                           */
 
         remain = nrows;
-        while (remain != 0) {
+        while remain != 0 {
             ntodo = cmp::min(remain, 10000);
             Evaluate_Parser(lParse, firstrow, ntodo);
-            if (lParse.status != 0) {
+            if lParse.status != 0 {
                 break;
             }
 
@@ -1840,16 +1839,16 @@ fn fits_parser_workfn_safe(
             /*  Copy results into data array  */
 
             result = &mut lParse.Nodes[lParse.resultNode as usize];
-            if (result.operation == CONST_OP) {
+            if result.operation == CONST_OP {
                 constant = 1;
             }
 
-            match (result.ntype.into()) {
+            match result.ntype.into() {
                 fits_parser_yytokentype::BOOLEAN
                 | fits_parser_yytokentype::LONG
                 | fits_parser_yytokentype::DOUBLE => {
-                    if (constant != 0) {
-                        let mut undef: c_char = 0;
+                    if constant != 0 {
+                        let undef: c_char = 0;
                         for kk in 0..ntodo {
                             for jj in 0..pv.repeat {
                                 ffcvtn(
@@ -1858,7 +1857,7 @@ fn fits_parser_workfn_safe(
                                     &undef,
                                     result.value.nelem, /* 1 */
                                     (*(pv.userInfo)).datatype,
-                                    (pv.Null),
+                                    pv.Null,
                                     (pv.Data as *mut c_char).add(
                                         ((kk * (pv.repeat) + jj) * (pv.datasize as c_long))
                                             .try_into()
@@ -1870,19 +1869,19 @@ fn fits_parser_workfn_safe(
                             }
                         }
                     } else {
-                        if ((pv.repeat) == result.value.nelem) {
+                        if (pv.repeat) == result.value.nelem {
                             ffcvtn(
                                 lParse.datatype,
                                 result.value.data.ptr,
                                 result.value.undef,
                                 result.value.nelem * ntodo,
                                 (*(pv.userInfo)).datatype,
-                                (pv.Null),
-                                (pv.Data),
+                                pv.Null,
+                                pv.Data,
                                 &mut anyNullThisTime,
                                 &mut lParse.status,
                             );
-                        } else if (result.value.nelem == 1) {
+                        } else if result.value.nelem == 1 {
                             for kk in 0..ntodo {
                                 for jj in 0..pv.repeat {
                                     ffcvtn(
@@ -1894,7 +1893,7 @@ fn fits_parser_workfn_safe(
                                             .add(kk.try_into().unwrap()),
                                         1,
                                         (*(pv.userInfo)).datatype,
-                                        (pv.Null),
+                                        pv.Null,
                                         (pv.Data as *mut c_char).add(
                                             ((kk * (pv.repeat) + jj) * (pv.datasize as c_long))
                                                 .try_into()
@@ -1906,8 +1905,7 @@ fn fits_parser_workfn_safe(
                                 }
                             }
                         } else {
-                            let mut nCopy: c_int =
-                                cmp::min((pv.repeat), result.value.nelem) as c_int;
+                            let nCopy: c_int = cmp::min(pv.repeat, result.value.nelem) as c_int;
                             for kk in 0..ntodo {
                                 ffcvtn(
                                     lParse.datatype,
@@ -1920,7 +1918,7 @@ fn fits_parser_workfn_safe(
                                         .add((kk * result.value.nelem).try_into().unwrap()),
                                     nCopy as c_long,
                                     (*(pv.userInfo)).datatype,
-                                    (pv.Null),
+                                    pv.Null,
                                     (pv.Data as *mut c_char).add(
                                         ((kk * (pv.repeat)) * (pv.datasize as c_long))
                                             .try_into()
@@ -1944,11 +1942,11 @@ fn fits_parser_workfn_safe(
                                 }
                             }
                         }
-                        if (result.operation > 0) {
+                        if result.operation > 0 {
                             FREE!(result.value.data.ptr);
                         }
                     }
-                    if (lParse.status == OVERFLOW_ERR) {
+                    if lParse.status == OVERFLOW_ERR {
                         lParse.status = NUM_OVERFLOW;
                         ffpmsg_str(
                             "Numerical overflow while converting expression to necessary datatype",
@@ -1957,39 +1955,37 @@ fn fits_parser_workfn_safe(
                 }
 
                 fits_parser_yytokentype::BITSTR => {
-                    match ((*(pv.userInfo)).datatype) {
+                    match (*(pv.userInfo)).datatype {
                         TBYTE => {
                             idx = -1;
                             for kk in 0..(ntodo) {
                                 for jj in 0..result.value.nelem {
-                                    if (jj % 8 == 0) {
+                                    if jj % 8 == 0 {
                                         idx += 1;
                                         *((pv.Data as *mut c_char).add(idx.try_into().unwrap())) =
                                             0;
                                     }
-                                    if (constant != 0) {
-                                        if (result.value.data.astr[jj as usize] == b'1' as c_char) {
+                                    if constant != 0 {
+                                        if result.value.data.astr[jj as usize] == b'1' as c_char {
                                             *((pv.Data as *mut c_uchar)
                                                 .add(idx.try_into().unwrap())) |= 128 >> (jj % 8);
                                         }
-                                    } else {
-                                        if *(*(result
-                                            .value
-                                            .data
-                                            .strptr
-                                            .add(kk.try_into().unwrap())))
-                                        .add(jj.try_into().unwrap())
-                                            == b'1' as c_char
-                                        {
-                                            *((pv.Data as *mut c_uchar)
-                                                .add(idx.try_into().unwrap())) |= 128 >> (jj % 8);
-                                        }
+                                    } else if *(*(result
+                                        .value
+                                        .data
+                                        .strptr
+                                        .add(kk.try_into().unwrap())))
+                                    .add(jj.try_into().unwrap())
+                                        == b'1' as c_char
+                                    {
+                                        *((pv.Data as *mut c_uchar)
+                                            .add(idx.try_into().unwrap())) |= 128 >> (jj % 8);
                                     }
                                 }
                             }
                         }
                         TBIT | TLOGICAL => {
-                            if (constant != 0) {
+                            if constant != 0 {
                                 for kk in 0..ntodo {
                                     for jj in 0..result.value.nelem {
                                         let r = if (result.value.data.astr
@@ -2008,13 +2004,13 @@ fn fits_parser_workfn_safe(
                             } else {
                                 for kk in 0..ntodo {
                                     for jj in 0..result.value.nelem {
-                                        let r = if ((*(*(result
+                                        let r = if (*(*(result
                                             .value
                                             .data
                                             .strptr
                                             .add(kk.try_into().unwrap())))
                                         .add(jj.try_into().unwrap()))
-                                            == b'1' as c_char)
+                                            == b'1' as c_char
                                         {
                                             1
                                         } else {
@@ -2028,7 +2024,7 @@ fn fits_parser_workfn_safe(
                             }
                         }
                         TSTRING => {
-                            if (constant != 0) {
+                            if constant != 0 {
                                 for jj in 0..ntodo {
                                     strcpy(
                                         *((pv.Data as *mut *mut c_char)
@@ -2051,15 +2047,15 @@ fn fits_parser_workfn_safe(
                             lParse.status = PARSE_BAD_TYPE;
                         }
                     }
-                    if (result.operation > 0) {
+                    if result.operation > 0 {
                         FREE!(*(result.value.data.strptr));
                         FREE!(result.value.data.strptr);
                     }
                     break;
                 }
                 fits_parser_yytokentype::STRING => {
-                    if ((*(pv.userInfo)).datatype == TSTRING) {
-                        if (constant != 0) {
+                    if (*(pv.userInfo)).datatype == TSTRING {
+                        if constant != 0 {
                             for jj in 0..ntodo {
                                 strcpy(
                                     *((pv.Data as *mut *mut c_char).add(jj.try_into().unwrap())),
@@ -2088,7 +2084,7 @@ fn fits_parser_workfn_safe(
                         ffpmsg_str("Cannot convert string expression to desired type.");
                         lParse.status = PARSE_BAD_TYPE;
                     }
-                    if (result.operation > 0) {
+                    if result.operation > 0 {
                         FREE!(*(result.value.data.strptr));
                         FREE!(result.value.data.strptr);
                     }
@@ -2096,21 +2092,21 @@ fn fits_parser_workfn_safe(
                 _ => {}
             }
 
-            if (lParse.status != 0) {
+            if lParse.status != 0 {
                 break;
             }
 
             /*  Increment Data to point to where the next block should go  */
 
-            if (result.ntype == fits_parser_yytokentype::BITSTR as c_int
-                && (*(pv.userInfo)).datatype == TBYTE)
+            if result.ntype == fits_parser_yytokentype::BITSTR as c_int
+                && (*(pv.userInfo)).datatype == TBYTE
             {
                 (pv.Data) = (pv.Data as *mut c_char).add(
                     ((pv.datasize as c_long) * ((result.value.nelem + 7) / 8) * ntodo)
                         .try_into()
                         .unwrap(),
                 ) as *mut c_void;
-            } else if (result.ntype == fits_parser_yytokentype::STRING as c_int) {
+            } else if result.ntype == fits_parser_yytokentype::STRING as c_int {
                 (pv.Data) = (pv.Data as *mut c_char)
                     .add(((pv.datasize as c_long) * ntodo).try_into().unwrap())
                     as *mut c_void;
@@ -2127,29 +2123,29 @@ fn fits_parser_workfn_safe(
         what the null value is expected to be */
         outcol = &mut colData[(nCols - 1) as usize]; // Re-bind 
 
-        if (pv.Null != outcol.array
+        if pv.Null != outcol.array
             && (Data0)
                 == (outcol.array as *mut c_char).add((pv.datasize).try_into().unwrap())
-                    as *mut c_void)
+                    as *mut c_void
         {
-            if ((*(pv.userInfo)).datatype == TSTRING) {
+            if (*(pv.userInfo)).datatype == TSTRING {
                 memcpy(
                     outcol.array,
                     (*(pv.Null as *mut *mut c_char)) as *mut c_void,
                     2,
                 );
             } else {
-                memcpy(outcol.array, (pv.Null), (pv.datasize.try_into().unwrap()));
+                memcpy(outcol.array, pv.Null, pv.datasize.try_into().unwrap());
             }
         }
 
         /* If no NULLs encountered during this pass, set Null value to */
         /* zero to make the writing of the output column data faster   */
 
-        if (anyNullThisTime != 0) {
+        if anyNullThisTime != 0 {
             (*(pv.userInfo)).anyNull = 1;
-        } else if (pv.Null == outcol.array) {
-            if ((*(pv.userInfo)).datatype == TSTRING) {
+        } else if pv.Null == outcol.array {
+            if (*(pv.userInfo)).datatype == TSTRING {
                 memcpy(
                     (*(pv.Null as *mut *mut c_char)) as *mut c_void,
                     zeros.as_mut_ptr() as *mut c_void,
@@ -2157,7 +2153,7 @@ fn fits_parser_workfn_safe(
                 );
             } else {
                 memcpy(
-                    (pv.Null),
+                    pv.Null,
                     zeros.as_mut_ptr() as *mut c_void,
                     (pv.datasize).try_into().unwrap(),
                 );
@@ -2172,13 +2168,15 @@ fn fits_parser_workfn_safe(
         /*  of rows in the table should be processed, return a value of -1 */
         /*  once all the rows have been done, if no other error occurred.  */
 
-        if (lParse.hdutype != IMAGE_HDU && firstrow - 1 == (pv.lastRow)) {
-            if (lParse.status == 0 && (*(pv.userInfo)).maxRows < totalrows) {
-                return (-1);
-            }
+        if lParse.hdutype != IMAGE_HDU
+            && firstrow - 1 == (pv.lastRow)
+            && lParse.status == 0
+            && (*(pv.userInfo)).maxRows < totalrows
+        {
+            return -1;
         }
 
-        return (lParse.status); /* return successful status */
+        lParse.status /* return successful status */
     }
 }
 
@@ -2189,11 +2187,216 @@ fn fits_parser_workfn_safe(
 fn Setup_DataArrays(
     lParse: &mut ParseData,
     nCols: c_int,
-    cols: &[iteratorCol],
+    cols: &mut [iteratorCol],
     fRow: c_long,
     nRows: c_long,
 ) {
-    todo!();
+    unsafe {
+        let i: c_int = 0;
+        let mut nelem: c_long = 0;
+        let mut len: c_long = 0;
+        let mut row: c_long = 0;
+        let mut idx: c_long = 0;
+
+        let mut bitStrs: *mut *mut c_char = std::ptr::null_mut();
+        let mut sptr: *mut *mut c_char = std::ptr::null_mut();
+        let mut barray: *mut c_char = std::ptr::null_mut();
+        let mut iarray: *mut c_long = std::ptr::null_mut();
+        let mut rarray: *mut c_double = std::ptr::null_mut();
+        let mut msg: [c_char; 80] = [0; 80];
+        let mut do_realloc: c_int = 0;
+
+        lParse.firstDataRow = fRow;
+        lParse.nDataRows = nRows;
+        /* Only perform reallocations if the number of rows changed */
+        if lParse.nPrevDataRows != nRows {
+            do_realloc = 1;
+        }
+
+        /*  Resize and fill in UNDEF arrays for each column  */
+        for i in 0..nCols as usize {
+            let icol: &mut iteratorCol = &mut cols[i];
+            let varData = &mut lParse.varData[i];
+
+            if icol.iotype == OutputCol || icol.iotype == TemporaryCol {
+                continue;
+            }
+
+            nelem = varData.nelem;
+            len = nelem * nRows;
+
+            match varData.dtype.into() {
+                fits_parser_yytokentype::BITSTR => {
+                    /* No need for UNDEF array, but must make string DATA array */
+                    len = (nelem + 1) * nRows; /* Count '\0' */
+                    bitStrs = varData.data as *mut *mut c_char;
+                    if do_realloc != 0 {
+                        if !bitStrs.is_null() {
+                            FREE!(*bitStrs);
+                        }
+                        free(bitStrs as *mut c_void);
+                        bitStrs =
+                            malloc(nRows as usize * size_of::<*mut c_char>()) as *mut *mut c_char;
+                        if bitStrs.is_null() {
+                            varData.undef = ptr::null_mut();
+                            varData.data = ptr::null_mut();
+                            lParse.status = MEMORY_ALLOCATION;
+                            break;
+                        }
+                        *bitStrs = malloc(len as usize * size_of::<c_char>()) as *mut c_char;
+                        if (*bitStrs).is_null() {
+                            free(bitStrs as *mut c_void);
+                            varData.undef = ptr::null_mut();
+                            varData.data = ptr::null_mut();
+                            lParse.status = MEMORY_ALLOCATION;
+                            break;
+                        }
+                    }
+
+                    for row in 0..nRows as usize {
+                        *bitStrs.add(row) =
+                            (*bitStrs.add(0)).add((row as c_long * (nelem + 1)) as usize);
+                        idx = (row as c_long) * ((nelem + 7) / 8) + 1;
+                        for len in 0..nelem as usize {
+                            if (*(icol.array as *mut c_char).add(idx as usize)
+                                & (1 << (7 - (len % 8))))
+                                != 0
+                            {
+                                *(*bitStrs.add(row)).add(len) = b'1' as c_char;
+                            } else {
+                                *(*bitStrs.add(row)).add(len) = b'0' as c_char;
+                            }
+                            if len % 8 == 7 {
+                                idx += 1;
+                            }
+                        }
+                        *(*bitStrs.add(row)).add(len as usize) = 0;
+                    }
+                    varData.undef = bitStrs as *mut c_char;
+                    varData.data = bitStrs as *mut c_void;
+                }
+
+                fits_parser_yytokentype::STRING => {
+                    sptr = icol.array as *mut *mut c_char;
+                    if do_realloc != 0 {
+                        if !varData.undef.is_null() {
+                            free(varData.undef as *mut c_void);
+                        }
+                        varData.undef = malloc(nRows as usize * size_of::<c_char>()) as *mut c_char;
+                        if varData.undef.is_null() {
+                            lParse.status = MEMORY_ALLOCATION;
+                            break;
+                        }
+                    }
+                    row = nRows;
+                    while row > 0 {
+                        row -= 1;
+                        *varData.undef.add(row as usize) = (**sptr != 0
+                            && FSTRCMP(
+                                cast_slice(CStr::from_ptr(*sptr.add(0)).to_bytes_with_nul()),
+                                cast_slice(
+                                    CStr::from_ptr(*sptr.add((row + 1) as usize))
+                                        .to_bytes_with_nul(),
+                                ),
+                            ) == 0)
+                            as c_char;
+                    }
+                    varData.data = sptr.add(1) as *mut c_void;
+                }
+
+                fits_parser_yytokentype::BOOLEAN => {
+                    barray = icol.array as *mut c_char;
+                    if do_realloc != 0 {
+                        if !varData.undef.is_null() {
+                            free(varData.undef as *mut c_void);
+                        }
+                        varData.undef = malloc(len as usize * size_of::<c_char>()) as *mut c_char;
+                        if varData.undef.is_null() {
+                            lParse.status = MEMORY_ALLOCATION;
+                            break;
+                        }
+                    }
+                    while len > 0 {
+                        len -= 1;
+                        *varData.undef.add(len as usize) = (*barray.add(0) != 0
+                            && *barray.add(0) == *barray.add((len + 1) as usize))
+                            as c_char;
+                    }
+                    varData.data = barray.add(1) as *mut c_void;
+                }
+
+                fits_parser_yytokentype::LONG => {
+                    iarray = icol.array as *mut c_long;
+                    if do_realloc != 0 {
+                        if !varData.undef.is_null() {
+                            free(varData.undef as *mut c_void);
+                        }
+                        varData.undef = malloc(len as usize * size_of::<c_char>()) as *mut c_char;
+                        if varData.undef.is_null() {
+                            lParse.status = MEMORY_ALLOCATION;
+                            break;
+                        }
+                    }
+                    while len > 0 {
+                        len -= 1;
+                        *varData.undef.add(len as usize) = (*iarray.add(0) != 0
+                            && *iarray.add(0) == *iarray.add((len + 1) as usize))
+                            as c_char;
+                    }
+                    varData.data = iarray.add(1) as *mut c_void;
+                }
+
+                fits_parser_yytokentype::DOUBLE => {
+                    rarray = icol.array as *mut c_double;
+                    if do_realloc != 0 {
+                        if !varData.undef.is_null() {
+                            free(varData.undef as *mut c_void);
+                        }
+                        varData.undef = malloc(len as usize * size_of::<c_char>()) as *mut c_char;
+                        if varData.undef.is_null() {
+                            lParse.status = MEMORY_ALLOCATION;
+                            break;
+                        }
+                    }
+                    while len > 0 {
+                        len -= 1;
+                        *varData.undef.add(len as usize) = (*rarray.add(0) != 0.0
+                            && *rarray.add(0) == *rarray.add((len + 1) as usize))
+                            as c_char;
+                    }
+                    varData.data = rarray.add(1) as *mut c_void;
+                }
+
+                _ => {
+                    int_snprintf!(
+                        &mut msg,
+                        80,
+                        "SetupDataArrays, unhandled type {}\n",
+                        varData.dtype
+                    );
+                    ffpmsg_slice(&msg);
+                }
+            }
+
+            if lParse.status != 0 {
+                /*  Deallocate NULL arrays of previous columns */
+                let mut j = i;
+                while j > 0 {
+                    j -= 1;
+                    let varData = &mut lParse.varData[j];
+                    if varData.dtype == fits_parser_yytokentype::BITSTR as c_int {
+                        FREE!(*(varData.data as *mut *mut c_char).add(0));
+                    }
+                    FREE!(varData.undef);
+                    varData.undef = ptr::null_mut();
+                }
+                lParse.nPrevDataRows = 0;
+                return;
+            }
+        }
+
+        lParse.nPrevDataRows = nRows;
+    }
 }
 
 /*--------------------------------------------------------------------------*/

--- a/src/eval_f.rs
+++ b/src/eval_f.rs
@@ -50,6 +50,7 @@
 /*                                                                      */
 /************************************************************************/
 
+use libc::{memcpy, memset};
 use std::{cmp, mem, ptr};
 
 use crate::buffers::{ffgbyt, ffgtbb_safe, ffmbyt_safe, ffpbyt, ffptbb_safe};
@@ -65,7 +66,8 @@ use crate::aliases::rust_api::{
 use crate::cfileio::ffimport_file_safer;
 use crate::editcol::{ffdrow_safe, fficol_safe, ffirow_safe};
 use crate::eval_defs::{
-    CONST_OP, DataInfo, MAX_STRLEN, MAXDIMS, MAXVARNAME, Node, P_ERROR, ParseData, parseInfo,
+    CONST_OP, DataInfo, MAX_STRLEN, MAXDIMS, MAXVARNAME, Node, P_ERROR, ParseData,
+    ParseStatusVariables, parseInfo,
 };
 use crate::eval_l::{
     fits_parser_yylex_destroy, fits_parser_yylex_init_extra, fits_parser_yyrestart, yyguts_t,
@@ -83,8 +85,8 @@ use crate::getcold::{ffgcfd_safe, ffgcvd_safe};
 use crate::getcolj::{ffgcfj_safe, ffgcvj_safe};
 use crate::getcoll::ffgcfl_safe;
 use crate::getcols::{ffgcfs_safe, ffgcvs_safe};
-use crate::getkey::ffgcrd_safe;
 use crate::getkey::ffgkyj_safe;
+use crate::getkey::{ffgcrd_safe, ffgknjj_safe};
 use crate::modkey::{ffdkey_safe, ffukyd_safe, ffukyj_safe, ffukyl_safe, ffukys_safe};
 use crate::putcol::{ffiter_safe, fits_iter_set_by_num_safe};
 use crate::putkey::{ffpcom_safe, ffphis_safe, ffpkyj_safe, ffpkys_safe, ffptdm_safe};
@@ -418,8 +420,7 @@ pub fn ffsrow_safe(
         /*  Fill out Info data for parser  */
         /***********************************/
 
-        Info.dataPtr =
-            malloc((inExt.numRows + 1) as usize * mem::size_of::<c_char>()) as *mut c_void;
+        Info.dataPtr = malloc((inExt.numRows + 1) as usize * size_of::<c_char>()) as *mut c_void;
         Info.nullPtr = ptr::null_mut();
         Info.maxRows = inExt.numRows as c_long;
         Info.parseData = &mut lParse as *mut ParseData;
@@ -997,7 +998,8 @@ pub fn ffcalc_rng_safe(
                         }
                     }
                     parInfo = &tform;
-                } else if !({ parInfo[0] } as char).is_ascii_digit() && lParse.hdutype == BINARY_TBL
+                } else if !((parInfo[0] as u8) as char).is_ascii_digit()
+                    && lParse.hdutype == BINARY_TBL
                 {
                     if Info.datatype == TBIT && parInfo[0] == b'B' as c_char {
                         nelem = (nelem + 7) / 8;
@@ -1007,7 +1009,7 @@ pub fn ffcalc_rng_safe(
                         16,
                         "{}{}",
                         nelem,
-                        std::str::from_utf8(parInfo).unwrap_or("")
+                        std::str::from_utf8(cast_slice(parInfo)).unwrap_or("")
                     );
                     parInfo = &tform;
                 }
@@ -1398,7 +1400,7 @@ pub(crate) fn ffiprs(
         } else {
             lexpr = strlen_safe(expr) as c_int;
             lParse.expr =
-                malloc(((2 + lexpr as usize) * mem::size_of::<c_char>()) as usize) as *mut c_char;
+                malloc(((2 + lexpr as usize) * size_of::<c_char>()) as usize) as *mut c_char;
             strcpy(lParse.expr, expr.as_ptr());
         }
         strcat(
@@ -1563,16 +1565,652 @@ extern "C" fn fits_parser_workfn(
     fits_parser_workfn_safe(totalrows, offset, firstrow, nrows, nCols, colData, userPtr)
 }
 
+/*---------------------------------------------------------------------------*/
+/// Iterator work function which calls the parser and copies the results
+/// into either an OutputCol or a data pointer supplied in the userPtr
+/// structure.
 fn fits_parser_workfn_safe(
     totalrows: c_long,           /* I - Total rows to be processed     */
     offset: c_long,              /* I - Number of rows skipped at start*/
-    firstrow: c_long,            /* I - First row of this iteration    */
-    nrows: c_long,               /* I - Number of rows in this iter    */
+    mut firstrow: c_long,        /* I - First row of this iteration    */
+    mut nrows: c_long,           /* I - Number of rows in this iter    */
     nCols: c_int,                /* I - Number of columns in use       */
     colData: &mut [iteratorCol], /* IO- Column information/data        */
     userPtr: *mut c_void,        /* I - Data handling instructions     */
 ) -> c_int {
-    todo!()
+    unsafe {
+        let mut status: c_int = 0;
+        let mut constant: c_int = 0;
+        let mut anyNullThisTime: c_int = 0;
+        let mut jj: c_long = 0;
+        let mut kk: c_long = 0;
+        let mut idx: c_long = 0;
+        let mut remain: c_long = 0;
+        let mut ntodo: c_long = 0;
+        let mut result: &mut Node;
+        let mut outcol: &mut iteratorCol;
+        let mut lParse: &mut ParseData = unsafe {
+            (userPtr as *mut parseInfo)
+                .as_mut()
+                .unwrap()
+                .parseData
+                .as_mut()
+                .unwrap()
+        };
+        let pv: &mut ParseStatusVariables =
+            unsafe { &mut (userPtr as *mut parseInfo).as_mut().unwrap().parseVariables };
+        let Data0: *mut c_void;
+
+        /* declare variables static to preserve their values between calls */
+        let mut zeros: [c_long; 4] = [0, 0, 0, 0];
+
+        if (DEBUG_PIXFILTER != 0) {
+            println!(
+                "fits_parser_workfn(total={}, offset={}, first={}, rows={}, cols={})",
+                totalrows, offset, firstrow, nrows, nCols
+            );
+        }
+        /*--------------------------------------------------------*/
+        /*  Initialization procedures: execute on the first call  */
+        /*--------------------------------------------------------*/
+        outcol = &mut colData[(nCols - 1) as usize];
+        if (firstrow == offset + 1) {
+            (pv.userInfo) = userPtr as *mut parseInfo;
+            (*(pv.userInfo)).anyNull = 0;
+
+            /* Unfortunately there are two copies of the iterator columns,
+            one inside the parser and one outside maintained by the
+            higher level.  (This could happen if the histogramming
+            routines are binning multiple columns, and so there are
+            multiple parsers being managed at one time.) Upon the first
+            call we make sure they match */
+            for jj in 0..(nCols as usize) {
+                lParse.colData[jj].repeat = colData[jj].repeat;
+            }
+
+            outcol = &mut colData[(nCols - 1) as usize]; // Re-bind
+
+            if ((*(pv.userInfo)).maxRows > 0) {
+                (*(pv.userInfo)).maxRows = cmp::min(totalrows, (*(pv.userInfo)).maxRows);
+            } else if ((*(pv.userInfo)).maxRows < 0) {
+                (*(pv.userInfo)).maxRows = totalrows;
+            } else {
+                (*(pv.userInfo)).maxRows = nrows;
+            }
+
+            (pv.lastRow) = firstrow + (*(pv.userInfo)).maxRows - 1;
+
+            /* dataPtr == NULL indicates an iterator-derived column, which
+            means that the first value will be a null value and the remaining
+            values will be the where the outputs are placed */
+            if ((*(pv.userInfo)).dataPtr.is_null()) {
+                if (outcol.iotype == InputCol) {
+                    ffpmsg_str("Output column for parser results not found!");
+                    return (PARSE_NO_OUTPUT);
+                }
+                /* Data gets set later */
+                (pv.Null) = outcol.array;
+                (*(pv.userInfo)).datatype = outcol.datatype;
+
+                /* Check for a TNULL/BLANK keyword for output column/image */
+
+                status = 0;
+                (pv.jnull) = 0;
+                if (lParse.hdutype == IMAGE_HDU) {
+                    if (*(lParse.pixFilter)).blank != 0 {
+                        (pv.jnull) = (*(lParse.pixFilter)).blank as LONGLONG;
+                    }
+                } else {
+                    if (outcol.iotype != TemporaryCol) {
+                        let mut jj_tmp: c_int = 0;
+                        ffgknjj_safe(
+                            outcol.fptr.as_mut().unwrap(),
+                            cs!(c"TNULL"),
+                            outcol.colnum,
+                            1,
+                            &mut [(pv.jnull)],
+                            &mut jj_tmp,
+                            &mut status,
+                        );
+                        jj = jj_tmp as c_long;
+                    }
+
+                    if (status == BAD_INTKEY || outcol.iotype == TemporaryCol) {
+                        /*  Probably ASCII table with text TNULL keyword  */
+                        match ((*(pv.userInfo)).datatype) {
+                            TSHORT => {
+                                (pv.jnull) = SHRT_MIN as LONGLONG;
+                            }
+                            TINT => {
+                                (pv.jnull) = INT_MIN as LONGLONG;
+                            }
+                            TLONG => {
+                                (pv.jnull) = LONG_MIN as LONGLONG;
+                            }
+                            _ => {}
+                        }
+                    }
+                }
+                (pv.repeat) = outcol.repeat;
+                /*
+                          if (DEBUG_PIXFILTER)
+                            printf("fits_parser_workfn: using null value %ld\n", (pv.jnull));
+                */
+            } else {
+                /* This clause applies if the user is passing user-allocated
+                data arrays, which is where the data will be placed.  This
+                means they should also be passing null values */
+                (pv.Data) = (*(pv.userInfo)).dataPtr;
+                (pv.Null) = if !(*(pv.userInfo)).nullPtr.is_null() {
+                    (*(pv.userInfo)).nullPtr
+                } else {
+                    zeros.as_ptr() as *mut c_void
+                };
+                (pv.repeat) = lParse.Nodes[lParse.resultNode as usize].value.nelem;
+            }
+
+            /* Determine the size of each element of the returned result */
+
+            match ((*(pv.userInfo)).datatype) {
+                TBIT | TLOGICAL | TBYTE => {
+                    (pv.datasize) = size_of::<c_char>() as c_int;
+                }
+                TSHORT => {
+                    (pv.datasize) = size_of::<c_short>() as c_int;
+                }
+                TINT => {
+                    (pv.datasize) = size_of::<c_int>() as c_int;
+                }
+                TLONG => {
+                    (pv.datasize) = size_of::<c_long>() as c_int;
+                }
+                TLONGLONG => {
+                    (pv.datasize) = size_of::<LONGLONG>() as c_int;
+                }
+                TFLOAT => {
+                    (pv.datasize) = size_of::<f32>() as c_int;
+                }
+                TDOUBLE => {
+                    (pv.datasize) = size_of::<f64>() as c_int;
+                }
+                TSTRING => {
+                    (pv.datasize) = size_of::<*mut c_char>() as c_int;
+                }
+                _ => {}
+            }
+
+            /* Determine the size of each element of the calculated result */
+            /*   (only matters for numeric/logical data)                   */
+
+            match (lParse.Nodes[lParse.resultNode as usize].ntype) {
+                BOOLEAN => {
+                    (pv.resDataSize) = size_of::<c_char>() as c_long;
+                }
+                LONG => {
+                    (pv.resDataSize) = size_of::<c_long>() as c_long;
+                }
+                DOUBLE => {
+                    (pv.resDataSize) = size_of::<f64>() as c_long;
+                }
+            }
+        }
+
+        /*-------------------------------------------*/
+        /*  Main loop: process all the rows of data  */
+        /*-------------------------------------------*/
+
+        /*  If writing to output column, set first element to appropriate  */
+        /*  null value.  If no NULLs encounter, zero out before returning. */
+        /*
+                  if (DEBUG_PIXFILTER)
+                    printf("fits_parser_workfn: using null value %ld\n", (pv.jnull));
+        */
+
+        if ((*(pv.userInfo)).dataPtr.is_null()) {
+            /* First, reset Data pointer to start of output array, plus 1
+            because the 0th element is the null value (cute undocumented
+            feature of the iterator!) */
+            (pv.Data) =
+                (outcol.array as *mut c_char).add(pv.datasize.try_into().unwrap()) as *mut c_void;
+
+            /* A TemporaryCol with null value specified explicitly */
+            if (outcol.iotype == TemporaryCol && !(*(pv.userInfo)).nullPtr.is_null()) {
+                pv.Null = (*(pv.userInfo)).nullPtr;
+            } else {
+                /* ... or an OutputCol or TemporaryCol with no explicit null */
+                match ((*(pv.userInfo)).datatype) {
+                    TLOGICAL => {
+                        *(pv.Null as *mut c_char) = b'U' as c_char;
+                    }
+                    TBYTE => {
+                        *(pv.Null as *mut c_char) = (pv.jnull) as (c_char);
+                    }
+                    TSHORT => {
+                        *(pv.Null as *mut c_short) = (pv.jnull) as (c_short);
+                    }
+                    TINT => {
+                        *(pv.Null as *mut c_int) = (pv.jnull) as (c_int);
+                    }
+                    TLONG => {
+                        *(pv.Null as *mut c_long) = (pv.jnull) as (c_long);
+                    }
+                    TLONGLONG => {
+                        *(pv.Null as *mut LONGLONG) = (pv.jnull) as (LONGLONG);
+                    }
+                    TFLOAT => {
+                        *(pv.Null as *mut f32) = FLOATNULLVALUE;
+                    }
+                    TDOUBLE => {
+                        *(pv.Null as *mut f64) = DOUBLENULLVALUE;
+                    }
+                    TSTRING => {
+                        (**(pv.Null as *mut *mut c_char)) = 1;
+                        *(*(pv.Null as *mut *mut c_char)).add(1) = 0;
+                    }
+                    _ => {}
+                }
+            }
+        }
+
+        /* Alter nrows in case calling routine didn't want to do all rows */
+
+        Data0 = pv.Data; /* Record starting point */
+        nrows = cmp::min(nrows, (pv.lastRow) - firstrow + 1);
+
+        Setup_DataArrays(lParse, nCols, colData, firstrow, nrows);
+
+        /* Parser allocates arrays for each column and calculation it performs. */
+        /* Limit number of rows processed during each pass to reduce memory     */
+        /* requirements... In most cases, iterator will limit rows to less      */
+        /* than 10000 rows per iteration, so this is really only relevant for    */
+        /* hk-compressed files which must be decompressed in memory and sent    */
+        /* whole to fits_parser_workfn in a single iteration.                           */
+
+        remain = nrows;
+        while (remain != 0) {
+            ntodo = cmp::min(remain, 10000);
+            Evaluate_Parser(lParse, firstrow, ntodo);
+            if (lParse.status != 0) {
+                break;
+            }
+
+            firstrow += ntodo;
+            remain -= ntodo;
+
+            /*  Copy results into data array  */
+
+            result = &mut lParse.Nodes[lParse.resultNode as usize];
+            if (result.operation == CONST_OP) {
+                constant = 1;
+            }
+
+            match (result.ntype.into()) {
+                fits_parser_yytokentype::BOOLEAN
+                | fits_parser_yytokentype::LONG
+                | fits_parser_yytokentype::DOUBLE => {
+                    if (constant != 0) {
+                        let mut undef: c_char = 0;
+                        for kk in 0..ntodo {
+                            for jj in 0..pv.repeat {
+                                ffcvtn(
+                                    lParse.datatype,
+                                    &(result.value.data) as *const _ as *const c_void,
+                                    &undef,
+                                    result.value.nelem, /* 1 */
+                                    (*(pv.userInfo)).datatype,
+                                    (pv.Null),
+                                    (pv.Data as *mut c_char).add(
+                                        ((kk * (pv.repeat) + jj) * (pv.datasize as c_long))
+                                            .try_into()
+                                            .unwrap(),
+                                    ) as *mut c_void,
+                                    &mut anyNullThisTime,
+                                    &mut lParse.status,
+                                );
+                            }
+                        }
+                    } else {
+                        if ((pv.repeat) == result.value.nelem) {
+                            ffcvtn(
+                                lParse.datatype,
+                                result.value.data.ptr,
+                                result.value.undef,
+                                result.value.nelem * ntodo,
+                                (*(pv.userInfo)).datatype,
+                                (pv.Null),
+                                (pv.Data),
+                                &mut anyNullThisTime,
+                                &mut lParse.status,
+                            );
+                        } else if (result.value.nelem == 1) {
+                            for kk in 0..ntodo {
+                                for jj in 0..pv.repeat {
+                                    ffcvtn(
+                                        lParse.datatype,
+                                        (result.value.data.ptr as *mut c_char)
+                                            .add((kk * (pv.resDataSize)).try_into().unwrap())
+                                            as *const c_void,
+                                        (result.value.undef as *mut c_char)
+                                            .add(kk.try_into().unwrap()),
+                                        1,
+                                        (*(pv.userInfo)).datatype,
+                                        (pv.Null),
+                                        (pv.Data as *mut c_char).add(
+                                            ((kk * (pv.repeat) + jj) * (pv.datasize as c_long))
+                                                .try_into()
+                                                .unwrap(),
+                                        ) as *mut c_void,
+                                        &mut anyNullThisTime,
+                                        &mut lParse.status,
+                                    );
+                                }
+                            }
+                        } else {
+                            let mut nCopy: c_int =
+                                cmp::min((pv.repeat), result.value.nelem) as c_int;
+                            for kk in 0..ntodo {
+                                ffcvtn(
+                                    lParse.datatype,
+                                    (result.value.data.ptr as *const c_char).add(
+                                        (kk * result.value.nelem * (pv.resDataSize))
+                                            .try_into()
+                                            .unwrap(),
+                                    ) as *const c_void,
+                                    (result.value.undef as *mut c_char)
+                                        .add((kk * result.value.nelem).try_into().unwrap()),
+                                    nCopy as c_long,
+                                    (*(pv.userInfo)).datatype,
+                                    (pv.Null),
+                                    (pv.Data as *mut c_char).add(
+                                        ((kk * (pv.repeat)) * (pv.datasize as c_long))
+                                            .try_into()
+                                            .unwrap(),
+                                    ) as *mut c_void,
+                                    &mut anyNullThisTime,
+                                    &mut lParse.status,
+                                );
+                                if (nCopy as c_long) < (pv.repeat) {
+                                    memset(
+                                        (pv.Data as *mut c_char).add(
+                                            ((kk * (pv.repeat) + nCopy as c_long)
+                                                * (pv.datasize as c_long))
+                                                .try_into()
+                                                .unwrap(),
+                                        ) as *mut c_void,
+                                        0,
+                                        (((pv.repeat) - nCopy as c_long) * (pv.datasize as c_long))
+                                            as usize,
+                                    );
+                                }
+                            }
+                        }
+                        if (result.operation > 0) {
+                            FREE!(result.value.data.ptr);
+                        }
+                    }
+                    if (lParse.status == OVERFLOW_ERR) {
+                        lParse.status = NUM_OVERFLOW;
+                        ffpmsg_str(
+                            "Numerical overflow while converting expression to necessary datatype",
+                        );
+                    }
+                }
+
+                fits_parser_yytokentype::BITSTR => {
+                    match ((*(pv.userInfo)).datatype) {
+                        TBYTE => {
+                            idx = -1;
+                            for kk in 0..(ntodo) {
+                                for jj in 0..result.value.nelem {
+                                    if (jj % 8 == 0) {
+                                        idx += 1;
+                                        *((pv.Data as *mut c_char).add(idx.try_into().unwrap())) =
+                                            0;
+                                    }
+                                    if (constant != 0) {
+                                        if (result.value.data.astr[jj as usize] == b'1' as c_char) {
+                                            *((pv.Data as *mut c_uchar)
+                                                .add(idx.try_into().unwrap())) |= 128 >> (jj % 8);
+                                        }
+                                    } else {
+                                        if *(*(result
+                                            .value
+                                            .data
+                                            .strptr
+                                            .add(kk.try_into().unwrap())))
+                                        .add(jj.try_into().unwrap())
+                                            == b'1' as c_char
+                                        {
+                                            *((pv.Data as *mut c_uchar)
+                                                .add(idx.try_into().unwrap())) |= 128 >> (jj % 8);
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        TBIT | TLOGICAL => {
+                            if (constant != 0) {
+                                for kk in 0..ntodo {
+                                    for jj in 0..result.value.nelem {
+                                        let r = if (result.value.data.astr
+                                            [<i64 as TryInto<usize>>::try_into(jj).unwrap()])
+                                            == b'1' as c_char
+                                        {
+                                            1
+                                        } else {
+                                            0
+                                        };
+                                        *((pv.Data as *mut c_char).add(
+                                            (jj + kk * result.value.nelem).try_into().unwrap(),
+                                        )) = r;
+                                    }
+                                }
+                            } else {
+                                for kk in 0..ntodo {
+                                    for jj in 0..result.value.nelem {
+                                        let r = if ((*(*(result
+                                            .value
+                                            .data
+                                            .strptr
+                                            .add(kk.try_into().unwrap())))
+                                        .add(jj.try_into().unwrap()))
+                                            == b'1' as c_char)
+                                        {
+                                            1
+                                        } else {
+                                            0
+                                        };
+                                        *((pv.Data as *mut c_char).add(
+                                            (jj + kk * result.value.nelem).try_into().unwrap(),
+                                        )) = r;
+                                    }
+                                }
+                            }
+                        }
+                        TSTRING => {
+                            if (constant != 0) {
+                                for jj in 0..ntodo {
+                                    strcpy(
+                                        *((pv.Data as *mut *mut c_char)
+                                            .add(jj.try_into().unwrap())),
+                                        result.value.data.astr.as_ptr(),
+                                    );
+                                }
+                            } else {
+                                for jj in 0..ntodo {
+                                    strcpy(
+                                        *((pv.Data as *mut *mut c_char)
+                                            .add(jj.try_into().unwrap())),
+                                        *(result.value.data.strptr.add(jj.try_into().unwrap())),
+                                    );
+                                }
+                            }
+                        }
+                        _ => {
+                            ffpmsg_str("Cannot convert bit expression to desired type.");
+                            lParse.status = PARSE_BAD_TYPE;
+                        }
+                    }
+                    if (result.operation > 0) {
+                        FREE!(*(result.value.data.strptr));
+                        FREE!(result.value.data.strptr);
+                    }
+                    break;
+                }
+                fits_parser_yytokentype::STRING => {
+                    if ((*(pv.userInfo)).datatype == TSTRING) {
+                        if (constant != 0) {
+                            for jj in 0..ntodo {
+                                strcpy(
+                                    *((pv.Data as *mut *mut c_char).add(jj.try_into().unwrap())),
+                                    result.value.data.astr.as_ptr(),
+                                );
+                            }
+                        } else {
+                            for jj in 0..ntodo {
+                                if *(result.value.undef.add(jj.try_into().unwrap())) != 0 {
+                                    anyNullThisTime = 1;
+                                    strcpy(
+                                        *((pv.Data as *mut *mut c_char)
+                                            .add(jj.try_into().unwrap())),
+                                        *(pv.Null as *mut *mut c_char),
+                                    );
+                                } else {
+                                    strcpy(
+                                        *((pv.Data as *mut *mut c_char)
+                                            .add(jj.try_into().unwrap())),
+                                        *(result.value.data.strptr.add(jj.try_into().unwrap())),
+                                    );
+                                }
+                            }
+                        }
+                    } else {
+                        ffpmsg_str("Cannot convert string expression to desired type.");
+                        lParse.status = PARSE_BAD_TYPE;
+                    }
+                    if (result.operation > 0) {
+                        FREE!(*(result.value.data.strptr));
+                        FREE!(result.value.data.strptr);
+                    }
+                }
+                _ => {}
+            }
+
+            if (lParse.status != 0) {
+                break;
+            }
+
+            /*  Increment Data to point to where the next block should go  */
+
+            if (result.ntype == fits_parser_yytokentype::BITSTR as c_int
+                && (*(pv.userInfo)).datatype == TBYTE)
+            {
+                (pv.Data) = (pv.Data as *mut c_char).add(
+                    ((pv.datasize as c_long) * ((result.value.nelem + 7) / 8) * ntodo)
+                        .try_into()
+                        .unwrap(),
+                ) as *mut c_void;
+            } else if (result.ntype == fits_parser_yytokentype::STRING as c_int) {
+                (pv.Data) = (pv.Data as *mut c_char)
+                    .add(((pv.datasize as c_long) * ntodo).try_into().unwrap())
+                    as *mut c_void;
+            } else {
+                (pv.Data) = (pv.Data as *mut c_char).add(
+                    ((pv.datasize as c_long) * ntodo * (pv.repeat))
+                        .try_into()
+                        .unwrap(),
+                ) as *mut c_void;
+            }
+        }
+
+        /* If a TemporaryCol output is used, we want to inform the caller
+        what the null value is expected to be */
+        outcol = &mut colData[(nCols - 1) as usize]; // Re-bind 
+
+        if (pv.Null != outcol.array
+            && (Data0)
+                == (outcol.array as *mut c_char).add((pv.datasize).try_into().unwrap())
+                    as *mut c_void)
+        {
+            if ((*(pv.userInfo)).datatype == TSTRING) {
+                memcpy(
+                    outcol.array,
+                    (*(pv.Null as *mut *mut c_char)) as *mut c_void,
+                    2,
+                );
+            } else {
+                memcpy(outcol.array, (pv.Null), (pv.datasize.try_into().unwrap()));
+            }
+        }
+
+        /* If no NULLs encountered during this pass, set Null value to */
+        /* zero to make the writing of the output column data faster   */
+
+        if (anyNullThisTime != 0) {
+            (*(pv.userInfo)).anyNull = 1;
+        } else if (pv.Null == outcol.array) {
+            if ((*(pv.userInfo)).datatype == TSTRING) {
+                memcpy(
+                    (*(pv.Null as *mut *mut c_char)) as *mut c_void,
+                    zeros.as_mut_ptr() as *mut c_void,
+                    2,
+                );
+            } else {
+                memcpy(
+                    (pv.Null),
+                    zeros.as_mut_ptr() as *mut c_void,
+                    (pv.datasize).try_into().unwrap(),
+                );
+            }
+        }
+
+        /*-------------------------------------------------------*/
+        /*  Clean up procedures:  after processing all the rows  */
+        /*-------------------------------------------------------*/
+
+        /*  if the calling routine specified that only a limited number    */
+        /*  of rows in the table should be processed, return a value of -1 */
+        /*  once all the rows have been done, if no other error occurred.  */
+
+        if (lParse.hdutype != IMAGE_HDU && firstrow - 1 == (pv.lastRow)) {
+            if (lParse.status == 0 && (*(pv.userInfo)).maxRows < totalrows) {
+                return (-1);
+            }
+        }
+
+        return (lParse.status); /* return successful status */
+    }
+}
+
+/***********************************************************************/
+/// Setup the varData array in gParse to contain the fits column data.
+/// Then, allocate and initialize the necessary UNDEF arrays for each
+/// column used by the parser.
+fn Setup_DataArrays(
+    lParse: &mut ParseData,
+    nCols: c_int,
+    cols: &[iteratorCol],
+    fRow: c_long,
+    nRows: c_long,
+) {
+    todo!();
+}
+
+/*--------------------------------------------------------------------------*/
+/// Convert an array of any input data type to an array of any output
+/// data type, using an array of UNDEF flags to assign nulvals to
+fn ffcvtn(
+    inputType: c_int,      /* I - Data type of input array               */
+    input: *const c_void,  /* I - Input array of type inputType          */
+    undef: *const c_char,  /* I - Array of flags indicating UNDEF elems  */
+    ntodo: c_long,         /* I - Number of elements to process          */
+    outputType: c_int,     /* I - Data type of output array              */
+    nulval: *const c_void, /* I - Ptr to value to use for UNDEF elements */
+    output: *mut c_void,   /* O - Output array of type outputType        */
+    anynull: &mut c_int,   /* O - Any nulls flagged?                     */
+    status: &mut c_int,    /* O - Error status                           */
+) -> c_int {
+    todo!();
 }
 
 /*---------------------------------------------------------------------------*/
@@ -2199,7 +2837,7 @@ fn fits_uncompress_hkdata(
                     &mut parName,
                     256,
                     "Parameter not found: {:<30}",
-                    str::from_utf8(&(var_data).name).unwrap(),
+                    str::from_utf8(cast_slice(&(var_data).name)).unwrap(),
                 );
                 ffpmsg_slice(&parName);
                 *status = PARSE_SYNTAX_ERR;
@@ -2297,7 +2935,7 @@ pub fn fits_pixel_filter_safer(
         let result: *mut Node = std::ptr::null_mut();
         let mut datatype: c_int = 0;
 
-        let default_tags: [c_char; 2] = [b'X', 0];
+        let default_tags: [c_char; 2] = [b'X' as c_char, 0];
         let mut msg: [c_char; 256] = [0; 256];
         let mut write_blank_kwd: c_int = 0; /* write BLANK if any output nulls? */
         let mut lParse: ParseData = ParseData::default();
@@ -2750,7 +3388,7 @@ fn set_image_col_types(
                     if DEBUG_PIXFILTER != 0 {
                         println!(
                             "usefits_parser_yytokentype::DOUBLE as c_int for {} with BSCALE={}/BZERO={}",
-                            str::from_utf8(name).unwrap(),
+                            str::from_utf8(cast_slice(name)).unwrap(),
                             tscale,
                             tzero,
                         );
@@ -2803,7 +3441,10 @@ fn find_column(lParse: &mut ParseData, colName: &[c_char], itslval: *mut c_void)
         let colIter: &mut iteratorCol;
 
         if DEBUG_PIXFILTER != 0 {
-            println!("find_column({})", str::from_utf8(colName).unwrap());
+            println!(
+                "find_column({})",
+                str::from_utf8(cast_slice(colName)).unwrap()
+            );
         }
 
         if colName[0] == b'#' as c_char {
@@ -2840,7 +3481,7 @@ fn find_column(lParse: &mut ParseData, colName: &[c_char], itslval: *mut c_void)
                     &mut temp,
                     80,
                     "find_column: PixelFilter tag {} not found",
-                    str::from_utf8(colName).unwrap()
+                    str::from_utf8(cast_slice(colName)).unwrap()
                 );
                 ffpmsg_slice(&temp);
                 lParse.status = COL_NOT_FOUND;

--- a/src/eval_f.rs
+++ b/src/eval_f.rs
@@ -1,5 +1,3 @@
-#![allow(deprecated)]
-
 /************************************************************************/
 /*                                                                      */
 /*                       CFITSIO Lexical Parser                         */
@@ -52,11 +50,10 @@
 /*                                                                      */
 /************************************************************************/
 
-use std::ffi::c_void;
 use std::{cmp, mem, ptr};
 
 use crate::buffers::{ffgbyt, ffgtbb_safe, ffmbyt_safe, ffpbyt, ffptbb_safe};
-use crate::c_types::{c_char, c_int, c_long};
+use crate::c_types::{c_char, c_double, c_int, c_long, c_short, c_uchar, c_void};
 
 use crate::aliases::rust_api::{fits_binary_tform, fits_set_atblnull, fits_set_btblnull};
 use crate::aliases::rust_api::{
@@ -69,18 +66,17 @@ use crate::cfileio::ffimport_file_safer;
 use crate::editcol::{ffdrow_safe, fficol_safe, ffirow_safe};
 use crate::eval_defs::{
     CONST_OP, DataInfo, MAX_STRLEN, MAXDIMS, MAXVARNAME, Node, ParseData, pERROR, parseInfo,
-    yyscan_t,
 };
 use crate::eval_l::{
-    fits_parser_yylex_destroy, fits_parser_yylex_init_extra, fits_parser_yyrestart,
+    fits_parser_yylex_destroy, fits_parser_yylex_init_extra, fits_parser_yyrestart, yyguts_t,
 };
 use crate::eval_tab::{FITS_PARSER_YYSTYPE, fits_parser_yytokentype};
 use crate::eval_y::{Evaluate_Parser, fits_parser_yyparse, gtifilt_fct, regfilt_fct};
 use crate::fitscore::{
     ffcmph_safer, ffcmsg_safe, ffgcno_safe, ffgdesll_safe, ffgncl_safe, ffgnrw_safe, ffiblk,
-    ffkeyn_safe, ffmahd_safe, ffpdes_safe, ffpmrk, fits_strcasecmp,
+    ffkeyn_safe, ffmahd_safe, ffpdes_safe, ffpmrk_safe, fits_strcasecmp,
 };
-use crate::fitscore::{ffpmsg_slice, ffpmsg_str, ffrdef_safe, fits_recalloc};
+use crate::fitscore::{ffpmsg_slice, ffpmsg_str, ffrdef_safe};
 use crate::fitsio2::{IGNORE_EOF, REPORT_EOF};
 use crate::getcolb::ffgcvb_safe;
 use crate::getcold::{ffgcfd_safe, ffgcvd_safe};
@@ -90,15 +86,14 @@ use crate::getcols::{ffgcfs_safe, ffgcvs_safe};
 use crate::getkey::ffgcrd_safe;
 use crate::getkey::ffgkyj_safe;
 use crate::modkey::{ffdkey_safe, ffukyd_safe, ffukyj_safe, ffukyl_safe, ffukys_safe};
-use crate::putcol::{ffiter_safe, fits_iter_set_by_num};
+use crate::putcol::{ffiter_safe, fits_iter_set_by_num_safe};
 use crate::putkey::{ffpcom_safe, ffphis_safe, ffpkyj_safe, ffpkys_safe, ffptdm_safe};
 use crate::region::{SAORegion, fits_free_region};
-use crate::wrappers::{strcat, strcpy, strlen, strlen_safe, strncpy};
+use crate::wrappers::{strcat, strcpy, strlen, strlen_safe, strncpy_safe};
 use crate::{BL, cs, fitsio::*, int_snprintf, raw_to_slice};
 use bytemuck::{cast_slice, cast_slice_mut};
 use core::ffi::CStr;
-use libc::{c_double, c_uchar, free, malloc, memset, printf, snprintf};
-use std::os::raw::c_short;
+use libc::{free, malloc};
 
 // Constants needed for the function
 const UCHAR_MAX: LONGLONG = 255;
@@ -226,8 +221,7 @@ pub fn fffrow_safe(
         Info.maxRows = nrows;
         Info.parseData = &mut lParse;
 
-        let colData_slice =
-            unsafe { std::slice::from_raw_parts_mut(lParse.colData, lParse.nCols as usize) };
+        let colData_slice = &mut lParse.colData[..];
         if ffiter_safe(
             lParse.nCols,
             colData_slice,
@@ -238,7 +232,7 @@ pub fn fffrow_safe(
             status,
         ) == -1
         {
-            *status = 0; /* -1 indicates exitted without error before end... OK */
+            *status = 0; /* -1 indicates exited without error before end... OK */
         }
 
         if *status != 0 {
@@ -319,7 +313,7 @@ pub fn ffsrow_safe(
     let mut outbyteloc: LONGLONG = 0;
     let mut hsize: LONGLONG = 0;
     let mut freespace: c_long = 0;
-    let mut buffer: *mut c_uchar = std::ptr::null_mut();
+    let mut buffer: Vec<u8> = Vec::new();
     let mut result: c_char = 0;
 
     #[derive(Default)]
@@ -449,7 +443,7 @@ pub fn ffsrow_safe(
             }
             nGood = if result != 0 { inExt.numRows } else { 0 } as c_long;
         } else {
-            let col_slice = std::slice::from_raw_parts_mut(lParse.colData, lParse.nCols as usize);
+            let col_slice = &mut lParse.colData[..];
             ffiter_safe(
                 lParse.nCols,
                 col_slice,
@@ -473,17 +467,19 @@ pub fn ffsrow_safe(
             /* Error... Do nothing */
         } else {
             rdlen = inExt.rowLength as c_long;
-            buffer = malloc(
-                (cmp::max(500000, rdlen) as usize * mem::size_of::<c_char>())
-                    .try_into()
-                    .unwrap(),
-            ) as *mut c_uchar;
-            if buffer.is_null() {
+
+            if buffer
+                .try_reserve_exact(cmp::max(500000, rdlen) as usize)
+                .is_err()
+            {
                 FREE!(Info.dataPtr);
                 ffcprs(&mut lParse);
                 *status = MEMORY_ALLOCATION;
                 return *status;
+            } else {
+                buffer.resize(cmp::max(500000, rdlen) as usize, 0);
             }
+
             maxrows = cmp::max(500000 / rdlen, 1);
             nbuff = 0;
             inloc = 1;
@@ -502,16 +498,12 @@ pub fn ffsrow_safe(
 
             loop {
                 if *(Info.dataPtr as *mut c_char).add((inloc - 1) as usize) != 0 {
-                    let buffer_part = std::slice::from_raw_parts_mut(
-                        buffer.add((rdlen * nbuff) as usize),
-                        rdlen as usize,
-                    );
+                    let buffer_part = &mut buffer[((rdlen * nbuff) as usize)..];
+
                     ffgtbb_safe(infptr, inloc, 1, rdlen, buffer_part, status);
                     nbuff += 1;
                     if nbuff == maxrows {
-                        let buffer_slice =
-                            std::slice::from_raw_parts(buffer, (rdlen * nbuff) as usize);
-                        ffptbb_safe(outfptr, outloc, 1, rdlen * nbuff, buffer_slice, status);
+                        ffptbb_safe(outfptr, outloc, 1, rdlen * nbuff, &buffer, status);
                         outloc += nbuff;
                         nbuff = 0;
                     }
@@ -523,8 +515,9 @@ pub fn ffsrow_safe(
             }
 
             if nbuff != 0 {
-                let buffer_slice = std::slice::from_raw_parts(buffer, (rdlen * nbuff) as usize);
-                ffptbb_safe(outfptr, outloc, 1, rdlen * nbuff, buffer_slice, status);
+                let buffer_part = &buffer[((rdlen * nbuff) as usize)..];
+
+                ffptbb_safe(outfptr, outloc, 1, rdlen * nbuff, buffer_part, status);
                 outloc += nbuff;
             }
 
@@ -587,11 +580,9 @@ pub fn ffsrow_safe(
                 while ntodo != 0 && *status == 0 {
                     rdlen = cmp::min(ntodo, 500000) as c_long;
                     ffmbyt_safe(infptr, inbyteloc, REPORT_EOF, status);
-                    let buffer_slice = std::slice::from_raw_parts_mut(buffer, rdlen as usize);
-                    ffgbyt(infptr, rdlen, buffer_slice, status);
+                    ffgbyt(infptr, rdlen, &mut buffer[..rdlen as usize], status);
                     ffmbyt_safe(outfptr, outbyteloc, IGNORE_EOF, status);
-                    let buffer_slice = std::slice::from_raw_parts(buffer, rdlen as usize);
-                    ffpbyt(outfptr, rdlen, buffer_slice, status);
+                    ffpbyt(outfptr, rdlen, &mut buffer[..rdlen as usize], status);
                     inbyteloc += rdlen;
                     outbyteloc += rdlen;
                     ntodo -= rdlen;
@@ -623,8 +614,6 @@ pub fn ffsrow_safe(
                     }
                 }
             } /*  End of HEAP copy  */
-
-            FREE!(buffer);
         }
 
         FREE!(Info.dataPtr);
@@ -735,8 +724,7 @@ pub fn ffcrow_safe(
     Info.maxRows = nelements / nelem1;
     Info.parseData = &mut lParse;
 
-    let colData_slice =
-        unsafe { std::slice::from_raw_parts_mut(lParse.colData, lParse.nCols as usize) };
+    let colData_slice = &mut lParse.colData[..];
     if ffiter_safe(
         lParse.nCols,
         colData_slice,
@@ -829,17 +817,15 @@ pub unsafe extern "C" fn ffcalc_rng(
         raw_to_slice!(expr);
         raw_to_slice!(parName);
         raw_to_slice!(parInfo);
-        unsafe {
-            let infptr = infptr.as_mut().expect(NULL_MSG);
-            let outfptr = outfptr.as_mut().expect(NULL_MSG);
-            let status = status.as_mut().expect(NULL_MSG);
-            let start = start.as_mut().expect(NULL_MSG);
-            let end = end.as_mut().expect(NULL_MSG);
+        let infptr = infptr.as_mut().expect(NULL_MSG);
+        let outfptr = outfptr.as_mut().expect(NULL_MSG);
+        let status = status.as_mut().expect(NULL_MSG);
+        let start = start.as_mut().expect(NULL_MSG);
+        let end = end.as_mut().expect(NULL_MSG);
 
-            ffcalc_rng_safe(
-                infptr, expr, outfptr, parName, parInfo, nRngs, start, end, status,
-            )
-        }
+        ffcalc_rng_safe(
+            infptr, expr, outfptr, parName, parInfo, nRngs, start, end, status,
+        )
     }
 }
 
@@ -880,7 +866,7 @@ pub fn ffcalc_rng_safe(
         let mut width: c_long = 0;
         let col_cnt: c_int;
         let mut colNo: c_int;
-        let result: *mut Node;
+        let result: &mut Node;
         let mut card: [c_char; FLEN_CARD] = [0; FLEN_CARD];
         let mut tform: [c_char; 16] = [0; 16];
         let mut nullKwd: [c_char; 9] = [0; 9];
@@ -920,7 +906,7 @@ pub fn ffcalc_rng_safe(
         /*  Case (1): If column exists put it there  */
 
         colNo = 0;
-        ffpmrk(); /* prevent lack of column name from sullying the stack */
+        ffpmrk_safe(); /* prevent lack of column name from sullying the stack */
         ffgcno_safe(outfptr, CASEINSEN as c_int, parName, &mut colNo, status);
         ffcmsg_safe();
         if *status == 0 {
@@ -929,7 +915,7 @@ pub fn ffcalc_rng_safe(
             /* Case (2): Does parName indicate result should be put into keyword */
 
             *status = 0;
-            if parName[0] == b'#' as i8 {
+            if parName[0] == b'#' as c_char {
                 if constant == 0 {
                     ffcprs(&mut lParse);
                     ffpmsg_str("Cannot put tabular result into keyword (ffcalc)");
@@ -1011,10 +997,9 @@ pub fn ffcalc_rng_safe(
                         }
                     }
                     parInfo = &tform;
-                } else if !(parInfo[0] as u8 as char).is_ascii_digit()
-                    && lParse.hdutype == BINARY_TBL
+                } else if !({ parInfo[0] } as char).is_ascii_digit() && lParse.hdutype == BINARY_TBL
                 {
-                    if Info.datatype == TBIT && parInfo[0] == b'B' as i8 {
+                    if Info.datatype == TBIT && parInfo[0] == b'B' as c_char {
                         nelem = (nelem + 7) / 8;
                     }
                     int_snprintf!(
@@ -1022,10 +1007,7 @@ pub fn ffcalc_rng_safe(
                         16,
                         "{}{}",
                         nelem,
-                        std::str::from_utf8(unsafe {
-                            std::slice::from_raw_parts(parInfo.as_ptr() as *const u8, parInfo.len())
-                        })
-                        .unwrap_or("")
+                        std::str::from_utf8(parInfo).unwrap_or("")
                     );
                     parInfo = &tform;
                 }
@@ -1141,13 +1123,14 @@ pub fn ffcalc_rng_safe(
                 return *status;
             }
 
-            fits_iter_set_by_num(
-                lParse.colData.wrapping_add(col_cnt as usize),
+            fits_iter_set_by_num_safe(
+                &mut lParse.colData[col_cnt as usize],
                 outfptr,
                 colNo,
                 0,
                 OutputCol,
             );
+
             lParse.nCols += 1;
 
             for i in 0..nRngs {
@@ -1176,8 +1159,7 @@ pub fn ffcalc_rng_safe(
                     nPerLp = Info.maxRows as c_int;
                 }
 
-                let colData_slice =
-                    std::slice::from_raw_parts_mut(lParse.colData, lParse.nCols as usize);
+                let colData_slice = &mut lParse.colData[..];
                 if ffiter_safe(
                     lParse.nCols,
                     colData_slice,
@@ -1210,7 +1192,7 @@ pub fn ffcalc_rng_safe(
                     ffukyd_safe(
                         outfptr,
                         parName,
-                        unsafe { (*result).value.data.dbl },
+                        unsafe { result.value.data.dbl },
                         15,
                         Some(parInfo),
                         status,
@@ -1220,7 +1202,7 @@ pub fn ffcalc_rng_safe(
                     ffukyj_safe(
                         outfptr,
                         parName,
-                        unsafe { (*result).value.data.lng },
+                        unsafe { result.value.data.lng },
                         Some(parInfo),
                         status,
                     );
@@ -1229,21 +1211,21 @@ pub fn ffcalc_rng_safe(
                     ffukyl_safe(
                         outfptr,
                         parName,
-                        unsafe { (*result).value.data.log } as i32,
+                        unsafe { result.value.data.log } as i32,
                         Some(parInfo),
                         status,
                     );
                 }
                 TBIT | TSTRING => {
                     if fits_strcasecmp(parName, cs!(c"HISTORY")) == 0 {
-                        ffphis_safe(outfptr, unsafe { &(*result).value.data.astr }, status);
+                        ffphis_safe(outfptr, unsafe { &result.value.data.astr }, status);
                     } else if fits_strcasecmp(parName, cs!(c"COMMENT")) == 0 {
-                        ffpcom_safe(outfptr, unsafe { &(*result).value.data.astr }, status);
+                        ffpcom_safe(outfptr, unsafe { &result.value.data.astr }, status);
                     } else {
                         ffukys_safe(
                             outfptr,
                             parName,
-                            unsafe { &(*result).value.data.astr },
+                            unsafe { &result.value.data.astr },
                             Some(parInfo),
                             status,
                         );
@@ -1331,15 +1313,12 @@ pub(crate) fn ffiprs(
     status: &mut c_int,     /* O - Error status                        */
 ) -> c_int {
     unsafe {
-        let mut result: *mut Node = ptr::null_mut();
         let i: c_int = 0;
         let mut lexpr: c_int = 0;
         let mut tstatus: c_int = 0;
         let mut xaxis: c_int = 0;
         let mut bitpix: c_int = 0;
         let mut xaxes: [c_long; 9] = [0; 9];
-        let mut yylex_scanner: yyscan_t = ptr::null_mut(); /* Used internally by FLEX lexer */
-        let mut pixFilter: *mut PixelFilter = ptr::null_mut();
 
         if *status != 0 {
             return *status;
@@ -1352,9 +1331,8 @@ pub(crate) fn ffiprs(
 
         /*  Initialize the Parser structure  */
 
-        /* Unfortunately we need to preserve the pixFilter value since it
-        is pre-set when ffiprs() is called */
-        pixFilter = lParse.pixFilter;
+        /* Unfortunately we need to preserve the pixFilter value since it is pre-set when ffiprs() is called */
+        let pixFilter: &mut PixelFilter = &mut *lParse.pixFilter;
 
         lParse.reset();
 
@@ -1363,8 +1341,8 @@ pub(crate) fn ffiprs(
         lParse.def_fptr = fptr;
         lParse.compressed = compressed;
         lParse.nCols = 0;
-        lParse.colData = ptr::null_mut();
-        lParse.varData = ptr::null_mut();
+        lParse.colData = Vec::new();
+        lParse.varData = Vec::new();
         lParse.getData = Some(find_column);
         lParse.loadData = Some(load_column);
         lParse.Nodes = Vec::new();
@@ -1412,7 +1390,7 @@ pub(crate) fn ffiprs(
 
         /*  Copy expression into parser... read from file if necessary  */
 
-        if expr[0] == b'@' as i8 {
+        if expr[0] == b'@' as c_char {
             if ffimport_file_safer(&expr[1..], &mut lParse.expr, status) != 0 {
                 return *status;
             }
@@ -1433,10 +1411,12 @@ pub(crate) fn ffiprs(
         /*  Parse the expression, building the Nodes and determing  */
         /*  which columns are needed and what data type is returned  */
 
+        let mut yylex_scanner: Option<Box<yyguts_t>> = None; /* Used internally by FLEX lexer */
+
         fits_parser_yylex_init_extra(lParse, &mut yylex_scanner);
-        fits_parser_yyrestart(ptr::null_mut(), yylex_scanner);
-        *status = fits_parser_yyparse(yylex_scanner, lParse);
-        fits_parser_yylex_destroy(yylex_scanner);
+        fits_parser_yyrestart(ptr::null_mut(), yylex_scanner.as_deref_mut().unwrap());
+        *status = fits_parser_yyparse(yylex_scanner.as_deref_mut().unwrap(), lParse);
+        fits_parser_yylex_destroy(yylex_scanner.unwrap());
 
         if *status != 0 {
             *status = PARSE_SYNTAX_ERR;
@@ -1455,33 +1435,31 @@ pub(crate) fn ffiprs(
             return *status;
         }
         if lParse.nCols == 0 {
-            lParse.colData = malloc(size_of::<iteratorCol>()) as *mut iteratorCol;
-            if lParse.colData.is_null() {
+            if lParse.colData.try_reserve_exact(1).is_err() {
                 ffpmsg_str("memory allocation failed (ffiprs)");
                 *status = MEMORY_ALLOCATION;
                 return *status;
+            } else {
+                lParse.colData.resize(1, iteratorCol::default());
             }
-            /* This allows iterator to know value of */
-            /* fptr when no columns are referenced   */
-            memset(lParse.colData as *mut c_void, 0, size_of::<iteratorCol>());
-            unsafe {
-                (*lParse.colData.wrapping_add(0)).fptr = fptr;
-            }
+
+            /* This allows iterator to know value of fptr when no columns are referenced   */
+            (lParse.colData[0]).fptr = fptr;
         }
 
-        result = &mut lParse.Nodes[lParse.resultNode as usize];
+        let result: &mut Node = &mut lParse.Nodes[lParse.resultNode as usize];
 
-        lParse.nAxis = (*result).value.naxis;
+        lParse.nAxis = result.value.naxis;
         *naxis = lParse.nAxis;
-        lParse.nElements = (*result).value.nelem;
+        lParse.nElements = result.value.nelem;
         *nelem = lParse.nElements;
 
         for i in 0..cmp::max(*naxis, maxdim) {
-            lParse.nAxes[i as usize] = (*result).value.naxes[i as usize];
+            lParse.nAxes[i as usize] = result.value.naxes[i as usize];
             naxes[i as usize] = lParse.nAxes[i as usize];
         }
 
-        match (*result).ntype {
+        match result.ntype {
             val if val == fits_parser_yytokentype::BOOLEAN as c_int => *datatype = TLOGICAL,
 
             val if val == fits_parser_yytokentype::LONG as c_int => *datatype = TLONG,
@@ -1502,7 +1480,7 @@ pub(crate) fn ffiprs(
         lParse.datatype = *datatype;
         FREE!(lParse.expr);
 
-        if (*result).operation == CONST_OP {
+        if result.operation == CONST_OP {
             *nelem = -*nelem;
         }
         *status
@@ -1518,51 +1496,41 @@ fn ffcprs(lParse: &mut ParseData) {
         let mut i: c_int = 0;
 
         if lParse.nCols > 0 {
-            FREE!(lParse.colData);
+            lParse.colData.clear();
+
             for col in 0..lParse.nCols {
-                if unsafe { (*lParse.varData.wrapping_add(col as usize)).undef.is_null() } {
+                if lParse.varData[col as usize].undef.is_null() {
                     continue;
                 }
-                if unsafe {
-                    (*lParse.varData.wrapping_add(col as usize)).dtype
-                        == fits_parser_yytokentype::BITSTR as c_int
-                } {
-                    unsafe {
-                        let data_ptr =
-                            (*lParse.varData.wrapping_add(col as usize)).data as *mut *mut c_char;
-                        let mut first_ptr = *data_ptr;
-                        FREE!(first_ptr);
-                    }
+                if lParse.varData[col as usize].dtype == fits_parser_yytokentype::BITSTR as c_int {
+                    let data_ptr = lParse.varData[col as usize].data as *mut *mut c_char;
+                    let mut first_ptr = *data_ptr;
+                    FREE!(first_ptr);
                 }
-                free(unsafe { (*lParse.varData.wrapping_add(col as usize)).undef } as *mut c_void);
+                free(lParse.varData[col as usize].undef as *mut c_void);
             }
-            FREE!(lParse.varData);
+            lParse.varData.clear();
             lParse.nCols = 0;
-        } else if !lParse.colData.is_null() {
+        } else if !lParse.colData.is_empty() {
             /* Special case if colData needed to be created with no columns */
-            FREE!(lParse.colData);
+            lParse.colData.clear();
         }
 
         if lParse.nNodes > 0 {
             node = lParse.nNodes;
             while node != 0 {
                 node -= 1;
-                if unsafe { (lParse.Nodes[node as usize]).operation == gtifilt_fct as c_int } {
-                    i = unsafe { lParse.Nodes[node as usize].SubNodes[0] };
-                    if unsafe { !(lParse.Nodes[i as usize]).value.data.ptr.is_null() } {
-                        unsafe {
-                            let mut data_ptr = (lParse.Nodes[i as usize]).value.data.ptr;
-                            FREE!(data_ptr);
-                        }
+                if (lParse.Nodes[node as usize]).operation == gtifilt_fct as c_int {
+                    i = lParse.Nodes[node as usize].SubNodes[0];
+                    if !(lParse.Nodes[i as usize]).value.data.ptr.is_null() {
+                        let mut data_ptr = (lParse.Nodes[i as usize]).value.data.ptr;
+                        FREE!(data_ptr);
                     }
-                } else if unsafe { (lParse.Nodes[node as usize]).operation == regfilt_fct as c_int }
-                {
-                    i = unsafe { (lParse.Nodes[node as usize]).SubNodes[0] };
-                    unsafe {
-                        fits_free_region(Box::from_raw(
-                            (lParse.Nodes[i as usize]).value.data.ptr as *mut SAORegion,
-                        ));
-                    }
+                } else if (lParse.Nodes[node as usize]).operation == regfilt_fct as c_int {
+                    i = (lParse.Nodes[node as usize]).SubNodes[0];
+                    fits_free_region(Box::from_raw(
+                        (lParse.Nodes[i as usize]).value.data.ptr as *mut SAORegion,
+                    ));
                 }
             }
             lParse.nNodes = 0;
@@ -1582,13 +1550,27 @@ fn ffcprs(lParse: &mut ParseData) {
 /// into either an OutputCol or a data pointer supplied in the userPtr
 /// structure.
 extern "C" fn fits_parser_workfn(
-    _totalrows: c_long,         /* I - Total rows to be processed     */
-    _offset: c_long,            /* I - Number of rows skipped at start*/
-    _firstrow: c_long,          /* I - First row of this iteration    */
-    _nrows: c_long,             /* I - Number of rows in this iter    */
-    _nCols: c_int,              /* I - Number of columns in use       */
-    _colData: *mut iteratorCol, /* IO- Column information/data        */
-    _userPtr: *mut c_void,      /* I - Data handling instructions     */
+    totalrows: c_long,         /* I - Total rows to be processed     */
+    offset: c_long,            /* I - Number of rows skipped at start*/
+    firstrow: c_long,          /* I - First row of this iteration    */
+    nrows: c_long,             /* I - Number of rows in this iter    */
+    nCols: c_int,              /* I - Number of columns in use       */
+    colData: *mut iteratorCol, /* IO- Column information/data        */
+    userPtr: *mut c_void,      /* I - Data handling instructions     */
+) -> c_int {
+    let colData = unsafe { std::slice::from_raw_parts_mut(colData, nCols as usize) };
+
+    fits_parser_workfn_safe(totalrows, offset, firstrow, nrows, nCols, colData, userPtr)
+}
+
+fn fits_parser_workfn_safe(
+    totalrows: c_long,           /* I - Total rows to be processed     */
+    offset: c_long,              /* I - Number of rows skipped at start*/
+    firstrow: c_long,            /* I - First row of this iteration    */
+    nrows: c_long,               /* I - Number of rows in this iter    */
+    nCols: c_int,                /* I - Number of columns in use       */
+    colData: &mut [iteratorCol], /* IO- Column information/data        */
+    userPtr: *mut c_void,        /* I - Data handling instructions     */
 ) -> c_int {
     todo!()
 }
@@ -1731,23 +1713,23 @@ pub fn fffrwc_safe(
         parNo = lParse.nCols;
         while parNo > 0 {
             parNo -= 1;
-            let col_data = lParse.colData.wrapping_add(parNo as usize);
-            match (*col_data).datatype {
+            let mut col_data = lParse.colData[parNo as usize];
+            match col_data.datatype {
                 TLONG => {
-                    (*col_data).array =
+                    col_data.array =
                         malloc(((ntimes + 1) as usize) * size_of::<c_long>()) as *mut c_void;
-                    if !(*col_data).array.is_null() {
-                        let array_ptr = (*col_data).array as *mut c_long;
+                    if !col_data.array.is_null() {
+                        let array_ptr = col_data.array as *mut c_long;
                         *array_ptr.wrapping_add(0) = 1234554321;
                     } else {
                         *status = MEMORY_ALLOCATION;
                     }
                 }
                 TDOUBLE => {
-                    (*col_data).array =
+                    col_data.array =
                         malloc(((ntimes + 1) as usize) * size_of::<c_double>()) as *mut c_void;
-                    if !(*col_data).array.is_null() {
-                        let array_ptr = (*col_data).array as *mut c_double;
+                    if !col_data.array.is_null() {
+                        let array_ptr = col_data.array as *mut c_double;
                         *array_ptr.wrapping_add(0) = DOUBLENULLVALUE;
                     } else {
                         *status = MEMORY_ALLOCATION;
@@ -1764,11 +1746,10 @@ pub fn fffrwc_safe(
                     ) == 0
                     {
                         alen += 1;
-                        (*col_data).array =
-                            malloc(((ntimes + 1) as usize) * size_of::<*mut c_char>())
-                                as *mut c_void;
-                        if !(*col_data).array.is_null() {
-                            let str_array = (*col_data).array as *mut *mut c_char;
+                        col_data.array = malloc(((ntimes + 1) as usize) * size_of::<*mut c_char>())
+                            as *mut c_void;
+                        if !col_data.array.is_null() {
+                            let str_array = col_data.array as *mut *mut c_char;
                             let first_str = malloc(((ntimes + 1) * alen) as usize) as *mut c_char;
                             *str_array.wrapping_add(0) = first_str;
                             if !first_str.is_null() {
@@ -1779,7 +1760,7 @@ pub fn fffrwc_safe(
                                 }
                                 *(*str_array.wrapping_add(0)).wrapping_add(0) = 0;
                             } else {
-                                free((*col_data).array);
+                                free(col_data.array);
                                 *status = MEMORY_ALLOCATION;
                             }
                         } else {
@@ -1789,18 +1770,19 @@ pub fn fffrwc_safe(
                 }
                 _ => {}
             }
+
             if *status != 0 {
                 while parNo > 0 {
                     parNo -= 1;
-                    let col_data2 = lParse.colData.wrapping_add(parNo as usize);
-                    if (*col_data2).datatype == TSTRING {
-                        let str_array = (*col_data2).array as *mut *mut c_char;
+                    let col_data2 = lParse.colData[parNo as usize];
+                    if (col_data2).datatype == TSTRING {
+                        let str_array = (col_data2).array as *mut *mut c_char;
                         if !str_array.is_null() {
                             let mut first_str = *str_array.wrapping_add(0);
                             FREE!(first_str);
                         }
                     }
-                    let mut array_ptr = (*col_data2).array;
+                    let mut array_ptr = (col_data2).array;
                     FREE!(array_ptr);
                 }
                 return *status;
@@ -1824,13 +1806,13 @@ pub fn fffrwc_safe(
                 Info.dataPtr = time_status.as_mut_ptr() as *mut c_void;
                 Info.nullPtr = ptr::null_mut();
                 Info.maxRows = ntimes;
-                *status = fits_parser_workfn(
+                *status = fits_parser_workfn_safe(
                     ntimes,
                     0,
                     1,
                     ntimes,
                     lParse.nCols,
-                    lParse.colData,
+                    &mut lParse.colData,
                     (&mut Info) as *mut parseInfo as *mut c_void,
                 );
             }
@@ -1843,15 +1825,15 @@ pub fn fffrwc_safe(
         parNo = lParse.nCols;
         while parNo > 0 {
             parNo -= 1;
-            let col_data = lParse.colData.wrapping_add(parNo as usize);
-            if (*col_data).datatype == TSTRING {
-                let str_array = (*col_data).array as *mut *mut c_char;
+            let col_data = lParse.colData[parNo as usize];
+            if (col_data).datatype == TSTRING {
+                let str_array = (col_data).array as *mut *mut c_char;
                 if !str_array.is_null() {
                     let mut first_str = *str_array.wrapping_add(0);
                     FREE!(first_str);
                 }
             }
-            let mut array_ptr = (*col_data).array;
+            let mut array_ptr = (col_data).array;
             FREE!(array_ptr);
         }
 
@@ -1952,8 +1934,7 @@ pub fn ffffrw_safer(
                 prownum: rownum,
                 lParse: &mut lParse as *mut ParseData,
             };
-            let colData_slice =
-                unsafe { std::slice::from_raw_parts_mut(lParse.colData, lParse.nCols as usize) };
+            let colData_slice = &mut lParse.colData[..];
             if ffiter_safe(
                 (lParse).nCols,
                 colData_slice,
@@ -1995,18 +1976,17 @@ fn fits_parser_set_temporary_col(
         }
 
         /* Set important variables for TemporaryCol where calculated results end up */
-        unsafe {
-            fits_iter_set_by_num(
-                lParse.colData.wrapping_add(col_cnt as usize),
-                ptr::null_mut(),
-                0,
-                TDOUBLE,
-                TemporaryCol,
-            );
-        }
-        unsafe {
-            (*lParse.colData.wrapping_add(col_cnt as usize)).repeat = lParse.nElements;
-        }
+
+        fits_iter_set_by_num_safe(
+            &mut lParse.colData[col_cnt as usize],
+            ptr::null_mut(),
+            0,
+            TDOUBLE,
+            TemporaryCol,
+        );
+
+        (lParse.colData[col_cnt as usize]).repeat = lParse.nElements;
+
         Info.dataPtr = ptr::null_mut();
         Info.nullPtr = nulval;
         Info.maxRows = nrows;
@@ -2082,20 +2062,20 @@ fn fits_uncompress_hkdata(
                 parNo = lParse.nCols;
                 while parNo > 0 {
                     parNo -= 1;
-                    let col_data = lParse.colData.wrapping_add(parNo as usize);
-                    match (*col_data).datatype {
+                    let col_data = lParse.colData[parNo as usize];
+                    match col_data.datatype {
                         TLONG => {
-                            let array = (*col_data).array as *mut c_long;
+                            let array = col_data.array as *mut c_long;
                             *array.wrapping_add(currelem as usize) =
                                 *array.wrapping_add((currelem - 1) as usize);
                         }
                         TDOUBLE => {
-                            let array = (*col_data).array as *mut f64;
+                            let array = col_data.array as *mut f64;
                             *array.wrapping_add(currelem as usize) =
                                 *array.wrapping_add((currelem - 1) as usize);
                         }
                         TSTRING => {
-                            let str_array = (*col_data).array as *mut *mut c_char;
+                            let str_array = col_data.array as *mut *mut c_char;
                             strcpy(
                                 *str_array.wrapping_add(currelem as usize),
                                 *str_array.wrapping_add((currelem - 1) as usize),
@@ -2124,12 +2104,12 @@ fn fits_uncompress_hkdata(
             parNo = lParse.nCols;
             while parNo > 0 {
                 parNo -= 1;
-                let var_data = lParse.varData.wrapping_add(parNo as usize);
+                let var_data = &lParse.varData[parNo as usize];
                 if fits_strcasecmp(
-                    std::slice::from_raw_parts(parName.as_ptr(), strlen(parName.as_ptr())),
+                    std::slice::from_raw_parts(parName.as_ptr(), strlen_safe(&parName)),
                     std::slice::from_raw_parts(
-                        (*var_data).name.as_ptr(),
-                        strlen((*var_data).name.as_ptr()),
+                        (var_data).name.as_ptr(),
+                        strlen_safe(&(var_data).name),
                     ),
                 ) == 0
                 {
@@ -2139,10 +2119,10 @@ fn fits_uncompress_hkdata(
 
             if parNo >= 0 {
                 found[parNo as usize] = 1; /* Flag this parameter as found */
-                let col_data = lParse.colData.wrapping_add(parNo as usize);
-                match (*col_data).datatype {
+                let col_data = lParse.colData[parNo as usize];
+                match col_data.datatype {
                     TLONG => {
-                        let array = (*col_data).array as *mut c_long;
+                        let array = col_data.array as *mut c_long;
                         ffgcvj_safe(
                             fptr,
                             lParse.valCol,
@@ -2159,7 +2139,7 @@ fn fits_uncompress_hkdata(
                         );
                     }
                     TDOUBLE => {
-                        let array = (*col_data).array as *mut f64;
+                        let array = col_data.array as *mut f64;
                         ffgcvd_safe(
                             fptr,
                             lParse.valCol,
@@ -2176,7 +2156,7 @@ fn fits_uncompress_hkdata(
                         );
                     }
                     TSTRING => {
-                        let str_array = (*col_data).array as *mut *mut c_char;
+                        let str_array = col_data.array as *mut *mut c_char;
                         ffgcvs_safe(
                             fptr,
                             lParse.valCol,
@@ -2214,12 +2194,12 @@ fn fits_uncompress_hkdata(
         while parNo > 0 {
             parNo -= 1;
             if found[parNo as usize] == 0 {
-                let var_data = lParse.varData.wrapping_add(parNo as usize);
-                snprintf(
-                    parName.as_mut_ptr(),
+                let var_data = &lParse.varData[parNo as usize];
+                int_snprintf!(
+                    &mut parName,
                     256,
-                    c"Parameter not found: %-30s".as_ptr() as *const c_char,
-                    (*var_data).name.as_ptr(),
+                    "Parameter not found: {:<30}",
+                    str::from_utf8(&(var_data).name).unwrap(),
                 );
                 ffpmsg_slice(&parName);
                 *status = PARSE_SYNTAX_ERR;
@@ -2258,7 +2238,7 @@ pub(crate) fn ffffrw_work_safe(
     userPtr: *mut c_void,
 ) -> c_int {
     unsafe {
-        let result: *mut Node;
+        let result: &mut Node;
         let workData: *mut ffffrw_workdata = userPtr as *mut ffffrw_workdata;
         let lParse: &mut ParseData = &mut *(*workData).lParse;
 
@@ -2266,15 +2246,15 @@ pub(crate) fn ffffrw_work_safe(
 
         if (lParse.status) == 0 {
             result = &mut lParse.Nodes[lParse.resultNode as usize];
-            if (*result).operation == CONST_OP {
-                if (*result).value.data.log != 0 {
+            if result.operation == CONST_OP {
+                if result.value.data.log != 0 {
                     *((*workData).prownum) = firstrow;
                     return -1;
                 }
             } else {
                 for idx in 0..(nrows as usize) {
-                    if *((*result).value.data.logptr.add(idx)) != 0
-                        && *((*result).value.undef.add(idx)) == 0
+                    if *(result.value.data.logptr.add(idx)) != 0
+                        && *(result.value.undef.add(idx)) == 0
                     {
                         *((*workData).prownum) = firstrow + idx as c_long;
                         return -1;
@@ -2314,10 +2294,10 @@ pub fn fits_pixel_filter_safer(
         let mut nelem: c_long = 0;
         let mut naxes: [c_long; MAXDIMS as usize] = [0; MAXDIMS as usize];
         let mut col_cnt: c_int = 0;
-        let mut result: *mut Node = std::ptr::null_mut();
+        let result: *mut Node = std::ptr::null_mut();
         let mut datatype: c_int = 0;
 
-        let default_tags: [c_char; 2] = ['X' as c_char, 0];
+        let default_tags: [c_char; 2] = [b'X', 0];
         let mut msg: [c_char; 256] = [0; 256];
         let mut write_blank_kwd: c_int = 0; /* write BLANK if any output nulls? */
         let mut lParse: ParseData = ParseData::default();
@@ -2483,12 +2463,7 @@ pub fn fits_pixel_filter_safer(
                 ) != 0
                 {
                     unsafe {
-                        snprintf(
-                            msg.as_mut_ptr(),
-                            256,
-                            c"pixel_filter: unable to read keycard %d".as_ptr() as *const c_char,
-                            i,
-                        );
+                        int_snprintf!(&mut msg, 256, "pixel_filter: unable to read keycard {}", i,);
                     }
                     ffpmsg_slice(&msg);
                     ffcprs(&mut lParse);
@@ -2508,10 +2483,10 @@ pub fn fits_pixel_filter_safer(
                     != 0
                 {
                     unsafe {
-                        snprintf(
-                            msg.as_mut_ptr(),
+                        int_snprintf!(
+                            &mut msg,
                             256,
-                            c"pixel_filter: unable to write keycard [%d]".as_ptr() as *const c_char,
+                            "pixel_filter: unable to write keycard [{}]",
                             *status,
                         );
                     }
@@ -2600,9 +2575,6 @@ pub fn fits_pixel_filter_safer(
         }
 
         if unsafe { *filter.keyword.as_ptr() } == 0 {
-            let mut colIter: *mut iteratorCol = std::ptr::null_mut();
-            let mut varInfo: *mut DataInfo = std::ptr::null_mut();
-
             /*************************************/
             /* Create new iterator Output Column */
             /*************************************/
@@ -2613,16 +2585,16 @@ pub fn fits_pixel_filter_safer(
             }
             lParse.nCols += 1;
 
-            colIter = unsafe { lParse.colData.add(col_cnt as usize) };
-            unsafe { (*colIter).fptr = filter.ofptr };
-            unsafe { (*colIter).iotype = OutputCol };
-            varInfo = unsafe { lParse.varData.add(col_cnt as usize) };
+            let colIter: &mut iteratorCol = &mut lParse.colData[col_cnt as usize];
+            unsafe { colIter.fptr = filter.ofptr };
+            unsafe { colIter.iotype = OutputCol };
+
             set_image_col_types(
-                &mut lParse,
-                unsafe { (*colIter).fptr.as_mut().unwrap() },
+                &mut lParse.status,
+                unsafe { colIter.fptr.as_mut().unwrap() },
                 cs!(c"CREATED"),
                 bitpix,
-                &mut *varInfo,
+                &mut lParse.varData[col_cnt as usize],
                 colIter,
             );
 
@@ -2630,11 +2602,10 @@ pub fn fits_pixel_filter_safer(
             info.parseData = &mut lParse;
 
             if unsafe {
+                let colData_slice = &mut lParse.colData[..];
                 ffiter_safe(
                     lParse.nCols,
-                    unsafe {
-                        std::slice::from_raw_parts_mut((lParse).colData, (lParse).nCols as usize)
-                    },
+                    colData_slice,
                     0,
                     0,
                     fits_parser_workfn,
@@ -2668,27 +2639,26 @@ pub fn fits_pixel_filter_safer(
                 }
             } else if bitpix > 0 {
                 // never used a null
-                if fits_set_imgnull(unsafe { outfptr.as_mut().unwrap() }, -1234554321, status) != 0
-                {
+                if fits_set_imgnull(outfptr.as_mut().unwrap(), -1234554321, status) != 0 {
                     ffpmsg_str("pixel_filter: unable to reset imgnull");
                 }
             }
         } else {
             // Put constant result into keyword
             let par_name = unsafe { &filter.keyword };
-            let par_info: Option<&[i8]> = if filter.comment[0] == 0 {
+            let par_info: Option<&[c_char]> = if filter.comment[0] == 0 {
                 None
             } else {
-                Some(unsafe { &filter.comment })
+                Some(&filter.comment)
             };
 
-            result = &mut lParse.Nodes[lParse.resultNode as usize];
+            let result = &mut lParse.Nodes[lParse.resultNode as usize];
             match info.datatype {
                 TDOUBLE => {
                     ffukyd_safe(
-                        unsafe { outfptr.as_mut().unwrap() },
+                        outfptr.as_mut().unwrap(),
                         par_name,
-                        unsafe { (*result).value.data.dbl },
+                        result.value.data.dbl,
                         15,
                         par_info,
                         status,
@@ -2696,18 +2666,18 @@ pub fn fits_pixel_filter_safer(
                 }
                 TLONG => {
                     ffukyj_safe(
-                        unsafe { outfptr.as_mut().unwrap() },
+                        outfptr.as_mut().unwrap(),
                         par_name,
-                        unsafe { (*result).value.data.lng },
+                        result.value.data.lng,
                         par_info,
                         status,
                     );
                 }
                 TLOGICAL => {
                     ffukyl_safe(
-                        unsafe { outfptr.as_mut().unwrap() },
+                        outfptr.as_mut().unwrap(),
                         par_name,
-                        unsafe { (*result).value.data.log.into() },
+                        result.value.data.log.into(),
                         par_info,
                         status,
                     );
@@ -2715,12 +2685,12 @@ pub fn fits_pixel_filter_safer(
                 TBIT | TSTRING => {
                     let str_val = unsafe {
                         std::slice::from_raw_parts(
-                            (*result).value.data.astr.as_ptr(),
-                            strlen((*result).value.data.astr.as_ptr()),
+                            result.value.data.astr.as_ptr(),
+                            strlen_safe(&result.value.data.astr),
                         )
                     };
                     ffukys_safe(
-                        unsafe { outfptr.as_mut().unwrap() },
+                        outfptr.as_mut().unwrap(),
                         par_name,
                         str_val,
                         par_info,
@@ -2728,14 +2698,13 @@ pub fn fits_pixel_filter_safer(
                     );
                 }
                 _ => {
-                    unsafe {
-                        int_snprintf!(
-                            &mut msg,
-                            256,
-                            "pixel_filter: unexpected constant result type [{}]",
-                            info.datatype,
-                        );
-                    }
+                    int_snprintf!(
+                        &mut msg,
+                        256,
+                        "pixel_filter: unexpected constant result type [{}]",
+                        info.datatype,
+                    );
+
                     ffpmsg_slice(&msg);
                 }
             }
@@ -2747,12 +2716,12 @@ pub fn fits_pixel_filter_safer(
 }
 
 fn set_image_col_types(
-    lParse: &mut ParseData,
+    lParse_status: &mut c_int,
     fptr: &mut fitsfile,
     name: &[c_char],
     bitpix: c_int,
     varInfo: &mut DataInfo,
-    colIter: *mut iteratorCol,
+    colIter: &mut iteratorCol,
 ) -> c_int {
     unsafe {
         let mut istatus: c_int = 0;
@@ -2774,14 +2743,14 @@ fn set_image_col_types(
 
                 if tscale == 1.0 && (tzero == 0.0 || tzero == 32768.0) {
                     varInfo.dtype = fits_parser_yytokentype::LONG as c_int;
-                    (*colIter).datatype = TLONG;
+                    colIter.datatype = TLONG;
                 } else {
                     varInfo.dtype = fits_parser_yytokentype::DOUBLE as c_int;
-                    (*colIter).datatype = TDOUBLE;
+                    colIter.datatype = TDOUBLE;
                     if DEBUG_PIXFILTER != 0 {
-                        printf(
-                            c"usefits_parser_yytokentype::DOUBLE as c_int for %s with BSCALE=%g/BZERO=%g\n".as_ptr() as *const c_char,
-                            name,
+                        println!(
+                            "usefits_parser_yytokentype::DOUBLE as c_int for {} with BSCALE={}/BZERO={}",
+                            str::from_utf8(name).unwrap(),
                             tscale,
                             tzero,
                         );
@@ -2790,7 +2759,7 @@ fn set_image_col_types(
             }
             LONGLONG_IMG | FLOAT_IMG | DOUBLE_IMG => {
                 varInfo.dtype = fits_parser_yytokentype::DOUBLE as c_int;
-                (*colIter).datatype = TDOUBLE;
+                colIter.datatype = TDOUBLE;
             }
             _ => {
                 int_snprintf!(
@@ -2800,8 +2769,8 @@ fn set_image_col_types(
                     bitpix
                 );
                 ffpmsg_slice(&temp);
-                lParse.status = PARSE_BAD_TYPE;
-                return lParse.status;
+                *lParse_status = PARSE_BAD_TYPE;
+                return *lParse_status;
             }
         }
         0
@@ -2830,14 +2799,14 @@ fn find_column(lParse: &mut ParseData, colName: &[c_char], itslval: *mut c_void)
         let mut tzero: f64 = 0.0;
         let mut tscale: f64 = 1.0;
         let mut istatus: c_int;
-        let varInfo: *mut DataInfo;
-        let colIter: *mut iteratorCol;
+        let varInfo: &mut DataInfo;
+        let colIter: &mut iteratorCol;
 
         if DEBUG_PIXFILTER != 0 {
-            printf(c"find_column(%s)\n".as_ptr() as *const c_char, colName);
+            println!("find_column({})", str::from_utf8(colName).unwrap());
         }
 
-        if colName[0] == b'#' as i8 {
+        if colName[0] == b'#' as c_char {
             return find_keywd(lParse, &colName[1..], itslval);
         }
 
@@ -2867,11 +2836,11 @@ fn find_column(lParse: &mut ParseData, colName: &[c_char], itslval: *mut c_void)
                 }
             }
             if colnum < 0 {
-                snprintf(
-                    temp.as_mut_ptr(),
+                int_snprintf!(
+                    &mut temp,
                     80,
-                    c"find_column: PixelFilter tag %s not found".as_ptr() as *const c_char,
-                    colName,
+                    "find_column: PixelFilter tag {} not found",
+                    str::from_utf8(colName).unwrap()
                 );
                 ffpmsg_slice(&temp);
                 lParse.status = COL_NOT_FOUND;
@@ -2885,8 +2854,8 @@ fn find_column(lParse: &mut ParseData, colName: &[c_char], itslval: *mut c_void)
             }
             lParse.status = tstatus;
 
-            varInfo = lParse.varData.wrapping_add(col_cnt as usize);
-            colIter = lParse.colData.wrapping_add(col_cnt as usize);
+            varInfo = &mut lParse.varData[col_cnt as usize];
+            colIter = &mut lParse.colData[col_cnt as usize];
 
             fptr = unsafe {
                 (*lParse.pixFilter)
@@ -2894,18 +2863,21 @@ fn find_column(lParse: &mut ParseData, colName: &[c_char], itslval: *mut c_void)
                     .wrapping_add(colnum as usize)
                     .read()
             };
+
             fits_get_img_param(
                 unsafe { &mut *fptr },
                 MAXDIMS,
                 Some(&mut typecode), /* actually bitpix */
-                Some(unsafe { &mut (*varInfo).naxis }),
-                Some(unsafe { &mut (*varInfo).naxes }),
+                Some(unsafe { &mut varInfo.naxis }),
+                Some(unsafe { &mut varInfo.naxes }),
                 &mut status,
             );
-            (*varInfo).nelem = 1;
+
+            varInfo.nelem = 1;
             ktype = fits_parser_yytokentype::COLUMN as c_int;
+
             if set_image_col_types(
-                lParse,
+                &mut lParse.status,
                 unsafe { &mut *fptr },
                 colName,
                 typecode,
@@ -2915,8 +2887,8 @@ fn find_column(lParse: &mut ParseData, colName: &[c_char], itslval: *mut c_void)
             {
                 return pERROR;
             }
-            (*colIter).fptr = fptr;
-            (*colIter).iotype = InputCol;
+            colIter.fptr = fptr;
+            colIter.iotype = InputCol;
         } else {
             /* HDU holds a table */
             if lParse.compressed != 0 {
@@ -2960,33 +2932,28 @@ fn find_column(lParse: &mut ParseData, colName: &[c_char], itslval: *mut c_void)
             }
             lParse.status = tstatus;
 
-            varInfo = lParse.varData.wrapping_add(col_cnt as usize);
-            colIter = lParse.colData.wrapping_add(col_cnt as usize);
+            varInfo = &mut lParse.varData[col_cnt as usize];
+            colIter = &mut lParse.colData[col_cnt as usize];
 
-            fits_iter_set_by_num(colIter, fptr, colnum, 0, InputCol);
+            fits_iter_set_by_num_safe(colIter, fptr, colnum, 0, InputCol);
         }
 
         /*  Make sure we don't overflow variable name array  */
-        strncpy((*varInfo).name.as_mut_ptr(), colName.as_ptr(), MAXVARNAME);
-        (*varInfo).name[MAXVARNAME] = 0;
+        strncpy_safe(&mut varInfo.name, colName, MAXVARNAME);
+        varInfo.name[MAXVARNAME] = 0;
 
         if lParse.hdutype != IMAGE_HDU {
             match typecode {
                 TBIT => {
-                    (*varInfo).dtype = fits_parser_yytokentype::BITSTR as c_int;
-                    (*colIter).datatype = TBYTE;
+                    varInfo.dtype = fits_parser_yytokentype::BITSTR as c_int;
+                    colIter.datatype = TBYTE;
                     ktype = fits_parser_yytokentype::BITCOL as c_int;
                 }
                 TBYTE | TSHORT | TLONG => {
                     /* The datatype of column with TZERO and TSCALE keywords might be
                        float or double.
                     */
-                    snprintf(
-                        temp.as_mut_ptr(),
-                        80,
-                        c"TZERO%d".as_ptr() as *const c_char,
-                        colnum,
-                    );
+                    int_snprintf!(&mut temp, 80, "TZERO{}", colnum,);
                     istatus = 0;
                     if fits_read_key_dbl(
                         unsafe { &mut *fptr },
@@ -2998,12 +2965,7 @@ fn find_column(lParse: &mut ParseData, colName: &[c_char], itslval: *mut c_void)
                     {
                         tzero = 0.0;
                     }
-                    snprintf(
-                        temp.as_mut_ptr(),
-                        80,
-                        c"TSCAL%d".as_ptr() as *const c_char,
-                        colnum,
-                    );
+                    int_snprintf!(&mut temp, 80, "TSCAL{}", colnum,);
                     istatus = 0;
                     if fits_read_key_dbl(
                         unsafe { &mut *fptr },
@@ -3016,8 +2978,8 @@ fn find_column(lParse: &mut ParseData, colName: &[c_char], itslval: *mut c_void)
                         tscale = 1.0;
                     }
                     if tscale == 1.0 && (tzero == 0.0 || tzero == 32768.0) {
-                        (*varInfo).dtype = fits_parser_yytokentype::LONG as c_int;
-                        (*colIter).datatype = TLONG;
+                        varInfo.dtype = fits_parser_yytokentype::LONG as c_int;
+                        colIter.datatype = TLONG;
                     /*    Reading an unsigned long column as a long can cause overflow errors.
                          Treat the column as a double instead.
                          } else if (tscale == 1.0 &&  tzero == 2147483648.0 ) {
@@ -3025,8 +2987,8 @@ fn find_column(lParse: &mut ParseData, colName: &[c_char], itslval: *mut c_void)
                              (*colIter).datatype = TULONG;
                     */
                     } else {
-                        (*varInfo).dtype = fits_parser_yytokentype::DOUBLE as c_int;
-                        (*colIter).datatype = TDOUBLE;
+                        varInfo.dtype = fits_parser_yytokentype::DOUBLE as c_int;
+                        colIter.datatype = TDOUBLE;
                     }
                     ktype = fits_parser_yytokentype::COLUMN as c_int;
                 }
@@ -3036,25 +2998,24 @@ fn find_column(lParse: &mut ParseData, colName: &[c_char], itslval: *mut c_void)
                   will be to add support for TLONGLONG as a separate datatype.
                 */
                 TLONGLONG | TFLOAT | TDOUBLE => {
-                    (*varInfo).dtype = fits_parser_yytokentype::DOUBLE as c_int;
-                    (*colIter).datatype = TDOUBLE;
+                    varInfo.dtype = fits_parser_yytokentype::DOUBLE as c_int;
+                    colIter.datatype = TDOUBLE;
                     ktype = fits_parser_yytokentype::COLUMN as c_int;
                 }
                 TLOGICAL => {
-                    (*varInfo).dtype = fits_parser_yytokentype::BOOLEAN as c_int;
-                    (*colIter).datatype = TLOGICAL;
+                    varInfo.dtype = fits_parser_yytokentype::BOOLEAN as c_int;
+                    colIter.datatype = TLOGICAL;
                     ktype = fits_parser_yytokentype::BCOLUMN as c_int;
                 }
                 TSTRING => {
-                    (*varInfo).dtype = fits_parser_yytokentype::STRING as c_int;
-                    (*colIter).datatype = TSTRING;
+                    varInfo.dtype = fits_parser_yytokentype::STRING as c_int;
+                    colIter.datatype = TSTRING;
                     ktype = fits_parser_yytokentype::SCOLUMN as c_int;
                     if width >= MAX_STRLEN.into() {
-                        snprintf(
-                            temp.as_mut_ptr(),
+                        int_snprintf!(
+                            &mut temp,
                             80,
-                            c"column %d is wider than maximum %d characters".as_ptr()
-                                as *const c_char,
+                            "column {} is wider than maximum {} characters",
                             colnum,
                             MAX_STRLEN - 1,
                         );
@@ -3068,11 +3029,10 @@ fn find_column(lParse: &mut ParseData, colName: &[c_char], itslval: *mut c_void)
                 }
                 _ => {
                     if typecode < 0 {
-                        snprintf(
-                            temp.as_mut_ptr(),
+                        int_snprintf!(
+                            &mut temp,
                             80,
-                            c"variable-length array columns are not supported. typecode = %d"
-                                .as_ptr() as *const c_char,
+                            "variable-length array columns are not supported. typecode = {}",
                             typecode,
                         );
                         ffpmsg_slice(&temp);
@@ -3081,15 +3041,15 @@ fn find_column(lParse: &mut ParseData, colName: &[c_char], itslval: *mut c_void)
                     return pERROR;
                 }
             }
-            (*varInfo).nelem = repeat;
-            (*colIter).repeat = 0; /* ffiter() will fill in this value */
+            varInfo.nelem = repeat;
+            colIter.repeat = 0; /* ffiter() will fill in this value */
             if repeat > 1 && typecode != TSTRING {
                 if fits_read_tdim(
                     unsafe { &mut *fptr },
                     colnum,
                     MAXDIMS,
-                    unsafe { &mut (*varInfo).naxis },
-                    unsafe { &mut (*varInfo).naxes },
+                    unsafe { &mut varInfo.naxis },
+                    unsafe { &mut varInfo.naxes },
                     &mut status,
                 ) != 0
                 {
@@ -3097,8 +3057,8 @@ fn find_column(lParse: &mut ParseData, colName: &[c_char], itslval: *mut c_void)
                     return pERROR;
                 }
             } else {
-                (*varInfo).naxis = 1;
-                (*varInfo).naxes[0] = 1;
+                varInfo.naxis = 1;
+                varInfo.naxes[0] = 1;
             }
         }
         lParse.nCols += 1;
@@ -3157,7 +3117,7 @@ fn find_keywd(lParse: &mut ParseData, keyname: &[c_char], itslval: *mut c_void) 
         /* Read appropriate value type and set to CONST_OP */
         match dtype as u8 {
             b'C' => {
-                // 'C' as i8
+                // 'C' as c_char
                 fits_read_key_str(
                     unsafe { &mut *fptr },
                     keyname,
@@ -3169,7 +3129,7 @@ fn find_keywd(lParse: &mut ParseData, keyname: &[c_char], itslval: *mut c_void) 
                 strcpy(unsafe { (*thelval).astr.as_mut_ptr() }, keyvalue.as_ptr());
             }
             b'L' => {
-                // 'L' as i8
+                // 'L' as c_char
                 fits_read_key_log(unsafe { &mut *fptr }, keyname, &mut bval, None, &mut status);
                 ktype = fits_parser_yytokentype::BOOLEAN as c_int;
                 unsafe {
@@ -3177,7 +3137,7 @@ fn find_keywd(lParse: &mut ParseData, keyname: &[c_char], itslval: *mut c_void) 
                 }
             }
             b'I' => {
-                // 'I' as i8
+                // 'I' as c_char
                 fits_read_key_lng(unsafe { &mut *fptr }, keyname, &mut ival, None, &mut status);
                 ktype = fits_parser_yytokentype::LONG as c_int;
                 unsafe {
@@ -3185,7 +3145,7 @@ fn find_keywd(lParse: &mut ParseData, keyname: &[c_char], itslval: *mut c_void) 
                 }
             }
             b'F' => {
-                // 'F' as i8
+                // 'F' as c_char
                 fits_read_key_dbl(unsafe { &mut *fptr }, keyname, &mut rval, None, &mut status);
                 ktype = fits_parser_yytokentype::DOUBLE as c_int;
                 unsafe {
@@ -3206,54 +3166,29 @@ fn find_keywd(lParse: &mut ParseData, keyname: &[c_char], itslval: *mut c_void) 
     }
 }
 
-/* Allocates parser iterator column storage for 25 columns *more* than
-nCols */
+/// Allocates parser iterator column storage for 25 columns *more* than nCols
 fn fits_parser_allocateCol(lParse: &mut ParseData, nCol: c_int, status: &mut c_int) -> c_int {
-    unsafe {
-        if (nCol % 25) == 0 {
-            lParse.colData = fits_recalloc(
-                lParse.colData as *mut c_void,
-                nCol.try_into().unwrap(),
-                (nCol + 25).try_into().unwrap(),
-                size_of::<iteratorCol>(),
-            ) as *mut iteratorCol;
-            lParse.varData = fits_recalloc(
-                lParse.varData as *mut c_void,
-                nCol.try_into().unwrap(),
-                (nCol + 25).try_into().unwrap(),
-                size_of::<DataInfo>(),
-            ) as *mut DataInfo;
+    if (nCol % 25) == 0 {
+        if lParse.colData.try_reserve_exact(25).is_err() {
+            lParse.colData.clear();
+            lParse.varData.clear();
 
-            memset(
-                (lParse.colData as *mut c_void).add(nCol as usize * size_of::<iteratorCol>()),
-                0x00,
-                size_of::<iteratorCol>() * 25,
-            );
-            memset(
-                (lParse.varData as *mut c_void).add(nCol as usize * size_of::<DataInfo>()),
-                0x00,
-                size_of::<DataInfo>() * 25,
-            );
+            *status = MEMORY_ALLOCATION;
+            return *status;
+        }
 
-            if lParse.colData.is_null() || lParse.varData.is_null() {
-                if !lParse.colData.is_null() {
-                    free(lParse.colData as *mut c_void);
-                }
-                if !lParse.varData.is_null() {
-                    free(lParse.varData as *mut c_void);
-                }
-                lParse.colData = ptr::null_mut();
-                lParse.varData = ptr::null_mut();
-                *status = MEMORY_ALLOCATION;
-                return *status;
-            }
+        if lParse.varData.try_reserve_exact(25).is_err() {
+            lParse.colData.clear();
+            lParse.varData.clear();
+
+            *status = MEMORY_ALLOCATION;
+            return *status;
         }
-        unsafe {
-            (*lParse.varData.wrapping_add(nCol as usize)).data = ptr::null_mut();
-            (*lParse.varData.wrapping_add(nCol as usize)).undef = ptr::null_mut();
-        }
-        0
     }
+    (lParse.varData[nCol as usize]).data = ptr::null_mut();
+    (lParse.varData[nCol as usize]).undef = ptr::null_mut();
+
+    0
 }
 
 fn load_column(
@@ -3276,13 +3211,13 @@ fn load_column(
         let mut status: c_int = 0;
         let mut anynul: c_int = 0;
 
-        let var: *mut iteratorCol = lParse.colData.wrapping_add(varNum as usize);
+        let var: &mut iteratorCol = &mut lParse.colData[varNum as usize];
         if lParse.hdutype == IMAGE_HDU {
             /* This test would need to be on a per varNum basis to support
              * cross HDU operations */
             fits_read_imgnull(
-                unsafe { &mut *(*var).fptr },
-                (*var).datatype,
+                unsafe { &mut *var.fptr },
+                var.datatype,
                 fRow,
                 nRows,
                 unsafe { std::slice::from_raw_parts_mut(data as *mut u8, (nRows * 8) as usize) }, // Assuming 8 bytes per element
@@ -3291,24 +3226,22 @@ fn load_column(
                 &mut status,
             );
             if DEBUG_PIXFILTER != 0 {
-                printf(
-                    c"load_column: IMAGE_HDU fRow=%ld, nRows=%ld => %d\n".as_ptr() as *const c_char,
-                    fRow,
-                    nRows,
-                    status,
+                println!(
+                    "load_column: IMAGE_HDU fRow={}, nRows={} => {}",
+                    fRow, nRows, status,
                 );
             }
         } else {
-            nelem = nRows * (*var).repeat;
+            nelem = nRows * var.repeat;
 
-            match (*var).datatype {
+            match var.datatype {
                 TBYTE => {
-                    nbytes = (((*var).repeat + 7) / 8) * nRows;
+                    nbytes = ((var.repeat + 7) / 8) * nRows;
                     bytes = malloc((nbytes as usize) * size_of::<c_char>()) as *mut c_uchar;
 
                     ffgcvb_safe(
-                        unsafe { &mut *(*var).fptr },
-                        (*var).colnum,
+                        unsafe { &mut *var.fptr },
+                        var.colnum,
                         fRow,
                         1,
                         nbytes,
@@ -3318,7 +3251,7 @@ fn load_column(
                         &mut status,
                     );
 
-                    nelem = (*var).repeat;
+                    nelem = var.repeat;
                     bitStrs = data as *mut *mut c_char;
                     for row in 0..nRows {
                         idx = (row) * ((nelem + 7) / 8) + 1;
@@ -3328,12 +3261,12 @@ fn load_column(
                             {
                                 unsafe {
                                     *(*bitStrs.wrapping_add(row as usize))
-                                        .wrapping_add(len as usize) = b'1' as i8;
+                                        .wrapping_add(len as usize) = b'1' as c_char;
                                 }
                             } else {
                                 unsafe {
                                     *(*bitStrs.wrapping_add(row as usize))
-                                        .wrapping_add(len as usize) = b'0' as i8;
+                                        .wrapping_add(len as usize) = b'0' as c_char;
                                 }
                             }
                             if len % 8 == 7 {
@@ -3353,7 +3286,7 @@ fn load_column(
                     let mut string_vec = Vec::new();
                     for i in 0..nRows {
                         let str_ptr = unsafe { *data_ptr_array.wrapping_add(i as usize) };
-                        let str_len = unsafe { strlen(str_ptr as *const c_char) };
+                        let str_len = strlen(str_ptr as *const c_char);
                         let str_slice =
                             unsafe { std::slice::from_raw_parts_mut(str_ptr, str_len + 1) };
                         string_vec.push(str_slice);
@@ -3362,8 +3295,8 @@ fn load_column(
                         unsafe { std::slice::from_raw_parts_mut(undef, nRows as usize) };
 
                     ffgcfs_safe(
-                        unsafe { &mut *(*var).fptr },
-                        (*var).colnum,
+                        unsafe { &mut *var.fptr },
+                        var.colnum,
                         fRow,
                         1,
                         nRows,
@@ -3381,8 +3314,8 @@ fn load_column(
                         unsafe { std::slice::from_raw_parts_mut(undef, nelem as usize) };
 
                     ffgcfl_safe(
-                        unsafe { &mut *(*var).fptr },
-                        (*var).colnum,
+                        unsafe { &mut *var.fptr },
+                        var.colnum,
                         fRow,
                         1,
                         nelem,
@@ -3394,8 +3327,8 @@ fn load_column(
                 }
                 TLONG => {
                     ffgcfj_safe(
-                        &mut *(*var).fptr,
-                        (*var).colnum,
+                        &mut *var.fptr,
+                        var.colnum,
                         fRow,
                         1,
                         nelem,
@@ -3414,8 +3347,8 @@ fn load_column(
                         unsafe { std::slice::from_raw_parts_mut(undef, nelem as usize) };
 
                     ffgcfd_safe(
-                        unsafe { &mut *(*var).fptr },
-                        (*var).colnum,
+                        unsafe { &mut *var.fptr },
+                        var.colnum,
                         fRow,
                         1,
                         nelem,
@@ -3426,11 +3359,11 @@ fn load_column(
                     );
                 }
                 _ => {
-                    snprintf(
-                        msg.as_mut_ptr(),
+                    int_snprintf!(
+                        &mut msg,
                         80,
-                        b"load_column: unexpected datatype %d\0".as_ptr() as *const c_char,
-                        (*var).datatype,
+                        "load_column: unexpected datatype {}",
+                        var.datatype,
                     );
                     ffpmsg_slice(&msg);
                 }

--- a/src/eval_f.rs
+++ b/src/eval_f.rs
@@ -1332,7 +1332,7 @@ pub(crate) fn ffiprs(
         /*  Initialize the Parser structure  */
 
         /* Unfortunately we need to preserve the pixFilter value since it is pre-set when ffiprs() is called */
-        let pixFilter: &mut PixelFilter = &mut *lParse.pixFilter;
+        let pixFilter: *mut PixelFilter = lParse.pixFilter;
 
         lParse.reset();
 
@@ -3169,20 +3169,30 @@ fn find_keywd(lParse: &mut ParseData, keyname: &[c_char], itslval: *mut c_void) 
 /// Allocates parser iterator column storage for 25 columns *more* than nCols
 fn fits_parser_allocateCol(lParse: &mut ParseData, nCol: c_int, status: &mut c_int) -> c_int {
     if (nCol % 25) == 0 {
+        let existing_len = lParse.colData.len();
         if lParse.colData.try_reserve_exact(25).is_err() {
             lParse.colData.clear();
             lParse.varData.clear();
 
             *status = MEMORY_ALLOCATION;
             return *status;
+        } else {
+            lParse
+                .colData
+                .resize(existing_len + 25, iteratorCol::default());
         }
 
+        let existing_len = lParse.varData.len();
         if lParse.varData.try_reserve_exact(25).is_err() {
             lParse.colData.clear();
             lParse.varData.clear();
 
             *status = MEMORY_ALLOCATION;
             return *status;
+        } else {
+            lParse
+                .varData
+                .resize(existing_len + 25, DataInfo::default());
         }
     }
     (lParse.varData[nCol as usize]).data = ptr::null_mut();

--- a/src/eval_f.rs
+++ b/src/eval_f.rs
@@ -1616,7 +1616,7 @@ fn fits_parser_workfn_safe(
         /*--------------------------------------------------------*/
         /*  Initialization procedures: execute on the first call  */
         /*--------------------------------------------------------*/
-        outcol = &mut colData[(nCols - 1) as usize];
+
         if firstrow == offset + 1 {
             (pv.userInfo) = userPtr as *mut parseInfo;
             (*(pv.userInfo)).anyNull = 0;
@@ -1630,8 +1630,6 @@ fn fits_parser_workfn_safe(
             for jj in 0..(nCols as usize) {
                 lParse.colData[jj].repeat = colData[jj].repeat;
             }
-
-            outcol = &mut colData[(nCols - 1) as usize]; // Re-bind
 
             if (*(pv.userInfo)).maxRows > 0 {
                 (*(pv.userInfo)).maxRows = cmp::min(totalrows, (*(pv.userInfo)).maxRows);
@@ -1647,6 +1645,7 @@ fn fits_parser_workfn_safe(
             means that the first value will be a null value and the remaining
             values will be the where the outputs are placed */
             if (*(pv.userInfo)).dataPtr.is_null() {
+                outcol = &mut colData[(nCols - 1) as usize]; // Re-bind
                 if outcol.iotype == InputCol {
                     ffpmsg_str("Output column for parser results not found!");
                     return PARSE_NO_OUTPUT;
@@ -1770,6 +1769,8 @@ fn fits_parser_workfn_safe(
         */
 
         if (*(pv.userInfo)).dataPtr.is_null() {
+            outcol = &mut colData[(nCols - 1) as usize]; // Re-bind
+
             /* First, reset Data pointer to start of output array, plus 1
             because the 0th element is the null value (cute undocumented
             feature of the iterator!) */
@@ -2124,7 +2125,11 @@ fn fits_parser_workfn_safe(
 
         /* If a TemporaryCol output is used, we want to inform the caller
         what the null value is expected to be */
-        outcol = &mut colData[(nCols - 1) as usize]; // Re-bind 
+        
+        // WARNING - THIS IS DANGEROUS. If nCols = 0, points to invalid memory.
+        // In the case of the where expr = "#ROW > 2" there are no columns.
+        outcol = colData.as_mut_ptr().offset((nCols - 1) as isize).as_mut().unwrap(); 
+        // outcol = &mut colData[(nCols - 1) as usize]; // Re-bind 
 
         if pv.Null != outcol.array
             && (Data0)

--- a/src/eval_f.rs
+++ b/src/eval_f.rs
@@ -65,7 +65,7 @@ use crate::aliases::rust_api::{
 use crate::cfileio::ffimport_file_safer;
 use crate::editcol::{ffdrow_safe, fficol_safe, ffirow_safe};
 use crate::eval_defs::{
-    CONST_OP, DataInfo, MAX_STRLEN, MAXDIMS, MAXVARNAME, Node, ParseData, pERROR, parseInfo,
+    CONST_OP, DataInfo, MAX_STRLEN, MAXDIMS, MAXVARNAME, Node, P_ERROR, ParseData, parseInfo,
 };
 use crate::eval_l::{
     fits_parser_yylex_destroy, fits_parser_yylex_init_extra, fits_parser_yyrestart, yyguts_t,
@@ -1493,7 +1493,7 @@ fn ffcprs(lParse: &mut ParseData) {
     unsafe {
         let col: c_int = 0;
         let mut node: c_int = 0;
-        let mut i: c_int = 0;
+        let mut i: usize = 0;
 
         if lParse.nCols > 0 {
             lParse.colData.clear();
@@ -1522,14 +1522,14 @@ fn ffcprs(lParse: &mut ParseData) {
                 node -= 1;
                 if (lParse.Nodes[node as usize]).operation == gtifilt_fct as c_int {
                     i = lParse.Nodes[node as usize].SubNodes[0];
-                    if !(lParse.Nodes[i as usize]).value.data.ptr.is_null() {
-                        let mut data_ptr = (lParse.Nodes[i as usize]).value.data.ptr;
+                    if !(lParse.Nodes[i]).value.data.ptr.is_null() {
+                        let mut data_ptr = (lParse.Nodes[i]).value.data.ptr;
                         FREE!(data_ptr);
                     }
                 } else if (lParse.Nodes[node as usize]).operation == regfilt_fct as c_int {
                     i = (lParse.Nodes[node as usize]).SubNodes[0];
                     fits_free_region(Box::from_raw(
-                        (lParse.Nodes[i as usize]).value.data.ptr as *mut SAORegion,
+                        (lParse.Nodes[i]).value.data.ptr as *mut SAORegion,
                     ));
                 }
             }
@@ -2362,7 +2362,7 @@ pub fn fits_pixel_filter_safer(
                 }
                 TSTRING => {
                     rtype = "STRING";
-                    *status = pERROR;
+                    *status = P_ERROR;
                     ffpmsg_str("pixel_filter: cannot have string image");
                 }
                 TBIT => {
@@ -2373,7 +2373,7 @@ pub fn fits_pixel_filter_safer(
                 }
                 _ => {
                     rtype = "UNKNOWN?!";
-                    *status = pERROR;
+                    *status = P_ERROR;
                     ffpmsg_str("pixel_filter: unexpected result datatype");
                 }
             }
@@ -2529,7 +2529,7 @@ pub fn fits_pixel_filter_safer(
                     );
                 }
                 ffpmsg_slice(&msg);
-                *status = pERROR;
+                *status = P_ERROR;
                 ffcprs(&mut lParse);
                 return *status;
             }
@@ -2820,7 +2820,7 @@ fn find_column(lParse: &mut ParseData, colName: &[c_char], itslval: *mut c_void)
             if lParse.pixFilter.is_null() {
                 lParse.status = COL_NOT_FOUND;
                 ffpmsg_str("find_column: IMAGE_HDU but no PixelFilter");
-                return pERROR;
+                return P_ERROR;
             }
 
             colnum = -1;
@@ -2844,13 +2844,13 @@ fn find_column(lParse: &mut ParseData, colName: &[c_char], itslval: *mut c_void)
                 );
                 ffpmsg_slice(&temp);
                 lParse.status = COL_NOT_FOUND;
-                return pERROR;
+                return P_ERROR;
             }
 
             let mut tstatus = 0;
             if fits_parser_allocateCol(lParse, col_cnt, &mut tstatus) != 0 {
                 lParse.status = tstatus;
-                return pERROR;
+                return P_ERROR;
             }
             lParse.status = tstatus;
 
@@ -2885,7 +2885,7 @@ fn find_column(lParse: &mut ParseData, colName: &[c_char], itslval: *mut c_void)
                 colIter,
             ) != 0
             {
-                return pERROR;
+                return P_ERROR;
             }
             colIter.fptr = fptr;
             colIter.iotype = InputCol;
@@ -2903,13 +2903,13 @@ fn find_column(lParse: &mut ParseData, colName: &[c_char], itslval: *mut c_void)
             {
                 if status == COL_NOT_FOUND {
                     ktype = find_keywd(lParse, colName, itslval);
-                    if ktype != pERROR {
+                    if ktype != P_ERROR {
                         ffcmsg_safe();
                     }
                     return ktype;
                 }
                 lParse.status = status;
-                return pERROR;
+                return P_ERROR;
             }
 
             if fits_get_coltype(
@@ -2922,13 +2922,13 @@ fn find_column(lParse: &mut ParseData, colName: &[c_char], itslval: *mut c_void)
             ) != 0
             {
                 lParse.status = status;
-                return pERROR;
+                return P_ERROR;
             }
 
             let mut tstatus = 0;
             if fits_parser_allocateCol(lParse, col_cnt, &mut tstatus) != 0 {
                 lParse.status = tstatus;
-                return pERROR;
+                return P_ERROR;
             }
             lParse.status = tstatus;
 
@@ -3021,7 +3021,7 @@ fn find_column(lParse: &mut ParseData, colName: &[c_char], itslval: *mut c_void)
                         );
                         ffpmsg_slice(&temp);
                         lParse.status = PARSE_LRG_VECTOR;
-                        return pERROR;
+                        return P_ERROR;
                     }
                     if lParse.hdutype == ASCII_TBL {
                         repeat = width;
@@ -3038,7 +3038,7 @@ fn find_column(lParse: &mut ParseData, colName: &[c_char], itslval: *mut c_void)
                         ffpmsg_slice(&temp);
                     }
                     lParse.status = PARSE_BAD_TYPE;
-                    return pERROR;
+                    return P_ERROR;
                 }
             }
             varInfo.nelem = repeat;
@@ -3054,7 +3054,7 @@ fn find_column(lParse: &mut ParseData, colName: &[c_char], itslval: *mut c_void)
                 ) != 0
                 {
                     lParse.status = status;
-                    return pERROR;
+                    return P_ERROR;
                 }
             } else {
                 varInfo.naxis = 1;
@@ -3106,12 +3106,12 @@ fn find_keywd(lParse: &mut ParseData, keyname: &[c_char], itslval: *mut c_void) 
                 ffpmsg_slice(&keyvalue);
             }
             lParse.status = status;
-            return pERROR;
+            return P_ERROR;
         }
 
         if fits_get_keytype(&keyvalue, &mut dtype, &mut status) != 0 {
             lParse.status = status;
-            return pERROR;
+            return P_ERROR;
         }
 
         /* Read appropriate value type and set to CONST_OP */
@@ -3153,13 +3153,13 @@ fn find_keywd(lParse: &mut ParseData, keyname: &[c_char], itslval: *mut c_void) 
                 }
             }
             _ => {
-                ktype = pERROR;
+                ktype = P_ERROR;
             }
         }
 
         if status != 0 {
             lParse.status = status;
-            return pERROR;
+            return P_ERROR;
         }
 
         ktype
@@ -3371,7 +3371,7 @@ fn load_column(
         }
         if status != 0 {
             lParse.status = status;
-            return pERROR;
+            return P_ERROR;
         }
 
         0

--- a/src/eval_f.rs
+++ b/src/eval_f.rs
@@ -2125,11 +2125,15 @@ fn fits_parser_workfn_safe(
 
         /* If a TemporaryCol output is used, we want to inform the caller
         what the null value is expected to be */
-        
+
         // WARNING - THIS IS DANGEROUS. If nCols = 0, points to invalid memory.
         // In the case of the where expr = "#ROW > 2" there are no columns.
-        outcol = colData.as_mut_ptr().offset((nCols - 1) as isize).as_mut().unwrap(); 
-        // outcol = &mut colData[(nCols - 1) as usize]; // Re-bind 
+        outcol = colData
+            .as_mut_ptr()
+            .offset((nCols - 1) as isize)
+            .as_mut()
+            .unwrap();
+        // outcol = &mut colData[(nCols - 1) as usize]; // Re-bind
 
         if pv.Null != outcol.array
             && (Data0)

--- a/src/eval_l.rs
+++ b/src/eval_l.rs
@@ -8,13 +8,16 @@
     unused_mut
 )]
 
+use std::ffi::CStr;
+
+use bytemuck::cast_slice;
 use libc::{
     __errno_location, FILE, atof, atol, exit, fileno, fprintf, free, fwrite, isatty, malloc,
     memset, realloc, size_t,
 };
 
 use crate::c_types::{c_char, c_int, c_long, c_short, c_uchar, c_uint, c_ulong, c_void};
-use crate::eval_defs::ParseData;
+use crate::eval_defs::{MAXVARNAME, ParseData, yyscan_t};
 use crate::eval_tab::*;
 use crate::wrappers::isdigit_safe;
 use crate::{
@@ -34,7 +37,7 @@ pub type int16_t = __int16_t;
 pub type uint8_t = __uint8_t;
 pub type flex_uint8_t = uint8_t;
 pub type flex_int16_t = int16_t;
-pub type yyscan_t = *mut c_void;
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct yy_buffer_state {
@@ -117,8 +120,8 @@ unsafe fn expr_read(mut lParse: *mut ParseData, mut buf: *mut c_char, mut nbytes
 }
 
 pub unsafe fn fits_parser_yyGetVariable(
-    mut lParse: *mut ParseData,
-    mut varName: *mut c_char,
+    lParse: &mut ParseData,
+    varName: &[c_char],
     mut thelval: *mut FITS_PARSER_YYSTYPE,
 ) -> c_int {
     unsafe {
@@ -127,24 +130,24 @@ pub unsafe fn fits_parser_yyGetVariable(
         let mut errMsg: [c_char; 105] = [0; 105];
         varNum = find_variable(lParse, varName);
         if varNum < 0 as c_int {
-            if ((*lParse).getData).is_some() {
-                dtype = ((*lParse).getData).expect("non-null function pointer")(
+            if (lParse.getData).is_some() {
+                dtype = (lParse.getData).expect("non-null function pointer")(
                     lParse,
                     varName,
                     thelval as *mut c_void,
                 );
             } else {
                 dtype = -(1);
-                (*lParse).status = 431 as c_int;
+                lParse.status = 431 as c_int;
                 strcpy(
                     errMsg.as_mut_ptr(),
                     b"Unable to find data: \0" as *const u8 as *const c_char,
                 );
-                strncat(errMsg.as_mut_ptr(), varName, 80);
+                strncat(errMsg.as_mut_ptr(), varName.as_ptr(), MAXVARNAME);
                 ffpmsg_slice(&errMsg);
             }
         } else {
-            match (*((*lParse).varData).offset(varNum as isize)).dtype {
+            match (*(lParse.varData).offset(varNum as isize)).dtype {
                 259 | 260 => {
                     dtype = fits_parser_yytokentype::COLUMN as c_int;
                 }
@@ -159,12 +162,12 @@ pub unsafe fn fits_parser_yyGetVariable(
                 }
                 _ => {
                     dtype = -(1);
-                    (*lParse).status = 431 as c_int;
+                    lParse.status = 431 as c_int;
                     strcpy(
                         errMsg.as_mut_ptr(),
                         b"Bad datatype for data: \0" as *const u8 as *const c_char,
                     );
-                    strncat(errMsg.as_mut_ptr(), varName, 80);
+                    strncat(errMsg.as_mut_ptr(), varName.as_ptr(), 80);
                     ffpmsg_slice(&errMsg);
                 }
             }
@@ -173,19 +176,18 @@ pub unsafe fn fits_parser_yyGetVariable(
         dtype
     }
 }
-unsafe fn find_variable(mut lParse: *mut ParseData, mut varName: *mut c_char) -> c_int {
+unsafe fn find_variable(lParse: &mut ParseData, varName: &[c_char]) -> c_int {
     unsafe {
         let mut i: c_int = 0;
-        if (*lParse).nCols != 0 {
+        if lParse.nCols != 0 {
             i = 0 as c_int;
-            while i < (*lParse).nCols {
+            while i < lParse.nCols {
                 if {
                     let s1 = std::slice::from_raw_parts(
-                        ((*((*lParse).varData).offset(i as isize)).name).as_ptr(),
-                        80,
+                        ((*(lParse.varData).offset(i as isize)).name).as_ptr(),
+                        MAXVARNAME,
                     );
-                    let s2 = std::slice::from_raw_parts(varName, 80);
-                    fits_strncasecmp(s1, s2, 80 as c_int as size_t)
+                    fits_strncasecmp(s1, varName, MAXVARNAME)
                 } == 0
                 {
                     return i;
@@ -829,10 +831,15 @@ pub unsafe fn fits_parser_yylex(
                                             0_i32 as c_char;
                                         (*yyg).yytext_r = ((*(*yyg).yylval_r).astr).as_mut_ptr();
                                     }
+
+                                    let yytext_r_slice = cast_slice(
+                                        CStr::from_ptr((*yyg).yytext_r).to_bytes_with_nul(),
+                                    );
+
                                     result = ((*(*yyg).yyextra_r).getData)
                                         .expect("non-null function pointer")(
-                                        (*yyg).yyextra_r,
-                                        (*yyg).yytext_r,
+                                        &mut *(*yyg).yyextra_r,
+                                        yytext_r_slice,
                                         (*yyg).yylval_r as *mut c_void,
                                     );
                                     return result;
@@ -885,9 +892,13 @@ pub unsafe fn fits_parser_yylex(
                                     (*(*yyg).yylval_r).astr[len_4 as usize] = 0_i32 as c_char;
                                     (*yyg).yytext_r = ((*(*yyg).yylval_r).astr).as_mut_ptr();
                                 }
+
+                                let yytext_r_slice =
+                                    cast_slice(CStr::from_ptr((*yyg).yytext_r).to_bytes_with_nul());
+
                                 dtype = fits_parser_yyGetVariable(
-                                    (*yyg).yyextra_r,
-                                    (*yyg).yytext_r,
+                                    &mut *(*yyg).yyextra_r,
+                                    yytext_r_slice,
                                     (*yyg).yylval_r,
                                 );
                                 return dtype;

--- a/src/eval_l.rs
+++ b/src/eval_l.rs
@@ -1,21 +1,25 @@
+#![deny(dead_code)]
+
 use errno::{Errno, set_errno};
 
 use std::ffi::CStr;
+use std::process::exit;
 
 use bytemuck::cast_slice;
 use libc::{
-    __errno_location, ENOMEM, FILE, atof, atol, exit, fileno, fprintf, free, fwrite, isatty,
-    malloc, memset, realloc, size_t,
+    __errno_location, ENOMEM, FILE, atof, atol, fileno, free, fwrite, isatty, malloc, memset,
+    realloc, size_t,
 };
 
 use crate::c_types::{c_char, c_int, c_long, c_short, c_uchar, c_uint, c_ulong, c_void};
-use crate::eval_defs::{MAXVARNAME, ParseData};
+use crate::eval_defs::{MAXVARNAME, P_ERROR, ParseData};
+use crate::fitsio::PARSE_SYNTAX_ERR;
 use crate::helpers::boxed::box_try_new;
 use crate::wrappers::{isdigit_safe, strcpy_safe, strncat_safe};
 use crate::{cs, eval_tab::*};
 use crate::{
     fitscore::{ffpmsg_slice, fits_strcasecmp, fits_strncasecmp},
-    stderr, stdin, stdout,
+    stdin, stdout,
     wrappers::{strcat, strcmp, strcpy, strlen, strncat, strncpy, toupper},
 };
 
@@ -131,81 +135,67 @@ fn expr_read(lParse: &mut ParseData, buf: *mut c_char, nbytes: c_int) -> c_int {
 pub(crate) fn fits_parser_yyGetVariable(
     lParse: &mut ParseData,
     varName: &[c_char],
-    thelval: *mut FITS_PARSER_YYSTYPE,
+    thelval: &mut FITS_PARSER_YYSTYPE,
 ) -> c_int {
-    unsafe {
-        let mut varNum: c_int = 0;
-        let mut dtype: c_int = 0;
-        let mut errMsg: [c_char; 105] = [0; 105];
-        varNum = find_variable(lParse, varName);
-        if varNum < 0 as c_int {
-            if (lParse.getData).is_some() {
-                dtype = (lParse.getData).expect("non-null function pointer")(
-                    lParse,
-                    varName,
-                    thelval as *mut c_void,
-                );
-            } else {
-                dtype = -(1);
-                lParse.status = 431 as c_int;
-                strcpy_safe(&mut errMsg, cs!(c"Unable to find data: "));
+    let varNum: c_int = find_variable(lParse, varName);
+    let mut dtype: c_int = 0;
+    let mut errMsg: [c_char; 105] = [0; 105];
+
+    if varNum < 0 as c_int {
+        if (lParse.getData).is_some() {
+            dtype = (lParse.getData).expect("non-null function pointer")(
+                lParse,
+                varName,
+                thelval as *mut _ as *mut c_void,
+            );
+        } else {
+            dtype = -(1);
+            lParse.status = 431 as c_int;
+            strcpy_safe(&mut errMsg, cs!(c"Unable to find data: "));
+            strncat_safe(&mut errMsg, varName, MAXVARNAME);
+            ffpmsg_slice(&errMsg);
+        }
+    } else {
+        /*  Convert variable type into expression type  */
+        match ((lParse.varData)[varNum as usize]).dtype.into() {
+            fits_parser_yytokentype::LONG | fits_parser_yytokentype::DOUBLE => {
+                dtype = fits_parser_yytokentype::COLUMN as c_int;
+            }
+            fits_parser_yytokentype::BOOLEAN => {
+                dtype = fits_parser_yytokentype::BCOLUMN as c_int;
+            }
+            fits_parser_yytokentype::STRING => {
+                dtype = fits_parser_yytokentype::SCOLUMN as c_int;
+            }
+            fits_parser_yytokentype::BITSTR => {
+                dtype = fits_parser_yytokentype::BITCOL as c_int;
+            }
+            _ => {
+                dtype = P_ERROR;
+                lParse.status = PARSE_SYNTAX_ERR;
+                strcpy_safe(&mut errMsg, cs!(c"Bad datatype for data: "));
                 strncat_safe(&mut errMsg, varName, MAXVARNAME);
                 ffpmsg_slice(&errMsg);
             }
-        } else {
-            match ((lParse.varData)[varNum as usize]).dtype {
-                259 | 260 => {
-                    dtype = fits_parser_yytokentype::COLUMN as c_int;
-                }
-                258 => {
-                    dtype = fits_parser_yytokentype::BCOLUMN as c_int;
-                }
-                261 => {
-                    dtype = fits_parser_yytokentype::SCOLUMN as c_int;
-                }
-                262 => {
-                    dtype = fits_parser_yytokentype::BITCOL as c_int;
-                }
-                _ => {
-                    dtype = -(1);
-                    lParse.status = 431 as c_int;
-                    strcpy(
-                        errMsg.as_mut_ptr(),
-                        b"Bad datatype for data: \0" as *const u8 as *const c_char,
-                    );
-                    strncat(errMsg.as_mut_ptr(), varName.as_ptr(), 80);
-                    ffpmsg_slice(&errMsg);
-                }
-            }
-            (*thelval).lng = varNum as c_long;
         }
-        dtype
+
+        thelval.lng = varNum as c_long;
     }
+    dtype
 }
+
 fn find_variable(lParse: &mut ParseData, varName: &[c_char]) -> c_int {
-    unsafe {
-        let mut i: c_int = 0;
-        if lParse.nCols != 0 {
-            i = 0 as c_int;
-            while i < lParse.nCols {
-                if {
-                    let s1 = std::slice::from_raw_parts(
-                        (((lParse.varData)[i as usize]).name).as_ptr(),
-                        MAXVARNAME,
-                    );
-                    fits_strncasecmp(s1, varName, MAXVARNAME)
-                } == 0
-                {
-                    return i;
-                }
-                i += 1;
-                i;
+    if lParse.nCols != 0 {
+        for i in 0..lParse.nCols {
+            if fits_strncasecmp(&((lParse.varData)[i as usize]).name, varName, MAXVARNAME) == 0 {
+                return i;
             }
         }
-        -(1)
     }
+    -1
 }
-static mut YY_ACCEPT: [flex_int16_t; 174] = [
+
+static YY_ACCEPT: [flex_int16_t; 174] = [
     0, 0, 0, 31, 29, 1, 28, 18, 29, 29, 29, 29, 29, 29, 29, 10, 8, 8, 24, 29, 23, 13, 13, 13, 13,
     9, 13, 13, 13, 13, 13, 17, 13, 13, 13, 13, 13, 13, 13, 29, 1, 22, 0, 12, 0, 11, 0, 13, 20, 0,
     0, 0, 0, 0, 0, 0, 17, 0, 10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 8, 0, 0, 0, 0, 26,
@@ -214,7 +204,7 @@ static mut YY_ACCEPT: [flex_int16_t; 174] = [
     0, 0, 0, 10, 5, 6, 7, 14, 13, 23, 24, 13, 13, 13, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 18, 0, 0,
     15, 0, 0, 0, 0, 0, 0, 0, 16, 0, 0,
 ];
-static mut YY_EC: [YY_CHAR; 256] = [
+static YY_EC: [YY_CHAR; 256] = [
     0, 1, 1, 1, 1, 1, 1, 1, 1, 2, 3, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
     2, 4, 5, 6, 7, 1, 8, 9, 10, 11, 12, 13, 1, 13, 14, 1, 15, 16, 17, 17, 17, 17, 17, 17, 18, 18,
     1, 1, 19, 20, 21, 1, 1, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 31, 32, 31, 33, 34, 31, 35, 36,
@@ -225,11 +215,11 @@ static mut YY_EC: [YY_CHAR; 256] = [
     1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
     1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
 ];
-static mut YY_META: [YY_CHAR; 59] = [
+static YY_META: [YY_CHAR; 59] = [
     0, 1, 1, 2, 1, 1, 1, 3, 1, 1, 1, 1, 1, 1, 1, 4, 4, 4, 4, 1, 1, 1, 4, 4, 4, 4, 4, 4, 5, 5, 5, 5,
     5, 5, 5, 5, 5, 5, 5, 5, 1, 1, 5, 4, 4, 4, 4, 4, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 1,
 ];
-static mut YY_BASE: [flex_int16_t; 182] = [
+static YY_BASE: [flex_int16_t; 182] = [
     0, 0, 0, 412, 413, 409, 413, 390, 404, 401, 400, 398, 396, 34, 392, 70, 114, 16, 383, 46, 382,
     29, 84, 359, 28, 358, 52, 157, 64, 91, 128, 358, 0, 40, 27, 69, 92, 100, 171, 340, 395, 413,
     391, 413, 388, 387, 386, 413, 413, 383, 357, 358, 356, 336, 337, 335, 413, 139, 190, 352, 349,
@@ -241,7 +231,7 @@ static mut YY_BASE: [flex_int16_t; 182] = [
     213, 208, 197, 413, 166, 160, 413, 128, 122, 150, 154, 105, 101, 96, 413, 84, 413, 351, 354,
     359, 364, 366, 368, 373, 89,
 ];
-static mut YY_DEF: [flex_int16_t; 182] = [
+static YY_DEF: [flex_int16_t; 182] = [
     0, 173, 1, 173, 173, 173, 173, 173, 174, 175, 176, 173, 177, 173, 173, 173, 173, 16, 173, 173,
     173, 178, 178, 178, 178, 178, 178, 178, 178, 178, 178, 173, 179, 178, 178, 178, 178, 178, 178,
     173, 173, 173, 174, 173, 180, 175, 176, 173, 173, 177, 173, 173, 173, 173, 173, 173, 173, 173,
@@ -253,7 +243,7 @@ static mut YY_DEF: [flex_int16_t; 182] = [
     173, 173, 173, 173, 173, 173, 173, 173, 173, 173, 173, 173, 173, 173, 173, 173, 173, 173, 173,
     173, 0, 173, 173, 173, 173, 173, 173, 173, 173,
 ];
-static mut YY_NXT: [flex_int16_t; 472] = [
+static YY_NXT: [flex_int16_t; 472] = [
     0, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 4, 14, 4, 15, 16, 17, 17, 17, 18, 19, 20, 21, 22, 23, 23,
     24, 25, 26, 27, 23, 23, 28, 29, 30, 23, 23, 25, 23, 23, 4, 31, 32, 33, 22, 23, 34, 25, 35, 23,
     36, 37, 38, 23, 23, 25, 23, 23, 39, 50, 173, 51, 83, 86, 52, 79, 80, 81, 173, 84, 84, 84, 136,
@@ -278,7 +268,7 @@ static mut YY_NXT: [flex_int16_t; 472] = [
     173, 173, 173, 173, 173, 173, 173, 173, 173, 173, 173, 173, 173, 173, 173, 173, 173, 173, 173,
     173,
 ];
-static mut YY_CHK: [flex_int16_t; 472] = [
+static YY_CHK: [flex_int16_t; 472] = [
     0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
     1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 13, 17, 13,
     21, 24, 13, 19, 19, 19, 17, 34, 24, 21, 75, 17, 75, 75, 75, 75, 26, 13, 34, 13, 33, 13, 15, 15,
@@ -304,7 +294,7 @@ static mut YY_CHK: [flex_int16_t; 472] = [
 ];
 
 pub(crate) fn fits_parser_yylex(
-    yylval_param: *mut FITS_PARSER_YYSTYPE,
+    yylval_param: &mut FITS_PARSER_YYSTYPE,
     yyscanner: &mut yyguts_t,
 ) -> c_int {
     unsafe {
@@ -367,7 +357,6 @@ pub(crate) fn fits_parser_yylex(
                         [(YY_BASE[yy_current_state as usize] as c_int + yy_c as c_int) as usize]
                         as yy_state_type;
                     yy_cp = yy_cp.offset(1);
-                    yy_cp;
                     if YY_BASE[yy_current_state as usize] as c_int == 413 as c_int {
                         break;
                     }
@@ -402,7 +391,6 @@ pub(crate) fn fits_parser_yylex(
                                     == ' ' as i32
                                 {
                                     len -= 1;
-                                    len;
                                 }
                                 len -= 1;
                                 strncpy(
@@ -442,7 +430,6 @@ pub(crate) fn fits_parser_yylex(
                                         == ' ' as i32
                                     {
                                         len_0 -= 1;
-                                        len_0;
                                     }
                                     len_0 -= 1;
                                     strncpy(
@@ -513,7 +500,6 @@ pub(crate) fn fits_parser_yylex(
                                         _ => {}
                                     }
                                     len_0 += 1;
-                                    len_0;
                                 }
                                 strcpy(
                                     ((*yyscanner.yylval_r).astr).as_mut_ptr(),
@@ -550,7 +536,6 @@ pub(crate) fn fits_parser_yylex(
                                         == ' ' as i32
                                     {
                                         len_1 -= 1;
-                                        len_1;
                                     }
                                     len_1 -= 1;
                                     strncpy(
@@ -669,12 +654,8 @@ pub(crate) fn fits_parser_yylex(
                                         _ => {}
                                     }
                                     len_1 += 1;
-                                    len_1;
                                 }
-                                strcpy(
-                                    ((*yyscanner.yylval_r).astr).as_mut_ptr(),
-                                    bitstring_0.as_mut_ptr(),
-                                );
+                                strcpy_safe(&mut ((*yyscanner.yylval_r).astr), &bitstring_0);
                                 return fits_parser_yytokentype::BITSTR as c_int;
                             }
                             5 => {
@@ -686,7 +667,6 @@ pub(crate) fn fits_parser_yylex(
                                     constval = constval << 1
                                         | (*p as c_int == '1' as i32) as c_int as c_long;
                                     p = p.offset(1);
-                                    p;
                                 }
                                 (*yyscanner.yylval_r).lng = constval;
                                 return fits_parser_yytokentype::LONG as c_int;
@@ -700,7 +680,6 @@ pub(crate) fn fits_parser_yylex(
                                     constval_0 = constval_0 << 3 as c_int
                                         | (*p_0 as c_int - '0' as i32) as c_long;
                                     p_0 = p_0.offset(1);
-                                    p_0;
                                 }
                                 (*yyscanner.yylval_r).lng = constval_0;
                                 return fits_parser_yytokentype::LONG as c_int;
@@ -718,7 +697,6 @@ pub(crate) fn fits_parser_yylex(
                                     };
                                     constval_1 = constval_1 << 4 as c_int | v as c_long;
                                     p_1 = p_1.offset(1);
-                                    p_1;
                                 }
                                 (*yyscanner.yylval_r).lng = constval_1;
                                 return fits_parser_yytokentype::LONG as c_int;
@@ -909,7 +887,7 @@ pub(crate) fn fits_parser_yylex(
                                 dtype = fits_parser_yyGetVariable(
                                     &mut *yyscanner.yyextra_r,
                                     yytext_r_slice,
-                                    yyscanner.yylval_r,
+                                    yyscanner.yylval_r.as_mut().unwrap(),
                                 );
                                 return dtype;
                             }
@@ -931,7 +909,6 @@ pub(crate) fn fits_parser_yylex(
                                         break;
                                     }
                                     len_5 += 1;
-                                    len_5;
                                 }
                                 if (if (*fname.offset(0 as c_int as isize) as c_int)
                                     < (*::core::mem::transmute::<&[u8; 5], &[c_char; 5]>(b"BOX(\0"))
@@ -1235,10 +1212,7 @@ pub(crate) fn fits_parser_yylex(
                             }
                             _ => {
                                 yy_fatal_error(
-                                    b"fatal flex scanner internal error--no action found\0"
-                                        as *const u8
-                                        as *const c_char,
-                                    yyscanner,
+                                    "fatal flex scanner internal error--no action found",
                                 );
                             }
                         }
@@ -1259,6 +1233,7 @@ pub(crate) fn fits_parser_yylex(
         }
     }
 }
+
 fn yy_get_next_buffer(yyscanner: &mut yyguts_t) -> c_int {
     unsafe {
         let mut dest: *mut c_char =
@@ -1271,11 +1246,7 @@ fn yy_get_next_buffer(yyscanner: &mut yyguts_t) -> c_int {
             > &mut *((**(yyscanner.yy_buffer_stack).add(yyscanner.yy_buffer_stack_top)).yy_ch_buf)
                 .offset((yyscanner.yy_n_chars + 1) as isize) as *mut c_char
         {
-            yy_fatal_error(
-                b"fatal flex scanner internal error--end of buffer missed\0" as *const u8
-                    as *const c_char,
-                yyscanner,
-            );
+            yy_fatal_error("fatal flex scanner internal error--end of buffer missed");
         }
         if (**(yyscanner.yy_buffer_stack).add(yyscanner.yy_buffer_stack_top)).yy_fill_buffer
             == 0 as c_int
@@ -1299,7 +1270,6 @@ fn yy_get_next_buffer(yyscanner: &mut yyguts_t) -> c_int {
             dest = dest.offset(1);
             *fresh6 = *fresh5;
             i += 1;
-            i;
         }
         if (**(yyscanner.yy_buffer_stack).add(yyscanner.yy_buffer_stack_top)).yy_buffer_status
             == 2 as c_int
@@ -1332,11 +1302,7 @@ fn yy_get_next_buffer(yyscanner: &mut yyguts_t) -> c_int {
                     (*b).yy_ch_buf = std::ptr::null_mut::<c_char>();
                 }
                 if ((*b).yy_ch_buf).is_null() {
-                    yy_fatal_error(
-                        b"fatal error - scanner input buffer overflow\0" as *const u8
-                            as *const c_char,
-                        yyscanner,
-                    );
+                    yy_fatal_error("fatal error - scanner input buffer overflow");
                 }
                 yyscanner.yy_c_buf_p =
                     &mut *((*b).yy_ch_buf).offset(yy_c_buf_p_offset as isize) as *mut c_char;
@@ -1355,10 +1321,7 @@ fn yy_get_next_buffer(yyscanner: &mut yyguts_t) -> c_int {
                 num_to_read,
             );
             if yyscanner.yy_n_chars < 0 as c_int {
-                yy_fatal_error(
-                    b"read() in flex scanner failed\0" as *const u8 as *const c_char,
-                    yyscanner,
-                );
+                yy_fatal_error("read() in flex scanner failed");
             }
             (**(yyscanner.yy_buffer_stack).add(yyscanner.yy_buffer_stack_top)).yy_n_chars =
                 yyscanner.yy_n_chars;
@@ -1390,11 +1353,7 @@ fn yy_get_next_buffer(yyscanner: &mut yyguts_t) -> c_int {
             if ((**(yyscanner.yy_buffer_stack).add(yyscanner.yy_buffer_stack_top)).yy_ch_buf)
                 .is_null()
             {
-                yy_fatal_error(
-                    b"out of dynamic memory in yy_get_next_buffer()\0" as *const u8
-                        as *const c_char,
-                    yyscanner,
-                );
+                yy_fatal_error("out of dynamic memory in yy_get_next_buffer()");
             }
             (**(yyscanner.yy_buffer_stack).add(yyscanner.yy_buffer_stack_top)).yy_buf_size =
                 new_size_0 - 2 as c_int;
@@ -1441,42 +1400,39 @@ fn yy_get_previous_state(yyscanner: &mut yyguts_t) -> yy_state_type {
                 [(YY_BASE[yy_current_state as usize] as c_int + yy_c as c_int) as usize]
                 as yy_state_type;
             yy_cp = yy_cp.offset(1);
-            yy_cp;
         }
         yy_current_state
     }
 }
+
 fn yy_try_NUL_trans(
     mut yy_current_state: yy_state_type,
     yyscanner: &mut yyguts_t,
 ) -> yy_state_type {
-    unsafe {
-        let mut yy_is_jam: c_int = 0;
+    let mut yy_is_jam: c_int = 0;
 
-        let yy_cp: *mut c_char = yyscanner.yy_c_buf_p;
-        let mut yy_c: YY_CHAR = 1 as YY_CHAR;
-        if YY_ACCEPT[yy_current_state as usize] != 0 {
-            yyscanner.yy_last_accepting_state = yy_current_state;
-            yyscanner.yy_last_accepting_cpos = yy_cp;
+    let yy_cp: *mut c_char = yyscanner.yy_c_buf_p;
+    let mut yy_c: YY_CHAR = 1 as YY_CHAR;
+    if YY_ACCEPT[yy_current_state as usize] != 0 {
+        yyscanner.yy_last_accepting_state = yy_current_state;
+        yyscanner.yy_last_accepting_cpos = yy_cp;
+    }
+    while YY_CHK[(YY_BASE[yy_current_state as usize] as c_int + yy_c as c_int) as usize] as c_int
+        != yy_current_state
+    {
+        yy_current_state = YY_DEF[yy_current_state as usize] as c_int;
+        if yy_current_state >= 174 as c_int {
+            yy_c = YY_META[yy_c as usize];
         }
-        while YY_CHK[(YY_BASE[yy_current_state as usize] as c_int + yy_c as c_int) as usize]
-            as c_int
-            != yy_current_state
-        {
-            yy_current_state = YY_DEF[yy_current_state as usize] as c_int;
-            if yy_current_state >= 174 as c_int {
-                yy_c = YY_META[yy_c as usize];
-            }
-        }
-        yy_current_state = YY_NXT
-            [(YY_BASE[yy_current_state as usize] as c_int + yy_c as c_int) as usize]
-            as yy_state_type;
-        yy_is_jam = (yy_current_state == 173 as c_int) as c_int;
-        if yy_is_jam != 0 {
-            0 as c_int
-        } else {
-            yy_current_state
-        }
+    }
+    yy_current_state = YY_NXT
+        [(YY_BASE[yy_current_state as usize] as c_int + yy_c as c_int) as usize]
+        as yy_state_type;
+    yy_is_jam = (yy_current_state == 173 as c_int) as c_int;
+    if yy_is_jam != 0 {
+        0 as c_int
+    } else {
+        yy_current_state
     }
 }
 
@@ -1506,6 +1462,7 @@ pub(crate) fn fits_parser_yyrestart(input_file: *mut FILE, yyscanner: &mut yygut
     }
 }
 
+/*
 pub(crate) fn fits_parser_yy_switch_to_buffer(
     new_buffer: YY_BUFFER_STATE,
     yyscanner: &mut yyguts_t,
@@ -1540,6 +1497,8 @@ pub(crate) fn fits_parser_yy_switch_to_buffer(
         yyscanner.yy_did_buffer_switch_on_eof = 1;
     }
 }
+*/
+
 fn fits_parser_yy_load_buffer_state(yyscanner: &mut yyguts_t) {
     unsafe {
         yyscanner.yy_n_chars =
@@ -1566,19 +1525,13 @@ pub(crate) fn fits_parser_yy_create_buffer(
                 .unwrap(),
         ) as YY_BUFFER_STATE;
         if b.is_null() {
-            yy_fatal_error(
-                b"out of dynamic memory in yy_create_buffer()\0" as *const u8 as *const c_char,
-                yyscanner,
-            );
+            yy_fatal_error("out of dynamic memory in yy_create_buffer()");
         }
         (*b).yy_buf_size = size;
         (*b).yy_ch_buf =
             fits_parser_yyalloc(((*b).yy_buf_size + 2 as c_int) as yy_size_t) as *mut c_char;
         if ((*b).yy_ch_buf).is_null() {
-            yy_fatal_error(
-                b"out of dynamic memory in yy_create_buffer()\0" as *const u8 as *const c_char,
-                yyscanner,
-            );
+            yy_fatal_error("out of dynamic memory in yy_create_buffer()");
         }
         (*b).yy_is_our_buffer = 1;
         fits_parser_yy_init_buffer(b, file, yyscanner);
@@ -1605,6 +1558,7 @@ pub(crate) fn fits_parser_yy_delete_buffer(b: YY_BUFFER_STATE, yyscanner: &mut y
         fits_parser_yyfree(b as *mut c_void);
     }
 }
+
 fn fits_parser_yy_init_buffer(b: YY_BUFFER_STATE, file: *mut FILE, yyscanner: &mut yyguts_t) {
     unsafe {
         let oerrno: c_int = *__errno_location();
@@ -1650,6 +1604,7 @@ pub(crate) fn fits_parser_yy_flush_buffer(b: YY_BUFFER_STATE, yyscanner: &mut yy
     }
 }
 
+/*
 pub(crate) fn fits_parser_yypush_buffer_state(
     new_buffer: YY_BUFFER_STATE,
     yyscanner: &mut yyguts_t,
@@ -1689,6 +1644,7 @@ pub(crate) fn fits_parser_yypush_buffer_state(
         yyscanner.yy_did_buffer_switch_on_eof = 1;
     }
 }
+*/
 
 pub(crate) fn fits_parser_yypop_buffer_state(yyscanner: &mut yyguts_t) {
     unsafe {
@@ -1742,11 +1698,7 @@ fn fits_parser_yyensure_buffer_stack(yyscanner: &mut yyguts_t) {
                 ),
             ) as *mut *mut yy_buffer_state;
             if (yyscanner.yy_buffer_stack).is_null() {
-                yy_fatal_error(
-                    b"out of dynamic memory in yyensure_buffer_stack()\0" as *const u8
-                        as *const c_char,
-                    yyscanner,
-                );
+                yy_fatal_error("out of dynamic memory in yyensure_buffer_stack()");
             }
             memset(
                 yyscanner.yy_buffer_stack as *mut c_void,
@@ -1767,11 +1719,7 @@ fn fits_parser_yyensure_buffer_stack(yyscanner: &mut yyguts_t) {
                 num_to_alloc.wrapping_mul(::core::mem::size_of::<*mut yy_buffer_state>()),
             ) as *mut *mut yy_buffer_state;
             if (yyscanner.yy_buffer_stack).is_null() {
-                yy_fatal_error(
-                    b"out of dynamic memory in yyensure_buffer_stack()\0" as *const u8
-                        as *const c_char,
-                    yyscanner,
-                );
+                yy_fatal_error("out of dynamic memory in yyensure_buffer_stack()");
             }
             memset(
                 (yyscanner.yy_buffer_stack).add(yyscanner.yy_buffer_stack_max) as *mut c_void,
@@ -1783,6 +1731,7 @@ fn fits_parser_yyensure_buffer_stack(yyscanner: &mut yyguts_t) {
     }
 }
 
+/*
 pub(crate) fn fits_parser_yy_scan_buffer(
     base: *mut c_char,
     size: yy_size_t,
@@ -1802,10 +1751,7 @@ pub(crate) fn fits_parser_yy_scan_buffer(
                 .unwrap(),
         ) as YY_BUFFER_STATE;
         if b.is_null() {
-            yy_fatal_error(
-                b"out of dynamic memory in yy_scan_buffer()\0" as *const u8 as *const c_char,
-                yyscanner,
-            );
+            yy_fatal_error("out of dynamic memory in yy_scan_buffer()");
         }
         (*b).yy_buf_size = size.wrapping_sub(2 as c_int as yy_size_t) as c_int;
         (*b).yy_ch_buf = base;
@@ -1821,14 +1767,18 @@ pub(crate) fn fits_parser_yy_scan_buffer(
         b
     }
 }
+*/
 
+/*
 pub(crate) fn fits_parser_yy_scan_string(
     yystr: *const c_char,
     yyscanner: &mut yyguts_t,
 ) -> YY_BUFFER_STATE {
     unsafe { fits_parser_yy_scan_bytes(yystr, strlen(yystr) as c_int, yyscanner) }
 }
+*/
 
+/*
 pub(crate) fn fits_parser_yy_scan_bytes(
     yybytes: *const c_char,
     mut _yybytes_len: c_int,
@@ -1843,8 +1793,7 @@ pub(crate) fn fits_parser_yy_scan_bytes(
         buf = fits_parser_yyalloc(n) as *mut c_char;
         if buf.is_null() {
             yy_fatal_error(
-                b"out of dynamic memory in yy_scan_bytes()\0" as *const u8 as *const c_char,
-                yyscanner,
+                "out of dynamic memory in yy_scan_bytes()"
             );
         }
         i = 0 as c_int;
@@ -1859,24 +1808,23 @@ pub(crate) fn fits_parser_yy_scan_bytes(
         b = fits_parser_yy_scan_buffer(buf, n, yyscanner);
         if b.is_null() {
             yy_fatal_error(
-                b"bad buffer in yy_scan_bytes()\0" as *const u8 as *const c_char,
-                yyscanner,
+                "bad buffer in yy_scan_bytes()"
             );
         }
         (*b).yy_is_our_buffer = 1;
         b
     }
 }
+*/
 
 const YY_EXIT_FAILURE: c_int = 2;
 
-fn yy_fatal_error(msg: *const c_char, yyscanner: &mut yyguts_t) -> ! {
-    unsafe {
-        fprintf(stderr, c"%s\n".as_ptr(), msg);
-        exit(YY_EXIT_FAILURE);
-    }
+fn yy_fatal_error(msg: &str) -> ! {
+    eprintln!("{}", msg);
+    exit(YY_EXIT_FAILURE);
 }
 
+/*
 pub(crate) fn fits_parser_yyget_lineno(yyscanner: &mut yyguts_t) -> c_int {
     unsafe {
         if if !(yyscanner.yy_buffer_stack).is_null() {
@@ -1891,7 +1839,9 @@ pub(crate) fn fits_parser_yyget_lineno(yyscanner: &mut yyguts_t) -> c_int {
         (**(yyscanner.yy_buffer_stack).add(yyscanner.yy_buffer_stack_top)).yy_bs_lineno
     }
 }
+*/
 
+/*
 pub(crate) fn fits_parser_yyget_column(yyscanner: &mut yyguts_t) -> c_int {
     unsafe {
         if if !(yyscanner.yy_buffer_stack).is_null() {
@@ -1906,22 +1856,30 @@ pub(crate) fn fits_parser_yyget_column(yyscanner: &mut yyguts_t) -> c_int {
         (**(yyscanner.yy_buffer_stack).add(yyscanner.yy_buffer_stack_top)).yy_bs_column
     }
 }
-
+*/
+/*
 pub(crate) fn fits_parser_yyget_in(yyscanner: &mut yyguts_t) -> *mut FILE {
-    unsafe { yyscanner.yyin_r }
+    yyscanner.yyin_r
 }
+ */
 
-pub(crate) fn fits_parser_yyget_out(yyscanner: &mut yyguts_t) -> *mut FILE {
-    unsafe { yyscanner.yyout_r }
+/*
+ pub(crate) fn fits_parser_yyget_out(yyscanner: &mut yyguts_t) -> *mut FILE {
+    yyscanner.yyout_r
 }
+ */
 
+/*
 pub(crate) fn fits_parser_yyget_leng(yyscanner: &mut yyguts_t) -> c_int {
-    unsafe { yyscanner.yyleng_r }
+    yyscanner.yyleng_r
 }
+ */
 
+/*
 pub(crate) fn fits_parser_yyget_text(yyscanner: &mut yyguts_t) -> *mut c_char {
-    unsafe { yyscanner.yytext_r }
+    yyscanner.yytext_r
 }
+ */
 
 /** Set the user-defined data. This data is never touched by the scanner.
  * @param user_defined The data to be associated with this scanner.
@@ -1931,6 +1889,7 @@ pub(crate) fn fits_parser_yyset_extra(user_defined: &mut ParseData, yyscanner: &
     yyscanner.yyextra_r = user_defined;
 }
 
+/*
 pub(crate) fn fits_parser_yyset_lineno(mut _line_number: c_int, yyscanner: &mut yyguts_t) {
     unsafe {
         if if !(yyscanner.yy_buffer_stack).is_null() {
@@ -1940,16 +1899,15 @@ pub(crate) fn fits_parser_yyset_lineno(mut _line_number: c_int, yyscanner: &mut 
         }
         .is_null()
         {
-            yy_fatal_error(
-                b"yyset_lineno called with no buffer\0" as *const u8 as *const c_char,
-                yyscanner,
-            );
+            yy_fatal_error("yyset_lineno called with no buffer");
         }
         (**(yyscanner.yy_buffer_stack).add(yyscanner.yy_buffer_stack_top)).yy_bs_lineno =
             _line_number;
     }
 }
+ */
 
+/*
 pub(crate) fn fits_parser_yyset_column(mut _column_no: c_int, yyscanner: &mut yyguts_t) {
     unsafe {
         if if !(yyscanner.yy_buffer_stack).is_null() {
@@ -1959,51 +1917,54 @@ pub(crate) fn fits_parser_yyset_column(mut _column_no: c_int, yyscanner: &mut yy
         }
         .is_null()
         {
-            yy_fatal_error(
-                b"yyset_column called with no buffer\0" as *const u8 as *const c_char,
-                yyscanner,
-            );
+            yy_fatal_error("yyset_column called with no buffer");
         }
         (**(yyscanner.yy_buffer_stack).add(yyscanner.yy_buffer_stack_top)).yy_bs_column =
             _column_no;
     }
 }
+ */
 
+/*
 pub(crate) fn fits_parser_yyset_in(mut _in_str: *mut FILE, yyscanner: &mut yyguts_t) {
-    unsafe {
-        yyscanner.yyin_r = _in_str;
-    }
+    yyscanner.yyin_r = _in_str;
 }
+*/
 
+/*
 pub(crate) fn fits_parser_yyset_out(mut _out_str: *mut FILE, yyscanner: &mut yyguts_t) {
-    unsafe {
-        yyscanner.yyout_r = _out_str;
-    }
+    yyscanner.yyout_r = _out_str;
 }
+ */
 
+/*
 pub(crate) fn fits_parser_yyget_debug(yyscanner: &mut yyguts_t) -> c_int {
-    unsafe { yyscanner.yy_flex_debug_r }
+    yyscanner.yy_flex_debug_r
 }
+ */
 
+/*
 pub(crate) fn fits_parser_yyset_debug(mut _bdebug: c_int, yyscanner: &mut yyguts_t) {
-    unsafe {
-        yyscanner.yy_flex_debug_r = _bdebug;
-    }
+    yyscanner.yy_flex_debug_r = _bdebug;
 }
+ */
 
+/*
 pub(crate) fn fits_parser_yyget_lval(yyscanner: &mut yyguts_t) -> *mut FITS_PARSER_YYSTYPE {
-    unsafe { yyscanner.yylval_r }
+    yyscanner.yylval_r
 }
+ */
 
+/*
 pub(crate) fn fits_parser_yyset_lval(
     yylval_param: *mut FITS_PARSER_YYSTYPE,
     yyscanner: &mut yyguts_t,
 ) {
-    unsafe {
-        yyscanner.yylval_r = yylval_param;
-    }
+    yyscanner.yylval_r = yylval_param;
 }
+ */
 
+/*
 pub(crate) fn fits_parser_yylex_init(ptr_yy_globals: &mut Option<Box<yyguts_t>>) -> c_int {
     let b = box_try_new(yyguts_t::default());
 
@@ -2016,6 +1977,7 @@ pub(crate) fn fits_parser_yylex_init(ptr_yy_globals: &mut Option<Box<yyguts_t>>)
 
     yy_init_globals(ptr_yy_globals.as_deref_mut().unwrap())
 }
+ */
 
 /* yylex_init_extra has the same functionality as yylex_init, but follows the
  * convention of taking the scanner as the last argument. Note however, that
@@ -2028,43 +1990,39 @@ pub(crate) fn fits_parser_yylex_init_extra(
     yy_user_defined: &mut ParseData,
     ptr_yy_globals: &mut Option<Box<yyguts_t>>,
 ) -> c_int {
-    unsafe {
-        let mut dummy_yyguts = yyguts_t::default();
+    let mut dummy_yyguts = yyguts_t::default();
 
-        fits_parser_yyset_extra(yy_user_defined, &mut dummy_yyguts);
+    fits_parser_yyset_extra(yy_user_defined, &mut dummy_yyguts);
 
-        let b = box_try_new(yyguts_t::default());
+    let b = box_try_new(yyguts_t::default());
 
-        if b.is_err() {
-            set_errno(Errno(ENOMEM));
-            return 1;
-        }
-
-        let mut b = b.unwrap();
-
-        fits_parser_yyset_extra(yy_user_defined, &mut b);
-
-        *ptr_yy_globals = Some(b);
-
-        yy_init_globals(ptr_yy_globals.as_deref_mut().unwrap())
+    if b.is_err() {
+        set_errno(Errno(ENOMEM));
+        return 1;
     }
+
+    let mut b = b.unwrap();
+
+    fits_parser_yyset_extra(yy_user_defined, &mut b);
+
+    *ptr_yy_globals = Some(b);
+
+    yy_init_globals(ptr_yy_globals.as_deref_mut().unwrap())
 }
 
 fn yy_init_globals(yyscanner: &mut yyguts_t) -> c_int {
-    unsafe {
-        yyscanner.yy_buffer_stack = std::ptr::null_mut::<YY_BUFFER_STATE>();
-        yyscanner.yy_buffer_stack_top = 0 as c_int as size_t;
-        yyscanner.yy_buffer_stack_max = 0 as c_int as size_t;
-        yyscanner.yy_c_buf_p = std::ptr::null_mut::<c_char>();
-        yyscanner.yy_init = 0 as c_int;
-        yyscanner.yy_start = 0 as c_int;
-        yyscanner.yy_start_stack_ptr = 0 as c_int;
-        yyscanner.yy_start_stack_depth = 0 as c_int;
-        yyscanner.yy_start_stack = std::ptr::null_mut::<c_int>();
-        yyscanner.yyin_r = std::ptr::null_mut::<FILE>();
-        yyscanner.yyout_r = std::ptr::null_mut::<FILE>();
-        0 as c_int
-    }
+    yyscanner.yy_buffer_stack = std::ptr::null_mut::<YY_BUFFER_STATE>();
+    yyscanner.yy_buffer_stack_top = 0 as c_int as size_t;
+    yyscanner.yy_buffer_stack_max = 0 as c_int as size_t;
+    yyscanner.yy_c_buf_p = std::ptr::null_mut::<c_char>();
+    yyscanner.yy_init = 0 as c_int;
+    yyscanner.yy_start = 0 as c_int;
+    yyscanner.yy_start_stack_ptr = 0 as c_int;
+    yyscanner.yy_start_stack_depth = 0 as c_int;
+    yyscanner.yy_start_stack = std::ptr::null_mut::<c_int>();
+    yyscanner.yyin_r = std::ptr::null_mut::<FILE>();
+    yyscanner.yyout_r = std::ptr::null_mut::<FILE>();
+    0 as c_int
 }
 
 pub(crate) fn fits_parser_yylex_destroy(mut yyscanner: Box<yyguts_t>) -> c_int {

--- a/src/eval_l.rs
+++ b/src/eval_l.rs
@@ -1,1 +1,2172 @@
-// NOT IMPLEMENTED
+#![allow(
+    dead_code,
+    mutable_transmutes,
+    non_camel_case_types,
+    non_snake_case,
+    non_upper_case_globals,
+    unused_assignments,
+    unused_mut
+)]
+
+use libc::{
+    __errno_location, FILE, atof, atol, exit, fileno, fprintf, free, fwrite, isatty, malloc,
+    memset, realloc, size_t,
+};
+
+use crate::c_types::{c_char, c_int, c_long, c_short, c_uchar, c_uint, c_ulong, c_void};
+use crate::eval_defs::ParseData;
+use crate::eval_tab::*;
+use crate::wrappers::isdigit_safe;
+use crate::{
+    fitscore::{ffpmsg_slice, fits_strcasecmp, fits_strncasecmp},
+    stderr, stdin, stdout,
+    wrappers::{strcat, strcmp, strcpy, strlen, strncat, strncpy, toupper},
+};
+
+pub type __uint8_t = c_uchar;
+pub type __int16_t = c_short;
+pub type __off_t = c_long;
+pub type __off64_t = c_long;
+
+pub type _IO_lock_t = ();
+
+pub type int16_t = __int16_t;
+pub type uint8_t = __uint8_t;
+pub type flex_uint8_t = uint8_t;
+pub type flex_int16_t = int16_t;
+pub type yyscan_t = *mut c_void;
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct yy_buffer_state {
+    pub yy_input_file: *mut FILE,
+    pub yy_ch_buf: *mut c_char,
+    pub yy_buf_pos: *mut c_char,
+    pub yy_buf_size: c_int,
+    pub yy_n_chars: c_int,
+    pub yy_is_our_buffer: c_int,
+    pub yy_is_interactive: c_int,
+    pub yy_at_bol: c_int,
+    pub yy_bs_lineno: c_int,
+    pub yy_bs_column: c_int,
+    pub yy_fill_buffer: c_int,
+    pub yy_buffer_status: c_int,
+}
+pub type YY_BUFFER_STATE = *mut yy_buffer_state;
+pub type yy_size_t = size_t;
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct yyguts_t {
+    pub yyextra_r: *mut ParseData,
+    pub yyin_r: *mut FILE,
+    pub yyout_r: *mut FILE,
+    pub yy_buffer_stack_top: size_t,
+    pub yy_buffer_stack_max: size_t,
+    pub yy_buffer_stack: *mut YY_BUFFER_STATE,
+    pub yy_hold_char: c_char,
+    pub yy_n_chars: c_int,
+    pub yyleng_r: c_int,
+    pub yy_c_buf_p: *mut c_char,
+    pub yy_init: c_int,
+    pub yy_start: c_int,
+    pub yy_did_buffer_switch_on_eof: c_int,
+    pub yy_start_stack_ptr: c_int,
+    pub yy_start_stack_depth: c_int,
+    pub yy_start_stack: *mut c_int,
+    pub yy_last_accepting_state: yy_state_type,
+    pub yy_last_accepting_cpos: *mut c_char,
+    pub yylineno_r: c_int,
+    pub yy_flex_debug_r: c_int,
+    pub yytext_r: *mut c_char,
+    pub yy_more_flag: c_int,
+    pub yy_more_len: c_int,
+    pub yylval_r: *mut FITS_PARSER_YYSTYPE,
+}
+
+pub type yy_state_type = c_int;
+
+pub type YY_CHAR = flex_uint8_t;
+pub type uint = c_uint;
+
+pub unsafe fn fits_parser_yywrap(mut scanner: yyscan_t) -> c_int {
+    1
+}
+unsafe fn expr_read(mut lParse: *mut ParseData, mut buf: *mut c_char, mut nbytes: c_int) -> c_int {
+    unsafe {
+        let mut n: c_int = 0;
+        n = 0 as c_int;
+        if (*lParse).is_eobuf == 0 {
+            loop {
+                let fresh0 = (*lParse).index;
+                (*lParse).index += 1;
+                let fresh1 = n;
+                n += 1;
+                *buf.offset(fresh1 as isize) = *((*lParse).expr).offset(fresh0 as isize);
+                if !(n < nbytes
+                    && *((*lParse).expr).offset((*lParse).index as isize) as c_int != 0_i32)
+                {
+                    break;
+                }
+            }
+            if *((*lParse).expr).offset((*lParse).index as isize) as c_int == 0_i32 {
+                (*lParse).is_eobuf = 1;
+            }
+        }
+        *buf.offset(n as isize) = 0_i32 as c_char;
+        n
+    }
+}
+
+pub unsafe fn fits_parser_yyGetVariable(
+    mut lParse: *mut ParseData,
+    mut varName: *mut c_char,
+    mut thelval: *mut FITS_PARSER_YYSTYPE,
+) -> c_int {
+    unsafe {
+        let mut varNum: c_int = 0;
+        let mut dtype: c_int = 0;
+        let mut errMsg: [c_char; 105] = [0; 105];
+        varNum = find_variable(lParse, varName);
+        if varNum < 0 as c_int {
+            if ((*lParse).getData).is_some() {
+                dtype = ((*lParse).getData).expect("non-null function pointer")(
+                    lParse,
+                    varName,
+                    thelval as *mut c_void,
+                );
+            } else {
+                dtype = -(1);
+                (*lParse).status = 431 as c_int;
+                strcpy(
+                    errMsg.as_mut_ptr(),
+                    b"Unable to find data: \0" as *const u8 as *const c_char,
+                );
+                strncat(errMsg.as_mut_ptr(), varName, 80);
+                ffpmsg_slice(&errMsg);
+            }
+        } else {
+            match (*((*lParse).varData).offset(varNum as isize)).dtype {
+                259 | 260 => {
+                    dtype = fits_parser_yytokentype::COLUMN as c_int;
+                }
+                258 => {
+                    dtype = fits_parser_yytokentype::BCOLUMN as c_int;
+                }
+                261 => {
+                    dtype = fits_parser_yytokentype::SCOLUMN as c_int;
+                }
+                262 => {
+                    dtype = fits_parser_yytokentype::BITCOL as c_int;
+                }
+                _ => {
+                    dtype = -(1);
+                    (*lParse).status = 431 as c_int;
+                    strcpy(
+                        errMsg.as_mut_ptr(),
+                        b"Bad datatype for data: \0" as *const u8 as *const c_char,
+                    );
+                    strncat(errMsg.as_mut_ptr(), varName, 80);
+                    ffpmsg_slice(&errMsg);
+                }
+            }
+            (*thelval).lng = varNum as c_long;
+        }
+        dtype
+    }
+}
+unsafe fn find_variable(mut lParse: *mut ParseData, mut varName: *mut c_char) -> c_int {
+    unsafe {
+        let mut i: c_int = 0;
+        if (*lParse).nCols != 0 {
+            i = 0 as c_int;
+            while i < (*lParse).nCols {
+                if {
+                    let s1 = std::slice::from_raw_parts(
+                        ((*((*lParse).varData).offset(i as isize)).name).as_ptr(),
+                        80,
+                    );
+                    let s2 = std::slice::from_raw_parts(varName, 80);
+                    fits_strncasecmp(s1, s2, 80 as c_int as size_t)
+                } == 0
+                {
+                    return i;
+                }
+                i += 1;
+                i;
+            }
+        }
+        -(1)
+    }
+}
+static mut yy_accept: [flex_int16_t; 174] = [
+    0, 0, 0, 31, 29, 1, 28, 18, 29, 29, 29, 29, 29, 29, 29, 10, 8, 8, 24, 29, 23, 13, 13, 13, 13,
+    9, 13, 13, 13, 13, 13, 17, 13, 13, 13, 13, 13, 13, 13, 29, 1, 22, 0, 12, 0, 11, 0, 13, 20, 0,
+    0, 0, 0, 0, 0, 0, 17, 0, 10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 8, 0, 0, 0, 0, 26,
+    21, 25, 13, 13, 13, 2, 13, 13, 13, 4, 13, 13, 13, 13, 3, 13, 27, 13, 13, 13, 13, 13, 13, 13,
+    13, 13, 19, 0, 11, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 10, 5, 6, 7, 14, 13, 23, 24, 13, 13, 13, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 18, 0, 0,
+    15, 0, 0, 0, 0, 0, 0, 0, 16, 0, 0,
+];
+static mut yy_ec: [YY_CHAR; 256] = [
+    0, 1, 1, 1, 1, 1, 1, 1, 1, 2, 3, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    2, 4, 5, 6, 7, 1, 8, 9, 10, 11, 12, 13, 1, 13, 14, 1, 15, 16, 17, 17, 17, 17, 17, 17, 18, 18,
+    1, 1, 19, 20, 21, 1, 1, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 31, 32, 31, 33, 34, 31, 35, 36,
+    31, 37, 38, 31, 31, 39, 31, 31, 1, 1, 40, 41, 42, 1, 43, 44, 24, 45, 46, 47, 48, 29, 49, 31,
+    31, 50, 31, 51, 52, 31, 53, 54, 31, 55, 56, 31, 31, 57, 31, 31, 1, 58, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+];
+static mut yy_meta: [YY_CHAR; 59] = [
+    0, 1, 1, 2, 1, 1, 1, 3, 1, 1, 1, 1, 1, 1, 1, 4, 4, 4, 4, 1, 1, 1, 4, 4, 4, 4, 4, 4, 5, 5, 5, 5,
+    5, 5, 5, 5, 5, 5, 5, 5, 1, 1, 5, 4, 4, 4, 4, 4, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 1,
+];
+static mut yy_base: [flex_int16_t; 182] = [
+    0, 0, 0, 412, 413, 409, 413, 390, 404, 401, 400, 398, 396, 34, 392, 70, 114, 16, 383, 46, 382,
+    29, 84, 359, 28, 358, 52, 157, 64, 91, 128, 358, 0, 40, 27, 69, 92, 100, 171, 340, 395, 413,
+    391, 413, 388, 387, 386, 413, 413, 383, 357, 358, 356, 336, 337, 335, 413, 139, 190, 352, 349,
+    71, 111, 135, 347, 348, 330, 327, 59, 64, 116, 325, 323, 175, 0, 59, 120, 326, 0, 413, 413,
+    413, 153, 184, 0, 202, 209, 210, 219, 351, 220, 228, 229, 211, 230, 240, 413, 221, 246, 254,
+    263, 264, 265, 266, 239, 275, 413, 346, 342, 310, 313, 309, 289, 292, 288, 275, 317, 327, 326,
+    325, 324, 323, 322, 298, 320, 297, 287, 317, 315, 314, 312, 311, 310, 249, 289, 243, 294, 298,
+    134, 246, 0, 413, 285, 413, 413, 288, 308, 309, 261, 261, 256, 221, 215, 246, 241, 223, 218,
+    213, 208, 197, 413, 166, 160, 413, 128, 122, 150, 154, 105, 101, 96, 413, 84, 413, 351, 354,
+    359, 364, 366, 368, 373, 89,
+];
+static mut yy_def: [flex_int16_t; 182] = [
+    0, 173, 1, 173, 173, 173, 173, 173, 174, 175, 176, 173, 177, 173, 173, 173, 173, 16, 173, 173,
+    173, 178, 178, 178, 178, 178, 178, 178, 178, 178, 178, 173, 179, 178, 178, 178, 178, 178, 178,
+    173, 173, 173, 174, 173, 180, 175, 176, 173, 173, 177, 173, 173, 173, 173, 173, 173, 173, 173,
+    173, 173, 173, 173, 173, 173, 173, 173, 173, 173, 173, 173, 173, 173, 173, 173, 17, 173, 173,
+    173, 181, 173, 173, 173, 178, 178, 179, 178, 178, 178, 178, 27, 178, 178, 178, 178, 178, 178,
+    173, 178, 178, 178, 178, 178, 178, 178, 178, 178, 173, 180, 180, 173, 173, 173, 173, 173, 173,
+    173, 173, 173, 173, 173, 173, 173, 173, 173, 173, 173, 173, 173, 173, 173, 173, 173, 173, 173,
+    173, 173, 173, 173, 173, 173, 181, 173, 178, 173, 173, 178, 178, 178, 173, 173, 173, 173, 173,
+    173, 173, 173, 173, 173, 173, 173, 173, 173, 173, 173, 173, 173, 173, 173, 173, 173, 173, 173,
+    173, 0, 173, 173, 173, 173, 173, 173, 173, 173,
+];
+static mut yy_nxt: [flex_int16_t; 472] = [
+    0, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 4, 14, 4, 15, 16, 17, 17, 17, 18, 19, 20, 21, 22, 23, 23,
+    24, 25, 26, 27, 23, 23, 28, 29, 30, 23, 23, 25, 23, 23, 4, 31, 32, 33, 22, 23, 34, 25, 35, 23,
+    36, 37, 38, 23, 23, 25, 23, 23, 39, 50, 173, 51, 83, 86, 52, 79, 80, 81, 173, 84, 84, 84, 136,
+    173, 137, 137, 137, 137, 87, 53, 98, 54, 84, 55, 57, 58, 58, 58, 58, 88, 90, 97, 59, 140, 84,
+    171, 60, 118, 61, 85, 85, 91, 62, 63, 64, 128, 84, 171, 119, 65, 130, 84, 171, 66, 129, 99, 67,
+    92, 68, 131, 69, 70, 71, 85, 100, 93, 84, 72, 73, 74, 74, 74, 74, 84, 84, 138, 138, 120, 101,
+    75, 75, 85, 84, 94, 94, 94, 103, 102, 121, 138, 138, 172, 104, 57, 115, 115, 115, 115, 76, 75,
+    75, 122, 132, 141, 95, 171, 77, 94, 133, 123, 84, 78, 89, 89, 89, 89, 170, 169, 168, 89, 89,
+    89, 89, 89, 89, 94, 94, 94, 94, 57, 58, 58, 58, 58, 141, 84, 89, 167, 166, 84, 89, 89, 89, 89,
+    89, 58, 58, 58, 58, 142, 94, 96, 141, 84, 89, 75, 75, 85, 85, 141, 141, 141, 160, 80, 81, 105,
+    84, 48, 94, 141, 141, 141, 96, 143, 79, 75, 75, 160, 141, 141, 141, 85, 144, 41, 84, 94, 94,
+    94, 145, 141, 141, 84, 84, 84, 106, 48, 141, 163, 165, 85, 80, 84, 84, 84, 141, 164, 146, 163,
+    81, 94, 84, 84, 84, 141, 141, 141, 141, 143, 79, 144, 41, 84, 84, 162, 161, 141, 139, 94, 84,
+    106, 115, 115, 115, 115, 147, 141, 84, 159, 141, 48, 75, 75, 160, 106, 158, 84, 84, 84, 84,
+    137, 137, 137, 137, 137, 137, 137, 137, 84, 141, 141, 75, 75, 48, 160, 41, 144, 79, 84, 143,
+    81, 84, 80, 157, 156, 106, 155, 41, 144, 79, 143, 81, 80, 154, 153, 152, 151, 150, 149, 148,
+    108, 84, 84, 42, 108, 42, 42, 42, 45, 45, 45, 46, 141, 46, 46, 46, 49, 139, 49, 49, 49, 82, 82,
+    84, 84, 107, 135, 107, 107, 107, 134, 127, 126, 125, 124, 117, 116, 114, 113, 112, 111, 110,
+    109, 43, 47, 173, 108, 43, 40, 106, 96, 84, 84, 81, 79, 56, 43, 48, 47, 44, 43, 41, 40, 173, 3,
+    173, 173, 173, 173, 173, 173, 173, 173, 173, 173, 173, 173, 173, 173, 173, 173, 173, 173, 173,
+    173, 173, 173, 173, 173, 173, 173, 173, 173, 173, 173, 173, 173, 173, 173, 173, 173, 173, 173,
+    173, 173, 173, 173, 173, 173, 173, 173, 173, 173, 173, 173, 173, 173, 173, 173, 173, 173, 173,
+    173,
+];
+static mut yy_chk: [flex_int16_t; 472] = [
+    0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 13, 17, 13,
+    21, 24, 13, 19, 19, 19, 17, 34, 24, 21, 75, 17, 75, 75, 75, 75, 26, 13, 34, 13, 33, 13, 15, 15,
+    15, 15, 15, 26, 28, 33, 15, 181, 26, 172, 15, 61, 15, 22, 22, 28, 15, 15, 15, 68, 28, 170, 61,
+    15, 69, 35, 169, 15, 68, 35, 15, 29, 15, 69, 15, 15, 15, 22, 35, 29, 22, 15, 16, 16, 16, 16,
+    16, 29, 36, 76, 76, 62, 36, 16, 16, 22, 37, 30, 30, 30, 37, 36, 62, 138, 138, 168, 37, 57, 57,
+    57, 57, 57, 16, 16, 16, 63, 70, 82, 30, 167, 16, 30, 70, 63, 30, 16, 27, 27, 27, 27, 166, 165,
+    164, 27, 27, 27, 27, 27, 27, 30, 38, 38, 38, 73, 73, 73, 73, 73, 83, 82, 27, 162, 161, 27, 27,
+    27, 27, 27, 27, 58, 58, 58, 58, 83, 38, 159, 85, 38, 27, 58, 58, 85, 85, 86, 87, 93, 158, 86,
+    87, 38, 83, 157, 38, 88, 90, 97, 156, 88, 90, 58, 58, 155, 91, 92, 94, 85, 91, 92, 85, 94, 94,
+    94, 93, 104, 95, 86, 87, 93, 95, 154, 98, 153, 152, 85, 98, 88, 90, 97, 99, 151, 97, 150, 99,
+    94, 91, 92, 94, 100, 101, 102, 103, 100, 101, 102, 103, 104, 95, 149, 148, 105, 139, 94, 98,
+    105, 115, 115, 115, 115, 104, 142, 99, 135, 145, 142, 115, 115, 145, 134, 133, 100, 101, 102,
+    103, 136, 136, 136, 136, 137, 137, 137, 137, 105, 146, 147, 115, 115, 146, 147, 132, 131, 130,
+    142, 129, 128, 145, 127, 126, 125, 124, 123, 122, 121, 120, 119, 118, 117, 116, 114, 113, 112,
+    111, 110, 109, 108, 146, 147, 174, 107, 174, 174, 174, 175, 175, 175, 176, 89, 176, 176, 176,
+    177, 77, 177, 177, 177, 178, 178, 179, 179, 180, 72, 180, 180, 180, 71, 67, 66, 65, 64, 60, 59,
+    55, 54, 53, 52, 51, 50, 49, 46, 45, 44, 42, 40, 39, 31, 25, 23, 20, 18, 14, 12, 11, 10, 9, 8,
+    7, 5, 3, 173, 173, 173, 173, 173, 173, 173, 173, 173, 173, 173, 173, 173, 173, 173, 173, 173,
+    173, 173, 173, 173, 173, 173, 173, 173, 173, 173, 173, 173, 173, 173, 173, 173, 173, 173, 173,
+    173, 173, 173, 173, 173, 173, 173, 173, 173, 173, 173, 173, 173, 173, 173, 173, 173, 173, 173,
+    173, 173, 173, 173,
+];
+
+pub unsafe fn fits_parser_yylex(
+    mut yylval_param: *mut FITS_PARSER_YYSTYPE,
+    mut yyscanner: yyscan_t,
+) -> c_int {
+    unsafe {
+        let mut yy_amount_of_matched_text: c_int = 0;
+        let mut yy_next_state: yy_state_type = 0;
+        let mut current_block: u64;
+        let mut yy_current_state: yy_state_type = 0;
+        let mut yy_cp: *mut c_char = std::ptr::null_mut::<c_char>();
+        let mut yy_bp: *mut c_char = std::ptr::null_mut::<c_char>();
+        let mut yy_act: c_int = 0;
+        let mut yyg: *mut yyguts_t = yyscanner as *mut yyguts_t;
+        (*yyg).yylval_r = yylval_param;
+        if (*yyg).yy_init == 0 {
+            (*yyg).yy_init = 1;
+            if (*yyg).yy_start == 0 {
+                (*yyg).yy_start = 1;
+            }
+            if ((*yyg).yyin_r).is_null() {
+                (*yyg).yyin_r = stdin;
+            }
+            if ((*yyg).yyout_r).is_null() {
+                (*yyg).yyout_r = stdout;
+            }
+            if if !((*yyg).yy_buffer_stack).is_null() {
+                *((*yyg).yy_buffer_stack).add((*yyg).yy_buffer_stack_top)
+            } else {
+                0 as YY_BUFFER_STATE
+            }
+            .is_null()
+            {
+                fits_parser_yyensure_buffer_stack(yyscanner);
+                let fresh2 = &mut *((*yyg).yy_buffer_stack).add((*yyg).yy_buffer_stack_top);
+                *fresh2 = fits_parser_yy_create_buffer((*yyg).yyin_r, 16384 as c_int, yyscanner);
+            }
+            fits_parser_yy_load_buffer_state(yyscanner);
+        }
+        loop {
+            yy_cp = (*yyg).yy_c_buf_p;
+            *yy_cp = (*yyg).yy_hold_char;
+            yy_bp = yy_cp;
+            yy_current_state = (*yyg).yy_start;
+            '_yy_match: loop {
+                loop {
+                    let mut yy_c: YY_CHAR = yy_ec[*yy_cp as YY_CHAR as usize];
+                    if yy_accept[yy_current_state as usize] != 0 {
+                        (*yyg).yy_last_accepting_state = yy_current_state;
+                        (*yyg).yy_last_accepting_cpos = yy_cp;
+                    }
+                    while yy_chk
+                        [(yy_base[yy_current_state as usize] as c_int + yy_c as c_int) as usize]
+                        as c_int
+                        != yy_current_state
+                    {
+                        yy_current_state = yy_def[yy_current_state as usize] as c_int;
+                        if yy_current_state >= 174 as c_int {
+                            yy_c = yy_meta[yy_c as usize];
+                        }
+                    }
+                    yy_current_state = yy_nxt
+                        [(yy_base[yy_current_state as usize] as c_int + yy_c as c_int) as usize]
+                        as yy_state_type;
+                    yy_cp = yy_cp.offset(1);
+                    yy_cp;
+                    if yy_base[yy_current_state as usize] as c_int == 413 as c_int {
+                        break;
+                    }
+                }
+                '_yy_find_action: loop {
+                    yy_act = yy_accept[yy_current_state as usize] as c_int;
+                    if yy_act == 0 as c_int {
+                        yy_cp = (*yyg).yy_last_accepting_cpos;
+                        yy_current_state = (*yyg).yy_last_accepting_state;
+                        yy_act = yy_accept[yy_current_state as usize] as c_int;
+                    }
+                    (*yyg).yytext_r = yy_bp;
+                    (*yyg).yyleng_r = yy_cp.offset_from(yy_bp) as c_long as c_int;
+                    (*yyg).yy_hold_char = *yy_cp;
+                    *yy_cp = 0_i32 as c_char;
+                    (*yyg).yy_c_buf_p = yy_cp;
+                    loop {
+                        match yy_act {
+                            0 => {
+                                *yy_cp = (*yyg).yy_hold_char;
+                                yy_cp = (*yyg).yy_last_accepting_cpos;
+                                yy_current_state = (*yyg).yy_last_accepting_state;
+                                continue '_yy_find_action;
+                            }
+                            1 => {
+                                break '_yy_match;
+                            }
+                            2 => {
+                                let mut len: c_int = 0;
+                                len = strlen((*yyg).yytext_r) as c_int;
+                                while *((*yyg).yytext_r).offset(len as isize) as c_int == ' ' as i32
+                                {
+                                    len -= 1;
+                                    len;
+                                }
+                                len -= 1;
+                                strncpy(
+                                    ((*(*yyg).yylval_r).astr).as_mut_ptr(),
+                                    &mut *((*yyg).yytext_r).offset(1 as c_int as isize),
+                                    len as usize,
+                                );
+                                (*(*yyg).yylval_r).astr[len as usize] = 0_i32 as c_char;
+                                return fits_parser_yytokentype::BITSTR as c_int;
+                            }
+                            3 => {
+                                let mut len_0: c_int = 0;
+                                let mut tmpstring: [c_char; 256] = [0; 256];
+                                let mut bitstring: [c_char; 256] = [0; 256];
+                                len_0 = strlen((*yyg).yytext_r) as c_int;
+                                if len_0 >= 256 as c_int {
+                                    let mut errMsg: [c_char; 100] = [0; 100];
+                                    (*(*yyg).yyextra_r).status = 431 as c_int;
+                                    strcpy(
+                                        errMsg.as_mut_ptr(),
+                                        b"Bit string exceeds maximum length: '\0" as *const u8
+                                            as *const c_char,
+                                    );
+                                    strncat(
+                                        errMsg.as_mut_ptr(),
+                                        &mut *((*yyg).yytext_r).offset(0 as c_int as isize),
+                                        20,
+                                    );
+                                    strcat(
+                                        errMsg.as_mut_ptr(),
+                                        b"...'\0" as *const u8 as *const c_char,
+                                    );
+                                    ffpmsg_slice(&errMsg);
+                                    len_0 = 0 as c_int;
+                                } else {
+                                    while *((*yyg).yytext_r).offset(len_0 as isize) as c_int
+                                        == ' ' as i32
+                                    {
+                                        len_0 -= 1;
+                                        len_0;
+                                    }
+                                    len_0 -= 1;
+                                    strncpy(
+                                        tmpstring.as_mut_ptr(),
+                                        &mut *((*yyg).yytext_r).offset(1 as c_int as isize),
+                                        len_0 as usize,
+                                    );
+                                }
+                                tmpstring[len_0 as usize] = 0_i32 as c_char;
+                                bitstring[0 as c_int as usize] = 0_i32 as c_char;
+                                len_0 = 0 as c_int;
+                                while tmpstring[len_0 as usize] as c_int != 0_i32 {
+                                    match tmpstring[len_0 as usize] as c_int {
+                                        48 => {
+                                            strcat(
+                                                bitstring.as_mut_ptr(),
+                                                b"000\0" as *const u8 as *const c_char,
+                                            );
+                                        }
+                                        49 => {
+                                            strcat(
+                                                bitstring.as_mut_ptr(),
+                                                b"001\0" as *const u8 as *const c_char,
+                                            );
+                                        }
+                                        50 => {
+                                            strcat(
+                                                bitstring.as_mut_ptr(),
+                                                b"010\0" as *const u8 as *const c_char,
+                                            );
+                                        }
+                                        51 => {
+                                            strcat(
+                                                bitstring.as_mut_ptr(),
+                                                b"011\0" as *const u8 as *const c_char,
+                                            );
+                                        }
+                                        52 => {
+                                            strcat(
+                                                bitstring.as_mut_ptr(),
+                                                b"100\0" as *const u8 as *const c_char,
+                                            );
+                                        }
+                                        53 => {
+                                            strcat(
+                                                bitstring.as_mut_ptr(),
+                                                b"101\0" as *const u8 as *const c_char,
+                                            );
+                                        }
+                                        54 => {
+                                            strcat(
+                                                bitstring.as_mut_ptr(),
+                                                b"110\0" as *const u8 as *const c_char,
+                                            );
+                                        }
+                                        55 => {
+                                            strcat(
+                                                bitstring.as_mut_ptr(),
+                                                b"111\0" as *const u8 as *const c_char,
+                                            );
+                                        }
+                                        120 | 88 => {
+                                            strcat(
+                                                bitstring.as_mut_ptr(),
+                                                b"xxx\0" as *const u8 as *const c_char,
+                                            );
+                                        }
+                                        _ => {}
+                                    }
+                                    len_0 += 1;
+                                    len_0;
+                                }
+                                strcpy(
+                                    ((*(*yyg).yylval_r).astr).as_mut_ptr(),
+                                    bitstring.as_mut_ptr(),
+                                );
+                                return fits_parser_yytokentype::BITSTR as c_int;
+                            }
+                            4 => {
+                                let mut len_1: c_int = 0;
+                                let mut tmpstring_0: [c_char; 256] = [0; 256];
+                                let mut bitstring_0: [c_char; 256] = [0; 256];
+                                len_1 = strlen((*yyg).yytext_r) as c_int;
+                                if len_1 >= 256 as c_int {
+                                    let mut errMsg_0: [c_char; 100] = [0; 100];
+                                    (*(*yyg).yyextra_r).status = 431 as c_int;
+                                    strcpy(
+                                        errMsg_0.as_mut_ptr(),
+                                        b"Hex string exceeds maximum length: '\0" as *const u8
+                                            as *const c_char,
+                                    );
+                                    strncat(
+                                        errMsg_0.as_mut_ptr(),
+                                        &mut *((*yyg).yytext_r).offset(0 as c_int as isize),
+                                        20,
+                                    );
+                                    strcat(
+                                        errMsg_0.as_mut_ptr(),
+                                        b"...'\0" as *const u8 as *const c_char,
+                                    );
+                                    ffpmsg_slice(&errMsg_0);
+                                    len_1 = 0 as c_int;
+                                } else {
+                                    while *((*yyg).yytext_r).offset(len_1 as isize) as c_int
+                                        == ' ' as i32
+                                    {
+                                        len_1 -= 1;
+                                        len_1;
+                                    }
+                                    len_1 -= 1;
+                                    strncpy(
+                                        tmpstring_0.as_mut_ptr(),
+                                        &mut *((*yyg).yytext_r).offset(1 as c_int as isize),
+                                        len_1 as usize,
+                                    );
+                                }
+                                tmpstring_0[len_1 as usize] = 0_i32 as c_char;
+                                bitstring_0[0 as c_int as usize] = 0_i32 as c_char;
+                                len_1 = 0 as c_int;
+                                while tmpstring_0[len_1 as usize] as c_int != 0_i32 {
+                                    match tmpstring_0[len_1 as usize] as c_int {
+                                        48 => {
+                                            strcat(
+                                                bitstring_0.as_mut_ptr(),
+                                                b"0000\0" as *const u8 as *const c_char,
+                                            );
+                                        }
+                                        49 => {
+                                            strcat(
+                                                bitstring_0.as_mut_ptr(),
+                                                b"0001\0" as *const u8 as *const c_char,
+                                            );
+                                        }
+                                        50 => {
+                                            strcat(
+                                                bitstring_0.as_mut_ptr(),
+                                                b"0010\0" as *const u8 as *const c_char,
+                                            );
+                                        }
+                                        51 => {
+                                            strcat(
+                                                bitstring_0.as_mut_ptr(),
+                                                b"0011\0" as *const u8 as *const c_char,
+                                            );
+                                        }
+                                        52 => {
+                                            strcat(
+                                                bitstring_0.as_mut_ptr(),
+                                                b"0100\0" as *const u8 as *const c_char,
+                                            );
+                                        }
+                                        53 => {
+                                            strcat(
+                                                bitstring_0.as_mut_ptr(),
+                                                b"0101\0" as *const u8 as *const c_char,
+                                            );
+                                        }
+                                        54 => {
+                                            strcat(
+                                                bitstring_0.as_mut_ptr(),
+                                                b"0110\0" as *const u8 as *const c_char,
+                                            );
+                                        }
+                                        55 => {
+                                            strcat(
+                                                bitstring_0.as_mut_ptr(),
+                                                b"0111\0" as *const u8 as *const c_char,
+                                            );
+                                        }
+                                        56 => {
+                                            strcat(
+                                                bitstring_0.as_mut_ptr(),
+                                                b"1000\0" as *const u8 as *const c_char,
+                                            );
+                                        }
+                                        57 => {
+                                            strcat(
+                                                bitstring_0.as_mut_ptr(),
+                                                b"1001\0" as *const u8 as *const c_char,
+                                            );
+                                        }
+                                        97 | 65 => {
+                                            strcat(
+                                                bitstring_0.as_mut_ptr(),
+                                                b"1010\0" as *const u8 as *const c_char,
+                                            );
+                                        }
+                                        98 | 66 => {
+                                            strcat(
+                                                bitstring_0.as_mut_ptr(),
+                                                b"1011\0" as *const u8 as *const c_char,
+                                            );
+                                        }
+                                        99 | 67 => {
+                                            strcat(
+                                                bitstring_0.as_mut_ptr(),
+                                                b"1100\0" as *const u8 as *const c_char,
+                                            );
+                                        }
+                                        100 | 68 => {
+                                            strcat(
+                                                bitstring_0.as_mut_ptr(),
+                                                b"1101\0" as *const u8 as *const c_char,
+                                            );
+                                        }
+                                        101 | 69 => {
+                                            strcat(
+                                                bitstring_0.as_mut_ptr(),
+                                                b"1110\0" as *const u8 as *const c_char,
+                                            );
+                                        }
+                                        102 | 70 => {
+                                            strcat(
+                                                bitstring_0.as_mut_ptr(),
+                                                b"1111\0" as *const u8 as *const c_char,
+                                            );
+                                        }
+                                        120 | 88 => {
+                                            strcat(
+                                                bitstring_0.as_mut_ptr(),
+                                                b"xxxx\0" as *const u8 as *const c_char,
+                                            );
+                                        }
+                                        _ => {}
+                                    }
+                                    len_1 += 1;
+                                    len_1;
+                                }
+                                strcpy(
+                                    ((*(*yyg).yylval_r).astr).as_mut_ptr(),
+                                    bitstring_0.as_mut_ptr(),
+                                );
+                                return fits_parser_yytokentype::BITSTR as c_int;
+                            }
+                            5 => {
+                                let mut constval: c_long = 0 as c_int as c_long;
+                                let mut p: *mut c_char = std::ptr::null_mut::<c_char>();
+                                p = &mut *((*yyg).yytext_r).offset(2 as c_int as isize)
+                                    as *mut c_char;
+                                while *p != 0 {
+                                    constval = constval << 1
+                                        | (*p as c_int == '1' as i32) as c_int as c_long;
+                                    p = p.offset(1);
+                                    p;
+                                }
+                                (*(*yyg).yylval_r).lng = constval;
+                                return fits_parser_yytokentype::LONG as c_int;
+                            }
+                            6 => {
+                                let mut constval_0: c_long = 0 as c_int as c_long;
+                                let mut p_0: *mut c_char = std::ptr::null_mut::<c_char>();
+                                p_0 = &mut *((*yyg).yytext_r).offset(2 as c_int as isize)
+                                    as *mut c_char;
+                                while *p_0 != 0 {
+                                    constval_0 = constval_0 << 3 as c_int
+                                        | (*p_0 as c_int - '0' as i32) as c_long;
+                                    p_0 = p_0.offset(1);
+                                    p_0;
+                                }
+                                (*(*yyg).yylval_r).lng = constval_0;
+                                return fits_parser_yytokentype::LONG as c_int;
+                            }
+                            7 => {
+                                let mut constval_1: c_long = 0 as c_int as c_long;
+                                let mut p_1: *mut c_char = std::ptr::null_mut::<c_char>();
+                                p_1 = &mut *((*yyg).yytext_r).offset(2 as c_int as isize)
+                                    as *mut c_char;
+                                while *p_1 != 0 {
+                                    let mut v: c_int = if isdigit_safe(*p_1) {
+                                        *p_1 as c_int - '0' as i32
+                                    } else {
+                                        *p_1 as c_int - 'a' as i32 + 10 as c_int
+                                    };
+                                    constval_1 = constval_1 << 4 as c_int | v as c_long;
+                                    p_1 = p_1.offset(1);
+                                    p_1;
+                                }
+                                (*(*yyg).yylval_r).lng = constval_1;
+                                return fits_parser_yytokentype::LONG as c_int;
+                            }
+                            8 => {
+                                (*(*yyg).yylval_r).lng = atol((*yyg).yytext_r);
+                                return fits_parser_yytokentype::LONG as c_int;
+                            }
+                            9 => {
+                                if *((*yyg).yytext_r).offset(0 as c_int as isize) as c_int
+                                    == 't' as i32
+                                    || *((*yyg).yytext_r).offset(0 as c_int as isize) as c_int
+                                        == 'T' as i32
+                                {
+                                    (*(*yyg).yylval_r).log = 1 as c_char;
+                                } else {
+                                    (*(*yyg).yylval_r).log = 0 as c_int as c_char;
+                                }
+                                return fits_parser_yytokentype::BOOLEAN as c_int;
+                            }
+                            10 => {
+                                (*(*yyg).yylval_r).dbl = atof((*yyg).yytext_r);
+                                return fits_parser_yytokentype::DOUBLE as c_int;
+                            }
+                            11 => {
+                                if {
+                                    let s1 = std::slice::from_raw_parts(
+                                        (*yyg).yytext_r,
+                                        strlen((*yyg).yytext_r) as usize + 1,
+                                    );
+                                    let s2 = unsafe {
+                                        std::mem::transmute::<&[u8], &[c_char]>(b"#PI\0")
+                                    };
+                                    fits_strcasecmp(s1, s2)
+                                } == 0
+                                {
+                                    (*(*yyg).yylval_r).dbl = 4.0 * (1.0_f64).atan();
+                                    return fits_parser_yytokentype::DOUBLE as c_int;
+                                } else if {
+                                    let s1 = std::slice::from_raw_parts(
+                                        (*yyg).yytext_r,
+                                        strlen((*yyg).yytext_r) as usize + 1,
+                                    );
+                                    let s2 =
+                                        unsafe { std::mem::transmute::<&[u8], &[c_char]>(b"#E\0") };
+                                    fits_strcasecmp(s1, s2)
+                                } == 0
+                                {
+                                    (*(*yyg).yylval_r).dbl = (1.0_f64).exp();
+                                    return fits_parser_yytokentype::DOUBLE as c_int;
+                                } else if {
+                                    let s1 = std::slice::from_raw_parts(
+                                        (*yyg).yytext_r,
+                                        strlen((*yyg).yytext_r) as usize + 1,
+                                    );
+                                    let s2 = unsafe {
+                                        std::mem::transmute::<&[u8], &[c_char]>(b"#DEG\0")
+                                    };
+                                    fits_strcasecmp(s1, s2)
+                                } == 0
+                                {
+                                    (*(*yyg).yylval_r).dbl = 4.0 * (1.0_f64).atan() / 180.0;
+                                    return fits_parser_yytokentype::DOUBLE as c_int;
+                                } else if {
+                                    let s1 = std::slice::from_raw_parts(
+                                        (*yyg).yytext_r,
+                                        strlen((*yyg).yytext_r) as usize + 1,
+                                    );
+                                    let s2 = unsafe {
+                                        std::mem::transmute::<&[u8], &[c_char]>(b"#ROW\0")
+                                    };
+                                    fits_strcasecmp(s1, s2)
+                                } == 0
+                                {
+                                    return fits_parser_yytokentype::ROWREF as c_int;
+                                } else if {
+                                    let s1 = std::slice::from_raw_parts(
+                                        (*yyg).yytext_r,
+                                        strlen((*yyg).yytext_r) as usize + 1,
+                                    );
+                                    let s2 = unsafe {
+                                        std::mem::transmute::<&[u8], &[c_char]>(b"#NULL\0")
+                                    };
+                                    fits_strcasecmp(s1, s2)
+                                } == 0
+                                {
+                                    return fits_parser_yytokentype::NULLREF as c_int;
+                                } else if {
+                                    let s1 = std::slice::from_raw_parts(
+                                        (*yyg).yytext_r,
+                                        strlen((*yyg).yytext_r) as usize + 1,
+                                    );
+                                    let s2 = unsafe {
+                                        std::mem::transmute::<&[u8], &[c_char]>(b"#SNULL\0")
+                                    };
+                                    fits_strcasecmp(s1, s2)
+                                } == 0
+                                {
+                                    return fits_parser_yytokentype::SNULLREF as c_int;
+                                } else {
+                                    let mut len_2: c_int = 0;
+                                    let mut result: c_int = 0;
+                                    if *((*yyg).yytext_r).offset(1 as c_int as isize) as c_int
+                                        == '$' as i32
+                                    {
+                                        len_2 = (strlen((*yyg).yytext_r)).wrapping_sub(3) as c_int;
+                                        (*(*yyg).yylval_r).astr[0 as c_int as usize] =
+                                            '#' as i32 as c_char;
+                                        strncpy(
+                                            ((*(*yyg).yylval_r).astr)
+                                                .as_mut_ptr()
+                                                .offset(1 as c_int as isize),
+                                            &mut *((*yyg).yytext_r).offset(2 as c_int as isize),
+                                            len_2 as usize,
+                                        );
+                                        (*(*yyg).yylval_r).astr[(len_2 + 1) as usize] =
+                                            0_i32 as c_char;
+                                        (*yyg).yytext_r = ((*(*yyg).yylval_r).astr).as_mut_ptr();
+                                    }
+                                    result = ((*(*yyg).yyextra_r).getData)
+                                        .expect("non-null function pointer")(
+                                        (*yyg).yyextra_r,
+                                        (*yyg).yytext_r,
+                                        (*yyg).yylval_r as *mut c_void,
+                                    );
+                                    return result;
+                                }
+                            }
+                            12 => {
+                                let mut len_3: c_int = 0;
+                                len_3 = (strlen((*yyg).yytext_r)).wrapping_sub(2) as c_int;
+                                if len_3 >= 256 as c_int {
+                                    let mut errMsg_1: [c_char; 100] = [0; 100];
+                                    (*(*yyg).yyextra_r).status = 431 as c_int;
+                                    strcpy(
+                                        errMsg_1.as_mut_ptr(),
+                                        b"String exceeds maximum length: '\0" as *const u8
+                                            as *const c_char,
+                                    );
+                                    strncat(
+                                        errMsg_1.as_mut_ptr(),
+                                        &mut *((*yyg).yytext_r).offset(1 as c_int as isize),
+                                        20,
+                                    );
+                                    strcat(
+                                        errMsg_1.as_mut_ptr(),
+                                        b"...'\0" as *const u8 as *const c_char,
+                                    );
+                                    ffpmsg_slice(&errMsg_1);
+                                    len_3 = 0 as c_int;
+                                } else {
+                                    strncpy(
+                                        ((*(*yyg).yylval_r).astr).as_mut_ptr(),
+                                        &mut *((*yyg).yytext_r).offset(1 as c_int as isize),
+                                        len_3 as usize,
+                                    );
+                                }
+                                (*(*yyg).yylval_r).astr[len_3 as usize] = 0_i32 as c_char;
+                                return fits_parser_yytokentype::STRING as c_int;
+                            }
+                            13 => {
+                                let mut len_4: c_int = 0;
+                                let mut dtype: c_int = 0;
+                                if *((*yyg).yytext_r).offset(0 as c_int as isize) as c_int
+                                    == '$' as i32
+                                {
+                                    len_4 = (strlen((*yyg).yytext_r)).wrapping_sub(2) as c_int;
+                                    strncpy(
+                                        ((*(*yyg).yylval_r).astr).as_mut_ptr(),
+                                        &mut *((*yyg).yytext_r).offset(1 as c_int as isize),
+                                        len_4 as usize,
+                                    );
+                                    (*(*yyg).yylval_r).astr[len_4 as usize] = 0_i32 as c_char;
+                                    (*yyg).yytext_r = ((*(*yyg).yylval_r).astr).as_mut_ptr();
+                                }
+                                dtype = fits_parser_yyGetVariable(
+                                    (*yyg).yyextra_r,
+                                    (*yyg).yytext_r,
+                                    (*yyg).yylval_r,
+                                );
+                                return dtype;
+                            }
+                            14 => {
+                                let mut fname: *mut c_char = std::ptr::null_mut::<c_char>();
+                                let mut len_5: c_int = 0 as c_int;
+                                fname = &mut *((*(*yyg).yylval_r).astr)
+                                    .as_mut_ptr()
+                                    .offset(0 as c_int as isize)
+                                    as *mut c_char;
+                                loop {
+                                    let fresh3 = &mut *fname.offset(len_5 as isize);
+                                    *fresh3 = toupper(
+                                        (*((*yyg).yytext_r).offset(len_5 as isize) as c_int)
+                                            .try_into()
+                                            .unwrap(),
+                                    ) as c_char;
+                                    if *fresh3 == 0 {
+                                        break;
+                                    }
+                                    len_5 += 1;
+                                    len_5;
+                                }
+                                if (if (*fname.offset(0 as c_int as isize) as c_int)
+                                    < (*::core::mem::transmute::<&[u8; 5], &[c_char; 5]>(b"BOX(\0"))
+                                        [0 as c_int as usize]
+                                        as c_int
+                                {
+                                    -(1)
+                                } else if *fname.offset(0 as c_int as isize) as c_int
+                                    > (*::core::mem::transmute::<&[u8; 5], &[c_char; 5]>(b"BOX(\0"))
+                                        [0 as c_int as usize]
+                                        as c_int
+                                {
+                                    1
+                                } else {
+                                    strcmp(fname, b"BOX(\0" as *const u8 as *const c_char)
+                                }) == 0 as c_int
+                                    || (if (*fname.offset(0 as c_int as isize) as c_int)
+                                        < (*::core::mem::transmute::<&[u8; 8], &[c_char; 8]>(
+                                            b"CIRCLE(\0",
+                                        ))[0 as c_int as usize]
+                                            as c_int
+                                    {
+                                        -(1)
+                                    } else if *fname.offset(0 as c_int as isize) as c_int
+                                        > (*::core::mem::transmute::<&[u8; 8], &[c_char; 8]>(
+                                            b"CIRCLE(\0",
+                                        ))[0 as c_int as usize]
+                                            as c_int
+                                    {
+                                        1
+                                    } else {
+                                        strcmp(fname, b"CIRCLE(\0" as *const u8 as *const c_char)
+                                    }) == 0 as c_int
+                                    || (if (*fname.offset(0 as c_int as isize) as c_int)
+                                        < (*::core::mem::transmute::<&[u8; 9], &[c_char; 9]>(
+                                            b"ELLIPSE(\0",
+                                        ))[0 as c_int as usize]
+                                            as c_int
+                                    {
+                                        -(1)
+                                    } else if *fname.offset(0 as c_int as isize) as c_int
+                                        > (*::core::mem::transmute::<&[u8; 9], &[c_char; 9]>(
+                                            b"ELLIPSE(\0",
+                                        ))[0 as c_int as usize]
+                                            as c_int
+                                    {
+                                        1
+                                    } else {
+                                        strcmp(fname, b"ELLIPSE(\0" as *const u8 as *const c_char)
+                                    }) == 0 as c_int
+                                    || (if (*fname.offset(0 as c_int as isize) as c_int)
+                                        < (*::core::mem::transmute::<&[u8; 6], &[c_char; 6]>(
+                                            b"NEAR(\0",
+                                        ))[0 as c_int as usize]
+                                            as c_int
+                                    {
+                                        -(1)
+                                    } else if *fname.offset(0 as c_int as isize) as c_int
+                                        > (*::core::mem::transmute::<&[u8; 6], &[c_char; 6]>(
+                                            b"NEAR(\0",
+                                        ))[0 as c_int as usize]
+                                            as c_int
+                                    {
+                                        1
+                                    } else {
+                                        strcmp(fname, b"NEAR(\0" as *const u8 as *const c_char)
+                                    }) == 0 as c_int
+                                    || (if (*fname.offset(0 as c_int as isize) as c_int)
+                                        < (*::core::mem::transmute::<&[u8; 8], &[c_char; 8]>(
+                                            b"ISNULL(\0",
+                                        ))[0 as c_int as usize]
+                                            as c_int
+                                    {
+                                        -(1)
+                                    } else if *fname.offset(0 as c_int as isize) as c_int
+                                        > (*::core::mem::transmute::<&[u8; 8], &[c_char; 8]>(
+                                            b"ISNULL(\0",
+                                        ))[0 as c_int as usize]
+                                            as c_int
+                                    {
+                                        1
+                                    } else {
+                                        strcmp(fname, b"ISNULL(\0" as *const u8 as *const c_char)
+                                    }) == 0 as c_int
+                                {
+                                    return fits_parser_yytokentype::BFUNCTION as c_int;
+                                } else if (if (*fname.offset(0 as c_int as isize) as c_int)
+                                    < (*::core::mem::transmute::<&[u8; 11], &[c_char; 11]>(
+                                        b"GTIFILTER(\0",
+                                    ))[0 as c_int as usize]
+                                        as c_int
+                                {
+                                    -(1)
+                                } else if *fname.offset(0 as c_int as isize) as c_int
+                                    > (*::core::mem::transmute::<&[u8; 11], &[c_char; 11]>(
+                                        b"GTIFILTER(\0",
+                                    ))[0 as c_int as usize]
+                                        as c_int
+                                {
+                                    1
+                                } else {
+                                    strcmp(fname, b"GTIFILTER(\0" as *const u8 as *const c_char)
+                                }) == 0 as c_int
+                                {
+                                    return fits_parser_yytokentype::GTIFILTER as c_int;
+                                } else if (if (*fname.offset(0 as c_int as isize) as c_int)
+                                    < (*::core::mem::transmute::<&[u8; 12], &[c_char; 12]>(
+                                        b"GTIOVERLAP(\0",
+                                    ))[0 as c_int as usize]
+                                        as c_int
+                                {
+                                    -(1)
+                                } else if *fname.offset(0 as c_int as isize) as c_int
+                                    > (*::core::mem::transmute::<&[u8; 12], &[c_char; 12]>(
+                                        b"GTIOVERLAP(\0",
+                                    ))[0 as c_int as usize]
+                                        as c_int
+                                {
+                                    1
+                                } else {
+                                    strcmp(fname, b"GTIOVERLAP(\0" as *const u8 as *const c_char)
+                                }) == 0 as c_int
+                                {
+                                    return fits_parser_yytokentype::GTIOVERLAP as c_int;
+                                } else if (if (*fname.offset(0 as c_int as isize) as c_int)
+                                    < (*::core::mem::transmute::<&[u8; 9], &[c_char; 9]>(
+                                        b"GTIFIND(\0",
+                                    ))[0 as c_int as usize]
+                                        as c_int
+                                {
+                                    -(1)
+                                } else if *fname.offset(0 as c_int as isize) as c_int
+                                    > (*::core::mem::transmute::<&[u8; 9], &[c_char; 9]>(
+                                        b"GTIFIND(\0",
+                                    ))[0 as c_int as usize]
+                                        as c_int
+                                {
+                                    1
+                                } else {
+                                    strcmp(fname, b"GTIFIND(\0" as *const u8 as *const c_char)
+                                }) == 0 as c_int
+                                {
+                                    return fits_parser_yytokentype::GTIFIND as c_int;
+                                } else if (if (*fname.offset(0 as c_int as isize) as c_int)
+                                    < (*::core::mem::transmute::<&[u8; 11], &[c_char; 11]>(
+                                        b"REGFILTER(\0",
+                                    ))[0 as c_int as usize]
+                                        as c_int
+                                {
+                                    -(1)
+                                } else if *fname.offset(0 as c_int as isize) as c_int
+                                    > (*::core::mem::transmute::<&[u8; 11], &[c_char; 11]>(
+                                        b"REGFILTER(\0",
+                                    ))[0 as c_int as usize]
+                                        as c_int
+                                {
+                                    1
+                                } else {
+                                    strcmp(fname, b"REGFILTER(\0" as *const u8 as *const c_char)
+                                }) == 0 as c_int
+                                {
+                                    return fits_parser_yytokentype::REGFILTER as c_int;
+                                } else if (if (*fname.offset(0 as c_int as isize) as c_int)
+                                    < (*::core::mem::transmute::<&[u8; 8], &[c_char; 8]>(
+                                        b"STRSTR(\0",
+                                    ))[0 as c_int as usize]
+                                        as c_int
+                                {
+                                    -(1)
+                                } else if *fname.offset(0 as c_int as isize) as c_int
+                                    > (*::core::mem::transmute::<&[u8; 8], &[c_char; 8]>(
+                                        b"STRSTR(\0",
+                                    ))[0 as c_int as usize]
+                                        as c_int
+                                {
+                                    1
+                                } else {
+                                    strcmp(fname, b"STRSTR(\0" as *const u8 as *const c_char)
+                                }) == 0 as c_int
+                                {
+                                    return fits_parser_yytokentype::IFUNCTION as c_int;
+                                } else {
+                                    return fits_parser_yytokentype::FUNCTION as c_int;
+                                }
+                            }
+                            15 => return fits_parser_yytokentype::INTCAST as c_int,
+                            16 => return fits_parser_yytokentype::FLTCAST as c_int,
+                            17 => return fits_parser_yytokentype::POWER as c_int,
+                            18 => return fits_parser_yytokentype::NOT as c_int,
+                            19 => return fits_parser_yytokentype::OR as c_int,
+                            20 => return fits_parser_yytokentype::AND as c_int,
+                            21 => return fits_parser_yytokentype::EQ as c_int,
+                            22 => return fits_parser_yytokentype::NE as c_int,
+                            23 => return fits_parser_yytokentype::GT as c_int,
+                            24 => return fits_parser_yytokentype::LT as c_int,
+                            25 => return fits_parser_yytokentype::GTE as c_int,
+                            26 => return fits_parser_yytokentype::LTE as c_int,
+                            27 => return fits_parser_yytokentype::XOR as c_int,
+                            28 => return '\n' as i32,
+                            29 => {
+                                return *((*yyg).yytext_r).offset(0 as c_int as isize) as c_int;
+                            }
+                            30 => {
+                                fwrite(
+                                    (*yyg).yytext_r as *const c_void,
+                                    (*yyg).yyleng_r as usize,
+                                    1,
+                                    (*yyg).yyout_r,
+                                );
+                                0;
+                                break '_yy_match;
+                            }
+                            32 => return 0 as c_int,
+                            31 => {
+                                yy_amount_of_matched_text =
+                                    yy_cp.offset_from((*yyg).yytext_r) as c_long as c_int - 1;
+                                *yy_cp = (*yyg).yy_hold_char;
+                                if (**((*yyg).yy_buffer_stack).add((*yyg).yy_buffer_stack_top))
+                                    .yy_buffer_status
+                                    == 0 as c_int
+                                {
+                                    (*yyg).yy_n_chars = (**((*yyg).yy_buffer_stack)
+                                        .add((*yyg).yy_buffer_stack_top))
+                                    .yy_n_chars;
+                                    let fresh4 = &mut (**((*yyg).yy_buffer_stack)
+                                        .add((*yyg).yy_buffer_stack_top))
+                                    .yy_input_file;
+                                    *fresh4 = (*yyg).yyin_r;
+                                    (**((*yyg).yy_buffer_stack).add((*yyg).yy_buffer_stack_top))
+                                        .yy_buffer_status = 1;
+                                }
+                                if (*yyg).yy_c_buf_p
+                                    <= &mut *((**((*yyg).yy_buffer_stack)
+                                        .add((*yyg).yy_buffer_stack_top))
+                                    .yy_ch_buf)
+                                        .offset((*yyg).yy_n_chars as isize)
+                                        as *mut c_char
+                                {
+                                    yy_next_state = 0;
+                                    (*yyg).yy_c_buf_p = ((*yyg).yytext_r)
+                                        .offset(yy_amount_of_matched_text as isize);
+                                    yy_current_state = yy_get_previous_state(yyscanner);
+                                    yy_next_state = yy_try_NUL_trans(yy_current_state, yyscanner);
+                                    yy_bp = ((*yyg).yytext_r).offset(0 as c_int as isize);
+                                    if yy_next_state != 0 {
+                                        current_block = 2606663910910355487;
+                                        break;
+                                    } else {
+                                        current_block = 7986280648684494582;
+                                        break;
+                                    }
+                                } else {
+                                    match yy_get_next_buffer(yyscanner) {
+                                        1 => {
+                                            (*yyg).yy_did_buffer_switch_on_eof = 0 as c_int;
+                                            if fits_parser_yywrap(yyscanner) != 0 {
+                                                (*yyg).yy_c_buf_p =
+                                                    ((*yyg).yytext_r).offset(0 as c_int as isize);
+                                                yy_act = 31 as c_int
+                                                    + ((*yyg).yy_start - 1) / 2 as c_int
+                                                    + 1;
+                                            } else {
+                                                if (*yyg).yy_did_buffer_switch_on_eof == 0 {
+                                                    fits_parser_yyrestart((*yyg).yyin_r, yyscanner);
+                                                }
+                                                break '_yy_match;
+                                            }
+                                        }
+                                        0 => {
+                                            (*yyg).yy_c_buf_p = ((*yyg).yytext_r)
+                                                .offset(yy_amount_of_matched_text as isize);
+                                            yy_current_state = yy_get_previous_state(yyscanner);
+                                            yy_cp = (*yyg).yy_c_buf_p;
+                                            yy_bp = ((*yyg).yytext_r).offset(0 as c_int as isize);
+                                            break '_yy_find_action;
+                                        }
+                                        2 => {
+                                            (*yyg).yy_c_buf_p = &mut *((**((*yyg).yy_buffer_stack)
+                                                .add((*yyg).yy_buffer_stack_top))
+                                            .yy_ch_buf)
+                                                .offset((*yyg).yy_n_chars as isize)
+                                                as *mut c_char;
+                                            yy_current_state = yy_get_previous_state(yyscanner);
+                                            yy_cp = (*yyg).yy_c_buf_p;
+                                            yy_bp = ((*yyg).yytext_r).offset(0 as c_int as isize);
+                                            continue '_yy_find_action;
+                                        }
+                                        _ => {
+                                            break '_yy_match;
+                                        }
+                                    }
+                                }
+                            }
+                            _ => {
+                                yy_fatal_error(
+                                    b"fatal flex scanner internal error--no action found\0"
+                                        as *const u8
+                                        as *const c_char,
+                                    yyscanner,
+                                );
+                            }
+                        }
+                    }
+                    match current_block {
+                        7986280648684494582 => {
+                            yy_cp = (*yyg).yy_c_buf_p;
+                        }
+                        _ => {
+                            (*yyg).yy_c_buf_p = ((*yyg).yy_c_buf_p).offset(1);
+                            yy_cp = (*yyg).yy_c_buf_p;
+                            yy_current_state = yy_next_state;
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+unsafe fn yy_get_next_buffer(mut yyscanner: yyscan_t) -> c_int {
+    unsafe {
+        let mut yyg: *mut yyguts_t = yyscanner as *mut yyguts_t;
+        let mut dest: *mut c_char =
+            (**((*yyg).yy_buffer_stack).add((*yyg).yy_buffer_stack_top)).yy_ch_buf;
+        let mut source: *mut c_char = (*yyg).yytext_r;
+        let mut number_to_move: c_int = 0;
+        let mut i: c_int = 0;
+        let mut ret_val: c_int = 0;
+        if (*yyg).yy_c_buf_p
+            > &mut *((**((*yyg).yy_buffer_stack).add((*yyg).yy_buffer_stack_top)).yy_ch_buf)
+                .offset(((*yyg).yy_n_chars + 1) as isize) as *mut c_char
+        {
+            yy_fatal_error(
+                b"fatal flex scanner internal error--end of buffer missed\0" as *const u8
+                    as *const c_char,
+                yyscanner,
+            );
+        }
+        if (**((*yyg).yy_buffer_stack).add((*yyg).yy_buffer_stack_top)).yy_fill_buffer == 0 as c_int
+        {
+            if ((*yyg).yy_c_buf_p).offset_from((*yyg).yytext_r) as c_long - 0 as c_int as c_long
+                == 1
+            {
+                return 1;
+            } else {
+                return 2 as c_int;
+            }
+        }
+        number_to_move = (((*yyg).yy_c_buf_p).offset_from((*yyg).yytext_r) as c_long - 1) as c_int;
+        i = 0 as c_int;
+        while i < number_to_move {
+            let fresh5 = source;
+            source = source.offset(1);
+            let fresh6 = dest;
+            dest = dest.offset(1);
+            *fresh6 = *fresh5;
+            i += 1;
+            i;
+        }
+        if (**((*yyg).yy_buffer_stack).add((*yyg).yy_buffer_stack_top)).yy_buffer_status
+            == 2 as c_int
+        {
+            (*yyg).yy_n_chars = 0 as c_int;
+            (**((*yyg).yy_buffer_stack).add((*yyg).yy_buffer_stack_top)).yy_n_chars =
+                (*yyg).yy_n_chars;
+        } else {
+            let mut num_to_read: c_int =
+                (**((*yyg).yy_buffer_stack).add((*yyg).yy_buffer_stack_top)).yy_buf_size
+                    - number_to_move
+                    - 1;
+            while num_to_read <= 0 as c_int {
+                let mut b: YY_BUFFER_STATE =
+                    *((*yyg).yy_buffer_stack).add((*yyg).yy_buffer_stack_top);
+                let mut yy_c_buf_p_offset: c_int =
+                    ((*yyg).yy_c_buf_p).offset_from((*b).yy_ch_buf) as c_long as c_int;
+                if (*b).yy_is_our_buffer != 0 {
+                    let mut new_size: c_int = (*b).yy_buf_size * 2 as c_int;
+                    if new_size <= 0 as c_int {
+                        (*b).yy_buf_size += (*b).yy_buf_size / 8 as c_int;
+                    } else {
+                        (*b).yy_buf_size *= 2 as c_int;
+                    }
+                    (*b).yy_ch_buf = fits_parser_yyrealloc(
+                        (*b).yy_ch_buf as *mut c_void,
+                        ((*b).yy_buf_size + 2 as c_int) as yy_size_t,
+                        yyscanner,
+                    ) as *mut c_char;
+                } else {
+                    (*b).yy_ch_buf = std::ptr::null_mut::<c_char>();
+                }
+                if ((*b).yy_ch_buf).is_null() {
+                    yy_fatal_error(
+                        b"fatal error - scanner input buffer overflow\0" as *const u8
+                            as *const c_char,
+                        yyscanner,
+                    );
+                }
+                (*yyg).yy_c_buf_p =
+                    &mut *((*b).yy_ch_buf).offset(yy_c_buf_p_offset as isize) as *mut c_char;
+                num_to_read = (**((*yyg).yy_buffer_stack).add((*yyg).yy_buffer_stack_top))
+                    .yy_buf_size
+                    - number_to_move
+                    - 1;
+            }
+            if num_to_read > 8192 as c_int {
+                num_to_read = 8192 as c_int;
+            }
+            (*yyg).yy_n_chars = expr_read(
+                (*yyg).yyextra_r,
+                &mut *((**((*yyg).yy_buffer_stack).add((*yyg).yy_buffer_stack_top)).yy_ch_buf)
+                    .offset(number_to_move as isize) as *mut c_char,
+                num_to_read,
+            );
+            if (*yyg).yy_n_chars < 0 as c_int {
+                yy_fatal_error(
+                    b"read() in flex scanner failed\0" as *const u8 as *const c_char,
+                    yyscanner,
+                );
+            }
+            (**((*yyg).yy_buffer_stack).add((*yyg).yy_buffer_stack_top)).yy_n_chars =
+                (*yyg).yy_n_chars;
+        }
+        if (*yyg).yy_n_chars == 0 as c_int {
+            if number_to_move == 0 as c_int {
+                ret_val = 1;
+                fits_parser_yyrestart((*yyg).yyin_r, yyscanner);
+            } else {
+                ret_val = 2 as c_int;
+                (**((*yyg).yy_buffer_stack).add((*yyg).yy_buffer_stack_top)).yy_buffer_status =
+                    2 as c_int;
+            }
+        } else {
+            ret_val = 0 as c_int;
+        }
+        if (*yyg).yy_n_chars + number_to_move
+            > (**((*yyg).yy_buffer_stack).add((*yyg).yy_buffer_stack_top)).yy_buf_size
+        {
+            let mut new_size_0: c_int =
+                (*yyg).yy_n_chars + number_to_move + ((*yyg).yy_n_chars >> 1);
+            let fresh7 =
+                &mut (**((*yyg).yy_buffer_stack).add((*yyg).yy_buffer_stack_top)).yy_ch_buf;
+            *fresh7 = fits_parser_yyrealloc(
+                (**((*yyg).yy_buffer_stack).add((*yyg).yy_buffer_stack_top)).yy_ch_buf
+                    as *mut c_void,
+                new_size_0 as yy_size_t,
+                yyscanner,
+            ) as *mut c_char;
+            if ((**((*yyg).yy_buffer_stack).add((*yyg).yy_buffer_stack_top)).yy_ch_buf).is_null() {
+                yy_fatal_error(
+                    b"out of dynamic memory in yy_get_next_buffer()\0" as *const u8
+                        as *const c_char,
+                    yyscanner,
+                );
+            }
+            (**((*yyg).yy_buffer_stack).add((*yyg).yy_buffer_stack_top)).yy_buf_size =
+                new_size_0 - 2 as c_int;
+        }
+        (*yyg).yy_n_chars += number_to_move;
+        *((**((*yyg).yy_buffer_stack).add((*yyg).yy_buffer_stack_top)).yy_ch_buf)
+            .offset((*yyg).yy_n_chars as isize) = 0 as c_int as c_char;
+        *((**((*yyg).yy_buffer_stack).add((*yyg).yy_buffer_stack_top)).yy_ch_buf)
+            .offset(((*yyg).yy_n_chars + 1) as isize) = 0 as c_int as c_char;
+        (*yyg).yytext_r = &mut *((**((*yyg).yy_buffer_stack).add((*yyg).yy_buffer_stack_top))
+            .yy_ch_buf)
+            .offset(0 as c_int as isize) as *mut c_char;
+        ret_val
+    }
+}
+unsafe fn yy_get_previous_state(mut yyscanner: yyscan_t) -> yy_state_type {
+    unsafe {
+        let mut yy_current_state: yy_state_type = 0;
+        let mut yy_cp: *mut c_char = std::ptr::null_mut::<c_char>();
+        let mut yyg: *mut yyguts_t = yyscanner as *mut yyguts_t;
+        yy_current_state = (*yyg).yy_start;
+        yy_cp = ((*yyg).yytext_r).offset(0 as c_int as isize);
+        while yy_cp < (*yyg).yy_c_buf_p {
+            let mut yy_c: YY_CHAR = (if *yy_cp as c_int != 0 {
+                yy_ec[*yy_cp as YY_CHAR as usize] as c_int
+            } else {
+                1
+            }) as YY_CHAR;
+            if yy_accept[yy_current_state as usize] != 0 {
+                (*yyg).yy_last_accepting_state = yy_current_state;
+                (*yyg).yy_last_accepting_cpos = yy_cp;
+            }
+            while yy_chk[(yy_base[yy_current_state as usize] as c_int + yy_c as c_int) as usize]
+                as c_int
+                != yy_current_state
+            {
+                yy_current_state = yy_def[yy_current_state as usize] as c_int;
+                if yy_current_state >= 174 as c_int {
+                    yy_c = yy_meta[yy_c as usize];
+                }
+            }
+            yy_current_state = yy_nxt
+                [(yy_base[yy_current_state as usize] as c_int + yy_c as c_int) as usize]
+                as yy_state_type;
+            yy_cp = yy_cp.offset(1);
+            yy_cp;
+        }
+        yy_current_state
+    }
+}
+unsafe fn yy_try_NUL_trans(
+    mut yy_current_state: yy_state_type,
+    mut yyscanner: yyscan_t,
+) -> yy_state_type {
+    unsafe {
+        let mut yy_is_jam: c_int = 0;
+        let mut yyg: *mut yyguts_t = yyscanner as *mut yyguts_t;
+        let mut yy_cp: *mut c_char = (*yyg).yy_c_buf_p;
+        let mut yy_c: YY_CHAR = 1 as YY_CHAR;
+        if yy_accept[yy_current_state as usize] != 0 {
+            (*yyg).yy_last_accepting_state = yy_current_state;
+            (*yyg).yy_last_accepting_cpos = yy_cp;
+        }
+        while yy_chk[(yy_base[yy_current_state as usize] as c_int + yy_c as c_int) as usize]
+            as c_int
+            != yy_current_state
+        {
+            yy_current_state = yy_def[yy_current_state as usize] as c_int;
+            if yy_current_state >= 174 as c_int {
+                yy_c = yy_meta[yy_c as usize];
+            }
+        }
+        yy_current_state = yy_nxt
+            [(yy_base[yy_current_state as usize] as c_int + yy_c as c_int) as usize]
+            as yy_state_type;
+        yy_is_jam = (yy_current_state == 173 as c_int) as c_int;
+        if yy_is_jam != 0 {
+            0 as c_int
+        } else {
+            yy_current_state
+        }
+    }
+}
+
+pub unsafe fn fits_parser_yyrestart(mut input_file: *mut FILE, mut yyscanner: yyscan_t) {
+    unsafe {
+        let mut yyg: *mut yyguts_t = yyscanner as *mut yyguts_t;
+        if if !((*yyg).yy_buffer_stack).is_null() {
+            *((*yyg).yy_buffer_stack).add((*yyg).yy_buffer_stack_top)
+        } else {
+            0 as YY_BUFFER_STATE
+        }
+        .is_null()
+        {
+            fits_parser_yyensure_buffer_stack(yyscanner);
+            let fresh8 = &mut *((*yyg).yy_buffer_stack).add((*yyg).yy_buffer_stack_top);
+            *fresh8 = fits_parser_yy_create_buffer((*yyg).yyin_r, 16384 as c_int, yyscanner);
+        }
+        fits_parser_yy_init_buffer(
+            if !((*yyg).yy_buffer_stack).is_null() {
+                *((*yyg).yy_buffer_stack).add((*yyg).yy_buffer_stack_top)
+            } else {
+                0 as YY_BUFFER_STATE
+            },
+            input_file,
+            yyscanner,
+        );
+        fits_parser_yy_load_buffer_state(yyscanner);
+    }
+}
+
+pub unsafe fn fits_parser_yy_switch_to_buffer(
+    mut new_buffer: YY_BUFFER_STATE,
+    mut yyscanner: yyscan_t,
+) {
+    unsafe {
+        let mut yyg: *mut yyguts_t = yyscanner as *mut yyguts_t;
+        fits_parser_yyensure_buffer_stack(yyscanner);
+        if (if !((*yyg).yy_buffer_stack).is_null() {
+            *((*yyg).yy_buffer_stack).add((*yyg).yy_buffer_stack_top)
+        } else {
+            0 as YY_BUFFER_STATE
+        }) == new_buffer
+        {
+            return;
+        }
+        if !if !((*yyg).yy_buffer_stack).is_null() {
+            *((*yyg).yy_buffer_stack).add((*yyg).yy_buffer_stack_top)
+        } else {
+            0 as YY_BUFFER_STATE
+        }
+        .is_null()
+        {
+            *(*yyg).yy_c_buf_p = (*yyg).yy_hold_char;
+            let fresh9 =
+                &mut (**((*yyg).yy_buffer_stack).add((*yyg).yy_buffer_stack_top)).yy_buf_pos;
+            *fresh9 = (*yyg).yy_c_buf_p;
+            (**((*yyg).yy_buffer_stack).add((*yyg).yy_buffer_stack_top)).yy_n_chars =
+                (*yyg).yy_n_chars;
+        }
+        let fresh10 = &mut *((*yyg).yy_buffer_stack).add((*yyg).yy_buffer_stack_top);
+        *fresh10 = new_buffer;
+        fits_parser_yy_load_buffer_state(yyscanner);
+        (*yyg).yy_did_buffer_switch_on_eof = 1;
+    }
+}
+unsafe fn fits_parser_yy_load_buffer_state(mut yyscanner: yyscan_t) {
+    unsafe {
+        let mut yyg: *mut yyguts_t = yyscanner as *mut yyguts_t;
+        (*yyg).yy_n_chars = (**((*yyg).yy_buffer_stack).add((*yyg).yy_buffer_stack_top)).yy_n_chars;
+        (*yyg).yy_c_buf_p = (**((*yyg).yy_buffer_stack).add((*yyg).yy_buffer_stack_top)).yy_buf_pos;
+        (*yyg).yytext_r = (*yyg).yy_c_buf_p;
+        (*yyg).yyin_r = (**((*yyg).yy_buffer_stack).add((*yyg).yy_buffer_stack_top)).yy_input_file;
+        (*yyg).yy_hold_char = *(*yyg).yy_c_buf_p;
+    }
+}
+
+pub unsafe fn fits_parser_yy_create_buffer(
+    mut file: *mut FILE,
+    mut size: c_int,
+    mut yyscanner: yyscan_t,
+) -> YY_BUFFER_STATE {
+    unsafe {
+        let mut b: YY_BUFFER_STATE = std::ptr::null_mut::<yy_buffer_state>();
+        b = fits_parser_yyalloc(
+            (::core::mem::size_of::<yy_buffer_state>() as c_ulong)
+                .try_into()
+                .unwrap(),
+            yyscanner,
+        ) as YY_BUFFER_STATE;
+        if b.is_null() {
+            yy_fatal_error(
+                b"out of dynamic memory in yy_create_buffer()\0" as *const u8 as *const c_char,
+                yyscanner,
+            );
+        }
+        (*b).yy_buf_size = size;
+        (*b).yy_ch_buf =
+            fits_parser_yyalloc(((*b).yy_buf_size + 2 as c_int) as yy_size_t, yyscanner)
+                as *mut c_char;
+        if ((*b).yy_ch_buf).is_null() {
+            yy_fatal_error(
+                b"out of dynamic memory in yy_create_buffer()\0" as *const u8 as *const c_char,
+                yyscanner,
+            );
+        }
+        (*b).yy_is_our_buffer = 1;
+        fits_parser_yy_init_buffer(b, file, yyscanner);
+        b
+    }
+}
+
+pub unsafe fn fits_parser_yy_delete_buffer(mut b: YY_BUFFER_STATE, mut yyscanner: yyscan_t) {
+    unsafe {
+        let mut yyg: *mut yyguts_t = yyscanner as *mut yyguts_t;
+        if b.is_null() {
+            return;
+        }
+        if b == (if !((*yyg).yy_buffer_stack).is_null() {
+            *((*yyg).yy_buffer_stack).add((*yyg).yy_buffer_stack_top)
+        } else {
+            0 as YY_BUFFER_STATE
+        }) {
+            let fresh11 = &mut *((*yyg).yy_buffer_stack).add((*yyg).yy_buffer_stack_top);
+            *fresh11 = 0 as YY_BUFFER_STATE;
+        }
+        if (*b).yy_is_our_buffer != 0 {
+            fits_parser_yyfree((*b).yy_ch_buf as *mut c_void, yyscanner);
+        }
+        fits_parser_yyfree(b as *mut c_void, yyscanner);
+    }
+}
+unsafe fn fits_parser_yy_init_buffer(
+    mut b: YY_BUFFER_STATE,
+    mut file: *mut FILE,
+    mut yyscanner: yyscan_t,
+) {
+    unsafe {
+        let mut oerrno: c_int = *__errno_location();
+        let mut yyg: *mut yyguts_t = yyscanner as *mut yyguts_t;
+        fits_parser_yy_flush_buffer(b, yyscanner);
+        (*b).yy_input_file = file;
+        (*b).yy_fill_buffer = 1;
+        if b != (if !((*yyg).yy_buffer_stack).is_null() {
+            *((*yyg).yy_buffer_stack).add((*yyg).yy_buffer_stack_top)
+        } else {
+            0 as YY_BUFFER_STATE
+        }) {
+            (*b).yy_bs_lineno = 1;
+            (*b).yy_bs_column = 0 as c_int;
+        }
+        (*b).yy_is_interactive = if !file.is_null() {
+            (isatty(fileno(file)) > 0 as c_int) as c_int
+        } else {
+            0 as c_int
+        };
+        *__errno_location() = oerrno;
+    }
+}
+
+pub unsafe fn fits_parser_yy_flush_buffer(mut b: YY_BUFFER_STATE, mut yyscanner: yyscan_t) {
+    unsafe {
+        let mut yyg: *mut yyguts_t = yyscanner as *mut yyguts_t;
+        if b.is_null() {
+            return;
+        }
+        (*b).yy_n_chars = 0 as c_int;
+        *((*b).yy_ch_buf).offset(0 as c_int as isize) = 0 as c_int as c_char;
+        *((*b).yy_ch_buf).offset(1 as c_int as isize) = 0 as c_int as c_char;
+        (*b).yy_buf_pos = &mut *((*b).yy_ch_buf).offset(0 as c_int as isize) as *mut c_char;
+        (*b).yy_at_bol = 1;
+        (*b).yy_buffer_status = 0 as c_int;
+        if b == (if !((*yyg).yy_buffer_stack).is_null() {
+            *((*yyg).yy_buffer_stack).add((*yyg).yy_buffer_stack_top)
+        } else {
+            0 as YY_BUFFER_STATE
+        }) {
+            fits_parser_yy_load_buffer_state(yyscanner);
+        }
+    }
+}
+
+pub unsafe fn fits_parser_yypush_buffer_state(
+    mut new_buffer: YY_BUFFER_STATE,
+    mut yyscanner: yyscan_t,
+) {
+    unsafe {
+        let mut yyg: *mut yyguts_t = yyscanner as *mut yyguts_t;
+        if new_buffer.is_null() {
+            return;
+        }
+        fits_parser_yyensure_buffer_stack(yyscanner);
+        if !if !((*yyg).yy_buffer_stack).is_null() {
+            *((*yyg).yy_buffer_stack).add((*yyg).yy_buffer_stack_top)
+        } else {
+            0 as YY_BUFFER_STATE
+        }
+        .is_null()
+        {
+            *(*yyg).yy_c_buf_p = (*yyg).yy_hold_char;
+            let fresh12 =
+                &mut (**((*yyg).yy_buffer_stack).add((*yyg).yy_buffer_stack_top)).yy_buf_pos;
+            *fresh12 = (*yyg).yy_c_buf_p;
+            (**((*yyg).yy_buffer_stack).add((*yyg).yy_buffer_stack_top)).yy_n_chars =
+                (*yyg).yy_n_chars;
+        }
+        if !if !((*yyg).yy_buffer_stack).is_null() {
+            *((*yyg).yy_buffer_stack).add((*yyg).yy_buffer_stack_top)
+        } else {
+            0 as YY_BUFFER_STATE
+        }
+        .is_null()
+        {
+            (*yyg).yy_buffer_stack_top = ((*yyg).yy_buffer_stack_top).wrapping_add(1);
+            (*yyg).yy_buffer_stack_top;
+        }
+        let fresh13 = &mut *((*yyg).yy_buffer_stack).add((*yyg).yy_buffer_stack_top);
+        *fresh13 = new_buffer;
+        fits_parser_yy_load_buffer_state(yyscanner);
+        (*yyg).yy_did_buffer_switch_on_eof = 1;
+    }
+}
+
+pub unsafe fn fits_parser_yypop_buffer_state(mut yyscanner: yyscan_t) {
+    unsafe {
+        let mut yyg: *mut yyguts_t = yyscanner as *mut yyguts_t;
+        if if !((*yyg).yy_buffer_stack).is_null() {
+            *((*yyg).yy_buffer_stack).add((*yyg).yy_buffer_stack_top)
+        } else {
+            0 as YY_BUFFER_STATE
+        }
+        .is_null()
+        {
+            return;
+        }
+        fits_parser_yy_delete_buffer(
+            if !((*yyg).yy_buffer_stack).is_null() {
+                *((*yyg).yy_buffer_stack).add((*yyg).yy_buffer_stack_top)
+            } else {
+                0 as YY_BUFFER_STATE
+            },
+            yyscanner,
+        );
+        let fresh14 = &mut *((*yyg).yy_buffer_stack).add((*yyg).yy_buffer_stack_top);
+        *fresh14 = 0 as YY_BUFFER_STATE;
+        if (*yyg).yy_buffer_stack_top > 0 as c_int as size_t {
+            (*yyg).yy_buffer_stack_top = ((*yyg).yy_buffer_stack_top).wrapping_sub(1);
+            (*yyg).yy_buffer_stack_top;
+        }
+        if !if !((*yyg).yy_buffer_stack).is_null() {
+            *((*yyg).yy_buffer_stack).add((*yyg).yy_buffer_stack_top)
+        } else {
+            0 as YY_BUFFER_STATE
+        }
+        .is_null()
+        {
+            fits_parser_yy_load_buffer_state(yyscanner);
+            (*yyg).yy_did_buffer_switch_on_eof = 1;
+        }
+    }
+}
+unsafe fn fits_parser_yyensure_buffer_stack(mut yyscanner: yyscan_t) {
+    unsafe {
+        let mut num_to_alloc: yy_size_t = 0;
+        let mut yyg: *mut yyguts_t = yyscanner as *mut yyguts_t;
+        if ((*yyg).yy_buffer_stack).is_null() {
+            num_to_alloc = 1 as yy_size_t;
+            (*yyg).yy_buffer_stack = fits_parser_yyalloc(
+                num_to_alloc.wrapping_mul(
+                    (::core::mem::size_of::<*mut yy_buffer_state>() as c_ulong)
+                        .try_into()
+                        .unwrap(),
+                ),
+                yyscanner,
+            ) as *mut *mut yy_buffer_state;
+            if ((*yyg).yy_buffer_stack).is_null() {
+                yy_fatal_error(
+                    b"out of dynamic memory in yyensure_buffer_stack()\0" as *const u8
+                        as *const c_char,
+                    yyscanner,
+                );
+            }
+            memset(
+                (*yyg).yy_buffer_stack as *mut c_void,
+                0 as c_int,
+                num_to_alloc.wrapping_mul(::core::mem::size_of::<*mut yy_buffer_state>()),
+            );
+            (*yyg).yy_buffer_stack_max = num_to_alloc;
+            (*yyg).yy_buffer_stack_top = 0 as c_int as size_t;
+            return;
+        }
+        if (*yyg).yy_buffer_stack_top
+            >= ((*yyg).yy_buffer_stack_max).wrapping_sub(1 as c_int as size_t)
+        {
+            let mut grow_size: yy_size_t = 8 as c_int as yy_size_t;
+            num_to_alloc = ((*yyg).yy_buffer_stack_max).wrapping_add(grow_size);
+            (*yyg).yy_buffer_stack = fits_parser_yyrealloc(
+                (*yyg).yy_buffer_stack as *mut c_void,
+                num_to_alloc.wrapping_mul(::core::mem::size_of::<*mut yy_buffer_state>()),
+                yyscanner,
+            ) as *mut *mut yy_buffer_state;
+            if ((*yyg).yy_buffer_stack).is_null() {
+                yy_fatal_error(
+                    b"out of dynamic memory in yyensure_buffer_stack()\0" as *const u8
+                        as *const c_char,
+                    yyscanner,
+                );
+            }
+            memset(
+                ((*yyg).yy_buffer_stack).add((*yyg).yy_buffer_stack_max) as *mut c_void,
+                0 as c_int,
+                grow_size.wrapping_mul(::core::mem::size_of::<*mut yy_buffer_state>()),
+            );
+            (*yyg).yy_buffer_stack_max = num_to_alloc;
+        }
+    }
+}
+
+pub unsafe fn fits_parser_yy_scan_buffer(
+    mut base: *mut c_char,
+    mut size: yy_size_t,
+    mut yyscanner: yyscan_t,
+) -> YY_BUFFER_STATE {
+    unsafe {
+        let mut b: YY_BUFFER_STATE = std::ptr::null_mut::<yy_buffer_state>();
+        if size < 2 as c_int as yy_size_t
+            || *base.add(size.wrapping_sub(2 as c_int as yy_size_t)) as c_int != 0 as c_int
+            || *base.add(size.wrapping_sub(1 as c_int as yy_size_t)) as c_int != 0 as c_int
+        {
+            return 0 as YY_BUFFER_STATE;
+        }
+        b = fits_parser_yyalloc(
+            (::core::mem::size_of::<yy_buffer_state>() as c_ulong)
+                .try_into()
+                .unwrap(),
+            yyscanner,
+        ) as YY_BUFFER_STATE;
+        if b.is_null() {
+            yy_fatal_error(
+                b"out of dynamic memory in yy_scan_buffer()\0" as *const u8 as *const c_char,
+                yyscanner,
+            );
+        }
+        (*b).yy_buf_size = size.wrapping_sub(2 as c_int as yy_size_t) as c_int;
+        (*b).yy_ch_buf = base;
+        (*b).yy_buf_pos = (*b).yy_ch_buf;
+        (*b).yy_is_our_buffer = 0 as c_int;
+        (*b).yy_input_file = std::ptr::null_mut::<FILE>();
+        (*b).yy_n_chars = (*b).yy_buf_size;
+        (*b).yy_is_interactive = 0 as c_int;
+        (*b).yy_at_bol = 1;
+        (*b).yy_fill_buffer = 0 as c_int;
+        (*b).yy_buffer_status = 0 as c_int;
+        fits_parser_yy_switch_to_buffer(b, yyscanner);
+        b
+    }
+}
+
+pub unsafe fn fits_parser_yy_scan_string(
+    mut yystr: *const c_char,
+    mut yyscanner: yyscan_t,
+) -> YY_BUFFER_STATE {
+    unsafe { fits_parser_yy_scan_bytes(yystr, strlen(yystr) as c_int, yyscanner) }
+}
+
+pub unsafe fn fits_parser_yy_scan_bytes(
+    mut yybytes: *const c_char,
+    mut _yybytes_len: c_int,
+    mut yyscanner: yyscan_t,
+) -> YY_BUFFER_STATE {
+    unsafe {
+        let mut b: YY_BUFFER_STATE = std::ptr::null_mut::<yy_buffer_state>();
+        let mut buf: *mut c_char = std::ptr::null_mut::<c_char>();
+        let mut n: yy_size_t = 0;
+        let mut i: c_int = 0;
+        n = (_yybytes_len + 2 as c_int) as yy_size_t;
+        buf = fits_parser_yyalloc(n, yyscanner) as *mut c_char;
+        if buf.is_null() {
+            yy_fatal_error(
+                b"out of dynamic memory in yy_scan_bytes()\0" as *const u8 as *const c_char,
+                yyscanner,
+            );
+        }
+        i = 0 as c_int;
+        while i < _yybytes_len {
+            *buf.offset(i as isize) = *yybytes.offset(i as isize);
+            i += 1;
+            i;
+        }
+        let fresh15 = &mut *buf.offset((_yybytes_len + 1) as isize);
+        *fresh15 = 0 as c_int as c_char;
+        *buf.offset(_yybytes_len as isize) = *fresh15;
+        b = fits_parser_yy_scan_buffer(buf, n, yyscanner);
+        if b.is_null() {
+            yy_fatal_error(
+                b"bad buffer in yy_scan_bytes()\0" as *const u8 as *const c_char,
+                yyscanner,
+            );
+        }
+        (*b).yy_is_our_buffer = 1;
+        b
+    }
+}
+unsafe fn yy_fatal_error(mut msg: *const c_char, mut yyscanner: yyscan_t) -> ! {
+    unsafe {
+        let mut yyg: *mut yyguts_t = yyscanner as *mut yyguts_t;
+        fprintf(stderr, b"%s\n\0" as *const u8 as *const c_char, msg);
+        exit(2 as c_int);
+    }
+}
+
+pub unsafe fn fits_parser_yyget_extra(mut yyscanner: yyscan_t) -> *mut ParseData {
+    unsafe {
+        let mut yyg: *mut yyguts_t = yyscanner as *mut yyguts_t;
+        (*yyg).yyextra_r
+    }
+}
+
+pub unsafe fn fits_parser_yyget_lineno(mut yyscanner: yyscan_t) -> c_int {
+    unsafe {
+        let mut yyg: *mut yyguts_t = yyscanner as *mut yyguts_t;
+        if if !((*yyg).yy_buffer_stack).is_null() {
+            *((*yyg).yy_buffer_stack).add((*yyg).yy_buffer_stack_top)
+        } else {
+            0 as YY_BUFFER_STATE
+        }
+        .is_null()
+        {
+            return 0 as c_int;
+        }
+        (**((*yyg).yy_buffer_stack).add((*yyg).yy_buffer_stack_top)).yy_bs_lineno
+    }
+}
+
+pub unsafe fn fits_parser_yyget_column(mut yyscanner: yyscan_t) -> c_int {
+    unsafe {
+        let mut yyg: *mut yyguts_t = yyscanner as *mut yyguts_t;
+        if if !((*yyg).yy_buffer_stack).is_null() {
+            *((*yyg).yy_buffer_stack).add((*yyg).yy_buffer_stack_top)
+        } else {
+            0 as YY_BUFFER_STATE
+        }
+        .is_null()
+        {
+            return 0 as c_int;
+        }
+        (**((*yyg).yy_buffer_stack).add((*yyg).yy_buffer_stack_top)).yy_bs_column
+    }
+}
+
+pub unsafe fn fits_parser_yyget_in(mut yyscanner: yyscan_t) -> *mut FILE {
+    unsafe {
+        let mut yyg: *mut yyguts_t = yyscanner as *mut yyguts_t;
+        (*yyg).yyin_r
+    }
+}
+
+pub unsafe fn fits_parser_yyget_out(mut yyscanner: yyscan_t) -> *mut FILE {
+    unsafe {
+        let mut yyg: *mut yyguts_t = yyscanner as *mut yyguts_t;
+        (*yyg).yyout_r
+    }
+}
+
+pub unsafe fn fits_parser_yyget_leng(mut yyscanner: yyscan_t) -> c_int {
+    unsafe {
+        let mut yyg: *mut yyguts_t = yyscanner as *mut yyguts_t;
+        (*yyg).yyleng_r
+    }
+}
+
+pub unsafe fn fits_parser_yyget_text(mut yyscanner: yyscan_t) -> *mut c_char {
+    unsafe {
+        let mut yyg: *mut yyguts_t = yyscanner as *mut yyguts_t;
+        (*yyg).yytext_r
+    }
+}
+
+pub unsafe fn fits_parser_yyset_extra(mut user_defined: *mut ParseData, mut yyscanner: yyscan_t) {
+    unsafe {
+        let mut yyg: *mut yyguts_t = yyscanner as *mut yyguts_t;
+        (*yyg).yyextra_r = user_defined;
+    }
+}
+
+pub unsafe fn fits_parser_yyset_lineno(mut _line_number: c_int, mut yyscanner: yyscan_t) {
+    unsafe {
+        let mut yyg: *mut yyguts_t = yyscanner as *mut yyguts_t;
+        if if !((*yyg).yy_buffer_stack).is_null() {
+            *((*yyg).yy_buffer_stack).add((*yyg).yy_buffer_stack_top)
+        } else {
+            0 as YY_BUFFER_STATE
+        }
+        .is_null()
+        {
+            yy_fatal_error(
+                b"yyset_lineno called with no buffer\0" as *const u8 as *const c_char,
+                yyscanner,
+            );
+        }
+        (**((*yyg).yy_buffer_stack).add((*yyg).yy_buffer_stack_top)).yy_bs_lineno = _line_number;
+    }
+}
+
+pub unsafe fn fits_parser_yyset_column(mut _column_no: c_int, mut yyscanner: yyscan_t) {
+    unsafe {
+        let mut yyg: *mut yyguts_t = yyscanner as *mut yyguts_t;
+        if if !((*yyg).yy_buffer_stack).is_null() {
+            *((*yyg).yy_buffer_stack).add((*yyg).yy_buffer_stack_top)
+        } else {
+            0 as YY_BUFFER_STATE
+        }
+        .is_null()
+        {
+            yy_fatal_error(
+                b"yyset_column called with no buffer\0" as *const u8 as *const c_char,
+                yyscanner,
+            );
+        }
+        (**((*yyg).yy_buffer_stack).add((*yyg).yy_buffer_stack_top)).yy_bs_column = _column_no;
+    }
+}
+
+pub unsafe fn fits_parser_yyset_in(mut _in_str: *mut FILE, mut yyscanner: yyscan_t) {
+    unsafe {
+        let mut yyg: *mut yyguts_t = yyscanner as *mut yyguts_t;
+        (*yyg).yyin_r = _in_str;
+    }
+}
+
+pub unsafe fn fits_parser_yyset_out(mut _out_str: *mut FILE, mut yyscanner: yyscan_t) {
+    unsafe {
+        let mut yyg: *mut yyguts_t = yyscanner as *mut yyguts_t;
+        (*yyg).yyout_r = _out_str;
+    }
+}
+
+pub unsafe fn fits_parser_yyget_debug(mut yyscanner: yyscan_t) -> c_int {
+    unsafe {
+        let mut yyg: *mut yyguts_t = yyscanner as *mut yyguts_t;
+        (*yyg).yy_flex_debug_r
+    }
+}
+
+pub unsafe fn fits_parser_yyset_debug(mut _bdebug: c_int, mut yyscanner: yyscan_t) {
+    unsafe {
+        let mut yyg: *mut yyguts_t = yyscanner as *mut yyguts_t;
+        (*yyg).yy_flex_debug_r = _bdebug;
+    }
+}
+
+pub unsafe fn fits_parser_yyget_lval(mut yyscanner: yyscan_t) -> *mut FITS_PARSER_YYSTYPE {
+    unsafe {
+        let mut yyg: *mut yyguts_t = yyscanner as *mut yyguts_t;
+        (*yyg).yylval_r
+    }
+}
+
+pub unsafe fn fits_parser_yyset_lval(
+    mut yylval_param: *mut FITS_PARSER_YYSTYPE,
+    mut yyscanner: yyscan_t,
+) {
+    unsafe {
+        let mut yyg: *mut yyguts_t = yyscanner as *mut yyguts_t;
+        (*yyg).yylval_r = yylval_param;
+    }
+}
+
+pub unsafe fn fits_parser_yylex_init(mut ptr_yy_globals: *mut yyscan_t) -> c_int {
+    unsafe {
+        if ptr_yy_globals.is_null() {
+            *__errno_location() = 22 as c_int;
+            return 1;
+        }
+        *ptr_yy_globals = fits_parser_yyalloc(
+            (::core::mem::size_of::<yyguts_t>() as c_ulong)
+                .try_into()
+                .unwrap(),
+            std::ptr::null_mut::<c_void>(),
+        );
+        if (*ptr_yy_globals).is_null() {
+            *__errno_location() = 12 as c_int;
+            return 1;
+        }
+        memset(
+            *ptr_yy_globals,
+            0 as c_int,
+            ::core::mem::size_of::<yyguts_t>(),
+        );
+        yy_init_globals(*ptr_yy_globals)
+    }
+}
+
+pub unsafe fn fits_parser_yylex_init_extra(
+    mut yy_user_defined: *mut ParseData,
+    mut ptr_yy_globals: *mut yyscan_t,
+) -> c_int {
+    unsafe {
+        let mut dummy_yyguts: yyguts_t = yyguts_t {
+            yyextra_r: std::ptr::null_mut::<ParseData>(),
+            yyin_r: std::ptr::null_mut::<FILE>(),
+            yyout_r: std::ptr::null_mut::<FILE>(),
+            yy_buffer_stack_top: 0,
+            yy_buffer_stack_max: 0,
+            yy_buffer_stack: std::ptr::null_mut::<YY_BUFFER_STATE>(),
+            yy_hold_char: 0,
+            yy_n_chars: 0,
+            yyleng_r: 0,
+            yy_c_buf_p: std::ptr::null_mut::<c_char>(),
+            yy_init: 0,
+            yy_start: 0,
+            yy_did_buffer_switch_on_eof: 0,
+            yy_start_stack_ptr: 0,
+            yy_start_stack_depth: 0,
+            yy_start_stack: std::ptr::null_mut::<c_int>(),
+            yy_last_accepting_state: 0,
+            yy_last_accepting_cpos: std::ptr::null_mut::<c_char>(),
+            yylineno_r: 0,
+            yy_flex_debug_r: 0,
+            yytext_r: std::ptr::null_mut::<c_char>(),
+            yy_more_flag: 0,
+            yy_more_len: 0,
+            yylval_r: std::ptr::null_mut::<FITS_PARSER_YYSTYPE>(),
+        };
+        fits_parser_yyset_extra(
+            yy_user_defined,
+            &mut dummy_yyguts as *mut yyguts_t as yyscan_t,
+        );
+        if ptr_yy_globals.is_null() {
+            *__errno_location() = 22 as c_int;
+            return 1;
+        }
+        *ptr_yy_globals = fits_parser_yyalloc(
+            (::core::mem::size_of::<yyguts_t>() as c_ulong)
+                .try_into()
+                .unwrap(),
+            &mut dummy_yyguts as *mut yyguts_t as yyscan_t,
+        );
+        if (*ptr_yy_globals).is_null() {
+            *__errno_location() = 12 as c_int;
+            return 1;
+        }
+        memset(
+            *ptr_yy_globals,
+            0 as c_int,
+            ::core::mem::size_of::<yyguts_t>(),
+        );
+        fits_parser_yyset_extra(yy_user_defined, *ptr_yy_globals);
+        yy_init_globals(*ptr_yy_globals)
+    }
+}
+unsafe fn yy_init_globals(mut yyscanner: yyscan_t) -> c_int {
+    unsafe {
+        let mut yyg: *mut yyguts_t = yyscanner as *mut yyguts_t;
+        (*yyg).yy_buffer_stack = std::ptr::null_mut::<YY_BUFFER_STATE>();
+        (*yyg).yy_buffer_stack_top = 0 as c_int as size_t;
+        (*yyg).yy_buffer_stack_max = 0 as c_int as size_t;
+        (*yyg).yy_c_buf_p = std::ptr::null_mut::<c_char>();
+        (*yyg).yy_init = 0 as c_int;
+        (*yyg).yy_start = 0 as c_int;
+        (*yyg).yy_start_stack_ptr = 0 as c_int;
+        (*yyg).yy_start_stack_depth = 0 as c_int;
+        (*yyg).yy_start_stack = std::ptr::null_mut::<c_int>();
+        (*yyg).yyin_r = std::ptr::null_mut::<FILE>();
+        (*yyg).yyout_r = std::ptr::null_mut::<FILE>();
+        0 as c_int
+    }
+}
+
+pub unsafe fn fits_parser_yylex_destroy(mut yyscanner: yyscan_t) -> c_int {
+    unsafe {
+        let mut yyg: *mut yyguts_t = yyscanner as *mut yyguts_t;
+        while !if !((*yyg).yy_buffer_stack).is_null() {
+            *((*yyg).yy_buffer_stack).add((*yyg).yy_buffer_stack_top)
+        } else {
+            0 as YY_BUFFER_STATE
+        }
+        .is_null()
+        {
+            fits_parser_yy_delete_buffer(
+                if !((*yyg).yy_buffer_stack).is_null() {
+                    *((*yyg).yy_buffer_stack).add((*yyg).yy_buffer_stack_top)
+                } else {
+                    0 as YY_BUFFER_STATE
+                },
+                yyscanner,
+            );
+            let fresh16 = &mut *((*yyg).yy_buffer_stack).add((*yyg).yy_buffer_stack_top);
+            *fresh16 = 0 as YY_BUFFER_STATE;
+            fits_parser_yypop_buffer_state(yyscanner);
+        }
+        fits_parser_yyfree((*yyg).yy_buffer_stack as *mut c_void, yyscanner);
+        (*yyg).yy_buffer_stack = std::ptr::null_mut::<YY_BUFFER_STATE>();
+        fits_parser_yyfree((*yyg).yy_start_stack as *mut c_void, yyscanner);
+        (*yyg).yy_start_stack = std::ptr::null_mut::<c_int>();
+        yy_init_globals(yyscanner);
+        fits_parser_yyfree(yyscanner, yyscanner);
+        yyscanner = std::ptr::null_mut::<c_void>();
+        0 as c_int
+    }
+}
+
+pub unsafe fn fits_parser_yyalloc(mut size: yy_size_t, mut yyscanner: yyscan_t) -> *mut c_void {
+    unsafe {
+        let mut yyg: *mut yyguts_t = yyscanner as *mut yyguts_t;
+        malloc(size)
+    }
+}
+
+pub unsafe fn fits_parser_yyrealloc(
+    mut ptr: *mut c_void,
+    mut size: yy_size_t,
+    mut yyscanner: yyscan_t,
+) -> *mut c_void {
+    unsafe {
+        let mut yyg: *mut yyguts_t = yyscanner as *mut yyguts_t;
+        realloc(ptr, size)
+    }
+}
+
+pub unsafe fn fits_parser_yyfree(mut ptr: *mut c_void, mut yyscanner: yyscan_t) {
+    unsafe {
+        let mut yyg: *mut yyguts_t = yyscanner as *mut yyguts_t;
+        free(ptr as *mut c_char as *mut c_void);
+    }
+}

--- a/src/eval_l.rs
+++ b/src/eval_l.rs
@@ -1,25 +1,18 @@
-#![allow(
-    dead_code,
-    mutable_transmutes,
-    non_camel_case_types,
-    non_snake_case,
-    non_upper_case_globals,
-    unused_assignments,
-    unused_mut
-)]
+use errno::{Errno, set_errno};
 
 use std::ffi::CStr;
 
 use bytemuck::cast_slice;
 use libc::{
-    __errno_location, FILE, atof, atol, exit, fileno, fprintf, free, fwrite, isatty, malloc,
-    memset, realloc, size_t,
+    __errno_location, ENOMEM, FILE, atof, atol, exit, fileno, fprintf, free, fwrite, isatty,
+    malloc, memset, realloc, size_t,
 };
 
 use crate::c_types::{c_char, c_int, c_long, c_short, c_uchar, c_uint, c_ulong, c_void};
-use crate::eval_defs::{MAXVARNAME, ParseData, yyscan_t};
-use crate::eval_tab::*;
-use crate::wrappers::isdigit_safe;
+use crate::eval_defs::{MAXVARNAME, ParseData};
+use crate::helpers::boxed::box_try_new;
+use crate::wrappers::{isdigit_safe, strcpy_safe, strncat_safe};
+use crate::{cs, eval_tab::*};
 use crate::{
     fitscore::{ffpmsg_slice, fits_strcasecmp, fits_strncasecmp},
     stderr, stdin, stdout,
@@ -55,16 +48,25 @@ pub struct yy_buffer_state {
     pub yy_buffer_status: c_int,
 }
 pub type YY_BUFFER_STATE = *mut yy_buffer_state;
+
 pub type yy_size_t = size_t;
-#[derive(Copy, Clone)]
+
+/* Holds the entire state of the reentrant scanner. */
+#[derive(Default, Copy, Clone)]
 #[repr(C)]
 pub struct yyguts_t {
+    /* User-defined. Not touched by flex. */
     pub yyextra_r: *mut ParseData,
+
+    /* The rest are the same as the globals declared in the non-reentrant scanner. */
     pub yyin_r: *mut FILE,
     pub yyout_r: *mut FILE,
     pub yy_buffer_stack_top: size_t,
+    /**< index of top of stack. */
     pub yy_buffer_stack_max: size_t,
+    /**< capacity of stack. */
     pub yy_buffer_stack: *mut YY_BUFFER_STATE,
+    /**< Stack as an array. */
     pub yy_hold_char: c_char,
     pub yy_n_chars: c_int,
     pub yyleng_r: c_int,
@@ -90,39 +92,46 @@ pub type yy_state_type = c_int;
 pub type YY_CHAR = flex_uint8_t;
 pub type uint = c_uint;
 
-pub unsafe fn fits_parser_yywrap(mut scanner: yyscan_t) -> c_int {
+pub(crate) fn fits_parser_yywrap() -> c_int {
     1
 }
-unsafe fn expr_read(mut lParse: *mut ParseData, mut buf: *mut c_char, mut nbytes: c_int) -> c_int {
+
+/*
+   expr_read is lifted from old ftools.skel.
+   Now we can use any version of flex with
+   no .skel file necessary! MJT - 13 June 1996
+
+   keep a memory of how many bytes have been
+   read previously, so that an unlimited-sized
+   buffer can be supported. PDW - 28 Feb 1998
+*/
+fn expr_read(lParse: &mut ParseData, buf: *mut c_char, nbytes: c_int) -> c_int {
     unsafe {
         let mut n: c_int = 0;
-        n = 0 as c_int;
-        if (*lParse).is_eobuf == 0 {
+        if lParse.is_eobuf == 0 {
             loop {
-                let fresh0 = (*lParse).index;
-                (*lParse).index += 1;
+                let fresh0 = lParse.index;
+                lParse.index += 1;
                 let fresh1 = n;
                 n += 1;
-                *buf.offset(fresh1 as isize) = *((*lParse).expr).offset(fresh0 as isize);
-                if !(n < nbytes
-                    && *((*lParse).expr).offset((*lParse).index as isize) as c_int != 0_i32)
-                {
+                *buf.offset(fresh1 as isize) = *(lParse.expr).offset(fresh0 as isize);
+                if !(n < nbytes && *(lParse.expr).offset(lParse.index as isize) as c_int != 0) {
                     break;
                 }
             }
-            if *((*lParse).expr).offset((*lParse).index as isize) as c_int == 0_i32 {
-                (*lParse).is_eobuf = 1;
+            if *(lParse.expr).offset(lParse.index as isize) as c_int == 0 {
+                lParse.is_eobuf = 1;
             }
         }
-        *buf.offset(n as isize) = 0_i32 as c_char;
+        *buf.offset(n as isize) = 0;
         n
     }
 }
 
-pub unsafe fn fits_parser_yyGetVariable(
+pub(crate) fn fits_parser_yyGetVariable(
     lParse: &mut ParseData,
     varName: &[c_char],
-    mut thelval: *mut FITS_PARSER_YYSTYPE,
+    thelval: *mut FITS_PARSER_YYSTYPE,
 ) -> c_int {
     unsafe {
         let mut varNum: c_int = 0;
@@ -139,15 +148,12 @@ pub unsafe fn fits_parser_yyGetVariable(
             } else {
                 dtype = -(1);
                 lParse.status = 431 as c_int;
-                strcpy(
-                    errMsg.as_mut_ptr(),
-                    b"Unable to find data: \0" as *const u8 as *const c_char,
-                );
-                strncat(errMsg.as_mut_ptr(), varName.as_ptr(), MAXVARNAME);
+                strcpy_safe(&mut errMsg, cs!(c"Unable to find data: "));
+                strncat_safe(&mut errMsg, varName, MAXVARNAME);
                 ffpmsg_slice(&errMsg);
             }
         } else {
-            match (*(lParse.varData).offset(varNum as isize)).dtype {
+            match ((lParse.varData)[varNum as usize]).dtype {
                 259 | 260 => {
                     dtype = fits_parser_yytokentype::COLUMN as c_int;
                 }
@@ -176,7 +182,7 @@ pub unsafe fn fits_parser_yyGetVariable(
         dtype
     }
 }
-unsafe fn find_variable(lParse: &mut ParseData, varName: &[c_char]) -> c_int {
+fn find_variable(lParse: &mut ParseData, varName: &[c_char]) -> c_int {
     unsafe {
         let mut i: c_int = 0;
         if lParse.nCols != 0 {
@@ -184,7 +190,7 @@ unsafe fn find_variable(lParse: &mut ParseData, varName: &[c_char]) -> c_int {
             while i < lParse.nCols {
                 if {
                     let s1 = std::slice::from_raw_parts(
-                        ((*(lParse.varData).offset(i as isize)).name).as_ptr(),
+                        (((lParse.varData)[i as usize]).name).as_ptr(),
                         MAXVARNAME,
                     );
                     fits_strncasecmp(s1, varName, MAXVARNAME)
@@ -199,7 +205,7 @@ unsafe fn find_variable(lParse: &mut ParseData, varName: &[c_char]) -> c_int {
         -(1)
     }
 }
-static mut yy_accept: [flex_int16_t; 174] = [
+static mut YY_ACCEPT: [flex_int16_t; 174] = [
     0, 0, 0, 31, 29, 1, 28, 18, 29, 29, 29, 29, 29, 29, 29, 10, 8, 8, 24, 29, 23, 13, 13, 13, 13,
     9, 13, 13, 13, 13, 13, 17, 13, 13, 13, 13, 13, 13, 13, 29, 1, 22, 0, 12, 0, 11, 0, 13, 20, 0,
     0, 0, 0, 0, 0, 0, 17, 0, 10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 8, 0, 0, 0, 0, 26,
@@ -208,7 +214,7 @@ static mut yy_accept: [flex_int16_t; 174] = [
     0, 0, 0, 10, 5, 6, 7, 14, 13, 23, 24, 13, 13, 13, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 18, 0, 0,
     15, 0, 0, 0, 0, 0, 0, 0, 16, 0, 0,
 ];
-static mut yy_ec: [YY_CHAR; 256] = [
+static mut YY_EC: [YY_CHAR; 256] = [
     0, 1, 1, 1, 1, 1, 1, 1, 1, 2, 3, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
     2, 4, 5, 6, 7, 1, 8, 9, 10, 11, 12, 13, 1, 13, 14, 1, 15, 16, 17, 17, 17, 17, 17, 17, 18, 18,
     1, 1, 19, 20, 21, 1, 1, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 31, 32, 31, 33, 34, 31, 35, 36,
@@ -219,11 +225,11 @@ static mut yy_ec: [YY_CHAR; 256] = [
     1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
     1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
 ];
-static mut yy_meta: [YY_CHAR; 59] = [
+static mut YY_META: [YY_CHAR; 59] = [
     0, 1, 1, 2, 1, 1, 1, 3, 1, 1, 1, 1, 1, 1, 1, 4, 4, 4, 4, 1, 1, 1, 4, 4, 4, 4, 4, 4, 5, 5, 5, 5,
     5, 5, 5, 5, 5, 5, 5, 5, 1, 1, 5, 4, 4, 4, 4, 4, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 1,
 ];
-static mut yy_base: [flex_int16_t; 182] = [
+static mut YY_BASE: [flex_int16_t; 182] = [
     0, 0, 0, 412, 413, 409, 413, 390, 404, 401, 400, 398, 396, 34, 392, 70, 114, 16, 383, 46, 382,
     29, 84, 359, 28, 358, 52, 157, 64, 91, 128, 358, 0, 40, 27, 69, 92, 100, 171, 340, 395, 413,
     391, 413, 388, 387, 386, 413, 413, 383, 357, 358, 356, 336, 337, 335, 413, 139, 190, 352, 349,
@@ -235,7 +241,7 @@ static mut yy_base: [flex_int16_t; 182] = [
     213, 208, 197, 413, 166, 160, 413, 128, 122, 150, 154, 105, 101, 96, 413, 84, 413, 351, 354,
     359, 364, 366, 368, 373, 89,
 ];
-static mut yy_def: [flex_int16_t; 182] = [
+static mut YY_DEF: [flex_int16_t; 182] = [
     0, 173, 1, 173, 173, 173, 173, 173, 174, 175, 176, 173, 177, 173, 173, 173, 173, 16, 173, 173,
     173, 178, 178, 178, 178, 178, 178, 178, 178, 178, 178, 173, 179, 178, 178, 178, 178, 178, 178,
     173, 173, 173, 174, 173, 180, 175, 176, 173, 173, 177, 173, 173, 173, 173, 173, 173, 173, 173,
@@ -247,7 +253,7 @@ static mut yy_def: [flex_int16_t; 182] = [
     173, 173, 173, 173, 173, 173, 173, 173, 173, 173, 173, 173, 173, 173, 173, 173, 173, 173, 173,
     173, 0, 173, 173, 173, 173, 173, 173, 173, 173,
 ];
-static mut yy_nxt: [flex_int16_t; 472] = [
+static mut YY_NXT: [flex_int16_t; 472] = [
     0, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 4, 14, 4, 15, 16, 17, 17, 17, 18, 19, 20, 21, 22, 23, 23,
     24, 25, 26, 27, 23, 23, 28, 29, 30, 23, 23, 25, 23, 23, 4, 31, 32, 33, 22, 23, 34, 25, 35, 23,
     36, 37, 38, 23, 23, 25, 23, 23, 39, 50, 173, 51, 83, 86, 52, 79, 80, 81, 173, 84, 84, 84, 136,
@@ -272,7 +278,7 @@ static mut yy_nxt: [flex_int16_t; 472] = [
     173, 173, 173, 173, 173, 173, 173, 173, 173, 173, 173, 173, 173, 173, 173, 173, 173, 173, 173,
     173,
 ];
-static mut yy_chk: [flex_int16_t; 472] = [
+static mut YY_CHK: [flex_int16_t; 472] = [
     0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
     1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 13, 17, 13,
     21, 24, 13, 19, 19, 19, 17, 34, 24, 21, 75, 17, 75, 75, 75, 75, 26, 13, 34, 13, 33, 13, 15, 15,
@@ -297,9 +303,9 @@ static mut yy_chk: [flex_int16_t; 472] = [
     173, 173, 173, 173,
 ];
 
-pub unsafe fn fits_parser_yylex(
-    mut yylval_param: *mut FITS_PARSER_YYSTYPE,
-    mut yyscanner: yyscan_t,
+pub(crate) fn fits_parser_yylex(
+    yylval_param: *mut FITS_PARSER_YYSTYPE,
+    yyscanner: &mut yyguts_t,
 ) -> c_int {
     unsafe {
         let mut yy_amount_of_matched_text: c_int = 0;
@@ -309,81 +315,81 @@ pub unsafe fn fits_parser_yylex(
         let mut yy_cp: *mut c_char = std::ptr::null_mut::<c_char>();
         let mut yy_bp: *mut c_char = std::ptr::null_mut::<c_char>();
         let mut yy_act: c_int = 0;
-        let mut yyg: *mut yyguts_t = yyscanner as *mut yyguts_t;
-        (*yyg).yylval_r = yylval_param;
-        if (*yyg).yy_init == 0 {
-            (*yyg).yy_init = 1;
-            if (*yyg).yy_start == 0 {
-                (*yyg).yy_start = 1;
+
+        yyscanner.yylval_r = yylval_param;
+        if yyscanner.yy_init == 0 {
+            yyscanner.yy_init = 1;
+            if yyscanner.yy_start == 0 {
+                yyscanner.yy_start = 1;
             }
-            if ((*yyg).yyin_r).is_null() {
-                (*yyg).yyin_r = stdin;
+            if (yyscanner.yyin_r).is_null() {
+                yyscanner.yyin_r = stdin;
             }
-            if ((*yyg).yyout_r).is_null() {
-                (*yyg).yyout_r = stdout;
+            if (yyscanner.yyout_r).is_null() {
+                yyscanner.yyout_r = stdout;
             }
-            if if !((*yyg).yy_buffer_stack).is_null() {
-                *((*yyg).yy_buffer_stack).add((*yyg).yy_buffer_stack_top)
+            if if !(yyscanner.yy_buffer_stack).is_null() {
+                *(yyscanner.yy_buffer_stack).add(yyscanner.yy_buffer_stack_top)
             } else {
                 0 as YY_BUFFER_STATE
             }
             .is_null()
             {
                 fits_parser_yyensure_buffer_stack(yyscanner);
-                let fresh2 = &mut *((*yyg).yy_buffer_stack).add((*yyg).yy_buffer_stack_top);
-                *fresh2 = fits_parser_yy_create_buffer((*yyg).yyin_r, 16384 as c_int, yyscanner);
+                let fresh2 = &mut *(yyscanner.yy_buffer_stack).add(yyscanner.yy_buffer_stack_top);
+                *fresh2 = fits_parser_yy_create_buffer(yyscanner.yyin_r, 16384 as c_int, yyscanner);
             }
             fits_parser_yy_load_buffer_state(yyscanner);
         }
         loop {
-            yy_cp = (*yyg).yy_c_buf_p;
-            *yy_cp = (*yyg).yy_hold_char;
+            yy_cp = yyscanner.yy_c_buf_p;
+            *yy_cp = yyscanner.yy_hold_char;
             yy_bp = yy_cp;
-            yy_current_state = (*yyg).yy_start;
+            yy_current_state = yyscanner.yy_start;
             '_yy_match: loop {
                 loop {
-                    let mut yy_c: YY_CHAR = yy_ec[*yy_cp as YY_CHAR as usize];
-                    if yy_accept[yy_current_state as usize] != 0 {
-                        (*yyg).yy_last_accepting_state = yy_current_state;
-                        (*yyg).yy_last_accepting_cpos = yy_cp;
+                    let mut yy_c: YY_CHAR = YY_EC[*yy_cp as YY_CHAR as usize];
+                    if YY_ACCEPT[yy_current_state as usize] != 0 {
+                        yyscanner.yy_last_accepting_state = yy_current_state;
+                        yyscanner.yy_last_accepting_cpos = yy_cp;
                     }
-                    while yy_chk
-                        [(yy_base[yy_current_state as usize] as c_int + yy_c as c_int) as usize]
+                    while YY_CHK
+                        [(YY_BASE[yy_current_state as usize] as c_int + yy_c as c_int) as usize]
                         as c_int
                         != yy_current_state
                     {
-                        yy_current_state = yy_def[yy_current_state as usize] as c_int;
+                        yy_current_state = YY_DEF[yy_current_state as usize] as c_int;
                         if yy_current_state >= 174 as c_int {
-                            yy_c = yy_meta[yy_c as usize];
+                            yy_c = YY_META[yy_c as usize];
                         }
                     }
-                    yy_current_state = yy_nxt
-                        [(yy_base[yy_current_state as usize] as c_int + yy_c as c_int) as usize]
+                    yy_current_state = YY_NXT
+                        [(YY_BASE[yy_current_state as usize] as c_int + yy_c as c_int) as usize]
                         as yy_state_type;
                     yy_cp = yy_cp.offset(1);
                     yy_cp;
-                    if yy_base[yy_current_state as usize] as c_int == 413 as c_int {
+                    if YY_BASE[yy_current_state as usize] as c_int == 413 as c_int {
                         break;
                     }
                 }
                 '_yy_find_action: loop {
-                    yy_act = yy_accept[yy_current_state as usize] as c_int;
+                    yy_act = YY_ACCEPT[yy_current_state as usize] as c_int;
                     if yy_act == 0 as c_int {
-                        yy_cp = (*yyg).yy_last_accepting_cpos;
-                        yy_current_state = (*yyg).yy_last_accepting_state;
-                        yy_act = yy_accept[yy_current_state as usize] as c_int;
+                        yy_cp = yyscanner.yy_last_accepting_cpos;
+                        yy_current_state = yyscanner.yy_last_accepting_state;
+                        yy_act = YY_ACCEPT[yy_current_state as usize] as c_int;
                     }
-                    (*yyg).yytext_r = yy_bp;
-                    (*yyg).yyleng_r = yy_cp.offset_from(yy_bp) as c_long as c_int;
-                    (*yyg).yy_hold_char = *yy_cp;
-                    *yy_cp = 0_i32 as c_char;
-                    (*yyg).yy_c_buf_p = yy_cp;
+                    yyscanner.yytext_r = yy_bp;
+                    yyscanner.yyleng_r = yy_cp.offset_from(yy_bp) as c_long as c_int;
+                    yyscanner.yy_hold_char = *yy_cp;
+                    *yy_cp = 0 as c_char;
+                    yyscanner.yy_c_buf_p = yy_cp;
                     loop {
                         match yy_act {
                             0 => {
-                                *yy_cp = (*yyg).yy_hold_char;
-                                yy_cp = (*yyg).yy_last_accepting_cpos;
-                                yy_current_state = (*yyg).yy_last_accepting_state;
+                                *yy_cp = yyscanner.yy_hold_char;
+                                yy_cp = yyscanner.yy_last_accepting_cpos;
+                                yy_current_state = yyscanner.yy_last_accepting_state;
                                 continue '_yy_find_action;
                             }
                             1 => {
@@ -391,29 +397,30 @@ pub unsafe fn fits_parser_yylex(
                             }
                             2 => {
                                 let mut len: c_int = 0;
-                                len = strlen((*yyg).yytext_r) as c_int;
-                                while *((*yyg).yytext_r).offset(len as isize) as c_int == ' ' as i32
+                                len = strlen(yyscanner.yytext_r) as c_int;
+                                while *(yyscanner.yytext_r).offset(len as isize) as c_int
+                                    == ' ' as i32
                                 {
                                     len -= 1;
                                     len;
                                 }
                                 len -= 1;
                                 strncpy(
-                                    ((*(*yyg).yylval_r).astr).as_mut_ptr(),
-                                    &mut *((*yyg).yytext_r).offset(1 as c_int as isize),
+                                    ((*yyscanner.yylval_r).astr).as_mut_ptr(),
+                                    &mut *(yyscanner.yytext_r).offset(1 as c_int as isize),
                                     len as usize,
                                 );
-                                (*(*yyg).yylval_r).astr[len as usize] = 0_i32 as c_char;
+                                (*yyscanner.yylval_r).astr[len as usize] = 0 as c_char;
                                 return fits_parser_yytokentype::BITSTR as c_int;
                             }
                             3 => {
                                 let mut len_0: c_int = 0;
                                 let mut tmpstring: [c_char; 256] = [0; 256];
                                 let mut bitstring: [c_char; 256] = [0; 256];
-                                len_0 = strlen((*yyg).yytext_r) as c_int;
+                                len_0 = strlen(yyscanner.yytext_r) as c_int;
                                 if len_0 >= 256 as c_int {
                                     let mut errMsg: [c_char; 100] = [0; 100];
-                                    (*(*yyg).yyextra_r).status = 431 as c_int;
+                                    (*yyscanner.yyextra_r).status = 431 as c_int;
                                     strcpy(
                                         errMsg.as_mut_ptr(),
                                         b"Bit string exceeds maximum length: '\0" as *const u8
@@ -421,7 +428,7 @@ pub unsafe fn fits_parser_yylex(
                                     );
                                     strncat(
                                         errMsg.as_mut_ptr(),
-                                        &mut *((*yyg).yytext_r).offset(0 as c_int as isize),
+                                        &mut *(yyscanner.yytext_r).offset(0 as c_int as isize),
                                         20,
                                     );
                                     strcat(
@@ -431,7 +438,7 @@ pub unsafe fn fits_parser_yylex(
                                     ffpmsg_slice(&errMsg);
                                     len_0 = 0 as c_int;
                                 } else {
-                                    while *((*yyg).yytext_r).offset(len_0 as isize) as c_int
+                                    while *(yyscanner.yytext_r).offset(len_0 as isize) as c_int
                                         == ' ' as i32
                                     {
                                         len_0 -= 1;
@@ -440,14 +447,14 @@ pub unsafe fn fits_parser_yylex(
                                     len_0 -= 1;
                                     strncpy(
                                         tmpstring.as_mut_ptr(),
-                                        &mut *((*yyg).yytext_r).offset(1 as c_int as isize),
+                                        &mut *(yyscanner.yytext_r).offset(1 as c_int as isize),
                                         len_0 as usize,
                                     );
                                 }
-                                tmpstring[len_0 as usize] = 0_i32 as c_char;
-                                bitstring[0 as c_int as usize] = 0_i32 as c_char;
+                                tmpstring[len_0 as usize] = 0 as c_char;
+                                bitstring[0 as c_int as usize] = 0 as c_char;
                                 len_0 = 0 as c_int;
-                                while tmpstring[len_0 as usize] as c_int != 0_i32 {
+                                while tmpstring[len_0 as usize] as c_int != 0 {
                                     match tmpstring[len_0 as usize] as c_int {
                                         48 => {
                                             strcat(
@@ -509,7 +516,7 @@ pub unsafe fn fits_parser_yylex(
                                     len_0;
                                 }
                                 strcpy(
-                                    ((*(*yyg).yylval_r).astr).as_mut_ptr(),
+                                    ((*yyscanner.yylval_r).astr).as_mut_ptr(),
                                     bitstring.as_mut_ptr(),
                                 );
                                 return fits_parser_yytokentype::BITSTR as c_int;
@@ -518,10 +525,10 @@ pub unsafe fn fits_parser_yylex(
                                 let mut len_1: c_int = 0;
                                 let mut tmpstring_0: [c_char; 256] = [0; 256];
                                 let mut bitstring_0: [c_char; 256] = [0; 256];
-                                len_1 = strlen((*yyg).yytext_r) as c_int;
+                                len_1 = strlen(yyscanner.yytext_r) as c_int;
                                 if len_1 >= 256 as c_int {
                                     let mut errMsg_0: [c_char; 100] = [0; 100];
-                                    (*(*yyg).yyextra_r).status = 431 as c_int;
+                                    (*yyscanner.yyextra_r).status = 431 as c_int;
                                     strcpy(
                                         errMsg_0.as_mut_ptr(),
                                         b"Hex string exceeds maximum length: '\0" as *const u8
@@ -529,7 +536,7 @@ pub unsafe fn fits_parser_yylex(
                                     );
                                     strncat(
                                         errMsg_0.as_mut_ptr(),
-                                        &mut *((*yyg).yytext_r).offset(0 as c_int as isize),
+                                        &mut *(yyscanner.yytext_r).offset(0 as c_int as isize),
                                         20,
                                     );
                                     strcat(
@@ -539,7 +546,7 @@ pub unsafe fn fits_parser_yylex(
                                     ffpmsg_slice(&errMsg_0);
                                     len_1 = 0 as c_int;
                                 } else {
-                                    while *((*yyg).yytext_r).offset(len_1 as isize) as c_int
+                                    while *(yyscanner.yytext_r).offset(len_1 as isize) as c_int
                                         == ' ' as i32
                                     {
                                         len_1 -= 1;
@@ -548,14 +555,14 @@ pub unsafe fn fits_parser_yylex(
                                     len_1 -= 1;
                                     strncpy(
                                         tmpstring_0.as_mut_ptr(),
-                                        &mut *((*yyg).yytext_r).offset(1 as c_int as isize),
+                                        &mut *(yyscanner.yytext_r).offset(1 as c_int as isize),
                                         len_1 as usize,
                                     );
                                 }
-                                tmpstring_0[len_1 as usize] = 0_i32 as c_char;
-                                bitstring_0[0 as c_int as usize] = 0_i32 as c_char;
+                                tmpstring_0[len_1 as usize] = 0 as c_char;
+                                bitstring_0[0 as c_int as usize] = 0 as c_char;
                                 len_1 = 0 as c_int;
-                                while tmpstring_0[len_1 as usize] as c_int != 0_i32 {
+                                while tmpstring_0[len_1 as usize] as c_int != 0 {
                                     match tmpstring_0[len_1 as usize] as c_int {
                                         48 => {
                                             strcat(
@@ -665,7 +672,7 @@ pub unsafe fn fits_parser_yylex(
                                     len_1;
                                 }
                                 strcpy(
-                                    ((*(*yyg).yylval_r).astr).as_mut_ptr(),
+                                    ((*yyscanner.yylval_r).astr).as_mut_ptr(),
                                     bitstring_0.as_mut_ptr(),
                                 );
                                 return fits_parser_yytokentype::BITSTR as c_int;
@@ -673,7 +680,7 @@ pub unsafe fn fits_parser_yylex(
                             5 => {
                                 let mut constval: c_long = 0 as c_int as c_long;
                                 let mut p: *mut c_char = std::ptr::null_mut::<c_char>();
-                                p = &mut *((*yyg).yytext_r).offset(2 as c_int as isize)
+                                p = &mut *(yyscanner.yytext_r).offset(2 as c_int as isize)
                                     as *mut c_char;
                                 while *p != 0 {
                                     constval = constval << 1
@@ -681,13 +688,13 @@ pub unsafe fn fits_parser_yylex(
                                     p = p.offset(1);
                                     p;
                                 }
-                                (*(*yyg).yylval_r).lng = constval;
+                                (*yyscanner.yylval_r).lng = constval;
                                 return fits_parser_yytokentype::LONG as c_int;
                             }
                             6 => {
                                 let mut constval_0: c_long = 0 as c_int as c_long;
                                 let mut p_0: *mut c_char = std::ptr::null_mut::<c_char>();
-                                p_0 = &mut *((*yyg).yytext_r).offset(2 as c_int as isize)
+                                p_0 = &mut *(yyscanner.yytext_r).offset(2 as c_int as isize)
                                     as *mut c_char;
                                 while *p_0 != 0 {
                                     constval_0 = constval_0 << 3 as c_int
@@ -695,16 +702,16 @@ pub unsafe fn fits_parser_yylex(
                                     p_0 = p_0.offset(1);
                                     p_0;
                                 }
-                                (*(*yyg).yylval_r).lng = constval_0;
+                                (*yyscanner.yylval_r).lng = constval_0;
                                 return fits_parser_yytokentype::LONG as c_int;
                             }
                             7 => {
                                 let mut constval_1: c_long = 0 as c_int as c_long;
                                 let mut p_1: *mut c_char = std::ptr::null_mut::<c_char>();
-                                p_1 = &mut *((*yyg).yytext_r).offset(2 as c_int as isize)
+                                p_1 = &mut *(yyscanner.yytext_r).offset(2 as c_int as isize)
                                     as *mut c_char;
                                 while *p_1 != 0 {
-                                    let mut v: c_int = if isdigit_safe(*p_1) {
+                                    let v: c_int = if isdigit_safe(*p_1) {
                                         *p_1 as c_int - '0' as i32
                                     } else {
                                         *p_1 as c_int - 'a' as i32 + 10 as c_int
@@ -713,34 +720,34 @@ pub unsafe fn fits_parser_yylex(
                                     p_1 = p_1.offset(1);
                                     p_1;
                                 }
-                                (*(*yyg).yylval_r).lng = constval_1;
+                                (*yyscanner.yylval_r).lng = constval_1;
                                 return fits_parser_yytokentype::LONG as c_int;
                             }
                             8 => {
-                                (*(*yyg).yylval_r).lng = atol((*yyg).yytext_r);
+                                (*yyscanner.yylval_r).lng = atol(yyscanner.yytext_r);
                                 return fits_parser_yytokentype::LONG as c_int;
                             }
                             9 => {
-                                if *((*yyg).yytext_r).offset(0 as c_int as isize) as c_int
+                                if *(yyscanner.yytext_r).offset(0 as c_int as isize) as c_int
                                     == 't' as i32
-                                    || *((*yyg).yytext_r).offset(0 as c_int as isize) as c_int
+                                    || *(yyscanner.yytext_r).offset(0 as c_int as isize) as c_int
                                         == 'T' as i32
                                 {
-                                    (*(*yyg).yylval_r).log = 1 as c_char;
+                                    (*yyscanner.yylval_r).log = 1 as c_char;
                                 } else {
-                                    (*(*yyg).yylval_r).log = 0 as c_int as c_char;
+                                    (*yyscanner.yylval_r).log = 0 as c_int as c_char;
                                 }
                                 return fits_parser_yytokentype::BOOLEAN as c_int;
                             }
                             10 => {
-                                (*(*yyg).yylval_r).dbl = atof((*yyg).yytext_r);
+                                (*yyscanner.yylval_r).dbl = atof(yyscanner.yytext_r);
                                 return fits_parser_yytokentype::DOUBLE as c_int;
                             }
                             11 => {
                                 if {
                                     let s1 = std::slice::from_raw_parts(
-                                        (*yyg).yytext_r,
-                                        strlen((*yyg).yytext_r) as usize + 1,
+                                        yyscanner.yytext_r,
+                                        strlen(yyscanner.yytext_r) as usize + 1,
                                     );
                                     let s2 = unsafe {
                                         std::mem::transmute::<&[u8], &[c_char]>(b"#PI\0")
@@ -748,24 +755,24 @@ pub unsafe fn fits_parser_yylex(
                                     fits_strcasecmp(s1, s2)
                                 } == 0
                                 {
-                                    (*(*yyg).yylval_r).dbl = 4.0 * (1.0_f64).atan();
+                                    (*yyscanner.yylval_r).dbl = 4.0 * (1.0_f64).atan();
                                     return fits_parser_yytokentype::DOUBLE as c_int;
                                 } else if {
                                     let s1 = std::slice::from_raw_parts(
-                                        (*yyg).yytext_r,
-                                        strlen((*yyg).yytext_r) as usize + 1,
+                                        yyscanner.yytext_r,
+                                        strlen(yyscanner.yytext_r) as usize + 1,
                                     );
                                     let s2 =
                                         unsafe { std::mem::transmute::<&[u8], &[c_char]>(b"#E\0") };
                                     fits_strcasecmp(s1, s2)
                                 } == 0
                                 {
-                                    (*(*yyg).yylval_r).dbl = (1.0_f64).exp();
+                                    (*yyscanner.yylval_r).dbl = (1.0_f64).exp();
                                     return fits_parser_yytokentype::DOUBLE as c_int;
                                 } else if {
                                     let s1 = std::slice::from_raw_parts(
-                                        (*yyg).yytext_r,
-                                        strlen((*yyg).yytext_r) as usize + 1,
+                                        yyscanner.yytext_r,
+                                        strlen(yyscanner.yytext_r) as usize + 1,
                                     );
                                     let s2 = unsafe {
                                         std::mem::transmute::<&[u8], &[c_char]>(b"#DEG\0")
@@ -773,12 +780,12 @@ pub unsafe fn fits_parser_yylex(
                                     fits_strcasecmp(s1, s2)
                                 } == 0
                                 {
-                                    (*(*yyg).yylval_r).dbl = 4.0 * (1.0_f64).atan() / 180.0;
+                                    (*yyscanner.yylval_r).dbl = 4.0 * (1.0_f64).atan() / 180.0;
                                     return fits_parser_yytokentype::DOUBLE as c_int;
                                 } else if {
                                     let s1 = std::slice::from_raw_parts(
-                                        (*yyg).yytext_r,
-                                        strlen((*yyg).yytext_r) as usize + 1,
+                                        yyscanner.yytext_r,
+                                        strlen(yyscanner.yytext_r) as usize + 1,
                                     );
                                     let s2 = unsafe {
                                         std::mem::transmute::<&[u8], &[c_char]>(b"#ROW\0")
@@ -789,8 +796,8 @@ pub unsafe fn fits_parser_yylex(
                                     return fits_parser_yytokentype::ROWREF as c_int;
                                 } else if {
                                     let s1 = std::slice::from_raw_parts(
-                                        (*yyg).yytext_r,
-                                        strlen((*yyg).yytext_r) as usize + 1,
+                                        yyscanner.yytext_r,
+                                        strlen(yyscanner.yytext_r) as usize + 1,
                                     );
                                     let s2 = unsafe {
                                         std::mem::transmute::<&[u8], &[c_char]>(b"#NULL\0")
@@ -801,8 +808,8 @@ pub unsafe fn fits_parser_yylex(
                                     return fits_parser_yytokentype::NULLREF as c_int;
                                 } else if {
                                     let s1 = std::slice::from_raw_parts(
-                                        (*yyg).yytext_r,
-                                        strlen((*yyg).yytext_r) as usize + 1,
+                                        yyscanner.yytext_r,
+                                        strlen(yyscanner.yytext_r) as usize + 1,
                                     );
                                     let s2 = unsafe {
                                         std::mem::transmute::<&[u8], &[c_char]>(b"#SNULL\0")
@@ -814,43 +821,45 @@ pub unsafe fn fits_parser_yylex(
                                 } else {
                                     let mut len_2: c_int = 0;
                                     let mut result: c_int = 0;
-                                    if *((*yyg).yytext_r).offset(1 as c_int as isize) as c_int
+                                    if *(yyscanner.yytext_r).offset(1 as c_int as isize) as c_int
                                         == '$' as i32
                                     {
-                                        len_2 = (strlen((*yyg).yytext_r)).wrapping_sub(3) as c_int;
-                                        (*(*yyg).yylval_r).astr[0 as c_int as usize] =
+                                        len_2 =
+                                            (strlen(yyscanner.yytext_r)).wrapping_sub(3) as c_int;
+                                        (*yyscanner.yylval_r).astr[0 as c_int as usize] =
                                             '#' as i32 as c_char;
                                         strncpy(
-                                            ((*(*yyg).yylval_r).astr)
+                                            ((*yyscanner.yylval_r).astr)
                                                 .as_mut_ptr()
                                                 .offset(1 as c_int as isize),
-                                            &mut *((*yyg).yytext_r).offset(2 as c_int as isize),
+                                            &mut *(yyscanner.yytext_r).offset(2 as c_int as isize),
                                             len_2 as usize,
                                         );
-                                        (*(*yyg).yylval_r).astr[(len_2 + 1) as usize] =
-                                            0_i32 as c_char;
-                                        (*yyg).yytext_r = ((*(*yyg).yylval_r).astr).as_mut_ptr();
+                                        (*yyscanner.yylval_r).astr[(len_2 + 1) as usize] =
+                                            0 as c_char;
+                                        yyscanner.yytext_r =
+                                            ((*yyscanner.yylval_r).astr).as_mut_ptr();
                                     }
 
                                     let yytext_r_slice = cast_slice(
-                                        CStr::from_ptr((*yyg).yytext_r).to_bytes_with_nul(),
+                                        CStr::from_ptr(yyscanner.yytext_r).to_bytes_with_nul(),
                                     );
 
-                                    result = ((*(*yyg).yyextra_r).getData)
+                                    result = ((*yyscanner.yyextra_r).getData)
                                         .expect("non-null function pointer")(
-                                        &mut *(*yyg).yyextra_r,
+                                        &mut *yyscanner.yyextra_r,
                                         yytext_r_slice,
-                                        (*yyg).yylval_r as *mut c_void,
+                                        yyscanner.yylval_r as *mut c_void,
                                     );
                                     return result;
                                 }
                             }
                             12 => {
                                 let mut len_3: c_int = 0;
-                                len_3 = (strlen((*yyg).yytext_r)).wrapping_sub(2) as c_int;
+                                len_3 = (strlen(yyscanner.yytext_r)).wrapping_sub(2) as c_int;
                                 if len_3 >= 256 as c_int {
                                     let mut errMsg_1: [c_char; 100] = [0; 100];
-                                    (*(*yyg).yyextra_r).status = 431 as c_int;
+                                    (*yyscanner.yyextra_r).status = 431 as c_int;
                                     strcpy(
                                         errMsg_1.as_mut_ptr(),
                                         b"String exceeds maximum length: '\0" as *const u8
@@ -858,7 +867,7 @@ pub unsafe fn fits_parser_yylex(
                                     );
                                     strncat(
                                         errMsg_1.as_mut_ptr(),
-                                        &mut *((*yyg).yytext_r).offset(1 as c_int as isize),
+                                        &mut *(yyscanner.yytext_r).offset(1 as c_int as isize),
                                         20,
                                     );
                                     strcat(
@@ -869,51 +878,52 @@ pub unsafe fn fits_parser_yylex(
                                     len_3 = 0 as c_int;
                                 } else {
                                     strncpy(
-                                        ((*(*yyg).yylval_r).astr).as_mut_ptr(),
-                                        &mut *((*yyg).yytext_r).offset(1 as c_int as isize),
+                                        ((*yyscanner.yylval_r).astr).as_mut_ptr(),
+                                        &mut *(yyscanner.yytext_r).offset(1 as c_int as isize),
                                         len_3 as usize,
                                     );
                                 }
-                                (*(*yyg).yylval_r).astr[len_3 as usize] = 0_i32 as c_char;
+                                (*yyscanner.yylval_r).astr[len_3 as usize] = 0 as c_char;
                                 return fits_parser_yytokentype::STRING as c_int;
                             }
                             13 => {
                                 let mut len_4: c_int = 0;
                                 let mut dtype: c_int = 0;
-                                if *((*yyg).yytext_r).offset(0 as c_int as isize) as c_int
+                                if *(yyscanner.yytext_r).offset(0 as c_int as isize) as c_int
                                     == '$' as i32
                                 {
-                                    len_4 = (strlen((*yyg).yytext_r)).wrapping_sub(2) as c_int;
+                                    len_4 = (strlen(yyscanner.yytext_r)).wrapping_sub(2) as c_int;
                                     strncpy(
-                                        ((*(*yyg).yylval_r).astr).as_mut_ptr(),
-                                        &mut *((*yyg).yytext_r).offset(1 as c_int as isize),
+                                        ((*yyscanner.yylval_r).astr).as_mut_ptr(),
+                                        &mut *(yyscanner.yytext_r).offset(1 as c_int as isize),
                                         len_4 as usize,
                                     );
-                                    (*(*yyg).yylval_r).astr[len_4 as usize] = 0_i32 as c_char;
-                                    (*yyg).yytext_r = ((*(*yyg).yylval_r).astr).as_mut_ptr();
+                                    (*yyscanner.yylval_r).astr[len_4 as usize] = 0 as c_char;
+                                    yyscanner.yytext_r = ((*yyscanner.yylval_r).astr).as_mut_ptr();
                                 }
 
-                                let yytext_r_slice =
-                                    cast_slice(CStr::from_ptr((*yyg).yytext_r).to_bytes_with_nul());
+                                let yytext_r_slice = cast_slice(
+                                    CStr::from_ptr(yyscanner.yytext_r).to_bytes_with_nul(),
+                                );
 
                                 dtype = fits_parser_yyGetVariable(
-                                    &mut *(*yyg).yyextra_r,
+                                    &mut *yyscanner.yyextra_r,
                                     yytext_r_slice,
-                                    (*yyg).yylval_r,
+                                    yyscanner.yylval_r,
                                 );
                                 return dtype;
                             }
                             14 => {
                                 let mut fname: *mut c_char = std::ptr::null_mut::<c_char>();
                                 let mut len_5: c_int = 0 as c_int;
-                                fname = &mut *((*(*yyg).yylval_r).astr)
+                                fname = &mut *((*yyscanner.yylval_r).astr)
                                     .as_mut_ptr()
                                     .offset(0 as c_int as isize)
                                     as *mut c_char;
                                 loop {
                                     let fresh3 = &mut *fname.offset(len_5 as isize);
                                     *fresh3 = toupper(
-                                        (*((*yyg).yytext_r).offset(len_5 as isize) as c_int)
+                                        (*(yyscanner.yytext_r).offset(len_5 as isize) as c_int)
                                             .try_into()
                                             .unwrap(),
                                     ) as c_char;
@@ -1122,14 +1132,14 @@ pub unsafe fn fits_parser_yylex(
                             27 => return fits_parser_yytokentype::XOR as c_int,
                             28 => return '\n' as i32,
                             29 => {
-                                return *((*yyg).yytext_r).offset(0 as c_int as isize) as c_int;
+                                return *(yyscanner.yytext_r).offset(0 as c_int as isize) as c_int;
                             }
                             30 => {
                                 fwrite(
-                                    (*yyg).yytext_r as *const c_void,
-                                    (*yyg).yyleng_r as usize,
+                                    yyscanner.yytext_r as *const c_void,
+                                    yyscanner.yyleng_r as usize,
                                     1,
-                                    (*yyg).yyout_r,
+                                    yyscanner.yyout_r,
                                 );
                                 0;
                                 break '_yy_match;
@@ -1137,35 +1147,37 @@ pub unsafe fn fits_parser_yylex(
                             32 => return 0 as c_int,
                             31 => {
                                 yy_amount_of_matched_text =
-                                    yy_cp.offset_from((*yyg).yytext_r) as c_long as c_int - 1;
-                                *yy_cp = (*yyg).yy_hold_char;
-                                if (**((*yyg).yy_buffer_stack).add((*yyg).yy_buffer_stack_top))
-                                    .yy_buffer_status
+                                    yy_cp.offset_from(yyscanner.yytext_r) as c_long as c_int - 1;
+                                *yy_cp = yyscanner.yy_hold_char;
+                                if (**(yyscanner.yy_buffer_stack)
+                                    .add(yyscanner.yy_buffer_stack_top))
+                                .yy_buffer_status
                                     == 0 as c_int
                                 {
-                                    (*yyg).yy_n_chars = (**((*yyg).yy_buffer_stack)
-                                        .add((*yyg).yy_buffer_stack_top))
+                                    yyscanner.yy_n_chars = (**(yyscanner.yy_buffer_stack)
+                                        .add(yyscanner.yy_buffer_stack_top))
                                     .yy_n_chars;
-                                    let fresh4 = &mut (**((*yyg).yy_buffer_stack)
-                                        .add((*yyg).yy_buffer_stack_top))
+                                    let fresh4 = &mut (**(yyscanner.yy_buffer_stack)
+                                        .add(yyscanner.yy_buffer_stack_top))
                                     .yy_input_file;
-                                    *fresh4 = (*yyg).yyin_r;
-                                    (**((*yyg).yy_buffer_stack).add((*yyg).yy_buffer_stack_top))
-                                        .yy_buffer_status = 1;
+                                    *fresh4 = yyscanner.yyin_r;
+                                    (**(yyscanner.yy_buffer_stack)
+                                        .add(yyscanner.yy_buffer_stack_top))
+                                    .yy_buffer_status = 1;
                                 }
-                                if (*yyg).yy_c_buf_p
-                                    <= &mut *((**((*yyg).yy_buffer_stack)
-                                        .add((*yyg).yy_buffer_stack_top))
+                                if yyscanner.yy_c_buf_p
+                                    <= &mut *((**(yyscanner.yy_buffer_stack)
+                                        .add(yyscanner.yy_buffer_stack_top))
                                     .yy_ch_buf)
-                                        .offset((*yyg).yy_n_chars as isize)
+                                        .offset(yyscanner.yy_n_chars as isize)
                                         as *mut c_char
                                 {
                                     yy_next_state = 0;
-                                    (*yyg).yy_c_buf_p = ((*yyg).yytext_r)
+                                    yyscanner.yy_c_buf_p = (yyscanner.yytext_r)
                                         .offset(yy_amount_of_matched_text as isize);
                                     yy_current_state = yy_get_previous_state(yyscanner);
                                     yy_next_state = yy_try_NUL_trans(yy_current_state, yyscanner);
-                                    yy_bp = ((*yyg).yytext_r).offset(0 as c_int as isize);
+                                    yy_bp = (yyscanner.yytext_r).offset(0 as c_int as isize);
                                     if yy_next_state != 0 {
                                         current_block = 2606663910910355487;
                                         break;
@@ -1176,37 +1188,43 @@ pub unsafe fn fits_parser_yylex(
                                 } else {
                                     match yy_get_next_buffer(yyscanner) {
                                         1 => {
-                                            (*yyg).yy_did_buffer_switch_on_eof = 0 as c_int;
-                                            if fits_parser_yywrap(yyscanner) != 0 {
-                                                (*yyg).yy_c_buf_p =
-                                                    ((*yyg).yytext_r).offset(0 as c_int as isize);
+                                            yyscanner.yy_did_buffer_switch_on_eof = 0 as c_int;
+                                            if fits_parser_yywrap() != 0 {
+                                                yyscanner.yy_c_buf_p = (yyscanner.yytext_r)
+                                                    .offset(0 as c_int as isize);
                                                 yy_act = 31 as c_int
-                                                    + ((*yyg).yy_start - 1) / 2 as c_int
+                                                    + (yyscanner.yy_start - 1) / 2 as c_int
                                                     + 1;
                                             } else {
-                                                if (*yyg).yy_did_buffer_switch_on_eof == 0 {
-                                                    fits_parser_yyrestart((*yyg).yyin_r, yyscanner);
+                                                if yyscanner.yy_did_buffer_switch_on_eof == 0 {
+                                                    fits_parser_yyrestart(
+                                                        yyscanner.yyin_r,
+                                                        yyscanner,
+                                                    );
                                                 }
                                                 break '_yy_match;
                                             }
                                         }
                                         0 => {
-                                            (*yyg).yy_c_buf_p = ((*yyg).yytext_r)
+                                            yyscanner.yy_c_buf_p = (yyscanner.yytext_r)
                                                 .offset(yy_amount_of_matched_text as isize);
                                             yy_current_state = yy_get_previous_state(yyscanner);
-                                            yy_cp = (*yyg).yy_c_buf_p;
-                                            yy_bp = ((*yyg).yytext_r).offset(0 as c_int as isize);
+                                            yy_cp = yyscanner.yy_c_buf_p;
+                                            yy_bp =
+                                                (yyscanner.yytext_r).offset(0 as c_int as isize);
                                             break '_yy_find_action;
                                         }
                                         2 => {
-                                            (*yyg).yy_c_buf_p = &mut *((**((*yyg).yy_buffer_stack)
-                                                .add((*yyg).yy_buffer_stack_top))
+                                            yyscanner.yy_c_buf_p = &mut *((**(yyscanner
+                                                .yy_buffer_stack)
+                                                .add(yyscanner.yy_buffer_stack_top))
                                             .yy_ch_buf)
-                                                .offset((*yyg).yy_n_chars as isize)
+                                                .offset(yyscanner.yy_n_chars as isize)
                                                 as *mut c_char;
                                             yy_current_state = yy_get_previous_state(yyscanner);
-                                            yy_cp = (*yyg).yy_c_buf_p;
-                                            yy_bp = ((*yyg).yytext_r).offset(0 as c_int as isize);
+                                            yy_cp = yyscanner.yy_c_buf_p;
+                                            yy_bp =
+                                                (yyscanner.yytext_r).offset(0 as c_int as isize);
                                             continue '_yy_find_action;
                                         }
                                         _ => {
@@ -1227,11 +1245,11 @@ pub unsafe fn fits_parser_yylex(
                     }
                     match current_block {
                         7986280648684494582 => {
-                            yy_cp = (*yyg).yy_c_buf_p;
+                            yy_cp = yyscanner.yy_c_buf_p;
                         }
                         _ => {
-                            (*yyg).yy_c_buf_p = ((*yyg).yy_c_buf_p).offset(1);
-                            yy_cp = (*yyg).yy_c_buf_p;
+                            yyscanner.yy_c_buf_p = (yyscanner.yy_c_buf_p).offset(1);
+                            yy_cp = yyscanner.yy_c_buf_p;
                             yy_current_state = yy_next_state;
                             break;
                         }
@@ -1241,18 +1259,17 @@ pub unsafe fn fits_parser_yylex(
         }
     }
 }
-unsafe fn yy_get_next_buffer(mut yyscanner: yyscan_t) -> c_int {
+fn yy_get_next_buffer(yyscanner: &mut yyguts_t) -> c_int {
     unsafe {
-        let mut yyg: *mut yyguts_t = yyscanner as *mut yyguts_t;
         let mut dest: *mut c_char =
-            (**((*yyg).yy_buffer_stack).add((*yyg).yy_buffer_stack_top)).yy_ch_buf;
-        let mut source: *mut c_char = (*yyg).yytext_r;
+            (**(yyscanner.yy_buffer_stack).add(yyscanner.yy_buffer_stack_top)).yy_ch_buf;
+        let mut source: *mut c_char = yyscanner.yytext_r;
         let mut number_to_move: c_int = 0;
         let mut i: c_int = 0;
         let mut ret_val: c_int = 0;
-        if (*yyg).yy_c_buf_p
-            > &mut *((**((*yyg).yy_buffer_stack).add((*yyg).yy_buffer_stack_top)).yy_ch_buf)
-                .offset(((*yyg).yy_n_chars + 1) as isize) as *mut c_char
+        if yyscanner.yy_c_buf_p
+            > &mut *((**(yyscanner.yy_buffer_stack).add(yyscanner.yy_buffer_stack_top)).yy_ch_buf)
+                .offset((yyscanner.yy_n_chars + 1) as isize) as *mut c_char
         {
             yy_fatal_error(
                 b"fatal flex scanner internal error--end of buffer missed\0" as *const u8
@@ -1260,17 +1277,20 @@ unsafe fn yy_get_next_buffer(mut yyscanner: yyscan_t) -> c_int {
                 yyscanner,
             );
         }
-        if (**((*yyg).yy_buffer_stack).add((*yyg).yy_buffer_stack_top)).yy_fill_buffer == 0 as c_int
+        if (**(yyscanner.yy_buffer_stack).add(yyscanner.yy_buffer_stack_top)).yy_fill_buffer
+            == 0 as c_int
         {
-            if ((*yyg).yy_c_buf_p).offset_from((*yyg).yytext_r) as c_long - 0 as c_int as c_long
+            if (yyscanner.yy_c_buf_p).offset_from(yyscanner.yytext_r) as c_long
+                - 0 as c_int as c_long
                 == 1
             {
                 return 1;
             } else {
-                return 2 as c_int;
+                return 2;
             }
         }
-        number_to_move = (((*yyg).yy_c_buf_p).offset_from((*yyg).yytext_r) as c_long - 1) as c_int;
+        number_to_move =
+            ((yyscanner.yy_c_buf_p).offset_from(yyscanner.yytext_r) as c_long - 1) as c_int;
         i = 0 as c_int;
         while i < number_to_move {
             let fresh5 = source;
@@ -1281,24 +1301,24 @@ unsafe fn yy_get_next_buffer(mut yyscanner: yyscan_t) -> c_int {
             i += 1;
             i;
         }
-        if (**((*yyg).yy_buffer_stack).add((*yyg).yy_buffer_stack_top)).yy_buffer_status
+        if (**(yyscanner.yy_buffer_stack).add(yyscanner.yy_buffer_stack_top)).yy_buffer_status
             == 2 as c_int
         {
-            (*yyg).yy_n_chars = 0 as c_int;
-            (**((*yyg).yy_buffer_stack).add((*yyg).yy_buffer_stack_top)).yy_n_chars =
-                (*yyg).yy_n_chars;
+            yyscanner.yy_n_chars = 0 as c_int;
+            (**(yyscanner.yy_buffer_stack).add(yyscanner.yy_buffer_stack_top)).yy_n_chars =
+                yyscanner.yy_n_chars;
         } else {
             let mut num_to_read: c_int =
-                (**((*yyg).yy_buffer_stack).add((*yyg).yy_buffer_stack_top)).yy_buf_size
+                (**(yyscanner.yy_buffer_stack).add(yyscanner.yy_buffer_stack_top)).yy_buf_size
                     - number_to_move
                     - 1;
             while num_to_read <= 0 as c_int {
-                let mut b: YY_BUFFER_STATE =
-                    *((*yyg).yy_buffer_stack).add((*yyg).yy_buffer_stack_top);
-                let mut yy_c_buf_p_offset: c_int =
-                    ((*yyg).yy_c_buf_p).offset_from((*b).yy_ch_buf) as c_long as c_int;
+                let b: YY_BUFFER_STATE =
+                    *(yyscanner.yy_buffer_stack).add(yyscanner.yy_buffer_stack_top);
+                let yy_c_buf_p_offset: c_int =
+                    (yyscanner.yy_c_buf_p).offset_from((*b).yy_ch_buf) as c_long as c_int;
                 if (*b).yy_is_our_buffer != 0 {
-                    let mut new_size: c_int = (*b).yy_buf_size * 2 as c_int;
+                    let new_size: c_int = (*b).yy_buf_size * 2 as c_int;
                     if new_size <= 0 as c_int {
                         (*b).yy_buf_size += (*b).yy_buf_size / 8 as c_int;
                     } else {
@@ -1307,7 +1327,6 @@ unsafe fn yy_get_next_buffer(mut yyscanner: yyscan_t) -> c_int {
                     (*b).yy_ch_buf = fits_parser_yyrealloc(
                         (*b).yy_ch_buf as *mut c_void,
                         ((*b).yy_buf_size + 2 as c_int) as yy_size_t,
-                        yyscanner,
                     ) as *mut c_char;
                 } else {
                     (*b).yy_ch_buf = std::ptr::null_mut::<c_char>();
@@ -1319,9 +1338,9 @@ unsafe fn yy_get_next_buffer(mut yyscanner: yyscan_t) -> c_int {
                         yyscanner,
                     );
                 }
-                (*yyg).yy_c_buf_p =
+                yyscanner.yy_c_buf_p =
                     &mut *((*b).yy_ch_buf).offset(yy_c_buf_p_offset as isize) as *mut c_char;
-                num_to_read = (**((*yyg).yy_buffer_stack).add((*yyg).yy_buffer_stack_top))
+                num_to_read = (**(yyscanner.yy_buffer_stack).add(yyscanner.yy_buffer_stack_top))
                     .yy_buf_size
                     - number_to_move
                     - 1;
@@ -1329,95 +1348,97 @@ unsafe fn yy_get_next_buffer(mut yyscanner: yyscan_t) -> c_int {
             if num_to_read > 8192 as c_int {
                 num_to_read = 8192 as c_int;
             }
-            (*yyg).yy_n_chars = expr_read(
-                (*yyg).yyextra_r,
-                &mut *((**((*yyg).yy_buffer_stack).add((*yyg).yy_buffer_stack_top)).yy_ch_buf)
+            yyscanner.yy_n_chars = expr_read(
+                &mut *yyscanner.yyextra_r,
+                &mut *((**(yyscanner.yy_buffer_stack).add(yyscanner.yy_buffer_stack_top)).yy_ch_buf)
                     .offset(number_to_move as isize) as *mut c_char,
                 num_to_read,
             );
-            if (*yyg).yy_n_chars < 0 as c_int {
+            if yyscanner.yy_n_chars < 0 as c_int {
                 yy_fatal_error(
                     b"read() in flex scanner failed\0" as *const u8 as *const c_char,
                     yyscanner,
                 );
             }
-            (**((*yyg).yy_buffer_stack).add((*yyg).yy_buffer_stack_top)).yy_n_chars =
-                (*yyg).yy_n_chars;
+            (**(yyscanner.yy_buffer_stack).add(yyscanner.yy_buffer_stack_top)).yy_n_chars =
+                yyscanner.yy_n_chars;
         }
-        if (*yyg).yy_n_chars == 0 as c_int {
+        if yyscanner.yy_n_chars == 0 as c_int {
             if number_to_move == 0 as c_int {
                 ret_val = 1;
-                fits_parser_yyrestart((*yyg).yyin_r, yyscanner);
+                fits_parser_yyrestart(yyscanner.yyin_r, yyscanner);
             } else {
                 ret_val = 2 as c_int;
-                (**((*yyg).yy_buffer_stack).add((*yyg).yy_buffer_stack_top)).yy_buffer_status =
-                    2 as c_int;
+                (**(yyscanner.yy_buffer_stack).add(yyscanner.yy_buffer_stack_top))
+                    .yy_buffer_status = 2 as c_int;
             }
         } else {
             ret_val = 0 as c_int;
         }
-        if (*yyg).yy_n_chars + number_to_move
-            > (**((*yyg).yy_buffer_stack).add((*yyg).yy_buffer_stack_top)).yy_buf_size
+        if yyscanner.yy_n_chars + number_to_move
+            > (**(yyscanner.yy_buffer_stack).add(yyscanner.yy_buffer_stack_top)).yy_buf_size
         {
-            let mut new_size_0: c_int =
-                (*yyg).yy_n_chars + number_to_move + ((*yyg).yy_n_chars >> 1);
+            let new_size_0: c_int =
+                yyscanner.yy_n_chars + number_to_move + (yyscanner.yy_n_chars >> 1);
             let fresh7 =
-                &mut (**((*yyg).yy_buffer_stack).add((*yyg).yy_buffer_stack_top)).yy_ch_buf;
+                &mut (**(yyscanner.yy_buffer_stack).add(yyscanner.yy_buffer_stack_top)).yy_ch_buf;
             *fresh7 = fits_parser_yyrealloc(
-                (**((*yyg).yy_buffer_stack).add((*yyg).yy_buffer_stack_top)).yy_ch_buf
+                (**(yyscanner.yy_buffer_stack).add(yyscanner.yy_buffer_stack_top)).yy_ch_buf
                     as *mut c_void,
                 new_size_0 as yy_size_t,
-                yyscanner,
             ) as *mut c_char;
-            if ((**((*yyg).yy_buffer_stack).add((*yyg).yy_buffer_stack_top)).yy_ch_buf).is_null() {
+            if ((**(yyscanner.yy_buffer_stack).add(yyscanner.yy_buffer_stack_top)).yy_ch_buf)
+                .is_null()
+            {
                 yy_fatal_error(
                     b"out of dynamic memory in yy_get_next_buffer()\0" as *const u8
                         as *const c_char,
                     yyscanner,
                 );
             }
-            (**((*yyg).yy_buffer_stack).add((*yyg).yy_buffer_stack_top)).yy_buf_size =
+            (**(yyscanner.yy_buffer_stack).add(yyscanner.yy_buffer_stack_top)).yy_buf_size =
                 new_size_0 - 2 as c_int;
         }
-        (*yyg).yy_n_chars += number_to_move;
-        *((**((*yyg).yy_buffer_stack).add((*yyg).yy_buffer_stack_top)).yy_ch_buf)
-            .offset((*yyg).yy_n_chars as isize) = 0 as c_int as c_char;
-        *((**((*yyg).yy_buffer_stack).add((*yyg).yy_buffer_stack_top)).yy_ch_buf)
-            .offset(((*yyg).yy_n_chars + 1) as isize) = 0 as c_int as c_char;
-        (*yyg).yytext_r = &mut *((**((*yyg).yy_buffer_stack).add((*yyg).yy_buffer_stack_top))
-            .yy_ch_buf)
-            .offset(0 as c_int as isize) as *mut c_char;
+        yyscanner.yy_n_chars += number_to_move;
+        *((**(yyscanner.yy_buffer_stack).add(yyscanner.yy_buffer_stack_top)).yy_ch_buf)
+            .offset(yyscanner.yy_n_chars as isize) = 0 as c_int as c_char;
+        *((**(yyscanner.yy_buffer_stack).add(yyscanner.yy_buffer_stack_top)).yy_ch_buf)
+            .offset((yyscanner.yy_n_chars + 1) as isize) = 0 as c_int as c_char;
+        yyscanner.yytext_r =
+            &mut *((**(yyscanner.yy_buffer_stack).add(yyscanner.yy_buffer_stack_top)).yy_ch_buf)
+                .offset(0 as c_int as isize) as *mut c_char;
         ret_val
     }
 }
-unsafe fn yy_get_previous_state(mut yyscanner: yyscan_t) -> yy_state_type {
+
+fn yy_get_previous_state(yyscanner: &mut yyguts_t) -> yy_state_type {
     unsafe {
         let mut yy_current_state: yy_state_type = 0;
         let mut yy_cp: *mut c_char = std::ptr::null_mut::<c_char>();
-        let mut yyg: *mut yyguts_t = yyscanner as *mut yyguts_t;
-        yy_current_state = (*yyg).yy_start;
-        yy_cp = ((*yyg).yytext_r).offset(0 as c_int as isize);
-        while yy_cp < (*yyg).yy_c_buf_p {
+
+        yy_current_state = yyscanner.yy_start;
+        yy_cp = (yyscanner.yytext_r).offset(0 as c_int as isize);
+        while yy_cp < yyscanner.yy_c_buf_p {
             let mut yy_c: YY_CHAR = (if *yy_cp as c_int != 0 {
-                yy_ec[*yy_cp as YY_CHAR as usize] as c_int
+                YY_EC[*yy_cp as YY_CHAR as usize] as c_int
             } else {
                 1
             }) as YY_CHAR;
-            if yy_accept[yy_current_state as usize] != 0 {
-                (*yyg).yy_last_accepting_state = yy_current_state;
-                (*yyg).yy_last_accepting_cpos = yy_cp;
+            if YY_ACCEPT[yy_current_state as usize] != 0 {
+                yyscanner.yy_last_accepting_state = yy_current_state;
+                yyscanner.yy_last_accepting_cpos = yy_cp;
             }
-            while yy_chk[(yy_base[yy_current_state as usize] as c_int + yy_c as c_int) as usize]
+            while YY_CHK[(YY_BASE[yy_current_state as usize] as c_int + yy_c as c_int) as usize]
                 as c_int
                 != yy_current_state
             {
-                yy_current_state = yy_def[yy_current_state as usize] as c_int;
+                yy_current_state = YY_DEF[yy_current_state as usize] as c_int;
                 if yy_current_state >= 174 as c_int {
-                    yy_c = yy_meta[yy_c as usize];
+                    yy_c = YY_META[yy_c as usize];
                 }
             }
-            yy_current_state = yy_nxt
-                [(yy_base[yy_current_state as usize] as c_int + yy_c as c_int) as usize]
+            yy_current_state = YY_NXT
+                [(YY_BASE[yy_current_state as usize] as c_int + yy_c as c_int) as usize]
                 as yy_state_type;
             yy_cp = yy_cp.offset(1);
             yy_cp;
@@ -1425,30 +1446,30 @@ unsafe fn yy_get_previous_state(mut yyscanner: yyscan_t) -> yy_state_type {
         yy_current_state
     }
 }
-unsafe fn yy_try_NUL_trans(
+fn yy_try_NUL_trans(
     mut yy_current_state: yy_state_type,
-    mut yyscanner: yyscan_t,
+    yyscanner: &mut yyguts_t,
 ) -> yy_state_type {
     unsafe {
         let mut yy_is_jam: c_int = 0;
-        let mut yyg: *mut yyguts_t = yyscanner as *mut yyguts_t;
-        let mut yy_cp: *mut c_char = (*yyg).yy_c_buf_p;
+
+        let yy_cp: *mut c_char = yyscanner.yy_c_buf_p;
         let mut yy_c: YY_CHAR = 1 as YY_CHAR;
-        if yy_accept[yy_current_state as usize] != 0 {
-            (*yyg).yy_last_accepting_state = yy_current_state;
-            (*yyg).yy_last_accepting_cpos = yy_cp;
+        if YY_ACCEPT[yy_current_state as usize] != 0 {
+            yyscanner.yy_last_accepting_state = yy_current_state;
+            yyscanner.yy_last_accepting_cpos = yy_cp;
         }
-        while yy_chk[(yy_base[yy_current_state as usize] as c_int + yy_c as c_int) as usize]
+        while YY_CHK[(YY_BASE[yy_current_state as usize] as c_int + yy_c as c_int) as usize]
             as c_int
             != yy_current_state
         {
-            yy_current_state = yy_def[yy_current_state as usize] as c_int;
+            yy_current_state = YY_DEF[yy_current_state as usize] as c_int;
             if yy_current_state >= 174 as c_int {
-                yy_c = yy_meta[yy_c as usize];
+                yy_c = YY_META[yy_c as usize];
             }
         }
-        yy_current_state = yy_nxt
-            [(yy_base[yy_current_state as usize] as c_int + yy_c as c_int) as usize]
+        yy_current_state = YY_NXT
+            [(YY_BASE[yy_current_state as usize] as c_int + yy_c as c_int) as usize]
             as yy_state_type;
         yy_is_jam = (yy_current_state == 173 as c_int) as c_int;
         if yy_is_jam != 0 {
@@ -1459,23 +1480,22 @@ unsafe fn yy_try_NUL_trans(
     }
 }
 
-pub unsafe fn fits_parser_yyrestart(mut input_file: *mut FILE, mut yyscanner: yyscan_t) {
+pub(crate) fn fits_parser_yyrestart(input_file: *mut FILE, yyscanner: &mut yyguts_t) {
     unsafe {
-        let mut yyg: *mut yyguts_t = yyscanner as *mut yyguts_t;
-        if if !((*yyg).yy_buffer_stack).is_null() {
-            *((*yyg).yy_buffer_stack).add((*yyg).yy_buffer_stack_top)
+        if if !(yyscanner.yy_buffer_stack).is_null() {
+            *(yyscanner.yy_buffer_stack).add(yyscanner.yy_buffer_stack_top)
         } else {
             0 as YY_BUFFER_STATE
         }
         .is_null()
         {
             fits_parser_yyensure_buffer_stack(yyscanner);
-            let fresh8 = &mut *((*yyg).yy_buffer_stack).add((*yyg).yy_buffer_stack_top);
-            *fresh8 = fits_parser_yy_create_buffer((*yyg).yyin_r, 16384 as c_int, yyscanner);
+            let fresh8 = &mut *(yyscanner.yy_buffer_stack).add(yyscanner.yy_buffer_stack_top);
+            *fresh8 = fits_parser_yy_create_buffer(yyscanner.yyin_r, 16384 as c_int, yyscanner);
         }
         fits_parser_yy_init_buffer(
-            if !((*yyg).yy_buffer_stack).is_null() {
-                *((*yyg).yy_buffer_stack).add((*yyg).yy_buffer_stack_top)
+            if !(yyscanner.yy_buffer_stack).is_null() {
+                *(yyscanner.yy_buffer_stack).add(yyscanner.yy_buffer_stack_top)
             } else {
                 0 as YY_BUFFER_STATE
             },
@@ -1486,56 +1506,57 @@ pub unsafe fn fits_parser_yyrestart(mut input_file: *mut FILE, mut yyscanner: yy
     }
 }
 
-pub unsafe fn fits_parser_yy_switch_to_buffer(
-    mut new_buffer: YY_BUFFER_STATE,
-    mut yyscanner: yyscan_t,
+pub(crate) fn fits_parser_yy_switch_to_buffer(
+    new_buffer: YY_BUFFER_STATE,
+    yyscanner: &mut yyguts_t,
 ) {
     unsafe {
-        let mut yyg: *mut yyguts_t = yyscanner as *mut yyguts_t;
         fits_parser_yyensure_buffer_stack(yyscanner);
-        if (if !((*yyg).yy_buffer_stack).is_null() {
-            *((*yyg).yy_buffer_stack).add((*yyg).yy_buffer_stack_top)
+        if (if !(yyscanner.yy_buffer_stack).is_null() {
+            *(yyscanner.yy_buffer_stack).add(yyscanner.yy_buffer_stack_top)
         } else {
             0 as YY_BUFFER_STATE
         }) == new_buffer
         {
             return;
         }
-        if !if !((*yyg).yy_buffer_stack).is_null() {
-            *((*yyg).yy_buffer_stack).add((*yyg).yy_buffer_stack_top)
+        if !if !(yyscanner.yy_buffer_stack).is_null() {
+            *(yyscanner.yy_buffer_stack).add(yyscanner.yy_buffer_stack_top)
         } else {
             0 as YY_BUFFER_STATE
         }
         .is_null()
         {
-            *(*yyg).yy_c_buf_p = (*yyg).yy_hold_char;
+            *yyscanner.yy_c_buf_p = yyscanner.yy_hold_char;
             let fresh9 =
-                &mut (**((*yyg).yy_buffer_stack).add((*yyg).yy_buffer_stack_top)).yy_buf_pos;
-            *fresh9 = (*yyg).yy_c_buf_p;
-            (**((*yyg).yy_buffer_stack).add((*yyg).yy_buffer_stack_top)).yy_n_chars =
-                (*yyg).yy_n_chars;
+                &mut (**(yyscanner.yy_buffer_stack).add(yyscanner.yy_buffer_stack_top)).yy_buf_pos;
+            *fresh9 = yyscanner.yy_c_buf_p;
+            (**(yyscanner.yy_buffer_stack).add(yyscanner.yy_buffer_stack_top)).yy_n_chars =
+                yyscanner.yy_n_chars;
         }
-        let fresh10 = &mut *((*yyg).yy_buffer_stack).add((*yyg).yy_buffer_stack_top);
+        let fresh10 = &mut *(yyscanner.yy_buffer_stack).add(yyscanner.yy_buffer_stack_top);
         *fresh10 = new_buffer;
         fits_parser_yy_load_buffer_state(yyscanner);
-        (*yyg).yy_did_buffer_switch_on_eof = 1;
+        yyscanner.yy_did_buffer_switch_on_eof = 1;
     }
 }
-unsafe fn fits_parser_yy_load_buffer_state(mut yyscanner: yyscan_t) {
+fn fits_parser_yy_load_buffer_state(yyscanner: &mut yyguts_t) {
     unsafe {
-        let mut yyg: *mut yyguts_t = yyscanner as *mut yyguts_t;
-        (*yyg).yy_n_chars = (**((*yyg).yy_buffer_stack).add((*yyg).yy_buffer_stack_top)).yy_n_chars;
-        (*yyg).yy_c_buf_p = (**((*yyg).yy_buffer_stack).add((*yyg).yy_buffer_stack_top)).yy_buf_pos;
-        (*yyg).yytext_r = (*yyg).yy_c_buf_p;
-        (*yyg).yyin_r = (**((*yyg).yy_buffer_stack).add((*yyg).yy_buffer_stack_top)).yy_input_file;
-        (*yyg).yy_hold_char = *(*yyg).yy_c_buf_p;
+        yyscanner.yy_n_chars =
+            (**(yyscanner.yy_buffer_stack).add(yyscanner.yy_buffer_stack_top)).yy_n_chars;
+        yyscanner.yy_c_buf_p =
+            (**(yyscanner.yy_buffer_stack).add(yyscanner.yy_buffer_stack_top)).yy_buf_pos;
+        yyscanner.yytext_r = yyscanner.yy_c_buf_p;
+        yyscanner.yyin_r =
+            (**(yyscanner.yy_buffer_stack).add(yyscanner.yy_buffer_stack_top)).yy_input_file;
+        yyscanner.yy_hold_char = *yyscanner.yy_c_buf_p;
     }
 }
 
-pub unsafe fn fits_parser_yy_create_buffer(
-    mut file: *mut FILE,
-    mut size: c_int,
-    mut yyscanner: yyscan_t,
+pub(crate) fn fits_parser_yy_create_buffer(
+    file: *mut FILE,
+    size: c_int,
+    yyscanner: &mut yyguts_t,
 ) -> YY_BUFFER_STATE {
     unsafe {
         let mut b: YY_BUFFER_STATE = std::ptr::null_mut::<yy_buffer_state>();
@@ -1543,7 +1564,6 @@ pub unsafe fn fits_parser_yy_create_buffer(
             (::core::mem::size_of::<yy_buffer_state>() as c_ulong)
                 .try_into()
                 .unwrap(),
-            yyscanner,
         ) as YY_BUFFER_STATE;
         if b.is_null() {
             yy_fatal_error(
@@ -1553,8 +1573,7 @@ pub unsafe fn fits_parser_yy_create_buffer(
         }
         (*b).yy_buf_size = size;
         (*b).yy_ch_buf =
-            fits_parser_yyalloc(((*b).yy_buf_size + 2 as c_int) as yy_size_t, yyscanner)
-                as *mut c_char;
+            fits_parser_yyalloc(((*b).yy_buf_size + 2 as c_int) as yy_size_t) as *mut c_char;
         if ((*b).yy_ch_buf).is_null() {
             yy_fatal_error(
                 b"out of dynamic memory in yy_create_buffer()\0" as *const u8 as *const c_char,
@@ -1567,39 +1586,34 @@ pub unsafe fn fits_parser_yy_create_buffer(
     }
 }
 
-pub unsafe fn fits_parser_yy_delete_buffer(mut b: YY_BUFFER_STATE, mut yyscanner: yyscan_t) {
+pub(crate) fn fits_parser_yy_delete_buffer(b: YY_BUFFER_STATE, yyscanner: &mut yyguts_t) {
     unsafe {
-        let mut yyg: *mut yyguts_t = yyscanner as *mut yyguts_t;
         if b.is_null() {
             return;
         }
-        if b == (if !((*yyg).yy_buffer_stack).is_null() {
-            *((*yyg).yy_buffer_stack).add((*yyg).yy_buffer_stack_top)
+        if b == (if !(yyscanner.yy_buffer_stack).is_null() {
+            *(yyscanner.yy_buffer_stack).add(yyscanner.yy_buffer_stack_top)
         } else {
             0 as YY_BUFFER_STATE
         }) {
-            let fresh11 = &mut *((*yyg).yy_buffer_stack).add((*yyg).yy_buffer_stack_top);
+            let fresh11 = &mut *(yyscanner.yy_buffer_stack).add(yyscanner.yy_buffer_stack_top);
             *fresh11 = 0 as YY_BUFFER_STATE;
         }
         if (*b).yy_is_our_buffer != 0 {
-            fits_parser_yyfree((*b).yy_ch_buf as *mut c_void, yyscanner);
+            fits_parser_yyfree((*b).yy_ch_buf as *mut c_void);
         }
-        fits_parser_yyfree(b as *mut c_void, yyscanner);
+        fits_parser_yyfree(b as *mut c_void);
     }
 }
-unsafe fn fits_parser_yy_init_buffer(
-    mut b: YY_BUFFER_STATE,
-    mut file: *mut FILE,
-    mut yyscanner: yyscan_t,
-) {
+fn fits_parser_yy_init_buffer(b: YY_BUFFER_STATE, file: *mut FILE, yyscanner: &mut yyguts_t) {
     unsafe {
-        let mut oerrno: c_int = *__errno_location();
-        let mut yyg: *mut yyguts_t = yyscanner as *mut yyguts_t;
+        let oerrno: c_int = *__errno_location();
+
         fits_parser_yy_flush_buffer(b, yyscanner);
         (*b).yy_input_file = file;
         (*b).yy_fill_buffer = 1;
-        if b != (if !((*yyg).yy_buffer_stack).is_null() {
-            *((*yyg).yy_buffer_stack).add((*yyg).yy_buffer_stack_top)
+        if b != (if !(yyscanner.yy_buffer_stack).is_null() {
+            *(yyscanner.yy_buffer_stack).add(yyscanner.yy_buffer_stack_top)
         } else {
             0 as YY_BUFFER_STATE
         }) {
@@ -1611,13 +1625,12 @@ unsafe fn fits_parser_yy_init_buffer(
         } else {
             0 as c_int
         };
-        *__errno_location() = oerrno;
+        set_errno(Errno(oerrno));
     }
 }
 
-pub unsafe fn fits_parser_yy_flush_buffer(mut b: YY_BUFFER_STATE, mut yyscanner: yyscan_t) {
+pub(crate) fn fits_parser_yy_flush_buffer(b: YY_BUFFER_STATE, yyscanner: &mut yyguts_t) {
     unsafe {
-        let mut yyg: *mut yyguts_t = yyscanner as *mut yyguts_t;
         if b.is_null() {
             return;
         }
@@ -1627,8 +1640,8 @@ pub unsafe fn fits_parser_yy_flush_buffer(mut b: YY_BUFFER_STATE, mut yyscanner:
         (*b).yy_buf_pos = &mut *((*b).yy_ch_buf).offset(0 as c_int as isize) as *mut c_char;
         (*b).yy_at_bol = 1;
         (*b).yy_buffer_status = 0 as c_int;
-        if b == (if !((*yyg).yy_buffer_stack).is_null() {
-            *((*yyg).yy_buffer_stack).add((*yyg).yy_buffer_stack_top)
+        if b == (if !(yyscanner.yy_buffer_stack).is_null() {
+            *(yyscanner.yy_buffer_stack).add(yyscanner.yy_buffer_stack_top)
         } else {
             0 as YY_BUFFER_STATE
         }) {
@@ -1637,52 +1650,50 @@ pub unsafe fn fits_parser_yy_flush_buffer(mut b: YY_BUFFER_STATE, mut yyscanner:
     }
 }
 
-pub unsafe fn fits_parser_yypush_buffer_state(
-    mut new_buffer: YY_BUFFER_STATE,
-    mut yyscanner: yyscan_t,
+pub(crate) fn fits_parser_yypush_buffer_state(
+    new_buffer: YY_BUFFER_STATE,
+    yyscanner: &mut yyguts_t,
 ) {
     unsafe {
-        let mut yyg: *mut yyguts_t = yyscanner as *mut yyguts_t;
         if new_buffer.is_null() {
             return;
         }
         fits_parser_yyensure_buffer_stack(yyscanner);
-        if !if !((*yyg).yy_buffer_stack).is_null() {
-            *((*yyg).yy_buffer_stack).add((*yyg).yy_buffer_stack_top)
+        if !if !(yyscanner.yy_buffer_stack).is_null() {
+            *(yyscanner.yy_buffer_stack).add(yyscanner.yy_buffer_stack_top)
         } else {
             0 as YY_BUFFER_STATE
         }
         .is_null()
         {
-            *(*yyg).yy_c_buf_p = (*yyg).yy_hold_char;
+            *yyscanner.yy_c_buf_p = yyscanner.yy_hold_char;
             let fresh12 =
-                &mut (**((*yyg).yy_buffer_stack).add((*yyg).yy_buffer_stack_top)).yy_buf_pos;
-            *fresh12 = (*yyg).yy_c_buf_p;
-            (**((*yyg).yy_buffer_stack).add((*yyg).yy_buffer_stack_top)).yy_n_chars =
-                (*yyg).yy_n_chars;
+                &mut (**(yyscanner.yy_buffer_stack).add(yyscanner.yy_buffer_stack_top)).yy_buf_pos;
+            *fresh12 = yyscanner.yy_c_buf_p;
+            (**(yyscanner.yy_buffer_stack).add(yyscanner.yy_buffer_stack_top)).yy_n_chars =
+                yyscanner.yy_n_chars;
         }
-        if !if !((*yyg).yy_buffer_stack).is_null() {
-            *((*yyg).yy_buffer_stack).add((*yyg).yy_buffer_stack_top)
+        if !if !(yyscanner.yy_buffer_stack).is_null() {
+            *(yyscanner.yy_buffer_stack).add(yyscanner.yy_buffer_stack_top)
         } else {
             0 as YY_BUFFER_STATE
         }
         .is_null()
         {
-            (*yyg).yy_buffer_stack_top = ((*yyg).yy_buffer_stack_top).wrapping_add(1);
-            (*yyg).yy_buffer_stack_top;
+            yyscanner.yy_buffer_stack_top = (yyscanner.yy_buffer_stack_top).wrapping_add(1);
+            yyscanner.yy_buffer_stack_top;
         }
-        let fresh13 = &mut *((*yyg).yy_buffer_stack).add((*yyg).yy_buffer_stack_top);
+        let fresh13 = &mut *(yyscanner.yy_buffer_stack).add(yyscanner.yy_buffer_stack_top);
         *fresh13 = new_buffer;
         fits_parser_yy_load_buffer_state(yyscanner);
-        (*yyg).yy_did_buffer_switch_on_eof = 1;
+        yyscanner.yy_did_buffer_switch_on_eof = 1;
     }
 }
 
-pub unsafe fn fits_parser_yypop_buffer_state(mut yyscanner: yyscan_t) {
+pub(crate) fn fits_parser_yypop_buffer_state(yyscanner: &mut yyguts_t) {
     unsafe {
-        let mut yyg: *mut yyguts_t = yyscanner as *mut yyguts_t;
-        if if !((*yyg).yy_buffer_stack).is_null() {
-            *((*yyg).yy_buffer_stack).add((*yyg).yy_buffer_stack_top)
+        if if !(yyscanner.yy_buffer_stack).is_null() {
+            *(yyscanner.yy_buffer_stack).add(yyscanner.yy_buffer_stack_top)
         } else {
             0 as YY_BUFFER_STATE
         }
@@ -1691,46 +1702,46 @@ pub unsafe fn fits_parser_yypop_buffer_state(mut yyscanner: yyscan_t) {
             return;
         }
         fits_parser_yy_delete_buffer(
-            if !((*yyg).yy_buffer_stack).is_null() {
-                *((*yyg).yy_buffer_stack).add((*yyg).yy_buffer_stack_top)
+            if !(yyscanner.yy_buffer_stack).is_null() {
+                *(yyscanner.yy_buffer_stack).add(yyscanner.yy_buffer_stack_top)
             } else {
                 0 as YY_BUFFER_STATE
             },
             yyscanner,
         );
-        let fresh14 = &mut *((*yyg).yy_buffer_stack).add((*yyg).yy_buffer_stack_top);
+        let fresh14 = &mut *(yyscanner.yy_buffer_stack).add(yyscanner.yy_buffer_stack_top);
         *fresh14 = 0 as YY_BUFFER_STATE;
-        if (*yyg).yy_buffer_stack_top > 0 as c_int as size_t {
-            (*yyg).yy_buffer_stack_top = ((*yyg).yy_buffer_stack_top).wrapping_sub(1);
-            (*yyg).yy_buffer_stack_top;
+        if yyscanner.yy_buffer_stack_top > 0 as c_int as size_t {
+            yyscanner.yy_buffer_stack_top = (yyscanner.yy_buffer_stack_top).wrapping_sub(1);
+            yyscanner.yy_buffer_stack_top;
         }
-        if !if !((*yyg).yy_buffer_stack).is_null() {
-            *((*yyg).yy_buffer_stack).add((*yyg).yy_buffer_stack_top)
+        if !if !(yyscanner.yy_buffer_stack).is_null() {
+            *(yyscanner.yy_buffer_stack).add(yyscanner.yy_buffer_stack_top)
         } else {
             0 as YY_BUFFER_STATE
         }
         .is_null()
         {
             fits_parser_yy_load_buffer_state(yyscanner);
-            (*yyg).yy_did_buffer_switch_on_eof = 1;
+            yyscanner.yy_did_buffer_switch_on_eof = 1;
         }
     }
 }
-unsafe fn fits_parser_yyensure_buffer_stack(mut yyscanner: yyscan_t) {
+
+fn fits_parser_yyensure_buffer_stack(yyscanner: &mut yyguts_t) {
     unsafe {
         let mut num_to_alloc: yy_size_t = 0;
-        let mut yyg: *mut yyguts_t = yyscanner as *mut yyguts_t;
-        if ((*yyg).yy_buffer_stack).is_null() {
+
+        if (yyscanner.yy_buffer_stack).is_null() {
             num_to_alloc = 1 as yy_size_t;
-            (*yyg).yy_buffer_stack = fits_parser_yyalloc(
+            yyscanner.yy_buffer_stack = fits_parser_yyalloc(
                 num_to_alloc.wrapping_mul(
                     (::core::mem::size_of::<*mut yy_buffer_state>() as c_ulong)
                         .try_into()
                         .unwrap(),
                 ),
-                yyscanner,
             ) as *mut *mut yy_buffer_state;
-            if ((*yyg).yy_buffer_stack).is_null() {
+            if (yyscanner.yy_buffer_stack).is_null() {
                 yy_fatal_error(
                     b"out of dynamic memory in yyensure_buffer_stack()\0" as *const u8
                         as *const c_char,
@@ -1738,25 +1749,24 @@ unsafe fn fits_parser_yyensure_buffer_stack(mut yyscanner: yyscan_t) {
                 );
             }
             memset(
-                (*yyg).yy_buffer_stack as *mut c_void,
+                yyscanner.yy_buffer_stack as *mut c_void,
                 0 as c_int,
                 num_to_alloc.wrapping_mul(::core::mem::size_of::<*mut yy_buffer_state>()),
             );
-            (*yyg).yy_buffer_stack_max = num_to_alloc;
-            (*yyg).yy_buffer_stack_top = 0 as c_int as size_t;
+            yyscanner.yy_buffer_stack_max = num_to_alloc;
+            yyscanner.yy_buffer_stack_top = 0 as c_int as size_t;
             return;
         }
-        if (*yyg).yy_buffer_stack_top
-            >= ((*yyg).yy_buffer_stack_max).wrapping_sub(1 as c_int as size_t)
+        if yyscanner.yy_buffer_stack_top
+            >= (yyscanner.yy_buffer_stack_max).wrapping_sub(1 as c_int as size_t)
         {
-            let mut grow_size: yy_size_t = 8 as c_int as yy_size_t;
-            num_to_alloc = ((*yyg).yy_buffer_stack_max).wrapping_add(grow_size);
-            (*yyg).yy_buffer_stack = fits_parser_yyrealloc(
-                (*yyg).yy_buffer_stack as *mut c_void,
+            let grow_size: yy_size_t = 8 as c_int as yy_size_t;
+            num_to_alloc = (yyscanner.yy_buffer_stack_max).wrapping_add(grow_size);
+            yyscanner.yy_buffer_stack = fits_parser_yyrealloc(
+                yyscanner.yy_buffer_stack as *mut c_void,
                 num_to_alloc.wrapping_mul(::core::mem::size_of::<*mut yy_buffer_state>()),
-                yyscanner,
             ) as *mut *mut yy_buffer_state;
-            if ((*yyg).yy_buffer_stack).is_null() {
+            if (yyscanner.yy_buffer_stack).is_null() {
                 yy_fatal_error(
                     b"out of dynamic memory in yyensure_buffer_stack()\0" as *const u8
                         as *const c_char,
@@ -1764,19 +1774,19 @@ unsafe fn fits_parser_yyensure_buffer_stack(mut yyscanner: yyscan_t) {
                 );
             }
             memset(
-                ((*yyg).yy_buffer_stack).add((*yyg).yy_buffer_stack_max) as *mut c_void,
+                (yyscanner.yy_buffer_stack).add(yyscanner.yy_buffer_stack_max) as *mut c_void,
                 0 as c_int,
                 grow_size.wrapping_mul(::core::mem::size_of::<*mut yy_buffer_state>()),
             );
-            (*yyg).yy_buffer_stack_max = num_to_alloc;
+            yyscanner.yy_buffer_stack_max = num_to_alloc;
         }
     }
 }
 
-pub unsafe fn fits_parser_yy_scan_buffer(
-    mut base: *mut c_char,
-    mut size: yy_size_t,
-    mut yyscanner: yyscan_t,
+pub(crate) fn fits_parser_yy_scan_buffer(
+    base: *mut c_char,
+    size: yy_size_t,
+    yyscanner: &mut yyguts_t,
 ) -> YY_BUFFER_STATE {
     unsafe {
         let mut b: YY_BUFFER_STATE = std::ptr::null_mut::<yy_buffer_state>();
@@ -1790,7 +1800,6 @@ pub unsafe fn fits_parser_yy_scan_buffer(
             (::core::mem::size_of::<yy_buffer_state>() as c_ulong)
                 .try_into()
                 .unwrap(),
-            yyscanner,
         ) as YY_BUFFER_STATE;
         if b.is_null() {
             yy_fatal_error(
@@ -1813,17 +1822,17 @@ pub unsafe fn fits_parser_yy_scan_buffer(
     }
 }
 
-pub unsafe fn fits_parser_yy_scan_string(
-    mut yystr: *const c_char,
-    mut yyscanner: yyscan_t,
+pub(crate) fn fits_parser_yy_scan_string(
+    yystr: *const c_char,
+    yyscanner: &mut yyguts_t,
 ) -> YY_BUFFER_STATE {
     unsafe { fits_parser_yy_scan_bytes(yystr, strlen(yystr) as c_int, yyscanner) }
 }
 
-pub unsafe fn fits_parser_yy_scan_bytes(
-    mut yybytes: *const c_char,
+pub(crate) fn fits_parser_yy_scan_bytes(
+    yybytes: *const c_char,
     mut _yybytes_len: c_int,
-    mut yyscanner: yyscan_t,
+    yyscanner: &mut yyguts_t,
 ) -> YY_BUFFER_STATE {
     unsafe {
         let mut b: YY_BUFFER_STATE = std::ptr::null_mut::<yy_buffer_state>();
@@ -1831,7 +1840,7 @@ pub unsafe fn fits_parser_yy_scan_bytes(
         let mut n: yy_size_t = 0;
         let mut i: c_int = 0;
         n = (_yybytes_len + 2 as c_int) as yy_size_t;
-        buf = fits_parser_yyalloc(n, yyscanner) as *mut c_char;
+        buf = fits_parser_yyalloc(n) as *mut c_char;
         if buf.is_null() {
             yy_fatal_error(
                 b"out of dynamic memory in yy_scan_bytes()\0" as *const u8 as *const c_char,
@@ -1858,93 +1867,74 @@ pub unsafe fn fits_parser_yy_scan_bytes(
         b
     }
 }
-unsafe fn yy_fatal_error(mut msg: *const c_char, mut yyscanner: yyscan_t) -> ! {
+
+const YY_EXIT_FAILURE: c_int = 2;
+
+fn yy_fatal_error(msg: *const c_char, yyscanner: &mut yyguts_t) -> ! {
     unsafe {
-        let mut yyg: *mut yyguts_t = yyscanner as *mut yyguts_t;
-        fprintf(stderr, b"%s\n\0" as *const u8 as *const c_char, msg);
-        exit(2 as c_int);
+        fprintf(stderr, c"%s\n".as_ptr(), msg);
+        exit(YY_EXIT_FAILURE);
     }
 }
 
-pub unsafe fn fits_parser_yyget_extra(mut yyscanner: yyscan_t) -> *mut ParseData {
+pub(crate) fn fits_parser_yyget_lineno(yyscanner: &mut yyguts_t) -> c_int {
     unsafe {
-        let mut yyg: *mut yyguts_t = yyscanner as *mut yyguts_t;
-        (*yyg).yyextra_r
-    }
-}
-
-pub unsafe fn fits_parser_yyget_lineno(mut yyscanner: yyscan_t) -> c_int {
-    unsafe {
-        let mut yyg: *mut yyguts_t = yyscanner as *mut yyguts_t;
-        if if !((*yyg).yy_buffer_stack).is_null() {
-            *((*yyg).yy_buffer_stack).add((*yyg).yy_buffer_stack_top)
+        if if !(yyscanner.yy_buffer_stack).is_null() {
+            *(yyscanner.yy_buffer_stack).add(yyscanner.yy_buffer_stack_top)
         } else {
             0 as YY_BUFFER_STATE
         }
         .is_null()
         {
-            return 0 as c_int;
+            return 0;
         }
-        (**((*yyg).yy_buffer_stack).add((*yyg).yy_buffer_stack_top)).yy_bs_lineno
+        (**(yyscanner.yy_buffer_stack).add(yyscanner.yy_buffer_stack_top)).yy_bs_lineno
     }
 }
 
-pub unsafe fn fits_parser_yyget_column(mut yyscanner: yyscan_t) -> c_int {
+pub(crate) fn fits_parser_yyget_column(yyscanner: &mut yyguts_t) -> c_int {
     unsafe {
-        let mut yyg: *mut yyguts_t = yyscanner as *mut yyguts_t;
-        if if !((*yyg).yy_buffer_stack).is_null() {
-            *((*yyg).yy_buffer_stack).add((*yyg).yy_buffer_stack_top)
+        if if !(yyscanner.yy_buffer_stack).is_null() {
+            *(yyscanner.yy_buffer_stack).add(yyscanner.yy_buffer_stack_top)
         } else {
             0 as YY_BUFFER_STATE
         }
         .is_null()
         {
-            return 0 as c_int;
+            return 0;
         }
-        (**((*yyg).yy_buffer_stack).add((*yyg).yy_buffer_stack_top)).yy_bs_column
+        (**(yyscanner.yy_buffer_stack).add(yyscanner.yy_buffer_stack_top)).yy_bs_column
     }
 }
 
-pub unsafe fn fits_parser_yyget_in(mut yyscanner: yyscan_t) -> *mut FILE {
-    unsafe {
-        let mut yyg: *mut yyguts_t = yyscanner as *mut yyguts_t;
-        (*yyg).yyin_r
-    }
+pub(crate) fn fits_parser_yyget_in(yyscanner: &mut yyguts_t) -> *mut FILE {
+    unsafe { yyscanner.yyin_r }
 }
 
-pub unsafe fn fits_parser_yyget_out(mut yyscanner: yyscan_t) -> *mut FILE {
-    unsafe {
-        let mut yyg: *mut yyguts_t = yyscanner as *mut yyguts_t;
-        (*yyg).yyout_r
-    }
+pub(crate) fn fits_parser_yyget_out(yyscanner: &mut yyguts_t) -> *mut FILE {
+    unsafe { yyscanner.yyout_r }
 }
 
-pub unsafe fn fits_parser_yyget_leng(mut yyscanner: yyscan_t) -> c_int {
-    unsafe {
-        let mut yyg: *mut yyguts_t = yyscanner as *mut yyguts_t;
-        (*yyg).yyleng_r
-    }
+pub(crate) fn fits_parser_yyget_leng(yyscanner: &mut yyguts_t) -> c_int {
+    unsafe { yyscanner.yyleng_r }
 }
 
-pub unsafe fn fits_parser_yyget_text(mut yyscanner: yyscan_t) -> *mut c_char {
-    unsafe {
-        let mut yyg: *mut yyguts_t = yyscanner as *mut yyguts_t;
-        (*yyg).yytext_r
-    }
+pub(crate) fn fits_parser_yyget_text(yyscanner: &mut yyguts_t) -> *mut c_char {
+    unsafe { yyscanner.yytext_r }
 }
 
-pub unsafe fn fits_parser_yyset_extra(mut user_defined: *mut ParseData, mut yyscanner: yyscan_t) {
-    unsafe {
-        let mut yyg: *mut yyguts_t = yyscanner as *mut yyguts_t;
-        (*yyg).yyextra_r = user_defined;
-    }
+/** Set the user-defined data. This data is never touched by the scanner.
+ * @param user_defined The data to be associated with this scanner.
+ * @param yyscanner The scanner object.
+ */
+pub(crate) fn fits_parser_yyset_extra(user_defined: &mut ParseData, yyscanner: &mut yyguts_t) {
+    yyscanner.yyextra_r = user_defined;
 }
 
-pub unsafe fn fits_parser_yyset_lineno(mut _line_number: c_int, mut yyscanner: yyscan_t) {
+pub(crate) fn fits_parser_yyset_lineno(mut _line_number: c_int, yyscanner: &mut yyguts_t) {
     unsafe {
-        let mut yyg: *mut yyguts_t = yyscanner as *mut yyguts_t;
-        if if !((*yyg).yy_buffer_stack).is_null() {
-            *((*yyg).yy_buffer_stack).add((*yyg).yy_buffer_stack_top)
+        if if !(yyscanner.yy_buffer_stack).is_null() {
+            *(yyscanner.yy_buffer_stack).add(yyscanner.yy_buffer_stack_top)
         } else {
             0 as YY_BUFFER_STATE
         }
@@ -1955,15 +1945,15 @@ pub unsafe fn fits_parser_yyset_lineno(mut _line_number: c_int, mut yyscanner: y
                 yyscanner,
             );
         }
-        (**((*yyg).yy_buffer_stack).add((*yyg).yy_buffer_stack_top)).yy_bs_lineno = _line_number;
+        (**(yyscanner.yy_buffer_stack).add(yyscanner.yy_buffer_stack_top)).yy_bs_lineno =
+            _line_number;
     }
 }
 
-pub unsafe fn fits_parser_yyset_column(mut _column_no: c_int, mut yyscanner: yyscan_t) {
+pub(crate) fn fits_parser_yyset_column(mut _column_no: c_int, yyscanner: &mut yyguts_t) {
     unsafe {
-        let mut yyg: *mut yyguts_t = yyscanner as *mut yyguts_t;
-        if if !((*yyg).yy_buffer_stack).is_null() {
-            *((*yyg).yy_buffer_stack).add((*yyg).yy_buffer_stack_top)
+        if if !(yyscanner.yy_buffer_stack).is_null() {
+            *(yyscanner.yy_buffer_stack).add(yyscanner.yy_buffer_stack_top)
         } else {
             0 as YY_BUFFER_STATE
         }
@@ -1974,210 +1964,151 @@ pub unsafe fn fits_parser_yyset_column(mut _column_no: c_int, mut yyscanner: yys
                 yyscanner,
             );
         }
-        (**((*yyg).yy_buffer_stack).add((*yyg).yy_buffer_stack_top)).yy_bs_column = _column_no;
+        (**(yyscanner.yy_buffer_stack).add(yyscanner.yy_buffer_stack_top)).yy_bs_column =
+            _column_no;
     }
 }
 
-pub unsafe fn fits_parser_yyset_in(mut _in_str: *mut FILE, mut yyscanner: yyscan_t) {
+pub(crate) fn fits_parser_yyset_in(mut _in_str: *mut FILE, yyscanner: &mut yyguts_t) {
     unsafe {
-        let mut yyg: *mut yyguts_t = yyscanner as *mut yyguts_t;
-        (*yyg).yyin_r = _in_str;
+        yyscanner.yyin_r = _in_str;
     }
 }
 
-pub unsafe fn fits_parser_yyset_out(mut _out_str: *mut FILE, mut yyscanner: yyscan_t) {
+pub(crate) fn fits_parser_yyset_out(mut _out_str: *mut FILE, yyscanner: &mut yyguts_t) {
     unsafe {
-        let mut yyg: *mut yyguts_t = yyscanner as *mut yyguts_t;
-        (*yyg).yyout_r = _out_str;
+        yyscanner.yyout_r = _out_str;
     }
 }
 
-pub unsafe fn fits_parser_yyget_debug(mut yyscanner: yyscan_t) -> c_int {
+pub(crate) fn fits_parser_yyget_debug(yyscanner: &mut yyguts_t) -> c_int {
+    unsafe { yyscanner.yy_flex_debug_r }
+}
+
+pub(crate) fn fits_parser_yyset_debug(mut _bdebug: c_int, yyscanner: &mut yyguts_t) {
     unsafe {
-        let mut yyg: *mut yyguts_t = yyscanner as *mut yyguts_t;
-        (*yyg).yy_flex_debug_r
+        yyscanner.yy_flex_debug_r = _bdebug;
     }
 }
 
-pub unsafe fn fits_parser_yyset_debug(mut _bdebug: c_int, mut yyscanner: yyscan_t) {
-    unsafe {
-        let mut yyg: *mut yyguts_t = yyscanner as *mut yyguts_t;
-        (*yyg).yy_flex_debug_r = _bdebug;
-    }
+pub(crate) fn fits_parser_yyget_lval(yyscanner: &mut yyguts_t) -> *mut FITS_PARSER_YYSTYPE {
+    unsafe { yyscanner.yylval_r }
 }
 
-pub unsafe fn fits_parser_yyget_lval(mut yyscanner: yyscan_t) -> *mut FITS_PARSER_YYSTYPE {
-    unsafe {
-        let mut yyg: *mut yyguts_t = yyscanner as *mut yyguts_t;
-        (*yyg).yylval_r
-    }
-}
-
-pub unsafe fn fits_parser_yyset_lval(
-    mut yylval_param: *mut FITS_PARSER_YYSTYPE,
-    mut yyscanner: yyscan_t,
+pub(crate) fn fits_parser_yyset_lval(
+    yylval_param: *mut FITS_PARSER_YYSTYPE,
+    yyscanner: &mut yyguts_t,
 ) {
     unsafe {
-        let mut yyg: *mut yyguts_t = yyscanner as *mut yyguts_t;
-        (*yyg).yylval_r = yylval_param;
+        yyscanner.yylval_r = yylval_param;
     }
 }
 
-pub unsafe fn fits_parser_yylex_init(mut ptr_yy_globals: *mut yyscan_t) -> c_int {
-    unsafe {
-        if ptr_yy_globals.is_null() {
-            *__errno_location() = 22 as c_int;
-            return 1;
-        }
-        *ptr_yy_globals = fits_parser_yyalloc(
-            (::core::mem::size_of::<yyguts_t>() as c_ulong)
-                .try_into()
-                .unwrap(),
-            std::ptr::null_mut::<c_void>(),
-        );
-        if (*ptr_yy_globals).is_null() {
-            *__errno_location() = 12 as c_int;
-            return 1;
-        }
-        memset(
-            *ptr_yy_globals,
-            0 as c_int,
-            ::core::mem::size_of::<yyguts_t>(),
-        );
-        yy_init_globals(*ptr_yy_globals)
+pub(crate) fn fits_parser_yylex_init(ptr_yy_globals: &mut Option<Box<yyguts_t>>) -> c_int {
+    let b = box_try_new(yyguts_t::default());
+
+    if b.is_err() {
+        set_errno(Errno(ENOMEM));
+        return 1;
     }
+
+    *ptr_yy_globals = Some(b.unwrap());
+
+    yy_init_globals(ptr_yy_globals.as_deref_mut().unwrap())
 }
 
-pub unsafe fn fits_parser_yylex_init_extra(
-    mut yy_user_defined: *mut ParseData,
-    mut ptr_yy_globals: *mut yyscan_t,
+/* yylex_init_extra has the same functionality as yylex_init, but follows the
+ * convention of taking the scanner as the last argument. Note however, that
+ * this is a *pointer* to a scanner, as it will be allocated by this call (and
+ * is the reason, too, why this function also must handle its own declaration).
+ * The user defined value in the first argument will be available to yyalloc in
+ * the yyextra field.
+ */
+pub(crate) fn fits_parser_yylex_init_extra(
+    yy_user_defined: &mut ParseData,
+    ptr_yy_globals: &mut Option<Box<yyguts_t>>,
 ) -> c_int {
     unsafe {
-        let mut dummy_yyguts: yyguts_t = yyguts_t {
-            yyextra_r: std::ptr::null_mut::<ParseData>(),
-            yyin_r: std::ptr::null_mut::<FILE>(),
-            yyout_r: std::ptr::null_mut::<FILE>(),
-            yy_buffer_stack_top: 0,
-            yy_buffer_stack_max: 0,
-            yy_buffer_stack: std::ptr::null_mut::<YY_BUFFER_STATE>(),
-            yy_hold_char: 0,
-            yy_n_chars: 0,
-            yyleng_r: 0,
-            yy_c_buf_p: std::ptr::null_mut::<c_char>(),
-            yy_init: 0,
-            yy_start: 0,
-            yy_did_buffer_switch_on_eof: 0,
-            yy_start_stack_ptr: 0,
-            yy_start_stack_depth: 0,
-            yy_start_stack: std::ptr::null_mut::<c_int>(),
-            yy_last_accepting_state: 0,
-            yy_last_accepting_cpos: std::ptr::null_mut::<c_char>(),
-            yylineno_r: 0,
-            yy_flex_debug_r: 0,
-            yytext_r: std::ptr::null_mut::<c_char>(),
-            yy_more_flag: 0,
-            yy_more_len: 0,
-            yylval_r: std::ptr::null_mut::<FITS_PARSER_YYSTYPE>(),
-        };
-        fits_parser_yyset_extra(
-            yy_user_defined,
-            &mut dummy_yyguts as *mut yyguts_t as yyscan_t,
-        );
-        if ptr_yy_globals.is_null() {
-            *__errno_location() = 22 as c_int;
+        let mut dummy_yyguts = yyguts_t::default();
+
+        fits_parser_yyset_extra(yy_user_defined, &mut dummy_yyguts);
+
+        let b = box_try_new(yyguts_t::default());
+
+        if b.is_err() {
+            set_errno(Errno(ENOMEM));
             return 1;
         }
-        *ptr_yy_globals = fits_parser_yyalloc(
-            (::core::mem::size_of::<yyguts_t>() as c_ulong)
-                .try_into()
-                .unwrap(),
-            &mut dummy_yyguts as *mut yyguts_t as yyscan_t,
-        );
-        if (*ptr_yy_globals).is_null() {
-            *__errno_location() = 12 as c_int;
-            return 1;
-        }
-        memset(
-            *ptr_yy_globals,
-            0 as c_int,
-            ::core::mem::size_of::<yyguts_t>(),
-        );
-        fits_parser_yyset_extra(yy_user_defined, *ptr_yy_globals);
-        yy_init_globals(*ptr_yy_globals)
+
+        let mut b = b.unwrap();
+
+        fits_parser_yyset_extra(yy_user_defined, &mut b);
+
+        *ptr_yy_globals = Some(b);
+
+        yy_init_globals(ptr_yy_globals.as_deref_mut().unwrap())
     }
 }
-unsafe fn yy_init_globals(mut yyscanner: yyscan_t) -> c_int {
+
+fn yy_init_globals(yyscanner: &mut yyguts_t) -> c_int {
     unsafe {
-        let mut yyg: *mut yyguts_t = yyscanner as *mut yyguts_t;
-        (*yyg).yy_buffer_stack = std::ptr::null_mut::<YY_BUFFER_STATE>();
-        (*yyg).yy_buffer_stack_top = 0 as c_int as size_t;
-        (*yyg).yy_buffer_stack_max = 0 as c_int as size_t;
-        (*yyg).yy_c_buf_p = std::ptr::null_mut::<c_char>();
-        (*yyg).yy_init = 0 as c_int;
-        (*yyg).yy_start = 0 as c_int;
-        (*yyg).yy_start_stack_ptr = 0 as c_int;
-        (*yyg).yy_start_stack_depth = 0 as c_int;
-        (*yyg).yy_start_stack = std::ptr::null_mut::<c_int>();
-        (*yyg).yyin_r = std::ptr::null_mut::<FILE>();
-        (*yyg).yyout_r = std::ptr::null_mut::<FILE>();
+        yyscanner.yy_buffer_stack = std::ptr::null_mut::<YY_BUFFER_STATE>();
+        yyscanner.yy_buffer_stack_top = 0 as c_int as size_t;
+        yyscanner.yy_buffer_stack_max = 0 as c_int as size_t;
+        yyscanner.yy_c_buf_p = std::ptr::null_mut::<c_char>();
+        yyscanner.yy_init = 0 as c_int;
+        yyscanner.yy_start = 0 as c_int;
+        yyscanner.yy_start_stack_ptr = 0 as c_int;
+        yyscanner.yy_start_stack_depth = 0 as c_int;
+        yyscanner.yy_start_stack = std::ptr::null_mut::<c_int>();
+        yyscanner.yyin_r = std::ptr::null_mut::<FILE>();
+        yyscanner.yyout_r = std::ptr::null_mut::<FILE>();
         0 as c_int
     }
 }
 
-pub unsafe fn fits_parser_yylex_destroy(mut yyscanner: yyscan_t) -> c_int {
+pub(crate) fn fits_parser_yylex_destroy(mut yyscanner: Box<yyguts_t>) -> c_int {
     unsafe {
-        let mut yyg: *mut yyguts_t = yyscanner as *mut yyguts_t;
-        while !if !((*yyg).yy_buffer_stack).is_null() {
-            *((*yyg).yy_buffer_stack).add((*yyg).yy_buffer_stack_top)
+        let yyg = yyscanner.as_mut();
+        while !if !(yyscanner.yy_buffer_stack).is_null() {
+            *(yyscanner.yy_buffer_stack).add(yyscanner.yy_buffer_stack_top)
         } else {
             0 as YY_BUFFER_STATE
         }
         .is_null()
         {
             fits_parser_yy_delete_buffer(
-                if !((*yyg).yy_buffer_stack).is_null() {
-                    *((*yyg).yy_buffer_stack).add((*yyg).yy_buffer_stack_top)
+                if !(yyscanner.yy_buffer_stack).is_null() {
+                    *(yyscanner.yy_buffer_stack).add(yyscanner.yy_buffer_stack_top)
                 } else {
                     0 as YY_BUFFER_STATE
                 },
-                yyscanner,
+                &mut yyscanner,
             );
-            let fresh16 = &mut *((*yyg).yy_buffer_stack).add((*yyg).yy_buffer_stack_top);
+            let fresh16 = &mut *(yyscanner.yy_buffer_stack).add(yyscanner.yy_buffer_stack_top);
             *fresh16 = 0 as YY_BUFFER_STATE;
-            fits_parser_yypop_buffer_state(yyscanner);
+            fits_parser_yypop_buffer_state(&mut yyscanner);
         }
-        fits_parser_yyfree((*yyg).yy_buffer_stack as *mut c_void, yyscanner);
-        (*yyg).yy_buffer_stack = std::ptr::null_mut::<YY_BUFFER_STATE>();
-        fits_parser_yyfree((*yyg).yy_start_stack as *mut c_void, yyscanner);
-        (*yyg).yy_start_stack = std::ptr::null_mut::<c_int>();
-        yy_init_globals(yyscanner);
-        fits_parser_yyfree(yyscanner, yyscanner);
-        yyscanner = std::ptr::null_mut::<c_void>();
+        fits_parser_yyfree(yyscanner.yy_buffer_stack as *mut c_void);
+        yyscanner.yy_buffer_stack = std::ptr::null_mut::<YY_BUFFER_STATE>();
+        fits_parser_yyfree(yyscanner.yy_start_stack as *mut c_void);
+        yyscanner.yy_start_stack = std::ptr::null_mut::<c_int>();
+        yy_init_globals(&mut yyscanner);
+
         0 as c_int
     }
 }
 
-pub unsafe fn fits_parser_yyalloc(mut size: yy_size_t, mut yyscanner: yyscan_t) -> *mut c_void {
-    unsafe {
-        let mut yyg: *mut yyguts_t = yyscanner as *mut yyguts_t;
-        malloc(size)
-    }
+pub(crate) fn fits_parser_yyalloc(size: yy_size_t) -> *mut c_void {
+    unsafe { malloc(size) }
 }
 
-pub unsafe fn fits_parser_yyrealloc(
-    mut ptr: *mut c_void,
-    mut size: yy_size_t,
-    mut yyscanner: yyscan_t,
-) -> *mut c_void {
-    unsafe {
-        let mut yyg: *mut yyguts_t = yyscanner as *mut yyguts_t;
-        realloc(ptr, size)
-    }
+pub(crate) fn fits_parser_yyrealloc(ptr: *mut c_void, size: yy_size_t) -> *mut c_void {
+    unsafe { realloc(ptr, size) }
 }
 
-pub unsafe fn fits_parser_yyfree(mut ptr: *mut c_void, mut yyscanner: yyscan_t) {
+pub(crate) fn fits_parser_yyfree(ptr: *mut c_void) {
     unsafe {
-        let mut yyg: *mut yyguts_t = yyscanner as *mut yyguts_t;
-        free(ptr as *mut c_char as *mut c_void);
+        free(ptr);
     }
 }

--- a/src/eval_l.rs
+++ b/src/eval_l.rs
@@ -149,7 +149,7 @@ pub(crate) fn fits_parser_yyGetVariable(
                 thelval as *mut _ as *mut c_void,
             );
         } else {
-            dtype = -(1);
+            dtype = -1;
             lParse.status = 431 as c_int;
             strcpy_safe(&mut errMsg, cs!(c"Unable to find data: "));
             strncat_safe(&mut errMsg, varName, MAXVARNAME);
@@ -915,7 +915,7 @@ pub(crate) fn fits_parser_yylex(
                                         [0 as c_int as usize]
                                         as c_int
                                 {
-                                    -(1)
+                                    -1
                                 } else if *fname.offset(0 as c_int as isize) as c_int
                                     > (*::core::mem::transmute::<&[u8; 5], &[c_char; 5]>(b"BOX(\0"))
                                         [0 as c_int as usize]
@@ -931,7 +931,7 @@ pub(crate) fn fits_parser_yylex(
                                         ))[0 as c_int as usize]
                                             as c_int
                                     {
-                                        -(1)
+                                        -1
                                     } else if *fname.offset(0 as c_int as isize) as c_int
                                         > (*::core::mem::transmute::<&[u8; 8], &[c_char; 8]>(
                                             b"CIRCLE(\0",
@@ -948,7 +948,7 @@ pub(crate) fn fits_parser_yylex(
                                         ))[0 as c_int as usize]
                                             as c_int
                                     {
-                                        -(1)
+                                        -1
                                     } else if *fname.offset(0 as c_int as isize) as c_int
                                         > (*::core::mem::transmute::<&[u8; 9], &[c_char; 9]>(
                                             b"ELLIPSE(\0",
@@ -965,7 +965,7 @@ pub(crate) fn fits_parser_yylex(
                                         ))[0 as c_int as usize]
                                             as c_int
                                     {
-                                        -(1)
+                                        -1
                                     } else if *fname.offset(0 as c_int as isize) as c_int
                                         > (*::core::mem::transmute::<&[u8; 6], &[c_char; 6]>(
                                             b"NEAR(\0",
@@ -982,7 +982,7 @@ pub(crate) fn fits_parser_yylex(
                                         ))[0 as c_int as usize]
                                             as c_int
                                     {
-                                        -(1)
+                                        -1
                                     } else if *fname.offset(0 as c_int as isize) as c_int
                                         > (*::core::mem::transmute::<&[u8; 8], &[c_char; 8]>(
                                             b"ISNULL(\0",
@@ -1001,7 +1001,7 @@ pub(crate) fn fits_parser_yylex(
                                     ))[0 as c_int as usize]
                                         as c_int
                                 {
-                                    -(1)
+                                    -1
                                 } else if *fname.offset(0 as c_int as isize) as c_int
                                     > (*::core::mem::transmute::<&[u8; 11], &[c_char; 11]>(
                                         b"GTIFILTER(\0",
@@ -1020,7 +1020,7 @@ pub(crate) fn fits_parser_yylex(
                                     ))[0 as c_int as usize]
                                         as c_int
                                 {
-                                    -(1)
+                                    -1
                                 } else if *fname.offset(0 as c_int as isize) as c_int
                                     > (*::core::mem::transmute::<&[u8; 12], &[c_char; 12]>(
                                         b"GTIOVERLAP(\0",
@@ -1039,7 +1039,7 @@ pub(crate) fn fits_parser_yylex(
                                     ))[0 as c_int as usize]
                                         as c_int
                                 {
-                                    -(1)
+                                    -1
                                 } else if *fname.offset(0 as c_int as isize) as c_int
                                     > (*::core::mem::transmute::<&[u8; 9], &[c_char; 9]>(
                                         b"GTIFIND(\0",
@@ -1058,7 +1058,7 @@ pub(crate) fn fits_parser_yylex(
                                     ))[0 as c_int as usize]
                                         as c_int
                                 {
-                                    -(1)
+                                    -1
                                 } else if *fname.offset(0 as c_int as isize) as c_int
                                     > (*::core::mem::transmute::<&[u8; 11], &[c_char; 11]>(
                                         b"REGFILTER(\0",
@@ -1077,7 +1077,7 @@ pub(crate) fn fits_parser_yylex(
                                     ))[0 as c_int as usize]
                                         as c_int
                                 {
-                                    -(1)
+                                    -1
                                 } else if *fname.offset(0 as c_int as isize) as c_int
                                     > (*::core::mem::transmute::<&[u8; 8], &[c_char; 8]>(
                                         b"STRSTR(\0",

--- a/src/eval_l.rs
+++ b/src/eval_l.rs
@@ -1,14 +1,13 @@
 #![deny(dead_code)]
 
-use errno::{Errno, set_errno};
+use errno::{Errno, errno, set_errno};
 
 use std::ffi::CStr;
 use std::process::exit;
 
 use bytemuck::cast_slice;
 use libc::{
-    __errno_location, ENOMEM, FILE, atof, atol, fileno, free, fwrite, isatty, malloc, memset,
-    realloc, size_t,
+    ENOMEM, FILE, atof, atol, fileno, free, fwrite, isatty, malloc, memset, realloc, size_t,
 };
 
 use crate::c_types::{c_char, c_int, c_long, c_short, c_uchar, c_uint, c_ulong, c_void};
@@ -16,10 +15,9 @@ use crate::eval_defs::{MAXVARNAME, P_ERROR, ParseData};
 use crate::fitsio::PARSE_SYNTAX_ERR;
 use crate::helpers::boxed::box_try_new;
 use crate::wrappers::{isdigit_safe, strcpy_safe, strncat_safe};
-use crate::{cs, eval_tab::*};
+use crate::{STDIN, STDOUT, cs, eval_tab::*};
 use crate::{
     fitscore::{ffpmsg_slice, fits_strcasecmp, fits_strncasecmp},
-    stdin, stdout,
     wrappers::{strcat, strcmp, strcpy, strlen, strncat, strncpy, toupper},
 };
 
@@ -313,10 +311,10 @@ pub(crate) fn fits_parser_yylex(
                 yyscanner.yy_start = 1;
             }
             if (yyscanner.yyin_r).is_null() {
-                yyscanner.yyin_r = stdin;
+                yyscanner.yyin_r = STDIN!();
             }
             if (yyscanner.yyout_r).is_null() {
-                yyscanner.yyout_r = stdout;
+                yyscanner.yyout_r = STDOUT!();
             }
             if if !(yyscanner.yy_buffer_stack).is_null() {
                 *(yyscanner.yy_buffer_stack).add(yyscanner.yy_buffer_stack_top)
@@ -1561,7 +1559,7 @@ pub(crate) fn fits_parser_yy_delete_buffer(b: YY_BUFFER_STATE, yyscanner: &mut y
 
 fn fits_parser_yy_init_buffer(b: YY_BUFFER_STATE, file: *mut FILE, yyscanner: &mut yyguts_t) {
     unsafe {
-        let oerrno: c_int = *__errno_location();
+        let oerrno = errno().0;
 
         fits_parser_yy_flush_buffer(b, yyscanner);
         (*b).yy_input_file = file;

--- a/src/eval_l.rs
+++ b/src/eval_l.rs
@@ -395,7 +395,7 @@ pub(crate) fn fits_parser_yylex(
                                 len -= 1;
                                 strncpy(
                                     ((*yyscanner.yylval_r).astr).as_mut_ptr(),
-                                    &mut *(yyscanner.yytext_r).offset(1 as c_int as isize),
+                                    &*(yyscanner.yytext_r).offset(1 as c_int as isize),
                                     len as usize,
                                 );
                                 (*yyscanner.yylval_r).astr[len as usize] = 0 as c_char;
@@ -416,7 +416,7 @@ pub(crate) fn fits_parser_yylex(
                                     );
                                     strncat(
                                         errMsg.as_mut_ptr(),
-                                        &mut *(yyscanner.yytext_r).offset(0 as c_int as isize),
+                                        &*(yyscanner.yytext_r).offset(0 as c_int as isize),
                                         20,
                                     );
                                     strcat(
@@ -434,7 +434,7 @@ pub(crate) fn fits_parser_yylex(
                                     len_0 -= 1;
                                     strncpy(
                                         tmpstring.as_mut_ptr(),
-                                        &mut *(yyscanner.yytext_r).offset(1 as c_int as isize),
+                                        &*(yyscanner.yytext_r).offset(1 as c_int as isize),
                                         len_0 as usize,
                                     );
                                 }
@@ -522,7 +522,7 @@ pub(crate) fn fits_parser_yylex(
                                     );
                                     strncat(
                                         errMsg_0.as_mut_ptr(),
-                                        &mut *(yyscanner.yytext_r).offset(0 as c_int as isize),
+                                        &*(yyscanner.yytext_r).offset(0 as c_int as isize),
                                         20,
                                     );
                                     strcat(
@@ -540,7 +540,7 @@ pub(crate) fn fits_parser_yylex(
                                     len_1 -= 1;
                                     strncpy(
                                         tmpstring_0.as_mut_ptr(),
-                                        &mut *(yyscanner.yytext_r).offset(1 as c_int as isize),
+                                        &*(yyscanner.yytext_r).offset(1 as c_int as isize),
                                         len_1 as usize,
                                     );
                                 }
@@ -810,7 +810,7 @@ pub(crate) fn fits_parser_yylex(
                                             ((*yyscanner.yylval_r).astr)
                                                 .as_mut_ptr()
                                                 .offset(1 as c_int as isize),
-                                            &mut *(yyscanner.yytext_r).offset(2 as c_int as isize),
+                                            &*(yyscanner.yytext_r).offset(2 as c_int as isize),
                                             len_2 as usize,
                                         );
                                         (*yyscanner.yylval_r).astr[(len_2 + 1) as usize] =
@@ -845,7 +845,7 @@ pub(crate) fn fits_parser_yylex(
                                     );
                                     strncat(
                                         errMsg_1.as_mut_ptr(),
-                                        &mut *(yyscanner.yytext_r).offset(1 as c_int as isize),
+                                        &*(yyscanner.yytext_r).offset(1 as c_int as isize),
                                         20,
                                     );
                                     strcat(
@@ -857,7 +857,7 @@ pub(crate) fn fits_parser_yylex(
                                 } else {
                                     strncpy(
                                         ((*yyscanner.yylval_r).astr).as_mut_ptr(),
-                                        &mut *(yyscanner.yytext_r).offset(1 as c_int as isize),
+                                        &*(yyscanner.yytext_r).offset(1 as c_int as isize),
                                         len_3 as usize,
                                     );
                                 }
@@ -873,7 +873,7 @@ pub(crate) fn fits_parser_yylex(
                                     len_4 = (strlen(yyscanner.yytext_r)).wrapping_sub(2) as c_int;
                                     strncpy(
                                         ((*yyscanner.yylval_r).astr).as_mut_ptr(),
-                                        &mut *(yyscanner.yytext_r).offset(1 as c_int as isize),
+                                        &*(yyscanner.yytext_r).offset(1 as c_int as isize),
                                         len_4 as usize,
                                     );
                                     (*yyscanner.yylval_r).astr[len_4 as usize] = 0 as c_char;

--- a/src/eval_tab.rs
+++ b/src/eval_tab.rs
@@ -1,0 +1,56 @@
+use crate::{
+    c_types::{c_char, c_double, c_int, c_long},
+    eval_defs::MAX_STRLEN,
+};
+
+#[repr(i32)]
+pub(crate) enum fits_parser_yytokentype {
+    FITS_PARSER_YYEMPTY = -2,
+    FITS_PARSER_YYEOF = 0,     /* "end of file"  */
+    FITS_PARSER_YYerror = 256, /* error  */
+    FITS_PARSER_YYUNDEF = 257, /* "invalid token"  */
+    BOOLEAN = 258,             /* BOOLEAN  */
+    LONG = 259,                /* LONG  */
+    DOUBLE = 260,              /* DOUBLE  */
+    STRING = 261,              /* STRING  */
+    BITSTR = 262,              /* BITSTR  */
+    FUNCTION = 263,            /* FUNCTION  */
+    BFUNCTION = 264,           /* BFUNCTION  */
+    IFUNCTION = 265,           /* IFUNCTION  */
+    GTIFILTER = 266,           /* GTIFILTER  */
+    GTIOVERLAP = 267,          /* GTIOVERLAP  */
+    GTIFIND = 268,             /* GTIFIND  */
+    REGFILTER = 269,           /* REGFILTER  */
+    COLUMN = 270,              /* COLUMN  */
+    BCOLUMN = 271,             /* BCOLUMN  */
+    SCOLUMN = 272,             /* SCOLUMN  */
+    BITCOL = 273,              /* BITCOL  */
+    ROWREF = 274,              /* ROWREF  */
+    NULLREF = 275,             /* NULLREF  */
+    SNULLREF = 276,            /* SNULLREF  */
+    OR = 277,                  /* OR  */
+    AND = 278,                 /* AND  */
+    EQ = 279,                  /* EQ  */
+    NE = 280,                  /* NE  */
+    GT = 281,                  /* GT  */
+    LT = 282,                  /* LT  */
+    LTE = 283,                 /* LTE  */
+    GTE = 284,                 /* GTE  */
+    XOR = 285,                 /* XOR  */
+    POWER = 286,               /* POWER  */
+    NOT = 287,                 /* NOT  */
+    INTCAST = 288,             /* INTCAST  */
+    FLTCAST = 289,             /* FLTCAST  */
+    UMINUS = 290,              /* UMINUS  */
+    ACCUM = 291,               /* ACCUM  */
+    DIFF = 292,                /* DIFF  */
+}
+
+#[derive(Copy, Clone)]
+pub(crate) union FITS_PARSER_YYSTYPE {
+    pub(crate) Node: c_int,                         /* Index of Node */
+    pub(crate) dbl: c_double,                       /* real value    */
+    pub(crate) lng: c_long,                         /* integer value */
+    pub(crate) log: c_char,                         /* logical value */
+    pub(crate) astr: [c_char; MAX_STRLEN as usize], /* string value  */
+}

--- a/src/eval_tab.rs
+++ b/src/eval_tab.rs
@@ -46,6 +46,53 @@ pub(crate) enum fits_parser_yytokentype {
     DIFF = 292,                /* DIFF  */
 }
 
+impl From<c_int> for fits_parser_yytokentype {
+    fn from(value: c_int) -> Self {
+        match value {
+            -2 => Self::FITS_PARSER_YYEMPTY,
+            0 => Self::FITS_PARSER_YYEOF,
+            256 => Self::FITS_PARSER_YYerror,
+            257 => Self::FITS_PARSER_YYUNDEF,
+            258 => Self::BOOLEAN,
+            259 => Self::LONG,
+            260 => Self::DOUBLE,
+            261 => Self::STRING,
+            262 => Self::BITSTR,
+            263 => Self::FUNCTION,
+            264 => Self::BFUNCTION,
+            265 => Self::IFUNCTION,
+            266 => Self::GTIFILTER,
+            267 => Self::GTIOVERLAP,
+            268 => Self::GTIFIND,
+            269 => Self::REGFILTER,
+            270 => Self::COLUMN,
+            271 => Self::BCOLUMN,
+            272 => Self::SCOLUMN,
+            273 => Self::BITCOL,
+            274 => Self::ROWREF,
+            275 => Self::NULLREF,
+            276 => Self::SNULLREF,
+            277 => Self::OR,
+            278 => Self::AND,
+            279 => Self::EQ,
+            280 => Self::NE,
+            281 => Self::GT,
+            282 => Self::LT,
+            283 => Self::LTE,
+            284 => Self::GTE,
+            285 => Self::XOR,
+            286 => Self::POWER,
+            287 => Self::NOT,
+            288 => Self::INTCAST,
+            289 => Self::FLTCAST,
+            290 => Self::UMINUS,
+            291 => Self::ACCUM,
+            292 => Self::DIFF,
+            _ => panic!(),
+        }
+    }
+}
+
 #[derive(Copy, Clone)]
 pub(crate) union FITS_PARSER_YYSTYPE {
     pub(crate) Node: c_int,                         /* Index of Node */

--- a/src/eval_y.rs
+++ b/src/eval_y.rs
@@ -1,14 +1,3 @@
-#![allow(
-    dead_code,
-    mutable_transmutes,
-    non_camel_case_types,
-    non_snake_case,
-    non_upper_case_globals,
-    unused_assignments,
-    unused_mut,
-    deprecated
-)]
-
 use std::ffi::CStr;
 use std::rc::Rc;
 use std::{cmp, ptr};
@@ -75,20 +64,20 @@ fn tanh(x: f64) -> f64 {
 use crate::c_types::{
     c_char, c_double, c_int, c_long, c_schar, c_short, c_uchar, c_uint, c_ulong, c_void,
 };
-use crate::cfileio::{ffclos, ffexts, ffopen};
+use crate::cfileio::{ffclos_safer, ffexts_safer, ffopen_safer};
 use crate::eval_defs::{Node, ParseData, data_union, lval, yyscan_t};
-use crate::eval_l::{fits_parser_yyGetVariable, fits_parser_yylex};
+use crate::eval_l::{fits_parser_yyGetVariable, fits_parser_yylex, yyguts_t};
 use crate::eval_tab::{FITS_PARSER_YYSTYPE, fits_parser_yytokentype};
 use crate::fitscore::ffpmsg_slice;
-use crate::fitscore::{ffgcno, ffghdn, ffmahd, ffmnhd, ffupch};
+use crate::fitscore::{ffgcno_safe, ffghdn_safe, ffmahd_safe, ffmnhd_safe, ffupch_safe};
 use crate::fitsio::{LONGLONG, MEMORY_ALLOCATION, PARSE_SYNTAX_ERR, fitsfile};
-use crate::getcold::ffgcvd;
-use crate::getkey::{ffgkyd, ffgkyj, ffgkys};
+use crate::getcold::ffgcvd_safe;
+use crate::getkey::{ffgkyd_safe, ffgkyj_safe, ffgkys_safe};
 use crate::region::{MY_PI, SAORegion, WCSdata, fits_in_region, fits_read_rgnfile};
 use crate::simplerng::{
     simplerng_getnorm, simplerng_getpoisson, simplerng_getuniform, simplerng_srand,
 };
-use crate::wcssub::ffgtcs;
+use crate::wcssub::ffgtcs_safer;
 use crate::wrappers::strncpy_safe;
 use crate::wrappers::{strcat, strcmp, strcpy, strlen, strstr};
 use crate::{atoi, cs};
@@ -244,7 +233,7 @@ pub union yyalloc {
 
 /* YYTRANSLATE[TOKEN-NUM] -- Symbol number corresponding to TOKEN-NUM
 as returned by yylex.  */
-static yytranslate: [yytype_int8; 293] = [
+static YYTRANSLATE: [yytype_int8; 293] = [
     0, 2, 2, 2, 2, 2, 2, 2, 2, 2, 53, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
     2, 2, 2, 2, 2, 2, 39, 43, 2, 55, 56, 40, 37, 22, 38, 2, 41, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 24,
     2, 2, 23, 2, 27, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
@@ -259,7 +248,7 @@ static yytranslate: [yytype_int8; 293] = [
 
 /* YYPACT[STATE-NUM] -- Index in YYTABLE of the portion describing
 STATE-NUM.  */
-static yypact: [yytype_int16; 322] = [
+static YYPACT: [yytype_int16; 322] = [
     -41, 316, -41, -40, -41, -41, -41, -41, -41, 369, 423, 423, -5, 15, -4, 27, 36, 38, 40, 41,
     -41, -41, -41, 423, 423, 423, 423, 423, 423, -41, 423, -41, -7, 10, 1226, 81, 1646, 83, -41,
     -41, 450, 116, 309, 12, 479, 185, 152, 222, 1593, 1673, 1675, -19, -41, 13, -18, -41, 6, 423,
@@ -282,7 +271,7 @@ static yypact: [yytype_int16; 322] = [
 /* YYDEFACT[STATE-NUM] -- Default reduction number in state STATE-NUM.
 Performed when YYTABLE does not specify something else to do.  Zero
 means the default is an error.  */
-static yydefact: [yytype_uint8; 322] = [
+static YYDEFACT: [yytype_uint8; 322] = [
     2, 0, 1, 0, 74, 31, 32, 127, 18, 0, 0, 0, 0, 0, 0, 0, 33, 75, 128, 19, 35, 36, 130, 0, 0, 0, 0,
     0, 0, 4, 0, 3, 0, 0, 0, 0, 0, 0, 9, 54, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 109, 0, 0, 113, 0,
     0, 0, 0, 0, 12, 10, 0, 46, 47, 125, 29, 70, 71, 72, 73, 0, 0, 0, 0, 0, 17, 0, 16, 0, 0, 0, 0,
@@ -298,15 +287,15 @@ static yydefact: [yytype_uint8; 322] = [
 ];
 
 /* YYPGOTO[NTERM-NUM].  */
-static yypgoto: [yytype_int16; 9] = [-41, -41, -41, -41, -41, -1, 170, 96, 30];
+static YYPGOTO: [yytype_int16; 9] = [-41, -41, -41, -41, -41, -1, 170, 96, 30];
 
 /* YYDEFGOTO[NTERM-NUM].  */
-static yydefgoto: [yytype_int8; 9] = [0, 1, 31, 32, 33, 48, 49, 46, 63];
+static YYDEFGOTO: [yytype_int8; 9] = [0, 1, 31, 32, 33, 48, 49, 46, 63];
 
 /* YYTABLE[YYPACT[STATE-NUM]] -- What to do in state STATE-NUM.  If
 positive, shift that token.  If negative, reduce the rule whose
 number is the opposite.  If YYTABLE_NINF, syntax error.  */
-static yytable: [yytype_int16; 1777] = [
+static YYTABLE: [yytype_int16; 1777] = [
     34, 51, 54, 138, 141, 8, 114, 115, 40, 44, 102, 103, 113, 38, 116, 76, 19, 114, 115, 77, 104,
     53, 61, 64, 65, 116, 68, 70, 143, 72, 105, 37, 78, 56, 131, 140, 79, 139, 142, 43, 47, 50, 118,
     119, 185, 120, 121, 122, 123, 124, 96, 52, 55, 186, 104, 97, 145, 146, 147, 148, 75, 57, 144,
@@ -384,7 +373,7 @@ static yytable: [yytype_int16; 1777] = [
     0, 0, 0, 97, 88, 89, 90, 91, 92, 93, 94, 95, 96, 0, 0, 0, 0, 97,
 ];
 
-static yycheck: [yytype_int16; 1777] = [
+static YYCHECK: [yytype_int16; 1777] = [
     1, 6, 6, 22, 22, 7, 42, 43, 9, 10, 30, 31, 37, 53, 50, 22, 18, 42, 43, 26, 40, 6, 23, 24, 25,
     50, 27, 28, 22, 30, 50, 1, 22, 6, 22, 22, 26, 56, 56, 9, 10, 11, 30, 31, 46, 33, 34, 35, 36,
     37, 45, 56, 56, 55, 40, 50, 57, 58, 59, 60, 30, 25, 56, 25, 50, 25, 25, 50, 56, 50, 42, 43, 44,
@@ -464,7 +453,7 @@ static yycheck: [yytype_int16; 1777] = [
 
 /* YYSTOS[STATE-NUM] -- The symbol kind of the accessing symbol of
 state STATE-NUM.  */
-static yystos: [yytype_int8; 322] = [
+static YYSTOS: [yytype_int8; 322] = [
     0, 58, 0, 1, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 25, 37, 38,
     46, 47, 48, 53, 55, 59, 60, 61, 62, 63, 64, 65, 53, 56, 62, 63, 64, 65, 62, 63, 64, 65, 62, 63,
     65, 6, 56, 6, 6, 56, 6, 25, 25, 25, 25, 62, 63, 65, 62, 62, 63, 64, 62, 63, 62, 63, 62, 63, 64,
@@ -482,7 +471,7 @@ static yystos: [yytype_int8; 322] = [
 ];
 
 /* YYR1[RULE-NUM] -- Symbol kind of the left-hand side of rule RULE-NUM.  */
-static yyr1: [yytype_int8; 136] = [
+static YYR1: [yytype_int8; 136] = [
     0, 57, 58, 58, 59, 59, 59, 59, 59, 59, 60, 60, 61, 61, 61, 61, 62, 63, 64, 64, 64, 64, 64, 64,
     64, 64, 64, 64, 64, 64, 64, 62, 62, 62, 62, 62, 62, 62, 62, 62, 62, 62, 62, 62, 62, 62, 62, 62,
     62, 62, 62, 62, 62, 62, 62, 62, 62, 62, 62, 62, 62, 62, 62, 62, 62, 62, 62, 62, 62, 62, 62, 62,
@@ -492,7 +481,7 @@ static yyr1: [yytype_int8; 136] = [
 ];
 
 /* YYR2[RULE-NUM] -- Number of symbols on the right-hand side of rule RULE-NUM.  */
-static yyr2: [yytype_int8; 136] = [
+static YYR2: [yytype_int8; 136] = [
     0, 2, 0, 2, 1, 2, 2, 2, 2, 2, 2, 3, 2, 3, 3, 3, 2, 2, 1, 1, 4, 3, 3, 3, 4, 6, 8, 10, 12, 2, 3,
     1, 1, 1, 4, 1, 1, 3, 3, 3, 3, 3, 3, 3, 3, 3, 2, 2, 3, 3, 3, 5, 5, 5, 2, 3, 5, 3, 3, 3, 5, 5, 9,
     7, 11, 4, 6, 8, 10, 12, 2, 2, 2, 2, 1, 1, 4, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
@@ -522,16 +511,14 @@ fn Alloc_Node(lParse: &mut ParseData) -> c_int {
     lParse.nNodes
 }
 
-unsafe fn Free_Last_Node(lParse: &mut ParseData) {
-    unsafe {
-        if lParse.nNodes != 0 {
-            lParse.nNodes -= 1;
-            lParse.nNodes;
-        }
+fn Free_Last_Node(lParse: &mut ParseData) {
+    if lParse.nNodes != 0 {
+        lParse.nNodes -= 1;
+        lParse.nNodes;
     }
 }
 
-unsafe fn New_Const(
+fn New_Const(
     lParse: &mut ParseData,
     returnType: c_int,
     value: *const c_void,
@@ -559,7 +546,7 @@ unsafe fn New_Const(
         n
     }
 }
-unsafe fn New_Column(lParse: &mut ParseData, mut ColNum: c_int) -> c_int {
+fn New_Column(lParse: &mut ParseData, ColNum: c_int) -> c_int {
     unsafe {
         let mut this: *mut Node = std::ptr::null_mut::<Node>();
         let mut n: c_int = 0;
@@ -570,13 +557,13 @@ unsafe fn New_Column(lParse: &mut ParseData, mut ColNum: c_int) -> c_int {
             (*this).operation = -ColNum;
             (*this).DoOp = None;
             (*this).nSubNodes = 0;
-            (*this).ntype = (*(lParse.varData).offset(ColNum as isize)).dtype;
-            (*this).value.nelem = (*(lParse.varData).offset(ColNum as isize)).nelem;
-            (*this).value.naxis = (*(lParse.varData).offset(ColNum as isize)).naxis;
+            (*this).ntype = ((lParse.varData)[ColNum as usize]).dtype;
+            (*this).value.nelem = ((lParse.varData)[ColNum as usize]).nelem;
+            (*this).value.naxis = ((lParse.varData)[ColNum as usize]).naxis;
             i = 0;
-            while i < (*(lParse.varData).offset(ColNum as isize)).naxis {
+            while i < ((lParse.varData)[ColNum as usize]).naxis {
                 (*this).value.naxes[i as usize] =
-                    (*(lParse.varData).offset(ColNum as isize)).naxes[i as usize];
+                    ((lParse.varData)[ColNum as usize]).naxes[i as usize];
                 i += 1;
                 i;
             }
@@ -584,7 +571,7 @@ unsafe fn New_Column(lParse: &mut ParseData, mut ColNum: c_int) -> c_int {
         n
     }
 }
-unsafe fn New_Offset(lParse: &mut ParseData, mut ColNum: c_int, mut offsetNode: c_int) -> c_int {
+fn New_Offset(lParse: &mut ParseData, ColNum: c_int, offsetNode: c_int) -> c_int {
     unsafe {
         let mut this: *mut Node = std::ptr::null_mut::<Node>();
         let mut n: c_int = 0;
@@ -602,13 +589,13 @@ unsafe fn New_Offset(lParse: &mut ParseData, mut ColNum: c_int, mut offsetNode: 
             (*this).nSubNodes = 2 as c_int;
             (*this).SubNodes[0] = colNode;
             (*this).SubNodes[1] = offsetNode;
-            (*this).ntype = (*(lParse.varData).offset(ColNum as isize)).dtype;
-            (*this).value.nelem = (*(lParse.varData).offset(ColNum as isize)).nelem;
-            (*this).value.naxis = (*(lParse.varData).offset(ColNum as isize)).naxis;
+            (*this).ntype = ((lParse.varData)[ColNum as usize]).dtype;
+            (*this).value.nelem = ((lParse.varData)[ColNum as usize]).nelem;
+            (*this).value.naxis = ((lParse.varData)[ColNum as usize]).naxis;
             i = 0;
-            while i < (*(lParse.varData).offset(ColNum as isize)).naxis {
+            while i < ((lParse.varData)[ColNum as usize]).naxis {
                 (*this).value.naxes[i as usize] =
-                    (*(lParse.varData).offset(ColNum as isize)).naxes[i as usize];
+                    ((lParse.varData)[ColNum as usize]).naxes[i as usize];
                 i += 1;
                 i;
             }
@@ -616,12 +603,7 @@ unsafe fn New_Offset(lParse: &mut ParseData, mut ColNum: c_int, mut offsetNode: 
         n
     }
 }
-unsafe fn New_Unary(
-    lParse: &mut ParseData,
-    mut returnType: c_int,
-    mut Op: c_int,
-    mut Node1: c_int,
-) -> c_int {
+fn New_Unary(lParse: &mut ParseData, returnType: c_int, mut Op: c_int, Node1: c_int) -> c_int {
     unsafe {
         let mut this: *mut Node = std::ptr::null_mut::<Node>();
         let mut that: *mut Node = std::ptr::null_mut::<Node>();
@@ -675,12 +657,12 @@ unsafe fn New_Unary(
         n
     }
 }
-unsafe fn New_BinOp(
+fn New_BinOp(
     lParse: &mut ParseData,
-    mut returnType: c_int,
-    mut Node1: c_int,
-    mut Op: c_int,
-    mut Node2: c_int,
+    returnType: c_int,
+    Node1: c_int,
+    Op: c_int,
+    Node2: c_int,
 ) -> c_int {
     unsafe {
         let mut this: *mut Node = std::ptr::null_mut::<Node>();
@@ -709,7 +691,6 @@ unsafe fn New_BinOp(
             {
                 Free_Last_Node(lParse);
                 fits_parser_yyerror(
-                    ptr::null_mut(),
                     lParse,
                     cs!(c"Array sizes/dims do not match for binary operator"),
                 );
@@ -758,18 +739,18 @@ unsafe fn New_BinOp(
         n
     }
 }
-unsafe fn New_Func(
+fn New_Func(
     lParse: &mut ParseData,
-    mut returnType: c_int,
-    mut Op: funcOp,
-    mut nNodes: c_int,
-    mut Node1: c_int,
-    mut Node2: c_int,
-    mut Node3: c_int,
-    mut Node4: c_int,
-    mut Node5: c_int,
-    mut Node6: c_int,
-    mut Node7: c_int,
+    returnType: c_int,
+    Op: funcOp,
+    nNodes: c_int,
+    Node1: c_int,
+    Node2: c_int,
+    Node3: c_int,
+    Node4: c_int,
+    Node5: c_int,
+    Node6: c_int,
+    Node7: c_int,
 ) -> c_int {
     unsafe {
         New_FuncSize(
@@ -777,30 +758,31 @@ unsafe fn New_Func(
         )
     }
 }
-unsafe fn yydestruct(
+fn yydestruct(
     mut yymsg: *const c_char,
-    mut yykind: yysymbol_kind_t,
-    mut yyvaluep: *mut FITS_PARSER_YYSTYPE,
-    mut scanner: yyscan_t,
+    yykind: yysymbol_kind_t,
+    yyvaluep: *mut FITS_PARSER_YYSTYPE,
+    scanner: yyscan_t,
     lParse: &mut ParseData,
 ) {
     if yymsg.is_null() {
         yymsg = b"Deleting\0" as *const u8 as *const c_char;
     }
 }
-unsafe fn New_FuncSize(
+
+fn New_FuncSize(
     lParse: &mut ParseData,
-    mut returnType: c_int,
-    mut Op: funcOp,
-    mut nNodes: c_int,
-    mut Node1: c_int,
-    mut Node2: c_int,
-    mut Node3: c_int,
-    mut Node4: c_int,
-    mut Node5: c_int,
-    mut Node6: c_int,
-    mut Node7: c_int,
-    mut Size: c_int,
+    returnType: c_int,
+    Op: funcOp,
+    nNodes: c_int,
+    Node1: c_int,
+    Node2: c_int,
+    Node3: c_int,
+    Node4: c_int,
+    Node5: c_int,
+    Node6: c_int,
+    Node7: c_int,
+    Size: c_int,
 ) -> c_int {
     unsafe {
         let mut this: *mut Node = std::ptr::null_mut::<Node>();
@@ -867,12 +849,12 @@ unsafe fn New_FuncSize(
     }
 }
 
-pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, lParse: &mut ParseData) -> c_int {
+pub fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData) -> c_int {
     unsafe {
         let mut current_block: u64;
         let mut yychar: c_int = 0;
-        static mut yyval_default: FITS_PARSER_YYSTYPE = FITS_PARSER_YYSTYPE { Node: 0 };
-        let mut yylval: FITS_PARSER_YYSTYPE = yyval_default;
+        static mut YYVAL_DEFAULT: FITS_PARSER_YYSTYPE = FITS_PARSER_YYSTYPE { Node: 0 };
+        let mut yylval: FITS_PARSER_YYSTYPE = YYVAL_DEFAULT;
         let mut fits_parser_yynerrs: c_int = 0;
         let mut yystate: yy_state_fast_t = 0;
         let mut yyerrstatus: c_int = 0;
@@ -897,7 +879,7 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, lParse: &mut ParseData)
                 .offset(-(1 as c_int as isize))
                 <= yyssp
             {
-                let mut yysize: c_long = yyssp.offset_from(yyss) as c_long + 1;
+                let yysize: c_long = yyssp.offset_from(yyss) as c_long + 1;
                 if 10000 as c_long <= yystacksize {
                     current_block = 11794367917084412820;
                     break;
@@ -906,7 +888,7 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, lParse: &mut ParseData)
                 if (10000 as c_long) < yystacksize {
                     yystacksize = 10000 as c_long;
                 }
-                let mut yyss1: *mut yy_state_t = yyss;
+                let yyss1: *mut yy_state_t = yyss;
                 let mut yyptr: *mut yyalloc = malloc(
                     ((yystacksize
                         * (::core::mem::size_of::<yy_state_t>() as c_ulong as c_long
@@ -970,13 +952,12 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, lParse: &mut ParseData)
                 current_block = 15864720325503947191;
                 break;
             } else {
-                yyn = yypact[yystate as usize] as c_int;
+                yyn = YYPACT[yystate as usize] as c_int;
                 if yyn == -(41 as c_int) {
                     current_block = 5937473999264333383;
                 } else {
                     if yychar == fits_parser_yytokentype::FITS_PARSER_YYEMPTY as c_int {
-                        yychar =
-                            fits_parser_yylex(&mut yylval as *mut FITS_PARSER_YYSTYPE, scanner);
+                        yychar = fits_parser_yylex(&mut yylval, scanner);
                     }
                     if yychar <= fits_parser_yytokentype::FITS_PARSER_YYEOF as c_int {
                         yychar = fits_parser_yytokentype::FITS_PARSER_YYEOF as c_int;
@@ -988,7 +969,7 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, lParse: &mut ParseData)
                         current_block = 1774893048582444437;
                     } else {
                         yytoken = (if 0 <= yychar && yychar <= 292 as c_int {
-                            yytranslate[yychar as usize] as yysymbol_kind_t as c_int
+                            YYTRANSLATE[yychar as usize] as yysymbol_kind_t as c_int
                         } else {
                             YYSYMBOL_YYUNDEF as c_int
                         }) as yysymbol_kind_t;
@@ -1000,11 +981,11 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, lParse: &mut ParseData)
                             yyn += yytoken as c_int;
                             if yyn < 0
                                 || (1776 as c_int) < yyn
-                                || yycheck[yyn as usize] as c_int != yytoken as c_int
+                                || YYCHECK[yyn as usize] as c_int != yytoken as c_int
                             {
                                 current_block = 5937473999264333383;
                             } else {
-                                yyn = yytable[yyn as usize] as c_int;
+                                yyn = YYTABLE[yyn as usize] as c_int;
                                 if yyn <= 0 {
                                     yyn = -yyn;
                                     current_block = 670225253387957849;
@@ -1024,20 +1005,20 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, lParse: &mut ParseData)
                     }
                 }
                 if current_block == 5937473999264333383 {
-                    yyn = yydefact[yystate as usize] as c_int;
+                    yyn = YYDEFACT[yystate as usize] as c_int;
                     if yyn == 0 {
                         yytoken =
                             (if yychar == fits_parser_yytokentype::FITS_PARSER_YYEMPTY as c_int {
                                 YYSYMBOL_YYEMPTY as c_int
                             } else if 0 <= yychar && yychar <= 292 as c_int {
-                                yytranslate[yychar as usize] as yysymbol_kind_t as c_int
+                                YYTRANSLATE[yychar as usize] as yysymbol_kind_t as c_int
                             } else {
                                 YYSYMBOL_YYUNDEF as c_int
                             }) as yysymbol_kind_t;
                         if yyerrstatus == 0 {
                             fits_parser_yynerrs += 1;
                             fits_parser_yynerrs;
-                            fits_parser_yyerror(scanner, lParse, cs!(c"syntax error"));
+                            fits_parser_yyerror(lParse, cs!(c"syntax error"));
                         }
                         if yyerrstatus == 3 as c_int {
                             if yychar <= fits_parser_yytokentype::FITS_PARSER_YYEOF as c_int {
@@ -1062,7 +1043,7 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, lParse: &mut ParseData)
                     }
                 }
                 if current_block == 670225253387957849 {
-                    yylen = yyr2[yyn as usize] as c_int;
+                    yylen = YYR2[yyn as usize] as c_int;
                     yyval = *yyvsp.offset((1 as c_int - yylen) as isize);
                     match yyn {
                         4 => {
@@ -1071,7 +1052,6 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, lParse: &mut ParseData)
                         5 => {
                             if (*yyvsp.offset(-1)).Node < 0 {
                                 fits_parser_yyerror(
-                                    scanner,
                                     lParse,
                                     cs!(c"Couldn't build node structure: out of memory?"),
                                 );
@@ -1084,7 +1064,6 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, lParse: &mut ParseData)
                         6 => {
                             if (*yyvsp.offset(-1)).Node < 0 {
                                 fits_parser_yyerror(
-                                    scanner,
                                     lParse,
                                     cs!(c"Couldn't build node structure: out of memory?"),
                                 );
@@ -1097,7 +1076,6 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, lParse: &mut ParseData)
                         7 => {
                             if (*yyvsp.offset(-1)).Node < 0 {
                                 fits_parser_yyerror(
-                                    scanner,
                                     lParse,
                                     cs!(c"Couldn't build node structure: out of memory?"),
                                 );
@@ -1110,7 +1088,6 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, lParse: &mut ParseData)
                         8 => {
                             if (*yyvsp.offset(-1)).Node < 0 {
                                 fits_parser_yyerror(
-                                    scanner,
                                     lParse,
                                     cs!(c"Couldn't build node structure: out of memory?"),
                                 );
@@ -1328,7 +1305,6 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, lParse: &mut ParseData)
                                     != -1000
                             {
                                 fits_parser_yyerror(
-                                    scanner,
                                     lParse,
                                     cs!(c"Offset argument must be a constant integer"),
                                 );
@@ -1408,7 +1384,6 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, lParse: &mut ParseData)
                                 >= 256 as c_long
                             {
                                 fits_parser_yyerror(
-                                    scanner,
                                     lParse,
                                     cs!(c"Combined bit string size exceeds 255 bits"),
                                 );
@@ -1578,7 +1553,6 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, lParse: &mut ParseData)
                                     != -1000
                             {
                                 fits_parser_yyerror(
-                                    scanner,
                                     lParse,
                                     cs!(c"Offset argument must be a constant integer"),
                                 );
@@ -1800,7 +1774,6 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, lParse: &mut ParseData)
                                     != fits_parser_yytokentype::LONG as c_int
                             {
                                 fits_parser_yyerror(
-                                    scanner,
                                     lParse,
                                     cs!(c"Bitwise operations with incompatible types; only (bit OP bit) and (int OP int) are allowed"),
                                 );
@@ -1823,7 +1796,6 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, lParse: &mut ParseData)
                                     != fits_parser_yytokentype::LONG as c_int
                             {
                                 fits_parser_yyerror(
-                                    scanner,
                                     lParse,
                                     cs!(c"Bitwise operations with incompatible types; only (bit OP bit) and (int OP int) are allowed"),
                                 );
@@ -1846,7 +1818,6 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, lParse: &mut ParseData)
                                     != fits_parser_yytokentype::LONG as c_int
                             {
                                 fits_parser_yyerror(
-                                    scanner,
                                     lParse,
                                     cs!(c"Bitwise operations with incompatible types; only (bit OP bit) and (int OP int) are allowed"),
                                 );
@@ -1980,7 +1951,6 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, lParse: &mut ParseData)
                                 == 0
                             {
                                 fits_parser_yyerror(
-                                    scanner,
                                     lParse,
                                     cs!(c"Incompatible dimensions in '?:' arguments"),
                                 );
@@ -2016,7 +1986,6 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, lParse: &mut ParseData)
                                     if Test_Dims(lParse, (*yyvsp.offset(-4)).Node, yyval.Node) == 0
                                     {
                                         fits_parser_yyerror(
-                                            scanner,
                                             lParse,
                                             cs!(c"Incompatible dimensions in '?:' condition"),
                                         );
@@ -2060,7 +2029,6 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, lParse: &mut ParseData)
                                 == 0
                             {
                                 fits_parser_yyerror(
-                                    scanner,
                                     lParse,
                                     cs!(c"Incompatible dimensions in '?:' arguments"),
                                 );
@@ -2096,7 +2064,6 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, lParse: &mut ParseData)
                                     if Test_Dims(lParse, (*yyvsp.offset(-4)).Node, yyval.Node) == 0
                                     {
                                         fits_parser_yyerror(
-                                            scanner,
                                             lParse,
                                             cs!(c"Incompatible dimensions in '?:' condition"),
                                         );
@@ -2140,7 +2107,6 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, lParse: &mut ParseData)
                                 == 0
                             {
                                 fits_parser_yyerror(
-                                    scanner,
                                     lParse,
                                     cs!(c"Incompatible dimensions in '?:' arguments"),
                                 );
@@ -2176,7 +2142,6 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, lParse: &mut ParseData)
                                     if Test_Dims(lParse, (*yyvsp.offset(-4)).Node, yyval.Node) == 0
                                     {
                                         fits_parser_yyerror(
-                                            scanner,
                                             lParse,
                                             cs!(c"Incompatible dimensions in '?:' condition"),
                                         );
@@ -2260,11 +2225,7 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, lParse: &mut ParseData)
                                 );
                                 current_block = 1297461190301222800;
                             } else {
-                                fits_parser_yyerror(
-                                    scanner,
-                                    lParse,
-                                    cs!(c"Function() not supported"),
-                                );
+                                fits_parser_yyerror(lParse, cs!(c"Function() not supported"));
                                 current_block = 4830776507462815627;
                             }
                             match current_block {
@@ -2355,7 +2316,7 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, lParse: &mut ParseData)
                             }) == 0
                             {
                                 let mut zero: c_long = 0;
-                                let mut new_node = New_Const(
+                                let new_node = New_Const(
                                     lParse,
                                     fits_parser_yytokentype::LONG as c_int,
                                     &mut zero as *mut c_long as *mut c_void,
@@ -2371,11 +2332,7 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, lParse: &mut ParseData)
                                 );
                                 current_block = 10848699504537784535;
                             } else {
-                                fits_parser_yyerror(
-                                    scanner,
-                                    lParse,
-                                    cs!(c"Function(bool) not supported"),
-                                );
+                                fits_parser_yyerror(lParse, cs!(c"Function(bool) not supported"));
                                 current_block = 4830776507462815627;
                             }
                             match current_block {
@@ -2417,7 +2374,6 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, lParse: &mut ParseData)
                                         != 1
                                 {
                                     fits_parser_yyerror(
-                                        scanner,
                                         lParse,
                                         cs!(c"AXISELEM second argument must be a scalar constant"),
                                     );
@@ -2491,7 +2447,6 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, lParse: &mut ParseData)
                                         != 1
                                 {
                                     fits_parser_yyerror(
-                                        scanner,
                                         lParse,
                                         cs!(c"NAXES second argument must be a scalar constant"),
                                     );
@@ -2579,7 +2534,6 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, lParse: &mut ParseData)
                                 }
                             } else {
                                 fits_parser_yyerror(
-                                    scanner,
                                     lParse,
                                     cs!(c"Function(bool,expr) not supported"),
                                 );
@@ -2656,11 +2610,7 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, lParse: &mut ParseData)
                                 );
                                 current_block = 15752106442776732052;
                             } else {
-                                fits_parser_yyerror(
-                                    scanner,
-                                    lParse,
-                                    cs!(c"Function(str) not supported"),
-                                );
+                                fits_parser_yyerror(lParse, cs!(c"Function(str) not supported"));
                                 current_block = 4830776507462815627;
                             }
                             match current_block {
@@ -2810,7 +2760,7 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, lParse: &mut ParseData)
                             }) == 0
                             {
                                 let mut zero_0: c_long = 0;
-                                let mut new_node = New_Const(
+                                let new_node = New_Const(
                                     lParse,
                                     fits_parser_yytokentype::LONG as c_int,
                                     &mut zero_0 as *mut c_long as *mut c_void,
@@ -2858,11 +2808,7 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, lParse: &mut ParseData)
                                 (((lParse.Nodes)[yyval.Node as usize]).value).nelem = 1;
                                 current_block = 494012601817399562;
                             } else {
-                                fits_parser_yyerror(
-                                    scanner,
-                                    lParse,
-                                    cs!(c"Function(bits) not supported"),
-                                );
+                                fits_parser_yyerror(lParse, cs!(c"Function(bits) not supported"));
                                 current_block = 4830776507462815627;
                             }
                             match current_block {
@@ -3080,9 +3026,9 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, lParse: &mut ParseData)
                             {
                                 let mut zero_1: c_long = 0;
 
-                                let mut rc_parse: Rc<ParseData> = Rc::from_raw(lParse);
+                                let rc_parse: Rc<ParseData> = Rc::from_raw(lParse);
 
-                                let mut new_node = New_Const(
+                                let new_node = New_Const(
                                     lParse,
                                     fits_parser_yytokentype::LONG as c_int,
                                     &mut zero_1 as *mut c_long as *mut c_void,
@@ -3117,7 +3063,7 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, lParse: &mut ParseData)
                                     == fits_parser_yytokentype::DOUBLE as c_int
                             {
                                 let mut zero_2: c_double = 0.0;
-                                let mut new_node = New_Const(
+                                let new_node = New_Const(
                                     lParse,
                                     fits_parser_yytokentype::DOUBLE as c_int,
                                     &mut zero_2 as *mut c_double as *mut c_void,
@@ -3152,7 +3098,7 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, lParse: &mut ParseData)
                                     == fits_parser_yytokentype::LONG as c_int
                             {
                                 let mut zero_3: c_long = 0;
-                                let mut new_node = New_Const(
+                                let new_node = New_Const(
                                     lParse,
                                     fits_parser_yytokentype::LONG as c_int,
                                     &mut zero_3 as *mut c_long as *mut c_void,
@@ -3187,7 +3133,7 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, lParse: &mut ParseData)
                                     == fits_parser_yytokentype::DOUBLE as c_int
                             {
                                 let mut zero_4: c_double = 0.0;
-                                let mut new_node = New_Const(
+                                let new_node = New_Const(
                                     lParse,
                                     fits_parser_yytokentype::DOUBLE as c_int,
                                     &mut zero_4 as *mut c_double as *mut c_void,
@@ -4087,7 +4033,6 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, lParse: &mut ParseData)
                                     current_block = 7600445499126923600;
                                 } else {
                                     fits_parser_yyerror(
-                                        scanner,
                                         lParse,
                                         cs!(c"Function(expr) not supported"),
                                     );
@@ -4223,7 +4168,6 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, lParse: &mut ParseData)
                                     }
                                 } else {
                                     fits_parser_yyerror(
-                                        scanner,
                                         lParse,
                                         cs!(c"Dimensions of DEFNULL arguments are not compatible"),
                                     );
@@ -4301,7 +4245,6 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, lParse: &mut ParseData)
                                     }
                                 } else {
                                     fits_parser_yyerror(
-                                        scanner,
                                         lParse,
                                         cs!(c"Dimensions of arctan2 arguments are not compatible"),
                                     );
@@ -4378,7 +4321,6 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, lParse: &mut ParseData)
                                     }
                                 } else {
                                     fits_parser_yyerror(
-                                        scanner,
                                         lParse,
                                         cs!(c"Dimensions of min(a,b) arguments are not compatible"),
                                     );
@@ -4455,7 +4397,6 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, lParse: &mut ParseData)
                                     }
                                 } else {
                                     fits_parser_yyerror(
-                                        scanner,
                                         lParse,
                                         cs!(c"Dimensions of max(a,b) arguments are not compatible"),
                                     );
@@ -4486,7 +4427,6 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, lParse: &mut ParseData)
                                         != 1
                                 {
                                     fits_parser_yyerror(
-                                        scanner,
                                         lParse,
                                         cs!(c"SETNULL first argument must be a scalar constant"),
                                     );
@@ -4545,7 +4485,6 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, lParse: &mut ParseData)
                                         != 1
                                 {
                                     fits_parser_yyerror(
-                                        scanner,
                                         lParse,
                                         cs!(c"AXISELEM second argument must be a scalar constant"),
                                     );
@@ -4619,7 +4558,6 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, lParse: &mut ParseData)
                                         != 1
                                 {
                                     fits_parser_yyerror(
-                                        scanner,
                                         lParse,
                                         cs!(c"NAXES second argument must be a scalar constant"),
                                     );
@@ -4708,7 +4646,6 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, lParse: &mut ParseData)
                                 }
                             } else {
                                 fits_parser_yyerror(
-                                    scanner,
                                     lParse,
                                     cs!(c"Function(expr,expr) not supported"),
                                 );
@@ -4846,7 +4783,6 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, lParse: &mut ParseData)
                                     }
                                 } else {
                                     fits_parser_yyerror(
-                                        scanner,
                                         lParse,
                                         cs!(c"Dimensions of ANGSEP arguments are not compatible"),
                                     );
@@ -4854,7 +4790,6 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, lParse: &mut ParseData)
                                 }
                             } else {
                                 fits_parser_yyerror(
-                                    scanner,
                                     lParse,
                                     cs!(c"Function(expr,expr,expr,expr) not supported"),
                                 );
@@ -5058,7 +4993,6 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, lParse: &mut ParseData)
                                     != -1000
                             {
                                 fits_parser_yyerror(
-                                    scanner,
                                     lParse,
                                     cs!(c"Offset argument must be a constant integer"),
                                 );
@@ -5633,7 +5567,6 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, lParse: &mut ParseData)
                                 == 0
                             {
                                 fits_parser_yyerror(
-                                    scanner,
                                     lParse,
                                     cs!(c"Incompatible dimensions in '?:' arguments"),
                                 );
@@ -5667,7 +5600,6 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, lParse: &mut ParseData)
                                     if Test_Dims(lParse, (*yyvsp.offset(-4)).Node, yyval.Node) == 0
                                     {
                                         fits_parser_yyerror(
-                                            scanner,
                                             lParse,
                                             cs!(c"Incompatible dimensions in '?:' condition"),
                                         );
@@ -5725,7 +5657,6 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, lParse: &mut ParseData)
                                 }
                             } else {
                                 fits_parser_yyerror(
-                                    scanner,
                                     lParse,
                                     cs!(c"Boolean Function(expr) not supported"),
                                 );
@@ -5772,7 +5703,6 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, lParse: &mut ParseData)
                                 }
                             } else {
                                 fits_parser_yyerror(
-                                    scanner,
                                     lParse,
                                     cs!(c"Boolean Function(expr) not supported"),
                                 );
@@ -5817,7 +5747,6 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, lParse: &mut ParseData)
                                 }
                             } else {
                                 fits_parser_yyerror(
-                                    scanner,
                                     lParse,
                                     cs!(c"Boolean Function(expr) not supported"),
                                 );
@@ -5874,7 +5803,6 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, lParse: &mut ParseData)
                                     }
                                 } else {
                                     fits_parser_yyerror(
-                                        scanner,
                                         lParse,
                                         cs!(c"Dimensions of DEFNULL arguments are not compatible"),
                                     );
@@ -5882,7 +5810,6 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, lParse: &mut ParseData)
                                 }
                             } else {
                                 fits_parser_yyerror(
-                                    scanner,
                                     lParse,
                                     cs!(c"Boolean Function(expr,expr) not supported"),
                                 );
@@ -5932,7 +5859,6 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, lParse: &mut ParseData)
                                 ) != 0)
                             {
                                 fits_parser_yyerror(
-                                    scanner,
                                     lParse,
                                     cs!(c"Dimensions of NEAR arguments are not compatible"),
                                 );
@@ -5998,11 +5924,7 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, lParse: &mut ParseData)
                                     current_block = 17353983478346836848;
                                 }
                             } else {
-                                fits_parser_yyerror(
-                                    scanner,
-                                    lParse,
-                                    cs!(c"Boolean Function not supported"),
-                                );
+                                fits_parser_yyerror(lParse, cs!(c"Boolean Function not supported"));
                                 current_block = 4830776507462815627;
                             }
                         }
@@ -6079,7 +6001,6 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, lParse: &mut ParseData)
                                 ) != 0)
                             {
                                 fits_parser_yyerror(
-                                    scanner,
                                     lParse,
                                     cs!(c"Dimensions of CIRCLE arguments are not compatible"),
                                 );
@@ -6163,11 +6084,7 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, lParse: &mut ParseData)
                                     current_block = 17353983478346836848;
                                 }
                             } else {
-                                fits_parser_yyerror(
-                                    scanner,
-                                    lParse,
-                                    cs!(c"Boolean Function not supported"),
-                                );
+                                fits_parser_yyerror(lParse, cs!(c"Boolean Function not supported"));
                                 current_block = 4830776507462815627;
                             }
                         }
@@ -6274,7 +6191,6 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, lParse: &mut ParseData)
                                 ) != 0)
                             {
                                 fits_parser_yyerror(
-                                    scanner,
                                     lParse,
                                     cs!(c"Dimensions of BOX or ELLIPSE arguments are not compatible"),
                                 );
@@ -6346,7 +6262,6 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, lParse: &mut ParseData)
                                     current_block = 3023179740610631044;
                                 } else {
                                     fits_parser_yyerror(
-                                        scanner,
                                         lParse,
                                         cs!(c"SAO Image Function not supported"),
                                     );
@@ -6766,7 +6681,6 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, lParse: &mut ParseData)
                                     != -1000
                             {
                                 fits_parser_yyerror(
-                                    scanner,
                                     lParse,
                                     cs!(c"Offset argument must be a constant integer"),
                                 );
@@ -6812,7 +6726,6 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, lParse: &mut ParseData)
                                 >= 256 as c_long
                             {
                                 fits_parser_yyerror(
-                                    scanner,
                                     lParse,
                                     cs!(c"Combined string size exceeds 255 characters"),
                                 );
@@ -6847,7 +6760,6 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, lParse: &mut ParseData)
                                 != 1
                             {
                                 fits_parser_yyerror(
-                                    scanner,
                                     lParse,
                                     cs!(c"Cannot have a vector string column"),
                                 );
@@ -6959,7 +6871,6 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, lParse: &mut ParseData)
                                 }
                             } else {
                                 fits_parser_yyerror(
-                                    scanner,
                                     lParse,
                                     cs!(c"Function(string,string) not supported"),
                                 );
@@ -6999,7 +6910,7 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, lParse: &mut ParseData)
                                         != 1
                                 {
                                     fits_parser_yyerror(
-                                        scanner,
+
                                         lParse,
                                         cs!(c"When using STRMID(S,P,N), P and N must be integers (and not vector columns)"),
                                     );
@@ -7021,7 +6932,6 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, lParse: &mut ParseData)
                                     }
                                     if len <= 0 || len >= 256 as c_int {
                                         fits_parser_yyerror(
-                                            scanner,
                                             lParse,
                                             cs!(c"STRMID(S,P,N), N must be 1-255"),
                                         );
@@ -7050,7 +6960,6 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, lParse: &mut ParseData)
                                 }
                             } else {
                                 fits_parser_yyerror(
-                                    scanner,
                                     lParse,
                                     cs!(c"Function(string,expr,expr) not supported"),
                                 );
@@ -7077,15 +6986,15 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, lParse: &mut ParseData)
                             yylen = 0;
                             yyvsp = yyvsp.offset(1);
                             *yyvsp = yyval;
-                            let yylhs: c_int = yyr1[yyn as usize] as c_int - 57 as c_int;
-                            let yyi: c_int = yypgoto[yylhs as usize] as c_int + *yyssp as c_int;
+                            let yylhs: c_int = YYR1[yyn as usize] as c_int - 57 as c_int;
+                            let yyi: c_int = YYPGOTO[yylhs as usize] as c_int + *yyssp as c_int;
                             yystate = if 0 <= yyi
                                 && yyi <= 1776 as c_int
-                                && yycheck[yyi as usize] as c_int == *yyssp as c_int
+                                && YYCHECK[yyi as usize] as c_int == *yyssp as c_int
                             {
-                                yytable[yyi as usize] as c_int
+                                YYTABLE[yyi as usize] as c_int
                             } else {
-                                yydefgoto[yylhs as usize] as c_int
+                                YYDEFGOTO[yylhs as usize] as c_int
                             };
                             current_block = 7872030484262409139;
                         }
@@ -7094,14 +7003,14 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, lParse: &mut ParseData)
                 if current_block == 1774893048582444437 {
                     yyerrstatus = 3 as c_int;
                     loop {
-                        yyn = yypact[yystate as usize] as c_int;
+                        yyn = YYPACT[yystate as usize] as c_int;
                         if yyn != -(41 as c_int) {
                             yyn += YYSYMBOL_YYerror as c_int;
                             if 0 <= yyn
                                 && yyn <= 1776 as c_int
-                                && yycheck[yyn as usize] as c_int == YYSYMBOL_YYerror as c_int
+                                && YYCHECK[yyn as usize] as c_int == YYSYMBOL_YYerror as c_int
                             {
-                                yyn = yytable[yyn as usize] as c_int;
+                                yyn = YYTABLE[yyn as usize] as c_int;
                                 if (0 as c_int) < yyn {
                                     break;
                                 }
@@ -7113,7 +7022,7 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, lParse: &mut ParseData)
                         }
                         yydestruct(
                             b"Error: popping\0" as *const u8 as *const c_char,
-                            yystos[yystate as usize] as yysymbol_kind_t,
+                            YYSTOS[yystate as usize] as yysymbol_kind_t,
                             yyvsp,
                             scanner,
                             lParse,
@@ -7132,7 +7041,7 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, lParse: &mut ParseData)
         }
         match current_block {
             11794367917084412820 => {
-                fits_parser_yyerror(scanner, lParse, cs!(c"memory exhausted"));
+                fits_parser_yyerror(lParse, cs!(c"memory exhausted"));
                 yyresult = 2 as c_int;
             }
             3964311021479492664 => {
@@ -7142,7 +7051,7 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, lParse: &mut ParseData)
         }
         if yychar != fits_parser_yytokentype::FITS_PARSER_YYEMPTY as c_int {
             yytoken = (if 0 <= yychar && yychar <= 292 as c_int {
-                yytranslate[yychar as usize] as yysymbol_kind_t as c_int
+                YYTRANSLATE[yychar as usize] as yysymbol_kind_t as c_int
             } else {
                 YYSYMBOL_YYUNDEF as c_int
             }) as yysymbol_kind_t;
@@ -7159,7 +7068,7 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, lParse: &mut ParseData)
         while yyssp != yyss {
             yydestruct(
                 b"Cleanup: popping\0" as *const u8 as *const c_char,
-                yystos[*yyssp as usize] as yysymbol_kind_t,
+                YYSTOS[*yyssp as usize] as yysymbol_kind_t,
                 yyvsp,
                 scanner,
                 lParse,
@@ -7173,15 +7082,15 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, lParse: &mut ParseData)
         yyresult
     }
 }
-unsafe fn New_Deref(
+fn New_Deref(
     lParse: &mut ParseData,
-    mut Var: c_int,
-    mut nDim: c_int,
-    mut Dim1: c_int,
-    mut Dim2: c_int,
-    mut Dim3: c_int,
-    mut Dim4: c_int,
-    mut Dim5: c_int,
+    Var: c_int,
+    nDim: c_int,
+    Dim1: c_int,
+    Dim2: c_int,
+    Dim3: c_int,
+    Dim4: c_int,
+    Dim5: c_int,
 ) -> c_int {
     unsafe {
         let mut n: c_int = 0;
@@ -7196,7 +7105,7 @@ unsafe fn New_Deref(
         }
         theVar = &mut (lParse.Nodes)[Var as usize];
         if (*theVar).operation == -1000 || (*theVar).value.nelem == 1 {
-            fits_parser_yyerror(ptr::null_mut(), lParse, cs!(c"Cannot index a scalar value"));
+            fits_parser_yyerror(lParse, cs!(c"Cannot index a scalar value"));
             return -(1);
         }
         n = Alloc_Node(lParse);
@@ -7226,19 +7135,11 @@ unsafe fn New_Deref(
             while idx < nDim {
                 if (*theDim[idx as usize]).value.nelem > 1 {
                     Free_Last_Node(lParse);
-                    fits_parser_yyerror(
-                        ptr::null_mut(),
-                        lParse,
-                        cs!(c"Cannot use an array as an index value"),
-                    );
+                    fits_parser_yyerror(lParse, cs!(c"Cannot use an array as an index value"));
                     return -(1);
                 } else if (*theDim[idx as usize]).ntype != fits_parser_yytokentype::LONG as c_int {
                     Free_Last_Node(lParse);
-                    fits_parser_yyerror(
-                        ptr::null_mut(),
-                        lParse,
-                        cs!(c"Index value must be an integer type"),
-                    );
+                    fits_parser_yyerror(lParse, cs!(c"Index value must be an integer type"));
                     return -(1);
                 }
                 idx += 1;
@@ -7265,7 +7166,6 @@ unsafe fn New_Deref(
             } else {
                 Free_Last_Node(lParse);
                 fits_parser_yyerror(
-                    ptr::null_mut(),
                     lParse,
                     cs!(c"Must specify just one or all indices for vector"),
                 );
@@ -7279,9 +7179,9 @@ unsafe fn New_Deref(
     }
 }
 
-unsafe fn New_GTI(
+fn New_GTI(
     lParse: &mut ParseData,
-    mut Op: funcOp,
+    Op: funcOp,
     mut fname: *mut c_char,
     mut Node1: c_int,
     mut Node2: c_int,
@@ -7325,7 +7225,6 @@ unsafe fn New_GTI(
                 Node1 = New_Column(lParse, colVal.lng as c_int);
             } else {
                 fits_parser_yyerror(
-                    ptr::null_mut(),
                     lParse,
                     cs!(c"Could not build TIME column for GTIFILTER/GTIFIND"),
                 );
@@ -7335,7 +7234,6 @@ unsafe fn New_GTI(
         if Op as c_uint == gtiover_fct as c_int as c_uint {
             if Node1 == -99 || Node2 == -99 {
                 fits_parser_yyerror(
-                    ptr::null_mut(),
                     lParse,
                     cs!(c"startExpr and stopExpr values must be defined for GTIOVERLAP"),
                 );
@@ -7352,39 +7250,21 @@ unsafe fn New_GTI(
             return -(1);
         }
         fptr = lParse.def_fptr;
-        ffghdn(fptr, &mut evthdu);
+        let fptr = fptr.as_mut().unwrap();
+
+        ffghdn_safe(fptr, &mut evthdu);
         tstat = 0;
-        if ffgkyd(
-            fptr,
-            b"TIMEZERO\0" as *const u8 as *const c_char,
-            timeZeroI.as_mut_ptr(),
-            std::ptr::null_mut::<c_char>(),
-            &mut tstat,
-        ) != 0
-        {
+        if ffgkyd_safe(fptr, cs!(c"TIMEZERO"), &mut timeZeroI[0], None, &mut tstat) != 0 {
             tstat = 0;
-            if ffgkyd(
-                fptr,
-                b"TIMEZERI\0" as *const u8 as *const c_char,
-                timeZeroI.as_mut_ptr(),
-                std::ptr::null_mut::<c_char>(),
-                &mut tstat,
-            ) != 0
-            {
-                timeZeroF[0] = 0.0f64;
+            if ffgkyd_safe(fptr, cs!(c"TIMEZEROI"), &mut timeZeroI[0], None, &mut tstat) != 0 {
+                timeZeroF[0] = 0.0;
                 timeZeroI[0] = timeZeroF[0];
-            } else if ffgkyd(
-                fptr,
-                b"TIMEZERF\0" as *const u8 as *const c_char,
-                timeZeroF.as_mut_ptr(),
-                std::ptr::null_mut::<c_char>(),
-                &mut tstat,
-            ) != 0
+            } else if ffgkyd_safe(fptr, cs!(c"TIMEZEROF"), &mut timeZeroF[0], None, &mut tstat) != 0
             {
-                timeZeroF[0] = 0.0f64;
+                timeZeroF[0] = 0.0;
             }
         } else {
-            timeZeroF[0] = 0.0f64;
+            timeZeroF[0] = 0.0;
         }
         match *fname.offset(0) as c_int {
             0 => {
@@ -7404,8 +7284,12 @@ unsafe fn New_GTI(
                     *fname.offset(i as isize) = 0;
                     fname = fname.offset(1);
                     fname;
-                    ffexts(
-                        fname,
+                    let fname_str = CStr::from_ptr(fname).to_bytes();
+                    ffexts_safer(
+                        std::slice::from_raw_parts(
+                            fname_str.as_ptr() as *const c_char,
+                            fname_str.len(),
+                        ),
                         &mut hdunum,
                         extname.as_mut_ptr(),
                         &mut extvers,
@@ -7415,31 +7299,20 @@ unsafe fn New_GTI(
                         &mut lParse.status,
                     );
                     if *extname.as_mut_ptr() != 0 {
-                        ffmnhd(
-                            fptr,
-                            movetotype,
-                            extname.as_mut_ptr(),
-                            extvers,
-                            &mut lParse.status,
-                        );
-                        ffghdn(fptr, &mut hdunum);
+                        ffmnhd_safe(fptr, movetotype, &extname, extvers, &mut lParse.status);
+                        ffghdn_safe(fptr, &mut hdunum);
                     } else if hdunum != 0 {
                         hdunum += 1;
-                        ffmahd(fptr, hdunum, &mut hdutype, &mut lParse.status);
+                        ffmahd_safe(fptr, hdunum, Some(&mut hdutype), &mut lParse.status);
                     } else if lParse.status == 0 {
                         fits_parser_yyerror(
-                            ptr::null_mut(),
                             lParse,
                             cs!(c"Cannot use primary array for GTI filter"),
                         );
                         return -(1);
                     }
                 } else {
-                    fits_parser_yyerror(
-                        ptr::null_mut(),
-                        lParse,
-                        cs!(c"File extension specifier lacks closing ']'"),
-                    );
+                    fits_parser_yyerror(lParse, cs!(c"File extension specifier lacks closing ']'"));
                     return -(1);
                 }
             }
@@ -7448,10 +7321,9 @@ unsafe fn New_GTI(
                 hdunum =
                     atoi(std::ffi::CStr::from_ptr(fname).to_str().unwrap_or("0")).unwrap_or(0) + 1;
                 if hdunum > 1 {
-                    ffmahd(fptr, hdunum, &mut hdutype, &mut lParse.status);
+                    ffmahd_safe(fptr, hdunum, Some(&mut hdutype), &mut lParse.status);
                 } else {
                     fits_parser_yyerror(
-                        ptr::null_mut(),
                         lParse,
                         cs!(c"Cannot use primary array for GTI filter / GTIFIND"),
                     );
@@ -7460,10 +7332,19 @@ unsafe fn New_GTI(
             }
             _ => {
                 samefile = 0;
-                let mut fptr_tmp: *mut Option<Box<fitsfile>> =
-                    &mut None as *mut Option<Box<fitsfile>>;
-                if ffopen(fptr_tmp, fname, 0, &mut lParse.status) == 0 {
-                    ffghdn(fptr, &mut hdunum);
+                let mut fptr_tmp: Option<Box<fitsfile>> = None;
+                let fname_str = CStr::from_ptr(fname).to_bytes();
+                if ffopen_safer(
+                    &mut fptr_tmp,
+                    std::slice::from_raw_parts(
+                        fname_str.as_ptr() as *const c_char,
+                        fname_str.len(),
+                    ),
+                    0,
+                    &mut lParse.status,
+                ) == 0
+                {
+                    ffghdn_safe(fptr, &mut hdunum);
                 }
             }
         }
@@ -7474,24 +7355,17 @@ unsafe fn New_GTI(
             loop {
                 hdunum += 1;
                 hdunum;
-                if ffmahd(fptr, hdunum, &mut hdutype, &mut lParse.status) != 0 {
+                if ffmahd_safe(fptr, hdunum, Some(&mut hdutype), &mut lParse.status) != 0 {
                     break;
                 }
                 if hdutype == 0 {
                     continue;
                 }
                 tstat = 0;
-                if ffgkys(
-                    fptr,
-                    b"EXTNAME\0" as *const u8 as *const c_char,
-                    extname.as_mut_ptr(),
-                    std::ptr::null_mut::<c_char>(),
-                    &mut tstat,
-                ) != 0
-                {
+                if ffgkys_safe(fptr, cs!(c"EXTNAME"), &mut extname, None, &mut tstat) != 0 {
                     continue;
                 }
-                ffupch(extname.as_mut_ptr());
+                ffupch_safe(&mut extname);
                 if !(strstr(extname.as_mut_ptr(), b"GTI\0" as *const u8 as *const c_char)).is_null()
                 {
                     break;
@@ -7499,52 +7373,46 @@ unsafe fn New_GTI(
             }
             if lParse.status != 0 {
                 if lParse.status == 107 as c_int {
-                    fits_parser_yyerror(
-                        ptr::null_mut(),
-                        lParse,
-                        cs!(c"GTI extension not found in this file"),
-                    );
+                    fits_parser_yyerror(lParse, cs!(c"GTI extension not found in this file"));
                 }
                 return -(1);
             }
         }
-        ffgcno(fptr, 0, start, &mut startCol, &mut lParse.status);
-        ffgcno(fptr, 0, stop, &mut stopCol, &mut lParse.status);
+        let start_str = CStr::from_ptr(start).to_bytes();
+        let stop_str = CStr::from_ptr(stop).to_bytes();
+        ffgcno_safe(
+            fptr,
+            0,
+            unsafe {
+                std::slice::from_raw_parts(start_str.as_ptr() as *const c_char, start_str.len())
+            },
+            &mut startCol,
+            &mut lParse.status,
+        );
+        ffgcno_safe(
+            fptr,
+            0,
+            unsafe {
+                std::slice::from_raw_parts(stop_str.as_ptr() as *const c_char, stop_str.len())
+            },
+            &mut stopCol,
+            &mut lParse.status,
+        );
         if lParse.status != 0 {
             return -(1);
         }
         tstat = 0;
-        if ffgkyd(
-            fptr,
-            b"TIMEZERO\0" as *const u8 as *const c_char,
-            timeZeroI.as_mut_ptr().offset(1 as c_int as isize),
-            std::ptr::null_mut::<c_char>(),
-            &mut tstat,
-        ) != 0
-        {
+        if ffgkyd_safe(fptr, cs!(c"TIMEZERO"), &mut timeZeroI[1], None, &mut tstat) != 0 {
             tstat = 0;
-            if ffgkyd(
-                fptr,
-                b"TIMEZERI\0" as *const u8 as *const c_char,
-                timeZeroI.as_mut_ptr().offset(1 as c_int as isize),
-                std::ptr::null_mut::<c_char>(),
-                &mut tstat,
-            ) != 0
-            {
-                timeZeroF[1] = 0.0f64;
+            if ffgkyd_safe(fptr, cs!(c"TIMEZEROI"), &mut timeZeroI[1], None, &mut tstat) != 0 {
+                timeZeroF[1] = 0.0;
                 timeZeroI[1] = timeZeroF[1];
-            } else if ffgkyd(
-                fptr,
-                b"TIMEZERF\0" as *const u8 as *const c_char,
-                timeZeroF.as_mut_ptr().offset(1 as c_int as isize),
-                std::ptr::null_mut::<c_char>(),
-                &mut tstat,
-            ) != 0
+            } else if ffgkyd_safe(fptr, cs!(c"TIMEZERF"), &mut timeZeroF[1], None, &mut tstat) != 0
             {
-                timeZeroF[1] = 0.0f64;
+                timeZeroF[1] = 0.0;
             }
         } else {
-            timeZeroF[1] = 0.0f64;
+            timeZeroF[1] = 0.0;
         }
         n = Alloc_Node(lParse);
         if n >= 0 {
@@ -7578,7 +7446,6 @@ unsafe fn New_GTI(
                 that2 = &mut (lParse.Nodes)[Node2 as usize];
                 if (*that1).value.nelem != (*that2).value.nelem {
                     fits_parser_yyerror(
-                        ptr::null_mut(),
                         lParse,
                         cs!(c"Dimensions of TIME and TIME_STOP must match for GTIOVERLAP"),
                     );
@@ -7590,14 +7457,7 @@ unsafe fn New_GTI(
             (*that0).operation = -1000;
             (*that0).DoOp = None;
             (*that0).value.data.ptr = std::ptr::null_mut::<c_void>();
-            if ffgkyj(
-                fptr,
-                b"NAXIS2\0" as *const u8 as *const c_char,
-                &mut nrows,
-                std::ptr::null_mut::<c_char>(),
-                &mut lParse.status,
-            ) != 0
-            {
+            if ffgkyj_safe(fptr, cs!(c"NAXIS2"), &mut nrows, None, &mut lParse.status) != 0 {
                 return -(1);
             }
             (*that0).value.nelem = nrows;
@@ -7616,26 +7476,26 @@ unsafe fn New_GTI(
                 }
                 startptr = (*that0).value.data.dblptr;
                 stopptr = ((*that0).value.data.dblptr).offset(nrows as isize);
-                ffgcvd(
+                ffgcvd_safe(
                     fptr,
                     startCol,
-                    1 as LONGLONG,
-                    1 as LONGLONG,
+                    1,
+                    1,
                     nrows as LONGLONG,
-                    0.0f64,
-                    startptr,
-                    &mut i,
+                    0.0,
+                    unsafe { std::slice::from_raw_parts_mut(startptr, nrows as usize) },
+                    Some(&mut i),
                     &mut lParse.status,
                 );
-                ffgcvd(
+                ffgcvd_safe(
                     fptr,
                     stopCol,
-                    1 as LONGLONG,
-                    1 as LONGLONG,
+                    1,
+                    1,
                     nrows as LONGLONG,
-                    0.0f64,
-                    stopptr,
-                    &mut i,
+                    0.0,
+                    unsafe { std::slice::from_raw_parts_mut(stopptr, nrows as usize) },
+                    Some(&mut i),
                     &mut lParse.status,
                 );
                 if lParse.status != 0 {
@@ -7665,7 +7525,7 @@ unsafe fn New_GTI(
                             as *const c_char,
                         i + 1,
                     );
-                    fits_parser_yyerror(ptr::null_mut(), lParse, &errmsg);
+                    fits_parser_yyerror(lParse, &errmsg);
                     return -(1);
                 }
                 dt = timeZeroI[1] - timeZeroI[0] + (timeZeroF[1] - timeZeroF[0]);
@@ -7691,15 +7551,15 @@ unsafe fn New_GTI(
             }
         }
         if samefile != 0 {
-            ffmahd(fptr, evthdu, &mut hdutype, &mut lParse.status);
+            ffmahd_safe(fptr, evthdu, Some(&mut hdutype), &mut lParse.status);
         } else {
-            ffclos(Some(Box::from_raw(fptr)), &mut lParse.status);
+            ffclos_safer(unsafe { Box::from_raw(fptr) }, &mut lParse.status);
         }
         n
     }
 }
 
-unsafe fn New_REG(
+fn New_REG(
     lParse: &mut ParseData,
     fname: *mut c_char,
     mut NodeX: c_int,
@@ -7726,7 +7586,7 @@ unsafe fn New_REG(
             rot: 0.,
             dtype: [0; 5],
         };
-        let mut Rgn: *mut SAORegion = ptr::null_mut();
+        let Rgn: *mut SAORegion = ptr::null_mut();
         let mut cX: *mut c_char = ptr::null_mut();
         let mut cY: *mut c_char = ptr::null_mut();
         let mut colVal: FITS_PARSER_YYSTYPE = FITS_PARSER_YYSTYPE { Node: 0 };
@@ -7735,11 +7595,7 @@ unsafe fn New_REG(
             if type_0 == fits_parser_yytokentype::COLUMN as c_int {
                 NodeX = New_Column(lParse, colVal.lng as c_int);
             } else {
-                fits_parser_yyerror(
-                    ptr::null_mut(),
-                    lParse,
-                    cs!(c"Could not build X column for REGFILTER"),
-                );
+                fits_parser_yyerror(lParse, cs!(c"Could not build X column for REGFILTER"));
                 return -(1);
             }
         }
@@ -7748,11 +7604,7 @@ unsafe fn New_REG(
             if type_0 == fits_parser_yytokentype::COLUMN as c_int {
                 NodeY = New_Column(lParse, colVal.lng as c_int);
             } else {
-                fits_parser_yyerror(
-                    ptr::null_mut(),
-                    lParse,
-                    cs!(c"Could not build Y column for REGFILTER"),
-                );
+                fits_parser_yyerror(lParse, cs!(c"Could not build Y column for REGFILTER"));
                 return -(1);
             }
         }
@@ -7764,7 +7616,6 @@ unsafe fn New_REG(
         }
         if Test_Dims(lParse, NodeX, NodeY) == 0 {
             fits_parser_yyerror(
-                ptr::null_mut(),
                 lParse,
                 cs!(c"Dimensions of REGFILTER arguments are not compatible"),
             );
@@ -7818,18 +7669,36 @@ unsafe fn New_REG(
                 }
                 if *cY == 0 {
                     fits_parser_yyerror(
-                        ptr::null_mut(),
                         lParse,
                         cs!(c"Could not extract valid pair of column names from REGFILTER"),
                     );
                     Free_Last_Node(lParse);
                     return -(1);
                 }
-                ffgcno(lParse.def_fptr, 0, cX, &mut Xcol, &mut lParse.status);
-                ffgcno(lParse.def_fptr, 0, cY, &mut Ycol, &mut lParse.status);
+
+                let fptr = lParse.def_fptr.as_mut().unwrap();
+                let cX_str = CStr::from_ptr(cX).to_bytes();
+                let cY_str = CStr::from_ptr(cY).to_bytes();
+                ffgcno_safe(
+                    fptr,
+                    0,
+                    unsafe {
+                        std::slice::from_raw_parts(cX_str.as_ptr() as *const c_char, cX_str.len())
+                    },
+                    &mut Xcol,
+                    &mut lParse.status,
+                );
+                ffgcno_safe(
+                    fptr,
+                    0,
+                    unsafe {
+                        std::slice::from_raw_parts(cY_str.as_ptr() as *const c_char, cY_str.len())
+                    },
+                    &mut Ycol,
+                    &mut lParse.status,
+                );
                 if lParse.status != 0 {
                     fits_parser_yyerror(
-                        ptr::null_mut(),
                         lParse,
                         cs!(c"Could not locate columns indicated for WCS info"),
                     );
@@ -7841,7 +7710,6 @@ unsafe fn New_REG(
                 Ycol = Locate_Col(lParse, &(lParse.Nodes)[NodeY as usize]);
                 if Xcol < 0 || Ycol < 0 {
                     fits_parser_yyerror(
-                        ptr::null_mut(),
                         lParse,
                         cs!(c"Found multiple X/Y column references in REGFILTER"),
                     );
@@ -7852,8 +7720,9 @@ unsafe fn New_REG(
             wcs.exists = false;
             if Xcol > 0 && Ycol > 0 {
                 tstat = 0;
-                ffgtcs(
-                    lParse.def_fptr,
+                let fptr = lParse.def_fptr.as_mut().unwrap();
+                ffgtcs_safer(
+                    fptr,
                     Xcol,
                     Ycol,
                     &mut wcs.xrefval,
@@ -7899,7 +7768,8 @@ unsafe fn New_REG(
         n
     }
 }
-unsafe fn New_Vector(lParse: &mut ParseData, mut subNode: c_int) -> c_int {
+
+fn New_Vector(lParse: &mut ParseData, subNode: c_int) -> c_int {
     unsafe {
         let mut this: *mut Node = std::ptr::null_mut::<Node>();
         let mut that: *mut Node = std::ptr::null_mut::<Node>();
@@ -7917,7 +7787,7 @@ unsafe fn New_Vector(lParse: &mut ParseData, mut subNode: c_int) -> c_int {
         n
     }
 }
-unsafe fn Close_Vec(lParse: &mut ParseData, mut vecNode: c_int) -> c_int {
+fn Close_Vec(lParse: &mut ParseData, vecNode: c_int) -> c_int {
     unsafe {
         let mut this: *mut Node = std::ptr::null_mut::<Node>();
         let mut n: c_int = 0;
@@ -7945,7 +7815,7 @@ unsafe fn Close_Vec(lParse: &mut ParseData, mut vecNode: c_int) -> c_int {
         vecNode
     }
 }
-unsafe fn New_Array(lParse: &mut ParseData, mut valueNode: c_int, mut dimNode: c_int) -> c_int {
+fn New_Array(lParse: &mut ParseData, valueNode: c_int, mut dimNode: c_int) -> c_int {
     unsafe {
         let mut dims: *mut Node = std::ptr::null_mut::<Node>();
         let mut naxis: c_long = 0;
@@ -7976,7 +7846,6 @@ unsafe fn New_Array(lParse: &mut ParseData, mut valueNode: c_int, mut dimNode: c
         } else if ((lParse.Nodes)[dimNode as usize]).operation == '{' as i32 {
             if (*dims).nSubNodes > 5 as c_int {
                 fits_parser_yyerror(
-                    ptr::null_mut(),
                     lParse,
                     cs!(c"ARRAY(V,{...}) number of dimensions must not exceed 5"),
                 );
@@ -8007,7 +7876,6 @@ unsafe fn New_Array(lParse: &mut ParseData, mut valueNode: c_int, mut dimNode: c
             }
         } else {
             fits_parser_yyerror(
-                ptr::null_mut(),
                 lParse,
                 cs!(c"ARRAY(V,dims) dims must be either integer or const vector"),
             );
@@ -8017,11 +7885,7 @@ unsafe fn New_Array(lParse: &mut ParseData, mut valueNode: c_int, mut dimNode: c
         i = 0;
         while (i as c_long) < naxis {
             if naxes[i as usize] <= 0 {
-                fits_parser_yyerror(
-                    ptr::null_mut(),
-                    lParse,
-                    cs!(c"ARRAY(V,dims) must have positive dimensions"),
-                );
+                fits_parser_yyerror(lParse, cs!(c"ARRAY(V,dims) must have positive dimensions"));
                 return -(1);
             }
             nelem *= naxes[i as usize];
@@ -8031,14 +7895,12 @@ unsafe fn New_Array(lParse: &mut ParseData, mut valueNode: c_int, mut dimNode: c
         if !((((lParse.Nodes)[valueNode as usize]).value).nelem == nelem && nelem > 1) {
             if (((lParse.Nodes)[valueNode as usize]).value).nelem > 1 && nelem > 1 {
                 fits_parser_yyerror(
-                    ptr::null_mut(),
                     lParse,
                     cs!(c"ARRAY(V,d) mismatch between number of elements in V and d"),
                 );
                 return -(1);
             } else if (((lParse.Nodes)[valueNode as usize]).value).nelem > 1 {
                 fits_parser_yyerror(
-                    ptr::null_mut(),
                     lParse,
                     cs!(c"ARRAY(V,n) value V must have vector dimension of 1"),
                 );
@@ -8065,15 +7927,17 @@ unsafe fn New_Array(lParse: &mut ParseData, mut valueNode: c_int, mut dimNode: c
         n
     }
 }
-unsafe fn Locate_Col(lParse: &ParseData, this: &Node) -> c_int {
+fn Locate_Col(lParse: &ParseData, this: &Node) -> c_int {
     unsafe {
         let mut i: c_int = 0;
         let mut col: c_int = 0;
         let mut newCol: c_int = 0;
         let mut nfound: c_int = 0;
+
         if this.nSubNodes == 0 && this.operation <= 0 && this.operation != -1000 {
-            return (*(lParse.colData).offset(-this.operation as isize)).colnum;
+            return ((lParse.colData)[(-this.operation) as usize]).colnum;
         }
+
         i = 0;
         while i < this.nSubNodes {
             let that = &(lParse.Nodes)[this.SubNodes[i as usize] as usize];
@@ -8090,7 +7954,7 @@ unsafe fn Locate_Col(lParse: &ParseData, this: &Node) -> c_int {
                     nfound;
                 }
             } else if that.operation != -1000 {
-                newCol = (*(lParse.colData).offset(-that.operation as isize)).colnum;
+                newCol = ((lParse.colData)[(-that.operation) as usize]).colnum;
                 if nfound == 0 {
                     col = newCol;
                     nfound += 1;
@@ -8106,7 +7970,8 @@ unsafe fn Locate_Col(lParse: &ParseData, this: &Node) -> c_int {
         if nfound != 1 { -nfound } else { col }
     }
 }
-unsafe fn Test_Dims(lParse: &mut ParseData, mut Node1: c_int, mut Node2: c_int) -> c_int {
+
+fn Test_Dims(lParse: &mut ParseData, Node1: c_int, Node2: c_int) -> c_int {
     unsafe {
         let mut that1: *mut Node = std::ptr::null_mut::<Node>();
         let mut that2: *mut Node = std::ptr::null_mut::<Node>();
@@ -8138,7 +8003,7 @@ unsafe fn Test_Dims(lParse: &mut ParseData, mut Node1: c_int, mut Node2: c_int) 
         valid
     }
 }
-unsafe fn Copy_Dims(lParse: &mut ParseData, mut Node1: c_int, mut Node2: c_int) {
+fn Copy_Dims(lParse: &mut ParseData, Node1: c_int, Node2: c_int) {
     unsafe {
         let mut that1: *mut Node = std::ptr::null_mut::<Node>();
         let mut that2: *mut Node = std::ptr::null_mut::<Node>();
@@ -8159,16 +8024,16 @@ unsafe fn Copy_Dims(lParse: &mut ParseData, mut Node1: c_int, mut Node2: c_int) 
     }
 }
 
-pub unsafe fn Evaluate_Parser(lParse: &mut ParseData, mut firstRow: c_long, mut nRows: c_long) {
+pub fn Evaluate_Parser(lParse: &mut ParseData, firstRow: c_long, nRows: c_long) {
     unsafe {
         let mut i: c_int = 0;
         let mut column: c_int = 0;
         let mut offset: c_long = 0;
         let mut rowOffset: c_long = 0;
-        static mut rand_initialized: c_int = 0;
-        if rand_initialized == 0 {
+        static mut RAND_INITIALIZED: c_int = 0;
+        if RAND_INITIALIZED == 0 {
             simplerng_srand(time(std::ptr::null_mut::<time_t>()) as c_uint);
-            rand_initialized = 1;
+            RAND_INITIALIZED = 1;
         }
         lParse.firstRow = firstRow;
         lParse.nRows = nRows;
@@ -8179,43 +8044,40 @@ pub unsafe fn Evaluate_Parser(lParse: &mut ParseData, mut firstRow: c_long, mut 
                 || ((lParse.Nodes)[i as usize]).operation == -1000)
             {
                 column = -((lParse.Nodes)[i as usize]).operation;
-                offset = (*(lParse.varData).offset(column as isize)).nelem * rowOffset;
+                offset = ((lParse.varData)[column as usize]).nelem * rowOffset;
                 let fresh11 = &mut (((lParse.Nodes)[i as usize]).value).undef;
-                *fresh11 =
-                    ((*(lParse.varData).offset(column as isize)).undef).offset(offset as isize);
+                *fresh11 = (((lParse.varData)[column as usize]).undef).offset(offset as isize);
                 match ((lParse.Nodes)[i as usize]).ntype {
                     262 => {
                         let fresh12 = &mut (((lParse.Nodes)[i as usize]).value).data.strptr;
-                        *fresh12 = ((*(lParse.varData).offset(column as isize)).data
-                            as *mut *mut c_char)
+                        *fresh12 = (((lParse.varData)[column as usize]).data as *mut *mut c_char)
                             .offset(rowOffset as isize);
                         let fresh13 = &mut (((lParse.Nodes)[i as usize]).value).undef;
                         *fresh13 = ptr::null_mut();
                     }
                     261 => {
                         let fresh14 = &mut (((lParse.Nodes)[i as usize]).value).data.strptr;
-                        *fresh14 = ((*(lParse.varData).offset(column as isize)).data
-                            as *mut *mut c_char)
+                        *fresh14 = (((lParse.varData)[column as usize]).data as *mut *mut c_char)
                             .offset(rowOffset as isize);
                         let fresh15 = &mut (((lParse.Nodes)[i as usize]).value).undef;
-                        *fresh15 = ((*(lParse.varData).offset(column as isize)).undef)
-                            .offset(rowOffset as isize);
+                        *fresh15 =
+                            (((lParse.varData)[column as usize]).undef).offset(rowOffset as isize);
                     }
                     258 => {
                         let fresh16 = &mut (((lParse.Nodes)[i as usize]).value).data.logptr;
-                        *fresh16 = ((*(lParse.varData).offset(column as isize)).data as *const _
+                        *fresh16 = (((lParse.varData)[column as usize]).data as *const _
                             as *mut c_char)
                             .offset(offset as isize);
                     }
                     259 => {
                         let fresh17 = &mut (((lParse.Nodes)[i as usize]).value).data.lngptr;
-                        *fresh17 = ((*(lParse.varData).offset(column as isize)).data as *const _
+                        *fresh17 = (((lParse.varData)[column as usize]).data as *const _
                             as *mut c_long)
                             .offset(offset as isize);
                     }
                     260 => {
                         let fresh18 = &mut (((lParse.Nodes)[i as usize]).value).data.dblptr;
-                        *fresh18 = ((*(lParse.varData).offset(column as isize)).data as *const _
+                        *fresh18 = (((lParse.varData)[column as usize]).data as *const _
                             as *mut c_double)
                             .offset(offset as isize);
                     }
@@ -8228,7 +8090,7 @@ pub unsafe fn Evaluate_Parser(lParse: &mut ParseData, mut firstRow: c_long, mut 
         Evaluate_Node(lParse, lParse.resultNode);
     }
 }
-unsafe fn Evaluate_Node(lParse: &mut ParseData, mut thisNode: c_int) {
+fn Evaluate_Node(lParse: &mut ParseData, thisNode: c_int) {
     unsafe {
         let mut this: *mut Node = std::ptr::null_mut::<Node>();
         let mut i: c_int = 0;
@@ -8253,7 +8115,7 @@ unsafe fn Evaluate_Node(lParse: &mut ParseData, mut thisNode: c_int) {
         }
     }
 }
-unsafe fn Allocate_Ptrs(lParse: &mut ParseData, mut this: *mut Node) {
+fn Allocate_Ptrs(lParse: &mut ParseData, this: *mut Node) {
     unsafe {
         let mut elem: c_long = 0;
         let mut row: c_long = 0;
@@ -8331,7 +8193,7 @@ unsafe fn Allocate_Ptrs(lParse: &mut ParseData, mut this: *mut Node) {
         };
     }
 }
-unsafe fn Do_Unary(lParse: &mut ParseData, mut this: *mut Node) {
+fn Do_Unary(lParse: &mut ParseData, this: *mut Node) {
     unsafe {
         let mut that: *mut Node = std::ptr::null_mut::<Node>();
         let mut elem: c_long = 0;
@@ -8347,7 +8209,7 @@ unsafe fn Do_Unary(lParse: &mut ParseData, mut this: *mut Node) {
                         (*this).value.data.dbl = if (*that).value.data.log as c_int != 0 {
                             1.0f64
                         } else {
-                            0.0f64
+                            0.0
                         };
                     }
                 }
@@ -8366,11 +8228,7 @@ unsafe fn Do_Unary(lParse: &mut ParseData, mut this: *mut Node) {
                 }
                 x if x == fits_parser_yytokentype::BOOLEAN as c_int => {
                     if (*that).ntype == fits_parser_yytokentype::DOUBLE as c_int {
-                        (*this).value.data.log = if (*that).value.data.dbl != 0.0f64 {
-                            1
-                        } else {
-                            0
-                        };
+                        (*this).value.data.log = if (*that).value.data.dbl != 0.0 { 1 } else { 0 };
                     } else if (*that).ntype == fits_parser_yytokentype::LONG as c_int {
                         (*this).value.data.log = if (*that).value.data.lng != 0 { 1 } else { 0 };
                     }
@@ -8424,8 +8282,7 @@ unsafe fn Do_Unary(lParse: &mut ParseData, mut this: *mut Node) {
                                     break;
                                 }
                                 *((*this).value.data.logptr).offset(elem as isize) =
-                                    if *((*that).value.data.dblptr).offset(elem as isize) != 0.0f64
-                                    {
+                                    if *((*that).value.data.dblptr).offset(elem as isize) != 0.0 {
                                         1
                                     } else {
                                         0
@@ -8471,7 +8328,7 @@ unsafe fn Do_Unary(lParse: &mut ParseData, mut this: *mut Node) {
                                     {
                                         1.0f64
                                     } else {
-                                        0.0f64
+                                        0.0
                                     };
                             }
                         }
@@ -8564,7 +8421,7 @@ unsafe fn Do_Unary(lParse: &mut ParseData, mut this: *mut Node) {
         }
     }
 }
-unsafe fn Do_Offset(lParse: &mut ParseData, mut this: *mut Node) {
+fn Do_Offset(lParse: &mut ParseData, this: *mut Node) {
     unsafe {
         let mut col: *mut Node = std::ptr::null_mut::<Node>();
         let mut fRow: c_long = 0;
@@ -8782,7 +8639,7 @@ unsafe fn Do_Offset(lParse: &mut ParseData, mut this: *mut Node) {
         }
     }
 }
-unsafe fn Do_BinOp_bit(lParse: &mut ParseData, mut this: *mut Node) {
+fn Do_BinOp_bit(lParse: &mut ParseData, this: *mut Node) {
     unsafe {
         let mut that1: *mut Node = std::ptr::null_mut::<Node>();
         let mut that2: *mut Node = std::ptr::null_mut::<Node>();
@@ -8942,7 +8799,7 @@ unsafe fn Do_BinOp_bit(lParse: &mut ParseData, mut this: *mut Node) {
         }
     }
 }
-unsafe fn Do_BinOp_str(lParse: &mut ParseData, mut this: *mut Node) {
+fn Do_BinOp_str(lParse: &mut ParseData, this: *mut Node) {
     unsafe {
         let mut that1: *mut Node = std::ptr::null_mut::<Node>();
         let mut that2: *mut Node = std::ptr::null_mut::<Node>();
@@ -9220,7 +9077,7 @@ unsafe fn Do_BinOp_str(lParse: &mut ParseData, mut this: *mut Node) {
         }
     }
 }
-unsafe fn Do_BinOp_log(lParse: &mut ParseData, mut this: *mut Node) {
+fn Do_BinOp_log(lParse: &mut ParseData, this: *mut Node) {
     unsafe {
         let mut that1: *mut Node = std::ptr::null_mut::<Node>();
         let mut that2: *mut Node = std::ptr::null_mut::<Node>();
@@ -9421,7 +9278,7 @@ unsafe fn Do_BinOp_log(lParse: &mut ParseData, mut this: *mut Node) {
         }
     }
 }
-unsafe fn Do_BinOp_lng(lParse: &mut ParseData, mut this: *mut Node) {
+fn Do_BinOp_lng(lParse: &mut ParseData, this: *mut Node) {
     unsafe {
         let mut that1: *mut Node = std::ptr::null_mut::<Node>();
         let mut that2: *mut Node = std::ptr::null_mut::<Node>();
@@ -9490,14 +9347,14 @@ unsafe fn Do_BinOp_lng(lParse: &mut ParseData, mut this: *mut Node) {
                     if val2 != 0 {
                         (*this).value.data.lng = val1 % val2;
                     } else {
-                        fits_parser_yyerror(ptr::null_mut(), lParse, cs!(c"Divide by Zero"));
+                        fits_parser_yyerror(lParse, cs!(c"Divide by Zero"));
                     }
                 }
                 47 => {
                     if val2 != 0 {
                         (*this).value.data.lng = val1 / val2;
                     } else {
-                        fits_parser_yyerror(ptr::null_mut(), lParse, cs!(c"Divide by Zero"));
+                        fits_parser_yyerror(lParse, cs!(c"Divide by Zero"));
                     }
                 }
                 286 => {
@@ -9674,14 +9531,14 @@ unsafe fn Do_BinOp_lng(lParse: &mut ParseData, mut this: *mut Node) {
         }
     }
 }
-unsafe fn Do_BinOp_dbl(lParse: &mut ParseData, mut this: *mut Node) {
+fn Do_BinOp_dbl(lParse: &mut ParseData, this: *mut Node) {
     unsafe {
         let mut that1: *mut Node = std::ptr::null_mut::<Node>();
         let mut that2: *mut Node = std::ptr::null_mut::<Node>();
         let mut vector1: c_int = 0;
         let mut vector2: c_int = 0;
-        let mut val1: c_double = 0.0f64;
-        let mut val2: c_double = 0.0f64;
+        let mut val1: c_double = 0.0;
+        let mut val2: c_double = 0.0;
         let mut null1: c_char = 0;
         let mut null2: c_char = 0;
         let mut rows: c_long = 0;
@@ -9737,14 +9594,14 @@ unsafe fn Do_BinOp_dbl(lParse: &mut ParseData, mut this: *mut Node) {
                     if val2 != 0. {
                         (*this).value.data.dbl = val1 - val2 * (val1 / val2) as c_int as c_double;
                     } else {
-                        fits_parser_yyerror(ptr::null_mut(), lParse, cs!(c"Divide by Zero"));
+                        fits_parser_yyerror(lParse, cs!(c"Divide by Zero"));
                     }
                 }
                 47 => {
                     if val2 != 0. {
                         (*this).value.data.dbl = val1 / val2;
                     } else {
-                        fits_parser_yyerror(ptr::null_mut(), lParse, cs!(c"Divide by Zero"));
+                        fits_parser_yyerror(lParse, cs!(c"Divide by Zero"));
                     }
                 }
                 286 => {
@@ -9887,7 +9744,7 @@ unsafe fn Do_BinOp_dbl(lParse: &mut ParseData, mut this: *mut Node) {
                                 *((*this).value.data.dblptr).offset(elem as isize) =
                                     val1 - val2 * (val1 / val2) as c_int as c_double;
                             } else {
-                                *((*this).value.data.dblptr).offset(elem as isize) = 0.0f64;
+                                *((*this).value.data.dblptr).offset(elem as isize) = 0.0;
                                 *((*this).value.undef).offset(elem as isize) = 1;
                             }
                         }
@@ -9895,7 +9752,7 @@ unsafe fn Do_BinOp_dbl(lParse: &mut ParseData, mut this: *mut Node) {
                             if val2 != 0. {
                                 *((*this).value.data.dblptr).offset(elem as isize) = val1 / val2;
                             } else {
-                                *((*this).value.data.dblptr).offset(elem as isize) = 0.0f64;
+                                *((*this).value.data.dblptr).offset(elem as isize) = 0.0;
                                 *((*this).value.undef).offset(elem as isize) = 1;
                             }
                         }
@@ -9917,7 +9774,7 @@ unsafe fn Do_BinOp_dbl(lParse: &mut ParseData, mut this: *mut Node) {
     }
 }
 
-pub unsafe fn qselect_median_lng(mut arr: *mut c_long, mut n: c_int) -> c_long {
+pub fn qselect_median_lng(arr: *mut c_long, n: c_int) -> c_long {
     unsafe {
         let mut low: c_int = 0;
         let mut high: c_int = 0;
@@ -9934,7 +9791,7 @@ pub unsafe fn qselect_median_lng(mut arr: *mut c_long, mut n: c_int) -> c_long {
             }
             if high == low + 1 {
                 if *arr.offset(low as isize) > *arr.offset(high as isize) {
-                    let mut t: c_long = *arr.offset(low as isize);
+                    let t: c_long = *arr.offset(low as isize);
                     *arr.offset(low as isize) = *arr.offset(high as isize);
                     *arr.offset(high as isize) = t;
                 }
@@ -9942,21 +9799,21 @@ pub unsafe fn qselect_median_lng(mut arr: *mut c_long, mut n: c_int) -> c_long {
             }
             middle = (low + high) / 2 as c_int;
             if *arr.offset(middle as isize) > *arr.offset(high as isize) {
-                let mut t_0: c_long = *arr.offset(middle as isize);
+                let t_0: c_long = *arr.offset(middle as isize);
                 *arr.offset(middle as isize) = *arr.offset(high as isize);
                 *arr.offset(high as isize) = t_0;
             }
             if *arr.offset(low as isize) > *arr.offset(high as isize) {
-                let mut t_1: c_long = *arr.offset(low as isize);
+                let t_1: c_long = *arr.offset(low as isize);
                 *arr.offset(low as isize) = *arr.offset(high as isize);
                 *arr.offset(high as isize) = t_1;
             }
             if *arr.offset(middle as isize) > *arr.offset(low as isize) {
-                let mut t_2: c_long = *arr.offset(middle as isize);
+                let t_2: c_long = *arr.offset(middle as isize);
                 *arr.offset(middle as isize) = *arr.offset(low as isize);
                 *arr.offset(low as isize) = t_2;
             }
-            let mut t_3: c_long = *arr.offset(middle as isize);
+            let t_3: c_long = *arr.offset(middle as isize);
             *arr.offset(middle as isize) = *arr.offset((low + 1) as isize);
             *arr.offset((low + 1) as isize) = t_3;
             ll = low + 1;
@@ -9979,11 +9836,11 @@ pub unsafe fn qselect_median_lng(mut arr: *mut c_long, mut n: c_int) -> c_long {
                 if hh < ll {
                     break;
                 }
-                let mut t_4: c_long = *arr.offset(ll as isize);
+                let t_4: c_long = *arr.offset(ll as isize);
                 *arr.offset(ll as isize) = *arr.offset(hh as isize);
                 *arr.offset(hh as isize) = t_4;
             }
-            let mut t_5: c_long = *arr.offset(low as isize);
+            let t_5: c_long = *arr.offset(low as isize);
             *arr.offset(low as isize) = *arr.offset(hh as isize);
             *arr.offset(hh as isize) = t_5;
             if hh <= median {
@@ -9996,7 +9853,7 @@ pub unsafe fn qselect_median_lng(mut arr: *mut c_long, mut n: c_int) -> c_long {
     }
 }
 
-pub unsafe fn qselect_median_dbl(mut arr: *mut c_double, mut n: c_int) -> c_double {
+pub fn qselect_median_dbl(arr: *mut c_double, n: c_int) -> c_double {
     unsafe {
         let mut low: c_int = 0;
         let mut high: c_int = 0;
@@ -10013,7 +9870,7 @@ pub unsafe fn qselect_median_dbl(mut arr: *mut c_double, mut n: c_int) -> c_doub
             }
             if high == low + 1 {
                 if *arr.offset(low as isize) > *arr.offset(high as isize) {
-                    let mut t: c_double = *arr.offset(low as isize);
+                    let t: c_double = *arr.offset(low as isize);
                     *arr.offset(low as isize) = *arr.offset(high as isize);
                     *arr.offset(high as isize) = t;
                 }
@@ -10021,21 +9878,21 @@ pub unsafe fn qselect_median_dbl(mut arr: *mut c_double, mut n: c_int) -> c_doub
             }
             middle = (low + high) / 2 as c_int;
             if *arr.offset(middle as isize) > *arr.offset(high as isize) {
-                let mut t_0: c_double = *arr.offset(middle as isize);
+                let t_0: c_double = *arr.offset(middle as isize);
                 *arr.offset(middle as isize) = *arr.offset(high as isize);
                 *arr.offset(high as isize) = t_0;
             }
             if *arr.offset(low as isize) > *arr.offset(high as isize) {
-                let mut t_1: c_double = *arr.offset(low as isize);
+                let t_1: c_double = *arr.offset(low as isize);
                 *arr.offset(low as isize) = *arr.offset(high as isize);
                 *arr.offset(high as isize) = t_1;
             }
             if *arr.offset(middle as isize) > *arr.offset(low as isize) {
-                let mut t_2: c_double = *arr.offset(middle as isize);
+                let t_2: c_double = *arr.offset(middle as isize);
                 *arr.offset(middle as isize) = *arr.offset(low as isize);
                 *arr.offset(low as isize) = t_2;
             }
-            let mut t_3: c_double = *arr.offset(middle as isize);
+            let t_3: c_double = *arr.offset(middle as isize);
             *arr.offset(middle as isize) = *arr.offset((low + 1) as isize);
             *arr.offset((low + 1) as isize) = t_3;
             ll = low + 1;
@@ -10058,11 +9915,11 @@ pub unsafe fn qselect_median_dbl(mut arr: *mut c_double, mut n: c_int) -> c_doub
                 if hh < ll {
                     break;
                 }
-                let mut t_4: c_double = *arr.offset(ll as isize);
+                let t_4: c_double = *arr.offset(ll as isize);
                 *arr.offset(ll as isize) = *arr.offset(hh as isize);
                 *arr.offset(hh as isize) = t_4;
             }
-            let mut t_5: c_double = *arr.offset(low as isize);
+            let t_5: c_double = *arr.offset(low as isize);
             *arr.offset(low as isize) = *arr.offset(hh as isize);
             *arr.offset(hh as isize) = t_5;
             if hh <= median {
@@ -10075,33 +9932,28 @@ pub unsafe fn qselect_median_dbl(mut arr: *mut c_double, mut n: c_int) -> c_doub
     }
 }
 
-pub unsafe fn angsep_calc(
-    mut ra1: c_double,
-    mut dec1: c_double,
-    mut ra2: c_double,
-    mut dec2: c_double,
-) -> c_double {
+pub fn angsep_calc(ra1: c_double, dec1: c_double, ra2: c_double, dec2: c_double) -> c_double {
     unsafe {
-        static mut deg: c_double = 0.0;
+        static mut DEG: c_double = 0.0;
         let mut a: c_double = 0.0;
         let mut sdec: c_double = 0.0;
         let mut sra: c_double = 0.0;
-        if deg == 0.0 {
-            deg = 4.0 * atan(1.0) / 180.0;
+        if DEG == 0.0 {
+            DEG = 4.0 * atan(1.0) / 180.0;
         }
-        sra = ((ra2 - ra1) * deg / 2.0).sin();
-        sdec = ((dec2 - dec1) * deg / 2.0).sin();
-        a = sdec * sdec + (dec1 * deg).cos() * cos(dec2 * deg) * sra * sra;
+        sra = ((ra2 - ra1) * DEG / 2.0).sin();
+        sdec = ((dec2 - dec1) * DEG / 2.0).sin();
+        a = sdec * sdec + (dec1 * DEG).cos() * cos(dec2 * DEG) * sra * sra;
         if a < 0.0 {
             a = 0.0;
         }
         if a > 1 as c_double {
             a = 1 as c_double;
         }
-        2.0f64 * atan2((a).sqrt(), (1.0f64 - a).sqrt()) / deg
+        2.0f64 * atan2((a).sqrt(), (1.0f64 - a).sqrt()) / DEG
     }
 }
-unsafe fn Do_Func(lParse: &mut ParseData, mut this: *mut Node) {
+fn Do_Func(lParse: &mut ParseData, this: *mut Node) {
     unsafe {
         let mut theParams: [*mut Node; 10] = [std::ptr::null_mut::<Node>(); 10];
         let mut vector: [c_int; 10] = [0; 10];
@@ -10165,7 +10017,7 @@ unsafe fn Do_Func(lParse: &mut ParseData, mut this: *mut Node) {
             allConst = 0;
         }
         if allConst != 0 {
-            let mut current_block_139: u64;
+            let current_block_139: u64;
             match (*this).operation {
                 1002 => {
                     if (*theParams[0]).ntype == fits_parser_yytokentype::BOOLEAN as c_int {
@@ -10224,7 +10076,7 @@ unsafe fn Do_Func(lParse: &mut ParseData, mut this: *mut Node) {
                 1017 => {
                     if (*theParams[0]).ntype == fits_parser_yytokentype::DOUBLE as c_int {
                         dval = pVals[0].data.dbl;
-                        (*this).value.data.dbl = if dval > 0.0f64 { dval } else { -dval };
+                        (*this).value.data.dbl = if dval > 0.0 { dval } else { -dval };
                     } else {
                         ival = pVals[0].data.lng;
                         (*this).value.data.lng = if ival > 0 { ival } else { -ival };
@@ -10277,11 +10129,7 @@ unsafe fn Do_Func(lParse: &mut ParseData, mut this: *mut Node) {
                 1007 => {
                     dval = pVals[0].data.dbl;
                     if dval < -1.0f64 || dval > 1.0f64 {
-                        fits_parser_yyerror(
-                            ptr::null_mut(),
-                            lParse,
-                            cs!(c"Out of range argument to arcsin"),
-                        );
+                        fits_parser_yyerror(lParse, cs!(c"Out of range argument to arcsin"));
                     } else {
                         (*this).value.data.dbl = asin(dval);
                     }
@@ -10290,11 +10138,7 @@ unsafe fn Do_Func(lParse: &mut ParseData, mut this: *mut Node) {
                 1008 => {
                     dval = pVals[0].data.dbl;
                     if dval < -1.0f64 || dval > 1.0f64 {
-                        fits_parser_yyerror(
-                            ptr::null_mut(),
-                            lParse,
-                            cs!(c"Out of range argument to arccos"),
-                        );
+                        fits_parser_yyerror(lParse, cs!(c"Out of range argument to arccos"));
                     } else {
                         (*this).value.data.dbl = acos(dval);
                     }
@@ -10322,12 +10166,8 @@ unsafe fn Do_Func(lParse: &mut ParseData, mut this: *mut Node) {
                 }
                 1014 => {
                     dval = pVals[0].data.dbl;
-                    if dval <= 0.0f64 {
-                        fits_parser_yyerror(
-                            ptr::null_mut(),
-                            lParse,
-                            cs!(c"Out of range argument to log"),
-                        );
+                    if dval <= 0.0 {
+                        fits_parser_yyerror(lParse, cs!(c"Out of range argument to log"));
                     } else {
                         (*this).value.data.dbl = log(dval);
                     }
@@ -10335,12 +10175,8 @@ unsafe fn Do_Func(lParse: &mut ParseData, mut this: *mut Node) {
                 }
                 1015 => {
                     dval = pVals[0].data.dbl;
-                    if dval <= 0.0f64 {
-                        fits_parser_yyerror(
-                            ptr::null_mut(),
-                            lParse,
-                            cs!(c"Out of range argument to log10"),
-                        );
+                    if dval <= 0.0 {
+                        fits_parser_yyerror(lParse, cs!(c"Out of range argument to log10"));
                     } else {
                         (*this).value.data.dbl = log10(dval);
                     }
@@ -10348,12 +10184,8 @@ unsafe fn Do_Func(lParse: &mut ParseData, mut this: *mut Node) {
                 }
                 1016 => {
                     dval = pVals[0].data.dbl;
-                    if dval < 0.0f64 {
-                        fits_parser_yyerror(
-                            ptr::null_mut(),
-                            lParse,
-                            cs!(c"Out of range argument to sqrt"),
-                        );
+                    if dval < 0.0 {
+                        fits_parser_yyerror(lParse, cs!(c"Out of range argument to sqrt"));
                     } else {
                         (*this).value.data.dbl = sqrt(dval);
                     }
@@ -10520,7 +10352,7 @@ unsafe fn Do_Func(lParse: &mut ParseData, mut this: *mut Node) {
                     current_block_139 = 7627602990488000394;
                 }
                 1045 => {
-                    let mut res: *mut c_char = strstr(
+                    let res: *mut c_char = strstr(
                         (pVals[0].data.astr).as_mut_ptr(),
                         (pVals[1].data.astr).as_mut_ptr(),
                     );
@@ -10590,12 +10422,11 @@ unsafe fn Do_Func(lParse: &mut ParseData, mut this: *mut Node) {
                     1050 => {
                         let mut ielem: c_long = 0;
                         let mut iaxis: [c_long; 5] = [1, 1, 1, 1, 1];
-                        let mut ipos: c_long = pVals[1].data.lng - 1;
-                        let mut naxis: c_int = (*this).value.naxis;
+                        let ipos: c_long = pVals[1].data.lng - 1;
+                        let naxis: c_int = (*this).value.naxis;
                         let mut j: c_int = 0;
                         if ipos < 0 || ipos >= 5 as c_long {
                             fits_parser_yyerror(
-                                ptr::null_mut(),
                                 lParse,
                                 cs!(c"AXISELEM(V,n) n value exceeded maximum dimension"),
                             );
@@ -10629,7 +10460,7 @@ unsafe fn Do_Func(lParse: &mut ParseData, mut this: *mut Node) {
                     1049 => {
                         let mut ielem_0: c_long = 0;
                         let mut elemnum: c_long = 1;
-                        let mut j_0: c_int = 0;
+                        let j_0: c_int = 0;
                         ielem_0 = 0;
                         while ielem_0 < elem {
                             *((*this).value.data.lngptr).offset(ielem_0 as isize) = elemnum;
@@ -10808,7 +10639,7 @@ unsafe fn Do_Func(lParse: &mut ParseData, mut this: *mut Node) {
                                 if fresh66 == 0 {
                                     break;
                                 }
-                                *((*this).value.data.dblptr).offset(row as isize) = 0.0f64;
+                                *((*this).value.data.dblptr).offset(row as isize) = 0.0;
                                 *((*this).value.undef).offset(row as isize) = 1;
                                 nelem = (*theParams[0]).value.nelem;
                                 loop {
@@ -10977,11 +10808,10 @@ unsafe fn Do_Func(lParse: &mut ParseData, mut this: *mut Node) {
                                             as c_int
                                             == 0
                                         {
-                                            let mut dx: c_double =
-                                                *((*theParams[0]).value.data.lngptr)
-                                                    .offset(elem as isize)
-                                                    as c_double
-                                                    - sum;
+                                            let dx: c_double = *((*theParams[0]).value.data.lngptr)
+                                                .offset(elem as isize)
+                                                as c_double
+                                                - sum;
                                             sum2 += dx * dx;
                                         }
                                     }
@@ -11038,7 +10868,7 @@ unsafe fn Do_Func(lParse: &mut ParseData, mut this: *mut Node) {
                                             as c_int
                                             == 0
                                         {
-                                            let mut dx_0: c_double =
+                                            let dx_0: c_double =
                                                 *((*theParams[0]).value.data.dblptr)
                                                     .offset(elem as isize)
                                                     - sum_0;
@@ -11062,17 +10892,15 @@ unsafe fn Do_Func(lParse: &mut ParseData, mut this: *mut Node) {
                         if (*theParams[0]).ntype == fits_parser_yytokentype::LONG as c_int {
                             let mut dptr: *mut c_long = (*theParams[0]).value.data.lngptr;
                             let mut uptr: *mut c_char = (*theParams[0]).value.undef;
-                            let mut mptr: *mut c_long = malloc(
+                            let mptr: *mut c_long = malloc(
                                 (::core::mem::size_of::<c_long>() as c_ulong)
                                     .wrapping_mul(nelem as c_ulong)
                                     .try_into()
                                     .unwrap(),
-                            )
-                                as *mut c_long;
+                            ) as *mut c_long;
                             let mut irow: c_int = 0;
                             if mptr.is_null() {
                                 fits_parser_yyerror(
-                                    ptr::null_mut(),
                                     lParse,
                                     cs!(c"Could not allocate temporary memory in median function"),
                                 );
@@ -11115,7 +10943,7 @@ unsafe fn Do_Func(lParse: &mut ParseData, mut this: *mut Node) {
                         } else {
                             let mut dptr_0: *mut c_double = (*theParams[0]).value.data.dblptr;
                             let mut uptr_0: *mut c_char = (*theParams[0]).value.undef;
-                            let mut mptr_0: *mut c_double = malloc(
+                            let mptr_0: *mut c_double = malloc(
                                 (::core::mem::size_of::<c_double>() as c_ulong)
                                     .wrapping_mul(nelem as c_ulong)
                                     .try_into()
@@ -11125,7 +10953,6 @@ unsafe fn Do_Func(lParse: &mut ParseData, mut this: *mut Node) {
                             let mut irow_0: c_int = 0;
                             if mptr_0.is_null() {
                                 fits_parser_yyerror(
-                                    ptr::null_mut(),
                                     lParse,
                                     cs!(c"Could not allocate temporary memory in median function"),
                                 );
@@ -11177,7 +11004,7 @@ unsafe fn Do_Func(lParse: &mut ParseData, mut this: *mut Node) {
                                 }
                                 dval = *((*theParams[0]).value.data.dblptr).offset(elem as isize);
                                 *((*this).value.data.dblptr).offset(elem as isize) =
-                                    if dval > 0.0f64 { dval } else { -dval };
+                                    if dval > 0.0 { dval } else { -dval };
                                 *((*this).value.undef).offset(elem as isize) =
                                     *((*theParams[0]).value.undef).offset(elem as isize);
                             }
@@ -11515,7 +11342,7 @@ unsafe fn Do_Func(lParse: &mut ParseData, mut this: *mut Node) {
                         if *fresh110 == 0 {
                             dval = *((*theParams[0]).value.data.dblptr).offset(elem as isize);
                             if dval < -1.0f64 || dval > 1.0f64 {
-                                *((*this).value.data.dblptr).offset(elem as isize) = 0.0f64;
+                                *((*this).value.data.dblptr).offset(elem as isize) = 0.0;
                                 *((*this).value.undef).offset(elem as isize) = 1;
                             } else {
                                 *((*this).value.data.dblptr).offset(elem as isize) = asin(dval);
@@ -11533,7 +11360,7 @@ unsafe fn Do_Func(lParse: &mut ParseData, mut this: *mut Node) {
                         if *fresh112 == 0 {
                             dval = *((*theParams[0]).value.data.dblptr).offset(elem as isize);
                             if dval < -1.0f64 || dval > 1.0f64 {
-                                *((*this).value.data.dblptr).offset(elem as isize) = 0.0f64;
+                                *((*this).value.data.dblptr).offset(elem as isize) = 0.0;
                                 *((*this).value.undef).offset(elem as isize) = 1;
                             } else {
                                 *((*this).value.data.dblptr).offset(elem as isize) = acos(dval);
@@ -11615,8 +11442,8 @@ unsafe fn Do_Func(lParse: &mut ParseData, mut this: *mut Node) {
                         *fresh124 = *((*theParams[0]).value.undef).offset(elem as isize);
                         if *fresh124 == 0 {
                             dval = *((*theParams[0]).value.data.dblptr).offset(elem as isize);
-                            if dval <= 0.0f64 {
-                                *((*this).value.data.dblptr).offset(elem as isize) = 0.0f64;
+                            if dval <= 0.0 {
+                                *((*this).value.data.dblptr).offset(elem as isize) = 0.0;
                                 *((*this).value.undef).offset(elem as isize) = 1;
                             } else {
                                 *((*this).value.data.dblptr).offset(elem as isize) = log(dval);
@@ -11633,8 +11460,8 @@ unsafe fn Do_Func(lParse: &mut ParseData, mut this: *mut Node) {
                         *fresh126 = *((*theParams[0]).value.undef).offset(elem as isize);
                         if *fresh126 == 0 {
                             dval = *((*theParams[0]).value.data.dblptr).offset(elem as isize);
-                            if dval <= 0.0f64 {
-                                *((*this).value.data.dblptr).offset(elem as isize) = 0.0f64;
+                            if dval <= 0.0 {
+                                *((*this).value.data.dblptr).offset(elem as isize) = 0.0;
                                 *((*this).value.undef).offset(elem as isize) = 1;
                             } else {
                                 *((*this).value.data.dblptr).offset(elem as isize) = log10(dval);
@@ -11651,8 +11478,8 @@ unsafe fn Do_Func(lParse: &mut ParseData, mut this: *mut Node) {
                         *fresh128 = *((*theParams[0]).value.undef).offset(elem as isize);
                         if *fresh128 == 0 {
                             dval = *((*theParams[0]).value.data.dblptr).offset(elem as isize);
-                            if dval < 0.0f64 {
-                                *((*this).value.data.dblptr).offset(elem as isize) = 0.0f64;
+                            if dval < 0.0 {
+                                *((*this).value.data.dblptr).offset(elem as isize) = 0.0;
                                 *((*this).value.undef).offset(elem as isize) = 1;
                             } else {
                                 *((*this).value.data.dblptr).offset(elem as isize) = sqrt(dval);
@@ -11842,7 +11669,7 @@ unsafe fn Do_Func(lParse: &mut ParseData, mut this: *mut Node) {
                                 *((*this).value.data.lngptr).offset(row as isize) = minVal;
                             }
                         } else if (*this).ntype == fits_parser_yytokentype::DOUBLE as c_int {
-                            let mut minVal_0: c_double = 0.0f64;
+                            let mut minVal_0: c_double = 0.0;
                             loop {
                                 let fresh145 = row;
                                 row -= 1;
@@ -12074,7 +11901,7 @@ unsafe fn Do_Func(lParse: &mut ParseData, mut this: *mut Node) {
                                 *((*this).value.data.lngptr).offset(row as isize) = maxVal;
                             }
                         } else if (*this).ntype == fits_parser_yytokentype::DOUBLE as c_int {
-                            let mut maxVal_0: c_double = 0.0f64;
+                            let mut maxVal_0: c_double = 0.0;
                             loop {
                                 let fresh156 = row;
                                 row -= 1;
@@ -12712,10 +12539,10 @@ unsafe fn Do_Func(lParse: &mut ParseData, mut this: *mut Node) {
                         _ => {}
                     },
                     1044 => {
-                        let mut strconst: c_int = ((*theParams[0]).operation == -1000) as c_int;
-                        let mut posconst: c_int = ((*theParams[1]).operation == -1000) as c_int;
-                        let mut lenconst: c_int = ((*theParams[2]).operation == -1000) as c_int;
-                        let mut dest_len: c_int = (*this).value.nelem as c_int;
+                        let strconst: c_int = ((*theParams[0]).operation == -1000) as c_int;
+                        let posconst: c_int = ((*theParams[1]).operation == -1000) as c_int;
+                        let lenconst: c_int = ((*theParams[2]).operation == -1000) as c_int;
+                        let dest_len: c_int = (*this).value.nelem as c_int;
                         let mut src_len: c_int = (*theParams[0]).value.nelem as c_int;
                         loop {
                             let fresh196 = row;
@@ -12776,8 +12603,8 @@ unsafe fn Do_Func(lParse: &mut ParseData, mut this: *mut Node) {
                         }
                     }
                     1045 => {
-                        let mut const1: c_int = ((*theParams[0]).operation == -1000) as c_int;
-                        let mut const2: c_int = ((*theParams[1]).operation == -1000) as c_int;
+                        let const1: c_int = ((*theParams[0]).operation == -1000) as c_int;
+                        let const2: c_int = ((*theParams[1]).operation == -1000) as c_int;
                         loop {
                             let fresh197 = row;
                             row -= 1;
@@ -12805,7 +12632,7 @@ unsafe fn Do_Func(lParse: &mut ParseData, mut this: *mut Node) {
                             }
                             *((*this).value.data.lngptr).offset(row as isize) = 0;
                             if undef_0 == 0 {
-                                let mut res_0: *mut c_char = strstr(str1, str2);
+                                let res_0: *mut c_char = strstr(str1, str2);
                                 if res_0.is_null() {
                                     undef_0 = 1;
                                     *((*this).value.data.lngptr).offset(row as isize) = 0;
@@ -12834,7 +12661,7 @@ unsafe fn Do_Func(lParse: &mut ParseData, mut this: *mut Node) {
         }
     }
 }
-unsafe fn Do_Deref(lParse: &mut ParseData, mut this: *mut Node) {
+fn Do_Deref(lParse: &mut ParseData, this: *mut Node) {
     unsafe {
         let mut theVar: *mut Node = std::ptr::null_mut::<Node>();
         let mut theDims: [*mut Node; 5] = [std::ptr::null_mut::<Node>(); 5];
@@ -12922,14 +12749,14 @@ unsafe fn Do_Deref(lParse: &mut ParseData, mut this: *mut Node) {
                         row;
                     }
                 } else {
-                    fits_parser_yyerror(ptr::null_mut(), lParse, cs!(c"Index out of range"));
+                    fits_parser_yyerror(lParse, cs!(c"Index out of range"));
                     free((*this).value.data.ptr);
                 }
             } else if allConst != 0 && nDims == 1 {
                 if dimVals[0] < 1
                     || dimVals[0] > (*theVar).value.naxes[((*theVar).value.naxis - 1) as usize]
                 {
-                    fits_parser_yyerror(ptr::null_mut(), lParse, cs!(c"Index out of range"));
+                    fits_parser_yyerror(lParse, cs!(c"Index out of range"));
                     free((*this).value.data.ptr);
                 } else if (*this).ntype == fits_parser_yytokentype::BITSTR as c_int
                     || (*this).ntype == fits_parser_yytokentype::STRING as c_int
@@ -13001,7 +12828,6 @@ unsafe fn Do_Deref(lParse: &mut ParseData, mut this: *mut Node) {
                         if isConst[i as usize] == 0 {
                             if *((*theDims[i as usize]).value.undef).offset(row as isize) != 0 {
                                 fits_parser_yyerror(
-                                    ptr::null_mut(),
                                     lParse,
                                     cs!(c"Null encountered as vector index"),
                                 );
@@ -13059,7 +12885,7 @@ unsafe fn Do_Deref(lParse: &mut ParseData, mut this: *mut Node) {
                                 .offset(1 as c_int as isize) = 0;
                         }
                     } else {
-                        fits_parser_yyerror(ptr::null_mut(), lParse, cs!(c"Index out of range"));
+                        fits_parser_yyerror(lParse, cs!(c"Index out of range"));
                         free((*this).value.data.ptr);
                     }
                     row += 1;
@@ -13069,11 +12895,7 @@ unsafe fn Do_Deref(lParse: &mut ParseData, mut this: *mut Node) {
                 row = 0;
                 while row < lParse.nRows {
                     if *((*theDims[0]).value.undef).offset(row as isize) != 0 {
-                        fits_parser_yyerror(
-                            ptr::null_mut(),
-                            lParse,
-                            cs!(c"Null encountered as vector index"),
-                        );
+                        fits_parser_yyerror(lParse, cs!(c"Null encountered as vector index"));
                         free((*this).value.data.ptr);
                         break;
                     } else {
@@ -13082,11 +12904,7 @@ unsafe fn Do_Deref(lParse: &mut ParseData, mut this: *mut Node) {
                             || dimVals[0]
                                 > (*theVar).value.naxes[((*theVar).value.naxis - 1) as usize]
                         {
-                            fits_parser_yyerror(
-                                ptr::null_mut(),
-                                lParse,
-                                cs!(c"Index out of range"),
-                            );
+                            fits_parser_yyerror(lParse, cs!(c"Index out of range"));
                             free((*this).value.data.ptr);
                         } else if (*this).ntype == fits_parser_yytokentype::BITSTR as c_int
                             || (*this).ntype == fits_parser_yytokentype::STRING as c_int
@@ -13165,7 +12983,7 @@ unsafe fn Do_Deref(lParse: &mut ParseData, mut this: *mut Node) {
         }
     }
 }
-unsafe fn Do_GTI(lParse: &mut ParseData, mut this: *mut Node) {
+fn Do_GTI(lParse: &mut ParseData, this: *mut Node) {
     unsafe {
         let mut theExpr: *mut Node = std::ptr::null_mut::<Node>();
         let mut theTimes: *mut Node = std::ptr::null_mut::<Node>();
@@ -13176,7 +12994,7 @@ unsafe fn Do_GTI(lParse: &mut ParseData, mut this: *mut Node) {
         let mut nGTI: c_long = 0;
         let mut gti: c_long = 0;
         let mut ordered: c_int = 0;
-        let mut dorow: c_int = ((*this).operation == gtifind_fct as c_int) as c_int;
+        let dorow: c_int = ((*this).operation == gtifind_fct as c_int) as c_int;
         theTimes = &mut (lParse.Nodes)[(*this).SubNodes[0] as usize];
         theExpr = &mut (lParse.Nodes)[(*this).SubNodes[1] as usize];
         nGTI = (*theTimes).value.nelem;
@@ -13266,7 +13084,7 @@ unsafe fn Do_GTI(lParse: &mut ParseData, mut this: *mut Node) {
         }
     }
 }
-unsafe fn Do_GTI_Over(lParse: &mut ParseData, mut this: *mut Node) {
+fn Do_GTI_Over(lParse: &mut ParseData, this: *mut Node) {
     unsafe {
         let mut theTimes: *mut Node = std::ptr::null_mut::<Node>();
         let mut theStart: *mut Node = std::ptr::null_mut::<Node>();
@@ -13278,8 +13096,8 @@ unsafe fn Do_GTI_Over(lParse: &mut ParseData, mut this: *mut Node) {
         let mut elem: c_long = 0;
         let mut nGTI: c_long = 0;
         let mut gti: c_long = 0;
-        let mut nextGTI: c_long = 0;
-        let mut ordered: c_int = 0;
+        let nextGTI: c_long = 0;
+        let ordered: c_int = 0;
         theTimes = &mut (lParse.Nodes)[(*this).SubNodes[0] as usize];
         theStop = &mut (lParse.Nodes)[(*this).SubNodes[2] as usize];
         theStart = &mut (lParse.Nodes)[(*this).SubNodes[1] as usize];
@@ -13313,7 +13131,7 @@ unsafe fn Do_GTI_Over(lParse: &mut ParseData, mut this: *mut Node) {
             if lParse.status == 0 {
                 elem = lParse.nRows * (*this).value.nelem;
                 if nGTI != 0 {
-                    let mut toverlap: c_double = 0.0f64;
+                    let mut toverlap: c_double = 0.0;
                     gti = -(1) as c_long;
                     loop {
                         let fresh206 = elem;
@@ -13357,7 +13175,7 @@ unsafe fn Do_GTI_Over(lParse: &mut ParseData, mut this: *mut Node) {
                         if fresh208 == 0 {
                             break;
                         }
-                        *((*this).value.data.dblptr).offset(elem as isize) = 0.0f64;
+                        *((*this).value.data.dblptr).offset(elem as isize) = 0.0;
                         *((*this).value.undef).offset(elem as isize) = 0;
                     }
                 }
@@ -13371,13 +13189,13 @@ unsafe fn Do_GTI_Over(lParse: &mut ParseData, mut this: *mut Node) {
         }
     }
 }
-unsafe fn GTI_Over(
-    mut evtStart: c_double,
-    mut evtStop: c_double,
-    mut nGTI: c_long,
-    mut start: *mut c_double,
-    mut stop: *mut c_double,
-    mut gtiout: *mut c_long,
+fn GTI_Over(
+    evtStart: c_double,
+    evtStop: c_double,
+    nGTI: c_long,
+    start: *mut c_double,
+    stop: *mut c_double,
+    gtiout: *mut c_long,
 ) -> c_double {
     unsafe {
         let mut gti1: c_long = 0;
@@ -13386,10 +13204,10 @@ unsafe fn GTI_Over(
         let mut nextGTI2: c_long = 0;
         let mut gti: c_long = 0;
         let mut nMax: c_long = 0;
-        let mut overlap: c_double = 0.0f64;
+        let mut overlap: c_double = 0.0;
         *gtiout = -(1 as c_long);
         if evtStop <= evtStart {
-            return 0.0f64;
+            return 0.0;
         }
         gti1 = Search_GTI(evtStart, nGTI, start, stop, 1, &mut nextGTI1);
         gti2 = Search_GTI(evtStop, nGTI, start, stop, 1, &mut nextGTI2);
@@ -13397,10 +13215,10 @@ unsafe fn GTI_Over(
             *gtiout = gti1;
         }
         if nextGTI1 < 0 && nextGTI2 < 0 {
-            return 0.0f64;
+            return 0.0;
         }
         if gti1 < 0 && gti2 < 0 && nextGTI1 == nextGTI2 {
-            return 0.0f64;
+            return 0.0;
         }
         if gti1 >= 0 && gti1 == gti2 {
             return evtStop - evtStart;
@@ -13429,13 +13247,13 @@ unsafe fn GTI_Over(
         overlap
     }
 }
-unsafe fn Search_GTI(
-    mut evtTime: c_double,
-    mut nGTI: c_long,
-    mut start: *mut c_double,
-    mut stop: *mut c_double,
-    mut ordered: c_int,
-    mut nextGTI0: *mut c_long,
+fn Search_GTI(
+    evtTime: c_double,
+    nGTI: c_long,
+    start: *mut c_double,
+    stop: *mut c_double,
+    ordered: c_int,
+    nextGTI0: *mut c_long,
 ) -> c_long {
     unsafe {
         let mut gti: c_long = 0;
@@ -13501,13 +13319,13 @@ unsafe fn Search_GTI(
         gti
     }
 }
-unsafe fn Do_REG(lParse: &mut ParseData, mut this: *mut Node) {
+fn Do_REG(lParse: &mut ParseData, this: *mut Node) {
     unsafe {
         let mut theRegion: *mut Node = std::ptr::null_mut::<Node>();
         let mut theX: *mut Node = std::ptr::null_mut::<Node>();
         let mut theY: *mut Node = std::ptr::null_mut::<Node>();
-        let mut Xval: c_double = 0.0f64;
-        let mut Yval: c_double = 0.0f64;
+        let mut Xval: c_double = 0.0;
+        let mut Yval: c_double = 0.0;
         let mut Xnull: c_char = 0;
         let mut Ynull: c_char = 0;
         let mut Xvector: c_int = 0;
@@ -13608,7 +13426,7 @@ unsafe fn Do_REG(lParse: &mut ParseData, mut this: *mut Node) {
         }
     }
 }
-unsafe fn Do_Vector(lParse: &mut ParseData, mut this: *mut Node) {
+fn Do_Vector(lParse: &mut ParseData, this: *mut Node) {
     unsafe {
         let mut that: *mut Node = std::ptr::null_mut::<Node>();
         let mut row: c_long = 0;
@@ -13705,15 +13523,15 @@ unsafe fn Do_Vector(lParse: &mut ParseData, mut this: *mut Node) {
     }
 }
 
-unsafe fn Do_Array(lParse: &mut ParseData, mut this: *mut Node) {
+fn Do_Array(lParse: &mut ParseData, this: *mut Node) {
     unsafe {
         let mut that: *mut Node = std::ptr::null_mut::<Node>();
         let mut row: c_long = 0;
         let mut elem: c_long = 0;
         let mut idx: c_long = 0;
-        let mut jdx: c_long = 0;
-        let mut offset: c_long = 0;
-        let mut node: c_int = 0;
+        let jdx: c_long = 0;
+        let offset: c_long = 0;
+        let node: c_int = 0;
         Allocate_Ptrs(lParse, this);
         if lParse.status == 0 {
             that = &mut (lParse.Nodes)[(*this).SubNodes[0] as usize];
@@ -13818,7 +13636,7 @@ unsafe fn Do_Array(lParse: &mut ParseData, mut this: *mut Node) {
     }
 }
 
-unsafe fn bitlgte(mut bits1: *mut c_char, mut oper: c_int, mut bits2: *mut c_char) -> c_char {
+fn bitlgte(mut bits1: *mut c_char, oper: c_int, mut bits2: *mut c_char) -> c_char {
     unsafe {
         let mut val1: c_int = 0;
         let mut val2: c_int = 0;
@@ -13949,7 +13767,7 @@ unsafe fn bitlgte(mut bits1: *mut c_char, mut oper: c_int, mut bits2: *mut c_cha
         result
     }
 }
-unsafe fn bitand(mut result: *mut c_char, mut bitstrm1: *mut c_char, mut bitstrm2: *mut c_char) {
+fn bitand(mut result: *mut c_char, mut bitstrm1: *mut c_char, mut bitstrm2: *mut c_char) {
     unsafe {
         let mut i: c_int = 0;
         let mut l1: c_int = 0;
@@ -14047,7 +13865,7 @@ unsafe fn bitand(mut result: *mut c_char, mut bitstrm1: *mut c_char, mut bitstrm
         *result = 0;
     }
 }
-unsafe fn bitor(mut result: *mut c_char, mut bitstrm1: *mut c_char, mut bitstrm2: *mut c_char) {
+fn bitor(mut result: *mut c_char, mut bitstrm1: *mut c_char, mut bitstrm2: *mut c_char) {
     unsafe {
         let mut i: c_int = 0;
         let mut l1: c_int = 0;
@@ -14145,7 +13963,7 @@ unsafe fn bitor(mut result: *mut c_char, mut bitstrm1: *mut c_char, mut bitstrm2
         *result = 0;
     }
 }
-unsafe fn bitnot(mut result: *mut c_char, mut bits: *mut c_char) {
+fn bitnot(mut result: *mut c_char, mut bits: *mut c_char) {
     unsafe {
         let mut length: c_int = 0;
         let mut chr: c_char = 0;
@@ -14173,7 +13991,7 @@ unsafe fn bitnot(mut result: *mut c_char, mut bits: *mut c_char) {
     }
 }
 
-unsafe fn bitcmp(mut bitstrm1: *mut c_char, mut bitstrm2: *mut c_char) -> c_char {
+fn bitcmp(bitstrm1: *mut c_char, bitstrm2: *mut c_char) -> c_char {
     unsafe {
         let mut i: c_int = 0;
         let mut ldiff: c_int = 0;
@@ -14190,7 +14008,7 @@ unsafe fn bitcmp(mut bitstrm1: *mut c_char, mut bitstrm2: *mut c_char) -> c_char
         largestStream = cmp::max(l1, l2);
 
         let mut stream_vec: Vec<c_char> = vec![0; (largestStream + 1) as usize];
-        let mut stream = &mut stream_vec[..];
+        let stream = &mut stream_vec[..];
 
         if l1 < l2 {
             ldiff = l2 - l1;
@@ -14350,7 +14168,7 @@ fn cstrmid(
     let mut src_len = src_len as usize;
 
     /* char fill_char = ' '; */
-    let mut fill_char: c_char = 0;
+    let fill_char: c_char = 0;
 
     if src_len == 0 {
         src_len = unsafe { strlen(src_str) };
@@ -14360,11 +14178,7 @@ fn cstrmid(
 
     /* Fill destination with blanks */
     if pos < 0 {
-        fits_parser_yyerror(
-            ptr::null_mut(),
-            lParse,
-            cs!(c"STRMID(S,P,N) P must be 0 or greater"),
-        );
+        fits_parser_yyerror(lParse, cs!(c"STRMID(S,P,N) P must be 0 or greater"));
         return -(1);
     }
 
@@ -14375,8 +14189,8 @@ fn cstrmid(
         dest_str[..dest_len].fill(fill_char);
     } else if pos + dest_len > src_len {
         /* Copy a subset */
-        let mut nsub = src_len - pos + 1;
-        let mut npad = dest_len - nsub;
+        let nsub = src_len - pos + 1;
+        let npad = dest_len - nsub;
         dest_str[..nsub].copy_from_slice(&src_str[(pos - 1)..(pos - 1 + nsub)]);
 
         /* Fill remaining string with blanks */
@@ -14392,7 +14206,7 @@ fn cstrmid(
     0
 }
 
-fn fits_parser_yyerror(scanner: yyscan_t, lParse: &mut ParseData, s: &[c_char]) {
+fn fits_parser_yyerror(lParse: &mut ParseData, s: &[c_char]) {
     let mut msg: [c_char; 80] = [0; 80];
     if lParse.status == 0 {
         lParse.status = PARSE_SYNTAX_ERR;

--- a/src/eval_y.rs
+++ b/src/eval_y.rs
@@ -500,20 +500,18 @@ fn Alloc_Node(lParse: &mut ParseData) -> c_int {
             lParse
                 .Nodes
                 .resize(lParse.nNodesAlloc as usize, Node::default());
+        } else if lParse
+            .Nodes
+            .try_reserve_exact(lParse.nNodesAlloc as usize)
+            .is_err()
+        {
+            lParse.status = MEMORY_ALLOCATION;
+            return -(1);
         } else {
-            if lParse
+            lParse.nNodesAlloc *= 2;
+            lParse
                 .Nodes
-                .try_reserve_exact(lParse.nNodesAlloc as usize)
-                .is_err()
-            {
-                lParse.status = MEMORY_ALLOCATION;
-                return -(1);
-            } else {
-                lParse.nNodesAlloc *= 2;
-                lParse
-                    .Nodes
-                    .resize(lParse.nNodesAlloc as usize, Node::default());
-            }
+                .resize(lParse.nNodesAlloc as usize, Node::default());
         }
     }
 

--- a/src/eval_y.rs
+++ b/src/eval_y.rs
@@ -1,4 +1,3 @@
-
 use std::ffi::CStr;
 use std::rc::Rc;
 use std::{cmp, ptr};
@@ -66,7 +65,7 @@ use crate::c_types::{
     c_char, c_double, c_int, c_long, c_schar, c_short, c_uchar, c_uint, c_ulong, c_void,
 };
 use crate::cfileio::{ffclos_safer, ffexts_safer, ffopen_safer};
-use crate::eval_defs::{data_union, lval, yyscan_t, Node, ParseData, CONST_OP, MAXDIMS, MAXSUBS};
+use crate::eval_defs::{CONST_OP, MAXDIMS, MAXSUBS, Node, ParseData, data_union, lval, yyscan_t};
 use crate::eval_l::{fits_parser_yyGetVariable, fits_parser_yylex, yyguts_t};
 use crate::eval_tab::{FITS_PARSER_YYSTYPE, fits_parser_yytokentype};
 use crate::fitscore::ffpmsg_slice;
@@ -233,22 +232,21 @@ pub union yyalloc {
 }
 
 /* YYFINAL -- State number of the termination state.  */
-const YYFINAL: usize= 2;
+const YYFINAL: usize = 2;
 /* YYLAST -- Last index in YYTABLE.  */
-const YYLAST: usize= 1776;
+const YYLAST: usize = 1776;
 
 /* YYNTOKENS -- Number of terminals.  */
-const YYNTOKENS: usize= 57;
+const YYNTOKENS: usize = 57;
 /* YYNNTS -- Number of nonterminals.  */
-const YYNNTS: usize= 9;
+const YYNNTS: usize = 9;
 /* YYNRULES -- Number of rules.  */
-const YYNRULES: usize= 135;
+const YYNRULES: usize = 135;
 /* YYNSTATES -- Number of states.  */
-const YYNSTATES: usize= 322;
+const YYNSTATES: usize = 322;
 
 /* YYMAXUTOK -- Last valid token kind.  */
-const YYMAXUTOK: usize= 292;
-
+const YYMAXUTOK: usize = 292;
 
 /* YYTRANSLATE[TOKEN-NUM] -- Symbol number corresponding to TOKEN-NUM as returned by yylex.  */
 static YYTRANSLATE: [yytype_int8; 293] = [
@@ -265,13 +263,16 @@ static YYTRANSLATE: [yytype_int8; 293] = [
 ];
 
 /* YYRLINE[YYN] -- Source line where rule number YYN was defined.  */
-static YYRLINE: [yytype_int16; 136] = [0,    266,  266,  267,  270,  271,  277,  283,  289,  295,  298,  300,  313,  315,  328,  339,  353,  357,  361,  365,  367,  376,  379,
-                                       382,  391,  393,  395,  397,  399,  401,  404,  408,  410,  412,  414,  423,  425,  427,  430,  433,  436,  439,  442,  451,  460,  469,
-                                       472,  474,  476,  478,  482,  486,  505,  524,  543,  554,  568,  617,  629,  660,  774,  782,  885,  911,  914,  918,  920,  922,  924,
-                                       926,  928,  930,  932,  934,  938,  940,  942,  951,  954,  957,  960,  963,  966,  969,  972,  975,  978,  981,  984,  987,  990,  993,
-                                       996,  999,  1002, 1005, 1008, 1010, 1012, 1014, 1017, 1024, 1041, 1054, 1067, 1078, 1094, 1118, 1146, 1183, 1187, 1191, 1194, 1200, 1204,
-                                       1208, 1211, 1216, 1220, 1223, 1227, 1229, 1231, 1233, 1235, 1237, 1239, 1243, 1246, 1248, 1257, 1259, 1261, 1270, 1289, 1308];
-
+static YYRLINE: [yytype_int16; 136] = [
+    0, 266, 266, 267, 270, 271, 277, 283, 289, 295, 298, 300, 313, 315, 328, 339, 353, 357, 361,
+    365, 367, 376, 379, 382, 391, 393, 395, 397, 399, 401, 404, 408, 410, 412, 414, 423, 425, 427,
+    430, 433, 436, 439, 442, 451, 460, 469, 472, 474, 476, 478, 482, 486, 505, 524, 543, 554, 568,
+    617, 629, 660, 774, 782, 885, 911, 914, 918, 920, 922, 924, 926, 928, 930, 932, 934, 938, 940,
+    942, 951, 954, 957, 960, 963, 966, 969, 972, 975, 978, 981, 984, 987, 990, 993, 996, 999, 1002,
+    1005, 1008, 1010, 1012, 1014, 1017, 1024, 1041, 1054, 1067, 1078, 1094, 1118, 1146, 1183, 1187,
+    1191, 1194, 1200, 1204, 1208, 1211, 1216, 1220, 1223, 1227, 1229, 1231, 1233, 1235, 1237, 1239,
+    1243, 1246, 1248, 1257, 1259, 1261, 1270, 1289, 1308,
+];
 
 /* YYPACT[STATE-NUM] -- Index in YYTABLE of the portion describing
 STATE-NUM.  */
@@ -516,10 +517,6 @@ static YYR2: [yytype_int8; 136] = [
     12, 2, 3, 1, 1, 4, 1, 3, 3, 5, 5, 7,
 ];
 
-
-
-
-
 fn Alloc_Node(lParse: &mut ParseData) -> c_int {
     // If number of nodes == number allocated, then realloc
     if lParse.nNodes == lParse.nNodesAlloc {
@@ -545,7 +542,7 @@ fn Alloc_Node(lParse: &mut ParseData) -> c_int {
     }
 
     lParse.nNodes += 1;
-    (lParse.nNodes-1)
+    lParse.nNodes - 1
 }
 
 fn Free_Last_Node(lParse: &mut ParseData) {
@@ -757,8 +754,7 @@ fn New_BinOp(
         (lParse.Nodes[this_node_idx]).value.naxis = (lParse.Nodes[that1_idx]).value.naxis;
 
         for i in 0..lParse.Nodes[that1_idx].value.naxis as usize {
-            (lParse.Nodes[this_node_idx]).value.naxes[i as usize] =
-                (lParse.Nodes[that1_idx]).value.naxes[i as usize];
+            (lParse.Nodes[this_node_idx]).value.naxes[i] = (lParse.Nodes[that1_idx]).value.naxes[i];
         }
 
         if Op == fits_parser_yytokentype::ACCUM as c_int
@@ -818,92 +814,90 @@ fn New_Func(
 }
 
 macro_rules! YY_SYMBOL_PRINT {
-    ($title:expr, $kind:expr, $value:expr, $scanner:expr, $lParse:expr) => {
-        {
-            if YYDEBUG {
-                eprintln!("{}", $title);
-                yy_symbol_print($kind, $value, $scanner, $lParse);
-                eprintln!();
-            }
+    ($title:expr, $kind:expr, $value:expr, $scanner:expr, $lParse:expr) => {{
+        if YYDEBUG {
+            eprintln!("{}", $title);
+            yy_symbol_print($kind, $value, $scanner, $lParse);
+            eprintln!();
         }
-    };
+    }};
 }
-
 
 fn yysymbol_name(yykind: yysymbol_kind_t) -> &'static str {
     YYTNAME[yykind as usize]
 }
 
 /* YYTNAME[SYMBOL-NUM] -- String name of the symbol SYMBOL-NUM.
-   First, the terminals, then, starting at YYNTOKENS, nonterminals.  */
-static YYTNAME: [&str; 67] = ["\"end of file\"",
-                                      "error",
-                                      "\"invalid token\"",
-                                      "BOOLEAN",
-                                      "LONG",
-                                      "DOUBLE",
-                                      "STRING",
-                                      "BITSTR",
-                                      "FUNCTION",
-                                      "BFUNCTION",
-                                      "IFUNCTION",
-                                      "GTIFILTER",
-                                      "GTIOVERLAP",
-                                      "GTIFIND",
-                                      "REGFILTER",
-                                      "COLUMN",
-                                      "BCOLUMN",
-                                      "SCOLUMN",
-                                      "BITCOL",
-                                      "ROWREF",
-                                      "NULLREF",
-                                      "SNULLREF",
-                                      "','",
-                                      "'='",
-                                      "':'",
-                                      "'{'",
-                                      "'}'",
-                                      "'?'",
-                                      "OR",
-                                      "AND",
-                                      "EQ",
-                                      "NE",
-                                      "'~'",
-                                      "GT",
-                                      "LT",
-                                      "LTE",
-                                      "GTE",
-                                      "'+'",
-                                      "'-'",
-                                      "'%'",
-                                      "'*'",
-                                      "'/'",
-                                      "'|'",
-                                      "'&'",
-                                      "XOR",
-                                      "POWER",
-                                      "NOT",
-                                      "INTCAST",
-                                      "FLTCAST",
-                                      "UMINUS",
-                                      "'['",
-                                      "ACCUM",
-                                      "DIFF",
-                                      "'\\n'",
-                                      "']'",
-                                      "'('",
-                                      "')'",
-                                      "$accept",
-                                      "lines",
-                                      "line",
-                                      "bvector",
-                                      "vector",
-                                      "expr",
-                                      "bexpr",
-                                      "bits",
-                                      "sexpr",
-                                      "NULL PTR"];
-
+First, the terminals, then, starting at YYNTOKENS, nonterminals.  */
+static YYTNAME: [&str; 67] = [
+    "\"end of file\"",
+    "error",
+    "\"invalid token\"",
+    "BOOLEAN",
+    "LONG",
+    "DOUBLE",
+    "STRING",
+    "BITSTR",
+    "FUNCTION",
+    "BFUNCTION",
+    "IFUNCTION",
+    "GTIFILTER",
+    "GTIOVERLAP",
+    "GTIFIND",
+    "REGFILTER",
+    "COLUMN",
+    "BCOLUMN",
+    "SCOLUMN",
+    "BITCOL",
+    "ROWREF",
+    "NULLREF",
+    "SNULLREF",
+    "','",
+    "'='",
+    "':'",
+    "'{'",
+    "'}'",
+    "'?'",
+    "OR",
+    "AND",
+    "EQ",
+    "NE",
+    "'~'",
+    "GT",
+    "LT",
+    "LTE",
+    "GTE",
+    "'+'",
+    "'-'",
+    "'%'",
+    "'*'",
+    "'/'",
+    "'|'",
+    "'&'",
+    "XOR",
+    "POWER",
+    "NOT",
+    "INTCAST",
+    "FLTCAST",
+    "UMINUS",
+    "'['",
+    "ACCUM",
+    "DIFF",
+    "'\\n'",
+    "']'",
+    "'('",
+    "')'",
+    "$accept",
+    "lines",
+    "line",
+    "bvector",
+    "vector",
+    "expr",
+    "bexpr",
+    "bits",
+    "sexpr",
+    "NULL PTR",
+];
 
 /*-----------------------------------.
 | Print this symbol's value on YYO.  |
@@ -915,9 +909,7 @@ fn yy_symbol_value_print(
     _scanner: yyscan_t,
     _lParse: &mut ParseData,
 ) {
-    return
 }
-
 
 /*---------------------------.
 | Print this symbol on YYO.  |
@@ -930,7 +922,15 @@ fn yy_symbol_print(
     lParse: &mut ParseData,
 ) {
     unsafe {
-        eprint!("{} {} (", if (yykind as usize) < YYNTOKENS { "token" } else { "nterm" }, yysymbol_name(yykind));
+        eprint!(
+            "{} {} (",
+            if (yykind as usize) < YYNTOKENS {
+                "token"
+            } else {
+                "nterm"
+            },
+            yysymbol_name(yykind)
+        );
         yy_symbol_value_print(yykind, yyvaluep, scanner, lParse);
         eprintln!(")");
     }
@@ -941,10 +941,7 @@ fn yy_symbol_print(
 | TOP (included).                                                   |
 `------------------------------------------------------------------*/
 
-fn yy_stackprint(
-    yybottom: *const yy_state_t,
-    yytop: *const yy_state_t,
-) {
+fn yy_stackprint(yybottom: *const yy_state_t, yytop: *const yy_state_t) {
     unsafe {
         eprint!("Stack now");
         let mut ptr = yybottom;
@@ -958,15 +955,12 @@ fn yy_stackprint(
 }
 
 macro_rules! YY_STACK_PRINT {
-    ($bottom:expr, $top:expr) => {
-        {
-            if YYDEBUG {
-                yy_stackprint($bottom, $top);
-            }
+    ($bottom:expr, $top:expr) => {{
+        if YYDEBUG {
+            yy_stackprint($bottom, $top);
         }
-    };
+    }};
 }
-
 
 /*------------------------------------------------.
 | Report that the YYRULE is going to be reduced.  |
@@ -997,18 +991,17 @@ fn yy_reduce_print(
     }
 }
 
-
 const YYDEBUG: bool = false;
 
 /* YYINITDEPTH -- initial size of the parser's stacks.  */
 const YYINITDEPTH: usize = 200;
 
 /* YYMAXDEPTH -- maximum size the stacks can grow to (effective only
-   if the built-in stack extension method is used).
+if the built-in stack extension method is used).
 
-   Do not make this value too large; the results are undefined if
-   YYSTACK_ALLOC_MAXIMUM < YYSTACK_BYTES (YYMAXDEPTH)
-   evaluated with infinite-precision integer arithmetic.  */
+Do not make this value too large; the results are undefined if
+YYSTACK_ALLOC_MAXIMUM < YYSTACK_BYTES (YYMAXDEPTH)
+evaluated with infinite-precision integer arithmetic.  */
 
 const YYMAXDEPTH: usize = 10000;
 
@@ -1088,7 +1081,6 @@ fn New_FuncSize(
                     == CONST_OP) as c_int;
         }
 
-        
         if returnType != 0 {
             (lParse.Nodes[n as usize]).ntype = returnType;
             (lParse.Nodes[n as usize]).value.nelem = 1;
@@ -1100,7 +1092,8 @@ fn New_FuncSize(
             (lParse.Nodes[n as usize]).value.naxis = (lParse.Nodes[Node1 as usize]).value.naxis;
             i = 0;
             while i < (lParse.Nodes[Node1 as usize]).value.naxis {
-                (lParse.Nodes[n as usize]).value.naxes[i as usize] = (lParse.Nodes[Node1 as usize]).value.naxes[i as usize];
+                (lParse.Nodes[n as usize]).value.naxes[i as usize] =
+                    (lParse.Nodes[Node1 as usize]).value.naxes[i as usize];
                 i += 1;
             }
         }
@@ -1110,7 +1103,9 @@ fn New_FuncSize(
         }
 
         if constant != 0 {
-            ((lParse.Nodes[n as usize]).DoOp).expect("non-null function pointer")(lParse, n as usize);
+            ((lParse.Nodes[n as usize]).DoOp).expect("non-null function pointer")(
+                lParse, n as usize,
+            );
         }
     }
     n
@@ -1145,23 +1140,20 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
             if YYDEBUG {
                 eprintln!("Entering state {}", yystate);
             }
-            assert!((0 <= yystate && yystate < YYNSTATES as c_int));
+            assert!(0 <= yystate && yystate < YYNSTATES as c_int);
             YY_STACK_PRINT!(yyss, yyssp);
 
             *yyssp = yystate as yy_state_t;
-            if yyss
-                .offset(yystacksize as isize)
-                .offset(-1)
-                <= yyssp
-            {
-                 /* Get the current used size of the three stacks, in elements.  */
+            if yyss.offset(yystacksize as isize).offset(-1) <= yyssp {
+                /* Get the current used size of the three stacks, in elements.  */
                 let yysize: c_long = yyssp.offset_from(yyss) as c_long + 1;
                 if YYMAXDEPTH as c_long <= yystacksize {
                     current_block = 11794367917084412820; // goto yyexhaustedlab;
                     break;
                 }
                 yystacksize *= 2 as c_long;
-                if (YYMAXDEPTH as c_long) < yystacksize { /* Extend the stack our own way.  */
+                if (YYMAXDEPTH as c_long) < yystacksize {
+                    /* Extend the stack our own way.  */
                     yystacksize = YYMAXDEPTH as c_long;
                 }
                 let yyss1: *mut yy_state_t = yyss;
@@ -1214,25 +1206,20 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                 }
                 yyssp = yyss.offset(yysize as isize).offset(-1);
                 yyvsp = yyvs.offset(yysize as isize).offset(-1);
-                if yyss
-                    .offset(yystacksize as isize)
-                    .offset(-1)
-                    <= yyssp
-                {
+                if yyss.offset(yystacksize as isize).offset(-1) <= yyssp {
                     current_block = 3964311021479492664; // goto yyabortlab;
                     break;
                 }
             }
-            if yystate == YYFINAL as c_int{
+            if yystate == YYFINAL as c_int {
                 yyresult = 0;
                 current_block = 15864720325503947191; // goto yyacceptlab;
                 break;
-            } else { 
-
+            } else {
                 /*-----------.
                 | yybackup.  |
                 `-----------*/
-                 /* Do appropriate processing given the current state.  Read a
+                /* Do appropriate processing given the current state.  Read a
                 lookahead token if we need one and don't already have one.  */
 
                 /* First try to decide what to do without reference to lookahead token.  */
@@ -1240,7 +1227,6 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                 if yyn == -41 {
                     current_block = 5937473999264333383; // goto yydefault;
                 } else {
-
                     /* Not known => get a lookahead token if don't already have one.  */
 
                     /* YYCHAR is either empty, or end-of-input, or a valid lookahead.  */
@@ -1272,7 +1258,8 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             YYTRANSLATE[yychar as usize] as yysymbol_kind_t as c_int
                         } else {
                             YYSYMBOL_YYUNDEF as c_int
-                        }) as yysymbol_kind_t; YY_SYMBOL_PRINT!("Next token is", yytoken, &yylval, scanner, lParse);
+                        }) as yysymbol_kind_t;
+                        YY_SYMBOL_PRINT!("Next token is", yytoken, &yylval, scanner, lParse);
                         current_block = 1924505913685386279;
                     }
                     match current_block {
@@ -1289,10 +1276,12 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 if yyn <= 0 {
                                     yyn = -yyn;
                                     current_block = 670225253387957849;
-                                } else { /* Count tokens shifted since error; after three, turn off error status.  */
+                                } else {
+                                    /* Count tokens shifted since error; after three, turn off error status.  */
                                     if yyerrstatus != 0 {
                                         yyerrstatus -= 1;
-                                    } /* Shift the lookahead token.  */ YY_SYMBOL_PRINT!("Shifting", yytoken, &yylval, scanner, lParse);
+                                    } /* Shift the lookahead token.  */
+                                    YY_SYMBOL_PRINT!("Shifting", yytoken, &yylval, scanner, lParse);
                                     yystate = yyn;
                                     yyvsp = yyvsp.offset(1);
                                     *yyvsp = yylval;
@@ -1305,12 +1294,13 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                 }
 
                 if current_block == 5937473999264333383 {
-                     /*-----------------------------------------------------------.
+                    /*-----------------------------------------------------------.
                     | yydefault -- do the default action for the current state.  |
                     `-----------------------------------------------------------*/
 
                     yyn = YYDEFACT[yystate as usize] as c_int;
-                    if yyn == 0 { // goto yyerrlab;
+                    if yyn == 0 {
+                        // goto yyerrlab;
                         yytoken =
                             (if yychar == fits_parser_yytokentype::FITS_PARSER_YYEMPTY as c_int {
                                 YYSYMBOL_YYEMPTY as c_int
@@ -1354,24 +1344,26 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                     yylen = YYR2[yyn as usize] as c_int;
 
                     /* If YYLEN is nonzero, implement the default value of the action:
-       '$$ = $1'.
+                    '$$ = $1'.
 
-       Otherwise, the following line sets YYVAL to garbage.
-       This behavior is undocumented and Bison
-       users should not rely upon it.  Assigning to YYVAL
-       unconditionally makes the parser a bit smaller, and it avoids a
-       GCC warning that YYVAL may be used uninitialized.  */
-                    yyval = *yyvsp.offset((1  - yylen) as isize);
+                    Otherwise, the following line sets YYVAL to garbage.
+                    This behavior is undocumented and Bison
+                    users should not rely upon it.  Assigning to YYVAL
+                    unconditionally makes the parser a bit smaller, and it avoids a
+                    GCC warning that YYVAL may be used uninitialized.  */
+                    yyval = *yyvsp.offset((1 - yylen) as isize);
 
                     if YYDEBUG {
                         yy_reduce_print(yyssp, yyvsp, yyn, scanner, lParse);
                     }
 
                     match yyn {
-                        4 => { /* line: '\n'  */
+                        4 => {
+                            /* line: '\n'  */
                             current_block = 17353983478346836848;
                         }
-                        5 => { /* line: expr '\n'  */
+                        5 => {
+                            /* line: expr '\n'  */
                             if (*yyvsp.offset(-1)).Node < 0 {
                                 fits_parser_yyerror(
                                     lParse,
@@ -1383,7 +1375,8 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        6 => { /* line: bexpr '\n'  */
+                        6 => {
+                            /* line: bexpr '\n'  */
                             if (*yyvsp.offset(-1)).Node < 0 {
                                 fits_parser_yyerror(
                                     lParse,
@@ -1395,7 +1388,8 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        7 => { /* line: sexpr '\n'  */
+                        7 => {
+                            /* line: sexpr '\n'  */
                             if (*yyvsp.offset(-1)).Node < 0 {
                                 fits_parser_yyerror(
                                     lParse,
@@ -1407,7 +1401,8 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        8 => { /* line: bits '\n'  */
+                        8 => {
+                            /* line: bits '\n'  */
                             if (*yyvsp.offset(-1)).Node < 0 {
                                 fits_parser_yyerror(
                                     lParse,
@@ -1419,11 +1414,13 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        9 => { /* line: error '\n'  */
+                        9 => {
+                            /* line: error '\n'  */
                             yyerrstatus = 0;
                             current_block = 17353983478346836848;
                         }
-                        10 => { /* bvector: '{' bexpr  */
+                        10 => {
+                            /* bvector: '{' bexpr  */
                             yyval.Node = New_Vector(lParse, (*yyvsp.offset(0)).Node);
                             if yyval.Node < 0 {
                                 current_block = 4830776507462815627;
@@ -1431,7 +1428,8 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        11 => { /* bvector: bvector ',' bexpr  */
+                        11 => {
+                            /* bvector: bvector ',' bexpr  */
                             if (lParse.Nodes[(*yyvsp.offset(-2)).Node as usize]).nSubNodes
                                 >= 10 as c_int
                             {
@@ -1465,7 +1463,8 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 }
                             }
                         }
-                        12 => {  /* vector: '{' expr  */
+                        12 => {
+                            /* vector: '{' expr  */
                             yyval.Node = New_Vector(lParse, (*yyvsp.offset(0)).Node);
                             if yyval.Node < 0 {
                                 current_block = 4830776507462815627;
@@ -1473,7 +1472,8 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        13 => { /* vector: vector ',' expr  */
+                        13 => {
+                            /* vector: vector ',' expr  */
                             if (lParse.Nodes[(*yyvsp.offset(-2)).Node as usize]).ntype
                                 < (lParse.Nodes[(*yyvsp.offset(0)).Node as usize]).ntype
                             {
@@ -1513,7 +1513,8 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 }
                             }
                         }
-                        14 => { /* vector: vector ',' bexpr  */
+                        14 => {
+                            /* vector: vector ',' bexpr  */
                             if (lParse.Nodes[(*yyvsp.offset(-2)).Node as usize]).nSubNodes
                                 >= MAXSUBS as c_int
                             {
@@ -1547,7 +1548,8 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 }
                             }
                         }
-                        15 => { /* vector: bvector ',' expr  */
+                        15 => {
+                            /* vector: bvector ',' expr  */
                             (lParse.Nodes[(*yyvsp.offset(-2)).Node as usize]).ntype =
                                 (lParse.Nodes[(*yyvsp.offset(0)).Node as usize]).ntype;
                             if (lParse.Nodes[(*yyvsp.offset(-2)).Node as usize]).nSubNodes
@@ -1583,7 +1585,8 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 }
                             }
                         }
-                        16 => {/* expr: vector '}'  */
+                        16 => {
+                            /* expr: vector '}'  */
                             yyval.Node = Close_Vec(lParse, (*yyvsp.offset(-1)).Node);
                             if yyval.Node < 0 {
                                 current_block = 4830776507462815627;
@@ -1591,7 +1594,8 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        17 => {/* bexpr: bvector '}'  */
+                        17 => {
+                            /* bexpr: bvector '}'  */
                             yyval.Node = Close_Vec(lParse, (*yyvsp.offset(-1)).Node);
                             if yyval.Node < 0 {
                                 current_block = 4830776507462815627;
@@ -1599,7 +1603,8 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        18 => {/* bits: BITSTR  */
+                        18 => {
+                            /* bits: BITSTR  */
                             yyval.Node = New_Const(
                                 lParse,
                                 fits_parser_yytokentype::BITSTR as c_int,
@@ -1616,7 +1621,8 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        19 => {/* bits: BITCOL  */
+                        19 => {
+                            /* bits: BITCOL  */
                             yyval.Node = New_Column(lParse, (*yyvsp.offset(0)).lng as c_int);
                             if yyval.Node < 0 {
                                 current_block = 4830776507462815627;
@@ -1624,7 +1630,8 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        20 => {/* bits: BITCOL '{' expr '}'  */
+                        20 => {
+                            /* bits: BITCOL '{' expr '}'  */
                             if ((lParse.Nodes)[(*yyvsp.offset(-1)).Node as usize]).ntype
                                 != fits_parser_yytokentype::LONG as c_int
                                 || ((lParse.Nodes)[(*yyvsp.offset(-1)).Node as usize]).operation
@@ -1648,7 +1655,8 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 }
                             }
                         }
-                        21 => {/* bits: bits '&' bits  */
+                        21 => {
+                            /* bits: bits '&' bits  */
                             yyval.Node = New_BinOp(
                                 lParse,
                                 fits_parser_yytokentype::BITSTR as c_int,
@@ -1675,7 +1683,8 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        22 => {/* bits: bits '|' bits  */
+                        22 => {
+                            /* bits: bits '|' bits  */
                             yyval.Node = New_BinOp(
                                 lParse,
                                 fits_parser_yytokentype::BITSTR as c_int,
@@ -1702,7 +1711,8 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        23 => {/* bits: bits '+' bits  */
+                        23 => {
+                            /* bits: bits '+' bits  */
                             if (lParse.Nodes[(*yyvsp.offset(-2)).Node as usize])
                                 .value
                                 .nelem
@@ -1736,7 +1746,8 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 }
                             }
                         }
-                        24 => {/* bits: bits '[' expr ']'  */
+                        24 => {
+                            /* bits: bits '[' expr ']'  */
                             yyval.Node = New_Deref(
                                 lParse,
                                 (*yyvsp.offset(-3)).Node,
@@ -1753,7 +1764,8 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        25 => {/* bits: bits '[' expr ',' expr ']'  */
+                        25 => {
+                            /* bits: bits '[' expr ',' expr ']'  */
                             yyval.Node = New_Deref(
                                 lParse,
                                 (*yyvsp.offset(-(5))).Node,
@@ -1770,7 +1782,8 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        26 => {/* bits: bits '[' expr ',' expr ',' expr ']'  */
+                        26 => {
+                            /* bits: bits '[' expr ',' expr ',' expr ']'  */
                             yyval.Node = New_Deref(
                                 lParse,
                                 (*yyvsp.offset(-7)).Node,
@@ -1787,7 +1800,8 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        27 => { /* bits: bits '[' expr ',' expr ',' expr ',' expr ']'  */
+                        27 => {
+                            /* bits: bits '[' expr ',' expr ',' expr ',' expr ']'  */
                             yyval.Node = New_Deref(
                                 lParse,
                                 (*yyvsp.offset(-9)).Node,
@@ -1804,7 +1818,8 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        28 => {/* bits: bits '[' expr ',' expr ',' expr ',' expr ',' expr ']'  */
+                        28 => {
+                            /* bits: bits '[' expr ',' expr ',' expr ',' expr ',' expr ']'  */
                             yyval.Node = New_Deref(
                                 lParse,
                                 (*yyvsp.offset(-11)).Node,
@@ -1821,7 +1836,8 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        29 => {/* bits: NOT bits  */
+                        29 => {
+                            /* bits: NOT bits  */
                             yyval.Node = New_Unary(
                                 lParse,
                                 fits_parser_yytokentype::BITSTR as c_int,
@@ -1834,11 +1850,13 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        30 => { /* bits: '(' bits ')'  */
+                        30 => {
+                            /* bits: '(' bits ')'  */
                             yyval.Node = (*yyvsp.offset(-1)).Node;
                             current_block = 17353983478346836848;
                         }
-                        31 => {/* expr: LONG  */
+                        31 => {
+                            /* expr: LONG  */
                             yyval.Node = New_Const(
                                 lParse,
                                 fits_parser_yytokentype::LONG as c_int,
@@ -1851,7 +1869,8 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        32 => { /* expr: DOUBLE  */
+                        32 => {
+                            /* expr: DOUBLE  */
                             yyval.Node = New_Const(
                                 lParse,
                                 fits_parser_yytokentype::DOUBLE as c_int,
@@ -1864,7 +1883,8 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        33 => {/* expr: COLUMN  */
+                        33 => {
+                            /* expr: COLUMN  */
                             yyval.Node = New_Column(lParse, (*yyvsp.offset(0)).lng as c_int);
                             if yyval.Node < 0 {
                                 current_block = 4830776507462815627;
@@ -1872,7 +1892,8 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        34 => {/* expr: COLUMN '{' expr '}'  */
+                        34 => {
+                            /* expr: COLUMN '{' expr '}'  */
                             if ((lParse.Nodes)[(*yyvsp.offset(-1)).Node as usize]).ntype
                                 != fits_parser_yytokentype::LONG as c_int
                                 || ((lParse.Nodes)[(*yyvsp.offset(-1)).Node as usize]).operation
@@ -1896,7 +1917,8 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 }
                             }
                         }
-                        35 => {/* expr: ROWREF  */
+                        35 => {
+                            /* expr: ROWREF  */
                             yyval.Node = New_Func(
                                 lParse,
                                 fits_parser_yytokentype::LONG as c_int,
@@ -1912,7 +1934,8 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             );
                             current_block = 17353983478346836848;
                         }
-                        36 => { /* expr: NULLREF  */
+                        36 => {
+                            /* expr: NULLREF  */
                             yyval.Node = New_Func(
                                 lParse,
                                 fits_parser_yytokentype::LONG as c_int,
@@ -1928,7 +1951,8 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             );
                             current_block = 17353983478346836848;
                         }
-                        37 => {/* expr: expr '%' expr  */
+                        37 => {
+                            /* expr: expr '%' expr  */
                             if (lParse.Nodes[(*yyvsp.offset(-2)).Node as usize]).ntype
                                 > (lParse.Nodes[(*yyvsp.offset(0)).Node as usize]).ntype
                             {
@@ -1961,7 +1985,8 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        38 => { /* expr: expr '+' expr  */
+                        38 => {
+                            /* expr: expr '+' expr  */
                             if (lParse.Nodes[(*yyvsp.offset(-2)).Node as usize]).ntype
                                 > (lParse.Nodes[(*yyvsp.offset(0)).Node as usize]).ntype
                             {
@@ -1994,7 +2019,8 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        39 => {/* expr: expr '-' expr  */
+                        39 => {
+                            /* expr: expr '-' expr  */
                             if (lParse.Nodes[(*yyvsp.offset(-2)).Node as usize]).ntype
                                 > (lParse.Nodes[(*yyvsp.offset(0)).Node as usize]).ntype
                             {
@@ -2027,7 +2053,8 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        40 => {/* expr: expr '*' expr  */
+                        40 => {
+                            /* expr: expr '*' expr  */
                             if (lParse.Nodes[(*yyvsp.offset(-2)).Node as usize]).ntype
                                 > (lParse.Nodes[(*yyvsp.offset(0)).Node as usize]).ntype
                             {
@@ -2060,7 +2087,8 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        41 => {/* expr: expr '/' expr  */
+                        41 => {
+                            /* expr: expr '/' expr  */
                             if (lParse.Nodes[(*yyvsp.offset(-2)).Node as usize]).ntype
                                 > (lParse.Nodes[(*yyvsp.offset(0)).Node as usize]).ntype
                             {
@@ -2093,7 +2121,8 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        42 => { /* expr: expr '&' expr  */
+                        42 => {
+                            /* expr: expr '&' expr  */
                             if (lParse.Nodes[(*yyvsp.offset(-2)).Node as usize]).ntype
                                 != fits_parser_yytokentype::LONG as c_int
                                 || (lParse.Nodes[(*yyvsp.offset(0)).Node as usize]).ntype
@@ -2115,7 +2144,8 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        43 => {/* expr: expr '|' expr  */
+                        43 => {
+                            /* expr: expr '|' expr  */
                             if (lParse.Nodes[(*yyvsp.offset(-2)).Node as usize]).ntype
                                 != fits_parser_yytokentype::LONG as c_int
                                 || (lParse.Nodes[(*yyvsp.offset(0)).Node as usize]).ntype
@@ -2137,7 +2167,8 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        44 => {/* expr: expr XOR expr  */
+                        44 => {
+                            /* expr: expr XOR expr  */
                             if (lParse.Nodes[(*yyvsp.offset(-2)).Node as usize]).ntype
                                 != fits_parser_yytokentype::LONG as c_int
                                 || (lParse.Nodes[(*yyvsp.offset(0)).Node as usize]).ntype
@@ -2159,7 +2190,8 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        45 => { /* expr: expr POWER expr  */
+                        45 => {
+                            /* expr: expr POWER expr  */
                             if (lParse.Nodes[(*yyvsp.offset(-2)).Node as usize]).ntype
                                 > (lParse.Nodes[(*yyvsp.offset(0)).Node as usize]).ntype
                             {
@@ -2192,11 +2224,13 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        46 => {/* expr: '+' expr  */
+                        46 => {
+                            /* expr: '+' expr  */
                             yyval.Node = (*yyvsp.offset(0)).Node;
                             current_block = 17353983478346836848;
                         }
-                        47 => {/* expr: '-' expr  */
+                        47 => {
+                            /* expr: '-' expr  */
                             yyval.Node = New_Unary(
                                 lParse,
                                 (lParse.Nodes[(*yyvsp.offset(0)).Node as usize]).ntype,
@@ -2209,11 +2243,13 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        48 => {/* expr: '(' expr ')'  */
+                        48 => {
+                            /* expr: '(' expr ')'  */
                             yyval.Node = (*yyvsp.offset(-1)).Node;
                             current_block = 17353983478346836848;
                         }
-                        49 => { /* expr: expr '*' bexpr  */
+                        49 => {
+                            /* expr: expr '*' bexpr  */
                             (*yyvsp.offset(0)).Node = New_Unary(
                                 lParse,
                                 (lParse.Nodes[(*yyvsp.offset(-2)).Node as usize]).ntype,
@@ -2233,7 +2269,8 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        50 => {/* expr: bexpr '*' expr  */
+                        50 => {
+                            /* expr: bexpr '*' expr  */
                             (*yyvsp.offset(-2)).Node = New_Unary(
                                 lParse,
                                 (lParse.Nodes[(*yyvsp.offset(0)).Node as usize]).ntype,
@@ -2253,7 +2290,8 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        51 => {/* expr: bexpr '?' expr ':' expr  */
+                        51 => {
+                            /* expr: bexpr '?' expr ':' expr  */
                             if (lParse.Nodes[(*yyvsp.offset(-2)).Node as usize]).ntype
                                 > (lParse.Nodes[(*yyvsp.offset(0)).Node as usize]).ntype
                             {
@@ -2331,7 +2369,8 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 }
                             }
                         }
-                        52 => {/* expr: bexpr '?' bexpr ':' expr  */
+                        52 => {
+                            /* expr: bexpr '?' bexpr ':' expr  */
                             if (lParse.Nodes[(*yyvsp.offset(-2)).Node as usize]).ntype
                                 > (lParse.Nodes[(*yyvsp.offset(0)).Node as usize]).ntype
                             {
@@ -2409,7 +2448,8 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 }
                             }
                         }
-                        53 => { /* expr: bexpr '?' expr ':' bexpr  */
+                        53 => {
+                            /* expr: bexpr '?' expr ':' bexpr  */
                             if (lParse.Nodes[(*yyvsp.offset(-2)).Node as usize]).ntype
                                 > (lParse.Nodes[(*yyvsp.offset(0)).Node as usize]).ntype
                             {
@@ -2487,7 +2527,8 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 }
                             }
                         }
-                        54 => { /* expr: FUNCTION ')'  */
+                        54 => {
+                            /* expr: FUNCTION ')'  */
                             if (if ((*yyvsp.offset(-1)).astr[0] as c_int)
                                 < (*::core::mem::transmute::<&[u8; 8], &[c_char; 8]>(b"RANDOM(\0"))
                                     [0] as c_int
@@ -2565,7 +2606,8 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 }
                             }
                         }
-                        55 => {/* expr: FUNCTION bexpr ')'  */
+                        55 => {
+                            /* expr: FUNCTION bexpr ')'  */
                             if (if ((*yyvsp.offset(-2)).astr[0] as c_int)
                                 < (*::core::mem::transmute::<&[u8; 5], &[c_char; 5]>(b"SUM(\0"))[0]
                                     as c_int
@@ -2672,7 +2714,8 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 }
                             }
                         }
-                        56 => {/* expr: FUNCTION bexpr ',' expr ')'  */
+                        56 => {
+                            /* expr: FUNCTION bexpr ',' expr ')'  */
                             if (if ((*yyvsp.offset(-4)).astr[0] as c_int)
                                 < (*::core::mem::transmute::<&[u8; 10], &[c_char; 10]>(
                                     b"AXISELEM(\0",
@@ -2876,7 +2919,8 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 }
                             }
                         }
-                        57 => {/* expr: FUNCTION sexpr ')'  */
+                        57 => {
+                            /* expr: FUNCTION sexpr ')'  */
                             if (if ((*yyvsp.offset(-2)).astr[0] as c_int)
                                 < (*::core::mem::transmute::<&[u8; 7], &[c_char; 7]>(b"NELEM(\0"))
                                     [0] as c_int
@@ -2950,7 +2994,8 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 }
                             }
                         }
-                        58 => { /* expr: FUNCTION bits ')'  */
+                        58 => {
+                            /* expr: FUNCTION bits ')'  */
                             if (if ((*yyvsp.offset(-2)).astr[0] as c_int)
                                 < (*::core::mem::transmute::<&[u8; 7], &[c_char; 7]>(b"NELEM(\0"))
                                     [0] as c_int
@@ -3148,7 +3193,8 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 }
                             }
                         }
-                        59 => {/* expr: FUNCTION expr ')'  */
+                        59 => {
+                            /* expr: FUNCTION expr ')'  */
                             if (if ((*yyvsp.offset(-2)).astr[0] as c_int)
                                 < (*::core::mem::transmute::<&[u8; 5], &[c_char; 5]>(b"SUM(\0"))[0]
                                     as c_int
@@ -4376,7 +4422,8 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 }
                             }
                         }
-                        60 => {/* expr: IFUNCTION sexpr ',' sexpr ')'  */
+                        60 => {
+                            /* expr: IFUNCTION sexpr ',' sexpr ')'  */
                             if (if ((*yyvsp.offset(-4)).astr[0] as c_int)
                                 < (*::core::mem::transmute::<&[u8; 8], &[c_char; 8]>(b"STRSTR(\0"))
                                     [0] as c_int
@@ -4422,7 +4469,8 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 }
                             }
                         }
-                        61 => {/* expr: FUNCTION expr ',' expr ')'  */
+                        61 => {
+                            /* expr: FUNCTION expr ',' expr ')'  */
                             if (if ((*yyvsp.offset(-4)).astr[0] as c_int)
                                 < (*::core::mem::transmute::<&[u8; 9], &[c_char; 9]>(b"DEFNULL(\0"))
                                     [0] as c_int
@@ -4984,7 +5032,8 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 }
                             }
                         }
-                        62 => {/* expr: FUNCTION expr ',' expr ',' expr ',' expr ')'  */
+                        62 => {
+                            /* expr: FUNCTION expr ',' expr ',' expr ',' expr ')'  */
                             if (if ((*yyvsp.offset(-8)).astr[0] as c_int)
                                 < (*::core::mem::transmute::<&[u8; 8], &[c_char; 8]>(b"ANGSEP(\0"))
                                     [0] as c_int
@@ -5122,7 +5171,8 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 4830776507462815627;
                             }
                         }
-                        63 => {/* expr: GTIOVERLAP STRING ',' expr ',' expr ')'  */
+                        63 => {
+                            /* expr: GTIOVERLAP STRING ',' expr ',' expr ')'  */
                             yyval.Node = New_GTI(
                                 lParse,
                                 gtiover_fct,
@@ -5138,7 +5188,8 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        64 => {/* expr: GTIOVERLAP STRING ',' expr ',' expr ',' STRING ',' STRING ')'  */
+                        64 => {
+                            /* expr: GTIOVERLAP STRING ',' expr ',' expr ',' STRING ',' STRING ')'  */
                             yyval.Node = New_GTI(
                                 lParse,
                                 gtiover_fct,
@@ -5154,7 +5205,8 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        65 => {/* expr: expr '[' expr ']'  */
+                        65 => {
+                            /* expr: expr '[' expr ']'  */
                             yyval.Node = New_Deref(
                                 lParse,
                                 (*yyvsp.offset(-3)).Node,
@@ -5171,7 +5223,8 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        66 => {/* expr: expr '[' expr ',' expr ']'  */
+                        66 => {
+                            /* expr: expr '[' expr ',' expr ']'  */
                             yyval.Node = New_Deref(
                                 lParse,
                                 (*yyvsp.offset(-(5))).Node,
@@ -5188,7 +5241,8 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        67 => {/* expr: expr '[' expr ',' expr ',' expr ']'  */
+                        67 => {
+                            /* expr: expr '[' expr ',' expr ',' expr ']'  */
                             yyval.Node = New_Deref(
                                 lParse,
                                 (*yyvsp.offset(-7)).Node,
@@ -5205,7 +5259,8 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        68 => {/* expr: expr '[' expr ',' expr ',' expr ',' expr ']'  */
+                        68 => {
+                            /* expr: expr '[' expr ',' expr ',' expr ',' expr ']'  */
                             yyval.Node = New_Deref(
                                 lParse,
                                 (*yyvsp.offset(-9)).Node,
@@ -5222,7 +5277,8 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        69 => {/* expr: expr '[' expr ',' expr ',' expr ',' expr ',' expr ']'  */
+                        69 => {
+                            /* expr: expr '[' expr ',' expr ',' expr ',' expr ',' expr ']'  */
                             yyval.Node = New_Deref(
                                 lParse,
                                 (*yyvsp.offset(-11)).Node,
@@ -5239,7 +5295,8 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        70 => {/* expr: INTCAST expr  */
+                        70 => {
+                            /* expr: INTCAST expr  */
                             yyval.Node = New_Unary(
                                 lParse,
                                 fits_parser_yytokentype::LONG as c_int,
@@ -5252,7 +5309,8 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        71 => {/* expr: INTCAST bexpr  */
+                        71 => {
+                            /* expr: INTCAST bexpr  */
                             yyval.Node = New_Unary(
                                 lParse,
                                 fits_parser_yytokentype::LONG as c_int,
@@ -5265,7 +5323,8 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        72 => { /* expr: FLTCAST expr  */
+                        72 => {
+                            /* expr: FLTCAST expr  */
                             yyval.Node = New_Unary(
                                 lParse,
                                 fits_parser_yytokentype::DOUBLE as c_int,
@@ -5278,7 +5337,8 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        73 => {/* expr: FLTCAST bexpr  */
+                        73 => {
+                            /* expr: FLTCAST bexpr  */
                             yyval.Node = New_Unary(
                                 lParse,
                                 fits_parser_yytokentype::DOUBLE as c_int,
@@ -5291,7 +5351,8 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        74 => {/* bexpr: BOOLEAN  */
+                        74 => {
+                            /* bexpr: BOOLEAN  */
                             yyval.Node = New_Const(
                                 lParse,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
@@ -5304,7 +5365,8 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        75 => {/* bexpr: BCOLUMN  */
+                        75 => {
+                            /* bexpr: BCOLUMN  */
                             yyval.Node = New_Column(lParse, (*yyvsp.offset(0)).lng as c_int);
                             if yyval.Node < 0 {
                                 current_block = 4830776507462815627;
@@ -5312,7 +5374,8 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        76 => {/* bexpr: BCOLUMN '{' expr '}'  */
+                        76 => {
+                            /* bexpr: BCOLUMN '{' expr '}'  */
                             if ((lParse.Nodes)[(*yyvsp.offset(-1)).Node as usize]).ntype
                                 != fits_parser_yytokentype::LONG as c_int
                                 || ((lParse.Nodes)[(*yyvsp.offset(-1)).Node as usize]).operation
@@ -5336,7 +5399,8 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 }
                             }
                         }
-                        77 => {/* bexpr: bits EQ bits  */
+                        77 => {
+                            /* bexpr: bits EQ bits  */
                             yyval.Node = New_BinOp(
                                 lParse,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
@@ -5351,7 +5415,8 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        78 => { /* bexpr: bits NE bits  */
+                        78 => {
+                            /* bexpr: bits NE bits  */
                             yyval.Node = New_BinOp(
                                 lParse,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
@@ -5366,7 +5431,8 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        79 => {/* bexpr: bits LT bits  */
+                        79 => {
+                            /* bexpr: bits LT bits  */
                             yyval.Node = New_BinOp(
                                 lParse,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
@@ -5381,7 +5447,8 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        80 => { /* bexpr: bits LTE bits  */
+                        80 => {
+                            /* bexpr: bits LTE bits  */
                             yyval.Node = New_BinOp(
                                 lParse,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
@@ -5396,7 +5463,8 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        81 => {/* bexpr: bits GT bits  */
+                        81 => {
+                            /* bexpr: bits GT bits  */
                             yyval.Node = New_BinOp(
                                 lParse,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
@@ -5411,7 +5479,8 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        82 => {/* bexpr: bits GTE bits  */
+                        82 => {
+                            /* bexpr: bits GTE bits  */
                             yyval.Node = New_BinOp(
                                 lParse,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
@@ -5426,7 +5495,8 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        83 => {/* bexpr: expr GT expr  */
+                        83 => {
+                            /* bexpr: expr GT expr  */
                             if (lParse.Nodes[(*yyvsp.offset(-2)).Node as usize]).ntype
                                 > (lParse.Nodes[(*yyvsp.offset(0)).Node as usize]).ntype
                             {
@@ -5459,7 +5529,8 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        84 => { /* bexpr: expr LT expr  */
+                        84 => {
+                            /* bexpr: expr LT expr  */
                             if (lParse.Nodes[(*yyvsp.offset(-2)).Node as usize]).ntype
                                 > (lParse.Nodes[(*yyvsp.offset(0)).Node as usize]).ntype
                             {
@@ -5492,7 +5563,8 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        85 => {/* bexpr: expr GTE expr  */
+                        85 => {
+                            /* bexpr: expr GTE expr  */
                             if (lParse.Nodes[(*yyvsp.offset(-2)).Node as usize]).ntype
                                 > (lParse.Nodes[(*yyvsp.offset(0)).Node as usize]).ntype
                             {
@@ -5525,7 +5597,8 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        86 => {/* bexpr: expr LTE expr  */
+                        86 => {
+                            /* bexpr: expr LTE expr  */
                             if (lParse.Nodes[(*yyvsp.offset(-2)).Node as usize]).ntype
                                 > (lParse.Nodes[(*yyvsp.offset(0)).Node as usize]).ntype
                             {
@@ -5558,7 +5631,8 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        87 => {/* bexpr: expr '~' expr  */
+                        87 => {
+                            /* bexpr: expr '~' expr  */
                             if (lParse.Nodes[(*yyvsp.offset(-2)).Node as usize]).ntype
                                 > (lParse.Nodes[(*yyvsp.offset(0)).Node as usize]).ntype
                             {
@@ -5591,7 +5665,8 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        88 => { /* bexpr: expr EQ expr  */
+                        88 => {
+                            /* bexpr: expr EQ expr  */
                             if (lParse.Nodes[(*yyvsp.offset(-2)).Node as usize]).ntype
                                 > (lParse.Nodes[(*yyvsp.offset(0)).Node as usize]).ntype
                             {
@@ -5624,7 +5699,8 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        89 => { /* bexpr: expr NE expr  */
+                        89 => {
+                            /* bexpr: expr NE expr  */
                             if (lParse.Nodes[(*yyvsp.offset(-2)).Node as usize]).ntype
                                 > (lParse.Nodes[(*yyvsp.offset(0)).Node as usize]).ntype
                             {
@@ -5657,7 +5733,8 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        90 => {/* bexpr: sexpr EQ sexpr  */
+                        90 => {
+                            /* bexpr: sexpr EQ sexpr  */
                             yyval.Node = New_BinOp(
                                 lParse,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
@@ -5672,7 +5749,8 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        91 => {/* bexpr: sexpr NE sexpr  */
+                        91 => {
+                            /* bexpr: sexpr NE sexpr  */
                             yyval.Node = New_BinOp(
                                 lParse,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
@@ -5687,7 +5765,8 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        92 => {/* bexpr: sexpr GT sexpr  */
+                        92 => {
+                            /* bexpr: sexpr GT sexpr  */
                             yyval.Node = New_BinOp(
                                 lParse,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
@@ -5702,7 +5781,8 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        93 => {/* bexpr: sexpr GTE sexpr  */
+                        93 => {
+                            /* bexpr: sexpr GTE sexpr  */
                             yyval.Node = New_BinOp(
                                 lParse,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
@@ -5717,7 +5797,8 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        94 => {/* bexpr: sexpr LT sexpr  */
+                        94 => {
+                            /* bexpr: sexpr LT sexpr  */
                             yyval.Node = New_BinOp(
                                 lParse,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
@@ -5732,7 +5813,8 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        95 => {/* bexpr: sexpr LTE sexpr  */
+                        95 => {
+                            /* bexpr: sexpr LTE sexpr  */
                             yyval.Node = New_BinOp(
                                 lParse,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
@@ -5747,7 +5829,8 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        96 => { /* bexpr: bexpr AND bexpr  */
+                        96 => {
+                            /* bexpr: bexpr AND bexpr  */
                             yyval.Node = New_BinOp(
                                 lParse,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
@@ -5761,7 +5844,8 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        97 => {/* bexpr: bexpr OR bexpr  */
+                        97 => {
+                            /* bexpr: bexpr OR bexpr  */
                             yyval.Node = New_BinOp(
                                 lParse,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
@@ -5775,7 +5859,8 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        98 => {/* bexpr: bexpr EQ bexpr  */
+                        98 => {
+                            /* bexpr: bexpr EQ bexpr  */
                             yyval.Node = New_BinOp(
                                 lParse,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
@@ -5789,7 +5874,8 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        99 => {/* bexpr: bexpr NE bexpr  */
+                        99 => {
+                            /* bexpr: bexpr NE bexpr  */
                             yyval.Node = New_BinOp(
                                 lParse,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
@@ -5803,7 +5889,8 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        100 => {/* bexpr: expr '=' expr ':' expr  */
+                        100 => {
+                            /* bexpr: expr '=' expr ':' expr  */
                             if ((lParse.Nodes)[(*yyvsp.offset(-4)).Node as usize]).ntype
                                 > (lParse.Nodes[(*yyvsp.offset(-2)).Node as usize]).ntype
                             {
@@ -5888,7 +5975,8 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        101 => { /* bexpr: bexpr '?' bexpr ':' bexpr  */
+                        101 => {
+                            /* bexpr: bexpr '?' bexpr ':' bexpr  */
                             if Test_Dims(lParse, (*yyvsp.offset(-2)).Node, (*yyvsp.offset(0)).Node)
                                 == 0
                             {
@@ -5943,7 +6031,8 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 }
                             }
                         }
-                        102 => {/* bexpr: BFUNCTION expr ')'  */
+                        102 => {
+                            /* bexpr: BFUNCTION expr ')'  */
                             if (if ((*yyvsp.offset(-2)).astr[0] as c_int)
                                 < (*::core::mem::transmute::<&[u8; 8], &[c_char; 8]>(b"ISNULL(\0"))
                                     [0] as c_int
@@ -5989,7 +6078,8 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 4830776507462815627;
                             }
                         }
-                        103 => {/* bexpr: BFUNCTION bexpr ')'  */
+                        103 => {
+                            /* bexpr: BFUNCTION bexpr ')'  */
                             if (if ((*yyvsp.offset(-2)).astr[0] as c_int)
                                 < (*::core::mem::transmute::<&[u8; 8], &[c_char; 8]>(b"ISNULL(\0"))
                                     [0] as c_int
@@ -6035,7 +6125,8 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 4830776507462815627;
                             }
                         }
-                        104 => { /* bexpr: BFUNCTION sexpr ')'  */
+                        104 => {
+                            /* bexpr: BFUNCTION sexpr ')'  */
                             if (if ((*yyvsp.offset(-2)).astr[0] as c_int)
                                 < (*::core::mem::transmute::<&[u8; 8], &[c_char; 8]>(b"ISNULL(\0"))
                                     [0] as c_int
@@ -6079,7 +6170,8 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 4830776507462815627;
                             }
                         }
-                        105 => {/* bexpr: FUNCTION bexpr ',' bexpr ')'  */
+                        105 => {
+                            /* bexpr: FUNCTION bexpr ',' bexpr ')'  */
                             if (if ((*yyvsp.offset(-4)).astr[0] as c_int)
                                 < (*::core::mem::transmute::<&[u8; 9], &[c_char; 9]>(b"DEFNULL(\0"))
                                     [0] as c_int
@@ -6142,7 +6234,8 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 4830776507462815627;
                             }
                         }
-                        106 => { /* bexpr: BFUNCTION expr ',' expr ',' expr ')'  */
+                        106 => {
+                            /* bexpr: BFUNCTION expr ',' expr ',' expr ')'  */
                             if ((lParse.Nodes)[(*yyvsp.offset(-(5))).Node as usize]).ntype
                                 != fits_parser_yytokentype::DOUBLE as c_int
                             {
@@ -6254,7 +6347,8 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 4830776507462815627;
                             }
                         }
-                        107 => {/* bexpr: BFUNCTION expr ',' expr ',' expr ',' expr ',' expr ')'  */
+                        107 => {
+                            /* bexpr: BFUNCTION expr ',' expr ',' expr ',' expr ',' expr ')'  */
                             if ((lParse.Nodes)[(*yyvsp.offset(-9)).Node as usize]).ntype
                                 != fits_parser_yytokentype::DOUBLE as c_int
                             {
@@ -6414,7 +6508,8 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 4830776507462815627;
                             }
                         }
-                        108 => { /* bexpr: BFUNCTION expr ',' expr ',' expr ',' expr ',' expr ',' expr ',' expr ')'  */
+                        108 => {
+                            /* bexpr: BFUNCTION expr ',' expr ',' expr ',' expr ',' expr ',' expr ',' expr ')'  */
                             if ((lParse.Nodes)[(*yyvsp.offset(-13)).Node as usize]).ntype
                                 != fits_parser_yytokentype::DOUBLE as c_int
                             {
@@ -6701,7 +6796,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 }
                             }
                         }
-                        109 => {/* bexpr: GTIFILTER ')'  */  /* Use defaults for all elements */
+                        109 => {
+                            /* bexpr: GTIFILTER ')'  */
+                            /* Use defaults for all elements */
                             yyval.Node = New_GTI(
                                 lParse,
                                 gtifilt_fct,
@@ -6717,7 +6814,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        110 => {/* bexpr: GTIFILTER STRING ')'  */  /* Use defaults for all except filename */
+                        110 => {
+                            /* bexpr: GTIFILTER STRING ')'  */
+                            /* Use defaults for all except filename */
                             yyval.Node = New_GTI(
                                 lParse,
                                 gtifilt_fct,
@@ -6733,7 +6832,8 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        111 => {/* bexpr: GTIFILTER STRING ',' expr ')'  */
+                        111 => {
+                            /* bexpr: GTIFILTER STRING ',' expr ')'  */
                             yyval.Node = New_GTI(
                                 lParse,
                                 gtifilt_fct,
@@ -6749,7 +6849,8 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        112 => {/* bexpr: GTIFILTER STRING ',' expr ',' STRING ',' STRING ')'  */
+                        112 => {
+                            /* bexpr: GTIFILTER STRING ',' expr ',' STRING ',' STRING ')'  */
                             yyval.Node = New_GTI(
                                 lParse,
                                 gtifilt_fct,
@@ -6765,7 +6866,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        113 => {/* bexpr: GTIFIND ')'  */ /* Use defaults for all elements */
+                        113 => {
+                            /* bexpr: GTIFIND ')'  */
+                            /* Use defaults for all elements */
                             yyval.Node = New_GTI(
                                 lParse,
                                 gtifind_fct,
@@ -6781,7 +6884,8 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        114 => { /* bexpr: GTIFIND STRING ')'  *//* Use defaults for all except filename */
+                        114 => {
+                            /* bexpr: GTIFIND STRING ')'  *//* Use defaults for all except filename */
                             yyval.Node = New_GTI(
                                 lParse,
                                 gtifind_fct,
@@ -6797,7 +6901,8 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        115 => {/* bexpr: GTIFIND STRING ',' expr ')'  */
+                        115 => {
+                            /* bexpr: GTIFIND STRING ',' expr ')'  */
                             yyval.Node = New_GTI(
                                 lParse,
                                 gtifind_fct,
@@ -6813,7 +6918,8 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        116 => {/* bexpr: GTIFIND STRING ',' expr ',' STRING ',' STRING ')'  */
+                        116 => {
+                            /* bexpr: GTIFIND STRING ',' expr ',' STRING ',' STRING ')'  */
                             yyval.Node = New_GTI(
                                 lParse,
                                 gtifind_fct,
@@ -6829,7 +6935,8 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        117 => {/* bexpr: REGFILTER STRING ')'  *//* Use defaults for all except filename */
+                        117 => {
+                            /* bexpr: REGFILTER STRING ')'  *//* Use defaults for all except filename */
                             let mut dummy = [0];
                             yyval.Node = New_REG(
                                 lParse,
@@ -6844,7 +6951,8 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        118 => {/* bexpr: REGFILTER STRING ',' expr ',' expr ')'  */
+                        118 => {
+                            /* bexpr: REGFILTER STRING ',' expr ',' expr ')'  */
                             let mut dummy = [0];
                             yyval.Node = New_REG(
                                 lParse,
@@ -6859,7 +6967,8 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        119 => {/* bexpr: REGFILTER STRING ',' expr ',' expr ',' STRING ')'  */
+                        119 => {
+                            /* bexpr: REGFILTER STRING ',' expr ',' expr ',' STRING ')'  */
                             yyval.Node = New_REG(
                                 lParse,
                                 ((*yyvsp.offset(-7)).astr).as_mut_ptr(),
@@ -6873,7 +6982,8 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        120 => {/* bexpr: bexpr '[' expr ']'  */
+                        120 => {
+                            /* bexpr: bexpr '[' expr ']'  */
                             yyval.Node = New_Deref(
                                 lParse,
                                 (*yyvsp.offset(-3)).Node,
@@ -6890,7 +7000,8 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        121 => { /* bexpr: bexpr '[' expr ',' expr ']'  */
+                        121 => {
+                            /* bexpr: bexpr '[' expr ',' expr ']'  */
                             yyval.Node = New_Deref(
                                 lParse,
                                 (*yyvsp.offset(-(5))).Node,
@@ -6907,7 +7018,8 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        122 => {/* bexpr: bexpr '[' expr ',' expr ',' expr ']'  */
+                        122 => {
+                            /* bexpr: bexpr '[' expr ',' expr ',' expr ']'  */
                             yyval.Node = New_Deref(
                                 lParse,
                                 (*yyvsp.offset(-7)).Node,
@@ -6924,7 +7036,8 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        123 => {/* bexpr: bexpr '[' expr ',' expr ',' expr ',' expr ']'  */
+                        123 => {
+                            /* bexpr: bexpr '[' expr ',' expr ',' expr ',' expr ']'  */
                             yyval.Node = New_Deref(
                                 lParse,
                                 (*yyvsp.offset(-9)).Node,
@@ -6941,7 +7054,8 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        124 => {/* bexpr: bexpr '[' expr ',' expr ',' expr ',' expr ',' expr ']'  */
+                        124 => {
+                            /* bexpr: bexpr '[' expr ',' expr ',' expr ',' expr ',' expr ']'  */
                             yyval.Node = New_Deref(
                                 lParse,
                                 (*yyvsp.offset(-11)).Node,
@@ -6958,7 +7072,8 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        125 => { /* bexpr: NOT bexpr  */
+                        125 => {
+                            /* bexpr: NOT bexpr  */
                             yyval.Node = New_Unary(
                                 lParse,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
@@ -6971,11 +7086,13 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        126 => {/* bexpr: '(' bexpr ')'  */
+                        126 => {
+                            /* bexpr: '(' bexpr ')'  */
                             yyval.Node = (*yyvsp.offset(-1)).Node;
                             current_block = 17353983478346836848;
                         }
-                        127 => {/* sexpr: STRING  */
+                        127 => {
+                            /* sexpr: STRING  */
                             yyval.Node = New_Const(
                                 lParse,
                                 fits_parser_yytokentype::STRING as c_int,
@@ -6992,7 +7109,8 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        128 => {/* sexpr: SCOLUMN  */
+                        128 => {
+                            /* sexpr: SCOLUMN  */
                             yyval.Node = New_Column(lParse, (*yyvsp.offset(0)).lng as c_int);
                             if yyval.Node < 0 {
                                 current_block = 4830776507462815627;
@@ -7000,7 +7118,8 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        129 => {/* sexpr: SCOLUMN '{' expr '}'  */
+                        129 => {
+                            /* sexpr: SCOLUMN '{' expr '}'  */
                             if ((lParse.Nodes)[(*yyvsp.offset(-1)).Node as usize]).ntype
                                 != fits_parser_yytokentype::LONG as c_int
                                 || ((lParse.Nodes)[(*yyvsp.offset(-1)).Node as usize]).operation
@@ -7024,7 +7143,8 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 }
                             }
                         }
-                        130 => { /* sexpr: SNULLREF  */
+                        130 => {
+                            /* sexpr: SNULLREF  */
                             yyval.Node = New_Func(
                                 lParse,
                                 fits_parser_yytokentype::STRING as c_int,
@@ -7040,11 +7160,13 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             );
                             current_block = 17353983478346836848;
                         }
-                        131 => { /* sexpr: '(' sexpr ')'  */
+                        131 => {
+                            /* sexpr: '(' sexpr ')'  */
                             yyval.Node = (*yyvsp.offset(-1)).Node;
                             current_block = 17353983478346836848;
                         }
-                        132 => {/* sexpr: sexpr '+' sexpr  */
+                        132 => {
+                            /* sexpr: sexpr '+' sexpr  */
                             if (lParse.Nodes[(*yyvsp.offset(-2)).Node as usize])
                                 .value
                                 .nelem
@@ -7078,7 +7200,8 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 }
                             }
                         }
-                        133 => { /* sexpr: bexpr '?' sexpr ':' sexpr  */
+                        133 => {
+                            /* sexpr: bexpr '?' sexpr ':' sexpr  */
                             let mut outSize: c_int = 0;
                             if ((lParse.Nodes)[(*yyvsp.offset(-4)).Node as usize])
                                 .value
@@ -7091,9 +7214,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 );
                                 current_block = 4830776507462815627; // goto yyerrorlab
                             } else {
-                                 /* Since the output can be calculated now, as a constant
-                                    scalar, we must precalculate the output size, in
-                                    order to avoid an overflow. */
+                                /* Since the output can be calculated now, as a constant
+                                scalar, we must precalculate the output size, in
+                                order to avoid an overflow. */
 
                                 outSize = (((lParse.Nodes)[(*yyvsp.offset(-2)).Node as usize])
                                     .value)
@@ -7136,7 +7259,8 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 }
                             }
                         }
-                        134 => { /* sexpr: FUNCTION sexpr ',' sexpr ')'  */
+                        134 => {
+                            /* sexpr: FUNCTION sexpr ',' sexpr ')'  */
                             if (if ((*yyvsp.offset(-4)).astr[0] as c_int)
                                 < (*::core::mem::transmute::<&[u8; 9], &[c_char; 9]>(b"DEFNULL(\0"))
                                     [0] as c_int
@@ -7154,7 +7278,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 )
                             }) == 0
                             {
-                                 /* Since the output can be calculated now, as a constant
+                                /* Since the output can be calculated now, as a constant
                                 scalar, we must precalculate the output size, in
                                 order to avoid an overflow. */
 
@@ -7211,7 +7335,8 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 4830776507462815627;
                             }
                         }
-                        135 => {/* sexpr: FUNCTION sexpr ',' expr ',' expr ')'  */
+                        135 => {
+                            /* sexpr: FUNCTION sexpr ',' expr ',' expr ')'  */
                             if (if ((*yyvsp.offset(-6)).astr[0] as c_int)
                                 < (*::core::mem::transmute::<&[u8; 8], &[c_char; 8]>(b"STRMID(\0"))
                                     [0] as c_int
@@ -7260,7 +7385,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                             .lng
                                             as c_int;
                                     } else {
-                                          /* Variable value: use the maximum possible (from $2) */
+                                        /* Variable value: use the maximum possible (from $2) */
                                         len = ((lParse.Nodes)[(*yyvsp.offset(-(5))).Node as usize])
                                             .value
                                             .nelem
@@ -7319,8 +7444,13 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                     to an incorrect destructor call or verbose syntax error message
                     before the lookahead is translated.  */
 
-
-                        YY_SYMBOL_PRINT!("-> $$ =", YYR1[yyn as usize] as yysymbol_kind_t, &yyval,  scanner, lParse);
+                    YY_SYMBOL_PRINT!(
+                        "-> $$ =",
+                        YYR1[yyn as usize] as yysymbol_kind_t,
+                        &yyval,
+                        scanner,
+                        lParse
+                    );
 
                     match current_block {
                         4830776507462815627 => {
@@ -7399,7 +7529,6 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                 yyssp = yyssp.offset(1);
                 /* In all cases, when you get here, the value and location stacks
                 have just been pushed.  So pushing a state here evens the stacks.  */
-
             }
         }
         match current_block {

--- a/src/eval_y.rs
+++ b/src/eval_y.rs
@@ -2,8 +2,8 @@ use std::ffi::CStr;
 use std::rc::Rc;
 use std::{cmp, ptr};
 
-use bytemuck::cast_slice;
-use libc::{calloc, free, malloc, memcpy, sprintf, time, time_t};
+use bytemuck::{cast_slice, cast_slice_mut};
+use libc::{calloc, free, malloc, memcpy, time, time_t};
 
 // Math function wrappers
 fn sqrt(x: f64) -> f64 {
@@ -80,7 +80,7 @@ use crate::simplerng::{
 use crate::wcssub::ffgtcs_safer;
 use crate::wrappers::strncpy_safe;
 use crate::wrappers::{strcat, strcmp, strcpy, strlen, strstr};
-use crate::{atoi, cs};
+use crate::{atoi, cs, int_snprintf};
 
 pub type yy_state_t = yytype_int16;
 pub type yytype_int16 = c_short;
@@ -8065,10 +8065,10 @@ fn New_GTI(
                     && Op as c_uint == gtiover_fct as c_int as c_uint
                 {
                     let mut errmsg: [c_char; 120] = [0; 120];
-                    sprintf(
-                        errmsg.as_mut_ptr(),
-                        b"Input GTI must be time-ordered for GTIOVERLAP (row %ld)\0" as *const u8
-                            as *const c_char,
+                    int_snprintf!(
+                        &mut errmsg,
+                        120,
+                        "Input GTI must be time-ordered for GTIOVERLAP (row {})",
                         i + 1,
                     );
                     fits_parser_yyerror(lParse, &errmsg);

--- a/src/eval_y.rs
+++ b/src/eval_y.rs
@@ -494,18 +494,26 @@ static YYR2: [yytype_int8; 136] = [
 fn Alloc_Node(lParse: &mut ParseData) -> c_int {
     // If number of nodes == number allocated, then realloc
     if lParse.nNodes == lParse.nNodesAlloc {
-        if lParse
-            .Nodes
-            .try_reserve_exact(lParse.nNodesAlloc as usize)
-            .is_err()
-        {
-            lParse.status = MEMORY_ALLOCATION;
-            return -(1);
-        } else {
-            lParse.nNodesAlloc *= 2;
+        if lParse.nNodesAlloc == 0 {
+            lParse.nNodesAlloc = 100;
+            lParse.Nodes = Vec::with_capacity(lParse.nNodesAlloc as usize);
             lParse
                 .Nodes
                 .resize(lParse.nNodesAlloc as usize, Node::default());
+        } else {
+            if lParse
+                .Nodes
+                .try_reserve_exact(lParse.nNodesAlloc as usize)
+                .is_err()
+            {
+                lParse.status = MEMORY_ALLOCATION;
+                return -(1);
+            } else {
+                lParse.nNodesAlloc *= 2;
+                lParse
+                    .Nodes
+                    .resize(lParse.nNodesAlloc as usize, Node::default());
+            }
         }
     }
 

--- a/src/eval_y.rs
+++ b/src/eval_y.rs
@@ -1,3 +1,5 @@
+#![deny(dead_code)]
+
 use std::ffi::CStr;
 use std::rc::Rc;
 use std::{cmp, ptr};
@@ -65,7 +67,7 @@ use crate::c_types::{
     c_char, c_double, c_int, c_long, c_schar, c_short, c_uchar, c_uint, c_ulong, c_void,
 };
 use crate::cfileio::{ffclos_safer, ffexts_safer, ffopen_safer};
-use crate::eval_defs::{Node, ParseData, data_union, lval, yyscan_t};
+use crate::eval_defs::{CONST_OP, MAXDIMS, Node, ParseData, data_union, lval, yyscan_t};
 use crate::eval_l::{fits_parser_yyGetVariable, fits_parser_yylex, yyguts_t};
 use crate::eval_tab::{FITS_PARSER_YYSTYPE, fits_parser_yytokentype};
 use crate::fitscore::ffpmsg_slice;
@@ -528,135 +530,148 @@ fn New_Const(
         let mut n: c_int = 0;
         n = Alloc_Node(lParse);
         if n >= 0 {
-            let this = &mut (lParse.Nodes)[n as usize];
-            this.operation = -1000;
-            this.DoOp = None;
-            this.nSubNodes = 0;
-            this.ntype = returnType;
+            let this_node = &mut lParse.Nodes[n as usize];
+            this_node.operation = CONST_OP; /* Flag a constant */
+            this_node.DoOp = None;
+            this_node.nSubNodes = 0;
+            this_node.ntype = returnType;
             memcpy(
-                &mut this.value.data as *const _ as *mut c_void,
+                &mut this_node.value.data as *const _ as *mut c_void,
                 value,
                 (len as c_ulong).try_into().unwrap(),
             );
-            this.value.undef = ptr::null_mut();
-            this.value.nelem = 1;
-            this.value.naxis = 1;
-            this.value.naxes[0] = 1;
+            this_node.value.undef = ptr::null_mut();
+            this_node.value.nelem = 1;
+            this_node.value.naxis = 1;
+            this_node.value.naxes[0] = 1;
         }
         n
     }
 }
+
 fn New_Column(lParse: &mut ParseData, ColNum: c_int) -> c_int {
-    unsafe {
-        let mut this: *mut Node = std::ptr::null_mut::<Node>();
-        let mut n: c_int = 0;
-        let mut i: c_int = 0;
-        n = Alloc_Node(lParse);
-        if n >= 0 {
-            this = &mut (lParse.Nodes)[n as usize];
-            (*this).operation = -ColNum;
-            (*this).DoOp = None;
-            (*this).nSubNodes = 0;
-            (*this).ntype = ((lParse.varData)[ColNum as usize]).dtype;
-            (*this).value.nelem = ((lParse.varData)[ColNum as usize]).nelem;
-            (*this).value.naxis = ((lParse.varData)[ColNum as usize]).naxis;
-            i = 0;
-            while i < ((lParse.varData)[ColNum as usize]).naxis {
-                (*this).value.naxes[i as usize] =
-                    ((lParse.varData)[ColNum as usize]).naxes[i as usize];
-                i += 1;
-                i;
-            }
+    let mut this_node_idx: usize;
+    let mut n: c_int = 0;
+    let mut i: c_int = 0;
+
+    n = Alloc_Node(lParse);
+
+    if n >= 0 {
+        let this_node = &mut lParse.Nodes[n as usize];
+        (this_node).operation = -ColNum;
+        (this_node).DoOp = None;
+        (this_node).nSubNodes = 0;
+        (this_node).ntype = ((lParse.varData)[ColNum as usize]).dtype;
+        (this_node).value.nelem = ((lParse.varData)[ColNum as usize]).nelem;
+        (this_node).value.naxis = ((lParse.varData)[ColNum as usize]).naxis;
+
+        while i < ((lParse.varData)[ColNum as usize]).naxis {
+            (this_node).value.naxes[i as usize] =
+                ((lParse.varData)[ColNum as usize]).naxes[i as usize];
+            i += 1;
         }
-        n
     }
+
+    n
 }
+
 fn New_Offset(lParse: &mut ParseData, ColNum: c_int, offsetNode: c_int) -> c_int {
-    unsafe {
-        let mut this: *mut Node = std::ptr::null_mut::<Node>();
-        let mut n: c_int = 0;
-        let mut i: c_int = 0;
-        let mut colNode: c_int = 0;
-        colNode = New_Column(lParse, ColNum);
-        if colNode < 0 {
-            return -(1);
-        }
-        n = Alloc_Node(lParse);
-        if n >= 0 {
-            this = &mut (lParse.Nodes)[n as usize];
-            (*this).operation = b'{' as i32;
-            (*this).DoOp = Some(Do_Offset);
-            (*this).nSubNodes = 2 as c_int;
-            (*this).SubNodes[0] = colNode;
-            (*this).SubNodes[1] = offsetNode;
-            (*this).ntype = ((lParse.varData)[ColNum as usize]).dtype;
-            (*this).value.nelem = ((lParse.varData)[ColNum as usize]).nelem;
-            (*this).value.naxis = ((lParse.varData)[ColNum as usize]).naxis;
-            i = 0;
-            while i < ((lParse.varData)[ColNum as usize]).naxis {
-                (*this).value.naxes[i as usize] =
-                    ((lParse.varData)[ColNum as usize]).naxes[i as usize];
-                i += 1;
-                i;
-            }
-        }
-        n
+    let mut this_node_idx: usize;
+    let mut n: c_int = 0;
+    let mut i: c_int = 0;
+    let mut colNode: c_int = 0;
+    colNode = New_Column(lParse, ColNum);
+    if colNode < 0 {
+        return -(1);
     }
+
+    let colNode = colNode as usize;
+
+    n = Alloc_Node(lParse);
+
+    if n >= 0 {
+        let this_node = &mut lParse.Nodes[n as usize];
+        (this_node).operation = b'{' as i32;
+        (this_node).DoOp = Some(Do_Offset);
+        (this_node).nSubNodes = 2;
+        (this_node).SubNodes[0] = colNode;
+        (this_node).SubNodes[1] = offsetNode.try_into().unwrap();
+        (this_node).ntype = ((lParse.varData)[ColNum as usize]).dtype;
+        (this_node).value.nelem = ((lParse.varData)[ColNum as usize]).nelem;
+        (this_node).value.naxis = ((lParse.varData)[ColNum as usize]).naxis;
+        i = 0;
+        while i < ((lParse.varData)[ColNum as usize]).naxis {
+            (this_node).value.naxes[i as usize] =
+                ((lParse.varData)[ColNum as usize]).naxes[i as usize];
+            i += 1;
+        }
+    }
+    n
 }
+
 fn New_Unary(lParse: &mut ParseData, returnType: c_int, mut Op: c_int, Node1: c_int) -> c_int {
-    unsafe {
-        let mut this: *mut Node = std::ptr::null_mut::<Node>();
-        let mut that: *mut Node = std::ptr::null_mut::<Node>();
-        let mut i: c_int = 0;
-        let mut n: c_int = 0;
-        if Node1 < 0 {
-            return -(1);
-        }
-        that = &mut (lParse.Nodes)[Node1 as usize];
-        if Op == 0 {
-            Op = returnType;
-        }
-        if (Op == fits_parser_yytokentype::DOUBLE as c_int
-            || Op == fits_parser_yytokentype::FLTCAST as c_int)
-            && (*that).ntype == fits_parser_yytokentype::DOUBLE as c_int
-        {
-            return Node1;
-        }
-        if (Op == fits_parser_yytokentype::LONG as c_int
-            || Op == fits_parser_yytokentype::INTCAST as c_int)
-            && (*that).ntype == fits_parser_yytokentype::LONG as c_int
-        {
-            return Node1;
-        }
-        if Op == fits_parser_yytokentype::BOOLEAN as c_int
-            && (*that).ntype == fits_parser_yytokentype::BOOLEAN as c_int
-        {
-            return Node1;
-        }
-        n = Alloc_Node(lParse);
-        if n >= 0 {
-            this = &mut (lParse.Nodes)[n as usize];
-            (*this).operation = Op;
-            (*this).DoOp = Some(Do_Unary);
-            (*this).nSubNodes = 1;
-            (*this).SubNodes[0] = Node1;
-            (*this).ntype = returnType;
-            that = &mut (lParse.Nodes)[Node1 as usize];
-            (*this).value.nelem = (*that).value.nelem;
-            (*this).value.naxis = (*that).value.naxis;
-            i = 0;
-            while i < (*that).value.naxis {
-                (*this).value.naxes[i as usize] = (*that).value.naxes[i as usize];
-                i += 1;
-                i;
-            }
-            if (*that).operation == -1000 {
-                ((*this).DoOp).expect("non-null function pointer")(lParse, this);
-            }
-        }
-        n
+    let mut this_node_idx: usize;
+
+    let mut i: c_int = 0;
+    let mut n: c_int = 0;
+
+    if Node1 < 0 {
+        return -(1);
     }
+
+    let that: &mut Node = &mut (lParse.Nodes)[Node1 as usize];
+
+    if Op == 0 {
+        Op = returnType;
+    }
+
+    if (Op == fits_parser_yytokentype::DOUBLE as c_int
+        || Op == fits_parser_yytokentype::FLTCAST as c_int)
+        && that.ntype == fits_parser_yytokentype::DOUBLE as c_int
+    {
+        return Node1;
+    }
+
+    if (Op == fits_parser_yytokentype::LONG as c_int
+        || Op == fits_parser_yytokentype::INTCAST as c_int)
+        && that.ntype == fits_parser_yytokentype::LONG as c_int
+    {
+        return Node1;
+    }
+
+    if Op == fits_parser_yytokentype::BOOLEAN as c_int
+        && that.ntype == fits_parser_yytokentype::BOOLEAN as c_int
+    {
+        return Node1;
+    }
+
+    n = Alloc_Node(lParse);
+
+    if n >= 0 {
+        let (this_node, that_node) =
+            get_this_that_nodes(&mut lParse.Nodes, n as usize, Node1 as usize);
+
+        (this_node).operation = Op;
+        (this_node).DoOp = Some(Do_Unary);
+        (this_node).nSubNodes = 1;
+        (this_node).SubNodes[0] = Node1.try_into().unwrap();
+        (this_node).ntype = returnType;
+
+        (this_node).value.nelem = (that_node).value.nelem;
+        (this_node).value.naxis = (that_node).value.naxis;
+
+        while i < (that_node).value.naxis {
+            (this_node).value.naxes[i as usize] = (that_node).value.naxes[i as usize];
+            i += 1;
+        }
+
+        if (that_node).operation == CONST_OP {
+            ((this_node).DoOp).expect("non-null function pointer")(lParse, n as usize);
+        }
+    }
+    n
 }
+
 fn New_BinOp(
     lParse: &mut ParseData,
     returnType: c_int,
@@ -664,81 +679,93 @@ fn New_BinOp(
     Op: c_int,
     Node2: c_int,
 ) -> c_int {
-    unsafe {
-        let mut this: *mut Node = std::ptr::null_mut::<Node>();
-        let mut that1: *mut Node = std::ptr::null_mut::<Node>();
-        let mut that2: *mut Node = std::ptr::null_mut::<Node>();
-        let mut n: c_int = 0;
-        let mut i: c_int = 0;
-        let mut constant: c_int = 0;
-        if Node1 < 0 || Node2 < 0 {
+    let mut n: c_int = 0;
+    let mut i: c_int = 0;
+    let mut constant: c_int = 0;
+
+    if Node1 < 0 || Node2 < 0 {
+        return -(1);
+    }
+
+    n = Alloc_Node(lParse);
+
+    if n >= 0 {
+        let that1_idx = Node1 as usize;
+        let that2_idx = Node2 as usize;
+        let this_node_idx = n as usize;
+
+        (lParse.Nodes[this_node_idx]).operation = Op;
+        (lParse.Nodes[this_node_idx]).nSubNodes = 2;
+        (lParse.Nodes[this_node_idx]).SubNodes[0] = Node1.try_into().unwrap();
+        (lParse.Nodes[this_node_idx]).SubNodes[1] = Node2.try_into().unwrap();
+        (lParse.Nodes[this_node_idx]).ntype = returnType;
+
+        constant = ((lParse.Nodes[that1_idx]).operation == CONST_OP
+            && (lParse.Nodes[that2_idx]).operation == CONST_OP) as c_int;
+
+        if (lParse.Nodes[that1_idx]).ntype != fits_parser_yytokentype::STRING as c_int
+            && (lParse.Nodes[that1_idx]).ntype != fits_parser_yytokentype::BITSTR as c_int
+            && Test_Dims(lParse, Node1, Node2) == 0
+        {
+            Free_Last_Node(lParse);
+            fits_parser_yyerror(
+                lParse,
+                cs!(c"Array sizes/dims do not match for binary operator"),
+            );
             return -(1);
         }
-        n = Alloc_Node(lParse);
-        if n >= 0 {
-            this = &mut (lParse.Nodes)[n as usize];
-            (*this).operation = Op;
-            (*this).nSubNodes = 2 as c_int;
-            (*this).SubNodes[0] = Node1;
-            (*this).SubNodes[1] = Node2;
-            (*this).ntype = returnType;
-            that1 = &mut (lParse.Nodes)[Node1 as usize];
-            that2 = &mut (lParse.Nodes)[Node2 as usize];
-            constant = ((*that1).operation == -1000 && (*that2).operation == -1000) as c_int;
-            if (*that1).ntype != fits_parser_yytokentype::STRING as c_int
-                && (*that1).ntype != fits_parser_yytokentype::BITSTR as c_int
-                && Test_Dims(lParse, Node1, Node2) == 0
-            {
-                Free_Last_Node(lParse);
-                fits_parser_yyerror(
-                    lParse,
-                    cs!(c"Array sizes/dims do not match for binary operator"),
-                );
-                return -(1);
-            }
-            if (*that1).value.nelem == 1 {
-                that1 = that2;
-            }
-            (*this).value.nelem = (*that1).value.nelem;
-            (*this).value.naxis = (*that1).value.naxis;
-            i = 0;
-            while i < (*that1).value.naxis {
-                (*this).value.naxes[i as usize] = (*that1).value.naxes[i as usize];
-                i += 1;
-                i;
-            }
-            if Op == fits_parser_yytokentype::ACCUM as c_int
-                && (*that1).ntype == fits_parser_yytokentype::BITSTR as c_int
-            {
-                (*this).value.nelem = 1;
-                (*this).value.naxis = 1;
-                (*this).value.naxes[0] = 1;
-            }
-            match (*that1).ntype {
-                262 => {
-                    (*this).DoOp = Some(Do_BinOp_bit);
-                }
-                261 => {
-                    (*this).DoOp = Some(Do_BinOp_str);
-                }
-                258 => {
-                    (*this).DoOp = Some(Do_BinOp_log);
-                }
-                259 => {
-                    (*this).DoOp = Some(Do_BinOp_lng);
-                }
-                260 => {
-                    (*this).DoOp = Some(Do_BinOp_dbl);
-                }
-                _ => {}
-            }
-            if constant != 0 {
-                ((*this).DoOp).expect("non-null function pointer")(lParse, this);
-            }
+
+        if (lParse.Nodes[that1_idx]).value.nelem == 1 {
+            (lParse.Nodes[that1_idx]) = lParse.Nodes[that2_idx];
         }
-        n
+
+        (lParse.Nodes[this_node_idx]).value.nelem = (lParse.Nodes[that1_idx]).value.nelem;
+        (lParse.Nodes[this_node_idx]).value.naxis = (lParse.Nodes[that1_idx]).value.naxis;
+
+        while i < (lParse.Nodes[that1_idx]).value.naxis {
+            (lParse.Nodes[this_node_idx]).value.naxes[i as usize] =
+                (lParse.Nodes[that1_idx]).value.naxes[i as usize];
+            i += 1;
+        }
+
+        if Op == fits_parser_yytokentype::ACCUM as c_int
+            && (lParse.Nodes[that1_idx]).ntype == fits_parser_yytokentype::BITSTR as c_int
+        {
+            /* ACCUM is rank-reducing on bit strings */
+            (lParse.Nodes[this_node_idx]).value.nelem = 1;
+            (lParse.Nodes[this_node_idx]).value.naxis = 1;
+            (lParse.Nodes[this_node_idx]).value.naxes[0] = 1;
+        }
+
+        /*  Both subnodes should be of same time  */
+        match (lParse.Nodes[that1_idx]).ntype.into() {
+            fits_parser_yytokentype::BITSTR => {
+                (lParse.Nodes[this_node_idx]).DoOp = Some(Do_BinOp_bit);
+            }
+            fits_parser_yytokentype::STRING => {
+                (lParse.Nodes[this_node_idx]).DoOp = Some(Do_BinOp_str);
+            }
+            fits_parser_yytokentype::BOOLEAN => {
+                (lParse.Nodes[this_node_idx]).DoOp = Some(Do_BinOp_log);
+            }
+            fits_parser_yytokentype::LONG => {
+                (lParse.Nodes[this_node_idx]).DoOp = Some(Do_BinOp_lng);
+            }
+            fits_parser_yytokentype::DOUBLE => {
+                (lParse.Nodes[this_node_idx]).DoOp = Some(Do_BinOp_dbl);
+            }
+            _ => {}
+        }
+
+        if constant != 0 {
+            ((lParse.Nodes[this_node_idx]).DoOp).expect("non-null function pointer")(
+                lParse, n as usize,
+            );
+        }
     }
+    n
 }
+
 fn New_Func(
     lParse: &mut ParseData,
     returnType: c_int,
@@ -752,12 +779,11 @@ fn New_Func(
     Node6: c_int,
     Node7: c_int,
 ) -> c_int {
-    unsafe {
-        New_FuncSize(
-            lParse, returnType, Op, nNodes, Node1, Node2, Node3, Node4, Node5, Node6, Node7, 0,
-        )
-    }
+    New_FuncSize(
+        lParse, returnType, Op, nNodes, Node1, Node2, Node3, Node4, Node5, Node6, Node7, 0,
+    )
 }
+
 fn yydestruct(
     mut yymsg: *const c_char,
     yykind: yysymbol_kind_t,
@@ -770,6 +796,8 @@ fn yydestruct(
     }
 }
 
+/* If returnType==0 , use Node1's type and vector sizes as returnType, */
+/* else return a single value of type returnType                       */
 fn New_FuncSize(
     lParse: &mut ParseData,
     returnType: c_int,
@@ -784,69 +812,78 @@ fn New_FuncSize(
     Node7: c_int,
     Size: c_int,
 ) -> c_int {
-    unsafe {
-        let mut this: *mut Node = std::ptr::null_mut::<Node>();
-        let mut that: *mut Node = std::ptr::null_mut::<Node>();
-        let mut i: c_int = 0;
-        let mut n: c_int = 0;
-        let mut constant: c_int = 0;
-        if Node1 < 0 || Node2 < 0 || Node3 < 0 || Node4 < 0 || Node5 < 0 || Node6 < 0 || Node7 < 0 {
-            return -(1);
-        }
-        n = Alloc_Node(lParse);
-        if n >= 0 {
-            this = &mut (lParse.Nodes)[n as usize];
-            (*this).operation = Op as c_int;
-            (*this).DoOp = Some(Do_Func);
-            (*this).nSubNodes = nNodes;
-            (*this).SubNodes[0] = Node1;
-            (*this).SubNodes[1] = Node2;
-            (*this).SubNodes[2] = Node3;
-            (*this).SubNodes[3] = Node4;
-            (*this).SubNodes[4] = Node5;
-            (*this).SubNodes[5] = Node6;
-            (*this).SubNodes[6] = Node7;
-            constant = nNodes;
-            i = constant;
-            if Op as c_uint == poirnd_fct as c_int as c_uint {
-                constant = 0;
-            }
-            loop {
-                let fresh1 = i;
-                i -= 1;
-                if fresh1 == 0 {
-                    break;
-                }
-                constant = (constant != 0
-                    && ((lParse.Nodes)[(*this).SubNodes[i as usize] as usize]).operation == -1000)
-                    as c_int;
-            }
-            if returnType != 0 {
-                (*this).ntype = returnType;
-                (*this).value.nelem = 1;
-                (*this).value.naxis = 1;
-                (*this).value.naxes[0] = 1;
-            } else {
-                that = &mut (lParse.Nodes)[Node1 as usize];
-                (*this).ntype = (*that).ntype;
-                (*this).value.nelem = (*that).value.nelem;
-                (*this).value.naxis = (*that).value.naxis;
-                i = 0;
-                while i < (*that).value.naxis {
-                    (*this).value.naxes[i as usize] = (*that).value.naxes[i as usize];
-                    i += 1;
-                    i;
-                }
-            }
-            if Size > 0 {
-                (*this).value.nelem = Size as c_long;
-            }
-            if constant != 0 {
-                ((*this).DoOp).expect("non-null function pointer")(lParse, this);
-            }
-        }
-        n
+    let mut this_node_idx: usize;
+    let mut i: c_int = 0;
+    let mut n: c_int = 0;
+    let mut constant: c_int = 0;
+
+    if Node1 < 0 || Node2 < 0 || Node3 < 0 || Node4 < 0 || Node5 < 0 || Node6 < 0 || Node7 < 0 {
+        return -(1);
     }
+
+    n = Alloc_Node(lParse);
+    if n >= 0 {
+        let this_node = &mut lParse.Nodes[n as usize];
+
+        (this_node).operation = Op as c_int;
+        (this_node).DoOp = Some(Do_Func);
+        (this_node).nSubNodes = nNodes;
+        (this_node).SubNodes[0] = Node1.try_into().unwrap();
+        (this_node).SubNodes[1] = Node2.try_into().unwrap();
+        (this_node).SubNodes[2] = Node3.try_into().unwrap();
+        (this_node).SubNodes[3] = Node4.try_into().unwrap();
+        (this_node).SubNodes[4] = Node5.try_into().unwrap();
+        (this_node).SubNodes[5] = Node6.try_into().unwrap();
+        (this_node).SubNodes[6] = Node7.try_into().unwrap();
+
+        constant = nNodes;
+
+        i = constant; /* Functions with zero params are not const */
+
+        if Op as c_uint == poirnd_fct as c_int as c_uint {
+            constant = 0; /* Nor is Poisson deviate */
+        }
+
+        loop {
+            let fresh1 = i;
+            i -= 1;
+            if fresh1 == 0 {
+                break;
+            }
+            constant = (constant != 0
+                && ((lParse.Nodes)[(lParse.Nodes[n as usize]).SubNodes[i as usize] as usize])
+                    .operation
+                    == CONST_OP) as c_int;
+        }
+
+        let (this_node, that_node) =
+            get_this_that_nodes(&mut lParse.Nodes, n as usize, Node1 as usize);
+
+        if returnType != 0 {
+            (this_node).ntype = returnType;
+            (this_node).value.nelem = 1;
+            (this_node).value.naxis = 1;
+            (this_node).value.naxes[0] = 1;
+        } else {
+            (this_node).ntype = (that_node).ntype;
+            (this_node).value.nelem = (that_node).value.nelem;
+            (this_node).value.naxis = (that_node).value.naxis;
+            i = 0;
+            while i < (that_node).value.naxis {
+                (this_node).value.naxes[i as usize] = (that_node).value.naxes[i as usize];
+                i += 1;
+            }
+        }
+
+        if Size > 0 {
+            (this_node).value.nelem = Size as c_long;
+        }
+
+        if constant != 0 {
+            ((this_node).DoOp).expect("non-null function pointer")(lParse, n as usize);
+        }
+    }
+    n
 }
 
 pub fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData) -> c_int {
@@ -947,7 +984,7 @@ pub fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData) -> c_
                     break;
                 }
             }
-            if yystate == 2 as c_int {
+            if yystate == 2 {
                 yyresult = 0;
                 current_block = 15864720325503947191;
                 break;
@@ -992,7 +1029,6 @@ pub fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData) -> c_
                                 } else {
                                     if yyerrstatus != 0 {
                                         yyerrstatus -= 1;
-                                        yyerrstatus;
                                     }
                                     yystate = yyn;
                                     yyvsp = yyvsp.offset(1);
@@ -1017,7 +1053,6 @@ pub fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData) -> c_
                             }) as yysymbol_kind_t;
                         if yyerrstatus == 0 {
                             fits_parser_yynerrs += 1;
-                            fits_parser_yynerrs;
                             fits_parser_yyerror(lParse, cs!(c"syntax error"));
                         }
                         if yyerrstatus == 3 as c_int {
@@ -1137,7 +1172,8 @@ pub fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData) -> c_
                                     let fresh3 = *fresh2;
                                     *fresh2 += 1;
                                     ((lParse.Nodes)[yyval.Node as usize]).SubNodes
-                                        [fresh3 as usize] = (*yyvsp.offset(0)).Node;
+                                        [fresh3 as usize] =
+                                        (*yyvsp.offset(0)).Node.try_into().unwrap();
                                     current_block = 17353983478346836848;
                                 }
                             }
@@ -1184,7 +1220,8 @@ pub fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData) -> c_
                                     let fresh5 = *fresh4;
                                     *fresh4 += 1;
                                     ((lParse.Nodes)[yyval.Node as usize]).SubNodes
-                                        [fresh5 as usize] = (*yyvsp.offset(0)).Node;
+                                        [fresh5 as usize] =
+                                        (*yyvsp.offset(0)).Node.try_into().unwrap();
                                     current_block = 17353983478346836848;
                                 }
                             }
@@ -1217,7 +1254,8 @@ pub fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData) -> c_
                                     let fresh7 = *fresh6;
                                     *fresh6 += 1;
                                     ((lParse.Nodes)[yyval.Node as usize]).SubNodes
-                                        [fresh7 as usize] = (*yyvsp.offset(0)).Node;
+                                        [fresh7 as usize] =
+                                        (*yyvsp.offset(0)).Node.try_into().unwrap();
                                     current_block = 17353983478346836848;
                                 }
                             }
@@ -1252,7 +1290,8 @@ pub fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData) -> c_
                                     let fresh9 = *fresh8;
                                     *fresh8 += 1;
                                     ((lParse.Nodes)[yyval.Node as usize]).SubNodes
-                                        [fresh9 as usize] = (*yyvsp.offset(0)).Node;
+                                        [fresh9 as usize] =
+                                        (*yyvsp.offset(0)).Node.try_into().unwrap();
                                     current_block = 17353983478346836848;
                                 }
                             }
@@ -1302,7 +1341,7 @@ pub fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData) -> c_
                             if ((lParse.Nodes)[(*yyvsp.offset(-1)).Node as usize]).ntype
                                 != fits_parser_yytokentype::LONG as c_int
                                 || ((lParse.Nodes)[(*yyvsp.offset(-1)).Node as usize]).operation
-                                    != -1000
+                                    != CONST_OP
                             {
                                 fits_parser_yyerror(
                                     lParse,
@@ -1431,7 +1470,7 @@ pub fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData) -> c_
                             yyval.Node = New_Deref(
                                 lParse,
                                 (*yyvsp.offset(-(5))).Node,
-                                2 as c_int,
+                                2,
                                 (*yyvsp.offset(-3)).Node,
                                 (*yyvsp.offset(-1)).Node,
                                 0,
@@ -1550,7 +1589,7 @@ pub fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData) -> c_
                             if ((lParse.Nodes)[(*yyvsp.offset(-1)).Node as usize]).ntype
                                 != fits_parser_yytokentype::LONG as c_int
                                 || ((lParse.Nodes)[(*yyvsp.offset(-1)).Node as usize]).operation
-                                    != -1000
+                                    != CONST_OP
                             {
                                 fits_parser_yyerror(
                                     lParse,
@@ -2367,7 +2406,7 @@ pub fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData) -> c_
                             }) == 0
                             {
                                 if ((lParse.Nodes)[(*yyvsp.offset(-1)).Node as usize]).operation
-                                    != -1000
+                                    != CONST_OP
                                     || ((lParse.Nodes)[(*yyvsp.offset(-1)).Node as usize])
                                         .value
                                         .nelem
@@ -2380,7 +2419,7 @@ pub fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData) -> c_
                                     current_block = 4830776507462815627;
                                 } else if ((lParse.Nodes)[(*yyvsp.offset(-3)).Node as usize])
                                     .operation
-                                    == -1000
+                                    == CONST_OP
                                 {
                                     let mut one: c_long = 1;
                                     yyval.Node = New_Const(
@@ -2405,7 +2444,7 @@ pub fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData) -> c_
                                         lParse,
                                         0,
                                         axiselem_fct,
-                                        2 as c_int,
+                                        2,
                                         (*yyvsp.offset(-3)).Node,
                                         (*yyvsp.offset(-1)).Node,
                                         0,
@@ -2440,7 +2479,7 @@ pub fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData) -> c_
                             }) == 0
                             {
                                 if ((lParse.Nodes)[(*yyvsp.offset(-1)).Node as usize]).operation
-                                    != -1000
+                                    != CONST_OP
                                     || ((lParse.Nodes)[(*yyvsp.offset(-1)).Node as usize])
                                         .value
                                         .nelem
@@ -2453,7 +2492,7 @@ pub fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData) -> c_
                                     current_block = 4830776507462815627;
                                 } else if ((lParse.Nodes)[(*yyvsp.offset(-3)).Node as usize])
                                     .operation
-                                    == -1000
+                                    == CONST_OP
                                 {
                                     let mut one_0: c_long = 1;
                                     yyval.Node = New_Const(
@@ -3335,7 +3374,7 @@ pub fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData) -> c_
                             }) == 0
                             {
                                 if ((lParse.Nodes)[(*yyvsp.offset(-1)).Node as usize]).operation
-                                    == -1000
+                                    == CONST_OP
                                 {
                                     let mut one_1: c_long = 1;
                                     yyval.Node = New_Const(
@@ -3385,7 +3424,7 @@ pub fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData) -> c_
                             }) == 0
                             {
                                 if ((lParse.Nodes)[(*yyvsp.offset(-1)).Node as usize]).operation
-                                    == -1000
+                                    == CONST_OP
                                 {
                                     let mut one_2: c_long = 1;
                                     yyval.Node = New_Const(
@@ -4072,7 +4111,7 @@ pub fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData) -> c_
                                     lParse,
                                     fits_parser_yytokentype::LONG as c_int,
                                     strpos_fct,
-                                    2 as c_int,
+                                    2,
                                     (*yyvsp.offset(-3)).Node,
                                     (*yyvsp.offset(-1)).Node,
                                     0,
@@ -4152,7 +4191,7 @@ pub fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData) -> c_
                                         lParse,
                                         0,
                                         defnull_fct,
-                                        2 as c_int,
+                                        2,
                                         (*yyvsp.offset(-3)).Node,
                                         (*yyvsp.offset(-1)).Node,
                                         0,
@@ -4220,7 +4259,7 @@ pub fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData) -> c_
                                         lParse,
                                         0,
                                         atan2_fct,
-                                        2 as c_int,
+                                        2,
                                         (*yyvsp.offset(-3)).Node,
                                         (*yyvsp.offset(-1)).Node,
                                         0,
@@ -4296,7 +4335,7 @@ pub fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData) -> c_
                                         lParse,
                                         0,
                                         min2_fct,
-                                        2 as c_int,
+                                        2,
                                         (*yyvsp.offset(-3)).Node,
                                         (*yyvsp.offset(-1)).Node,
                                         0,
@@ -4372,7 +4411,7 @@ pub fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData) -> c_
                                         lParse,
                                         0,
                                         max2_fct,
-                                        2 as c_int,
+                                        2,
                                         (*yyvsp.offset(-3)).Node,
                                         (*yyvsp.offset(-1)).Node,
                                         0,
@@ -4420,7 +4459,7 @@ pub fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData) -> c_
                             }) == 0
                             {
                                 if ((lParse.Nodes)[(*yyvsp.offset(-3)).Node as usize]).operation
-                                    != -1000
+                                    != CONST_OP
                                     || ((lParse.Nodes)[(*yyvsp.offset(-3)).Node as usize])
                                         .value
                                         .nelem
@@ -4447,7 +4486,7 @@ pub fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData) -> c_
                                         lParse,
                                         0,
                                         setnull_fct,
-                                        2 as c_int,
+                                        2,
                                         (*yyvsp.offset(-1)).Node,
                                         (*yyvsp.offset(-3)).Node,
                                         0,
@@ -4478,7 +4517,7 @@ pub fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData) -> c_
                             }) == 0
                             {
                                 if ((lParse.Nodes)[(*yyvsp.offset(-1)).Node as usize]).operation
-                                    != -1000
+                                    != CONST_OP
                                     || ((lParse.Nodes)[(*yyvsp.offset(-1)).Node as usize])
                                         .value
                                         .nelem
@@ -4491,7 +4530,7 @@ pub fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData) -> c_
                                     current_block = 4830776507462815627;
                                 } else if ((lParse.Nodes)[(*yyvsp.offset(-3)).Node as usize])
                                     .operation
-                                    == -1000
+                                    == CONST_OP
                                 {
                                     let mut one_3: c_long = 1;
                                     yyval.Node = New_Const(
@@ -4516,7 +4555,7 @@ pub fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData) -> c_
                                         lParse,
                                         0,
                                         axiselem_fct,
-                                        2 as c_int,
+                                        2,
                                         (*yyvsp.offset(-3)).Node,
                                         (*yyvsp.offset(-1)).Node,
                                         0,
@@ -4551,7 +4590,7 @@ pub fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData) -> c_
                             }) == 0
                             {
                                 if ((lParse.Nodes)[(*yyvsp.offset(-1)).Node as usize]).operation
-                                    != -1000
+                                    != CONST_OP
                                     || ((lParse.Nodes)[(*yyvsp.offset(-1)).Node as usize])
                                         .value
                                         .nelem
@@ -4564,7 +4603,7 @@ pub fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData) -> c_
                                     current_block = 4830776507462815627;
                                 } else if ((lParse.Nodes)[(*yyvsp.offset(-3)).Node as usize])
                                     .operation
-                                    == -1000
+                                    == CONST_OP
                                 {
                                     let mut one_4: c_long = 1;
                                     yyval.Node = New_Const(
@@ -4849,7 +4888,7 @@ pub fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData) -> c_
                             yyval.Node = New_Deref(
                                 lParse,
                                 (*yyvsp.offset(-(5))).Node,
-                                2 as c_int,
+                                2,
                                 (*yyvsp.offset(-3)).Node,
                                 (*yyvsp.offset(-1)).Node,
                                 0,
@@ -4990,7 +5029,7 @@ pub fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData) -> c_
                             if ((lParse.Nodes)[(*yyvsp.offset(-1)).Node as usize]).ntype
                                 != fits_parser_yytokentype::LONG as c_int
                                 || ((lParse.Nodes)[(*yyvsp.offset(-1)).Node as usize]).operation
-                                    != -1000
+                                    != CONST_OP
                             {
                                 fits_parser_yyerror(
                                     lParse,
@@ -5787,7 +5826,7 @@ pub fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData) -> c_
                                         lParse,
                                         0,
                                         defnull_fct,
-                                        2 as c_int,
+                                        2,
                                         (*yyvsp.offset(-3)).Node,
                                         (*yyvsp.offset(-1)).Node,
                                         0,
@@ -6568,7 +6607,7 @@ pub fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData) -> c_
                             yyval.Node = New_Deref(
                                 lParse,
                                 (*yyvsp.offset(-(5))).Node,
-                                2 as c_int,
+                                2,
                                 (*yyvsp.offset(-3)).Node,
                                 (*yyvsp.offset(-1)).Node,
                                 0,
@@ -6678,7 +6717,7 @@ pub fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData) -> c_
                             if ((lParse.Nodes)[(*yyvsp.offset(-1)).Node as usize]).ntype
                                 != fits_parser_yytokentype::LONG as c_int
                                 || ((lParse.Nodes)[(*yyvsp.offset(-1)).Node as usize]).operation
-                                    != -1000
+                                    != CONST_OP
                             {
                                 fits_parser_yyerror(
                                     lParse,
@@ -6842,7 +6881,7 @@ pub fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData) -> c_
                                     lParse,
                                     0,
                                     defnull_fct,
-                                    2 as c_int,
+                                    2,
                                     (*yyvsp.offset(-3)).Node,
                                     (*yyvsp.offset(-1)).Node,
                                     0,
@@ -6917,7 +6956,7 @@ pub fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData) -> c_
                                     current_block = 4830776507462815627;
                                 } else {
                                     if ((lParse.Nodes)[(*yyvsp.offset(-1)).Node as usize]).operation
-                                        == -1000
+                                        == CONST_OP
                                     {
                                         len = ((lParse.Nodes)[(*yyvsp.offset(-1)).Node as usize])
                                             .value
@@ -6973,7 +7012,6 @@ pub fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData) -> c_
                     match current_block {
                         4830776507462815627 => {
                             fits_parser_yynerrs += 1;
-                            fits_parser_yynerrs;
                             yyvsp = yyvsp.offset(-(yylen as isize));
                             yyssp = yyssp.offset(-(yylen as isize));
                             yylen = 0;
@@ -7036,13 +7074,12 @@ pub fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData) -> c_
                     yystate = yyn;
                 }
                 yyssp = yyssp.offset(1);
-                yyssp;
             }
         }
         match current_block {
             11794367917084412820 => {
                 fits_parser_yyerror(lParse, cs!(c"memory exhausted"));
-                yyresult = 2 as c_int;
+                yyresult = 2;
             }
             3964311021479492664 => {
                 yyresult = 1;
@@ -7082,6 +7119,7 @@ pub fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData) -> c_
         yyresult
     }
 }
+
 fn New_Deref(
     lParse: &mut ParseData,
     Var: c_int,
@@ -7092,91 +7130,113 @@ fn New_Deref(
     Dim4: c_int,
     Dim5: c_int,
 ) -> c_int {
-    unsafe {
-        let mut n: c_int = 0;
-        let mut idx: c_int = 0;
-        let mut constant: c_int = 0;
-        let mut elem: c_long = 0;
-        let mut this: *mut Node = std::ptr::null_mut::<Node>();
-        let mut theVar: *mut Node = std::ptr::null_mut::<Node>();
-        let mut theDim: [*mut Node; 5] = [std::ptr::null_mut::<Node>(); 5];
-        if Var < 0 || Dim1 < 0 || Dim2 < 0 || Dim3 < 0 || Dim4 < 0 || Dim5 < 0 {
-            return -(1);
+    let mut n: c_int = 0;
+    let mut idx: c_int = 0;
+    let mut constant: c_int = 0;
+    let mut elem: c_long = 0;
+    let this_node_idx: usize;
+    let mut theDim: [usize; 5] = [0; 5];
+
+    if Var < 0 || Dim1 < 0 || Dim2 < 0 || Dim3 < 0 || Dim4 < 0 || Dim5 < 0 {
+        return -(1);
+    }
+
+    let Var: usize = Var as usize;
+    let Dim1: usize = Dim1 as usize;
+    let Dim2: usize = Dim2 as usize;
+    let Dim3: usize = Dim3 as usize;
+    let Dim4: usize = Dim4 as usize;
+    let Dim5: usize = Dim5 as usize;
+
+    let theVar = Var;
+
+    if (lParse.Nodes[theVar]).operation == CONST_OP || (lParse.Nodes[theVar]).value.nelem == 1 {
+        fits_parser_yyerror(lParse, cs!(c"Cannot index a scalar value"));
+        return -(1);
+    }
+
+    n = Alloc_Node(lParse);
+
+    if n >= 0 {
+        this_node_idx = n as usize;
+        (lParse.Nodes[this_node_idx]).nSubNodes = nDim + 1;
+        (lParse.Nodes[this_node_idx]).SubNodes[0] = Var;
+
+        let theVar = (lParse.Nodes[this_node_idx]).SubNodes[0];
+
+        (lParse.Nodes[this_node_idx]).SubNodes[1] = Dim1;
+        (lParse.Nodes[this_node_idx]).SubNodes[2] = Dim2;
+        (lParse.Nodes[this_node_idx]).SubNodes[3] = Dim3;
+        (lParse.Nodes[this_node_idx]).SubNodes[4] = Dim4;
+        (lParse.Nodes[this_node_idx]).SubNodes[5] = Dim5;
+
+        theDim[0] = Dim1;
+        theDim[1] = Dim2;
+        theDim[2] = Dim3;
+        theDim[3] = Dim4;
+        theDim[4] = Dim5;
+
+        constant = ((lParse.Nodes[theVar]).operation == CONST_OP) as c_int;
+        idx = 0;
+        while idx < nDim {
+            constant = (constant != 0 && (lParse.Nodes[theDim[idx as usize]]).operation == CONST_OP)
+                as c_int;
+            idx += 1;
         }
-        theVar = &mut (lParse.Nodes)[Var as usize];
-        if (*theVar).operation == -1000 || (*theVar).value.nelem == 1 {
-            fits_parser_yyerror(lParse, cs!(c"Cannot index a scalar value"));
-            return -(1);
-        }
-        n = Alloc_Node(lParse);
-        if n >= 0 {
-            this = &mut (lParse.Nodes)[n as usize];
-            (*this).nSubNodes = nDim + 1;
-            (*this).SubNodes[0] = Var;
-            theVar = &mut (lParse.Nodes)[(*this).SubNodes[0] as usize];
-            (*this).SubNodes[1] = Dim1;
-            theDim[0] = &mut (lParse.Nodes)[(*this).SubNodes[1] as usize];
-            (*this).SubNodes[2] = Dim2;
-            theDim[1] = &mut (lParse.Nodes)[(*this).SubNodes[2] as usize];
-            (*this).SubNodes[3] = Dim3;
-            theDim[2] = &mut (lParse.Nodes)[(*this).SubNodes[3] as usize];
-            (*this).SubNodes[4] = Dim4;
-            theDim[3] = &mut (lParse.Nodes)[(*this).SubNodes[4] as usize];
-            (*this).SubNodes[5] = Dim5;
-            theDim[4] = &mut (lParse.Nodes)[(*this).SubNodes[5] as usize];
-            constant = ((*theVar).operation == -1000) as c_int;
-            idx = 0;
-            while idx < nDim {
-                constant = (constant != 0 && (*theDim[idx as usize]).operation == -1000) as c_int;
-                idx += 1;
-                idx;
-            }
-            idx = 0;
-            while idx < nDim {
-                if (*theDim[idx as usize]).value.nelem > 1 {
-                    Free_Last_Node(lParse);
-                    fits_parser_yyerror(lParse, cs!(c"Cannot use an array as an index value"));
-                    return -(1);
-                } else if (*theDim[idx as usize]).ntype != fits_parser_yytokentype::LONG as c_int {
-                    Free_Last_Node(lParse);
-                    fits_parser_yyerror(lParse, cs!(c"Index value must be an integer type"));
-                    return -(1);
-                }
-                idx += 1;
-                idx;
-            }
-            (*this).operation = '[' as i32;
-            (*this).DoOp = Some(Do_Deref);
-            (*this).ntype = (*theVar).ntype;
-            if (*theVar).value.naxis == nDim {
-                (*this).value.nelem = 1;
-                (*this).value.naxis = 1;
-                (*this).value.naxes[0] = 1;
-            } else if nDim == 1 {
-                elem = 1;
-                (*this).value.naxis = (*theVar).value.naxis - 1;
-                idx = 0;
-                while idx < (*this).value.naxis {
-                    (*this).value.naxes[idx as usize] = (*theVar).value.naxes[idx as usize];
-                    elem *= (*this).value.naxes[idx as usize];
-                    idx += 1;
-                    idx;
-                }
-                (*this).value.nelem = elem;
-            } else {
+        idx = 0;
+        while idx < nDim {
+            if (lParse.Nodes[theDim[idx as usize]]).value.nelem > 1 {
                 Free_Last_Node(lParse);
-                fits_parser_yyerror(
-                    lParse,
-                    cs!(c"Must specify just one or all indices for vector"),
-                );
+                fits_parser_yyerror(lParse, cs!(c"Cannot use an array as an index value"));
+                return -(1);
+            } else if (lParse.Nodes[theDim[idx as usize]]).ntype
+                != fits_parser_yytokentype::LONG as c_int
+            {
+                Free_Last_Node(lParse);
+                fits_parser_yyerror(lParse, cs!(c"Index value must be an integer type"));
                 return -(1);
             }
-            if constant != 0 {
-                ((*this).DoOp).expect("non-null function pointer")(lParse, this);
-            }
+            idx += 1;
         }
-        n
+
+        (lParse.Nodes[this_node_idx]).operation = '[' as i32;
+        (lParse.Nodes[this_node_idx]).DoOp = Some(Do_Deref);
+        (lParse.Nodes[this_node_idx]).ntype = (lParse.Nodes[theVar]).ntype;
+
+        if (lParse.Nodes[theVar]).value.naxis == nDim {
+            /* All dimensions specified */
+            (lParse.Nodes[this_node_idx]).value.nelem = 1;
+            (lParse.Nodes[this_node_idx]).value.naxis = 1;
+            (lParse.Nodes[this_node_idx]).value.naxes[0] = 1;
+        } else if nDim == 1 {
+            /* Dereference only one dimension */
+
+            elem = 1;
+            (lParse.Nodes[this_node_idx]).value.naxis = (lParse.Nodes[theVar]).value.naxis - 1;
+            idx = 0;
+            while idx < (lParse.Nodes[this_node_idx]).value.naxis {
+                (lParse.Nodes[this_node_idx]).value.naxes[idx as usize] =
+                    (lParse.Nodes[theVar]).value.naxes[idx as usize];
+                elem *= (lParse.Nodes[this_node_idx]).value.naxes[idx as usize];
+                idx += 1;
+            }
+            (lParse.Nodes[this_node_idx]).value.nelem = elem;
+        } else {
+            Free_Last_Node(lParse);
+            fits_parser_yyerror(
+                lParse,
+                cs!(c"Must specify just one or all indices for vector"),
+            );
+            return -(1);
+        }
+        if constant != 0 {
+            ((lParse.Nodes[this_node_idx]).DoOp).expect("non-null function pointer")(
+                lParse,
+                this_node_idx,
+            );
+        }
     }
+    n
 }
 
 fn New_GTI(
@@ -7190,10 +7250,7 @@ fn New_GTI(
 ) -> c_int {
     unsafe {
         let mut fptr: *mut fitsfile = std::ptr::null_mut();
-        let mut this: *mut Node = std::ptr::null_mut::<Node>();
-        let mut that0: *mut Node = std::ptr::null_mut::<Node>();
-        let mut that1: *mut Node = std::ptr::null_mut::<Node>();
-        let mut that2: *mut Node = std::ptr::null_mut::<Node>();
+        let this_node_idx: usize;
         let mut type_0: c_int = 0;
         let mut i: c_int = 0;
         let mut n: c_int = 0;
@@ -7216,6 +7273,7 @@ fn New_GTI(
         let mut xcol: [c_char; 20] = [0; 20];
         let mut xexpr: [c_char; 20] = [0; 20];
         let mut colVal: FITS_PARSER_YYSTYPE = FITS_PARSER_YYSTYPE { Node: 0 };
+
         if (Op as c_uint == gtifilt_fct as c_int as c_uint
             || Op as c_uint == gtifind_fct as c_int as c_uint)
             && Node1 == -99
@@ -7231,6 +7289,7 @@ fn New_GTI(
                 return -(1);
             }
         }
+
         if Op as c_uint == gtiover_fct as c_int as c_uint {
             if Node1 == -99 || Node2 == -99 {
                 fits_parser_yyerror(
@@ -7244,11 +7303,14 @@ fn New_GTI(
                 return -(1);
             }
         }
+
         Node1 = New_Unary(lParse, fits_parser_yytokentype::DOUBLE as c_int, 0, Node1);
         Node0 = Alloc_Node(lParse);
+
         if Node1 < 0 || Node0 < 0 {
             return -(1);
         }
+
         fptr = lParse.def_fptr;
         let fptr = fptr.as_mut().unwrap();
 
@@ -7266,24 +7328,25 @@ fn New_GTI(
         } else {
             timeZeroF[0] = 0.0;
         }
-        match *fname.offset(0) as c_int {
+
+        /*  Resolve filename parameter  */
+
+        match *fname.offset(0) {
             0 => {
                 samefile = 1;
                 hdunum = 1;
             }
-            91 => {
+            b'[' => {
                 samefile = 1;
                 i = 1;
                 while *fname.offset(i as isize) as c_int != 0_i32
                     && *fname.offset(i as isize) as c_int != ']' as i32
                 {
                     i += 1;
-                    i;
                 }
                 if *fname.offset(i as isize) != 0 {
                     *fname.offset(i as isize) = 0;
                     fname = fname.offset(1);
-                    fname;
                     let fname_str = CStr::from_ptr(fname).to_bytes();
                     ffexts_safer(
                         std::slice::from_raw_parts(
@@ -7316,7 +7379,7 @@ fn New_GTI(
                     return -(1);
                 }
             }
-            43 => {
+            b'+' => {
                 samefile = 1;
                 hdunum =
                     atoi(std::ffi::CStr::from_ptr(fname).to_str().unwrap_or("0")).unwrap_or(0) + 1;
@@ -7348,13 +7411,16 @@ fn New_GTI(
                 }
             }
         }
+
         if lParse.status != 0 {
             return -(1);
         }
+
+        /*  If at primary, search for GTI extension  */
+
         if hdunum == 1 {
             loop {
                 hdunum += 1;
-                hdunum;
                 if ffmahd_safe(fptr, hdunum, Some(&mut hdutype), &mut lParse.status) != 0 {
                     break;
                 }
@@ -7378,6 +7444,8 @@ fn New_GTI(
                 return -(1);
             }
         }
+
+        /*  Locate START/STOP Columns  */
         let start_str = CStr::from_ptr(start).to_bytes();
         let stop_str = CStr::from_ptr(stop).to_bytes();
         ffgcno_safe(
@@ -7398,9 +7466,12 @@ fn New_GTI(
             &mut stopCol,
             &mut lParse.status,
         );
+
         if lParse.status != 0 {
             return -(1);
         }
+
+        /*  Look for TIMEZERO keywords in GTI extension  */
         tstat = 0;
         if ffgkyd_safe(fptr, cs!(c"TIMEZERO"), &mut timeZeroI[1], None, &mut tstat) != 0 {
             tstat = 0;
@@ -7416,35 +7487,36 @@ fn New_GTI(
         }
         n = Alloc_Node(lParse);
         if n >= 0 {
-            this = &mut (lParse.Nodes)[n as usize];
-            (*this).SubNodes[1] = Node1;
-            (*this).operation = Op as c_int;
+            this_node_idx = n as usize;
+            (lParse.Nodes[this_node_idx]).SubNodes[1] = Node1.try_into().unwrap();
+            (lParse.Nodes[this_node_idx]).operation = Op as c_int;
             if Op as c_uint == gtifilt_fct as c_int as c_uint {
-                (*this).nSubNodes = 2 as c_int;
-                (*this).DoOp = Some(Do_GTI);
-                (*this).ntype = fits_parser_yytokentype::BOOLEAN as c_int;
+                (lParse.Nodes[this_node_idx]).nSubNodes = 2;
+                (lParse.Nodes[this_node_idx]).DoOp = Some(Do_GTI);
+                (lParse.Nodes[this_node_idx]).ntype = fits_parser_yytokentype::BOOLEAN as c_int;
             } else if Op as c_uint == gtifind_fct as c_int as c_uint {
-                (*this).nSubNodes = 2 as c_int;
-                (*this).DoOp = Some(Do_GTI);
-                (*this).ntype = fits_parser_yytokentype::LONG as c_int;
+                (lParse.Nodes[this_node_idx]).nSubNodes = 2;
+                (lParse.Nodes[this_node_idx]).DoOp = Some(Do_GTI);
+                (lParse.Nodes[this_node_idx]).ntype = fits_parser_yytokentype::LONG as c_int;
             } else {
-                (*this).nSubNodes = 3 as c_int;
-                (*this).DoOp = Some(Do_GTI_Over);
-                (*this).ntype = fits_parser_yytokentype::DOUBLE as c_int;
+                (lParse.Nodes[this_node_idx]).nSubNodes = 3 as c_int;
+                (lParse.Nodes[this_node_idx]).DoOp = Some(Do_GTI_Over);
+                (lParse.Nodes[this_node_idx]).ntype = fits_parser_yytokentype::DOUBLE as c_int;
             }
-            that1 = &mut (lParse.Nodes)[Node1 as usize];
-            (*this).value.nelem = (*that1).value.nelem;
-            (*this).value.naxis = (*that1).value.naxis;
+
+            let that1_idx = Node1 as usize;
+            (lParse.Nodes[this_node_idx]).value.nelem = (lParse.Nodes[that1_idx]).value.nelem;
+            (lParse.Nodes[this_node_idx]).value.naxis = (lParse.Nodes[that1_idx]).value.naxis;
             i = 0;
-            while i < (*that1).value.naxis {
-                (*this).value.naxes[i as usize] = (*that1).value.naxes[i as usize];
+            while i < (lParse.Nodes[that1_idx]).value.naxis {
+                (lParse.Nodes[this_node_idx]).value.naxes[i as usize] =
+                    (lParse.Nodes[that1_idx]).value.naxes[i as usize];
                 i += 1;
-                i;
             }
             if Op as c_uint == gtiover_fct as c_int as c_uint {
-                (*this).SubNodes[2] = Node2;
-                that2 = &mut (lParse.Nodes)[Node2 as usize];
-                if (*that1).value.nelem != (*that2).value.nelem {
+                (lParse.Nodes[this_node_idx]).SubNodes[2] = Node2.try_into().unwrap();
+                let that2_idx = Node2 as usize;
+                if (lParse.Nodes[that1_idx]).value.nelem != (lParse.Nodes[that2_idx]).value.nelem {
                     fits_parser_yyerror(
                         lParse,
                         cs!(c"Dimensions of TIME and TIME_STOP must match for GTIOVERLAP"),
@@ -7452,30 +7524,41 @@ fn New_GTI(
                     return -(1);
                 }
             }
-            (*this).SubNodes[0] = Node0;
-            that0 = &mut (lParse.Nodes)[Node0 as usize];
-            (*that0).operation = -1000;
-            (*that0).DoOp = None;
-            (*that0).value.data.ptr = std::ptr::null_mut::<c_void>();
+
+            /* Init START/STOP node to be treated as a "constant" */
+
+            (lParse.Nodes[this_node_idx]).SubNodes[0] = Node0.try_into().unwrap();
+            let that0_idx = Node0 as usize;
+            (lParse.Nodes[that0_idx]).operation = CONST_OP;
+            (lParse.Nodes[that0_idx]).DoOp = None;
+            (lParse.Nodes[that0_idx]).value.data.ptr = std::ptr::null_mut::<c_void>();
+
+            /*  Read in START/STOP times  */
+
             if ffgkyj_safe(fptr, cs!(c"NAXIS2"), &mut nrows, None, &mut lParse.status) != 0 {
                 return -(1);
             }
-            (*that0).value.nelem = nrows;
+
+            (lParse.Nodes[that0_idx]).value.nelem = nrows;
             if nrows != 0 {
                 let mut startptr: *mut c_double = std::ptr::null_mut::<c_double>();
                 let mut stopptr: *mut c_double = std::ptr::null_mut::<c_double>();
-                (*that0).value.data.dblptr = malloc(
+
+                /* We are allocating storage for both START and STOP with one pointer
+                and stop is stored at dblptr+nrows, we will use aliases below to
+                make this easier to read */
+                (lParse.Nodes[that0_idx]).value.data.dblptr = malloc(
                     ((2 as c_long * nrows) as c_ulong)
                         .wrapping_mul(::core::mem::size_of::<c_double>() as c_ulong)
                         .try_into()
                         .unwrap(),
                 ) as *mut c_double;
-                if ((*that0).value.data.dblptr).is_null() {
+                if ((lParse.Nodes[that0_idx]).value.data.dblptr).is_null() {
                     lParse.status = 113 as c_int;
                     return -(1);
                 }
-                startptr = (*that0).value.data.dblptr;
-                stopptr = ((*that0).value.data.dblptr).offset(nrows as isize);
+                startptr = (lParse.Nodes[that0_idx]).value.data.dblptr;
+                stopptr = ((lParse.Nodes[that0_idx]).value.data.dblptr).offset(nrows as isize);
                 ffgcvd_safe(
                     fptr,
                     startCol,
@@ -7499,25 +7582,33 @@ fn New_GTI(
                     &mut lParse.status,
                 );
                 if lParse.status != 0 {
-                    free((*that0).value.data.dblptr as *mut c_void);
+                    free((lParse.Nodes[that0_idx]).value.data.dblptr as *mut c_void);
                     return -(1);
                 }
-                (*that0).ntype = 1;
+
+                /*  Test for fully time-ordered GTI... both START && STOP  */
+                (lParse.Nodes[that0_idx]).ntype = 1; /*  Assume yes  */
                 i = nrows as c_int;
                 loop {
+                    /* the following are failure conditions for GTI ordering */
                     i -= 1;
                     if i == 0 {
                         break;
                     }
-                    if !(*startptr.offset(i as isize) > *stopptr.offset(i as isize)
+                    if !(*startptr.offset(i as isize) > *stopptr.offset(i as isize) /* START{j} > STOP{j} */
                         || *startptr.offset(i as isize) < *stopptr.offset((i - 1) as isize))
+                    /* START{j} < STOP{j-1} */
                     {
                         continue;
                     }
-                    (*that0).ntype = 0;
+                    (lParse.Nodes[that0_idx]).ntype = 0;
                     break;
                 }
-                if (*that0).ntype != 1 && Op as c_uint == gtiover_fct as c_int as c_uint {
+
+                /* GTIOVERLAP() requires ordered GTI */
+                if (lParse.Nodes[that0_idx]).ntype != 1
+                    && Op as c_uint == gtiover_fct as c_int as c_uint
+                {
                     let mut errmsg: [c_char; 120] = [0; 120];
                     sprintf(
                         errmsg.as_mut_ptr(),
@@ -7528,10 +7619,12 @@ fn New_GTI(
                     fits_parser_yyerror(lParse, &errmsg);
                     return -(1);
                 }
+
+                /*  Handle TIMEZERO offset, if any  */
                 dt = timeZeroI[1] - timeZeroI[0] + (timeZeroF[1] - timeZeroF[0]);
                 timeSpan = *stopptr.offset((nrows - 1) as isize) - *startptr.offset(0);
                 if timeSpan == 0.0 {
-                    timeSpan = 1.0f64;
+                    timeSpan = 1.0;
                 }
                 if fabs(dt / timeSpan) > 1e-12f64 {
                     i = 0;
@@ -7539,17 +7632,23 @@ fn New_GTI(
                         *startptr.offset(i as isize) += dt;
                         *stopptr.offset(i as isize) += dt;
                         i += 1;
-                        i;
                     }
                 }
             }
-            if ((lParse.Nodes)[Node1 as usize]).operation == -1000
+
+            /* If Node1 is constant (gtifilt_fct) or
+            Node1 and Node2 are constant (gtiover_fct), then evaluate now */
+            if ((lParse.Nodes)[Node1 as usize]).operation == CONST_OP
                 && (Op as c_uint == gtifilt_fct as c_int as c_uint
-                    || ((lParse.Nodes)[Node2 as usize]).operation == -1000)
+                    || ((lParse.Nodes)[Node2 as usize]).operation == CONST_OP)
             {
-                ((*this).DoOp).expect("non-null function pointer")(lParse, this);
+                ((lParse.Nodes[this_node_idx]).DoOp).expect("non-null function pointer")(
+                    lParse,
+                    this_node_idx,
+                );
             }
         }
+
         if samefile != 0 {
             ffmahd_safe(fptr, evthdu, Some(&mut hdutype), &mut lParse.status);
         } else {
@@ -7567,8 +7666,8 @@ fn New_REG(
     mut colNames: *mut c_char,
 ) -> c_int {
     unsafe {
-        let mut this: *mut Node = std::ptr::null_mut::<Node>();
-        let mut that0: *mut Node = std::ptr::null_mut::<Node>();
+        let this_node_idx: usize;
+        let mut that0: &mut Node;
         let mut type_0: c_int = 0;
         let mut n: c_int = 0;
         let mut Node0: c_int = 0;
@@ -7623,32 +7722,31 @@ fn New_REG(
         }
         n = Alloc_Node(lParse);
         if n >= 0 {
-            this = &mut (lParse.Nodes)[n as usize];
-            (*this).nSubNodes = 3 as c_int;
-            (*this).SubNodes[0] = Node0;
-            (*this).SubNodes[1] = NodeX;
-            (*this).SubNodes[2] = NodeY;
-            (*this).operation = regfilt_fct as c_int;
-            (*this).DoOp = Some(Do_REG);
-            (*this).ntype = fits_parser_yytokentype::BOOLEAN as c_int;
-            (*this).value.nelem = 1;
-            (*this).value.naxis = 1;
-            (*this).value.naxes[0] = 1;
+            this_node_idx = n as usize;
+            (lParse.Nodes[this_node_idx]).nSubNodes = 3 as c_int;
+            (lParse.Nodes[this_node_idx]).SubNodes[0] = Node0.try_into().unwrap();
+            (lParse.Nodes[this_node_idx]).SubNodes[1] = NodeX.try_into().unwrap();
+            (lParse.Nodes[this_node_idx]).SubNodes[2] = NodeY.try_into().unwrap();
+            (lParse.Nodes[this_node_idx]).operation = regfilt_fct as c_int;
+            (lParse.Nodes[this_node_idx]).DoOp = Some(Do_REG);
+            (lParse.Nodes[this_node_idx]).ntype = fits_parser_yytokentype::BOOLEAN as c_int;
+            (lParse.Nodes[this_node_idx]).value.nelem = 1;
+            (lParse.Nodes[this_node_idx]).value.naxis = 1;
+            (lParse.Nodes[this_node_idx]).value.naxes[0] = 1;
             Copy_Dims(lParse, n, NodeX);
             if (((lParse.Nodes)[NodeX as usize]).value).nelem
                 < (((lParse.Nodes)[NodeY as usize]).value).nelem
             {
                 Copy_Dims(lParse, n, NodeY);
             }
-            that0 = &mut (lParse.Nodes)[Node0 as usize];
-            (*that0).operation = -1000;
-            (*that0).DoOp = None;
+            let that0_idx = Node0 as usize;
+            (lParse.Nodes[that0_idx]).operation = CONST_OP;
+            (lParse.Nodes[that0_idx]).DoOp = None;
             Ycol = 0;
             Xcol = Ycol;
             if *colNames != 0 {
                 while *colNames as c_int == ' ' as i32 {
                     colNames = colNames.offset(1);
-                    colNames;
                 }
 
                 cY = colNames;
@@ -7656,7 +7754,6 @@ fn New_REG(
                 while *cY as c_int != 0 && *cY as c_int != ' ' as i32 && *cY as c_int != ',' as i32
                 {
                     cY = cY.offset(1);
-                    cY;
                 }
                 if *cY != 0 {
                     let fresh10 = cY;
@@ -7665,7 +7762,6 @@ fn New_REG(
                 }
                 while *cY as c_int == ' ' as i32 {
                     cY = cY.offset(1);
-                    cY;
                 }
                 if *cY == 0 {
                     fits_parser_yyerror(
@@ -7758,11 +7854,14 @@ fn New_REG(
                 Free_Last_Node(lParse);
                 return -(1);
             }
-            (*that0).value.data.ptr = Rgn as *mut c_void;
-            if ((lParse.Nodes)[NodeX as usize]).operation == -1000
-                && ((lParse.Nodes)[NodeY as usize]).operation == -1000
+            (lParse.Nodes[that0_idx]).value.data.ptr = Rgn as *mut c_void;
+            if ((lParse.Nodes)[NodeX as usize]).operation == CONST_OP
+                && ((lParse.Nodes)[NodeY as usize]).operation == CONST_OP
             {
-                ((*this).DoOp).expect("non-null function pointer")(lParse, this);
+                ((lParse.Nodes[this_node_idx]).DoOp).expect("non-null function pointer")(
+                    lParse,
+                    this_node_idx,
+                );
             }
         }
         n
@@ -7770,71 +7869,82 @@ fn New_REG(
 }
 
 fn New_Vector(lParse: &mut ParseData, subNode: c_int) -> c_int {
-    unsafe {
-        let mut this: *mut Node = std::ptr::null_mut::<Node>();
-        let mut that: *mut Node = std::ptr::null_mut::<Node>();
-        let mut n: c_int = 0;
-        n = Alloc_Node(lParse);
-        if n >= 0 {
-            this = &mut (lParse.Nodes)[n as usize];
-            that = &mut (lParse.Nodes)[subNode as usize];
-            (*this).ntype = (*that).ntype;
-            (*this).nSubNodes = 1;
-            (*this).SubNodes[0] = subNode;
-            (*this).operation = '{' as i32;
-            (*this).DoOp = Some(Do_Vector);
-        }
-        n
+    let mut n: c_int = 0;
+    n = Alloc_Node(lParse);
+    if n >= 0 {
+        let this_node_idx = n as usize;
+        let that = &mut (lParse.Nodes)[subNode as usize];
+        (lParse.Nodes[this_node_idx]).ntype = that.ntype;
+        (lParse.Nodes[this_node_idx]).nSubNodes = 1;
+        (lParse.Nodes[this_node_idx]).SubNodes[0] = subNode.try_into().unwrap();
+        (lParse.Nodes[this_node_idx]).operation = '{' as i32;
+        (lParse.Nodes[this_node_idx]).DoOp = Some(Do_Vector);
     }
+    n
 }
+
 fn Close_Vec(lParse: &mut ParseData, vecNode: c_int) -> c_int {
-    unsafe {
-        let mut this: *mut Node = std::ptr::null_mut::<Node>();
-        let mut n: c_int = 0;
-        let mut nelem: c_int = 0;
-        this = &mut (lParse.Nodes)[vecNode as usize];
-        n = 0;
-        while n < (*this).nSubNodes {
-            if ((lParse.Nodes)[(*this).SubNodes[n as usize] as usize]).ntype != (*this).ntype {
-                (*this).SubNodes[n as usize] =
-                    New_Unary(lParse, (*this).ntype, 0, (*this).SubNodes[n as usize]);
-                if (*this).SubNodes[n as usize] < 0 {
-                    return -(1);
-                }
+    let mut n: c_int = 0;
+    let mut nelem: c_int = 0;
+
+    let this_node_idx: usize = vecNode as usize;
+    n = 0;
+    while n < (lParse.Nodes[this_node_idx]).nSubNodes {
+        if ((lParse.Nodes)[(lParse.Nodes[this_node_idx]).SubNodes[n as usize] as usize]).ntype
+            != (lParse.Nodes[this_node_idx]).ntype
+        {
+            (lParse.Nodes[this_node_idx]).SubNodes[n as usize] = New_Unary(
+                lParse,
+                (lParse.Nodes[this_node_idx]).ntype,
+                0,
+                (lParse.Nodes[this_node_idx]).SubNodes[n as usize] as c_int,
+            )
+            .try_into()
+            .unwrap();
+            if (lParse.Nodes[this_node_idx]).SubNodes[n as usize] < 0 {
+                return -(1);
             }
-            nelem = (nelem as c_long
-                + ((lParse.Nodes)[(*this).SubNodes[n as usize] as usize])
-                    .value
-                    .nelem) as c_int;
-            n += 1;
-            n;
         }
-        (*this).value.naxis = 1;
-        (*this).value.nelem = nelem as c_long;
-        (*this).value.naxes[0] = nelem as c_long;
-        vecNode
+        nelem = (nelem as c_long
+            + ((lParse.Nodes)[(lParse.Nodes[this_node_idx]).SubNodes[n as usize] as usize])
+                .value
+                .nelem) as c_int;
+        n += 1;
     }
+    (lParse.Nodes[this_node_idx]).value.naxis = 1;
+    (lParse.Nodes[this_node_idx]).value.nelem = nelem as c_long;
+    (lParse.Nodes[this_node_idx]).value.naxes[0] = nelem as c_long;
+    vecNode
 }
+
 fn New_Array(lParse: &mut ParseData, valueNode: c_int, mut dimNode: c_int) -> c_int {
     unsafe {
-        let mut dims: *mut Node = std::ptr::null_mut::<Node>();
         let mut naxis: c_long = 0;
         let mut nelem: c_long = 0;
         let mut naxes: [c_long; 5] = [0; 5];
-        let mut this: *mut Node = std::ptr::null_mut::<Node>();
+        let this_node_idx: usize;
         let mut n: c_int = 0;
         let mut i: c_int = 0;
         if valueNode < 0 || dimNode < 0 {
             return -(1);
         }
-        dims = &mut (lParse.Nodes)[dimNode as usize];
+
+        /* Check that dimensions are {a,b,c,d}
+             - vector
+         - every element is constant integer
+         - 5 or fewer dimensions
+        */
+
+        let dims: usize = dimNode as usize;
         i = 0;
-        while i < 5 as c_int {
+        while i < MAXDIMS as c_int {
             naxes[i as usize] = 1;
             i += 1;
-            i;
         }
-        if ((lParse.Nodes)[dimNode as usize]).operation == -1000 {
+
+        if ((lParse.Nodes)[dimNode as usize]).operation == CONST_OP {
+            /* ARRAY(V,n) is a constant integer */
+
             if ((lParse.Nodes)[dimNode as usize]).ntype != fits_parser_yytokentype::LONG as c_int {
                 dimNode = New_Unary(lParse, fits_parser_yytokentype::LONG as c_int, 0, dimNode);
             }
@@ -7844,35 +7954,39 @@ fn New_Array(lParse: &mut ParseData, valueNode: c_int, mut dimNode: c_int) -> c_
             naxis = 1;
             naxes[0] = (((lParse.Nodes)[dimNode as usize]).value).data.lng;
         } else if ((lParse.Nodes)[dimNode as usize]).operation == '{' as i32 {
-            if (*dims).nSubNodes > 5 as c_int {
+            /* ARRAY(V,{a,b,c,d,e}) up to 5 dimensions */
+
+            if (lParse.Nodes[dims]).nSubNodes > 5 as c_int {
                 fits_parser_yyerror(
                     lParse,
                     cs!(c"ARRAY(V,{...}) number of dimensions must not exceed 5"),
                 );
                 return -(1);
             }
-            naxis = (*dims).nSubNodes as c_long;
+            naxis = (lParse.Nodes[dims]).nSubNodes as c_long;
             i = 0;
-            while i < (*dims).nSubNodes {
-                if ((lParse.Nodes)[(*dims).SubNodes[i as usize] as usize]).ntype
+            while i < (lParse.Nodes[dims]).nSubNodes {
+                if ((lParse.Nodes)[(lParse.Nodes[dims]).SubNodes[i as usize] as usize]).ntype
                     != fits_parser_yytokentype::LONG as c_int
                 {
-                    (*dims).SubNodes[i as usize] = New_Unary(
+                    (lParse.Nodes[dims]).SubNodes[i as usize] = New_Unary(
                         lParse,
                         fits_parser_yytokentype::LONG as c_int,
                         0,
-                        (*dims).SubNodes[i as usize],
-                    );
-                    if (*dims).SubNodes[i as usize] < 0 {
+                        (lParse.Nodes[dims]).SubNodes[i as usize] as c_int,
+                    )
+                    .try_into()
+                    .unwrap();
+                    if (lParse.Nodes[dims]).SubNodes[i as usize] < 0 {
                         return -(1);
                     }
                 }
-                naxes[i as usize] = ((lParse.Nodes)[(*dims).SubNodes[i as usize] as usize])
+                naxes[i as usize] = ((lParse.Nodes)
+                    [(lParse.Nodes[dims]).SubNodes[i as usize] as usize])
                     .value
                     .data
                     .lng;
                 i += 1;
-                i;
             }
         } else {
             fits_parser_yyerror(
@@ -7881,6 +7995,7 @@ fn New_Array(lParse: &mut ParseData, valueNode: c_int, mut dimNode: c_int) -> c_
             );
             return -(1);
         }
+
         nelem = 1;
         i = 0;
         while (i as c_long) < naxis {
@@ -7890,8 +8005,8 @@ fn New_Array(lParse: &mut ParseData, valueNode: c_int, mut dimNode: c_int) -> c_
             }
             nelem *= naxes[i as usize];
             i += 1;
-            i;
         }
+
         if !((((lParse.Nodes)[valueNode as usize]).value).nelem == nelem && nelem > 1) {
             if (((lParse.Nodes)[valueNode as usize]).value).nelem > 1 && nelem > 1 {
                 fits_parser_yyerror(
@@ -7909,118 +8024,113 @@ fn New_Array(lParse: &mut ParseData, valueNode: c_int, mut dimNode: c_int) -> c_
         }
         n = Alloc_Node(lParse);
         if n >= 0 {
-            this = &mut (lParse.Nodes)[n as usize];
-            (*this).operation = array_fct as c_int;
-            (*this).nSubNodes = 1;
-            (*this).SubNodes[0] = valueNode;
-            (*this).ntype = ((lParse.Nodes)[valueNode as usize]).ntype;
-            (*this).value.nelem = nelem;
-            (*this).value.naxis = naxis as c_int;
+            this_node_idx = n as usize;
+            (lParse.Nodes[this_node_idx]).operation = array_fct as c_int;
+            (lParse.Nodes[this_node_idx]).nSubNodes = 1;
+            (lParse.Nodes[this_node_idx]).SubNodes[0] = valueNode.try_into().unwrap();
+            (lParse.Nodes[this_node_idx]).ntype = ((lParse.Nodes)[valueNode as usize]).ntype;
+            (lParse.Nodes[this_node_idx]).value.nelem = nelem;
+            (lParse.Nodes[this_node_idx]).value.naxis = naxis as c_int;
             i = 0;
             while (i as c_long) < naxis {
-                (*this).value.naxes[i as usize] = naxes[i as usize];
+                (lParse.Nodes[this_node_idx]).value.naxes[i as usize] = naxes[i as usize];
                 i += 1;
-                i;
             }
-            (*this).DoOp = Some(Do_Array);
+            (lParse.Nodes[this_node_idx]).DoOp = Some(Do_Array);
         }
         n
     }
 }
+
+/*  Locate the TABLE column number of any columns in "this" calculation.  */
+/*  Return ZERO if none found, or negative if more than 1 found.          */
 fn Locate_Col(lParse: &ParseData, this: &Node) -> c_int {
-    unsafe {
-        let mut i: c_int = 0;
-        let mut col: c_int = 0;
-        let mut newCol: c_int = 0;
-        let mut nfound: c_int = 0;
+    let mut i: c_int = 0;
+    let mut col: c_int = 0;
+    let mut newCol: c_int = 0;
+    let mut nfound: c_int = 0;
 
-        if this.nSubNodes == 0 && this.operation <= 0 && this.operation != -1000 {
-            return ((lParse.colData)[(-this.operation) as usize]).colnum;
-        }
-
-        i = 0;
-        while i < this.nSubNodes {
-            let that = &(lParse.Nodes)[this.SubNodes[i as usize] as usize];
-            if that.operation > 0 {
-                newCol = Locate_Col(lParse, that);
-                if newCol <= 0 {
-                    nfound += -newCol;
-                } else if nfound == 0 {
-                    col = newCol;
-                    nfound += 1;
-                    nfound;
-                } else if col != newCol {
-                    nfound += 1;
-                    nfound;
-                }
-            } else if that.operation != -1000 {
-                newCol = ((lParse.colData)[(-that.operation) as usize]).colnum;
-                if nfound == 0 {
-                    col = newCol;
-                    nfound += 1;
-                    nfound;
-                } else if col != newCol {
-                    nfound += 1;
-                    nfound;
-                }
-            }
-            i += 1;
-            i;
-        }
-        if nfound != 1 { -nfound } else { col }
+    if this.nSubNodes == 0 && this.operation <= 0 && this.operation != CONST_OP {
+        return ((lParse.colData)[(-this.operation) as usize]).colnum;
     }
+
+    i = 0;
+    while i < this.nSubNodes {
+        let that = &(lParse.Nodes)[this.SubNodes[i as usize] as usize];
+        if that.operation > 0 {
+            newCol = Locate_Col(lParse, that);
+            if newCol <= 0 {
+                nfound += -newCol;
+            } else if nfound == 0 {
+                col = newCol;
+                nfound += 1;
+            } else if col != newCol {
+                nfound += 1;
+            }
+        } else if that.operation != CONST_OP {
+            newCol = ((lParse.colData)[(-that.operation) as usize]).colnum;
+            if nfound == 0 {
+                col = newCol;
+                nfound += 1;
+            } else if col != newCol {
+                nfound += 1;
+            }
+        }
+        i += 1;
+    }
+    if nfound != 1 { -nfound } else { col }
 }
 
 fn Test_Dims(lParse: &mut ParseData, Node1: c_int, Node2: c_int) -> c_int {
-    unsafe {
-        let mut that1: *mut Node = std::ptr::null_mut::<Node>();
-        let mut that2: *mut Node = std::ptr::null_mut::<Node>();
-        let mut valid: c_int = 0;
-        let mut i: c_int = 0;
-        if Node1 < 0 || Node2 < 0 {
-            return 0;
-        }
-        that1 = &mut (lParse.Nodes)[Node1 as usize];
-        that2 = &mut (lParse.Nodes)[Node2 as usize];
-        if (*that1).value.nelem == 1 || (*that2).value.nelem == 1 {
-            valid = 1;
-        } else if (*that1).ntype == (*that2).ntype
-            && (*that1).value.nelem == (*that2).value.nelem
-            && (*that1).value.naxis == (*that2).value.naxis
-        {
-            valid = 1;
-            i = 0;
-            while i < (*that1).value.naxis {
-                if (*that1).value.naxes[i as usize] != (*that2).value.naxes[i as usize] {
-                    valid = 0;
-                }
-                i += 1;
-                i;
-            }
-        } else {
-            valid = 0;
-        }
-        valid
+    let mut valid: c_int = 0;
+    let mut i: c_int = 0;
+
+    if Node1 < 0 || Node2 < 0 {
+        return 0;
     }
-}
-fn Copy_Dims(lParse: &mut ParseData, Node1: c_int, Node2: c_int) {
-    unsafe {
-        let mut that1: *mut Node = std::ptr::null_mut::<Node>();
-        let mut that2: *mut Node = std::ptr::null_mut::<Node>();
-        let mut i: c_int = 0;
-        if Node1 < 0 || Node2 < 0 {
-            return;
-        }
-        that1 = &mut (lParse.Nodes)[Node1 as usize];
-        that2 = &mut (lParse.Nodes)[Node2 as usize];
-        (*that1).value.nelem = (*that2).value.nelem;
-        (*that1).value.naxis = (*that2).value.naxis;
+
+    let that1_idx = Node1 as usize;
+    let that2_idx = Node2 as usize;
+
+    if (lParse.Nodes[that1_idx]).value.nelem == 1 || (lParse.Nodes[that2_idx]).value.nelem == 1 {
+        valid = 1;
+    } else if (lParse.Nodes[that1_idx]).ntype == (lParse.Nodes[that2_idx]).ntype
+        && (lParse.Nodes[that1_idx]).value.nelem == (lParse.Nodes[that2_idx]).value.nelem
+        && (lParse.Nodes[that1_idx]).value.naxis == (lParse.Nodes[that2_idx]).value.naxis
+    {
+        valid = 1;
         i = 0;
-        while i < (*that2).value.naxis {
-            (*that1).value.naxes[i as usize] = (*that2).value.naxes[i as usize];
+        while i < (lParse.Nodes[that1_idx]).value.naxis {
+            if (lParse.Nodes[that1_idx]).value.naxes[i as usize]
+                != (lParse.Nodes[that2_idx]).value.naxes[i as usize]
+            {
+                valid = 0;
+            }
             i += 1;
-            i;
         }
+    } else {
+        valid = 0;
+    }
+    valid
+}
+
+fn Copy_Dims(lParse: &mut ParseData, Node1: c_int, Node2: c_int) {
+    let mut i: c_int = 0;
+
+    if Node1 < 0 || Node2 < 0 {
+        return;
+    }
+
+    let that1_idx = Node1 as usize;
+    let that2_idx = Node2 as usize;
+
+    (lParse.Nodes[that1_idx]).value.nelem = (lParse.Nodes[that2_idx]).value.nelem;
+    (lParse.Nodes[that1_idx]).value.naxis = (lParse.Nodes[that2_idx]).value.naxis;
+    i = 0;
+    while i < (lParse.Nodes[that2_idx]).value.naxis {
+        (lParse.Nodes[that1_idx]).value.naxes[i as usize] =
+            (lParse.Nodes[that2_idx]).value.naxes[i as usize];
+        i += 1;
     }
 }
 
@@ -8041,21 +8151,21 @@ pub fn Evaluate_Parser(lParse: &mut ParseData, firstRow: c_long, nRows: c_long) 
         i = 0;
         while i < lParse.nNodes {
             if !(((lParse.Nodes)[i as usize]).operation > 0
-                || ((lParse.Nodes)[i as usize]).operation == -1000)
+                || ((lParse.Nodes)[i as usize]).operation == CONST_OP)
             {
                 column = -((lParse.Nodes)[i as usize]).operation;
                 offset = ((lParse.varData)[column as usize]).nelem * rowOffset;
                 let fresh11 = &mut (((lParse.Nodes)[i as usize]).value).undef;
                 *fresh11 = (((lParse.varData)[column as usize]).undef).offset(offset as isize);
-                match ((lParse.Nodes)[i as usize]).ntype {
-                    262 => {
+                match ((lParse.Nodes)[i as usize]).ntype.into() {
+                    fits_parser_yytokentype::BITSTR => {
                         let fresh12 = &mut (((lParse.Nodes)[i as usize]).value).data.strptr;
                         *fresh12 = (((lParse.varData)[column as usize]).data as *mut *mut c_char)
                             .offset(rowOffset as isize);
                         let fresh13 = &mut (((lParse.Nodes)[i as usize]).value).undef;
                         *fresh13 = ptr::null_mut();
                     }
-                    261 => {
+                    fits_parser_yytokentype::STRING => {
                         let fresh14 = &mut (((lParse.Nodes)[i as usize]).value).data.strptr;
                         *fresh14 = (((lParse.varData)[column as usize]).data as *mut *mut c_char)
                             .offset(rowOffset as isize);
@@ -8063,19 +8173,19 @@ pub fn Evaluate_Parser(lParse: &mut ParseData, firstRow: c_long, nRows: c_long) 
                         *fresh15 =
                             (((lParse.varData)[column as usize]).undef).offset(rowOffset as isize);
                     }
-                    258 => {
+                    fits_parser_yytokentype::BOOLEAN => {
                         let fresh16 = &mut (((lParse.Nodes)[i as usize]).value).data.logptr;
                         *fresh16 = (((lParse.varData)[column as usize]).data as *const _
                             as *mut c_char)
                             .offset(offset as isize);
                     }
-                    259 => {
+                    fits_parser_yytokentype::LONG => {
                         let fresh17 = &mut (((lParse.Nodes)[i as usize]).value).data.lngptr;
                         *fresh17 = (((lParse.varData)[column as usize]).data as *const _
                             as *mut c_long)
                             .offset(offset as isize);
                     }
-                    260 => {
+                    fits_parser_yytokentype::DOUBLE => {
                         let fresh18 = &mut (((lParse.Nodes)[i as usize]).value).data.dblptr;
                         *fresh18 = (((lParse.varData)[column as usize]).data as *const _
                             as *mut c_double)
@@ -8085,129 +8195,154 @@ pub fn Evaluate_Parser(lParse: &mut ParseData, firstRow: c_long, nRows: c_long) 
                 }
             }
             i += 1;
-            i;
         }
         Evaluate_Node(lParse, lParse.resultNode);
     }
 }
+
+/**********************************************************************/
+/*  Recursively evaluate thisNode's subNodes, then call one of the    */
+/*  Do_<Action> functions pointed to by thisNode's DoOp element.      */
+/**********************************************************************/
 fn Evaluate_Node(lParse: &mut ParseData, thisNode: c_int) {
-    unsafe {
-        let mut this: *mut Node = std::ptr::null_mut::<Node>();
-        let mut i: c_int = 0;
-        if lParse.status != 0 {
-            return;
-        }
-        this = &mut (lParse.Nodes)[thisNode as usize];
-        if (*this).operation > 0 {
-            i = (*this).nSubNodes;
-            loop {
-                let fresh19 = i;
-                i -= 1;
-                if fresh19 == 0 {
-                    break;
-                }
-                Evaluate_Node(lParse, (*this).SubNodes[i as usize]);
-                if lParse.status != 0 {
-                    return;
-                }
+    let mut this_node_idx: usize;
+    let mut i: c_int = 0;
+    if lParse.status != 0 {
+        return;
+    }
+
+    if (lParse.Nodes)[thisNode as usize].operation > 0 {
+        /* <=0 indicate constants and columns */
+        i = ((lParse.Nodes)[thisNode as usize]).nSubNodes;
+        loop {
+            if i == 0 {
+                break;
             }
-            ((*this).DoOp).expect("non-null function pointer")(lParse, this);
+
+            i -= 1;
+
+            Evaluate_Node(
+                lParse,
+                (lParse.Nodes)[thisNode as usize].SubNodes[i as usize] as c_int,
+            );
+
+            if lParse.status != 0 {
+                return;
+            }
         }
+        ((lParse.Nodes[thisNode as usize]).DoOp).expect("non-null function pointer")(
+            lParse,
+            thisNode as usize,
+        );
     }
 }
-fn Allocate_Ptrs(lParse: &mut ParseData, this: *mut Node) {
+
+fn Allocate_Ptrs(lParse: &mut ParseData, this_node_idx: usize) {
     unsafe {
         let mut elem: c_long = 0;
         let mut row: c_long = 0;
         let mut size: c_long = 0;
-        if (*this).ntype == fits_parser_yytokentype::BITSTR as c_int
-            || (*this).ntype == fits_parser_yytokentype::STRING as c_int
+        if (lParse.Nodes[this_node_idx]).ntype == fits_parser_yytokentype::BITSTR as c_int
+            || (lParse.Nodes[this_node_idx]).ntype == fits_parser_yytokentype::STRING as c_int
         {
-            (*this).value.data.strptr = malloc(
+            (lParse.Nodes[this_node_idx]).value.data.strptr = malloc(
                 (lParse.nRows as c_ulong)
                     .wrapping_mul(::core::mem::size_of::<*mut c_char>() as c_ulong)
                     .try_into()
                     .unwrap(),
             ) as *mut *mut c_char;
-            if !((*this).value.data.strptr).is_null() {
-                let fresh20 = &mut *((*this).value.data.strptr).offset(0);
+            if !((lParse.Nodes[this_node_idx]).value.data.strptr).is_null() {
+                let fresh20 = &mut *((lParse.Nodes[this_node_idx]).value.data.strptr).offset(0);
                 *fresh20 = malloc(
-                    ((lParse.nRows * ((*this).value.nelem + 2 as c_long)) as c_ulong)
+                    ((lParse.nRows * ((lParse.Nodes[this_node_idx]).value.nelem + 2 as c_long))
+                        as c_ulong)
                         .wrapping_mul(::core::mem::size_of::<c_char>() as c_ulong)
                         .try_into()
                         .unwrap(),
                 ) as *mut c_char;
-                if !(*((*this).value.data.strptr).offset(0)).is_null() {
+                if !(*((lParse.Nodes[this_node_idx]).value.data.strptr).offset(0)).is_null() {
                     row = 0;
                     loop {
                         row += 1;
                         if row >= lParse.nRows {
                             break;
                         }
-                        let fresh21 = &mut *((*this).value.data.strptr).offset(row as isize);
-                        *fresh21 = (*((*this).value.data.strptr).offset((row - 1) as isize))
-                            .offset((*this).value.nelem as isize)
-                            .offset(1 as c_int as isize);
-                    }
-                    if (*this).ntype == fits_parser_yytokentype::STRING as c_int {
-                        (*this).value.undef = (*((*this).value.data.strptr)
+                        let fresh21 = &mut *((lParse.Nodes[this_node_idx]).value.data.strptr)
+                            .offset(row as isize);
+                        *fresh21 = (*((lParse.Nodes[this_node_idx]).value.data.strptr)
                             .offset((row - 1) as isize))
-                        .offset((*this).value.nelem as isize)
+                        .offset((lParse.Nodes[this_node_idx]).value.nelem as isize)
                         .offset(1 as c_int as isize);
+                    }
+                    if (lParse.Nodes[this_node_idx]).ntype
+                        == fits_parser_yytokentype::STRING as c_int
+                    {
+                        (lParse.Nodes[this_node_idx]).value.undef =
+                            (*((lParse.Nodes[this_node_idx]).value.data.strptr)
+                                .offset((row - 1) as isize))
+                            .offset((lParse.Nodes[this_node_idx]).value.nelem as isize)
+                            .offset(1 as c_int as isize);
                     } else {
-                        (*this).value.undef = ptr::null_mut();
+                        (lParse.Nodes[this_node_idx]).value.undef = ptr::null_mut(); /* BITSTRs don't use undef array */
                     }
                 } else {
-                    lParse.status = 113 as c_int;
-                    free((*this).value.data.strptr as *mut c_void);
+                    lParse.status = MEMORY_ALLOCATION;
+                    free((lParse.Nodes[this_node_idx]).value.data.strptr as *mut c_void);
                 }
             } else {
-                lParse.status = 113 as c_int;
+                lParse.status = MEMORY_ALLOCATION;
             }
         } else {
-            elem = (*this).value.nelem * lParse.nRows;
-            match (*this).ntype {
-                260 => {
+            elem = (lParse.Nodes[this_node_idx]).value.nelem * lParse.nRows;
+            match (lParse.Nodes[this_node_idx]).ntype.into() {
+                fits_parser_yytokentype::DOUBLE => {
                     size = ::core::mem::size_of::<c_double>() as c_ulong as c_long;
                 }
-                259 => {
+                fits_parser_yytokentype::LONG => {
                     size = ::core::mem::size_of::<c_long>() as c_ulong as c_long;
                 }
-                258 => {
+                fits_parser_yytokentype::BOOLEAN => {
                     size = ::core::mem::size_of::<c_char>() as c_ulong as c_long;
                 }
                 _ => {
                     size = 1;
                 }
             }
-            (*this).value.data.ptr = calloc(
+            (lParse.Nodes[this_node_idx]).value.data.ptr = calloc(
                 ((size + 1) as c_ulong).try_into().unwrap(),
                 (elem as c_ulong).try_into().unwrap(),
             );
-            if ((*this).value.data.ptr).is_null() {
-                lParse.status = 113 as c_int;
+            if ((lParse.Nodes[this_node_idx]).value.data.ptr).is_null() {
+                lParse.status = MEMORY_ALLOCATION;
             } else {
-                (*this).value.undef =
-                    ((*this).value.data.ptr as *mut c_char).offset((elem * size) as isize);
+                (lParse.Nodes[this_node_idx]).value.undef =
+                    ((lParse.Nodes[this_node_idx]).value.data.ptr as *mut c_char)
+                        .offset((elem * size) as isize);
             }
         };
     }
 }
-fn Do_Unary(lParse: &mut ParseData, this: *mut Node) {
+
+fn Do_Unary(lParse: &mut ParseData, this_node_idx: usize) {
     unsafe {
-        let mut that: *mut Node = std::ptr::null_mut::<Node>();
+        let mut that: &mut Node;
         let mut elem: c_long = 0;
-        that = &mut (lParse.Nodes)[(*this).SubNodes[0] as usize];
-        if (*that).operation == -1000 {
-            match (*this).operation {
+
+        let that_idx = (lParse.Nodes[this_node_idx]).SubNodes[0];
+        let (this_node, that_node) =
+            get_this_that_nodes(&mut lParse.Nodes, this_node_idx, that_idx);
+
+        if that_node.operation == CONST_OP {
+            /* Operating on a constant! */
+            match (this_node).operation {
                 x if x == fits_parser_yytokentype::DOUBLE as c_int
                     || x == fits_parser_yytokentype::FLTCAST as c_int =>
                 {
-                    if (*that).ntype == fits_parser_yytokentype::LONG as c_int {
-                        (*this).value.data.dbl = (*that).value.data.lng as c_double;
-                    } else if (*that).ntype == fits_parser_yytokentype::BOOLEAN as c_int {
-                        (*this).value.data.dbl = if (*that).value.data.log as c_int != 0 {
-                            1.0f64
+                    if that_node.ntype == fits_parser_yytokentype::LONG as c_int {
+                        (this_node).value.data.dbl = that_node.value.data.lng as c_double;
+                    } else if that_node.ntype == fits_parser_yytokentype::BOOLEAN as c_int {
+                        (this_node).value.data.dbl = if that_node.value.data.log as c_int != 0 {
+                            1.0
                         } else {
                             0.0
                         };
@@ -8216,10 +8351,10 @@ fn Do_Unary(lParse: &mut ParseData, this: *mut Node) {
                 x if x == fits_parser_yytokentype::LONG as c_int
                     || x == fits_parser_yytokentype::INTCAST as c_int =>
                 {
-                    if (*that).ntype == fits_parser_yytokentype::DOUBLE as c_int {
-                        (*this).value.data.lng = (*that).value.data.dbl as c_long;
-                    } else if (*that).ntype == fits_parser_yytokentype::BOOLEAN as c_int {
-                        (*this).value.data.lng = if (*that).value.data.log as c_int != 0 {
+                    if that_node.ntype == fits_parser_yytokentype::DOUBLE as c_int {
+                        (this_node).value.data.lng = that_node.value.data.dbl as c_long;
+                    } else if that_node.ntype == fits_parser_yytokentype::BOOLEAN as c_int {
+                        (this_node).value.data.lng = if that_node.value.data.log as c_int != 0 {
                             1
                         } else {
                             0
@@ -8227,39 +8362,48 @@ fn Do_Unary(lParse: &mut ParseData, this: *mut Node) {
                     }
                 }
                 x if x == fits_parser_yytokentype::BOOLEAN as c_int => {
-                    if (*that).ntype == fits_parser_yytokentype::DOUBLE as c_int {
-                        (*this).value.data.log = if (*that).value.data.dbl != 0.0 { 1 } else { 0 };
-                    } else if (*that).ntype == fits_parser_yytokentype::LONG as c_int {
-                        (*this).value.data.log = if (*that).value.data.lng != 0 { 1 } else { 0 };
+                    if that_node.ntype == fits_parser_yytokentype::DOUBLE as c_int {
+                        (this_node).value.data.log = if that_node.value.data.dbl != 0.0 {
+                            1
+                        } else {
+                            0
+                        };
+                    } else if that_node.ntype == fits_parser_yytokentype::LONG as c_int {
+                        (this_node).value.data.log =
+                            if that_node.value.data.lng != 0 { 1 } else { 0 };
                     }
                 }
                 x if x == fits_parser_yytokentype::UMINUS as c_int => {
-                    if (*that).ntype == fits_parser_yytokentype::DOUBLE as c_int {
-                        (*this).value.data.dbl = -(*that).value.data.dbl;
-                    } else if (*that).ntype == fits_parser_yytokentype::LONG as c_int {
-                        (*this).value.data.lng = -(*that).value.data.lng;
+                    if that_node.ntype == fits_parser_yytokentype::DOUBLE as c_int {
+                        (this_node).value.data.dbl = -that_node.value.data.dbl;
+                    } else if that_node.ntype == fits_parser_yytokentype::LONG as c_int {
+                        (this_node).value.data.lng = -that_node.value.data.lng;
                     }
                 }
                 x if x == fits_parser_yytokentype::NOT as c_int => {
-                    if (*that).ntype == fits_parser_yytokentype::BOOLEAN as c_int {
-                        (*this).value.data.log = if (*that).value.data.log == 0 { 1 } else { 0 };
-                    } else if (*that).ntype == fits_parser_yytokentype::BITSTR as c_int {
+                    if that_node.ntype == fits_parser_yytokentype::BOOLEAN as c_int {
+                        (this_node).value.data.log =
+                            if that_node.value.data.log == 0 { 1 } else { 0 };
+                    } else if that_node.ntype == fits_parser_yytokentype::BITSTR as c_int {
                         bitnot(
-                            ((*this).value.data.astr).as_mut_ptr(),
-                            ((*that).value.data.astr).as_mut_ptr(),
+                            ((this_node).value.data.astr).as_mut_ptr(),
+                            (that_node.value.data.astr).as_mut_ptr(),
                         );
                     }
                 }
                 _ => {}
             }
-            (*this).operation = -1000;
+            (this_node).operation = CONST_OP;
         } else {
-            Allocate_Ptrs(lParse, this);
+            Allocate_Ptrs(lParse, this_node_idx);
+            let (this_node, that_node) =
+                get_this_that_nodes(&mut lParse.Nodes, this_node_idx, that_idx);
+
             if lParse.status == 0 {
-                if (*this).ntype != fits_parser_yytokentype::BITSTR as c_int {
+                if (this_node).ntype != fits_parser_yytokentype::BITSTR as c_int {
                     elem = lParse.nRows;
-                    if (*this).ntype != fits_parser_yytokentype::STRING as c_int {
-                        elem *= (*this).value.nelem;
+                    if (this_node).ntype != fits_parser_yytokentype::STRING as c_int {
+                        elem *= (this_node).value.nelem;
                     }
                     loop {
                         let fresh22 = elem;
@@ -8267,36 +8411,36 @@ fn Do_Unary(lParse: &mut ParseData, this: *mut Node) {
                         if fresh22 == 0 {
                             break;
                         }
-                        *((*this).value.undef).offset(elem as isize) =
-                            *((*that).value.undef).offset(elem as isize);
+                        *((this_node).value.undef).offset(elem as isize) =
+                            *(that_node.value.undef).offset(elem as isize);
                     }
                 }
-                elem = lParse.nRows * (*this).value.nelem;
-                match (*this).operation {
-                    258 => {
-                        if (*that).ntype == fits_parser_yytokentype::DOUBLE as c_int {
+                elem = lParse.nRows * (this_node).value.nelem;
+                match (this_node).operation.into() {
+                    fits_parser_yytokentype::BOOLEAN => {
+                        if that_node.ntype == fits_parser_yytokentype::DOUBLE as c_int {
                             loop {
                                 let fresh23 = elem;
                                 elem -= 1;
                                 if fresh23 == 0 {
                                     break;
                                 }
-                                *((*this).value.data.logptr).offset(elem as isize) =
-                                    if *((*that).value.data.dblptr).offset(elem as isize) != 0.0 {
+                                *((this_node).value.data.logptr).offset(elem as isize) =
+                                    if *(that_node.value.data.dblptr).offset(elem as isize) != 0.0 {
                                         1
                                     } else {
                                         0
                                     };
                             }
-                        } else if (*that).ntype == fits_parser_yytokentype::LONG as c_int {
+                        } else if that_node.ntype == fits_parser_yytokentype::LONG as c_int {
                             loop {
                                 let fresh24 = elem;
                                 elem -= 1;
                                 if fresh24 == 0 {
                                     break;
                                 }
-                                *((*this).value.data.logptr).offset(elem as isize) =
-                                    if *((*that).value.data.lngptr).offset(elem as isize) != 0 {
+                                *((this_node).value.data.logptr).offset(elem as isize) =
+                                    if *(that_node.value.data.lngptr).offset(elem as isize) != 0 {
                                         1
                                     } else {
                                         0
@@ -8304,55 +8448,56 @@ fn Do_Unary(lParse: &mut ParseData, this: *mut Node) {
                             }
                         }
                     }
-                    260 | 289 => {
-                        if (*that).ntype == fits_parser_yytokentype::LONG as c_int {
+                    fits_parser_yytokentype::DOUBLE | fits_parser_yytokentype::FLTCAST => {
+                        if that_node.ntype == fits_parser_yytokentype::LONG as c_int {
                             loop {
                                 let fresh25 = elem;
                                 elem -= 1;
                                 if fresh25 == 0 {
                                     break;
                                 }
-                                *((*this).value.data.dblptr).offset(elem as isize) =
-                                    *((*that).value.data.lngptr).offset(elem as isize) as c_double;
+                                *((this_node).value.data.dblptr).offset(elem as isize) =
+                                    *(that_node.value.data.lngptr).offset(elem as isize)
+                                        as c_double;
                             }
-                        } else if (*that).ntype == fits_parser_yytokentype::BOOLEAN as c_int {
+                        } else if that_node.ntype == fits_parser_yytokentype::BOOLEAN as c_int {
                             loop {
                                 let fresh26 = elem;
                                 elem -= 1;
                                 if fresh26 == 0 {
                                     break;
                                 }
-                                *((*this).value.data.dblptr).offset(elem as isize) =
-                                    if *((*that).value.data.logptr).offset(elem as isize) as c_int
+                                *((this_node).value.data.dblptr).offset(elem as isize) =
+                                    if *(that_node.value.data.logptr).offset(elem as isize) as c_int
                                         != 0
                                     {
-                                        1.0f64
+                                        1.0
                                     } else {
                                         0.0
                                     };
                             }
                         }
                     }
-                    259 | 288 => {
-                        if (*that).ntype == fits_parser_yytokentype::DOUBLE as c_int {
+                    fits_parser_yytokentype::LONG | fits_parser_yytokentype::INTCAST => {
+                        if that_node.ntype == fits_parser_yytokentype::DOUBLE as c_int {
                             loop {
                                 let fresh27 = elem;
                                 elem -= 1;
                                 if fresh27 == 0 {
                                     break;
                                 }
-                                *((*this).value.data.lngptr).offset(elem as isize) =
-                                    *((*that).value.data.dblptr).offset(elem as isize) as c_long;
+                                *((this_node).value.data.lngptr).offset(elem as isize) =
+                                    *(that_node.value.data.dblptr).offset(elem as isize) as c_long;
                             }
-                        } else if (*that).ntype == fits_parser_yytokentype::BOOLEAN as c_int {
+                        } else if that_node.ntype == fits_parser_yytokentype::BOOLEAN as c_int {
                             loop {
                                 let fresh28 = elem;
                                 elem -= 1;
                                 if fresh28 == 0 {
                                     break;
                                 }
-                                *((*this).value.data.lngptr).offset(elem as isize) =
-                                    if *((*that).value.data.logptr).offset(elem as isize) as c_int
+                                *((this_node).value.data.lngptr).offset(elem as isize) =
+                                    if *(that_node.value.data.logptr).offset(elem as isize) as c_int
                                         != 0
                                     {
                                         1
@@ -8362,42 +8507,42 @@ fn Do_Unary(lParse: &mut ParseData, this: *mut Node) {
                             }
                         }
                     }
-                    290 => {
-                        if (*that).ntype == fits_parser_yytokentype::DOUBLE as c_int {
+                    fits_parser_yytokentype::UMINUS => {
+                        if that_node.ntype == fits_parser_yytokentype::DOUBLE as c_int {
                             loop {
                                 let fresh29 = elem;
                                 elem -= 1;
                                 if fresh29 == 0 {
                                     break;
                                 }
-                                *((*this).value.data.dblptr).offset(elem as isize) =
-                                    -*((*that).value.data.dblptr).offset(elem as isize);
+                                *((this_node).value.data.dblptr).offset(elem as isize) =
+                                    -*(that_node.value.data.dblptr).offset(elem as isize);
                             }
-                        } else if (*that).ntype == fits_parser_yytokentype::LONG as c_int {
+                        } else if that_node.ntype == fits_parser_yytokentype::LONG as c_int {
                             loop {
                                 let fresh30 = elem;
                                 elem -= 1;
                                 if fresh30 == 0 {
                                     break;
                                 }
-                                *((*this).value.data.lngptr).offset(elem as isize) =
-                                    -*((*that).value.data.lngptr).offset(elem as isize);
+                                *((this_node).value.data.lngptr).offset(elem as isize) =
+                                    -*(that_node.value.data.lngptr).offset(elem as isize);
                             }
                         }
                     }
-                    287 => {
-                        if (*that).ntype == fits_parser_yytokentype::BOOLEAN as c_int {
+                    fits_parser_yytokentype::NOT => {
+                        if that_node.ntype == fits_parser_yytokentype::BOOLEAN as c_int {
                             loop {
                                 let fresh31 = elem;
                                 elem -= 1;
                                 if fresh31 == 0 {
                                     break;
                                 }
-                                *((*this).value.data.logptr).offset(elem as isize) =
-                                    (*((*that).value.data.logptr).offset(elem as isize) == 0)
+                                *((this_node).value.data.logptr).offset(elem as isize) =
+                                    (*(that_node.value.data.logptr).offset(elem as isize) == 0)
                                         as c_int as c_char;
                             }
-                        } else if (*that).ntype == fits_parser_yytokentype::BITSTR as c_int {
+                        } else if that_node.ntype == fits_parser_yytokentype::BITSTR as c_int {
                             elem = lParse.nRows;
                             loop {
                                 let fresh32 = elem;
@@ -8406,8 +8551,8 @@ fn Do_Unary(lParse: &mut ParseData, this: *mut Node) {
                                     break;
                                 }
                                 bitnot(
-                                    *((*this).value.data.strptr).offset(elem as isize),
-                                    *((*that).value.data.strptr).offset(elem as isize),
+                                    *((this_node).value.data.strptr).offset(elem as isize),
+                                    *(that_node.value.data.strptr).offset(elem as isize),
                                 );
                             }
                         }
@@ -8416,36 +8561,42 @@ fn Do_Unary(lParse: &mut ParseData, this: *mut Node) {
                 }
             }
         }
-        if (*that).operation > 0 {
-            free((*that).value.data.ptr);
+
+        let that_idx = (lParse.Nodes[this_node_idx]).SubNodes[0];
+
+        if (lParse.Nodes[that_idx]).operation > 0 {
+            free((lParse.Nodes[that_idx]).value.data.ptr);
         }
     }
 }
-fn Do_Offset(lParse: &mut ParseData, this: *mut Node) {
+
+fn Do_Offset(lParse: &mut ParseData, this_node_idx: usize) {
     unsafe {
-        let mut col: *mut Node = std::ptr::null_mut::<Node>();
         let mut fRow: c_long = 0;
         let mut nRowOverlap: c_long = 0;
         let mut nRowReload: c_long = 0;
-        let mut rowOffset: c_long = 0;
+        let rowOffset: c_long = 0;
         let mut nelem: c_long = 0;
         let mut elem: c_long = 0;
         let mut offset: c_long = 0;
         let mut nRealElem: c_long = 0;
         let mut status: c_int = 0;
-        col = &mut (lParse.Nodes)[(*this).SubNodes[0] as usize];
-        rowOffset = ((lParse.Nodes)[(*this).SubNodes[1] as usize])
+
+        let col_idx = (lParse.Nodes[this_node_idx]).SubNodes[0];
+        let rowOffset = ((lParse.Nodes)[(lParse.Nodes[this_node_idx]).SubNodes[1]])
             .value
             .data
             .lng;
-        Allocate_Ptrs(lParse, this);
+
+        Allocate_Ptrs(lParse, this_node_idx);
+
         fRow = lParse.firstRow + rowOffset;
-        if (*this).ntype == fits_parser_yytokentype::STRING as c_int
-            || (*this).ntype == fits_parser_yytokentype::BITSTR as c_int
+        if (lParse.Nodes[this_node_idx]).ntype == fits_parser_yytokentype::STRING as c_int
+            || (lParse.Nodes[this_node_idx]).ntype == fits_parser_yytokentype::BITSTR as c_int
         {
             nRealElem = 1;
         } else {
-            nRealElem = (*this).value.nelem;
+            nRealElem = (lParse.Nodes[this_node_idx]).value.nelem;
         }
         nelem = nRealElem;
         if fRow < lParse.firstDataRow {
@@ -8456,9 +8607,9 @@ fn Do_Offset(lParse: &mut ParseData, this: *mut Node) {
             nRowOverlap = lParse.nRows - nRowReload;
             offset = 0;
             while fRow < 1 && nRowReload > 0 {
-                if (*this).ntype == fits_parser_yytokentype::BITSTR as c_int {
-                    nelem = (*this).value.nelem;
-                    *(*((*this).value.data.strptr).offset(offset as isize))
+                if (lParse.Nodes[this_node_idx]).ntype == fits_parser_yytokentype::BITSTR as c_int {
+                    nelem = (lParse.Nodes[this_node_idx]).value.nelem;
+                    *(*((lParse.Nodes[this_node_idx]).value.data.strptr).offset(offset as isize))
                         .offset(nelem as isize) = 0;
                     loop {
                         let fresh33 = nelem;
@@ -8466,11 +8617,11 @@ fn Do_Offset(lParse: &mut ParseData, this: *mut Node) {
                         if fresh33 == 0 {
                             break;
                         }
-                        *(*((*this).value.data.strptr).offset(offset as isize))
-                            .offset(nelem as isize) = b'0' as c_char;
+                        *(*((lParse.Nodes[this_node_idx]).value.data.strptr)
+                            .offset(offset as isize))
+                        .offset(nelem as isize) = b'0' as c_char;
                     }
                     offset += 1;
-                    offset;
                 } else {
                     loop {
                         let fresh34 = nelem;
@@ -8480,14 +8631,12 @@ fn Do_Offset(lParse: &mut ParseData, this: *mut Node) {
                         }
                         let fresh35 = offset;
                         offset += 1;
-                        *((*this).value.undef).offset(fresh35 as isize) = 1;
+                        *((lParse.Nodes[this_node_idx]).value.undef).offset(fresh35 as isize) = 1;
                     }
                 }
                 nelem = nRealElem;
                 fRow += 1;
-                fRow;
                 nRowReload -= 1;
-                nRowReload;
             }
         } else if fRow + lParse.nRows > lParse.firstDataRow + lParse.nDataRows {
             nRowReload = fRow + lParse.nRows - (lParse.firstDataRow + lParse.nDataRows);
@@ -8500,20 +8649,20 @@ fn Do_Offset(lParse: &mut ParseData, this: *mut Node) {
             offset = nRowOverlap * nelem;
             elem = lParse.nRows * nelem;
             while fRow + nRowReload > lParse.totalRows && nRowReload > 0 {
-                if (*this).ntype == fits_parser_yytokentype::BITSTR as c_int {
-                    nelem = (*this).value.nelem;
+                if (lParse.Nodes[this_node_idx]).ntype == fits_parser_yytokentype::BITSTR as c_int {
+                    nelem = (lParse.Nodes[this_node_idx]).value.nelem;
                     elem -= 1;
-                    elem;
-                    *(*((*this).value.data.strptr).offset(elem as isize)).offset(nelem as isize) =
-                        0;
+                    *(*((lParse.Nodes[this_node_idx]).value.data.strptr).offset(elem as isize))
+                        .offset(nelem as isize) = 0;
                     loop {
                         let fresh36 = nelem;
                         nelem -= 1;
                         if fresh36 == 0 {
                             break;
                         }
-                        *(*((*this).value.data.strptr).offset(elem as isize))
-                            .offset(nelem as isize) = b'0' as c_char;
+                        *(*((lParse.Nodes[this_node_idx]).value.data.strptr)
+                            .offset(elem as isize))
+                        .offset(nelem as isize) = b'0' as c_char;
                     }
                 } else {
                     loop {
@@ -8523,12 +8672,11 @@ fn Do_Offset(lParse: &mut ParseData, this: *mut Node) {
                             break;
                         }
                         elem -= 1;
-                        *((*this).value.undef).offset(elem as isize) = 1;
+                        *((lParse.Nodes[this_node_idx]).value.undef).offset(elem as isize) = 1;
                     }
                 }
                 nelem = nRealElem;
                 nRowReload -= 1;
-                nRowReload;
             }
         } else {
             nRowReload = 0;
@@ -8536,45 +8684,49 @@ fn Do_Offset(lParse: &mut ParseData, this: *mut Node) {
             offset = 0;
         }
         if nRowReload > 0 {
-            match (*this).ntype {
-                262 | 261 => {
+            match (lParse.Nodes[this_node_idx]).ntype.into() {
+                fits_parser_yytokentype::BITSTR | fits_parser_yytokentype::STRING => {
                     status = (lParse.loadData).expect("non-null function pointer")(
                         lParse,
-                        -(*col).operation,
+                        -(lParse.Nodes[col_idx]).operation,
                         fRow,
                         nRowReload,
-                        ((*this).value.data.strptr).offset(offset as isize) as *mut c_void,
-                        ((*this).value.undef).offset(offset as isize),
+                        ((lParse.Nodes[this_node_idx]).value.data.strptr).offset(offset as isize)
+                            as *mut c_void,
+                        ((lParse.Nodes[this_node_idx]).value.undef).offset(offset as isize),
                     );
                 }
-                258 => {
+                fits_parser_yytokentype::BOOLEAN => {
                     status = (lParse.loadData).expect("non-null function pointer")(
                         lParse,
-                        -(*col).operation,
+                        -(lParse.Nodes[col_idx]).operation,
                         fRow,
                         nRowReload,
-                        ((*this).value.data.logptr).offset(offset as isize) as *mut c_void,
-                        ((*this).value.undef).offset(offset as isize),
+                        ((lParse.Nodes[this_node_idx]).value.data.logptr).offset(offset as isize)
+                            as *mut c_void,
+                        ((lParse.Nodes[this_node_idx]).value.undef).offset(offset as isize),
                     );
                 }
-                259 => {
+                fits_parser_yytokentype::LONG => {
                     status = (lParse.loadData).expect("non-null function pointer")(
                         lParse,
-                        -(*col).operation,
+                        -(lParse.Nodes[col_idx]).operation,
                         fRow,
                         nRowReload,
-                        ((*this).value.data.lngptr).offset(offset as isize) as *mut c_void,
-                        ((*this).value.undef).offset(offset as isize),
+                        ((lParse.Nodes[this_node_idx]).value.data.lngptr).offset(offset as isize)
+                            as *mut c_void,
+                        ((lParse.Nodes[this_node_idx]).value.undef).offset(offset as isize),
                     );
                 }
-                260 => {
+                fits_parser_yytokentype::DOUBLE => {
                     status = (lParse.loadData).expect("non-null function pointer")(
                         lParse,
-                        -(*col).operation,
+                        -(lParse.Nodes[col_idx]).operation,
                         fRow,
                         nRowReload,
-                        ((*this).value.data.dblptr).offset(offset as isize) as *mut c_void,
-                        ((*this).value.undef).offset(offset as isize),
+                        ((lParse.Nodes[this_node_idx]).value.data.dblptr).offset(offset as isize)
+                            as *mut c_void,
+                        ((lParse.Nodes[this_node_idx]).value.undef).offset(offset as isize),
                     );
                 }
                 _ => {}
@@ -8602,35 +8754,42 @@ fn Do_Offset(lParse: &mut ParseData, this: *mut Node) {
                     break;
                 }
                 elem -= 1;
-                elem;
-                if (*this).ntype != fits_parser_yytokentype::BITSTR as c_int {
-                    *((*this).value.undef).offset(elem as isize) =
-                        *((*col).value.undef).offset((elem + offset) as isize);
+
+                if (lParse.Nodes[this_node_idx]).ntype != fits_parser_yytokentype::BITSTR as c_int {
+                    *((lParse.Nodes[this_node_idx]).value.undef).offset(elem as isize) =
+                        *((lParse.Nodes[col_idx]).value.undef).offset((elem + offset) as isize);
                 }
-                match (*this).ntype {
-                    262 => {
+                match (lParse.Nodes[this_node_idx]).ntype.into() {
+                    fits_parser_yytokentype::BITSTR => {
                         strcpy(
-                            *((*this).value.data.strptr).offset(elem as isize),
-                            *((*col).value.data.strptr).offset((elem + offset) as isize),
+                            *((lParse.Nodes[this_node_idx]).value.data.strptr)
+                                .offset(elem as isize),
+                            *((lParse.Nodes[col_idx]).value.data.strptr)
+                                .offset((elem + offset) as isize),
                         );
                     }
-                    261 => {
+                    fits_parser_yytokentype::STRING => {
                         strcpy(
-                            *((*this).value.data.strptr).offset(elem as isize),
-                            *((*col).value.data.strptr).offset((elem + offset) as isize),
+                            *((lParse.Nodes[this_node_idx]).value.data.strptr)
+                                .offset(elem as isize),
+                            *((lParse.Nodes[col_idx]).value.data.strptr)
+                                .offset((elem + offset) as isize),
                         );
                     }
-                    258 => {
-                        *((*this).value.data.logptr).offset(elem as isize) =
-                            *((*col).value.data.logptr).offset((elem + offset) as isize);
+                    fits_parser_yytokentype::BOOLEAN => {
+                        *((lParse.Nodes[this_node_idx]).value.data.logptr).offset(elem as isize) =
+                            *((lParse.Nodes[col_idx]).value.data.logptr)
+                                .offset((elem + offset) as isize);
                     }
-                    259 => {
-                        *((*this).value.data.lngptr).offset(elem as isize) =
-                            *((*col).value.data.lngptr).offset((elem + offset) as isize);
+                    fits_parser_yytokentype::LONG => {
+                        *((lParse.Nodes[this_node_idx]).value.data.lngptr).offset(elem as isize) =
+                            *((lParse.Nodes[col_idx]).value.data.lngptr)
+                                .offset((elem + offset) as isize);
                     }
-                    260 => {
-                        *((*this).value.data.dblptr).offset(elem as isize) =
-                            *((*col).value.data.dblptr).offset((elem + offset) as isize);
+                    fits_parser_yytokentype::DOUBLE => {
+                        *((lParse.Nodes[this_node_idx]).value.data.dblptr).offset(elem as isize) =
+                            *((lParse.Nodes[col_idx]).value.data.dblptr)
+                                .offset((elem + offset) as isize);
                     }
                     _ => {}
                 }
@@ -8639,69 +8798,86 @@ fn Do_Offset(lParse: &mut ParseData, this: *mut Node) {
         }
     }
 }
-fn Do_BinOp_bit(lParse: &mut ParseData, this: *mut Node) {
+fn Do_BinOp_bit(lParse: &mut ParseData, this_node_idx: usize) {
     unsafe {
-        let mut that1: *mut Node = std::ptr::null_mut::<Node>();
-        let mut that2: *mut Node = std::ptr::null_mut::<Node>();
+        let mut that1: &mut Node;
+        let mut that2: &mut Node;
         let mut sptr1: *mut c_char = ptr::null_mut();
         let mut sptr2: *mut c_char = ptr::null_mut();
         let mut const1: c_int = 0;
         let mut const2: c_int = 0;
         let mut rows: c_long = 0;
-        that1 = &mut (lParse.Nodes)[(*this).SubNodes[0] as usize];
-        that2 = &mut (lParse.Nodes)[(*this).SubNodes[1] as usize];
-        const1 = ((*that1).operation == -1000) as c_int;
-        const2 = ((*that2).operation == -1000) as c_int;
+
+        let that1_idx = (lParse.Nodes[this_node_idx]).SubNodes[0];
+        let that2_idx = (lParse.Nodes[this_node_idx]).SubNodes[1];
+
+        const1 = ((lParse.Nodes[that1_idx]).operation == CONST_OP) as c_int;
+        const2 = ((lParse.Nodes[that2_idx]).operation == CONST_OP) as c_int;
         sptr1 = if const1 != 0 {
-            ((*that1).value.data.astr).as_mut_ptr()
+            ((lParse.Nodes[that1_idx]).value.data.astr).as_mut_ptr()
         } else {
             std::ptr::null_mut::<c_char>()
         };
         sptr2 = if const2 != 0 {
-            ((*that2).value.data.astr).as_mut_ptr()
+            ((lParse.Nodes[that2_idx]).value.data.astr).as_mut_ptr()
         } else {
             std::ptr::null_mut::<c_char>()
         };
         if const1 != 0 && const2 != 0 {
-            match (*this).operation {
+            match (lParse.Nodes[this_node_idx]).operation {
                 280 => {
-                    (*this).value.data.log = if bitcmp(sptr1, sptr2) == 0 { 1 } else { 0 };
+                    (lParse.Nodes[this_node_idx]).value.data.log =
+                        if bitcmp(sptr1, sptr2) == 0 { 1 } else { 0 };
                 }
                 279 => {
-                    (*this).value.data.log = bitcmp(sptr1, sptr2);
+                    (lParse.Nodes[this_node_idx]).value.data.log = bitcmp(sptr1, sptr2);
                 }
                 281..=284 => {
-                    (*this).value.data.log = bitlgte(sptr1, (*this).operation, sptr2);
+                    (lParse.Nodes[this_node_idx]).value.data.log =
+                        bitlgte(sptr1, (lParse.Nodes[this_node_idx]).operation, sptr2);
                 }
                 124 => {
-                    bitor(((*this).value.data.astr).as_mut_ptr(), sptr1, sptr2);
+                    bitor(
+                        ((lParse.Nodes[this_node_idx]).value.data.astr).as_mut_ptr(),
+                        sptr1,
+                        sptr2,
+                    );
                 }
                 38 => {
-                    bitand(((*this).value.data.astr).as_mut_ptr(), sptr1, sptr2);
+                    bitand(
+                        ((lParse.Nodes[this_node_idx]).value.data.astr).as_mut_ptr(),
+                        sptr1,
+                        sptr2,
+                    );
                 }
                 43 => {
-                    strcpy(((*this).value.data.astr).as_mut_ptr(), sptr1);
-                    strcat(((*this).value.data.astr).as_mut_ptr(), sptr2);
+                    strcpy(
+                        ((lParse.Nodes[this_node_idx]).value.data.astr).as_mut_ptr(),
+                        sptr1,
+                    );
+                    strcat(
+                        ((lParse.Nodes[this_node_idx]).value.data.astr).as_mut_ptr(),
+                        sptr2,
+                    );
                 }
                 291 => {
-                    (*this).value.data.lng = 0;
+                    (lParse.Nodes[this_node_idx]).value.data.lng = 0;
                     while *sptr1 != 0 {
                         if *sptr1 as c_int == '1' as i32 {
-                            (*this).value.data.lng += 1;
-                            (*this).value.data.lng;
+                            (lParse.Nodes[this_node_idx]).value.data.lng += 1;
+                            (lParse.Nodes[this_node_idx]).value.data.lng;
                         }
                         sptr1 = sptr1.offset(1);
-                        sptr1;
                     }
                 }
                 _ => {}
             }
-            (*this).operation = -1000;
+            (lParse.Nodes[this_node_idx]).operation = CONST_OP;
         } else {
-            Allocate_Ptrs(lParse, this);
+            Allocate_Ptrs(lParse, this_node_idx);
             if lParse.status == 0 {
                 rows = lParse.nRows;
-                match (*this).operation {
+                match (lParse.Nodes[this_node_idx]).operation {
                     279..=284 => loop {
                         let fresh40 = rows;
                         rows -= 1;
@@ -8709,27 +8885,31 @@ fn Do_BinOp_bit(lParse: &mut ParseData, this: *mut Node) {
                             break;
                         }
                         if const1 == 0 {
-                            sptr1 = *((*that1).value.data.strptr).offset(rows as isize);
+                            sptr1 = *((lParse.Nodes[that1_idx]).value.data.strptr)
+                                .offset(rows as isize);
                         }
                         if const2 == 0 {
-                            sptr2 = *((*that2).value.data.strptr).offset(rows as isize);
+                            sptr2 = *((lParse.Nodes[that2_idx]).value.data.strptr)
+                                .offset(rows as isize);
                         }
-                        match (*this).operation {
+                        match (lParse.Nodes[this_node_idx]).operation {
                             280 => {
-                                *((*this).value.data.logptr).offset(rows as isize) =
+                                *((lParse.Nodes[this_node_idx]).value.data.logptr)
+                                    .offset(rows as isize) =
                                     if bitcmp(sptr1, sptr2) == 0 { 1 } else { 0 };
                             }
                             279 => {
-                                *((*this).value.data.logptr).offset(rows as isize) =
-                                    bitcmp(sptr1, sptr2);
+                                *((lParse.Nodes[this_node_idx]).value.data.logptr)
+                                    .offset(rows as isize) = bitcmp(sptr1, sptr2);
                             }
                             281..=284 => {
-                                *((*this).value.data.logptr).offset(rows as isize) =
-                                    bitlgte(sptr1, (*this).operation, sptr2);
+                                *((lParse.Nodes[this_node_idx]).value.data.logptr)
+                                    .offset(rows as isize) =
+                                    bitlgte(sptr1, (lParse.Nodes[this_node_idx]).operation, sptr2);
                             }
                             _ => {}
                         }
-                        *((*this).value.undef).offset(rows as isize) = 0;
+                        *((lParse.Nodes[this_node_idx]).value.undef).offset(rows as isize) = 0;
                     },
                     124 | 38 | 43 => loop {
                         let fresh41 = rows;
@@ -8738,71 +8918,83 @@ fn Do_BinOp_bit(lParse: &mut ParseData, this: *mut Node) {
                             break;
                         }
                         if const1 == 0 {
-                            sptr1 = *((*that1).value.data.strptr).offset(rows as isize);
+                            sptr1 = *((lParse.Nodes[that1_idx]).value.data.strptr)
+                                .offset(rows as isize);
                         }
                         if const2 == 0 {
-                            sptr2 = *((*that2).value.data.strptr).offset(rows as isize);
+                            sptr2 = *((lParse.Nodes[that2_idx]).value.data.strptr)
+                                .offset(rows as isize);
                         }
-                        if (*this).operation == '|' as i32 {
+                        if (lParse.Nodes[this_node_idx]).operation == '|' as i32 {
                             bitor(
-                                *((*this).value.data.strptr).offset(rows as isize),
+                                *((lParse.Nodes[this_node_idx]).value.data.strptr)
+                                    .offset(rows as isize),
                                 sptr1,
                                 sptr2,
                             );
-                        } else if (*this).operation == '&' as i32 {
+                        } else if (lParse.Nodes[this_node_idx]).operation == '&' as i32 {
                             bitand(
-                                *((*this).value.data.strptr).offset(rows as isize),
+                                *((lParse.Nodes[this_node_idx]).value.data.strptr)
+                                    .offset(rows as isize),
                                 sptr1,
                                 sptr2,
                             );
                         } else {
-                            strcpy(*((*this).value.data.strptr).offset(rows as isize), sptr1);
-                            strcat(*((*this).value.data.strptr).offset(rows as isize), sptr2);
+                            strcpy(
+                                *((lParse.Nodes[this_node_idx]).value.data.strptr)
+                                    .offset(rows as isize),
+                                sptr1,
+                            );
+                            strcat(
+                                *((lParse.Nodes[this_node_idx]).value.data.strptr)
+                                    .offset(rows as isize),
+                                sptr2,
+                            );
                         }
                     },
                     291 => {
                         let mut i: c_long = 0;
                         let mut previous: c_long = 0;
                         let mut curr: c_long = 0;
-                        previous = (*that2).value.data.lng;
+                        previous = (lParse.Nodes[that2_idx]).value.data.lng;
                         i = 0;
                         while i < rows {
-                            sptr1 = *((*that1).value.data.strptr).offset(i as isize);
+                            sptr1 =
+                                *((lParse.Nodes[that1_idx]).value.data.strptr).offset(i as isize);
                             curr = 0;
                             while *sptr1 != 0 {
                                 if *sptr1 as c_int == '1' as i32 {
                                     curr += 1;
-                                    curr;
                                 }
                                 sptr1 = sptr1.offset(1);
-                                sptr1;
                             }
                             previous += curr;
-                            *((*this).value.data.lngptr).offset(i as isize) = previous;
-                            *((*this).value.undef).offset(i as isize) = 0;
+                            *((lParse.Nodes[this_node_idx]).value.data.lngptr).offset(i as isize) =
+                                previous;
+                            *((lParse.Nodes[this_node_idx]).value.undef).offset(i as isize) = 0;
                             i += 1;
-                            i;
                         }
-                        (*that2).value.data.lng = previous;
+                        (lParse.Nodes[that2_idx]).value.data.lng = previous;
                     }
                     _ => {}
                 }
             }
         }
-        if (*that1).operation > 0 {
-            free(*((*that1).value.data.strptr).offset(0) as *mut c_void);
-            free((*that1).value.data.strptr as *mut c_void);
+        if (lParse.Nodes[that1_idx]).operation > 0 {
+            free(*((lParse.Nodes[that1_idx]).value.data.strptr).offset(0) as *mut c_void);
+            free((lParse.Nodes[that1_idx]).value.data.strptr as *mut c_void);
         }
-        if (*that2).operation > 0 {
-            free(*((*that2).value.data.strptr).offset(0) as *mut c_void);
-            free((*that2).value.data.strptr as *mut c_void);
+        if (lParse.Nodes[that2_idx]).operation > 0 {
+            free(*((lParse.Nodes[that2_idx]).value.data.strptr).offset(0) as *mut c_void);
+            free((lParse.Nodes[that2_idx]).value.data.strptr as *mut c_void);
         }
     }
 }
-fn Do_BinOp_str(lParse: &mut ParseData, this: *mut Node) {
+
+fn Do_BinOp_str(lParse: &mut ParseData, this_node_idx: usize) {
     unsafe {
-        let mut that1: *mut Node = std::ptr::null_mut::<Node>();
-        let mut that2: *mut Node = std::ptr::null_mut::<Node>();
+        let mut that1: &mut Node;
+        let mut that2: &mut Node;
         let mut sptr1: *mut c_char = ptr::null_mut();
         let mut sptr2: *mut c_char = ptr::null_mut();
         let mut null1: c_char = 0;
@@ -8811,22 +9003,24 @@ fn Do_BinOp_str(lParse: &mut ParseData, this: *mut Node) {
         let mut const2: c_int = 0;
         let mut val: c_int = 0;
         let mut rows: c_long = 0;
-        that1 = &mut (lParse.Nodes)[(*this).SubNodes[0] as usize];
-        that2 = &mut (lParse.Nodes)[(*this).SubNodes[1] as usize];
-        const1 = ((*that1).operation == -1000) as c_int;
-        const2 = ((*that2).operation == -1000) as c_int;
+
+        let that1_idx = (lParse.Nodes[this_node_idx]).SubNodes[0];
+        let that2_idx = (lParse.Nodes[this_node_idx]).SubNodes[1];
+
+        const1 = ((lParse.Nodes[that1_idx]).operation == CONST_OP) as c_int;
+        const2 = ((lParse.Nodes[that2_idx]).operation == CONST_OP) as c_int;
         sptr1 = if const1 != 0 {
-            ((*that1).value.data.astr).as_mut_ptr()
+            ((lParse.Nodes[that1_idx]).value.data.astr).as_mut_ptr()
         } else {
             std::ptr::null_mut::<c_char>()
         };
         sptr2 = if const2 != 0 {
-            ((*that2).value.data.astr).as_mut_ptr()
+            ((lParse.Nodes[that2_idx]).value.data.astr).as_mut_ptr()
         } else {
             std::ptr::null_mut::<c_char>()
         };
         if const1 != 0 && const2 != 0 {
-            match (*this).operation {
+            match (lParse.Nodes[this_node_idx]).operation {
                 280 | 279 => {
                     val = ((if (*sptr1.offset(0) as c_int) < *sptr2.offset(0) as c_int {
                         -(1)
@@ -8835,15 +9029,17 @@ fn Do_BinOp_str(lParse: &mut ParseData, this: *mut Node) {
                     } else {
                         strcmp(sptr1, sptr2)
                     }) == 0) as c_int;
-                    (*this).value.data.log =
-                        (if (*this).operation == fits_parser_yytokentype::EQ as c_int {
-                            val
-                        } else {
-                            (val == 0) as c_int
-                        }) as c_char;
+                    (lParse.Nodes[this_node_idx]).value.data.log = (if (lParse.Nodes[this_node_idx])
+                        .operation
+                        == fits_parser_yytokentype::EQ as c_int
+                    {
+                        val
+                    } else {
+                        (val == 0) as c_int
+                    }) as c_char;
                 }
                 281 => {
-                    (*this).value.data.log =
+                    (lParse.Nodes[this_node_idx]).value.data.log =
                         if (if (*sptr1.offset(0) as c_int) < *sptr2.offset(0) as c_int {
                             -(1)
                         } else if *sptr1.offset(0) as c_int > *sptr2.offset(0) as c_int {
@@ -8858,7 +9054,7 @@ fn Do_BinOp_str(lParse: &mut ParseData, this: *mut Node) {
                         };
                 }
                 282 => {
-                    (*this).value.data.log =
+                    (lParse.Nodes[this_node_idx]).value.data.log =
                         if (if (*sptr1.offset(0) as c_int) < *sptr2.offset(0) as c_int {
                             -(1)
                         } else if *sptr1.offset(0) as c_int > *sptr2.offset(0) as c_int {
@@ -8873,7 +9069,7 @@ fn Do_BinOp_str(lParse: &mut ParseData, this: *mut Node) {
                         };
                 }
                 284 => {
-                    (*this).value.data.log =
+                    (lParse.Nodes[this_node_idx]).value.data.log =
                         if (if (*sptr1.offset(0) as c_int) < *sptr2.offset(0) as c_int {
                             -(1)
                         } else if *sptr1.offset(0) as c_int > *sptr2.offset(0) as c_int {
@@ -8888,7 +9084,7 @@ fn Do_BinOp_str(lParse: &mut ParseData, this: *mut Node) {
                         };
                 }
                 283 => {
-                    (*this).value.data.log =
+                    (lParse.Nodes[this_node_idx]).value.data.log =
                         if (if (*sptr1.offset(0) as c_int) < *sptr2.offset(0) as c_int {
                             -(1)
                         } else if *sptr1.offset(0) as c_int > *sptr2.offset(0) as c_int {
@@ -8903,17 +9099,23 @@ fn Do_BinOp_str(lParse: &mut ParseData, this: *mut Node) {
                         };
                 }
                 43 => {
-                    strcpy(((*this).value.data.astr).as_mut_ptr(), sptr1);
-                    strcat(((*this).value.data.astr).as_mut_ptr(), sptr2);
+                    strcpy(
+                        ((lParse.Nodes[this_node_idx]).value.data.astr).as_mut_ptr(),
+                        sptr1,
+                    );
+                    strcat(
+                        ((lParse.Nodes[this_node_idx]).value.data.astr).as_mut_ptr(),
+                        sptr2,
+                    );
                 }
                 _ => {}
             }
-            (*this).operation = -1000;
+            (lParse.Nodes[this_node_idx]).operation = CONST_OP;
         } else {
-            Allocate_Ptrs(lParse, this);
+            Allocate_Ptrs(lParse, this_node_idx);
             if lParse.status == 0 {
                 rows = lParse.nRows;
-                match (*this).operation {
+                match (lParse.Nodes[this_node_idx]).operation {
                     280 | 279 => loop {
                         let fresh42 = rows;
                         rows -= 1;
@@ -8921,23 +9123,25 @@ fn Do_BinOp_str(lParse: &mut ParseData, this: *mut Node) {
                             break;
                         }
                         if const1 == 0 {
-                            null1 = *((*that1).value.undef).offset(rows as isize);
+                            null1 = *((lParse.Nodes[that1_idx]).value.undef).offset(rows as isize);
                         }
                         if const2 == 0 {
-                            null2 = *((*that2).value.undef).offset(rows as isize);
+                            null2 = *((lParse.Nodes[that2_idx]).value.undef).offset(rows as isize);
                         }
-                        *((*this).value.undef).offset(rows as isize) =
+                        *((lParse.Nodes[this_node_idx]).value.undef).offset(rows as isize) =
                             if null1 as c_int != 0 || null2 as c_int != 0 {
                                 1
                             } else {
                                 0
                             };
-                        if *((*this).value.undef).offset(rows as isize) == 0 {
+                        if *((lParse.Nodes[this_node_idx]).value.undef).offset(rows as isize) == 0 {
                             if const1 == 0 {
-                                sptr1 = *((*that1).value.data.strptr).offset(rows as isize);
+                                sptr1 = *((lParse.Nodes[that1_idx]).value.data.strptr)
+                                    .offset(rows as isize);
                             }
                             if const2 == 0 {
-                                sptr2 = *((*that2).value.data.strptr).offset(rows as isize);
+                                sptr2 = *((lParse.Nodes[that2_idx]).value.data.strptr)
+                                    .offset(rows as isize);
                             }
                             val = ((if (*sptr1.offset(0) as c_int) < *sptr2.offset(0) as c_int {
                                 -(1)
@@ -8946,12 +9150,14 @@ fn Do_BinOp_str(lParse: &mut ParseData, this: *mut Node) {
                             } else {
                                 strcmp(sptr1, sptr2)
                             }) == 0) as c_int;
-                            *((*this).value.data.logptr).offset(rows as isize) =
-                                (if (*this).operation == fits_parser_yytokentype::EQ as c_int {
-                                    val
-                                } else {
-                                    (val == 0) as c_int
-                                }) as c_char;
+                            *((lParse.Nodes[this_node_idx]).value.data.logptr)
+                                .offset(rows as isize) = (if (lParse.Nodes[this_node_idx]).operation
+                                == fits_parser_yytokentype::EQ as c_int
+                            {
+                                val
+                            } else {
+                                (val == 0) as c_int
+                            }) as c_char;
                         }
                     },
                     281 | 282 => loop {
@@ -8961,23 +9167,25 @@ fn Do_BinOp_str(lParse: &mut ParseData, this: *mut Node) {
                             break;
                         }
                         if const1 == 0 {
-                            null1 = *((*that1).value.undef).offset(rows as isize);
+                            null1 = *((lParse.Nodes[that1_idx]).value.undef).offset(rows as isize);
                         }
                         if const2 == 0 {
-                            null2 = *((*that2).value.undef).offset(rows as isize);
+                            null2 = *((lParse.Nodes[that2_idx]).value.undef).offset(rows as isize);
                         }
-                        *((*this).value.undef).offset(rows as isize) =
+                        *((lParse.Nodes[this_node_idx]).value.undef).offset(rows as isize) =
                             if null1 as c_int != 0 || null2 as c_int != 0 {
                                 1
                             } else {
                                 0
                             };
-                        if *((*this).value.undef).offset(rows as isize) == 0 {
+                        if *((lParse.Nodes[this_node_idx]).value.undef).offset(rows as isize) == 0 {
                             if const1 == 0 {
-                                sptr1 = *((*that1).value.data.strptr).offset(rows as isize);
+                                sptr1 = *((lParse.Nodes[that1_idx]).value.data.strptr)
+                                    .offset(rows as isize);
                             }
                             if const2 == 0 {
-                                sptr2 = *((*that2).value.data.strptr).offset(rows as isize);
+                                sptr2 = *((lParse.Nodes[that2_idx]).value.data.strptr)
+                                    .offset(rows as isize);
                             }
                             val = if (*sptr1.offset(0) as c_int) < *sptr2.offset(0) as c_int {
                                 -(1)
@@ -8986,12 +9194,14 @@ fn Do_BinOp_str(lParse: &mut ParseData, this: *mut Node) {
                             } else {
                                 strcmp(sptr1, sptr2)
                             };
-                            *((*this).value.data.logptr).offset(rows as isize) =
-                                (if (*this).operation == fits_parser_yytokentype::GT as c_int {
-                                    (val > 0) as c_int
-                                } else {
-                                    (val < 0) as c_int
-                                }) as c_char;
+                            *((lParse.Nodes[this_node_idx]).value.data.logptr)
+                                .offset(rows as isize) = (if (lParse.Nodes[this_node_idx]).operation
+                                == fits_parser_yytokentype::GT as c_int
+                            {
+                                (val > 0) as c_int
+                            } else {
+                                (val < 0) as c_int
+                            }) as c_char;
                         }
                     },
                     284 | 283 => loop {
@@ -9001,23 +9211,25 @@ fn Do_BinOp_str(lParse: &mut ParseData, this: *mut Node) {
                             break;
                         }
                         if const1 == 0 {
-                            null1 = *((*that1).value.undef).offset(rows as isize);
+                            null1 = *((lParse.Nodes[that1_idx]).value.undef).offset(rows as isize);
                         }
                         if const2 == 0 {
-                            null2 = *((*that2).value.undef).offset(rows as isize);
+                            null2 = *((lParse.Nodes[that2_idx]).value.undef).offset(rows as isize);
                         }
-                        *((*this).value.undef).offset(rows as isize) =
+                        *((lParse.Nodes[this_node_idx]).value.undef).offset(rows as isize) =
                             if null1 as c_int != 0 || null2 as c_int != 0 {
                                 1
                             } else {
                                 0
                             };
-                        if *((*this).value.undef).offset(rows as isize) == 0 {
+                        if *((lParse.Nodes[this_node_idx]).value.undef).offset(rows as isize) == 0 {
                             if const1 == 0 {
-                                sptr1 = *((*that1).value.data.strptr).offset(rows as isize);
+                                sptr1 = *((lParse.Nodes[that1_idx]).value.data.strptr)
+                                    .offset(rows as isize);
                             }
                             if const2 == 0 {
-                                sptr2 = *((*that2).value.data.strptr).offset(rows as isize);
+                                sptr2 = *((lParse.Nodes[that2_idx]).value.data.strptr)
+                                    .offset(rows as isize);
                             }
                             val = if (*sptr1.offset(0) as c_int) < *sptr2.offset(0) as c_int {
                                 -(1)
@@ -9026,12 +9238,14 @@ fn Do_BinOp_str(lParse: &mut ParseData, this: *mut Node) {
                             } else {
                                 strcmp(sptr1, sptr2)
                             };
-                            *((*this).value.data.logptr).offset(rows as isize) =
-                                (if (*this).operation == fits_parser_yytokentype::GTE as c_int {
-                                    (val >= 0) as c_int
-                                } else {
-                                    (val <= 0) as c_int
-                                }) as c_char;
+                            *((lParse.Nodes[this_node_idx]).value.data.logptr)
+                                .offset(rows as isize) = (if (lParse.Nodes[this_node_idx]).operation
+                                == fits_parser_yytokentype::GTE as c_int
+                            {
+                                (val >= 0) as c_int
+                            } else {
+                                (val <= 0) as c_int
+                            }) as c_char;
                         }
                     },
                     43 => loop {
@@ -9041,46 +9255,56 @@ fn Do_BinOp_str(lParse: &mut ParseData, this: *mut Node) {
                             break;
                         }
                         if const1 == 0 {
-                            null1 = *((*that1).value.undef).offset(rows as isize);
+                            null1 = *((lParse.Nodes[that1_idx]).value.undef).offset(rows as isize);
                         }
                         if const2 == 0 {
-                            null2 = *((*that2).value.undef).offset(rows as isize);
+                            null2 = *((lParse.Nodes[that2_idx]).value.undef).offset(rows as isize);
                         }
-                        *((*this).value.undef).offset(rows as isize) =
+                        *((lParse.Nodes[this_node_idx]).value.undef).offset(rows as isize) =
                             if null1 as c_int != 0 || null2 as c_int != 0 {
                                 1
                             } else {
                                 0
                             };
-                        if *((*this).value.undef).offset(rows as isize) == 0 {
+                        if *((lParse.Nodes[this_node_idx]).value.undef).offset(rows as isize) == 0 {
                             if const1 == 0 {
-                                sptr1 = *((*that1).value.data.strptr).offset(rows as isize);
+                                sptr1 = *((lParse.Nodes[that1_idx]).value.data.strptr)
+                                    .offset(rows as isize);
                             }
                             if const2 == 0 {
-                                sptr2 = *((*that2).value.data.strptr).offset(rows as isize);
+                                sptr2 = *((lParse.Nodes[that2_idx]).value.data.strptr)
+                                    .offset(rows as isize);
                             }
-                            strcpy(*((*this).value.data.strptr).offset(rows as isize), sptr1);
-                            strcat(*((*this).value.data.strptr).offset(rows as isize), sptr2);
+                            strcpy(
+                                *((lParse.Nodes[this_node_idx]).value.data.strptr)
+                                    .offset(rows as isize),
+                                sptr1,
+                            );
+                            strcat(
+                                *((lParse.Nodes[this_node_idx]).value.data.strptr)
+                                    .offset(rows as isize),
+                                sptr2,
+                            );
                         }
                     },
                     _ => {}
                 }
             }
         }
-        if (*that1).operation > 0 {
-            free(*((*that1).value.data.strptr).offset(0) as *mut c_void);
-            free((*that1).value.data.strptr as *mut c_void);
+        if (lParse.Nodes[that1_idx]).operation > 0 {
+            free(*((lParse.Nodes[that1_idx]).value.data.strptr).offset(0) as *mut c_void);
+            free((lParse.Nodes[that1_idx]).value.data.strptr as *mut c_void);
         }
-        if (*that2).operation > 0 {
-            free(*((*that2).value.data.strptr).offset(0) as *mut c_void);
-            free((*that2).value.data.strptr as *mut c_void);
+        if (lParse.Nodes[that2_idx]).operation > 0 {
+            free(*((lParse.Nodes[that2_idx]).value.data.strptr).offset(0) as *mut c_void);
+            free((lParse.Nodes[that2_idx]).value.data.strptr as *mut c_void);
         }
     }
 }
-fn Do_BinOp_log(lParse: &mut ParseData, this: *mut Node) {
+fn Do_BinOp_log(lParse: &mut ParseData, this_node_idx: usize) {
     unsafe {
-        let mut that1: *mut Node = std::ptr::null_mut::<Node>();
-        let mut that2: *mut Node = std::ptr::null_mut::<Node>();
+        let mut that1: &mut Node;
+        let mut that2: &mut Node;
         let mut vector1: c_int = 0;
         let mut vector2: c_int = 0;
         let mut val1: c_char = 0;
@@ -9090,43 +9314,46 @@ fn Do_BinOp_log(lParse: &mut ParseData, this: *mut Node) {
         let mut rows: c_long = 0;
         let mut nelem: c_long = 0;
         let mut elem: c_long = 0;
-        that1 = &mut (lParse.Nodes)[(*this).SubNodes[0] as usize];
-        that2 = &mut (lParse.Nodes)[(*this).SubNodes[1] as usize];
-        vector1 = ((*that1).operation != -1000) as c_int;
+        let that1_idx = (lParse.Nodes[this_node_idx]).SubNodes[0];
+        let that2_idx = (lParse.Nodes[this_node_idx]).SubNodes[1];
+
+        vector1 = ((lParse.Nodes[that1_idx]).operation != CONST_OP) as c_int;
         if vector1 != 0 {
-            vector1 = (*that1).value.nelem as c_int;
+            vector1 = (lParse.Nodes[that1_idx]).value.nelem as c_int;
         } else {
-            val1 = (*that1).value.data.log;
+            val1 = (lParse.Nodes[that1_idx]).value.data.log;
         }
-        vector2 = ((*that2).operation != -1000) as c_int;
+        vector2 = ((lParse.Nodes[that2_idx]).operation != CONST_OP) as c_int;
         if vector2 != 0 {
-            vector2 = (*that2).value.nelem as c_int;
+            vector2 = (lParse.Nodes[that2_idx]).value.nelem as c_int;
         } else {
-            val2 = (*that2).value.data.log;
+            val2 = (lParse.Nodes[that2_idx]).value.data.log;
         }
         if vector1 == 0 && vector2 == 0 {
-            match (*this).operation {
+            match (lParse.Nodes[this_node_idx]).operation {
                 277 => {
-                    (*this).value.data.log = if val1 as c_int != 0 || val2 as c_int != 0 {
-                        1
-                    } else {
-                        0
-                    };
+                    (lParse.Nodes[this_node_idx]).value.data.log =
+                        if val1 as c_int != 0 || val2 as c_int != 0 {
+                            1
+                        } else {
+                            0
+                        };
                 }
                 278 => {
-                    (*this).value.data.log = if val1 as c_int != 0 && val2 as c_int != 0 {
-                        1
-                    } else {
-                        0
-                    };
+                    (lParse.Nodes[this_node_idx]).value.data.log =
+                        if val1 as c_int != 0 && val2 as c_int != 0 {
+                            1
+                        } else {
+                            0
+                        };
                 }
                 279 => {
-                    (*this).value.data.log = (val1 as c_int != 0 && val2 as c_int != 0
-                        || val1 == 0 && val2 == 0)
-                        as c_int as c_char;
+                    (lParse.Nodes[this_node_idx]).value.data.log =
+                        (val1 as c_int != 0 && val2 as c_int != 0 || val1 == 0 && val2 == 0)
+                            as c_int as c_char;
                 }
                 280 => {
-                    (*this).value.data.log =
+                    (lParse.Nodes[this_node_idx]).value.data.log =
                         if val1 as c_int != 0 && val2 == 0 || val1 == 0 && val2 as c_int != 0 {
                             1
                         } else {
@@ -9134,57 +9361,63 @@ fn Do_BinOp_log(lParse: &mut ParseData, this: *mut Node) {
                         };
                 }
                 291 => {
-                    (*this).value.data.lng = val1 as c_long;
+                    (lParse.Nodes[this_node_idx]).value.data.lng = val1 as c_long;
                 }
                 _ => {}
             }
-            (*this).operation = -1000;
-        } else if (*this).operation == fits_parser_yytokentype::ACCUM as c_int {
+            (lParse.Nodes[this_node_idx]).operation = CONST_OP;
+        } else if (lParse.Nodes[this_node_idx]).operation == fits_parser_yytokentype::ACCUM as c_int
+        {
             let mut i: c_long = 0;
             let mut previous: c_long = 0;
             let mut curr: c_long = 0;
             rows = lParse.nRows;
-            nelem = (*this).value.nelem;
-            elem = (*this).value.nelem * rows;
-            Allocate_Ptrs(lParse, this);
+            nelem = (lParse.Nodes[this_node_idx]).value.nelem;
+            elem = (lParse.Nodes[this_node_idx]).value.nelem * rows;
+            Allocate_Ptrs(lParse, this_node_idx);
             if lParse.status == 0 {
-                previous = (*that2).value.data.lng;
+                previous = (lParse.Nodes[that2_idx]).value.data.lng;
                 i = 0;
                 while i < elem {
-                    if *((*that1).value.undef).offset(i as isize) == 0 {
-                        curr = *((*that1).value.data.logptr).offset(i as isize) as c_long;
+                    if *((lParse.Nodes[that1_idx]).value.undef).offset(i as isize) == 0 {
+                        curr = *((lParse.Nodes[that1_idx]).value.data.logptr).offset(i as isize)
+                            as c_long;
                         previous += curr;
                     }
-                    *((*this).value.data.lngptr).offset(i as isize) = previous;
-                    *((*this).value.undef).offset(i as isize) = 0;
+                    *((lParse.Nodes[this_node_idx]).value.data.lngptr).offset(i as isize) =
+                        previous;
+                    *((lParse.Nodes[this_node_idx]).value.undef).offset(i as isize) = 0;
                     i += 1;
-                    i;
                 }
-                (*that2).value.data.lng = previous;
+                (lParse.Nodes[that2_idx]).value.data.lng = previous;
             }
         } else {
             rows = lParse.nRows;
-            nelem = (*this).value.nelem;
-            elem = (*this).value.nelem * rows;
-            Allocate_Ptrs(lParse, this);
+            nelem = (lParse.Nodes[this_node_idx]).value.nelem;
+            elem = (lParse.Nodes[this_node_idx]).value.nelem * rows;
+            Allocate_Ptrs(lParse, this_node_idx);
             if lParse.status == 0 {
-                if (*this).operation == fits_parser_yytokentype::ACCUM as c_int {
+                if (lParse.Nodes[this_node_idx]).operation
+                    == fits_parser_yytokentype::ACCUM as c_int
+                {
                     let mut i_0: c_long = 0;
                     let mut previous_0: c_long = 0;
                     let mut curr_0: c_long = 0;
-                    previous_0 = (*that2).value.data.lng;
+                    previous_0 = (lParse.Nodes[that2_idx]).value.data.lng;
                     i_0 = 0;
                     while i_0 < elem {
-                        if *((*that1).value.undef).offset(i_0 as isize) == 0 {
-                            curr_0 = *((*that1).value.data.logptr).offset(i_0 as isize) as c_long;
+                        if *((lParse.Nodes[that1_idx]).value.undef).offset(i_0 as isize) == 0 {
+                            curr_0 = *((lParse.Nodes[that1_idx]).value.data.logptr)
+                                .offset(i_0 as isize)
+                                as c_long;
                             previous_0 += curr_0;
                         }
-                        *((*this).value.data.lngptr).offset(i_0 as isize) = previous_0;
-                        *((*this).value.undef).offset(i_0 as isize) = 0;
+                        *((lParse.Nodes[this_node_idx]).value.data.lngptr).offset(i_0 as isize) =
+                            previous_0;
+                        *((lParse.Nodes[this_node_idx]).value.undef).offset(i_0 as isize) = 0;
                         i_0 += 1;
-                        i_0;
                     }
-                    (*that2).value.data.lng = previous_0;
+                    (lParse.Nodes[that2_idx]).value.data.lng = previous_0;
                 }
                 loop {
                     let fresh46 = rows;
@@ -9199,31 +9432,35 @@ fn Do_BinOp_log(lParse: &mut ParseData, this: *mut Node) {
                             break;
                         }
                         elem -= 1;
-                        elem;
                         if vector1 > 1 {
-                            val1 = *((*that1).value.data.logptr).offset(elem as isize);
-                            null1 = *((*that1).value.undef).offset(elem as isize);
+                            val1 = *((lParse.Nodes[that1_idx]).value.data.logptr)
+                                .offset(elem as isize);
+                            null1 = *((lParse.Nodes[that1_idx]).value.undef).offset(elem as isize);
                         } else if vector1 != 0 {
-                            val1 = *((*that1).value.data.logptr).offset(rows as isize);
-                            null1 = *((*that1).value.undef).offset(rows as isize);
+                            val1 = *((lParse.Nodes[that1_idx]).value.data.logptr)
+                                .offset(rows as isize);
+                            null1 = *((lParse.Nodes[that1_idx]).value.undef).offset(rows as isize);
                         }
                         if vector2 > 1 {
-                            val2 = *((*that2).value.data.logptr).offset(elem as isize);
-                            null2 = *((*that2).value.undef).offset(elem as isize);
+                            val2 = *((lParse.Nodes[that2_idx]).value.data.logptr)
+                                .offset(elem as isize);
+                            null2 = *((lParse.Nodes[that2_idx]).value.undef).offset(elem as isize);
                         } else if vector2 != 0 {
-                            val2 = *((*that2).value.data.logptr).offset(rows as isize);
-                            null2 = *((*that2).value.undef).offset(rows as isize);
+                            val2 = *((lParse.Nodes[that2_idx]).value.data.logptr)
+                                .offset(rows as isize);
+                            null2 = *((lParse.Nodes[that2_idx]).value.undef).offset(rows as isize);
                         }
-                        *((*this).value.undef).offset(elem as isize) =
+                        *((lParse.Nodes[this_node_idx]).value.undef).offset(elem as isize) =
                             if null1 as c_int != 0 || null2 as c_int != 0 {
                                 1
                             } else {
                                 0
                             };
-                        match (*this).operation {
+                        match (lParse.Nodes[this_node_idx]).operation {
                             277 => {
                                 if null1 == 0 && null2 == 0 {
-                                    *((*this).value.data.logptr).offset(elem as isize) =
+                                    *((lParse.Nodes[this_node_idx]).value.data.logptr)
+                                        .offset(elem as isize) =
                                         if val1 as c_int != 0 || val2 as c_int != 0 {
                                             1
                                         } else {
@@ -9232,13 +9469,16 @@ fn Do_BinOp_log(lParse: &mut ParseData, this: *mut Node) {
                                 } else if null1 as c_int != 0 && null2 == 0 && val2 as c_int != 0
                                     || null1 == 0 && null2 as c_int != 0 && val1 as c_int != 0
                                 {
-                                    *((*this).value.data.logptr).offset(elem as isize) = 1;
-                                    *((*this).value.undef).offset(elem as isize) = 0;
+                                    *((lParse.Nodes[this_node_idx]).value.data.logptr)
+                                        .offset(elem as isize) = 1;
+                                    *((lParse.Nodes[this_node_idx]).value.undef)
+                                        .offset(elem as isize) = 0;
                                 }
                             }
                             278 => {
                                 if null1 == 0 && null2 == 0 {
-                                    *((*this).value.data.logptr).offset(elem as isize) =
+                                    *((lParse.Nodes[this_node_idx]).value.data.logptr)
+                                        .offset(elem as isize) =
                                         if val1 as c_int != 0 && val2 as c_int != 0 {
                                             1
                                         } else {
@@ -9247,41 +9487,44 @@ fn Do_BinOp_log(lParse: &mut ParseData, this: *mut Node) {
                                 } else if null1 as c_int != 0 && null2 == 0 && val2 == 0
                                     || null1 == 0 && null2 as c_int != 0 && val1 == 0
                                 {
-                                    *((*this).value.data.logptr).offset(elem as isize) = 0;
-                                    *((*this).value.undef).offset(elem as isize) = 0;
+                                    *((lParse.Nodes[this_node_idx]).value.data.logptr)
+                                        .offset(elem as isize) = 0;
+                                    *((lParse.Nodes[this_node_idx]).value.undef)
+                                        .offset(elem as isize) = 0;
                                 }
                             }
                             279 => {
-                                *((*this).value.data.logptr).offset(elem as isize) =
+                                *((lParse.Nodes[this_node_idx]).value.data.logptr)
+                                    .offset(elem as isize) =
                                     (val1 as c_int != 0 && val2 as c_int != 0
                                         || val1 == 0 && val2 == 0)
                                         as c_int as c_char;
                             }
                             280 => {
-                                *((*this).value.data.logptr).offset(elem as isize) =
-                                    (val1 as c_int != 0 && val2 == 0
-                                        || val1 == 0 && val2 as c_int != 0)
-                                        as c_int as c_char;
+                                *((lParse.Nodes[this_node_idx]).value.data.logptr)
+                                    .offset(elem as isize) = (val1 as c_int != 0 && val2 == 0
+                                    || val1 == 0 && val2 as c_int != 0)
+                                    as c_int
+                                    as c_char;
                             }
                             _ => {}
                         }
                     }
-                    nelem = (*this).value.nelem;
+                    nelem = (lParse.Nodes[this_node_idx]).value.nelem;
                 }
             }
         }
-        if (*that1).operation > 0 {
-            free((*that1).value.data.ptr);
+        if (lParse.Nodes[that1_idx]).operation > 0 {
+            free((lParse.Nodes[that1_idx]).value.data.ptr);
         }
-        if (*that2).operation > 0 {
-            free((*that2).value.data.ptr);
+        if (lParse.Nodes[that2_idx]).operation > 0 {
+            free((lParse.Nodes[that2_idx]).value.data.ptr);
         }
     }
 }
-fn Do_BinOp_lng(lParse: &mut ParseData, this: *mut Node) {
+
+fn Do_BinOp_lng(lParse: &mut ParseData, this_node_idx: usize) {
     unsafe {
-        let mut that1: *mut Node = std::ptr::null_mut::<Node>();
-        let mut that2: *mut Node = std::ptr::null_mut::<Node>();
         let mut vector1: c_int = 0;
         let mut vector2: c_int = 0;
         let mut val1: c_long = 0;
@@ -9291,135 +9534,149 @@ fn Do_BinOp_lng(lParse: &mut ParseData, this: *mut Node) {
         let mut rows: c_long = 0;
         let mut nelem: c_long = 0;
         let mut elem: c_long = 0;
-        that1 = &mut (lParse.Nodes)[(*this).SubNodes[0] as usize];
-        that2 = &mut (lParse.Nodes)[(*this).SubNodes[1] as usize];
-        vector1 = ((*that1).operation != -1000) as c_int;
+
+        let that1_idx = (lParse.Nodes[this_node_idx]).SubNodes[0];
+        let that2_idx = (lParse.Nodes[this_node_idx]).SubNodes[1];
+        vector1 = ((lParse.Nodes[that1_idx]).operation != CONST_OP) as c_int;
+
         if vector1 != 0 {
-            vector1 = (*that1).value.nelem as c_int;
+            vector1 = (lParse.Nodes[that1_idx]).value.nelem as c_int;
         } else {
-            val1 = (*that1).value.data.lng;
+            val1 = (lParse.Nodes[that1_idx]).value.data.lng;
         }
-        vector2 = ((*that2).operation != -1000) as c_int;
+
+        vector2 = ((lParse.Nodes[that2_idx]).operation != CONST_OP) as c_int;
         if vector2 != 0 {
-            vector2 = (*that2).value.nelem as c_int;
+            vector2 = (lParse.Nodes[that2_idx]).value.nelem as c_int;
         } else {
-            val2 = (*that2).value.data.lng;
+            val2 = (lParse.Nodes[that2_idx]).value.data.lng;
         }
+
         if vector1 == 0 && vector2 == 0 {
-            match (*this).operation {
+            /*  Result is a constant  */
+
+            match (lParse.Nodes[this_node_idx]).operation {
                 126 | 279 => {
-                    (*this).value.data.log = if val1 == val2 { 1 } else { 0 };
+                    (lParse.Nodes[this_node_idx]).value.data.log = if val1 == val2 { 1 } else { 0 };
                 }
                 280 => {
-                    (*this).value.data.log = if val1 != val2 { 1 } else { 0 };
+                    (lParse.Nodes[this_node_idx]).value.data.log = if val1 != val2 { 1 } else { 0 };
                 }
                 281 => {
-                    (*this).value.data.log = if val1 > val2 { 1 } else { 0 };
+                    (lParse.Nodes[this_node_idx]).value.data.log = if val1 > val2 { 1 } else { 0 };
                 }
                 282 => {
-                    (*this).value.data.log = if val1 < val2 { 1 } else { 0 };
+                    (lParse.Nodes[this_node_idx]).value.data.log = if val1 < val2 { 1 } else { 0 };
                 }
                 283 => {
-                    (*this).value.data.log = if val1 <= val2 { 1 } else { 0 };
+                    (lParse.Nodes[this_node_idx]).value.data.log = if val1 <= val2 { 1 } else { 0 };
                 }
                 284 => {
-                    (*this).value.data.log = if val1 >= val2 { 1 } else { 0 };
+                    (lParse.Nodes[this_node_idx]).value.data.log = if val1 >= val2 { 1 } else { 0 };
                 }
                 43 => {
-                    (*this).value.data.lng = val1 + val2;
+                    (lParse.Nodes[this_node_idx]).value.data.lng = val1 + val2;
                 }
                 45 => {
-                    (*this).value.data.lng = val1 - val2;
+                    (lParse.Nodes[this_node_idx]).value.data.lng = val1 - val2;
                 }
                 42 => {
-                    (*this).value.data.lng = val1 * val2;
+                    (lParse.Nodes[this_node_idx]).value.data.lng = val1 * val2;
                 }
                 38 => {
-                    (*this).value.data.lng = val1 & val2;
+                    (lParse.Nodes[this_node_idx]).value.data.lng = val1 & val2;
                 }
                 124 => {
-                    (*this).value.data.lng = val1 | val2;
+                    (lParse.Nodes[this_node_idx]).value.data.lng = val1 | val2;
                 }
                 94 => {
-                    (*this).value.data.lng = val1 ^ val2;
+                    (lParse.Nodes[this_node_idx]).value.data.lng = val1 ^ val2;
                 }
                 37 => {
                     if val2 != 0 {
-                        (*this).value.data.lng = val1 % val2;
+                        (lParse.Nodes[this_node_idx]).value.data.lng = val1 % val2;
                     } else {
                         fits_parser_yyerror(lParse, cs!(c"Divide by Zero"));
                     }
                 }
                 47 => {
                     if val2 != 0 {
-                        (*this).value.data.lng = val1 / val2;
+                        (lParse.Nodes[this_node_idx]).value.data.lng = val1 / val2;
                     } else {
                         fits_parser_yyerror(lParse, cs!(c"Divide by Zero"));
                     }
                 }
                 286 => {
-                    (*this).value.data.lng = pow(val1 as c_double, val2 as c_double) as c_long;
+                    (lParse.Nodes[this_node_idx]).value.data.lng =
+                        pow(val1 as c_double, val2 as c_double) as c_long;
                 }
                 291 => {
-                    (*this).value.data.lng = val1;
+                    (lParse.Nodes[this_node_idx]).value.data.lng = val1;
                 }
                 292 => {
-                    (*this).value.data.lng = 0;
+                    (lParse.Nodes[this_node_idx]).value.data.lng = 0;
                 }
                 _ => {}
             }
-            (*this).operation = -1000;
-        } else if (*this).operation == fits_parser_yytokentype::ACCUM as c_int
-            || (*this).operation == fits_parser_yytokentype::DIFF as c_int
+            (lParse.Nodes[this_node_idx]).operation = CONST_OP;
+        } else if (lParse.Nodes[this_node_idx]).operation == fits_parser_yytokentype::ACCUM as c_int
+            || (lParse.Nodes[this_node_idx]).operation == fits_parser_yytokentype::DIFF as c_int
         {
             let mut i: c_long = 0;
             let mut previous: c_long = 0;
             let mut curr: c_long = 0;
             let mut undef: c_long = 0;
             rows = lParse.nRows;
-            nelem = (*this).value.nelem;
-            elem = (*this).value.nelem * rows;
-            Allocate_Ptrs(lParse, this);
+            nelem = (lParse.Nodes[this_node_idx]).value.nelem;
+            elem = (lParse.Nodes[this_node_idx]).value.nelem * rows;
+            Allocate_Ptrs(lParse, this_node_idx);
             if lParse.status == 0 {
-                previous = (*that2).value.data.lng;
-                undef = *(*that2).value.undef as c_long;
-                if (*this).operation == fits_parser_yytokentype::ACCUM as c_int {
+                previous = (lParse.Nodes[that2_idx]).value.data.lng;
+                undef = *(lParse.Nodes[that2_idx]).value.undef as c_long;
+                if (lParse.Nodes[this_node_idx]).operation
+                    == fits_parser_yytokentype::ACCUM as c_int
+                {
                     i = 0;
                     while i < elem {
-                        if *((*that1).value.undef).offset(i as isize) == 0 {
-                            curr = *((*that1).value.data.lngptr).offset(i as isize);
+                        if *((lParse.Nodes[that1_idx]).value.undef).offset(i as isize) == 0 {
+                            curr =
+                                *((lParse.Nodes[that1_idx]).value.data.lngptr).offset(i as isize);
                             previous += curr;
                         }
-                        *((*this).value.data.lngptr).offset(i as isize) = previous;
-                        *((*this).value.undef).offset(i as isize) = 0;
+                        *((lParse.Nodes[this_node_idx]).value.data.lngptr).offset(i as isize) =
+                            previous;
+                        *((lParse.Nodes[this_node_idx]).value.undef).offset(i as isize) = 0;
                         i += 1;
-                        i;
                     }
                 } else {
                     i = 0;
                     while i < elem {
-                        curr = *((*that1).value.data.lngptr).offset(i as isize);
-                        if *((*that1).value.undef).offset(i as isize) as c_int != 0 || undef != 0 {
-                            *((*this).value.data.lngptr).offset(i as isize) = 0;
-                            *((*this).value.undef).offset(i as isize) = 1;
+                        curr = *((lParse.Nodes[that1_idx]).value.data.lngptr).offset(i as isize);
+                        if *((lParse.Nodes[that1_idx]).value.undef).offset(i as isize) as c_int != 0
+                            || undef != 0
+                        {
+                            *((lParse.Nodes[this_node_idx]).value.data.lngptr).offset(i as isize) =
+                                0;
+                            *((lParse.Nodes[this_node_idx]).value.undef).offset(i as isize) = 1;
                         } else {
-                            *((*this).value.data.lngptr).offset(i as isize) = curr - previous;
-                            *((*this).value.undef).offset(i as isize) = 0;
+                            *((lParse.Nodes[this_node_idx]).value.data.lngptr).offset(i as isize) =
+                                curr - previous;
+                            *((lParse.Nodes[this_node_idx]).value.undef).offset(i as isize) = 0;
                         }
                         previous = curr;
-                        undef = *((*that1).value.undef).offset(i as isize) as c_long;
+                        undef =
+                            *((lParse.Nodes[that1_idx]).value.undef).offset(i as isize) as c_long;
                         i += 1;
-                        i;
                     }
                 }
-                (*that2).value.data.lng = previous;
-                (*that2).value.undef = undef as *mut c_char;
+                (lParse.Nodes[that2_idx]).value.data.lng = previous;
+                (lParse.Nodes[that2_idx]).value.undef = undef as *mut c_char;
             }
         } else {
             rows = lParse.nRows;
-            nelem = (*this).value.nelem;
-            elem = (*this).value.nelem * rows;
-            Allocate_Ptrs(lParse, this);
+            nelem = (lParse.Nodes[this_node_idx]).value.nelem;
+            elem = (lParse.Nodes[this_node_idx]).value.nelem * rows;
+            Allocate_Ptrs(lParse, this_node_idx);
             loop {
                 let fresh48 = rows;
                 rows -= 1;
@@ -9433,108 +9690,121 @@ fn Do_BinOp_lng(lParse: &mut ParseData, this: *mut Node) {
                         break;
                     }
                     elem -= 1;
-                    elem;
+
                     if vector1 > 1 {
-                        val1 = *((*that1).value.data.lngptr).offset(elem as isize);
-                        null1 = *((*that1).value.undef).offset(elem as isize);
+                        val1 = *((lParse.Nodes[that1_idx]).value.data.lngptr).offset(elem as isize);
+                        null1 = *((lParse.Nodes[that1_idx]).value.undef).offset(elem as isize);
                     } else if vector1 != 0 {
-                        val1 = *((*that1).value.data.lngptr).offset(rows as isize);
-                        null1 = *((*that1).value.undef).offset(rows as isize);
+                        val1 = *((lParse.Nodes[that1_idx]).value.data.lngptr).offset(rows as isize);
+                        null1 = *((lParse.Nodes[that1_idx]).value.undef).offset(rows as isize);
                     }
                     if vector2 > 1 {
-                        val2 = *((*that2).value.data.lngptr).offset(elem as isize);
-                        null2 = *((*that2).value.undef).offset(elem as isize);
+                        val2 = *((lParse.Nodes[that2_idx]).value.data.lngptr).offset(elem as isize);
+                        null2 = *((lParse.Nodes[that2_idx]).value.undef).offset(elem as isize);
                     } else if vector2 != 0 {
-                        val2 = *((*that2).value.data.lngptr).offset(rows as isize);
-                        null2 = *((*that2).value.undef).offset(rows as isize);
+                        val2 = *((lParse.Nodes[that2_idx]).value.data.lngptr).offset(rows as isize);
+                        null2 = *((lParse.Nodes[that2_idx]).value.undef).offset(rows as isize);
                     }
-                    *((*this).value.undef).offset(elem as isize) =
+                    *((lParse.Nodes[this_node_idx]).value.undef).offset(elem as isize) =
                         if null1 as c_int != 0 || null2 as c_int != 0 {
                             1
                         } else {
                             0
                         };
-                    match (*this).operation {
+                    match (lParse.Nodes[this_node_idx]).operation {
                         126 | 279 => {
-                            *((*this).value.data.logptr).offset(elem as isize) =
-                                if val1 == val2 { 1 } else { 0 };
+                            *((lParse.Nodes[this_node_idx]).value.data.logptr)
+                                .offset(elem as isize) = if val1 == val2 { 1 } else { 0 };
                         }
                         280 => {
-                            *((*this).value.data.logptr).offset(elem as isize) =
-                                if val1 != val2 { 1 } else { 0 };
+                            *((lParse.Nodes[this_node_idx]).value.data.logptr)
+                                .offset(elem as isize) = if val1 != val2 { 1 } else { 0 };
                         }
                         281 => {
-                            *((*this).value.data.logptr).offset(elem as isize) =
-                                if val1 > val2 { 1 } else { 0 };
+                            *((lParse.Nodes[this_node_idx]).value.data.logptr)
+                                .offset(elem as isize) = if val1 > val2 { 1 } else { 0 };
                         }
                         282 => {
-                            *((*this).value.data.logptr).offset(elem as isize) =
-                                if val1 < val2 { 1 } else { 0 };
+                            *((lParse.Nodes[this_node_idx]).value.data.logptr)
+                                .offset(elem as isize) = if val1 < val2 { 1 } else { 0 };
                         }
                         283 => {
-                            *((*this).value.data.logptr).offset(elem as isize) =
-                                if val1 <= val2 { 1 } else { 0 };
+                            *((lParse.Nodes[this_node_idx]).value.data.logptr)
+                                .offset(elem as isize) = if val1 <= val2 { 1 } else { 0 };
                         }
                         284 => {
-                            *((*this).value.data.logptr).offset(elem as isize) =
-                                if val1 >= val2 { 1 } else { 0 };
+                            *((lParse.Nodes[this_node_idx]).value.data.logptr)
+                                .offset(elem as isize) = if val1 >= val2 { 1 } else { 0 };
                         }
                         43 => {
-                            *((*this).value.data.lngptr).offset(elem as isize) = val1 + val2;
+                            *((lParse.Nodes[this_node_idx]).value.data.lngptr)
+                                .offset(elem as isize) = val1 + val2;
                         }
                         45 => {
-                            *((*this).value.data.lngptr).offset(elem as isize) = val1 - val2;
+                            *((lParse.Nodes[this_node_idx]).value.data.lngptr)
+                                .offset(elem as isize) = val1 - val2;
                         }
                         42 => {
-                            *((*this).value.data.lngptr).offset(elem as isize) = val1 * val2;
+                            *((lParse.Nodes[this_node_idx]).value.data.lngptr)
+                                .offset(elem as isize) = val1 * val2;
                         }
                         38 => {
-                            *((*this).value.data.lngptr).offset(elem as isize) = val1 & val2;
+                            *((lParse.Nodes[this_node_idx]).value.data.lngptr)
+                                .offset(elem as isize) = val1 & val2;
                         }
                         124 => {
-                            *((*this).value.data.lngptr).offset(elem as isize) = val1 | val2;
+                            *((lParse.Nodes[this_node_idx]).value.data.lngptr)
+                                .offset(elem as isize) = val1 | val2;
                         }
                         94 => {
-                            *((*this).value.data.lngptr).offset(elem as isize) = val1 ^ val2;
+                            *((lParse.Nodes[this_node_idx]).value.data.lngptr)
+                                .offset(elem as isize) = val1 ^ val2;
                         }
                         37 => {
                             if val2 != 0 {
-                                *((*this).value.data.lngptr).offset(elem as isize) = val1 % val2;
+                                *((lParse.Nodes[this_node_idx]).value.data.lngptr)
+                                    .offset(elem as isize) = val1 % val2;
                             } else {
-                                *((*this).value.data.lngptr).offset(elem as isize) = 0;
-                                *((*this).value.undef).offset(elem as isize) = 1;
+                                *((lParse.Nodes[this_node_idx]).value.data.lngptr)
+                                    .offset(elem as isize) = 0;
+                                *((lParse.Nodes[this_node_idx]).value.undef)
+                                    .offset(elem as isize) = 1;
                             }
                         }
                         47 => {
                             if val2 != 0 {
-                                *((*this).value.data.lngptr).offset(elem as isize) = val1 / val2;
+                                *((lParse.Nodes[this_node_idx]).value.data.lngptr)
+                                    .offset(elem as isize) = val1 / val2;
                             } else {
-                                *((*this).value.data.lngptr).offset(elem as isize) = 0;
-                                *((*this).value.undef).offset(elem as isize) = 1;
+                                *((lParse.Nodes[this_node_idx]).value.data.lngptr)
+                                    .offset(elem as isize) = 0;
+                                *((lParse.Nodes[this_node_idx]).value.undef)
+                                    .offset(elem as isize) = 1;
                             }
                         }
                         286 => {
-                            *((*this).value.data.lngptr).offset(elem as isize) =
+                            *((lParse.Nodes[this_node_idx]).value.data.lngptr)
+                                .offset(elem as isize) =
                                 pow(val1 as c_double, val2 as c_double) as c_long;
                         }
                         _ => {}
                     }
                 }
-                nelem = (*this).value.nelem;
+                nelem = (lParse.Nodes[this_node_idx]).value.nelem;
             }
         }
-        if (*that1).operation > 0 {
-            free((*that1).value.data.ptr);
+        if (lParse.Nodes[that1_idx]).operation > 0 {
+            free((lParse.Nodes[that1_idx]).value.data.ptr);
         }
-        if (*that2).operation > 0 {
-            free((*that2).value.data.ptr);
+        if (lParse.Nodes[that2_idx]).operation > 0 {
+            free((lParse.Nodes[that2_idx]).value.data.ptr);
         }
     }
 }
-fn Do_BinOp_dbl(lParse: &mut ParseData, this: *mut Node) {
+fn Do_BinOp_dbl(lParse: &mut ParseData, this_node_idx: usize) {
     unsafe {
-        let mut that1: *mut Node = std::ptr::null_mut::<Node>();
-        let mut that2: *mut Node = std::ptr::null_mut::<Node>();
+        let mut that1: &mut Node;
+        let mut that2: &mut Node;
         let mut vector1: c_int = 0;
         let mut vector2: c_int = 0;
         let mut val1: c_double = 0.0;
@@ -9544,129 +9814,140 @@ fn Do_BinOp_dbl(lParse: &mut ParseData, this: *mut Node) {
         let mut rows: c_long = 0;
         let mut nelem: c_long = 0;
         let mut elem: c_long = 0;
-        that1 = &mut (lParse.Nodes)[(*this).SubNodes[0] as usize];
-        that2 = &mut (lParse.Nodes)[(*this).SubNodes[1] as usize];
-        vector1 = ((*that1).operation != -1000) as c_int;
+
+        let that1_idx = (lParse.Nodes[this_node_idx]).SubNodes[0];
+        let that2_idx = (lParse.Nodes[this_node_idx]).SubNodes[1];
+
+        vector1 = ((lParse.Nodes[that1_idx]).operation != CONST_OP) as c_int;
         if vector1 != 0 {
-            vector1 = (*that1).value.nelem as c_int;
+            vector1 = (lParse.Nodes[that1_idx]).value.nelem as c_int;
         } else {
-            val1 = (*that1).value.data.dbl;
+            val1 = (lParse.Nodes[that1_idx]).value.data.dbl;
         }
-        vector2 = ((*that2).operation != -1000) as c_int;
+        vector2 = ((lParse.Nodes[that2_idx]).operation != CONST_OP) as c_int;
         if vector2 != 0 {
-            vector2 = (*that2).value.nelem as c_int;
+            vector2 = (lParse.Nodes[that2_idx]).value.nelem as c_int;
         } else {
-            val2 = (*that2).value.data.dbl;
+            val2 = (lParse.Nodes[that2_idx]).value.data.dbl;
         }
         if vector1 == 0 && vector2 == 0 {
-            match (*this).operation {
+            match (lParse.Nodes[this_node_idx]).operation {
                 126 => {
-                    (*this).value.data.log = if fabs(val1 - val2) < 1.0e-7f64 { 1 } else { 0 };
+                    (lParse.Nodes[this_node_idx]).value.data.log =
+                        if fabs(val1 - val2) < 1.0e-7f64 { 1 } else { 0 };
                 }
                 279 => {
-                    (*this).value.data.log = if val1 == val2 { 1 } else { 0 };
+                    (lParse.Nodes[this_node_idx]).value.data.log = if val1 == val2 { 1 } else { 0 };
                 }
                 280 => {
-                    (*this).value.data.log = if val1 != val2 { 1 } else { 0 };
+                    (lParse.Nodes[this_node_idx]).value.data.log = if val1 != val2 { 1 } else { 0 };
                 }
                 281 => {
-                    (*this).value.data.log = if val1 > val2 { 1 } else { 0 };
+                    (lParse.Nodes[this_node_idx]).value.data.log = if val1 > val2 { 1 } else { 0 };
                 }
                 282 => {
-                    (*this).value.data.log = if val1 < val2 { 1 } else { 0 };
+                    (lParse.Nodes[this_node_idx]).value.data.log = if val1 < val2 { 1 } else { 0 };
                 }
                 283 => {
-                    (*this).value.data.log = if val1 <= val2 { 1 } else { 0 };
+                    (lParse.Nodes[this_node_idx]).value.data.log = if val1 <= val2 { 1 } else { 0 };
                 }
                 284 => {
-                    (*this).value.data.log = if val1 >= val2 { 1 } else { 0 };
+                    (lParse.Nodes[this_node_idx]).value.data.log = if val1 >= val2 { 1 } else { 0 };
                 }
                 43 => {
-                    (*this).value.data.dbl = val1 + val2;
+                    (lParse.Nodes[this_node_idx]).value.data.dbl = val1 + val2;
                 }
                 45 => {
-                    (*this).value.data.dbl = val1 - val2;
+                    (lParse.Nodes[this_node_idx]).value.data.dbl = val1 - val2;
                 }
                 42 => {
-                    (*this).value.data.dbl = val1 * val2;
+                    (lParse.Nodes[this_node_idx]).value.data.dbl = val1 * val2;
                 }
                 37 => {
                     if val2 != 0. {
-                        (*this).value.data.dbl = val1 - val2 * (val1 / val2) as c_int as c_double;
+                        (lParse.Nodes[this_node_idx]).value.data.dbl =
+                            val1 - val2 * (val1 / val2) as c_int as c_double;
                     } else {
                         fits_parser_yyerror(lParse, cs!(c"Divide by Zero"));
                     }
                 }
                 47 => {
                     if val2 != 0. {
-                        (*this).value.data.dbl = val1 / val2;
+                        (lParse.Nodes[this_node_idx]).value.data.dbl = val1 / val2;
                     } else {
                         fits_parser_yyerror(lParse, cs!(c"Divide by Zero"));
                     }
                 }
                 286 => {
-                    (*this).value.data.dbl = pow(val1, val2);
+                    (lParse.Nodes[this_node_idx]).value.data.dbl = pow(val1, val2);
                 }
                 291 => {
-                    (*this).value.data.dbl = val1;
+                    (lParse.Nodes[this_node_idx]).value.data.dbl = val1;
                 }
                 292 => {
-                    (*this).value.data.dbl = 0.0;
+                    (lParse.Nodes[this_node_idx]).value.data.dbl = 0.0;
                 }
                 _ => {}
             }
-            (*this).operation = -1000;
-        } else if (*this).operation == fits_parser_yytokentype::ACCUM as c_int
-            || (*this).operation == fits_parser_yytokentype::DIFF as c_int
+            (lParse.Nodes[this_node_idx]).operation = CONST_OP;
+        } else if (lParse.Nodes[this_node_idx]).operation == fits_parser_yytokentype::ACCUM as c_int
+            || (lParse.Nodes[this_node_idx]).operation == fits_parser_yytokentype::DIFF as c_int
         {
             let mut i: c_long = 0;
             let mut undef: c_long = 0;
             let mut previous: c_double = 0.0;
             let mut curr: c_double = 0.0;
             rows = lParse.nRows;
-            nelem = (*this).value.nelem;
-            elem = (*this).value.nelem * rows;
-            Allocate_Ptrs(lParse, this);
+            nelem = (lParse.Nodes[this_node_idx]).value.nelem;
+            elem = (lParse.Nodes[this_node_idx]).value.nelem * rows;
+            Allocate_Ptrs(lParse, this_node_idx);
             if lParse.status == 0 {
-                previous = (*that2).value.data.dbl;
-                undef = *(*that2).value.undef as c_long;
-                if (*this).operation == fits_parser_yytokentype::ACCUM as c_int {
+                previous = (lParse.Nodes[that2_idx]).value.data.dbl;
+                undef = *(lParse.Nodes[that2_idx]).value.undef as c_long;
+                if (lParse.Nodes[this_node_idx]).operation
+                    == fits_parser_yytokentype::ACCUM as c_int
+                {
                     i = 0;
                     while i < elem {
-                        if *((*that1).value.undef).offset(i as isize) == 0 {
-                            curr = *((*that1).value.data.dblptr).offset(i as isize);
+                        if *((lParse.Nodes[that1_idx]).value.undef).offset(i as isize) == 0 {
+                            curr =
+                                *((lParse.Nodes[that1_idx]).value.data.dblptr).offset(i as isize);
                             previous += curr;
                         }
-                        *((*this).value.data.dblptr).offset(i as isize) = previous;
-                        *((*this).value.undef).offset(i as isize) = 0;
+                        *((lParse.Nodes[this_node_idx]).value.data.dblptr).offset(i as isize) =
+                            previous;
+                        *((lParse.Nodes[this_node_idx]).value.undef).offset(i as isize) = 0;
                         i += 1;
-                        i;
                     }
                 } else {
                     i = 0;
                     while i < elem {
-                        curr = *((*that1).value.data.dblptr).offset(i as isize);
-                        if *((*that1).value.undef).offset(i as isize) as c_int != 0 || undef != 0 {
-                            *((*this).value.data.dblptr).offset(i as isize) = 0.0;
-                            *((*this).value.undef).offset(i as isize) = 1;
+                        curr = *((lParse.Nodes[that1_idx]).value.data.dblptr).offset(i as isize);
+                        if *((lParse.Nodes[that1_idx]).value.undef).offset(i as isize) as c_int != 0
+                            || undef != 0
+                        {
+                            *((lParse.Nodes[this_node_idx]).value.data.dblptr).offset(i as isize) =
+                                0.0;
+                            *((lParse.Nodes[this_node_idx]).value.undef).offset(i as isize) = 1;
                         } else {
-                            *((*this).value.data.dblptr).offset(i as isize) = curr - previous;
-                            *((*this).value.undef).offset(i as isize) = 0;
+                            *((lParse.Nodes[this_node_idx]).value.data.dblptr).offset(i as isize) =
+                                curr - previous;
+                            *((lParse.Nodes[this_node_idx]).value.undef).offset(i as isize) = 0;
                         }
                         previous = curr;
-                        undef = *((*that1).value.undef).offset(i as isize) as c_long;
+                        undef =
+                            *((lParse.Nodes[that1_idx]).value.undef).offset(i as isize) as c_long;
                         i += 1;
-                        i;
                     }
                 }
-                (*that2).value.data.dbl = previous;
-                (*that2).value.undef = undef as *mut c_char;
+                (lParse.Nodes[that2_idx]).value.data.dbl = previous;
+                (lParse.Nodes[that2_idx]).value.undef = undef as *mut c_char;
             }
         } else {
             rows = lParse.nRows;
-            nelem = (*this).value.nelem;
-            elem = (*this).value.nelem * rows;
-            Allocate_Ptrs(lParse, this);
+            nelem = (lParse.Nodes[this_node_idx]).value.nelem;
+            elem = (lParse.Nodes[this_node_idx]).value.nelem * rows;
+            Allocate_Ptrs(lParse, this_node_idx);
             loop {
                 let fresh50 = rows;
                 rows -= 1;
@@ -9680,96 +9961,107 @@ fn Do_BinOp_dbl(lParse: &mut ParseData, this: *mut Node) {
                         break;
                     }
                     elem -= 1;
-                    elem;
+
                     if vector1 > 1 {
-                        val1 = *((*that1).value.data.dblptr).offset(elem as isize);
-                        null1 = *((*that1).value.undef).offset(elem as isize);
+                        val1 = *((lParse.Nodes[that1_idx]).value.data.dblptr).offset(elem as isize);
+                        null1 = *((lParse.Nodes[that1_idx]).value.undef).offset(elem as isize);
                     } else if vector1 != 0 {
-                        val1 = *((*that1).value.data.dblptr).offset(rows as isize);
-                        null1 = *((*that1).value.undef).offset(rows as isize);
+                        val1 = *((lParse.Nodes[that1_idx]).value.data.dblptr).offset(rows as isize);
+                        null1 = *((lParse.Nodes[that1_idx]).value.undef).offset(rows as isize);
                     }
                     if vector2 > 1 {
-                        val2 = *((*that2).value.data.dblptr).offset(elem as isize);
-                        null2 = *((*that2).value.undef).offset(elem as isize);
+                        val2 = *((lParse.Nodes[that2_idx]).value.data.dblptr).offset(elem as isize);
+                        null2 = *((lParse.Nodes[that2_idx]).value.undef).offset(elem as isize);
                     } else if vector2 != 0 {
-                        val2 = *((*that2).value.data.dblptr).offset(rows as isize);
-                        null2 = *((*that2).value.undef).offset(rows as isize);
+                        val2 = *((lParse.Nodes[that2_idx]).value.data.dblptr).offset(rows as isize);
+                        null2 = *((lParse.Nodes[that2_idx]).value.undef).offset(rows as isize);
                     }
-                    *((*this).value.undef).offset(elem as isize) =
+                    *((lParse.Nodes[this_node_idx]).value.undef).offset(elem as isize) =
                         if null1 as c_int != 0 || null2 as c_int != 0 {
                             1
                         } else {
                             0
                         };
-                    match (*this).operation {
+                    match (lParse.Nodes[this_node_idx]).operation {
                         126 => {
-                            *((*this).value.data.logptr).offset(elem as isize) =
+                            *((lParse.Nodes[this_node_idx]).value.data.logptr)
+                                .offset(elem as isize) =
                                 if fabs(val1 - val2) < 1.0e-7f64 { 1 } else { 0 };
                         }
                         279 => {
-                            *((*this).value.data.logptr).offset(elem as isize) =
-                                if val1 == val2 { 1 } else { 0 };
+                            *((lParse.Nodes[this_node_idx]).value.data.logptr)
+                                .offset(elem as isize) = if val1 == val2 { 1 } else { 0 };
                         }
                         280 => {
-                            *((*this).value.data.logptr).offset(elem as isize) =
-                                if val1 != val2 { 1 } else { 0 };
+                            *((lParse.Nodes[this_node_idx]).value.data.logptr)
+                                .offset(elem as isize) = if val1 != val2 { 1 } else { 0 };
                         }
                         281 => {
-                            *((*this).value.data.logptr).offset(elem as isize) =
-                                if val1 > val2 { 1 } else { 0 };
+                            *((lParse.Nodes[this_node_idx]).value.data.logptr)
+                                .offset(elem as isize) = if val1 > val2 { 1 } else { 0 };
                         }
                         282 => {
-                            *((*this).value.data.logptr).offset(elem as isize) =
-                                if val1 < val2 { 1 } else { 0 };
+                            *((lParse.Nodes[this_node_idx]).value.data.logptr)
+                                .offset(elem as isize) = if val1 < val2 { 1 } else { 0 };
                         }
                         283 => {
-                            *((*this).value.data.logptr).offset(elem as isize) =
-                                if val1 <= val2 { 1 } else { 0 };
+                            *((lParse.Nodes[this_node_idx]).value.data.logptr)
+                                .offset(elem as isize) = if val1 <= val2 { 1 } else { 0 };
                         }
                         284 => {
-                            *((*this).value.data.logptr).offset(elem as isize) =
-                                if val1 >= val2 { 1 } else { 0 };
+                            *((lParse.Nodes[this_node_idx]).value.data.logptr)
+                                .offset(elem as isize) = if val1 >= val2 { 1 } else { 0 };
                         }
                         43 => {
-                            *((*this).value.data.dblptr).offset(elem as isize) = val1 + val2;
+                            *((lParse.Nodes[this_node_idx]).value.data.dblptr)
+                                .offset(elem as isize) = val1 + val2;
                         }
                         45 => {
-                            *((*this).value.data.dblptr).offset(elem as isize) = val1 - val2;
+                            *((lParse.Nodes[this_node_idx]).value.data.dblptr)
+                                .offset(elem as isize) = val1 - val2;
                         }
                         42 => {
-                            *((*this).value.data.dblptr).offset(elem as isize) = val1 * val2;
+                            *((lParse.Nodes[this_node_idx]).value.data.dblptr)
+                                .offset(elem as isize) = val1 * val2;
                         }
                         37 => {
                             if val2 != 0. {
-                                *((*this).value.data.dblptr).offset(elem as isize) =
+                                *((lParse.Nodes[this_node_idx]).value.data.dblptr)
+                                    .offset(elem as isize) =
                                     val1 - val2 * (val1 / val2) as c_int as c_double;
                             } else {
-                                *((*this).value.data.dblptr).offset(elem as isize) = 0.0;
-                                *((*this).value.undef).offset(elem as isize) = 1;
+                                *((lParse.Nodes[this_node_idx]).value.data.dblptr)
+                                    .offset(elem as isize) = 0.0;
+                                *((lParse.Nodes[this_node_idx]).value.undef)
+                                    .offset(elem as isize) = 1;
                             }
                         }
                         47 => {
                             if val2 != 0. {
-                                *((*this).value.data.dblptr).offset(elem as isize) = val1 / val2;
+                                *((lParse.Nodes[this_node_idx]).value.data.dblptr)
+                                    .offset(elem as isize) = val1 / val2;
                             } else {
-                                *((*this).value.data.dblptr).offset(elem as isize) = 0.0;
-                                *((*this).value.undef).offset(elem as isize) = 1;
+                                *((lParse.Nodes[this_node_idx]).value.data.dblptr)
+                                    .offset(elem as isize) = 0.0;
+                                *((lParse.Nodes[this_node_idx]).value.undef)
+                                    .offset(elem as isize) = 1;
                             }
                         }
                         286 => {
-                            *((*this).value.data.dblptr).offset(elem as isize) = pow(val1, val2);
+                            *((lParse.Nodes[this_node_idx]).value.data.dblptr)
+                                .offset(elem as isize) = pow(val1, val2);
                         }
                         _ => {}
                     }
                 }
-                nelem = (*this).value.nelem;
+                nelem = (lParse.Nodes[this_node_idx]).value.nelem;
             }
         }
-        if (*that1).operation > 0 {
-            free((*that1).value.data.ptr);
+        if (lParse.Nodes[that1_idx]).operation > 0 {
+            free((lParse.Nodes[that1_idx]).value.data.ptr);
         }
-        if (*that2).operation > 0 {
-            free((*that2).value.data.ptr);
+        if (lParse.Nodes[that2_idx]).operation > 0 {
+            free((lParse.Nodes[that2_idx]).value.data.ptr);
         }
     }
 }
@@ -9784,7 +10076,7 @@ pub fn qselect_median_lng(arr: *mut c_long, n: c_int) -> c_long {
         let mut hh: c_int = 0;
         low = 0;
         high = n - 1;
-        median = (low + high) / 2 as c_int;
+        median = (low + high) / 2;
         loop {
             if high <= low {
                 return *arr.offset(median as isize);
@@ -9797,7 +10089,7 @@ pub fn qselect_median_lng(arr: *mut c_long, n: c_int) -> c_long {
                 }
                 return *arr.offset(median as isize);
             }
-            middle = (low + high) / 2 as c_int;
+            middle = (low + high) / 2;
             if *arr.offset(middle as isize) > *arr.offset(high as isize) {
                 let t_0: c_long = *arr.offset(middle as isize);
                 *arr.offset(middle as isize) = *arr.offset(high as isize);
@@ -9821,14 +10113,12 @@ pub fn qselect_median_lng(arr: *mut c_long, n: c_int) -> c_long {
             loop {
                 loop {
                     ll += 1;
-                    ll;
                     if *arr.offset(low as isize) <= *arr.offset(ll as isize) {
                         break;
                     }
                 }
                 loop {
                     hh -= 1;
-                    hh;
                     if *arr.offset(hh as isize) <= *arr.offset(low as isize) {
                         break;
                     }
@@ -9863,7 +10153,7 @@ pub fn qselect_median_dbl(arr: *mut c_double, n: c_int) -> c_double {
         let mut hh: c_int = 0;
         low = 0;
         high = n - 1;
-        median = (low + high) / 2 as c_int;
+        median = (low + high) / 2;
         loop {
             if high <= low {
                 return *arr.offset(median as isize);
@@ -9876,7 +10166,7 @@ pub fn qselect_median_dbl(arr: *mut c_double, n: c_int) -> c_double {
                 }
                 return *arr.offset(median as isize);
             }
-            middle = (low + high) / 2 as c_int;
+            middle = (low + high) / 2;
             if *arr.offset(middle as isize) > *arr.offset(high as isize) {
                 let t_0: c_double = *arr.offset(middle as isize);
                 *arr.offset(middle as isize) = *arr.offset(high as isize);
@@ -9900,14 +10190,12 @@ pub fn qselect_median_dbl(arr: *mut c_double, n: c_int) -> c_double {
             loop {
                 loop {
                     ll += 1;
-                    ll;
                     if !(*arr.offset(low as isize) > *arr.offset(ll as isize)) {
                         break;
                     }
                 }
                 loop {
                     hh -= 1;
-                    hh;
                     if !(*arr.offset(hh as isize) > *arr.offset(low as isize)) {
                         break;
                     }
@@ -9932,30 +10220,39 @@ pub fn qselect_median_dbl(arr: *mut c_double, n: c_int) -> c_double {
     }
 }
 
-pub fn angsep_calc(ra1: c_double, dec1: c_double, ra2: c_double, dec2: c_double) -> c_double {
-    unsafe {
-        static mut DEG: c_double = 0.0;
-        let mut a: c_double = 0.0;
-        let mut sdec: c_double = 0.0;
-        let mut sra: c_double = 0.0;
-        if DEG == 0.0 {
-            DEG = 4.0 * atan(1.0) / 180.0;
-        }
-        sra = ((ra2 - ra1) * DEG / 2.0).sin();
-        sdec = ((dec2 - dec1) * DEG / 2.0).sin();
-        a = sdec * sdec + (dec1 * DEG).cos() * cos(dec2 * DEG) * sra * sra;
-        if a < 0.0 {
-            a = 0.0;
-        }
-        if a > 1 as c_double {
-            a = 1 as c_double;
-        }
-        2.0f64 * atan2((a).sqrt(), (1.0f64 - a).sqrt()) / DEG
+pub(crate) fn angsep_calc(
+    ra1: c_double,
+    dec1: c_double,
+    ra2: c_double,
+    dec2: c_double,
+) -> c_double {
+    let DEG: c_double = 4.0 * (1.0_f64).atan() / 180.0;
+    let mut a: c_double = 0.0;
+    let mut sdec: c_double = 0.0;
+    let mut sra: c_double = 0.0;
+
+    /* The algorithm is the law of Haversines.  This algorithm is
+    stable even when the points are close together.  The normal
+    Law of Cosines fails for angles around 0.1 arcsec. */
+
+    sra = ((ra2 - ra1) * DEG / 2.0).sin();
+    sdec = ((dec2 - dec1) * DEG / 2.0).sin();
+    a = sdec * sdec + (dec1 * DEG).cos() * (dec2 * DEG).cos() * sra * sra;
+
+    /* Sanity checking to avoid a range error in the sqrt()'s below */
+    if a < 0.0 {
+        a = 0.0;
     }
+    if a > 1.0 {
+        a = 1.0;
+    }
+
+    2.0 * atan2((a).sqrt(), (1.0 - a).sqrt()) / DEG
 }
-fn Do_Func(lParse: &mut ParseData, this: *mut Node) {
+
+fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
     unsafe {
-        let mut theParams: [*mut Node; 10] = [std::ptr::null_mut::<Node>(); 10];
+        let mut theParams: [usize; 10] = [0; 10];
         let mut vector: [c_int; 10] = [0; 10];
         let mut allConst: c_int = 0;
         let mut pVals: [lval; 10] = [lval {
@@ -9973,7 +10270,7 @@ fn Do_Func(lParse: &mut ParseData, this: *mut Node) {
         let mut row: c_long = 0;
         let mut elem: c_long = 0;
         let mut nelem: c_long = 0;
-        i = (*this).nSubNodes;
+        i = (lParse.Nodes[this_node_idx]).nSubNodes;
         allConst = 1;
         loop {
             let fresh52 = i;
@@ -9981,187 +10278,231 @@ fn Do_Func(lParse: &mut ParseData, this: *mut Node) {
             if fresh52 == 0 {
                 break;
             }
-            theParams[i as usize] = &mut (lParse.Nodes)[(*this).SubNodes[i as usize] as usize];
-            vector[i as usize] = ((*theParams[i as usize]).operation != -1000) as c_int;
+            theParams[i as usize] = (lParse.Nodes[this_node_idx]).SubNodes[i as usize] as usize;
+            vector[i as usize] =
+                ((lParse.Nodes[theParams[i as usize]]).operation != CONST_OP) as c_int;
             if vector[i as usize] != 0 {
                 allConst = 0;
-                vector[i as usize] = (*theParams[i as usize]).value.nelem as c_int;
+                vector[i as usize] = (lParse.Nodes[theParams[i as usize]]).value.nelem as c_int;
             } else {
-                if (*theParams[i as usize]).ntype == fits_parser_yytokentype::DOUBLE as c_int {
-                    pVals[i as usize].data.dbl = (*theParams[i as usize]).value.data.dbl;
-                } else if (*theParams[i as usize]).ntype == fits_parser_yytokentype::LONG as c_int {
-                    pVals[i as usize].data.lng = (*theParams[i as usize]).value.data.lng;
-                } else if (*theParams[i as usize]).ntype
+                if (lParse.Nodes[theParams[i as usize]]).ntype
+                    == fits_parser_yytokentype::DOUBLE as c_int
+                {
+                    pVals[i as usize].data.dbl =
+                        (lParse.Nodes[theParams[i as usize]]).value.data.dbl;
+                } else if (lParse.Nodes[theParams[i as usize]]).ntype
+                    == fits_parser_yytokentype::LONG as c_int
+                {
+                    pVals[i as usize].data.lng =
+                        (lParse.Nodes[theParams[i as usize]]).value.data.lng;
+                } else if (lParse.Nodes[theParams[i as usize]]).ntype
                     == fits_parser_yytokentype::BOOLEAN as c_int
                 {
-                    pVals[i as usize].data.log = (*theParams[i as usize]).value.data.log;
+                    pVals[i as usize].data.log =
+                        (lParse.Nodes[theParams[i as usize]]).value.data.log;
                 } else {
                     strcpy(
                         (pVals[i as usize].data.astr).as_mut_ptr(),
-                        ((*theParams[i as usize]).value.data.astr).as_mut_ptr(),
+                        ((lParse.Nodes[theParams[i as usize]]).value.data.astr).as_mut_ptr(),
                     );
                 }
                 pNull[i as usize] = 0;
             }
         }
-        if (*this).nSubNodes == 0 {
+        if (lParse.Nodes[this_node_idx]).nSubNodes == 0 {
             allConst = 0;
         }
-        if (*this).operation == poirnd_fct as c_int {
+        if (lParse.Nodes[this_node_idx]).operation == poirnd_fct as c_int {
             allConst = 0;
         }
-        if (*this).operation == gasrnd_fct as c_int {
+        if (lParse.Nodes[this_node_idx]).operation == gasrnd_fct as c_int {
             allConst = 0;
         }
-        if (*this).operation == rnd_fct as c_int {
+        if (lParse.Nodes[this_node_idx]).operation == rnd_fct as c_int {
             allConst = 0;
         }
         if allConst != 0 {
             let current_block_139: u64;
-            match (*this).operation {
+            match (lParse.Nodes[this_node_idx]).operation as u32 {
                 1002 => {
-                    if (*theParams[0]).ntype == fits_parser_yytokentype::BOOLEAN as c_int {
-                        (*this).value.data.lng = (if pVals[0].data.log as c_int != 0 {
-                            1
-                        } else {
-                            0
-                        }) as c_long;
-                    } else if (*theParams[0]).ntype == fits_parser_yytokentype::LONG as c_int {
-                        (*this).value.data.lng = pVals[0].data.lng;
-                    } else if (*theParams[0]).ntype == fits_parser_yytokentype::DOUBLE as c_int {
-                        (*this).value.data.dbl = pVals[0].data.dbl;
-                    } else if (*theParams[0]).ntype == fits_parser_yytokentype::BITSTR as c_int {
+                    if (lParse.Nodes[theParams[0]]).ntype
+                        == fits_parser_yytokentype::BOOLEAN as c_int
+                    {
+                        (lParse.Nodes[this_node_idx]).value.data.lng =
+                            (if pVals[0].data.log as c_int != 0 {
+                                1
+                            } else {
+                                0
+                            }) as c_long;
+                    } else if (lParse.Nodes[theParams[0]]).ntype
+                        == fits_parser_yytokentype::LONG as c_int
+                    {
+                        (lParse.Nodes[this_node_idx]).value.data.lng = pVals[0].data.lng;
+                    } else if (lParse.Nodes[theParams[0]]).ntype
+                        == fits_parser_yytokentype::DOUBLE as c_int
+                    {
+                        (lParse.Nodes[this_node_idx]).value.data.dbl = pVals[0].data.dbl;
+                    } else if (lParse.Nodes[theParams[0]]).ntype
+                        == fits_parser_yytokentype::BITSTR as c_int
+                    {
                         strcpy(
-                            ((*this).value.data.astr).as_mut_ptr(),
+                            ((lParse.Nodes[this_node_idx]).value.data.astr).as_mut_ptr(),
                             (pVals[0].data.astr).as_mut_ptr(),
                         );
                     }
                     current_block_139 = 7627602990488000394;
                 }
                 1038 => {
-                    if (*theParams[0]).ntype == fits_parser_yytokentype::LONG as c_int {
-                        (*this).value.data.dbl = pVals[0].data.lng as c_double;
-                    } else if (*theParams[0]).ntype == fits_parser_yytokentype::DOUBLE as c_int {
-                        (*this).value.data.dbl = pVals[0].data.dbl;
+                    if (lParse.Nodes[theParams[0]]).ntype == fits_parser_yytokentype::LONG as c_int
+                    {
+                        (lParse.Nodes[this_node_idx]).value.data.dbl =
+                            pVals[0].data.lng as c_double;
+                    } else if (lParse.Nodes[theParams[0]]).ntype
+                        == fits_parser_yytokentype::DOUBLE as c_int
+                    {
+                        (lParse.Nodes[this_node_idx]).value.data.dbl = pVals[0].data.dbl;
                     }
                     current_block_139 = 7627602990488000394;
                 }
                 1039 => {
-                    (*this).value.data.dbl = 0.0;
+                    (lParse.Nodes[this_node_idx]).value.data.dbl = 0.0;
                     current_block_139 = 7627602990488000394;
                 }
                 1037 => {
-                    if (*theParams[0]).ntype == fits_parser_yytokentype::BOOLEAN as c_int {
-                        (*this).value.data.lng = (if pVals[0].data.log as c_int != 0 {
-                            1
-                        } else {
-                            0
-                        }) as c_long;
-                    } else if (*theParams[0]).ntype == fits_parser_yytokentype::LONG as c_int {
-                        (*this).value.data.lng = pVals[0].data.lng;
+                    if (lParse.Nodes[theParams[0]]).ntype
+                        == fits_parser_yytokentype::BOOLEAN as c_int
+                    {
+                        (lParse.Nodes[this_node_idx]).value.data.lng =
+                            (if pVals[0].data.log as c_int != 0 {
+                                1
+                            } else {
+                                0
+                            }) as c_long;
+                    } else if (lParse.Nodes[theParams[0]]).ntype
+                        == fits_parser_yytokentype::LONG as c_int
+                    {
+                        (lParse.Nodes[this_node_idx]).value.data.lng = pVals[0].data.lng;
                     } else {
-                        (*this).value.data.dbl = pVals[0].data.dbl;
+                        (lParse.Nodes[this_node_idx]).value.data.dbl = pVals[0].data.dbl;
                     }
                     current_block_139 = 7627602990488000394;
                 }
                 1043 => {
-                    if (*theParams[0]).ntype == fits_parser_yytokentype::DOUBLE as c_int {
-                        (*this).value.data.lng = simplerng_getpoisson(pVals[0].data.dbl) as c_long;
+                    if (lParse.Nodes[theParams[0]]).ntype
+                        == fits_parser_yytokentype::DOUBLE as c_int
+                    {
+                        (lParse.Nodes[this_node_idx]).value.data.lng =
+                            simplerng_getpoisson(pVals[0].data.dbl) as c_long;
                     } else {
-                        (*this).value.data.lng =
+                        (lParse.Nodes[this_node_idx]).value.data.lng =
                             simplerng_getpoisson(pVals[0].data.lng as c_double) as c_long;
                     }
                     current_block_139 = 7627602990488000394;
                 }
                 1017 => {
-                    if (*theParams[0]).ntype == fits_parser_yytokentype::DOUBLE as c_int {
+                    if (lParse.Nodes[theParams[0]]).ntype
+                        == fits_parser_yytokentype::DOUBLE as c_int
+                    {
                         dval = pVals[0].data.dbl;
-                        (*this).value.data.dbl = if dval > 0.0 { dval } else { -dval };
+                        (lParse.Nodes[this_node_idx]).value.data.dbl =
+                            if dval > 0.0 { dval } else { -dval };
                     } else {
                         ival = pVals[0].data.lng;
-                        (*this).value.data.lng = if ival > 0 { ival } else { -ival };
+                        (lParse.Nodes[this_node_idx]).value.data.lng =
+                            if ival > 0 { ival } else { -ival };
                     }
                     current_block_139 = 7627602990488000394;
                 }
                 1040 => {
-                    (*this).value.data.lng = 1;
+                    (lParse.Nodes[this_node_idx]).value.data.lng = 1;
                     current_block_139 = 7627602990488000394;
                 }
                 1030 => {
-                    (*this).value.data.log = 0;
+                    (lParse.Nodes[this_node_idx]).value.data.log = 0;
                     current_block_139 = 7627602990488000394;
                 }
                 1031 => {
-                    if (*this).ntype == fits_parser_yytokentype::BOOLEAN as c_int {
-                        (*this).value.data.log = pVals[0].data.log;
-                    } else if (*this).ntype == fits_parser_yytokentype::LONG as c_int {
-                        (*this).value.data.lng = pVals[0].data.lng;
-                    } else if (*this).ntype == fits_parser_yytokentype::DOUBLE as c_int {
-                        (*this).value.data.dbl = pVals[0].data.dbl;
-                    } else if (*this).ntype == fits_parser_yytokentype::STRING as c_int {
+                    if (lParse.Nodes[this_node_idx]).ntype
+                        == fits_parser_yytokentype::BOOLEAN as c_int
+                    {
+                        (lParse.Nodes[this_node_idx]).value.data.log = pVals[0].data.log;
+                    } else if (lParse.Nodes[this_node_idx]).ntype
+                        == fits_parser_yytokentype::LONG as c_int
+                    {
+                        (lParse.Nodes[this_node_idx]).value.data.lng = pVals[0].data.lng;
+                    } else if (lParse.Nodes[this_node_idx]).ntype
+                        == fits_parser_yytokentype::DOUBLE as c_int
+                    {
+                        (lParse.Nodes[this_node_idx]).value.data.dbl = pVals[0].data.dbl;
+                    } else if (lParse.Nodes[this_node_idx]).ntype
+                        == fits_parser_yytokentype::STRING as c_int
+                    {
                         strcpy(
-                            ((*this).value.data.astr).as_mut_ptr(),
+                            ((lParse.Nodes[this_node_idx]).value.data.astr).as_mut_ptr(),
                             (pVals[0].data.astr).as_mut_ptr(),
                         );
                     }
                     current_block_139 = 7627602990488000394;
                 }
                 1046 => {
-                    if (*this).ntype == fits_parser_yytokentype::LONG as c_int {
-                        (*this).value.data.lng = pVals[0].data.lng;
-                    } else if (*this).ntype == fits_parser_yytokentype::DOUBLE as c_int {
-                        (*this).value.data.dbl = pVals[0].data.dbl;
+                    if (lParse.Nodes[this_node_idx]).ntype == fits_parser_yytokentype::LONG as c_int
+                    {
+                        (lParse.Nodes[this_node_idx]).value.data.lng = pVals[0].data.lng;
+                    } else if (lParse.Nodes[this_node_idx]).ntype
+                        == fits_parser_yytokentype::DOUBLE as c_int
+                    {
+                        (lParse.Nodes[this_node_idx]).value.data.dbl = pVals[0].data.dbl;
                     }
                     current_block_139 = 7627602990488000394;
                 }
                 1004 => {
-                    (*this).value.data.dbl = sin(pVals[0].data.dbl);
+                    (lParse.Nodes[this_node_idx]).value.data.dbl = sin(pVals[0].data.dbl);
                     current_block_139 = 7627602990488000394;
                 }
                 1005 => {
-                    (*this).value.data.dbl = cos(pVals[0].data.dbl);
+                    (lParse.Nodes[this_node_idx]).value.data.dbl = cos(pVals[0].data.dbl);
                     current_block_139 = 7627602990488000394;
                 }
                 1006 => {
-                    (*this).value.data.dbl = tan(pVals[0].data.dbl);
+                    (lParse.Nodes[this_node_idx]).value.data.dbl = tan(pVals[0].data.dbl);
                     current_block_139 = 7627602990488000394;
                 }
                 1007 => {
                     dval = pVals[0].data.dbl;
-                    if dval < -1.0f64 || dval > 1.0f64 {
+                    if dval < -1.0 || dval > 1.0 {
                         fits_parser_yyerror(lParse, cs!(c"Out of range argument to arcsin"));
                     } else {
-                        (*this).value.data.dbl = asin(dval);
+                        (lParse.Nodes[this_node_idx]).value.data.dbl = asin(dval);
                     }
                     current_block_139 = 7627602990488000394;
                 }
                 1008 => {
                     dval = pVals[0].data.dbl;
-                    if dval < -1.0f64 || dval > 1.0f64 {
+                    if dval < -1.0 || dval > 1.0 {
                         fits_parser_yyerror(lParse, cs!(c"Out of range argument to arccos"));
                     } else {
-                        (*this).value.data.dbl = acos(dval);
+                        (lParse.Nodes[this_node_idx]).value.data.dbl = acos(dval);
                     }
                     current_block_139 = 7627602990488000394;
                 }
                 1009 => {
-                    (*this).value.data.dbl = atan(pVals[0].data.dbl);
+                    (lParse.Nodes[this_node_idx]).value.data.dbl = atan(pVals[0].data.dbl);
                     current_block_139 = 7627602990488000394;
                 }
                 1010 => {
-                    (*this).value.data.dbl = sinh(pVals[0].data.dbl);
+                    (lParse.Nodes[this_node_idx]).value.data.dbl = sinh(pVals[0].data.dbl);
                     current_block_139 = 7627602990488000394;
                 }
                 1011 => {
-                    (*this).value.data.dbl = cosh(pVals[0].data.dbl);
+                    (lParse.Nodes[this_node_idx]).value.data.dbl = cosh(pVals[0].data.dbl);
                     current_block_139 = 7627602990488000394;
                 }
                 1012 => {
-                    (*this).value.data.dbl = tanh(pVals[0].data.dbl);
+                    (lParse.Nodes[this_node_idx]).value.data.dbl = tanh(pVals[0].data.dbl);
                     current_block_139 = 7627602990488000394;
                 }
                 1013 => {
-                    (*this).value.data.dbl = exp(pVals[0].data.dbl);
+                    (lParse.Nodes[this_node_idx]).value.data.dbl = exp(pVals[0].data.dbl);
                     current_block_139 = 7627602990488000394;
                 }
                 1014 => {
@@ -10169,7 +10510,7 @@ fn Do_Func(lParse: &mut ParseData, this: *mut Node) {
                     if dval <= 0.0 {
                         fits_parser_yyerror(lParse, cs!(c"Out of range argument to log"));
                     } else {
-                        (*this).value.data.dbl = log(dval);
+                        (lParse.Nodes[this_node_idx]).value.data.dbl = log(dval);
                     }
                     current_block_139 = 7627602990488000394;
                 }
@@ -10178,7 +10519,7 @@ fn Do_Func(lParse: &mut ParseData, this: *mut Node) {
                     if dval <= 0.0 {
                         fits_parser_yyerror(lParse, cs!(c"Out of range argument to log10"));
                     } else {
-                        (*this).value.data.dbl = log10(dval);
+                        (lParse.Nodes[this_node_idx]).value.data.dbl = log10(dval);
                     }
                     current_block_139 = 7627602990488000394;
                 }
@@ -10187,28 +10528,29 @@ fn Do_Func(lParse: &mut ParseData, this: *mut Node) {
                     if dval < 0.0 {
                         fits_parser_yyerror(lParse, cs!(c"Out of range argument to sqrt"));
                     } else {
-                        (*this).value.data.dbl = sqrt(dval);
+                        (lParse.Nodes[this_node_idx]).value.data.dbl = sqrt(dval);
                     }
                     current_block_139 = 7627602990488000394;
                 }
                 1019 => {
-                    (*this).value.data.dbl = ceil(pVals[0].data.dbl);
+                    (lParse.Nodes[this_node_idx]).value.data.dbl = ceil(pVals[0].data.dbl);
                     current_block_139 = 7627602990488000394;
                 }
                 1020 => {
-                    (*this).value.data.dbl = floor(pVals[0].data.dbl);
+                    (lParse.Nodes[this_node_idx]).value.data.dbl = floor(pVals[0].data.dbl);
                     current_block_139 = 7627602990488000394;
                 }
                 1021 => {
-                    (*this).value.data.dbl = floor(pVals[0].data.dbl + 0.5);
+                    (lParse.Nodes[this_node_idx]).value.data.dbl = floor(pVals[0].data.dbl + 0.5);
                     current_block_139 = 7627602990488000394;
                 }
                 1018 => {
-                    (*this).value.data.dbl = atan2(pVals[0].data.dbl, pVals[1].data.dbl);
+                    (lParse.Nodes[this_node_idx]).value.data.dbl =
+                        atan2(pVals[0].data.dbl, pVals[1].data.dbl);
                     current_block_139 = 7627602990488000394;
                 }
                 1041 => {
-                    (*this).value.data.dbl = angsep_calc(
+                    (lParse.Nodes[this_node_idx]).value.data.dbl = angsep_calc(
                         pVals[0].data.dbl,
                         pVals[1].data.dbl,
                         pVals[2].data.dbl,
@@ -10220,57 +10562,75 @@ fn Do_Func(lParse: &mut ParseData, this: *mut Node) {
                     current_block_139 = 15934000668868306918;
                 }
                 1023 => {
-                    if (*this).ntype == fits_parser_yytokentype::DOUBLE as c_int {
-                        (*this).value.data.dbl = if pVals[0].data.dbl < pVals[1].data.dbl {
-                            pVals[0].data.dbl
-                        } else {
-                            pVals[1].data.dbl
-                        };
-                    } else if (*this).ntype == fits_parser_yytokentype::LONG as c_int {
-                        (*this).value.data.lng = if pVals[0].data.lng < pVals[1].data.lng {
-                            pVals[0].data.lng
-                        } else {
-                            pVals[1].data.lng
-                        };
+                    if (lParse.Nodes[this_node_idx]).ntype
+                        == fits_parser_yytokentype::DOUBLE as c_int
+                    {
+                        (lParse.Nodes[this_node_idx]).value.data.dbl =
+                            if pVals[0].data.dbl < pVals[1].data.dbl {
+                                pVals[0].data.dbl
+                            } else {
+                                pVals[1].data.dbl
+                            };
+                    } else if (lParse.Nodes[this_node_idx]).ntype
+                        == fits_parser_yytokentype::LONG as c_int
+                    {
+                        (lParse.Nodes[this_node_idx]).value.data.lng =
+                            if pVals[0].data.lng < pVals[1].data.lng {
+                                pVals[0].data.lng
+                            } else {
+                                pVals[1].data.lng
+                            };
                     }
                     current_block_139 = 7627602990488000394;
                 }
                 1024 => {
-                    if (*this).ntype == fits_parser_yytokentype::DOUBLE as c_int {
-                        (*this).value.data.dbl = pVals[0].data.dbl;
-                    } else if (*this).ntype == fits_parser_yytokentype::LONG as c_int {
-                        (*this).value.data.lng = pVals[0].data.lng;
-                    } else if (*this).ntype == fits_parser_yytokentype::BITSTR as c_int {
+                    if (lParse.Nodes[this_node_idx]).ntype
+                        == fits_parser_yytokentype::DOUBLE as c_int
+                    {
+                        (lParse.Nodes[this_node_idx]).value.data.dbl = pVals[0].data.dbl;
+                    } else if (lParse.Nodes[this_node_idx]).ntype
+                        == fits_parser_yytokentype::LONG as c_int
+                    {
+                        (lParse.Nodes[this_node_idx]).value.data.lng = pVals[0].data.lng;
+                    } else if (lParse.Nodes[this_node_idx]).ntype
+                        == fits_parser_yytokentype::BITSTR as c_int
+                    {
                         strcpy(
-                            ((*this).value.data.astr).as_mut_ptr(),
+                            ((lParse.Nodes[this_node_idx]).value.data.astr).as_mut_ptr(),
                             (pVals[0].data.astr).as_mut_ptr(),
                         );
                     }
                     current_block_139 = 7627602990488000394;
                 }
                 1025 => {
-                    if (*this).ntype == fits_parser_yytokentype::DOUBLE as c_int {
-                        (*this).value.data.dbl = if pVals[0].data.dbl > pVals[1].data.dbl {
-                            pVals[0].data.dbl
-                        } else {
-                            pVals[1].data.dbl
-                        };
-                    } else if (*this).ntype == fits_parser_yytokentype::LONG as c_int {
-                        (*this).value.data.lng = if pVals[0].data.lng > pVals[1].data.lng {
-                            pVals[0].data.lng
-                        } else {
-                            pVals[1].data.lng
-                        };
+                    if (lParse.Nodes[this_node_idx]).ntype
+                        == fits_parser_yytokentype::DOUBLE as c_int
+                    {
+                        (lParse.Nodes[this_node_idx]).value.data.dbl =
+                            if pVals[0].data.dbl > pVals[1].data.dbl {
+                                pVals[0].data.dbl
+                            } else {
+                                pVals[1].data.dbl
+                            };
+                    } else if (lParse.Nodes[this_node_idx]).ntype
+                        == fits_parser_yytokentype::LONG as c_int
+                    {
+                        (lParse.Nodes[this_node_idx]).value.data.lng =
+                            if pVals[0].data.lng > pVals[1].data.lng {
+                                pVals[0].data.lng
+                            } else {
+                                pVals[1].data.lng
+                            };
                     }
                     current_block_139 = 7627602990488000394;
                 }
                 1026 => {
-                    (*this).value.data.log =
+                    (lParse.Nodes[this_node_idx]).value.data.log =
                         bnear(pVals[0].data.dbl, pVals[1].data.dbl, pVals[2].data.dbl);
                     current_block_139 = 7627602990488000394;
                 }
                 1027 => {
-                    (*this).value.data.log = circle(
+                    (lParse.Nodes[this_node_idx]).value.data.log = circle(
                         pVals[0].data.dbl,
                         pVals[1].data.dbl,
                         pVals[2].data.dbl,
@@ -10280,7 +10640,7 @@ fn Do_Func(lParse: &mut ParseData, this: *mut Node) {
                     current_block_139 = 7627602990488000394;
                 }
                 1028 => {
-                    (*this).value.data.log = saobox(
+                    (lParse.Nodes[this_node_idx]).value.data.log = saobox(
                         pVals[0].data.dbl,
                         pVals[1].data.dbl,
                         pVals[2].data.dbl,
@@ -10292,7 +10652,7 @@ fn Do_Func(lParse: &mut ParseData, this: *mut Node) {
                     current_block_139 = 7627602990488000394;
                 }
                 1029 => {
-                    (*this).value.data.log = ellipse(
+                    (lParse.Nodes[this_node_idx]).value.data.log = ellipse(
                         pVals[0].data.dbl,
                         pVals[1].data.dbl,
                         pVals[2].data.dbl,
@@ -10304,31 +10664,34 @@ fn Do_Func(lParse: &mut ParseData, this: *mut Node) {
                     current_block_139 = 7627602990488000394;
                 }
                 1034 => {
-                    match (*this).ntype {
-                        258 => {
-                            (*this).value.data.log = (if pVals[2].data.log as c_int != 0 {
-                                pVals[0].data.log as c_int
-                            } else {
-                                pVals[1].data.log as c_int
-                            }) as c_char;
+                    match (lParse.Nodes[this_node_idx]).ntype.into() {
+                        fits_parser_yytokentype::BOOLEAN => {
+                            (lParse.Nodes[this_node_idx]).value.data.log =
+                                (if pVals[2].data.log as c_int != 0 {
+                                    pVals[0].data.log as c_int
+                                } else {
+                                    pVals[1].data.log as c_int
+                                }) as c_char;
                         }
-                        259 => {
-                            (*this).value.data.lng = if pVals[2].data.log as c_int != 0 {
-                                pVals[0].data.lng
-                            } else {
-                                pVals[1].data.lng
-                            };
+                        fits_parser_yytokentype::LONG => {
+                            (lParse.Nodes[this_node_idx]).value.data.lng =
+                                if pVals[2].data.log as c_int != 0 {
+                                    pVals[0].data.lng
+                                } else {
+                                    pVals[1].data.lng
+                                };
                         }
-                        260 => {
-                            (*this).value.data.dbl = if pVals[2].data.log as c_int != 0 {
-                                pVals[0].data.dbl
-                            } else {
-                                pVals[1].data.dbl
-                            };
+                        fits_parser_yytokentype::DOUBLE => {
+                            (lParse.Nodes[this_node_idx]).value.data.dbl =
+                                if pVals[2].data.log as c_int != 0 {
+                                    pVals[0].data.dbl
+                                } else {
+                                    pVals[1].data.dbl
+                                };
                         }
-                        261 => {
+                        fits_parser_yytokentype::STRING => {
                             strcpy(
-                                ((*this).value.data.astr).as_mut_ptr(),
+                                ((lParse.Nodes[this_node_idx]).value.data.astr).as_mut_ptr(),
                                 if pVals[2].data.log as c_int != 0 {
                                     (pVals[0].data.astr).as_mut_ptr()
                                 } else {
@@ -10340,11 +10703,13 @@ fn Do_Func(lParse: &mut ParseData, this: *mut Node) {
                     }
                     current_block_139 = 7627602990488000394;
                 }
-                1044 => {
+                strmid_fct => {
+                    let dest_str = ((lParse.Nodes[this_node_idx]).value.data.astr).as_mut_ptr();
+                    let dest_len = (lParse.Nodes[this_node_idx]).value.nelem as c_int;
                     cstrmid(
                         lParse,
-                        ((*this).value.data.astr).as_mut_ptr(),
-                        (*this).value.nelem as c_int,
+                        dest_str,
+                        dest_len,
                         (pVals[0].data.astr).as_mut_ptr(),
                         pVals[0].nelem as c_int,
                         pVals[1].data.lng as c_int,
@@ -10357,9 +10722,9 @@ fn Do_Func(lParse: &mut ParseData, this: *mut Node) {
                         (pVals[1].data.astr).as_mut_ptr(),
                     );
                     if res.is_null() {
-                        (*this).value.data.lng = 0;
+                        (lParse.Nodes[this_node_idx]).value.data.lng = 0;
                     } else {
-                        (*this).value.data.lng =
+                        (lParse.Nodes[this_node_idx]).value.data.lng =
                             res.offset_from((pVals[0].data.astr).as_mut_ptr()) as c_long + 1;
                     }
                     current_block_139 = 7627602990488000394;
@@ -10369,53 +10734,67 @@ fn Do_Func(lParse: &mut ParseData, this: *mut Node) {
                 }
             }
             if current_block_139 == 15934000668868306918 {
-                if (*this).ntype == fits_parser_yytokentype::DOUBLE as c_int {
-                    (*this).value.data.dbl = pVals[0].data.dbl;
-                } else if (*this).ntype == fits_parser_yytokentype::LONG as c_int {
-                    (*this).value.data.lng = pVals[0].data.lng;
-                } else if (*this).ntype == fits_parser_yytokentype::BITSTR as c_int {
+                if (lParse.Nodes[this_node_idx]).ntype == fits_parser_yytokentype::DOUBLE as c_int {
+                    (lParse.Nodes[this_node_idx]).value.data.dbl = pVals[0].data.dbl;
+                } else if (lParse.Nodes[this_node_idx]).ntype
+                    == fits_parser_yytokentype::LONG as c_int
+                {
+                    (lParse.Nodes[this_node_idx]).value.data.lng = pVals[0].data.lng;
+                } else if (lParse.Nodes[this_node_idx]).ntype
+                    == fits_parser_yytokentype::BITSTR as c_int
+                {
                     strcpy(
-                        ((*this).value.data.astr).as_mut_ptr(),
+                        ((lParse.Nodes[this_node_idx]).value.data.astr).as_mut_ptr(),
                         (pVals[0].data.astr).as_mut_ptr(),
                     );
                 }
             }
-            (*this).operation = -1000;
+            (lParse.Nodes[this_node_idx]).operation = CONST_OP;
         } else {
-            Allocate_Ptrs(lParse, this);
+            Allocate_Ptrs(lParse, this_node_idx);
             row = lParse.nRows;
-            elem = row * (*this).value.nelem;
+            elem = row * (lParse.Nodes[this_node_idx]).value.nelem;
             if lParse.status == 0 {
-                match (*this).operation {
+                match (lParse.Nodes[this_node_idx]).operation as u32 {
                     1035 => loop {
                         let fresh53 = row;
                         row -= 1;
                         if fresh53 == 0 {
                             break;
                         }
-                        *((*this).value.data.lngptr).offset(row as isize) = lParse.firstRow + row;
-                        *((*this).value.undef).offset(row as isize) = 0;
+                        *((lParse.Nodes[this_node_idx]).value.data.lngptr).offset(row as isize) =
+                            lParse.firstRow + row;
+                        *((lParse.Nodes[this_node_idx]).value.undef).offset(row as isize) = 0;
                     },
                     1036 => {
-                        if (*this).ntype == fits_parser_yytokentype::LONG as c_int {
+                        if (lParse.Nodes[this_node_idx]).ntype
+                            == fits_parser_yytokentype::LONG as c_int
+                        {
                             loop {
                                 let fresh54 = row;
                                 row -= 1;
                                 if fresh54 == 0 {
                                     break;
                                 }
-                                *((*this).value.data.lngptr).offset(row as isize) = 0;
-                                *((*this).value.undef).offset(row as isize) = 1;
+                                *((lParse.Nodes[this_node_idx]).value.data.lngptr)
+                                    .offset(row as isize) = 0;
+                                *((lParse.Nodes[this_node_idx]).value.undef).offset(row as isize) =
+                                    1;
                             }
-                        } else if (*this).ntype == fits_parser_yytokentype::STRING as c_int {
+                        } else if (lParse.Nodes[this_node_idx]).ntype
+                            == fits_parser_yytokentype::STRING as c_int
+                        {
                             loop {
                                 let fresh55 = row;
                                 row -= 1;
                                 if fresh55 == 0 {
                                     break;
                                 }
-                                *(*((*this).value.data.strptr).offset(row as isize)).offset(0) = 0;
-                                *((*this).value.undef).offset(row as isize) = 1;
+                                *(*((lParse.Nodes[this_node_idx]).value.data.strptr)
+                                    .offset(row as isize))
+                                .offset(0) = 0;
+                                *((lParse.Nodes[this_node_idx]).value.undef).offset(row as isize) =
+                                    1;
                             }
                         }
                     }
@@ -10423,25 +10802,28 @@ fn Do_Func(lParse: &mut ParseData, this: *mut Node) {
                         let mut ielem: c_long = 0;
                         let mut iaxis: [c_long; 5] = [1, 1, 1, 1, 1];
                         let ipos: c_long = pVals[1].data.lng - 1;
-                        let naxis: c_int = (*this).value.naxis;
+                        let naxis: c_int = (lParse.Nodes[this_node_idx]).value.naxis;
                         let mut j: c_int = 0;
                         if ipos < 0 || ipos >= 5 as c_long {
                             fits_parser_yyerror(
                                 lParse,
                                 cs!(c"AXISELEM(V,n) n value exceeded maximum dimension"),
                             );
-                            free((*this).value.data.ptr);
+                            free((lParse.Nodes[this_node_idx]).value.data.ptr);
                         } else {
                             ielem = 0;
                             while ielem < elem {
-                                *((*this).value.data.lngptr).offset(ielem as isize) =
-                                    iaxis[ipos as usize];
-                                *((*this).value.undef).offset(ielem as isize) = 0;
+                                *((lParse.Nodes[this_node_idx]).value.data.lngptr)
+                                    .offset(ielem as isize) = iaxis[ipos as usize];
+                                *((lParse.Nodes[this_node_idx]).value.undef)
+                                    .offset(ielem as isize) = 0;
                                 iaxis[0] += 1;
                                 iaxis[0];
                                 j = 0;
                                 while j < naxis {
-                                    if iaxis[j as usize] <= (*this).value.naxes[j as usize] {
+                                    if iaxis[j as usize]
+                                        <= (lParse.Nodes[this_node_idx]).value.naxes[j as usize]
+                                    {
                                         break;
                                     }
                                     iaxis[j as usize] = 1;
@@ -10450,10 +10832,8 @@ fn Do_Func(lParse: &mut ParseData, this: *mut Node) {
                                         iaxis[(j + 1) as usize];
                                     }
                                     j += 1;
-                                    j;
                                 }
                                 ielem += 1;
-                                ielem;
                             }
                         }
                     }
@@ -10463,15 +10843,15 @@ fn Do_Func(lParse: &mut ParseData, this: *mut Node) {
                         let j_0: c_int = 0;
                         ielem_0 = 0;
                         while ielem_0 < elem {
-                            *((*this).value.data.lngptr).offset(ielem_0 as isize) = elemnum;
-                            *((*this).value.undef).offset(ielem_0 as isize) = 0;
+                            *((lParse.Nodes[this_node_idx]).value.data.lngptr)
+                                .offset(ielem_0 as isize) = elemnum;
+                            *((lParse.Nodes[this_node_idx]).value.undef).offset(ielem_0 as isize) =
+                                0;
                             elemnum += 1;
-                            elemnum;
-                            if elemnum > (*this).value.nelem {
+                            if elemnum > (lParse.Nodes[this_node_idx]).value.nelem {
                                 elemnum = 1;
                             }
                             ielem_0 += 1;
-                            ielem_0;
                         }
                     }
                     1001 => loop {
@@ -10480,8 +10860,9 @@ fn Do_Func(lParse: &mut ParseData, this: *mut Node) {
                         if fresh56 == 0 {
                             break;
                         }
-                        *((*this).value.data.dblptr).offset(elem as isize) = simplerng_getuniform();
-                        *((*this).value.undef).offset(elem as isize) = 0;
+                        *((lParse.Nodes[this_node_idx]).value.data.dblptr).offset(elem as isize) =
+                            simplerng_getuniform();
+                        *((lParse.Nodes[this_node_idx]).value.undef).offset(elem as isize) = 0;
                     },
                     1042 => loop {
                         let fresh57 = elem;
@@ -10489,22 +10870,30 @@ fn Do_Func(lParse: &mut ParseData, this: *mut Node) {
                         if fresh57 == 0 {
                             break;
                         }
-                        *((*this).value.data.dblptr).offset(elem as isize) = simplerng_getnorm();
-                        *((*this).value.undef).offset(elem as isize) = 0;
+                        *((lParse.Nodes[this_node_idx]).value.data.dblptr).offset(elem as isize) =
+                            simplerng_getnorm();
+                        *((lParse.Nodes[this_node_idx]).value.undef).offset(elem as isize) = 0;
                     },
                     1043 => {
-                        if (*theParams[0]).ntype == fits_parser_yytokentype::DOUBLE as c_int {
-                            if (*theParams[0]).operation == -1000 {
+                        if (lParse.Nodes[theParams[0]]).ntype
+                            == fits_parser_yytokentype::DOUBLE as c_int
+                        {
+                            if (lParse.Nodes[theParams[0]]).operation == CONST_OP {
                                 loop {
                                     let fresh58 = elem;
                                     elem -= 1;
                                     if fresh58 == 0 {
                                         break;
                                     }
-                                    *((*this).value.undef).offset(elem as isize) =
+                                    *((lParse.Nodes[this_node_idx]).value.undef)
+                                        .offset(elem as isize) =
                                         if pVals[0].data.dbl < 0.0 { 1 } else { 0 };
-                                    if *((*this).value.undef).offset(elem as isize) == 0 {
-                                        *((*this).value.data.lngptr).offset(elem as isize) =
+                                    if *((lParse.Nodes[this_node_idx]).value.undef)
+                                        .offset(elem as isize)
+                                        == 0
+                                    {
+                                        *((lParse.Nodes[this_node_idx]).value.data.lngptr)
+                                            .offset(elem as isize) =
                                             simplerng_getpoisson(pVals[0].data.dbl) as c_long;
                                     }
                                 }
@@ -10515,33 +10904,46 @@ fn Do_Func(lParse: &mut ParseData, this: *mut Node) {
                                     if fresh59 == 0 {
                                         break;
                                     }
-                                    *((*this).value.undef).offset(elem as isize) =
-                                        *((*theParams[0]).value.undef).offset(elem as isize);
-                                    if *((*theParams[0]).value.data.dblptr).offset(elem as isize)
+                                    *((lParse.Nodes[this_node_idx]).value.undef)
+                                        .offset(elem as isize) =
+                                        *((lParse.Nodes[theParams[0]]).value.undef)
+                                            .offset(elem as isize);
+                                    if *((lParse.Nodes[theParams[0]]).value.data.dblptr)
+                                        .offset(elem as isize)
                                         < 0.0
                                     {
-                                        *((*this).value.undef).offset(elem as isize) = 1;
+                                        *((lParse.Nodes[this_node_idx]).value.undef)
+                                            .offset(elem as isize) = 1;
                                     }
-                                    if *((*this).value.undef).offset(elem as isize) == 0 {
-                                        *((*this).value.data.lngptr).offset(elem as isize) =
-                                            simplerng_getpoisson(
-                                                *((*theParams[0]).value.data.dblptr)
-                                                    .offset(elem as isize),
-                                            ) as c_long;
+                                    if *((lParse.Nodes[this_node_idx]).value.undef)
+                                        .offset(elem as isize)
+                                        == 0
+                                    {
+                                        *((lParse.Nodes[this_node_idx]).value.data.lngptr)
+                                            .offset(elem as isize) = simplerng_getpoisson(
+                                            *((lParse.Nodes[theParams[0]]).value.data.dblptr)
+                                                .offset(elem as isize),
+                                        )
+                                            as c_long;
                                     }
                                 }
                             }
-                        } else if (*theParams[0]).operation == -1000 {
+                        } else if (lParse.Nodes[theParams[0]]).operation == CONST_OP {
                             loop {
                                 let fresh60 = elem;
                                 elem -= 1;
                                 if fresh60 == 0 {
                                     break;
                                 }
-                                *((*this).value.undef).offset(elem as isize) =
+                                *((lParse.Nodes[this_node_idx]).value.undef)
+                                    .offset(elem as isize) =
                                     if pVals[0].data.lng < 0 { 1 } else { 0 };
-                                if *((*this).value.undef).offset(elem as isize) == 0 {
-                                    *((*this).value.data.lngptr).offset(elem as isize) =
+                                if *((lParse.Nodes[this_node_idx]).value.undef)
+                                    .offset(elem as isize)
+                                    == 0
+                                {
+                                    *((lParse.Nodes[this_node_idx]).value.data.lngptr)
+                                        .offset(elem as isize) =
                                         simplerng_getpoisson(pVals[0].data.lng as c_double)
                                             as c_long;
                                 }
@@ -10553,34 +10955,48 @@ fn Do_Func(lParse: &mut ParseData, this: *mut Node) {
                                 if fresh61 == 0 {
                                     break;
                                 }
-                                *((*this).value.undef).offset(elem as isize) =
-                                    *((*theParams[0]).value.undef).offset(elem as isize);
-                                if *((*theParams[0]).value.data.lngptr).offset(elem as isize) < 0 {
-                                    *((*this).value.undef).offset(elem as isize) = 1;
+                                *((lParse.Nodes[this_node_idx]).value.undef)
+                                    .offset(elem as isize) =
+                                    *((lParse.Nodes[theParams[0]]).value.undef)
+                                        .offset(elem as isize);
+                                if *((lParse.Nodes[theParams[0]]).value.data.lngptr)
+                                    .offset(elem as isize)
+                                    < 0
+                                {
+                                    *((lParse.Nodes[this_node_idx]).value.undef)
+                                        .offset(elem as isize) = 1;
                                 }
-                                if *((*this).value.undef).offset(elem as isize) == 0 {
-                                    *((*this).value.data.lngptr).offset(elem as isize) =
-                                        simplerng_getpoisson(
-                                            *((*theParams[0]).value.data.lngptr)
-                                                .offset(elem as isize)
-                                                as c_double,
-                                        ) as c_long;
+                                if *((lParse.Nodes[this_node_idx]).value.undef)
+                                    .offset(elem as isize)
+                                    == 0
+                                {
+                                    *((lParse.Nodes[this_node_idx]).value.data.lngptr)
+                                        .offset(elem as isize) = simplerng_getpoisson(
+                                        *((lParse.Nodes[theParams[0]]).value.data.lngptr)
+                                            .offset(elem as isize)
+                                            as c_double,
+                                    )
+                                        as c_long;
                                 }
                             }
                         }
                     }
                     1002 => {
-                        elem = row * (*theParams[0]).value.nelem;
-                        if (*theParams[0]).ntype == fits_parser_yytokentype::BOOLEAN as c_int {
+                        elem = row * (lParse.Nodes[theParams[0]]).value.nelem;
+                        if (lParse.Nodes[theParams[0]]).ntype
+                            == fits_parser_yytokentype::BOOLEAN as c_int
+                        {
                             loop {
                                 let fresh62 = row;
                                 row -= 1;
                                 if fresh62 == 0 {
                                     break;
                                 }
-                                *((*this).value.data.lngptr).offset(row as isize) = 0;
-                                *((*this).value.undef).offset(row as isize) = 1;
-                                nelem = (*theParams[0]).value.nelem;
+                                *((lParse.Nodes[this_node_idx]).value.data.lngptr)
+                                    .offset(row as isize) = 0;
+                                *((lParse.Nodes[this_node_idx]).value.undef).offset(row as isize) =
+                                    1;
+                                nelem = (lParse.Nodes[theParams[0]]).value.nelem;
                                 loop {
                                     let fresh63 = nelem;
                                     nelem -= 1;
@@ -10588,10 +11004,14 @@ fn Do_Func(lParse: &mut ParseData, this: *mut Node) {
                                         break;
                                     }
                                     elem -= 1;
-                                    elem;
-                                    if *((*theParams[0]).value.undef).offset(elem as isize) == 0 {
-                                        *((*this).value.data.lngptr).offset(row as isize) +=
-                                            (if *((*theParams[0]).value.data.logptr)
+
+                                    if *((lParse.Nodes[theParams[0]]).value.undef)
+                                        .offset(elem as isize)
+                                        == 0
+                                    {
+                                        *((lParse.Nodes[this_node_idx]).value.data.lngptr)
+                                            .offset(row as isize) +=
+                                            (if *((lParse.Nodes[theParams[0]]).value.data.logptr)
                                                 .offset(elem as isize)
                                                 as c_int
                                                 != 0
@@ -10601,20 +11021,25 @@ fn Do_Func(lParse: &mut ParseData, this: *mut Node) {
                                                 0
                                             })
                                                 as c_long;
-                                        *((*this).value.undef).offset(row as isize) = 0;
+                                        *((lParse.Nodes[this_node_idx]).value.undef)
+                                            .offset(row as isize) = 0;
                                     }
                                 }
                             }
-                        } else if (*theParams[0]).ntype == fits_parser_yytokentype::LONG as c_int {
+                        } else if (lParse.Nodes[theParams[0]]).ntype
+                            == fits_parser_yytokentype::LONG as c_int
+                        {
                             loop {
                                 let fresh64 = row;
                                 row -= 1;
                                 if fresh64 == 0 {
                                     break;
                                 }
-                                *((*this).value.data.lngptr).offset(row as isize) = 0;
-                                *((*this).value.undef).offset(row as isize) = 1;
-                                nelem = (*theParams[0]).value.nelem;
+                                *((lParse.Nodes[this_node_idx]).value.data.lngptr)
+                                    .offset(row as isize) = 0;
+                                *((lParse.Nodes[this_node_idx]).value.undef).offset(row as isize) =
+                                    1;
+                                nelem = (lParse.Nodes[theParams[0]]).value.nelem;
                                 loop {
                                     let fresh65 = nelem;
                                     nelem -= 1;
@@ -10622,16 +11047,22 @@ fn Do_Func(lParse: &mut ParseData, this: *mut Node) {
                                         break;
                                     }
                                     elem -= 1;
-                                    elem;
-                                    if *((*theParams[0]).value.undef).offset(elem as isize) == 0 {
-                                        *((*this).value.data.lngptr).offset(row as isize) +=
-                                            *((*theParams[0]).value.data.lngptr)
+
+                                    if *((lParse.Nodes[theParams[0]]).value.undef)
+                                        .offset(elem as isize)
+                                        == 0
+                                    {
+                                        *((lParse.Nodes[this_node_idx]).value.data.lngptr)
+                                            .offset(row as isize) +=
+                                            *((lParse.Nodes[theParams[0]]).value.data.lngptr)
                                                 .offset(elem as isize);
-                                        *((*this).value.undef).offset(row as isize) = 0;
+                                        *((lParse.Nodes[this_node_idx]).value.undef)
+                                            .offset(row as isize) = 0;
                                     }
                                 }
                             }
-                        } else if (*theParams[0]).ntype == fits_parser_yytokentype::DOUBLE as c_int
+                        } else if (lParse.Nodes[theParams[0]]).ntype
+                            == fits_parser_yytokentype::DOUBLE as c_int
                         {
                             loop {
                                 let fresh66 = row;
@@ -10639,9 +11070,11 @@ fn Do_Func(lParse: &mut ParseData, this: *mut Node) {
                                 if fresh66 == 0 {
                                     break;
                                 }
-                                *((*this).value.data.dblptr).offset(row as isize) = 0.0;
-                                *((*this).value.undef).offset(row as isize) = 1;
-                                nelem = (*theParams[0]).value.nelem;
+                                *((lParse.Nodes[this_node_idx]).value.data.dblptr)
+                                    .offset(row as isize) = 0.0;
+                                *((lParse.Nodes[this_node_idx]).value.undef).offset(row as isize) =
+                                    1;
+                                nelem = (lParse.Nodes[theParams[0]]).value.nelem;
                                 loop {
                                     let fresh67 = nelem;
                                     nelem -= 1;
@@ -10649,17 +11082,22 @@ fn Do_Func(lParse: &mut ParseData, this: *mut Node) {
                                         break;
                                     }
                                     elem -= 1;
-                                    elem;
-                                    if *((*theParams[0]).value.undef).offset(elem as isize) == 0 {
-                                        *((*this).value.data.dblptr).offset(row as isize) +=
-                                            *((*theParams[0]).value.data.dblptr)
+
+                                    if *((lParse.Nodes[theParams[0]]).value.undef)
+                                        .offset(elem as isize)
+                                        == 0
+                                    {
+                                        *((lParse.Nodes[this_node_idx]).value.data.dblptr)
+                                            .offset(row as isize) +=
+                                            *((lParse.Nodes[theParams[0]]).value.data.dblptr)
                                                 .offset(elem as isize);
-                                        *((*this).value.undef).offset(row as isize) = 0;
+                                        *((lParse.Nodes[this_node_idx]).value.undef)
+                                            .offset(row as isize) = 0;
                                     }
                                 }
                             }
                         } else {
-                            nelem = (*theParams[0]).value.nelem;
+                            nelem = (lParse.Nodes[theParams[0]]).value.nelem;
                             loop {
                                 let fresh68 = row;
                                 row -= 1;
@@ -10667,25 +11105,29 @@ fn Do_Func(lParse: &mut ParseData, this: *mut Node) {
                                     break;
                                 }
                                 let mut sptr1: *mut c_char =
-                                    *((*theParams[0]).value.data.strptr).offset(row as isize);
-                                *((*this).value.data.lngptr).offset(row as isize) = 0;
-                                *((*this).value.undef).offset(row as isize) = 0;
+                                    *((lParse.Nodes[theParams[0]]).value.data.strptr)
+                                        .offset(row as isize);
+                                *((lParse.Nodes[this_node_idx]).value.data.lngptr)
+                                    .offset(row as isize) = 0;
+                                *((lParse.Nodes[this_node_idx]).value.undef).offset(row as isize) =
+                                    0;
                                 while *sptr1 != 0 {
                                     if *sptr1 as c_int == '1' as i32 {
                                         let fresh69 =
-                                            &mut *((*this).value.data.lngptr).offset(row as isize);
+                                            &mut *((lParse.Nodes[this_node_idx]).value.data.lngptr)
+                                                .offset(row as isize);
                                         *fresh69 += 1;
-                                        *fresh69;
                                     }
                                     sptr1 = sptr1.offset(1);
-                                    sptr1;
                                 }
                             }
                         }
                     }
                     1038 => {
-                        elem = row * (*theParams[0]).value.nelem;
-                        if (*theParams[0]).ntype == fits_parser_yytokentype::LONG as c_int {
+                        elem = row * (lParse.Nodes[theParams[0]]).value.nelem;
+                        if (lParse.Nodes[theParams[0]]).ntype
+                            == fits_parser_yytokentype::LONG as c_int
+                        {
                             loop {
                                 let fresh70 = row;
                                 row -= 1;
@@ -10693,8 +11135,9 @@ fn Do_Func(lParse: &mut ParseData, this: *mut Node) {
                                     break;
                                 }
                                 let mut count: c_int = 0;
-                                *((*this).value.data.dblptr).offset(row as isize) = 0.0;
-                                nelem = (*theParams[0]).value.nelem;
+                                *((lParse.Nodes[this_node_idx]).value.data.dblptr)
+                                    .offset(row as isize) = 0.0;
+                                nelem = (lParse.Nodes[theParams[0]]).value.nelem;
                                 loop {
                                     let fresh71 = nelem;
                                     nelem -= 1;
@@ -10702,27 +11145,32 @@ fn Do_Func(lParse: &mut ParseData, this: *mut Node) {
                                         break;
                                     }
                                     elem -= 1;
-                                    elem;
-                                    if *((*theParams[0]).value.undef).offset(elem as isize) as c_int
+
+                                    if *((lParse.Nodes[theParams[0]]).value.undef)
+                                        .offset(elem as isize)
+                                        as c_int
                                         == 0
                                     {
-                                        *((*this).value.data.dblptr).offset(row as isize) +=
-                                            *((*theParams[0]).value.data.lngptr)
+                                        *((lParse.Nodes[this_node_idx]).value.data.dblptr)
+                                            .offset(row as isize) +=
+                                            *((lParse.Nodes[theParams[0]]).value.data.lngptr)
                                                 .offset(elem as isize)
                                                 as c_double;
                                         count += 1;
-                                        count;
                                     }
                                 }
                                 if count == 0 {
-                                    *((*this).value.undef).offset(row as isize) = 1;
+                                    *((lParse.Nodes[this_node_idx]).value.undef)
+                                        .offset(row as isize) = 1;
                                 } else {
-                                    *((*this).value.undef).offset(row as isize) = 0;
-                                    *((*this).value.data.dblptr).offset(row as isize) /=
-                                        count as c_double;
+                                    *((lParse.Nodes[this_node_idx]).value.undef)
+                                        .offset(row as isize) = 0;
+                                    *((lParse.Nodes[this_node_idx]).value.data.dblptr)
+                                        .offset(row as isize) /= count as c_double;
                                 }
                             }
-                        } else if (*theParams[0]).ntype == fits_parser_yytokentype::DOUBLE as c_int
+                        } else if (lParse.Nodes[theParams[0]]).ntype
+                            == fits_parser_yytokentype::DOUBLE as c_int
                         {
                             loop {
                                 let fresh72 = row;
@@ -10731,8 +11179,9 @@ fn Do_Func(lParse: &mut ParseData, this: *mut Node) {
                                     break;
                                 }
                                 let mut count_0: c_int = 0;
-                                *((*this).value.data.dblptr).offset(row as isize) = 0.0;
-                                nelem = (*theParams[0]).value.nelem;
+                                *((lParse.Nodes[this_node_idx]).value.data.dblptr)
+                                    .offset(row as isize) = 0.0;
+                                nelem = (lParse.Nodes[theParams[0]]).value.nelem;
                                 loop {
                                     let fresh73 = nelem;
                                     nelem -= 1;
@@ -10740,30 +11189,36 @@ fn Do_Func(lParse: &mut ParseData, this: *mut Node) {
                                         break;
                                     }
                                     elem -= 1;
-                                    elem;
-                                    if *((*theParams[0]).value.undef).offset(elem as isize) as c_int
+
+                                    if *((lParse.Nodes[theParams[0]]).value.undef)
+                                        .offset(elem as isize)
+                                        as c_int
                                         == 0
                                     {
-                                        *((*this).value.data.dblptr).offset(row as isize) +=
-                                            *((*theParams[0]).value.data.dblptr)
+                                        *((lParse.Nodes[this_node_idx]).value.data.dblptr)
+                                            .offset(row as isize) +=
+                                            *((lParse.Nodes[theParams[0]]).value.data.dblptr)
                                                 .offset(elem as isize);
                                         count_0 += 1;
-                                        count_0;
                                     }
                                 }
                                 if count_0 == 0 {
-                                    *((*this).value.undef).offset(row as isize) = 1;
+                                    *((lParse.Nodes[this_node_idx]).value.undef)
+                                        .offset(row as isize) = 1;
                                 } else {
-                                    *((*this).value.undef).offset(row as isize) = 0;
-                                    *((*this).value.data.dblptr).offset(row as isize) /=
-                                        count_0 as c_double;
+                                    *((lParse.Nodes[this_node_idx]).value.undef)
+                                        .offset(row as isize) = 0;
+                                    *((lParse.Nodes[this_node_idx]).value.data.dblptr)
+                                        .offset(row as isize) /= count_0 as c_double;
                                 }
                             }
                         }
                     }
                     1039 => {
-                        elem = row * (*theParams[0]).value.nelem;
-                        if (*theParams[0]).ntype == fits_parser_yytokentype::LONG as c_int {
+                        elem = row * (lParse.Nodes[theParams[0]]).value.nelem;
+                        if (lParse.Nodes[theParams[0]]).ntype
+                            == fits_parser_yytokentype::LONG as c_int
+                        {
                             loop {
                                 let fresh74 = row;
                                 row -= 1;
@@ -10773,7 +11228,7 @@ fn Do_Func(lParse: &mut ParseData, this: *mut Node) {
                                 let mut count_1: c_int = 0;
                                 let mut sum: c_double = 0.0;
                                 let mut sum2: c_double = 0.0;
-                                nelem = (*theParams[0]).value.nelem;
+                                nelem = (lParse.Nodes[theParams[0]]).value.nelem;
                                 loop {
                                     let fresh75 = nelem;
                                     nelem -= 1;
@@ -10781,20 +11236,21 @@ fn Do_Func(lParse: &mut ParseData, this: *mut Node) {
                                         break;
                                     }
                                     elem -= 1;
-                                    elem;
-                                    if *((*theParams[0]).value.undef).offset(elem as isize) as c_int
+
+                                    if *((lParse.Nodes[theParams[0]]).value.undef)
+                                        .offset(elem as isize)
+                                        as c_int
                                         == 0
                                     {
-                                        sum += *((*theParams[0]).value.data.lngptr)
+                                        sum += *((lParse.Nodes[theParams[0]]).value.data.lngptr)
                                             .offset(elem as isize)
                                             as c_double;
                                         count_1 += 1;
-                                        count_1;
                                     }
                                 }
                                 if count_1 > 1 {
                                     sum /= count_1 as c_double;
-                                    nelem = (*theParams[0]).value.nelem;
+                                    nelem = (lParse.Nodes[theParams[0]]).value.nelem;
                                     elem += nelem;
                                     loop {
                                         let fresh76 = nelem;
@@ -10803,27 +11259,34 @@ fn Do_Func(lParse: &mut ParseData, this: *mut Node) {
                                             break;
                                         }
                                         elem -= 1;
-                                        elem;
-                                        if *((*theParams[0]).value.undef).offset(elem as isize)
+
+                                        if *((lParse.Nodes[theParams[0]]).value.undef)
+                                            .offset(elem as isize)
                                             as c_int
                                             == 0
                                         {
-                                            let dx: c_double = *((*theParams[0]).value.data.lngptr)
-                                                .offset(elem as isize)
-                                                as c_double
-                                                - sum;
+                                            let dx: c_double =
+                                                *((lParse.Nodes[theParams[0]]).value.data.lngptr)
+                                                    .offset(elem as isize)
+                                                    as c_double
+                                                    - sum;
                                             sum2 += dx * dx;
                                         }
                                     }
                                     sum2 /= count_1 as c_double - 1 as c_double;
-                                    *((*this).value.undef).offset(row as isize) = 0;
-                                    *((*this).value.data.dblptr).offset(row as isize) = sqrt(sum2);
+                                    *((lParse.Nodes[this_node_idx]).value.undef)
+                                        .offset(row as isize) = 0;
+                                    *((lParse.Nodes[this_node_idx]).value.data.dblptr)
+                                        .offset(row as isize) = sqrt(sum2);
                                 } else {
-                                    *((*this).value.undef).offset(row as isize) = 0;
-                                    *((*this).value.data.dblptr).offset(row as isize) = 0.0;
+                                    *((lParse.Nodes[this_node_idx]).value.undef)
+                                        .offset(row as isize) = 0;
+                                    *((lParse.Nodes[this_node_idx]).value.data.dblptr)
+                                        .offset(row as isize) = 0.0;
                                 }
                             }
-                        } else if (*theParams[0]).ntype == fits_parser_yytokentype::DOUBLE as c_int
+                        } else if (lParse.Nodes[theParams[0]]).ntype
+                            == fits_parser_yytokentype::DOUBLE as c_int
                         {
                             loop {
                                 let fresh77 = row;
@@ -10834,7 +11297,7 @@ fn Do_Func(lParse: &mut ParseData, this: *mut Node) {
                                 let mut count_2: c_int = 0;
                                 let mut sum_0: c_double = 0.0;
                                 let mut sum2_0: c_double = 0.0;
-                                nelem = (*theParams[0]).value.nelem;
+                                nelem = (lParse.Nodes[theParams[0]]).value.nelem;
                                 loop {
                                     let fresh78 = nelem;
                                     nelem -= 1;
@@ -10842,19 +11305,20 @@ fn Do_Func(lParse: &mut ParseData, this: *mut Node) {
                                         break;
                                     }
                                     elem -= 1;
-                                    elem;
-                                    if *((*theParams[0]).value.undef).offset(elem as isize) as c_int
+
+                                    if *((lParse.Nodes[theParams[0]]).value.undef)
+                                        .offset(elem as isize)
+                                        as c_int
                                         == 0
                                     {
-                                        sum_0 += *((*theParams[0]).value.data.dblptr)
+                                        sum_0 += *((lParse.Nodes[theParams[0]]).value.data.dblptr)
                                             .offset(elem as isize);
                                         count_2 += 1;
-                                        count_2;
                                     }
                                 }
                                 if count_2 > 1 {
                                     sum_0 /= count_2 as c_double;
-                                    nelem = (*theParams[0]).value.nelem;
+                                    nelem = (lParse.Nodes[theParams[0]]).value.nelem;
                                     elem += nelem;
                                     loop {
                                         let fresh79 = nelem;
@@ -10863,35 +11327,42 @@ fn Do_Func(lParse: &mut ParseData, this: *mut Node) {
                                             break;
                                         }
                                         elem -= 1;
-                                        elem;
-                                        if *((*theParams[0]).value.undef).offset(elem as isize)
+
+                                        if *((lParse.Nodes[theParams[0]]).value.undef)
+                                            .offset(elem as isize)
                                             as c_int
                                             == 0
                                         {
                                             let dx_0: c_double =
-                                                *((*theParams[0]).value.data.dblptr)
+                                                *((lParse.Nodes[theParams[0]]).value.data.dblptr)
                                                     .offset(elem as isize)
                                                     - sum_0;
                                             sum2_0 += dx_0 * dx_0;
                                         }
                                     }
                                     sum2_0 /= count_2 as c_double - 1 as c_double;
-                                    *((*this).value.undef).offset(row as isize) = 0;
-                                    *((*this).value.data.dblptr).offset(row as isize) =
-                                        sqrt(sum2_0);
+                                    *((lParse.Nodes[this_node_idx]).value.undef)
+                                        .offset(row as isize) = 0;
+                                    *((lParse.Nodes[this_node_idx]).value.data.dblptr)
+                                        .offset(row as isize) = sqrt(sum2_0);
                                 } else {
-                                    *((*this).value.undef).offset(row as isize) = 0;
-                                    *((*this).value.data.dblptr).offset(row as isize) = 0.0;
+                                    *((lParse.Nodes[this_node_idx]).value.undef)
+                                        .offset(row as isize) = 0;
+                                    *((lParse.Nodes[this_node_idx]).value.data.dblptr)
+                                        .offset(row as isize) = 0.0;
                                 }
                             }
                         }
                     }
                     1037 => {
-                        elem = row * (*theParams[0]).value.nelem;
-                        nelem = (*theParams[0]).value.nelem;
-                        if (*theParams[0]).ntype == fits_parser_yytokentype::LONG as c_int {
-                            let mut dptr: *mut c_long = (*theParams[0]).value.data.lngptr;
-                            let mut uptr: *mut c_char = (*theParams[0]).value.undef;
+                        elem = row * (lParse.Nodes[theParams[0]]).value.nelem;
+                        nelem = (lParse.Nodes[theParams[0]]).value.nelem;
+                        if (lParse.Nodes[theParams[0]]).ntype
+                            == fits_parser_yytokentype::LONG as c_int
+                        {
+                            let mut dptr: *mut c_long =
+                                (lParse.Nodes[theParams[0]]).value.data.lngptr;
+                            let mut uptr: *mut c_char = (lParse.Nodes[theParams[0]]).value.undef;
                             let mptr: *mut c_long = malloc(
                                 (::core::mem::size_of::<c_long>() as c_ulong)
                                     .wrapping_mul(nelem as c_ulong)
@@ -10904,7 +11375,7 @@ fn Do_Func(lParse: &mut ParseData, this: *mut Node) {
                                     lParse,
                                     cs!(c"Could not allocate temporary memory in median function"),
                                 );
-                                free((*this).value.data.ptr);
+                                free((lParse.Nodes[this_node_idx]).value.data.ptr);
                             } else {
                                 irow = 0;
                                 while (irow as c_long) < row {
@@ -10922,27 +11393,29 @@ fn Do_Func(lParse: &mut ParseData, this: *mut Node) {
                                             *fresh81 = *dptr;
                                         }
                                         dptr = dptr.offset(1);
-                                        dptr;
                                         uptr = uptr.offset(1);
-                                        uptr;
                                     }
                                     nelem1 = p.offset_from(mptr) as c_long as c_int;
                                     if nelem1 > 0 {
-                                        *((*this).value.undef).offset(irow as isize) = 0;
-                                        *((*this).value.data.lngptr).offset(irow as isize) =
+                                        *((lParse.Nodes[this_node_idx]).value.undef)
+                                            .offset(irow as isize) = 0;
+                                        *((lParse.Nodes[this_node_idx]).value.data.lngptr)
+                                            .offset(irow as isize) =
                                             qselect_median_lng(mptr, nelem1);
                                     } else {
-                                        *((*this).value.undef).offset(irow as isize) = 1;
-                                        *((*this).value.data.lngptr).offset(irow as isize) = 0;
+                                        *((lParse.Nodes[this_node_idx]).value.undef)
+                                            .offset(irow as isize) = 1;
+                                        *((lParse.Nodes[this_node_idx]).value.data.lngptr)
+                                            .offset(irow as isize) = 0;
                                     }
                                     irow += 1;
-                                    irow;
                                 }
                                 free(mptr as *mut c_void);
                             }
                         } else {
-                            let mut dptr_0: *mut c_double = (*theParams[0]).value.data.dblptr;
-                            let mut uptr_0: *mut c_char = (*theParams[0]).value.undef;
+                            let mut dptr_0: *mut c_double =
+                                (lParse.Nodes[theParams[0]]).value.data.dblptr;
+                            let mut uptr_0: *mut c_char = (lParse.Nodes[theParams[0]]).value.undef;
                             let mptr_0: *mut c_double = malloc(
                                 (::core::mem::size_of::<c_double>() as c_ulong)
                                     .wrapping_mul(nelem as c_ulong)
@@ -10956,7 +11429,7 @@ fn Do_Func(lParse: &mut ParseData, this: *mut Node) {
                                     lParse,
                                     cs!(c"Could not allocate temporary memory in median function"),
                                 );
-                                free((*this).value.data.ptr);
+                                free((lParse.Nodes[this_node_idx]).value.data.ptr);
                             } else {
                                 irow_0 = 0;
                                 while (irow_0 as c_long) < row {
@@ -10974,39 +11447,45 @@ fn Do_Func(lParse: &mut ParseData, this: *mut Node) {
                                             *fresh83 = *dptr_0;
                                         }
                                         dptr_0 = dptr_0.offset(1);
-                                        dptr_0;
                                         uptr_0 = uptr_0.offset(1);
-                                        uptr_0;
                                     }
                                     nelem1_0 = p_0.offset_from(mptr_0) as c_long as c_int;
                                     if nelem1_0 > 0 {
-                                        *((*this).value.undef).offset(irow_0 as isize) = 0;
-                                        *((*this).value.data.dblptr).offset(irow_0 as isize) =
+                                        *((lParse.Nodes[this_node_idx]).value.undef)
+                                            .offset(irow_0 as isize) = 0;
+                                        *((lParse.Nodes[this_node_idx]).value.data.dblptr)
+                                            .offset(irow_0 as isize) =
                                             qselect_median_dbl(mptr_0, nelem1_0);
                                     } else {
-                                        *((*this).value.undef).offset(irow_0 as isize) = 1;
-                                        *((*this).value.data.dblptr).offset(irow_0 as isize) = 0.0;
+                                        *((lParse.Nodes[this_node_idx]).value.undef)
+                                            .offset(irow_0 as isize) = 1;
+                                        *((lParse.Nodes[this_node_idx]).value.data.dblptr)
+                                            .offset(irow_0 as isize) = 0.0;
                                     }
                                     irow_0 += 1;
-                                    irow_0;
                                 }
                                 free(mptr_0 as *mut c_void);
                             }
                         }
                     }
                     1017 => {
-                        if (*theParams[0]).ntype == fits_parser_yytokentype::DOUBLE as c_int {
+                        if (lParse.Nodes[theParams[0]]).ntype
+                            == fits_parser_yytokentype::DOUBLE as c_int
+                        {
                             loop {
                                 let fresh84 = elem;
                                 elem -= 1;
                                 if fresh84 == 0 {
                                     break;
                                 }
-                                dval = *((*theParams[0]).value.data.dblptr).offset(elem as isize);
-                                *((*this).value.data.dblptr).offset(elem as isize) =
-                                    if dval > 0.0 { dval } else { -dval };
-                                *((*this).value.undef).offset(elem as isize) =
-                                    *((*theParams[0]).value.undef).offset(elem as isize);
+                                dval = *((lParse.Nodes[theParams[0]]).value.data.dblptr)
+                                    .offset(elem as isize);
+                                *((lParse.Nodes[this_node_idx]).value.data.dblptr)
+                                    .offset(elem as isize) = if dval > 0.0 { dval } else { -dval };
+                                *((lParse.Nodes[this_node_idx]).value.undef)
+                                    .offset(elem as isize) =
+                                    *((lParse.Nodes[theParams[0]]).value.undef)
+                                        .offset(elem as isize);
                             }
                         } else {
                             loop {
@@ -11015,17 +11494,22 @@ fn Do_Func(lParse: &mut ParseData, this: *mut Node) {
                                 if fresh85 == 0 {
                                     break;
                                 }
-                                ival = *((*theParams[0]).value.data.lngptr).offset(elem as isize);
-                                *((*this).value.data.lngptr).offset(elem as isize) =
-                                    if ival > 0 { ival } else { -ival };
-                                *((*this).value.undef).offset(elem as isize) =
-                                    *((*theParams[0]).value.undef).offset(elem as isize);
+                                ival = *((lParse.Nodes[theParams[0]]).value.data.lngptr)
+                                    .offset(elem as isize);
+                                *((lParse.Nodes[this_node_idx]).value.data.lngptr)
+                                    .offset(elem as isize) = if ival > 0 { ival } else { -ival };
+                                *((lParse.Nodes[this_node_idx]).value.undef)
+                                    .offset(elem as isize) =
+                                    *((lParse.Nodes[theParams[0]]).value.undef)
+                                        .offset(elem as isize);
                             }
                         }
                     }
                     1040 => {
-                        nelem = (*theParams[0]).value.nelem;
-                        if (*theParams[0]).ntype == fits_parser_yytokentype::STRING as c_int {
+                        nelem = (lParse.Nodes[theParams[0]]).value.nelem;
+                        if (lParse.Nodes[theParams[0]]).ntype
+                            == fits_parser_yytokentype::STRING as c_int
+                        {
                             nelem = 1;
                         }
                         elem = row * nelem;
@@ -11036,8 +11520,9 @@ fn Do_Func(lParse: &mut ParseData, this: *mut Node) {
                                 break;
                             }
                             let mut nelem1_1: c_int = nelem as c_int;
-                            *((*this).value.undef).offset(row as isize) = 0;
-                            *((*this).value.data.lngptr).offset(row as isize) = 0;
+                            *((lParse.Nodes[this_node_idx]).value.undef).offset(row as isize) = 0;
+                            *((lParse.Nodes[this_node_idx]).value.data.lngptr)
+                                .offset(row as isize) = 0;
                             loop {
                                 let fresh87 = nelem1_1;
                                 nelem1_1 -= 1;
@@ -11045,20 +11530,23 @@ fn Do_Func(lParse: &mut ParseData, this: *mut Node) {
                                     break;
                                 }
                                 elem -= 1;
-                                elem;
-                                if *((*theParams[0]).value.undef).offset(elem as isize) as c_int
+
+                                if *((lParse.Nodes[theParams[0]]).value.undef).offset(elem as isize)
+                                    as c_int
                                     == 0
                                 {
                                     let fresh88 =
-                                        &mut *((*this).value.data.lngptr).offset(row as isize);
+                                        &mut *((lParse.Nodes[this_node_idx]).value.data.lngptr)
+                                            .offset(row as isize);
                                     *fresh88 += 1;
-                                    *fresh88;
                                 }
                             }
                         }
                     }
                     1030 => {
-                        if (*theParams[0]).ntype == fits_parser_yytokentype::STRING as c_int {
+                        if (lParse.Nodes[theParams[0]]).ntype
+                            == fits_parser_yytokentype::STRING as c_int
+                        {
                             elem = row;
                         }
                         loop {
@@ -11067,19 +11555,20 @@ fn Do_Func(lParse: &mut ParseData, this: *mut Node) {
                             if fresh89 == 0 {
                                 break;
                             }
-                            *((*this).value.data.logptr).offset(elem as isize) =
-                                *((*theParams[0]).value.undef).offset(elem as isize);
-                            *((*this).value.undef).offset(elem as isize) = 0;
+                            *((lParse.Nodes[this_node_idx]).value.data.logptr)
+                                .offset(elem as isize) =
+                                *((lParse.Nodes[theParams[0]]).value.undef).offset(elem as isize);
+                            *((lParse.Nodes[this_node_idx]).value.undef).offset(elem as isize) = 0;
                         }
                     }
-                    1031 => match (*this).ntype {
-                        258 => loop {
+                    1031 => match (lParse.Nodes[this_node_idx]).ntype.into() {
+                        fits_parser_yytokentype::BOOLEAN => loop {
                             let fresh90 = row;
                             row -= 1;
                             if fresh90 == 0 {
                                 break;
                             }
-                            nelem = (*this).value.nelem;
+                            nelem = (lParse.Nodes[this_node_idx]).value.nelem;
                             loop {
                                 let fresh91 = nelem;
                                 nelem -= 1;
@@ -11087,8 +11576,8 @@ fn Do_Func(lParse: &mut ParseData, this: *mut Node) {
                                     break;
                                 }
                                 elem -= 1;
-                                elem;
-                                i = 2 as c_int;
+
+                                i = 2;
                                 loop {
                                     let fresh92 = i;
                                     i -= 1;
@@ -11096,37 +11585,47 @@ fn Do_Func(lParse: &mut ParseData, this: *mut Node) {
                                         break;
                                     }
                                     if vector[i as usize] > 1 {
-                                        pNull[i as usize] = *((*theParams[i as usize]).value.undef)
-                                            .offset(elem as isize);
-                                        pVals[i as usize].data.log =
-                                            *((*theParams[i as usize]).value.data.logptr)
+                                        pNull[i as usize] =
+                                            *((lParse.Nodes[theParams[i as usize]]).value.undef)
                                                 .offset(elem as isize);
+                                        pVals[i as usize].data.log = *((lParse.Nodes
+                                            [theParams[i as usize]])
+                                            .value
+                                            .data
+                                            .logptr)
+                                            .offset(elem as isize);
                                     } else if vector[i as usize] != 0 {
-                                        pNull[i as usize] = *((*theParams[i as usize]).value.undef)
-                                            .offset(row as isize);
-                                        pVals[i as usize].data.log =
-                                            *((*theParams[i as usize]).value.data.logptr)
+                                        pNull[i as usize] =
+                                            *((lParse.Nodes[theParams[i as usize]]).value.undef)
                                                 .offset(row as isize);
+                                        pVals[i as usize].data.log = *((lParse.Nodes
+                                            [theParams[i as usize]])
+                                            .value
+                                            .data
+                                            .logptr)
+                                            .offset(row as isize);
                                     }
                                 }
                                 if pNull[0] != 0 {
-                                    *((*this).value.undef).offset(elem as isize) = pNull[1];
-                                    *((*this).value.data.logptr).offset(elem as isize) =
-                                        pVals[1].data.log;
+                                    *((lParse.Nodes[this_node_idx]).value.undef)
+                                        .offset(elem as isize) = pNull[1];
+                                    *((lParse.Nodes[this_node_idx]).value.data.logptr)
+                                        .offset(elem as isize) = pVals[1].data.log;
                                 } else {
-                                    *((*this).value.undef).offset(elem as isize) = 0;
-                                    *((*this).value.data.logptr).offset(elem as isize) =
-                                        pVals[0].data.log;
+                                    *((lParse.Nodes[this_node_idx]).value.undef)
+                                        .offset(elem as isize) = 0;
+                                    *((lParse.Nodes[this_node_idx]).value.data.logptr)
+                                        .offset(elem as isize) = pVals[0].data.log;
                                 }
                             }
                         },
-                        259 => loop {
+                        fits_parser_yytokentype::LONG => loop {
                             let fresh93 = row;
                             row -= 1;
                             if fresh93 == 0 {
                                 break;
                             }
-                            nelem = (*this).value.nelem;
+                            nelem = (lParse.Nodes[this_node_idx]).value.nelem;
                             loop {
                                 let fresh94 = nelem;
                                 nelem -= 1;
@@ -11134,8 +11633,8 @@ fn Do_Func(lParse: &mut ParseData, this: *mut Node) {
                                     break;
                                 }
                                 elem -= 1;
-                                elem;
-                                i = 2 as c_int;
+
+                                i = 2;
                                 loop {
                                     let fresh95 = i;
                                     i -= 1;
@@ -11143,37 +11642,47 @@ fn Do_Func(lParse: &mut ParseData, this: *mut Node) {
                                         break;
                                     }
                                     if vector[i as usize] > 1 {
-                                        pNull[i as usize] = *((*theParams[i as usize]).value.undef)
-                                            .offset(elem as isize);
-                                        pVals[i as usize].data.lng =
-                                            *((*theParams[i as usize]).value.data.lngptr)
+                                        pNull[i as usize] =
+                                            *((lParse.Nodes[theParams[i as usize]]).value.undef)
                                                 .offset(elem as isize);
+                                        pVals[i as usize].data.lng = *((lParse.Nodes
+                                            [theParams[i as usize]])
+                                            .value
+                                            .data
+                                            .lngptr)
+                                            .offset(elem as isize);
                                     } else if vector[i as usize] != 0 {
-                                        pNull[i as usize] = *((*theParams[i as usize]).value.undef)
-                                            .offset(row as isize);
-                                        pVals[i as usize].data.lng =
-                                            *((*theParams[i as usize]).value.data.lngptr)
+                                        pNull[i as usize] =
+                                            *((lParse.Nodes[theParams[i as usize]]).value.undef)
                                                 .offset(row as isize);
+                                        pVals[i as usize].data.lng = *((lParse.Nodes
+                                            [theParams[i as usize]])
+                                            .value
+                                            .data
+                                            .lngptr)
+                                            .offset(row as isize);
                                     }
                                 }
                                 if pNull[0] != 0 {
-                                    *((*this).value.undef).offset(elem as isize) = pNull[1];
-                                    *((*this).value.data.lngptr).offset(elem as isize) =
-                                        pVals[1].data.lng;
+                                    *((lParse.Nodes[this_node_idx]).value.undef)
+                                        .offset(elem as isize) = pNull[1];
+                                    *((lParse.Nodes[this_node_idx]).value.data.lngptr)
+                                        .offset(elem as isize) = pVals[1].data.lng;
                                 } else {
-                                    *((*this).value.undef).offset(elem as isize) = 0;
-                                    *((*this).value.data.lngptr).offset(elem as isize) =
-                                        pVals[0].data.lng;
+                                    *((lParse.Nodes[this_node_idx]).value.undef)
+                                        .offset(elem as isize) = 0;
+                                    *((lParse.Nodes[this_node_idx]).value.data.lngptr)
+                                        .offset(elem as isize) = pVals[0].data.lng;
                                 }
                             }
                         },
-                        260 => loop {
+                        fits_parser_yytokentype::DOUBLE => loop {
                             let fresh96 = row;
                             row -= 1;
                             if fresh96 == 0 {
                                 break;
                             }
-                            nelem = (*this).value.nelem;
+                            nelem = (lParse.Nodes[this_node_idx]).value.nelem;
                             loop {
                                 let fresh97 = nelem;
                                 nelem -= 1;
@@ -11181,8 +11690,8 @@ fn Do_Func(lParse: &mut ParseData, this: *mut Node) {
                                     break;
                                 }
                                 elem -= 1;
-                                elem;
-                                i = 2 as c_int;
+
+                                i = 2;
                                 loop {
                                     let fresh98 = i;
                                     i -= 1;
@@ -11190,37 +11699,47 @@ fn Do_Func(lParse: &mut ParseData, this: *mut Node) {
                                         break;
                                     }
                                     if vector[i as usize] > 1 {
-                                        pNull[i as usize] = *((*theParams[i as usize]).value.undef)
-                                            .offset(elem as isize);
-                                        pVals[i as usize].data.dbl =
-                                            *((*theParams[i as usize]).value.data.dblptr)
+                                        pNull[i as usize] =
+                                            *((lParse.Nodes[theParams[i as usize]]).value.undef)
                                                 .offset(elem as isize);
+                                        pVals[i as usize].data.dbl = *((lParse.Nodes
+                                            [theParams[i as usize]])
+                                            .value
+                                            .data
+                                            .dblptr)
+                                            .offset(elem as isize);
                                     } else if vector[i as usize] != 0 {
-                                        pNull[i as usize] = *((*theParams[i as usize]).value.undef)
-                                            .offset(row as isize);
-                                        pVals[i as usize].data.dbl =
-                                            *((*theParams[i as usize]).value.data.dblptr)
+                                        pNull[i as usize] =
+                                            *((lParse.Nodes[theParams[i as usize]]).value.undef)
                                                 .offset(row as isize);
+                                        pVals[i as usize].data.dbl = *((lParse.Nodes
+                                            [theParams[i as usize]])
+                                            .value
+                                            .data
+                                            .dblptr)
+                                            .offset(row as isize);
                                     }
                                 }
                                 if pNull[0] != 0 {
-                                    *((*this).value.undef).offset(elem as isize) = pNull[1];
-                                    *((*this).value.data.dblptr).offset(elem as isize) =
-                                        pVals[1].data.dbl;
+                                    *((lParse.Nodes[this_node_idx]).value.undef)
+                                        .offset(elem as isize) = pNull[1];
+                                    *((lParse.Nodes[this_node_idx]).value.data.dblptr)
+                                        .offset(elem as isize) = pVals[1].data.dbl;
                                 } else {
-                                    *((*this).value.undef).offset(elem as isize) = 0;
-                                    *((*this).value.data.dblptr).offset(elem as isize) =
-                                        pVals[0].data.dbl;
+                                    *((lParse.Nodes[this_node_idx]).value.undef)
+                                        .offset(elem as isize) = 0;
+                                    *((lParse.Nodes[this_node_idx]).value.data.dblptr)
+                                        .offset(elem as isize) = pVals[0].data.dbl;
                                 }
                             }
                         },
-                        261 => loop {
+                        fits_parser_yytokentype::STRING => loop {
                             let fresh99 = row;
                             row -= 1;
                             if fresh99 == 0 {
                                 break;
                             }
-                            i = 2 as c_int;
+                            i = 2;
                             loop {
                                 let fresh100 = i;
                                 i -= 1;
@@ -11228,66 +11747,85 @@ fn Do_Func(lParse: &mut ParseData, this: *mut Node) {
                                     break;
                                 }
                                 if vector[i as usize] != 0 {
-                                    pNull[i as usize] = *((*theParams[i as usize]).value.undef)
-                                        .offset(row as isize);
+                                    pNull[i as usize] =
+                                        *((lParse.Nodes[theParams[i as usize]]).value.undef)
+                                            .offset(row as isize);
                                     strcpy(
                                         (pVals[i as usize].data.astr).as_mut_ptr(),
-                                        *((*theParams[i as usize]).value.data.strptr)
+                                        *((lParse.Nodes[theParams[i as usize]]).value.data.strptr)
                                             .offset(row as isize),
                                     );
                                 }
                             }
                             if pNull[0] != 0 {
-                                *((*this).value.undef).offset(row as isize) = pNull[1];
+                                *((lParse.Nodes[this_node_idx]).value.undef).offset(row as isize) =
+                                    pNull[1];
                                 strcpy(
-                                    *((*this).value.data.strptr).offset(row as isize),
+                                    *((lParse.Nodes[this_node_idx]).value.data.strptr)
+                                        .offset(row as isize),
                                     (pVals[1].data.astr).as_mut_ptr(),
                                 );
                             } else {
-                                *((*this).value.undef).offset(elem as isize) = 0;
+                                *((lParse.Nodes[this_node_idx]).value.undef)
+                                    .offset(elem as isize) = 0;
                                 strcpy(
-                                    *((*this).value.data.strptr).offset(row as isize),
+                                    *((lParse.Nodes[this_node_idx]).value.data.strptr)
+                                        .offset(row as isize),
                                     (pVals[0].data.astr).as_mut_ptr(),
                                 );
                             }
                         },
                         _ => {}
                     },
-                    1046 => match (*this).ntype {
-                        259 => loop {
+                    1046 => match (lParse.Nodes[this_node_idx]).ntype.into() {
+                        fits_parser_yytokentype::LONG => loop {
                             let fresh101 = elem;
                             elem -= 1;
                             if fresh101 == 0 {
                                 break;
                             }
-                            if (*theParams[1]).value.data.lng
-                                == *((*theParams[0]).value.data.lngptr).offset(elem as isize)
+                            if (lParse.Nodes[theParams[1]]).value.data.lng
+                                == *((lParse.Nodes[theParams[0]]).value.data.lngptr)
+                                    .offset(elem as isize)
                             {
-                                *((*this).value.data.lngptr).offset(elem as isize) = 0;
-                                *((*this).value.undef).offset(elem as isize) = 1;
+                                *((lParse.Nodes[this_node_idx]).value.data.lngptr)
+                                    .offset(elem as isize) = 0;
+                                *((lParse.Nodes[this_node_idx]).value.undef)
+                                    .offset(elem as isize) = 1;
                             } else {
-                                *((*this).value.data.lngptr).offset(elem as isize) =
-                                    *((*theParams[0]).value.data.lngptr).offset(elem as isize);
-                                *((*this).value.undef).offset(elem as isize) =
-                                    *((*theParams[0]).value.undef).offset(elem as isize);
+                                *((lParse.Nodes[this_node_idx]).value.data.lngptr)
+                                    .offset(elem as isize) =
+                                    *((lParse.Nodes[theParams[0]]).value.data.lngptr)
+                                        .offset(elem as isize);
+                                *((lParse.Nodes[this_node_idx]).value.undef)
+                                    .offset(elem as isize) =
+                                    *((lParse.Nodes[theParams[0]]).value.undef)
+                                        .offset(elem as isize);
                             }
                         },
-                        260 => loop {
+                        fits_parser_yytokentype::DOUBLE => loop {
                             let fresh102 = elem;
                             elem -= 1;
                             if fresh102 == 0 {
                                 break;
                             }
-                            if (*theParams[1]).value.data.dbl
-                                == *((*theParams[0]).value.data.dblptr).offset(elem as isize)
+                            if (lParse.Nodes[theParams[1]]).value.data.dbl
+                                == *((lParse.Nodes[theParams[0]]).value.data.dblptr)
+                                    .offset(elem as isize)
                             {
-                                *((*this).value.data.dblptr).offset(elem as isize) = 0.0;
-                                *((*this).value.undef).offset(elem as isize) = 1;
+                                *((lParse.Nodes[this_node_idx]).value.data.dblptr)
+                                    .offset(elem as isize) = 0.0;
+                                *((lParse.Nodes[this_node_idx]).value.undef)
+                                    .offset(elem as isize) = 1;
                             } else {
-                                *((*this).value.data.dblptr).offset(elem as isize) =
-                                    *((*theParams[0]).value.data.dblptr).offset(elem as isize);
-                                *((*this).value.undef).offset(elem as isize) =
-                                    *((*theParams[0]).value.undef).offset(elem as isize);
+                                *((lParse.Nodes[this_node_idx]).value.data.dblptr)
+                                    .offset(elem as isize) =
+                                    *((lParse.Nodes[theParams[0]]).value.data.dblptr)
+                                        .offset(elem as isize);
+                                *((lParse.Nodes[this_node_idx]).value.undef)
+                                    .offset(elem as isize) =
+                                    *((lParse.Nodes[theParams[0]]).value.undef)
+                                        .offset(elem as isize);
                             }
                         },
                         _ => {}
@@ -11298,11 +11836,15 @@ fn Do_Func(lParse: &mut ParseData, this: *mut Node) {
                         if fresh103 == 0 {
                             break;
                         }
-                        let fresh104 = &mut *((*this).value.undef).offset(elem as isize);
-                        *fresh104 = *((*theParams[0]).value.undef).offset(elem as isize);
+                        let fresh104 =
+                            &mut *((lParse.Nodes[this_node_idx]).value.undef).offset(elem as isize);
+                        *fresh104 =
+                            *((lParse.Nodes[theParams[0]]).value.undef).offset(elem as isize);
                         if *fresh104 == 0 {
-                            *((*this).value.data.dblptr).offset(elem as isize) =
-                                sin(*((*theParams[0]).value.data.dblptr).offset(elem as isize));
+                            *((lParse.Nodes[this_node_idx]).value.data.dblptr)
+                                .offset(elem as isize) =
+                                sin(*((lParse.Nodes[theParams[0]]).value.data.dblptr)
+                                    .offset(elem as isize));
                         }
                     },
                     1005 => loop {
@@ -11311,11 +11853,15 @@ fn Do_Func(lParse: &mut ParseData, this: *mut Node) {
                         if fresh105 == 0 {
                             break;
                         }
-                        let fresh106 = &mut *((*this).value.undef).offset(elem as isize);
-                        *fresh106 = *((*theParams[0]).value.undef).offset(elem as isize);
+                        let fresh106 =
+                            &mut *((lParse.Nodes[this_node_idx]).value.undef).offset(elem as isize);
+                        *fresh106 =
+                            *((lParse.Nodes[theParams[0]]).value.undef).offset(elem as isize);
                         if *fresh106 == 0 {
-                            *((*this).value.data.dblptr).offset(elem as isize) =
-                                cos(*((*theParams[0]).value.data.dblptr).offset(elem as isize));
+                            *((lParse.Nodes[this_node_idx]).value.data.dblptr)
+                                .offset(elem as isize) =
+                                cos(*((lParse.Nodes[theParams[0]]).value.data.dblptr)
+                                    .offset(elem as isize));
                         }
                     },
                     1006 => loop {
@@ -11324,11 +11870,15 @@ fn Do_Func(lParse: &mut ParseData, this: *mut Node) {
                         if fresh107 == 0 {
                             break;
                         }
-                        let fresh108 = &mut *((*this).value.undef).offset(elem as isize);
-                        *fresh108 = *((*theParams[0]).value.undef).offset(elem as isize);
+                        let fresh108 =
+                            &mut *((lParse.Nodes[this_node_idx]).value.undef).offset(elem as isize);
+                        *fresh108 =
+                            *((lParse.Nodes[theParams[0]]).value.undef).offset(elem as isize);
                         if *fresh108 == 0 {
-                            *((*this).value.data.dblptr).offset(elem as isize) =
-                                tan(*((*theParams[0]).value.data.dblptr).offset(elem as isize));
+                            *((lParse.Nodes[this_node_idx]).value.data.dblptr)
+                                .offset(elem as isize) =
+                                tan(*((lParse.Nodes[theParams[0]]).value.data.dblptr)
+                                    .offset(elem as isize));
                         }
                     },
                     1007 => loop {
@@ -11337,15 +11887,21 @@ fn Do_Func(lParse: &mut ParseData, this: *mut Node) {
                         if fresh109 == 0 {
                             break;
                         }
-                        let fresh110 = &mut *((*this).value.undef).offset(elem as isize);
-                        *fresh110 = *((*theParams[0]).value.undef).offset(elem as isize);
+                        let fresh110 =
+                            &mut *((lParse.Nodes[this_node_idx]).value.undef).offset(elem as isize);
+                        *fresh110 =
+                            *((lParse.Nodes[theParams[0]]).value.undef).offset(elem as isize);
                         if *fresh110 == 0 {
-                            dval = *((*theParams[0]).value.data.dblptr).offset(elem as isize);
-                            if dval < -1.0f64 || dval > 1.0f64 {
-                                *((*this).value.data.dblptr).offset(elem as isize) = 0.0;
-                                *((*this).value.undef).offset(elem as isize) = 1;
+                            dval = *((lParse.Nodes[theParams[0]]).value.data.dblptr)
+                                .offset(elem as isize);
+                            if dval < -1.0 || dval > 1.0 {
+                                *((lParse.Nodes[this_node_idx]).value.data.dblptr)
+                                    .offset(elem as isize) = 0.0;
+                                *((lParse.Nodes[this_node_idx]).value.undef)
+                                    .offset(elem as isize) = 1;
                             } else {
-                                *((*this).value.data.dblptr).offset(elem as isize) = asin(dval);
+                                *((lParse.Nodes[this_node_idx]).value.data.dblptr)
+                                    .offset(elem as isize) = asin(dval);
                             }
                         }
                     },
@@ -11355,15 +11911,21 @@ fn Do_Func(lParse: &mut ParseData, this: *mut Node) {
                         if fresh111 == 0 {
                             break;
                         }
-                        let fresh112 = &mut *((*this).value.undef).offset(elem as isize);
-                        *fresh112 = *((*theParams[0]).value.undef).offset(elem as isize);
+                        let fresh112 =
+                            &mut *((lParse.Nodes[this_node_idx]).value.undef).offset(elem as isize);
+                        *fresh112 =
+                            *((lParse.Nodes[theParams[0]]).value.undef).offset(elem as isize);
                         if *fresh112 == 0 {
-                            dval = *((*theParams[0]).value.data.dblptr).offset(elem as isize);
-                            if dval < -1.0f64 || dval > 1.0f64 {
-                                *((*this).value.data.dblptr).offset(elem as isize) = 0.0;
-                                *((*this).value.undef).offset(elem as isize) = 1;
+                            dval = *((lParse.Nodes[theParams[0]]).value.data.dblptr)
+                                .offset(elem as isize);
+                            if dval < -1.0 || dval > 1.0 {
+                                *((lParse.Nodes[this_node_idx]).value.data.dblptr)
+                                    .offset(elem as isize) = 0.0;
+                                *((lParse.Nodes[this_node_idx]).value.undef)
+                                    .offset(elem as isize) = 1;
                             } else {
-                                *((*this).value.data.dblptr).offset(elem as isize) = acos(dval);
+                                *((lParse.Nodes[this_node_idx]).value.data.dblptr)
+                                    .offset(elem as isize) = acos(dval);
                             }
                         }
                     },
@@ -11373,11 +11935,15 @@ fn Do_Func(lParse: &mut ParseData, this: *mut Node) {
                         if fresh113 == 0 {
                             break;
                         }
-                        let fresh114 = &mut *((*this).value.undef).offset(elem as isize);
-                        *fresh114 = *((*theParams[0]).value.undef).offset(elem as isize);
+                        let fresh114 =
+                            &mut *((lParse.Nodes[this_node_idx]).value.undef).offset(elem as isize);
+                        *fresh114 =
+                            *((lParse.Nodes[theParams[0]]).value.undef).offset(elem as isize);
                         if *fresh114 == 0 {
-                            dval = *((*theParams[0]).value.data.dblptr).offset(elem as isize);
-                            *((*this).value.data.dblptr).offset(elem as isize) = atan(dval);
+                            dval = *((lParse.Nodes[theParams[0]]).value.data.dblptr)
+                                .offset(elem as isize);
+                            *((lParse.Nodes[this_node_idx]).value.data.dblptr)
+                                .offset(elem as isize) = atan(dval);
                         }
                     },
                     1010 => loop {
@@ -11386,11 +11952,16 @@ fn Do_Func(lParse: &mut ParseData, this: *mut Node) {
                         if fresh115 == 0 {
                             break;
                         }
-                        let fresh116 = &mut *((*this).value.undef).offset(elem as isize);
-                        *fresh116 = *((*theParams[0]).value.undef).offset(elem as isize);
+                        let fresh116 =
+                            &mut *((lParse.Nodes[this_node_idx]).value.undef).offset(elem as isize);
+                        *fresh116 =
+                            *((lParse.Nodes[theParams[0]]).value.undef).offset(elem as isize);
                         if *fresh116 == 0 {
-                            *((*this).value.data.dblptr).offset(elem as isize) =
-                                sinh(*((*theParams[0]).value.data.dblptr).offset(elem as isize));
+                            *((lParse.Nodes[this_node_idx]).value.data.dblptr)
+                                .offset(elem as isize) = sinh(
+                                *((lParse.Nodes[theParams[0]]).value.data.dblptr)
+                                    .offset(elem as isize),
+                            );
                         }
                     },
                     1011 => loop {
@@ -11399,11 +11970,16 @@ fn Do_Func(lParse: &mut ParseData, this: *mut Node) {
                         if fresh117 == 0 {
                             break;
                         }
-                        let fresh118 = &mut *((*this).value.undef).offset(elem as isize);
-                        *fresh118 = *((*theParams[0]).value.undef).offset(elem as isize);
+                        let fresh118 =
+                            &mut *((lParse.Nodes[this_node_idx]).value.undef).offset(elem as isize);
+                        *fresh118 =
+                            *((lParse.Nodes[theParams[0]]).value.undef).offset(elem as isize);
                         if *fresh118 == 0 {
-                            *((*this).value.data.dblptr).offset(elem as isize) =
-                                cosh(*((*theParams[0]).value.data.dblptr).offset(elem as isize));
+                            *((lParse.Nodes[this_node_idx]).value.data.dblptr)
+                                .offset(elem as isize) = cosh(
+                                *((lParse.Nodes[theParams[0]]).value.data.dblptr)
+                                    .offset(elem as isize),
+                            );
                         }
                     },
                     1012 => loop {
@@ -11412,11 +11988,16 @@ fn Do_Func(lParse: &mut ParseData, this: *mut Node) {
                         if fresh119 == 0 {
                             break;
                         }
-                        let fresh120 = &mut *((*this).value.undef).offset(elem as isize);
-                        *fresh120 = *((*theParams[0]).value.undef).offset(elem as isize);
+                        let fresh120 =
+                            &mut *((lParse.Nodes[this_node_idx]).value.undef).offset(elem as isize);
+                        *fresh120 =
+                            *((lParse.Nodes[theParams[0]]).value.undef).offset(elem as isize);
                         if *fresh120 == 0 {
-                            *((*this).value.data.dblptr).offset(elem as isize) =
-                                tanh(*((*theParams[0]).value.data.dblptr).offset(elem as isize));
+                            *((lParse.Nodes[this_node_idx]).value.data.dblptr)
+                                .offset(elem as isize) = tanh(
+                                *((lParse.Nodes[theParams[0]]).value.data.dblptr)
+                                    .offset(elem as isize),
+                            );
                         }
                     },
                     1013 => loop {
@@ -11425,11 +12006,15 @@ fn Do_Func(lParse: &mut ParseData, this: *mut Node) {
                         if fresh121 == 0 {
                             break;
                         }
-                        let fresh122 = &mut *((*this).value.undef).offset(elem as isize);
-                        *fresh122 = *((*theParams[0]).value.undef).offset(elem as isize);
+                        let fresh122 =
+                            &mut *((lParse.Nodes[this_node_idx]).value.undef).offset(elem as isize);
+                        *fresh122 =
+                            *((lParse.Nodes[theParams[0]]).value.undef).offset(elem as isize);
                         if *fresh122 == 0 {
-                            dval = *((*theParams[0]).value.data.dblptr).offset(elem as isize);
-                            *((*this).value.data.dblptr).offset(elem as isize) = exp(dval);
+                            dval = *((lParse.Nodes[theParams[0]]).value.data.dblptr)
+                                .offset(elem as isize);
+                            *((lParse.Nodes[this_node_idx]).value.data.dblptr)
+                                .offset(elem as isize) = exp(dval);
                         }
                     },
                     1014 => loop {
@@ -11438,15 +12023,21 @@ fn Do_Func(lParse: &mut ParseData, this: *mut Node) {
                         if fresh123 == 0 {
                             break;
                         }
-                        let fresh124 = &mut *((*this).value.undef).offset(elem as isize);
-                        *fresh124 = *((*theParams[0]).value.undef).offset(elem as isize);
+                        let fresh124 =
+                            &mut *((lParse.Nodes[this_node_idx]).value.undef).offset(elem as isize);
+                        *fresh124 =
+                            *((lParse.Nodes[theParams[0]]).value.undef).offset(elem as isize);
                         if *fresh124 == 0 {
-                            dval = *((*theParams[0]).value.data.dblptr).offset(elem as isize);
+                            dval = *((lParse.Nodes[theParams[0]]).value.data.dblptr)
+                                .offset(elem as isize);
                             if dval <= 0.0 {
-                                *((*this).value.data.dblptr).offset(elem as isize) = 0.0;
-                                *((*this).value.undef).offset(elem as isize) = 1;
+                                *((lParse.Nodes[this_node_idx]).value.data.dblptr)
+                                    .offset(elem as isize) = 0.0;
+                                *((lParse.Nodes[this_node_idx]).value.undef)
+                                    .offset(elem as isize) = 1;
                             } else {
-                                *((*this).value.data.dblptr).offset(elem as isize) = log(dval);
+                                *((lParse.Nodes[this_node_idx]).value.data.dblptr)
+                                    .offset(elem as isize) = log(dval);
                             }
                         }
                     },
@@ -11456,15 +12047,21 @@ fn Do_Func(lParse: &mut ParseData, this: *mut Node) {
                         if fresh125 == 0 {
                             break;
                         }
-                        let fresh126 = &mut *((*this).value.undef).offset(elem as isize);
-                        *fresh126 = *((*theParams[0]).value.undef).offset(elem as isize);
+                        let fresh126 =
+                            &mut *((lParse.Nodes[this_node_idx]).value.undef).offset(elem as isize);
+                        *fresh126 =
+                            *((lParse.Nodes[theParams[0]]).value.undef).offset(elem as isize);
                         if *fresh126 == 0 {
-                            dval = *((*theParams[0]).value.data.dblptr).offset(elem as isize);
+                            dval = *((lParse.Nodes[theParams[0]]).value.data.dblptr)
+                                .offset(elem as isize);
                             if dval <= 0.0 {
-                                *((*this).value.data.dblptr).offset(elem as isize) = 0.0;
-                                *((*this).value.undef).offset(elem as isize) = 1;
+                                *((lParse.Nodes[this_node_idx]).value.data.dblptr)
+                                    .offset(elem as isize) = 0.0;
+                                *((lParse.Nodes[this_node_idx]).value.undef)
+                                    .offset(elem as isize) = 1;
                             } else {
-                                *((*this).value.data.dblptr).offset(elem as isize) = log10(dval);
+                                *((lParse.Nodes[this_node_idx]).value.data.dblptr)
+                                    .offset(elem as isize) = log10(dval);
                             }
                         }
                     },
@@ -11474,15 +12071,21 @@ fn Do_Func(lParse: &mut ParseData, this: *mut Node) {
                         if fresh127 == 0 {
                             break;
                         }
-                        let fresh128 = &mut *((*this).value.undef).offset(elem as isize);
-                        *fresh128 = *((*theParams[0]).value.undef).offset(elem as isize);
+                        let fresh128 =
+                            &mut *((lParse.Nodes[this_node_idx]).value.undef).offset(elem as isize);
+                        *fresh128 =
+                            *((lParse.Nodes[theParams[0]]).value.undef).offset(elem as isize);
                         if *fresh128 == 0 {
-                            dval = *((*theParams[0]).value.data.dblptr).offset(elem as isize);
+                            dval = *((lParse.Nodes[theParams[0]]).value.data.dblptr)
+                                .offset(elem as isize);
                             if dval < 0.0 {
-                                *((*this).value.data.dblptr).offset(elem as isize) = 0.0;
-                                *((*this).value.undef).offset(elem as isize) = 1;
+                                *((lParse.Nodes[this_node_idx]).value.data.dblptr)
+                                    .offset(elem as isize) = 0.0;
+                                *((lParse.Nodes[this_node_idx]).value.undef)
+                                    .offset(elem as isize) = 1;
                             } else {
-                                *((*this).value.data.dblptr).offset(elem as isize) = sqrt(dval);
+                                *((lParse.Nodes[this_node_idx]).value.data.dblptr)
+                                    .offset(elem as isize) = sqrt(dval);
                             }
                         }
                     },
@@ -11492,11 +12095,16 @@ fn Do_Func(lParse: &mut ParseData, this: *mut Node) {
                         if fresh129 == 0 {
                             break;
                         }
-                        let fresh130 = &mut *((*this).value.undef).offset(elem as isize);
-                        *fresh130 = *((*theParams[0]).value.undef).offset(elem as isize);
+                        let fresh130 =
+                            &mut *((lParse.Nodes[this_node_idx]).value.undef).offset(elem as isize);
+                        *fresh130 =
+                            *((lParse.Nodes[theParams[0]]).value.undef).offset(elem as isize);
                         if *fresh130 == 0 {
-                            *((*this).value.data.dblptr).offset(elem as isize) =
-                                ceil(*((*theParams[0]).value.data.dblptr).offset(elem as isize));
+                            *((lParse.Nodes[this_node_idx]).value.data.dblptr)
+                                .offset(elem as isize) = ceil(
+                                *((lParse.Nodes[theParams[0]]).value.data.dblptr)
+                                    .offset(elem as isize),
+                            );
                         }
                     },
                     1020 => loop {
@@ -11505,11 +12113,16 @@ fn Do_Func(lParse: &mut ParseData, this: *mut Node) {
                         if fresh131 == 0 {
                             break;
                         }
-                        let fresh132 = &mut *((*this).value.undef).offset(elem as isize);
-                        *fresh132 = *((*theParams[0]).value.undef).offset(elem as isize);
+                        let fresh132 =
+                            &mut *((lParse.Nodes[this_node_idx]).value.undef).offset(elem as isize);
+                        *fresh132 =
+                            *((lParse.Nodes[theParams[0]]).value.undef).offset(elem as isize);
                         if *fresh132 == 0 {
-                            *((*this).value.data.dblptr).offset(elem as isize) =
-                                floor(*((*theParams[0]).value.data.dblptr).offset(elem as isize));
+                            *((lParse.Nodes[this_node_idx]).value.data.dblptr)
+                                .offset(elem as isize) = floor(
+                                *((lParse.Nodes[theParams[0]]).value.data.dblptr)
+                                    .offset(elem as isize),
+                            );
                         }
                     },
                     1021 => loop {
@@ -11518,11 +12131,16 @@ fn Do_Func(lParse: &mut ParseData, this: *mut Node) {
                         if fresh133 == 0 {
                             break;
                         }
-                        let fresh134 = &mut *((*this).value.undef).offset(elem as isize);
-                        *fresh134 = *((*theParams[0]).value.undef).offset(elem as isize);
+                        let fresh134 =
+                            &mut *((lParse.Nodes[this_node_idx]).value.undef).offset(elem as isize);
+                        *fresh134 =
+                            *((lParse.Nodes[theParams[0]]).value.undef).offset(elem as isize);
                         if *fresh134 == 0 {
-                            *((*this).value.data.dblptr).offset(elem as isize) = floor(
-                                *((*theParams[0]).value.data.dblptr).offset(elem as isize) + 0.5,
+                            *((lParse.Nodes[this_node_idx]).value.data.dblptr)
+                                .offset(elem as isize) = floor(
+                                *((lParse.Nodes[theParams[0]]).value.data.dblptr)
+                                    .offset(elem as isize)
+                                    + 0.5,
                             );
                         }
                     },
@@ -11532,7 +12150,7 @@ fn Do_Func(lParse: &mut ParseData, this: *mut Node) {
                         if fresh135 == 0 {
                             break;
                         }
-                        nelem = (*this).value.nelem;
+                        nelem = (lParse.Nodes[this_node_idx]).value.nelem;
                         loop {
                             let fresh136 = nelem;
                             nelem -= 1;
@@ -11540,8 +12158,8 @@ fn Do_Func(lParse: &mut ParseData, this: *mut Node) {
                                 break;
                             }
                             elem -= 1;
-                            elem;
-                            i = 2 as c_int;
+
+                            i = 2;
                             loop {
                                 let fresh137 = i;
                                 i -= 1;
@@ -11550,26 +12168,30 @@ fn Do_Func(lParse: &mut ParseData, this: *mut Node) {
                                 }
                                 if vector[i as usize] > 1 {
                                     pVals[i as usize].data.dbl =
-                                        *((*theParams[i as usize]).value.data.dblptr)
+                                        *((lParse.Nodes[theParams[i as usize]]).value.data.dblptr)
                                             .offset(elem as isize);
-                                    pNull[i as usize] = *((*theParams[i as usize]).value.undef)
-                                        .offset(elem as isize);
+                                    pNull[i as usize] =
+                                        *((lParse.Nodes[theParams[i as usize]]).value.undef)
+                                            .offset(elem as isize);
                                 } else if vector[i as usize] != 0 {
                                     pVals[i as usize].data.dbl =
-                                        *((*theParams[i as usize]).value.data.dblptr)
+                                        *((lParse.Nodes[theParams[i as usize]]).value.data.dblptr)
                                             .offset(row as isize);
-                                    pNull[i as usize] = *((*theParams[i as usize]).value.undef)
-                                        .offset(row as isize);
+                                    pNull[i as usize] =
+                                        *((lParse.Nodes[theParams[i as usize]]).value.undef)
+                                            .offset(row as isize);
                                 }
                             }
-                            let fresh138 = &mut *((*this).value.undef).offset(elem as isize);
+                            let fresh138 = &mut *((lParse.Nodes[this_node_idx]).value.undef)
+                                .offset(elem as isize);
                             *fresh138 = if pNull[0] as c_int != 0 || pNull[1] as c_int != 0 {
                                 1
                             } else {
                                 0
                             };
                             if *fresh138 == 0 {
-                                *((*this).value.data.dblptr).offset(elem as isize) =
+                                *((lParse.Nodes[this_node_idx]).value.data.dblptr)
+                                    .offset(elem as isize) =
                                     atan2(pVals[0].data.dbl, pVals[1].data.dbl);
                             }
                         }
@@ -11580,7 +12202,7 @@ fn Do_Func(lParse: &mut ParseData, this: *mut Node) {
                         if fresh139 == 0 {
                             break;
                         }
-                        nelem = (*this).value.nelem;
+                        nelem = (lParse.Nodes[this_node_idx]).value.nelem;
                         loop {
                             let fresh140 = nelem;
                             nelem -= 1;
@@ -11588,7 +12210,6 @@ fn Do_Func(lParse: &mut ParseData, this: *mut Node) {
                                 break;
                             }
                             elem -= 1;
-                            elem;
                             i = 4 as c_int;
                             loop {
                                 let fresh141 = i;
@@ -11598,26 +12219,30 @@ fn Do_Func(lParse: &mut ParseData, this: *mut Node) {
                                 }
                                 if vector[i as usize] > 1 {
                                     pVals[i as usize].data.dbl =
-                                        *((*theParams[i as usize]).value.data.dblptr)
+                                        *((lParse.Nodes[theParams[i as usize]]).value.data.dblptr)
                                             .offset(elem as isize);
-                                    pNull[i as usize] = *((*theParams[i as usize]).value.undef)
-                                        .offset(elem as isize);
+                                    pNull[i as usize] =
+                                        *((lParse.Nodes[theParams[i as usize]]).value.undef)
+                                            .offset(elem as isize);
                                 } else if vector[i as usize] != 0 {
                                     pVals[i as usize].data.dbl =
-                                        *((*theParams[i as usize]).value.data.dblptr)
+                                        *((lParse.Nodes[theParams[i as usize]]).value.data.dblptr)
                                             .offset(row as isize);
-                                    pNull[i as usize] = *((*theParams[i as usize]).value.undef)
-                                        .offset(row as isize);
+                                    pNull[i as usize] =
+                                        *((lParse.Nodes[theParams[i as usize]]).value.undef)
+                                            .offset(row as isize);
                                 }
                             }
-                            let fresh142 = &mut *((*this).value.undef).offset(elem as isize);
+                            let fresh142 = &mut *((lParse.Nodes[this_node_idx]).value.undef)
+                                .offset(elem as isize);
                             *fresh142 = (pNull[0] as c_int != 0
                                 || pNull[1] as c_int != 0
                                 || pNull[2] as c_int != 0
                                 || pNull[3] as c_int != 0)
                                 as c_int as c_char;
                             if *fresh142 == 0 {
-                                *((*this).value.data.dblptr).offset(elem as isize) = angsep_calc(
+                                *((lParse.Nodes[this_node_idx]).value.data.dblptr)
+                                    .offset(elem as isize) = angsep_calc(
                                     pVals[0].data.dbl,
                                     pVals[1].data.dbl,
                                     pVals[2].data.dbl,
@@ -11627,8 +12252,10 @@ fn Do_Func(lParse: &mut ParseData, this: *mut Node) {
                         }
                     },
                     1022 => {
-                        elem = row * (*theParams[0]).value.nelem;
-                        if (*this).ntype == fits_parser_yytokentype::LONG as c_int {
+                        elem = row * (lParse.Nodes[theParams[0]]).value.nelem;
+                        if (lParse.Nodes[this_node_idx]).ntype
+                            == fits_parser_yytokentype::LONG as c_int
+                        {
                             let mut minVal: c_long = 0;
                             loop {
                                 let fresh143 = row;
@@ -11637,8 +12264,9 @@ fn Do_Func(lParse: &mut ParseData, this: *mut Node) {
                                     break;
                                 }
                                 valInit = 1;
-                                *((*this).value.undef).offset(row as isize) = 1;
-                                nelem = (*theParams[0]).value.nelem;
+                                *((lParse.Nodes[this_node_idx]).value.undef).offset(row as isize) =
+                                    1;
+                                nelem = (lParse.Nodes[theParams[0]]).value.nelem;
                                 loop {
                                     let fresh144 = nelem;
                                     nelem -= 1;
@@ -11646,29 +12274,36 @@ fn Do_Func(lParse: &mut ParseData, this: *mut Node) {
                                         break;
                                     }
                                     elem -= 1;
-                                    elem;
-                                    if *((*theParams[0]).value.undef).offset(elem as isize) == 0 {
+                                    if *((lParse.Nodes[theParams[0]]).value.undef)
+                                        .offset(elem as isize)
+                                        == 0
+                                    {
                                         if valInit != 0 {
                                             valInit = 0;
-                                            minVal = *((*theParams[0]).value.data.lngptr)
-                                                .offset(elem as isize);
+                                            minVal =
+                                                *((lParse.Nodes[theParams[0]]).value.data.lngptr)
+                                                    .offset(elem as isize);
                                         } else {
                                             minVal = if minVal
-                                                < *((*theParams[0]).value.data.lngptr)
+                                                < *((lParse.Nodes[theParams[0]]).value.data.lngptr)
                                                     .offset(elem as isize)
                                             {
                                                 minVal
                                             } else {
-                                                *((*theParams[0]).value.data.lngptr)
+                                                *((lParse.Nodes[theParams[0]]).value.data.lngptr)
                                                     .offset(elem as isize)
                                             };
                                         }
-                                        *((*this).value.undef).offset(row as isize) = 0;
+                                        *((lParse.Nodes[this_node_idx]).value.undef)
+                                            .offset(row as isize) = 0;
                                     }
                                 }
-                                *((*this).value.data.lngptr).offset(row as isize) = minVal;
+                                *((lParse.Nodes[this_node_idx]).value.data.lngptr)
+                                    .offset(row as isize) = minVal;
                             }
-                        } else if (*this).ntype == fits_parser_yytokentype::DOUBLE as c_int {
+                        } else if (lParse.Nodes[this_node_idx]).ntype
+                            == fits_parser_yytokentype::DOUBLE as c_int
+                        {
                             let mut minVal_0: c_double = 0.0;
                             loop {
                                 let fresh145 = row;
@@ -11677,8 +12312,9 @@ fn Do_Func(lParse: &mut ParseData, this: *mut Node) {
                                     break;
                                 }
                                 valInit = 1;
-                                *((*this).value.undef).offset(row as isize) = 1;
-                                nelem = (*theParams[0]).value.nelem;
+                                *((lParse.Nodes[this_node_idx]).value.undef).offset(row as isize) =
+                                    1;
+                                nelem = (lParse.Nodes[theParams[0]]).value.nelem;
                                 loop {
                                     let fresh146 = nelem;
                                     nelem -= 1;
@@ -11686,29 +12322,36 @@ fn Do_Func(lParse: &mut ParseData, this: *mut Node) {
                                         break;
                                     }
                                     elem -= 1;
-                                    elem;
-                                    if *((*theParams[0]).value.undef).offset(elem as isize) == 0 {
+                                    if *((lParse.Nodes[theParams[0]]).value.undef)
+                                        .offset(elem as isize)
+                                        == 0
+                                    {
                                         if valInit != 0 {
                                             valInit = 0;
-                                            minVal_0 = *((*theParams[0]).value.data.dblptr)
-                                                .offset(elem as isize);
+                                            minVal_0 =
+                                                *((lParse.Nodes[theParams[0]]).value.data.dblptr)
+                                                    .offset(elem as isize);
                                         } else {
                                             minVal_0 = if minVal_0
-                                                < *((*theParams[0]).value.data.dblptr)
+                                                < *((lParse.Nodes[theParams[0]]).value.data.dblptr)
                                                     .offset(elem as isize)
                                             {
                                                 minVal_0
                                             } else {
-                                                *((*theParams[0]).value.data.dblptr)
+                                                *((lParse.Nodes[theParams[0]]).value.data.dblptr)
                                                     .offset(elem as isize)
                                             };
                                         }
-                                        *((*this).value.undef).offset(row as isize) = 0;
+                                        *((lParse.Nodes[this_node_idx]).value.undef)
+                                            .offset(row as isize) = 0;
                                     }
                                 }
-                                *((*this).value.data.dblptr).offset(row as isize) = minVal_0;
+                                *((lParse.Nodes[this_node_idx]).value.data.dblptr)
+                                    .offset(row as isize) = minVal_0;
                             }
-                        } else if (*this).ntype == fits_parser_yytokentype::BITSTR as c_int {
+                        } else if (lParse.Nodes[this_node_idx]).ntype
+                            == fits_parser_yytokentype::BITSTR as c_int
+                        {
                             let mut minVal_1: c_char = 0;
                             loop {
                                 let fresh147 = row;
@@ -11717,31 +12360,35 @@ fn Do_Func(lParse: &mut ParseData, this: *mut Node) {
                                     break;
                                 }
                                 let mut sptr1_0: *mut c_char =
-                                    *((*theParams[0]).value.data.strptr).offset(row as isize);
+                                    *((lParse.Nodes[theParams[0]]).value.data.strptr)
+                                        .offset(row as isize);
                                 minVal_1 = b'1' as c_char;
                                 while *sptr1_0 != 0 {
                                     if *sptr1_0 as c_int == '0' as i32 {
                                         minVal_1 = b'0' as c_char;
                                     }
                                     sptr1_0 = sptr1_0.offset(1);
-                                    sptr1_0;
                                 }
-                                *(*((*this).value.data.strptr).offset(row as isize)).offset(0) =
-                                    minVal_1;
-                                *(*((*this).value.data.strptr).offset(row as isize))
-                                    .offset(1 as c_int as isize) = 0;
+                                *(*((lParse.Nodes[this_node_idx]).value.data.strptr)
+                                    .offset(row as isize))
+                                .offset(0) = minVal_1;
+                                *(*((lParse.Nodes[this_node_idx]).value.data.strptr)
+                                    .offset(row as isize))
+                                .offset(1 as c_int as isize) = 0;
                             }
                         }
                     }
                     1023 => {
-                        if (*this).ntype == fits_parser_yytokentype::LONG as c_int {
+                        if (lParse.Nodes[this_node_idx]).ntype
+                            == fits_parser_yytokentype::LONG as c_int
+                        {
                             loop {
                                 let fresh148 = row;
                                 row -= 1;
                                 if fresh148 == 0 {
                                     break;
                                 }
-                                nelem = (*this).value.nelem;
+                                nelem = (lParse.Nodes[this_node_idx]).value.nelem;
                                 loop {
                                     let fresh149 = nelem;
                                     nelem -= 1;
@@ -11749,8 +12396,7 @@ fn Do_Func(lParse: &mut ParseData, this: *mut Node) {
                                         break;
                                     }
                                     elem -= 1;
-                                    elem;
-                                    i = 2 as c_int;
+                                    i = 2;
                                     loop {
                                         let fresh150 = i;
                                         i -= 1;
@@ -11758,35 +12404,51 @@ fn Do_Func(lParse: &mut ParseData, this: *mut Node) {
                                             break;
                                         }
                                         if vector[i as usize] > 1 {
-                                            pVals[i as usize].data.lng =
-                                                *((*theParams[i as usize]).value.data.lngptr)
-                                                    .offset(elem as isize);
-                                            pNull[i as usize] =
-                                                *((*theParams[i as usize]).value.undef)
-                                                    .offset(elem as isize);
+                                            pVals[i as usize].data.lng = *((lParse.Nodes
+                                                [theParams[i as usize]])
+                                                .value
+                                                .data
+                                                .lngptr)
+                                                .offset(elem as isize);
+                                            pNull[i as usize] = *((lParse.Nodes
+                                                [theParams[i as usize]])
+                                                .value
+                                                .undef)
+                                                .offset(elem as isize);
                                         } else if vector[i as usize] != 0 {
-                                            pVals[i as usize].data.lng =
-                                                *((*theParams[i as usize]).value.data.lngptr)
-                                                    .offset(row as isize);
-                                            pNull[i as usize] =
-                                                *((*theParams[i as usize]).value.undef)
-                                                    .offset(row as isize);
+                                            pVals[i as usize].data.lng = *((lParse.Nodes
+                                                [theParams[i as usize]])
+                                                .value
+                                                .data
+                                                .lngptr)
+                                                .offset(row as isize);
+                                            pNull[i as usize] = *((lParse.Nodes
+                                                [theParams[i as usize]])
+                                                .value
+                                                .undef)
+                                                .offset(row as isize);
                                         }
                                     }
                                     if pNull[0] as c_int != 0 && pNull[1] as c_int != 0 {
-                                        *((*this).value.undef).offset(elem as isize) = 1;
-                                        *((*this).value.data.lngptr).offset(elem as isize) = 0;
+                                        *((lParse.Nodes[this_node_idx]).value.undef)
+                                            .offset(elem as isize) = 1;
+                                        *((lParse.Nodes[this_node_idx]).value.data.lngptr)
+                                            .offset(elem as isize) = 0;
                                     } else if pNull[0] != 0 {
-                                        *((*this).value.undef).offset(elem as isize) = 0;
-                                        *((*this).value.data.lngptr).offset(elem as isize) =
-                                            pVals[1].data.lng;
+                                        *((lParse.Nodes[this_node_idx]).value.undef)
+                                            .offset(elem as isize) = 0;
+                                        *((lParse.Nodes[this_node_idx]).value.data.lngptr)
+                                            .offset(elem as isize) = pVals[1].data.lng;
                                     } else if pNull[1] != 0 {
-                                        *((*this).value.undef).offset(elem as isize) = 0;
-                                        *((*this).value.data.lngptr).offset(elem as isize) =
-                                            pVals[0].data.lng;
+                                        *((lParse.Nodes[this_node_idx]).value.undef)
+                                            .offset(elem as isize) = 0;
+                                        *((lParse.Nodes[this_node_idx]).value.data.lngptr)
+                                            .offset(elem as isize) = pVals[0].data.lng;
                                     } else {
-                                        *((*this).value.undef).offset(elem as isize) = 0;
-                                        *((*this).value.data.lngptr).offset(elem as isize) =
+                                        *((lParse.Nodes[this_node_idx]).value.undef)
+                                            .offset(elem as isize) = 0;
+                                        *((lParse.Nodes[this_node_idx]).value.data.lngptr)
+                                            .offset(elem as isize) =
                                             if pVals[0].data.lng < pVals[1].data.lng {
                                                 pVals[0].data.lng
                                             } else {
@@ -11795,14 +12457,16 @@ fn Do_Func(lParse: &mut ParseData, this: *mut Node) {
                                     }
                                 }
                             }
-                        } else if (*this).ntype == fits_parser_yytokentype::DOUBLE as c_int {
+                        } else if (lParse.Nodes[this_node_idx]).ntype
+                            == fits_parser_yytokentype::DOUBLE as c_int
+                        {
                             loop {
                                 let fresh151 = row;
                                 row -= 1;
                                 if fresh151 == 0 {
                                     break;
                                 }
-                                nelem = (*this).value.nelem;
+                                nelem = (lParse.Nodes[this_node_idx]).value.nelem;
                                 loop {
                                     let fresh152 = nelem;
                                     nelem -= 1;
@@ -11810,8 +12474,7 @@ fn Do_Func(lParse: &mut ParseData, this: *mut Node) {
                                         break;
                                     }
                                     elem -= 1;
-                                    elem;
-                                    i = 2 as c_int;
+                                    i = 2;
                                     loop {
                                         let fresh153 = i;
                                         i -= 1;
@@ -11819,35 +12482,51 @@ fn Do_Func(lParse: &mut ParseData, this: *mut Node) {
                                             break;
                                         }
                                         if vector[i as usize] > 1 {
-                                            pVals[i as usize].data.dbl =
-                                                *((*theParams[i as usize]).value.data.dblptr)
-                                                    .offset(elem as isize);
-                                            pNull[i as usize] =
-                                                *((*theParams[i as usize]).value.undef)
-                                                    .offset(elem as isize);
+                                            pVals[i as usize].data.dbl = *((lParse.Nodes
+                                                [theParams[i as usize]])
+                                                .value
+                                                .data
+                                                .dblptr)
+                                                .offset(elem as isize);
+                                            pNull[i as usize] = *((lParse.Nodes
+                                                [theParams[i as usize]])
+                                                .value
+                                                .undef)
+                                                .offset(elem as isize);
                                         } else if vector[i as usize] != 0 {
-                                            pVals[i as usize].data.dbl =
-                                                *((*theParams[i as usize]).value.data.dblptr)
-                                                    .offset(row as isize);
-                                            pNull[i as usize] =
-                                                *((*theParams[i as usize]).value.undef)
-                                                    .offset(row as isize);
+                                            pVals[i as usize].data.dbl = *((lParse.Nodes
+                                                [theParams[i as usize]])
+                                                .value
+                                                .data
+                                                .dblptr)
+                                                .offset(row as isize);
+                                            pNull[i as usize] = *((lParse.Nodes
+                                                [theParams[i as usize]])
+                                                .value
+                                                .undef)
+                                                .offset(row as isize);
                                         }
                                     }
                                     if pNull[0] as c_int != 0 && pNull[1] as c_int != 0 {
-                                        *((*this).value.undef).offset(elem as isize) = 1;
-                                        *((*this).value.data.dblptr).offset(elem as isize) = 0.0;
+                                        *((lParse.Nodes[this_node_idx]).value.undef)
+                                            .offset(elem as isize) = 1;
+                                        *((lParse.Nodes[this_node_idx]).value.data.dblptr)
+                                            .offset(elem as isize) = 0.0;
                                     } else if pNull[0] != 0 {
-                                        *((*this).value.undef).offset(elem as isize) = 0;
-                                        *((*this).value.data.dblptr).offset(elem as isize) =
-                                            pVals[1].data.dbl;
+                                        *((lParse.Nodes[this_node_idx]).value.undef)
+                                            .offset(elem as isize) = 0;
+                                        *((lParse.Nodes[this_node_idx]).value.data.dblptr)
+                                            .offset(elem as isize) = pVals[1].data.dbl;
                                     } else if pNull[1] != 0 {
-                                        *((*this).value.undef).offset(elem as isize) = 0;
-                                        *((*this).value.data.dblptr).offset(elem as isize) =
-                                            pVals[0].data.dbl;
+                                        *((lParse.Nodes[this_node_idx]).value.undef)
+                                            .offset(elem as isize) = 0;
+                                        *((lParse.Nodes[this_node_idx]).value.data.dblptr)
+                                            .offset(elem as isize) = pVals[0].data.dbl;
                                     } else {
-                                        *((*this).value.undef).offset(elem as isize) = 0;
-                                        *((*this).value.data.dblptr).offset(elem as isize) =
+                                        *((lParse.Nodes[this_node_idx]).value.undef)
+                                            .offset(elem as isize) = 0;
+                                        *((lParse.Nodes[this_node_idx]).value.data.dblptr)
+                                            .offset(elem as isize) =
                                             if pVals[0].data.dbl < pVals[1].data.dbl {
                                                 pVals[0].data.dbl
                                             } else {
@@ -11859,8 +12538,10 @@ fn Do_Func(lParse: &mut ParseData, this: *mut Node) {
                         }
                     }
                     1024 => {
-                        elem = row * (*theParams[0]).value.nelem;
-                        if (*this).ntype == fits_parser_yytokentype::LONG as c_int {
+                        elem = row * (lParse.Nodes[theParams[0]]).value.nelem;
+                        if (lParse.Nodes[this_node_idx]).ntype
+                            == fits_parser_yytokentype::LONG as c_int
+                        {
                             let mut maxVal: c_long = 0;
                             loop {
                                 let fresh154 = row;
@@ -11869,8 +12550,9 @@ fn Do_Func(lParse: &mut ParseData, this: *mut Node) {
                                     break;
                                 }
                                 valInit = 1;
-                                *((*this).value.undef).offset(row as isize) = 1;
-                                nelem = (*theParams[0]).value.nelem;
+                                *((lParse.Nodes[this_node_idx]).value.undef).offset(row as isize) =
+                                    1;
+                                nelem = (lParse.Nodes[theParams[0]]).value.nelem;
                                 loop {
                                     let fresh155 = nelem;
                                     nelem -= 1;
@@ -11878,29 +12560,36 @@ fn Do_Func(lParse: &mut ParseData, this: *mut Node) {
                                         break;
                                     }
                                     elem -= 1;
-                                    elem;
-                                    if *((*theParams[0]).value.undef).offset(elem as isize) == 0 {
+                                    if *((lParse.Nodes[theParams[0]]).value.undef)
+                                        .offset(elem as isize)
+                                        == 0
+                                    {
                                         if valInit != 0 {
                                             valInit = 0;
-                                            maxVal = *((*theParams[0]).value.data.lngptr)
-                                                .offset(elem as isize);
+                                            maxVal =
+                                                *((lParse.Nodes[theParams[0]]).value.data.lngptr)
+                                                    .offset(elem as isize);
                                         } else {
                                             maxVal = if maxVal
-                                                > *((*theParams[0]).value.data.lngptr)
+                                                > *((lParse.Nodes[theParams[0]]).value.data.lngptr)
                                                     .offset(elem as isize)
                                             {
                                                 maxVal
                                             } else {
-                                                *((*theParams[0]).value.data.lngptr)
+                                                *((lParse.Nodes[theParams[0]]).value.data.lngptr)
                                                     .offset(elem as isize)
                                             };
                                         }
-                                        *((*this).value.undef).offset(row as isize) = 0;
+                                        *((lParse.Nodes[this_node_idx]).value.undef)
+                                            .offset(row as isize) = 0;
                                     }
                                 }
-                                *((*this).value.data.lngptr).offset(row as isize) = maxVal;
+                                *((lParse.Nodes[this_node_idx]).value.data.lngptr)
+                                    .offset(row as isize) = maxVal;
                             }
-                        } else if (*this).ntype == fits_parser_yytokentype::DOUBLE as c_int {
+                        } else if (lParse.Nodes[this_node_idx]).ntype
+                            == fits_parser_yytokentype::DOUBLE as c_int
+                        {
                             let mut maxVal_0: c_double = 0.0;
                             loop {
                                 let fresh156 = row;
@@ -11909,8 +12598,9 @@ fn Do_Func(lParse: &mut ParseData, this: *mut Node) {
                                     break;
                                 }
                                 valInit = 1;
-                                *((*this).value.undef).offset(row as isize) = 1;
-                                nelem = (*theParams[0]).value.nelem;
+                                *((lParse.Nodes[this_node_idx]).value.undef).offset(row as isize) =
+                                    1;
+                                nelem = (lParse.Nodes[theParams[0]]).value.nelem;
                                 loop {
                                     let fresh157 = nelem;
                                     nelem -= 1;
@@ -11918,29 +12608,36 @@ fn Do_Func(lParse: &mut ParseData, this: *mut Node) {
                                         break;
                                     }
                                     elem -= 1;
-                                    elem;
-                                    if *((*theParams[0]).value.undef).offset(elem as isize) == 0 {
+                                    if *((lParse.Nodes[theParams[0]]).value.undef)
+                                        .offset(elem as isize)
+                                        == 0
+                                    {
                                         if valInit != 0 {
                                             valInit = 0;
-                                            maxVal_0 = *((*theParams[0]).value.data.dblptr)
-                                                .offset(elem as isize);
+                                            maxVal_0 =
+                                                *((lParse.Nodes[theParams[0]]).value.data.dblptr)
+                                                    .offset(elem as isize);
                                         } else {
                                             maxVal_0 = if maxVal_0
-                                                > *((*theParams[0]).value.data.dblptr)
+                                                > *((lParse.Nodes[theParams[0]]).value.data.dblptr)
                                                     .offset(elem as isize)
                                             {
                                                 maxVal_0
                                             } else {
-                                                *((*theParams[0]).value.data.dblptr)
+                                                *((lParse.Nodes[theParams[0]]).value.data.dblptr)
                                                     .offset(elem as isize)
                                             };
                                         }
-                                        *((*this).value.undef).offset(row as isize) = 0;
+                                        *((lParse.Nodes[this_node_idx]).value.undef)
+                                            .offset(row as isize) = 0;
                                     }
                                 }
-                                *((*this).value.data.dblptr).offset(row as isize) = maxVal_0;
+                                *((lParse.Nodes[this_node_idx]).value.data.dblptr)
+                                    .offset(row as isize) = maxVal_0;
                             }
-                        } else if (*this).ntype == fits_parser_yytokentype::BITSTR as c_int {
+                        } else if (lParse.Nodes[this_node_idx]).ntype
+                            == fits_parser_yytokentype::BITSTR as c_int
+                        {
                             let mut maxVal_1: c_char = 0;
                             loop {
                                 let fresh158 = row;
@@ -11949,31 +12646,35 @@ fn Do_Func(lParse: &mut ParseData, this: *mut Node) {
                                     break;
                                 }
                                 let mut sptr1_1: *mut c_char =
-                                    *((*theParams[0]).value.data.strptr).offset(row as isize);
+                                    *((lParse.Nodes[theParams[0]]).value.data.strptr)
+                                        .offset(row as isize);
                                 maxVal_1 = b'0' as c_char;
                                 while *sptr1_1 != 0 {
                                     if *sptr1_1 as c_int == '1' as i32 {
                                         maxVal_1 = b'1' as c_char;
                                     }
                                     sptr1_1 = sptr1_1.offset(1);
-                                    sptr1_1;
                                 }
-                                *(*((*this).value.data.strptr).offset(row as isize)).offset(0) =
-                                    maxVal_1;
-                                *(*((*this).value.data.strptr).offset(row as isize))
-                                    .offset(1 as c_int as isize) = 0;
+                                *(*((lParse.Nodes[this_node_idx]).value.data.strptr)
+                                    .offset(row as isize))
+                                .offset(0) = maxVal_1;
+                                *(*((lParse.Nodes[this_node_idx]).value.data.strptr)
+                                    .offset(row as isize))
+                                .offset(1 as c_int as isize) = 0;
                             }
                         }
                     }
                     1025 => {
-                        if (*this).ntype == fits_parser_yytokentype::LONG as c_int {
+                        if (lParse.Nodes[this_node_idx]).ntype
+                            == fits_parser_yytokentype::LONG as c_int
+                        {
                             loop {
                                 let fresh159 = row;
                                 row -= 1;
                                 if fresh159 == 0 {
                                     break;
                                 }
-                                nelem = (*this).value.nelem;
+                                nelem = (lParse.Nodes[this_node_idx]).value.nelem;
                                 loop {
                                     let fresh160 = nelem;
                                     nelem -= 1;
@@ -11981,8 +12682,7 @@ fn Do_Func(lParse: &mut ParseData, this: *mut Node) {
                                         break;
                                     }
                                     elem -= 1;
-                                    elem;
-                                    i = 2 as c_int;
+                                    i = 2;
                                     loop {
                                         let fresh161 = i;
                                         i -= 1;
@@ -11990,35 +12690,51 @@ fn Do_Func(lParse: &mut ParseData, this: *mut Node) {
                                             break;
                                         }
                                         if vector[i as usize] > 1 {
-                                            pVals[i as usize].data.lng =
-                                                *((*theParams[i as usize]).value.data.lngptr)
-                                                    .offset(elem as isize);
-                                            pNull[i as usize] =
-                                                *((*theParams[i as usize]).value.undef)
-                                                    .offset(elem as isize);
+                                            pVals[i as usize].data.lng = *((lParse.Nodes
+                                                [theParams[i as usize]])
+                                                .value
+                                                .data
+                                                .lngptr)
+                                                .offset(elem as isize);
+                                            pNull[i as usize] = *((lParse.Nodes
+                                                [theParams[i as usize]])
+                                                .value
+                                                .undef)
+                                                .offset(elem as isize);
                                         } else if vector[i as usize] != 0 {
-                                            pVals[i as usize].data.lng =
-                                                *((*theParams[i as usize]).value.data.lngptr)
-                                                    .offset(row as isize);
-                                            pNull[i as usize] =
-                                                *((*theParams[i as usize]).value.undef)
-                                                    .offset(row as isize);
+                                            pVals[i as usize].data.lng = *((lParse.Nodes
+                                                [theParams[i as usize]])
+                                                .value
+                                                .data
+                                                .lngptr)
+                                                .offset(row as isize);
+                                            pNull[i as usize] = *((lParse.Nodes
+                                                [theParams[i as usize]])
+                                                .value
+                                                .undef)
+                                                .offset(row as isize);
                                         }
                                     }
                                     if pNull[0] as c_int != 0 && pNull[1] as c_int != 0 {
-                                        *((*this).value.undef).offset(elem as isize) = 1;
-                                        *((*this).value.data.lngptr).offset(elem as isize) = 0;
+                                        *((lParse.Nodes[this_node_idx]).value.undef)
+                                            .offset(elem as isize) = 1;
+                                        *((lParse.Nodes[this_node_idx]).value.data.lngptr)
+                                            .offset(elem as isize) = 0;
                                     } else if pNull[0] != 0 {
-                                        *((*this).value.undef).offset(elem as isize) = 0;
-                                        *((*this).value.data.lngptr).offset(elem as isize) =
-                                            pVals[1].data.lng;
+                                        *((lParse.Nodes[this_node_idx]).value.undef)
+                                            .offset(elem as isize) = 0;
+                                        *((lParse.Nodes[this_node_idx]).value.data.lngptr)
+                                            .offset(elem as isize) = pVals[1].data.lng;
                                     } else if pNull[1] != 0 {
-                                        *((*this).value.undef).offset(elem as isize) = 0;
-                                        *((*this).value.data.lngptr).offset(elem as isize) =
-                                            pVals[0].data.lng;
+                                        *((lParse.Nodes[this_node_idx]).value.undef)
+                                            .offset(elem as isize) = 0;
+                                        *((lParse.Nodes[this_node_idx]).value.data.lngptr)
+                                            .offset(elem as isize) = pVals[0].data.lng;
                                     } else {
-                                        *((*this).value.undef).offset(elem as isize) = 0;
-                                        *((*this).value.data.lngptr).offset(elem as isize) =
+                                        *((lParse.Nodes[this_node_idx]).value.undef)
+                                            .offset(elem as isize) = 0;
+                                        *((lParse.Nodes[this_node_idx]).value.data.lngptr)
+                                            .offset(elem as isize) =
                                             if pVals[0].data.lng > pVals[1].data.lng {
                                                 pVals[0].data.lng
                                             } else {
@@ -12027,14 +12743,16 @@ fn Do_Func(lParse: &mut ParseData, this: *mut Node) {
                                     }
                                 }
                             }
-                        } else if (*this).ntype == fits_parser_yytokentype::DOUBLE as c_int {
+                        } else if (lParse.Nodes[this_node_idx]).ntype
+                            == fits_parser_yytokentype::DOUBLE as c_int
+                        {
                             loop {
                                 let fresh162 = row;
                                 row -= 1;
                                 if fresh162 == 0 {
                                     break;
                                 }
-                                nelem = (*this).value.nelem;
+                                nelem = (lParse.Nodes[this_node_idx]).value.nelem;
                                 loop {
                                     let fresh163 = nelem;
                                     nelem -= 1;
@@ -12042,8 +12760,7 @@ fn Do_Func(lParse: &mut ParseData, this: *mut Node) {
                                         break;
                                     }
                                     elem -= 1;
-                                    elem;
-                                    i = 2 as c_int;
+                                    i = 2;
                                     loop {
                                         let fresh164 = i;
                                         i -= 1;
@@ -12051,35 +12768,51 @@ fn Do_Func(lParse: &mut ParseData, this: *mut Node) {
                                             break;
                                         }
                                         if vector[i as usize] > 1 {
-                                            pVals[i as usize].data.dbl =
-                                                *((*theParams[i as usize]).value.data.dblptr)
-                                                    .offset(elem as isize);
-                                            pNull[i as usize] =
-                                                *((*theParams[i as usize]).value.undef)
-                                                    .offset(elem as isize);
+                                            pVals[i as usize].data.dbl = *((lParse.Nodes
+                                                [theParams[i as usize]])
+                                                .value
+                                                .data
+                                                .dblptr)
+                                                .offset(elem as isize);
+                                            pNull[i as usize] = *((lParse.Nodes
+                                                [theParams[i as usize]])
+                                                .value
+                                                .undef)
+                                                .offset(elem as isize);
                                         } else if vector[i as usize] != 0 {
-                                            pVals[i as usize].data.dbl =
-                                                *((*theParams[i as usize]).value.data.dblptr)
-                                                    .offset(row as isize);
-                                            pNull[i as usize] =
-                                                *((*theParams[i as usize]).value.undef)
-                                                    .offset(row as isize);
+                                            pVals[i as usize].data.dbl = *((lParse.Nodes
+                                                [theParams[i as usize]])
+                                                .value
+                                                .data
+                                                .dblptr)
+                                                .offset(row as isize);
+                                            pNull[i as usize] = *((lParse.Nodes
+                                                [theParams[i as usize]])
+                                                .value
+                                                .undef)
+                                                .offset(row as isize);
                                         }
                                     }
                                     if pNull[0] as c_int != 0 && pNull[1] as c_int != 0 {
-                                        *((*this).value.undef).offset(elem as isize) = 1;
-                                        *((*this).value.data.dblptr).offset(elem as isize) = 0.0;
+                                        *((lParse.Nodes[this_node_idx]).value.undef)
+                                            .offset(elem as isize) = 1;
+                                        *((lParse.Nodes[this_node_idx]).value.data.dblptr)
+                                            .offset(elem as isize) = 0.0;
                                     } else if pNull[0] != 0 {
-                                        *((*this).value.undef).offset(elem as isize) = 0;
-                                        *((*this).value.data.dblptr).offset(elem as isize) =
-                                            pVals[1].data.dbl;
+                                        *((lParse.Nodes[this_node_idx]).value.undef)
+                                            .offset(elem as isize) = 0;
+                                        *((lParse.Nodes[this_node_idx]).value.data.dblptr)
+                                            .offset(elem as isize) = pVals[1].data.dbl;
                                     } else if pNull[1] != 0 {
-                                        *((*this).value.undef).offset(elem as isize) = 0;
-                                        *((*this).value.data.dblptr).offset(elem as isize) =
-                                            pVals[0].data.dbl;
+                                        *((lParse.Nodes[this_node_idx]).value.undef)
+                                            .offset(elem as isize) = 0;
+                                        *((lParse.Nodes[this_node_idx]).value.data.dblptr)
+                                            .offset(elem as isize) = pVals[0].data.dbl;
                                     } else {
-                                        *((*this).value.undef).offset(elem as isize) = 0;
-                                        *((*this).value.data.dblptr).offset(elem as isize) =
+                                        *((lParse.Nodes[this_node_idx]).value.undef)
+                                            .offset(elem as isize) = 0;
+                                        *((lParse.Nodes[this_node_idx]).value.data.dblptr)
+                                            .offset(elem as isize) =
                                             if pVals[0].data.dbl > pVals[1].data.dbl {
                                                 pVals[0].data.dbl
                                             } else {
@@ -12096,7 +12829,7 @@ fn Do_Func(lParse: &mut ParseData, this: *mut Node) {
                         if fresh165 == 0 {
                             break;
                         }
-                        nelem = (*this).value.nelem;
+                        nelem = (lParse.Nodes[this_node_idx]).value.nelem;
                         loop {
                             let fresh166 = nelem;
                             nelem -= 1;
@@ -12104,7 +12837,6 @@ fn Do_Func(lParse: &mut ParseData, this: *mut Node) {
                                 break;
                             }
                             elem -= 1;
-                            elem;
                             i = 3 as c_int;
                             loop {
                                 let fresh167 = i;
@@ -12114,25 +12846,29 @@ fn Do_Func(lParse: &mut ParseData, this: *mut Node) {
                                 }
                                 if vector[i as usize] > 1 {
                                     pVals[i as usize].data.dbl =
-                                        *((*theParams[i as usize]).value.data.dblptr)
+                                        *((lParse.Nodes[theParams[i as usize]]).value.data.dblptr)
                                             .offset(elem as isize);
-                                    pNull[i as usize] = *((*theParams[i as usize]).value.undef)
-                                        .offset(elem as isize);
+                                    pNull[i as usize] =
+                                        *((lParse.Nodes[theParams[i as usize]]).value.undef)
+                                            .offset(elem as isize);
                                 } else if vector[i as usize] != 0 {
                                     pVals[i as usize].data.dbl =
-                                        *((*theParams[i as usize]).value.data.dblptr)
+                                        *((lParse.Nodes[theParams[i as usize]]).value.data.dblptr)
                                             .offset(row as isize);
-                                    pNull[i as usize] = *((*theParams[i as usize]).value.undef)
-                                        .offset(row as isize);
+                                    pNull[i as usize] =
+                                        *((lParse.Nodes[theParams[i as usize]]).value.undef)
+                                            .offset(row as isize);
                                 }
                             }
-                            let fresh168 = &mut *((*this).value.undef).offset(elem as isize);
+                            let fresh168 = &mut *((lParse.Nodes[this_node_idx]).value.undef)
+                                .offset(elem as isize);
                             *fresh168 = (pNull[0] as c_int != 0
                                 || pNull[1] as c_int != 0
                                 || pNull[2] as c_int != 0)
                                 as c_int as c_char;
                             if *fresh168 == 0 {
-                                *((*this).value.data.logptr).offset(elem as isize) =
+                                *((lParse.Nodes[this_node_idx]).value.data.logptr)
+                                    .offset(elem as isize) =
                                     bnear(pVals[0].data.dbl, pVals[1].data.dbl, pVals[2].data.dbl);
                             }
                         }
@@ -12143,7 +12879,7 @@ fn Do_Func(lParse: &mut ParseData, this: *mut Node) {
                         if fresh169 == 0 {
                             break;
                         }
-                        nelem = (*this).value.nelem;
+                        nelem = (lParse.Nodes[this_node_idx]).value.nelem;
                         loop {
                             let fresh170 = nelem;
                             nelem -= 1;
@@ -12151,7 +12887,6 @@ fn Do_Func(lParse: &mut ParseData, this: *mut Node) {
                                 break;
                             }
                             elem -= 1;
-                            elem;
                             i = 5 as c_int;
                             loop {
                                 let fresh171 = i;
@@ -12161,19 +12896,22 @@ fn Do_Func(lParse: &mut ParseData, this: *mut Node) {
                                 }
                                 if vector[i as usize] > 1 {
                                     pVals[i as usize].data.dbl =
-                                        *((*theParams[i as usize]).value.data.dblptr)
+                                        *((lParse.Nodes[theParams[i as usize]]).value.data.dblptr)
                                             .offset(elem as isize);
-                                    pNull[i as usize] = *((*theParams[i as usize]).value.undef)
-                                        .offset(elem as isize);
+                                    pNull[i as usize] =
+                                        *((lParse.Nodes[theParams[i as usize]]).value.undef)
+                                            .offset(elem as isize);
                                 } else if vector[i as usize] != 0 {
                                     pVals[i as usize].data.dbl =
-                                        *((*theParams[i as usize]).value.data.dblptr)
+                                        *((lParse.Nodes[theParams[i as usize]]).value.data.dblptr)
                                             .offset(row as isize);
-                                    pNull[i as usize] = *((*theParams[i as usize]).value.undef)
-                                        .offset(row as isize);
+                                    pNull[i as usize] =
+                                        *((lParse.Nodes[theParams[i as usize]]).value.undef)
+                                            .offset(row as isize);
                                 }
                             }
-                            let fresh172 = &mut *((*this).value.undef).offset(elem as isize);
+                            let fresh172 = &mut *((lParse.Nodes[this_node_idx]).value.undef)
+                                .offset(elem as isize);
                             *fresh172 = (pNull[0] as c_int != 0
                                 || pNull[1] as c_int != 0
                                 || pNull[2] as c_int != 0
@@ -12181,7 +12919,8 @@ fn Do_Func(lParse: &mut ParseData, this: *mut Node) {
                                 || pNull[4] as c_int != 0)
                                 as c_int as c_char;
                             if *fresh172 == 0 {
-                                *((*this).value.data.logptr).offset(elem as isize) = circle(
+                                *((lParse.Nodes[this_node_idx]).value.data.logptr)
+                                    .offset(elem as isize) = circle(
                                     pVals[0].data.dbl,
                                     pVals[1].data.dbl,
                                     pVals[2].data.dbl,
@@ -12197,7 +12936,7 @@ fn Do_Func(lParse: &mut ParseData, this: *mut Node) {
                         if fresh173 == 0 {
                             break;
                         }
-                        nelem = (*this).value.nelem;
+                        nelem = (lParse.Nodes[this_node_idx]).value.nelem;
                         loop {
                             let fresh174 = nelem;
                             nelem -= 1;
@@ -12205,7 +12944,6 @@ fn Do_Func(lParse: &mut ParseData, this: *mut Node) {
                                 break;
                             }
                             elem -= 1;
-                            elem;
                             i = 7 as c_int;
                             loop {
                                 let fresh175 = i;
@@ -12215,19 +12953,22 @@ fn Do_Func(lParse: &mut ParseData, this: *mut Node) {
                                 }
                                 if vector[i as usize] > 1 {
                                     pVals[i as usize].data.dbl =
-                                        *((*theParams[i as usize]).value.data.dblptr)
+                                        *((lParse.Nodes[theParams[i as usize]]).value.data.dblptr)
                                             .offset(elem as isize);
-                                    pNull[i as usize] = *((*theParams[i as usize]).value.undef)
-                                        .offset(elem as isize);
+                                    pNull[i as usize] =
+                                        *((lParse.Nodes[theParams[i as usize]]).value.undef)
+                                            .offset(elem as isize);
                                 } else if vector[i as usize] != 0 {
                                     pVals[i as usize].data.dbl =
-                                        *((*theParams[i as usize]).value.data.dblptr)
+                                        *((lParse.Nodes[theParams[i as usize]]).value.data.dblptr)
                                             .offset(row as isize);
-                                    pNull[i as usize] = *((*theParams[i as usize]).value.undef)
-                                        .offset(row as isize);
+                                    pNull[i as usize] =
+                                        *((lParse.Nodes[theParams[i as usize]]).value.undef)
+                                            .offset(row as isize);
                                 }
                             }
-                            let fresh176 = &mut *((*this).value.undef).offset(elem as isize);
+                            let fresh176 = &mut *((lParse.Nodes[this_node_idx]).value.undef)
+                                .offset(elem as isize);
                             *fresh176 = (pNull[0] as c_int != 0
                                 || pNull[1] as c_int != 0
                                 || pNull[2] as c_int != 0
@@ -12237,7 +12978,8 @@ fn Do_Func(lParse: &mut ParseData, this: *mut Node) {
                                 || pNull[6] as c_int != 0)
                                 as c_int as c_char;
                             if *fresh176 == 0 {
-                                *((*this).value.data.logptr).offset(elem as isize) = saobox(
+                                *((lParse.Nodes[this_node_idx]).value.data.logptr)
+                                    .offset(elem as isize) = saobox(
                                     pVals[0].data.dbl,
                                     pVals[1].data.dbl,
                                     pVals[2].data.dbl,
@@ -12255,7 +12997,7 @@ fn Do_Func(lParse: &mut ParseData, this: *mut Node) {
                         if fresh177 == 0 {
                             break;
                         }
-                        nelem = (*this).value.nelem;
+                        nelem = (lParse.Nodes[this_node_idx]).value.nelem;
                         loop {
                             let fresh178 = nelem;
                             nelem -= 1;
@@ -12263,7 +13005,6 @@ fn Do_Func(lParse: &mut ParseData, this: *mut Node) {
                                 break;
                             }
                             elem -= 1;
-                            elem;
                             i = 7 as c_int;
                             loop {
                                 let fresh179 = i;
@@ -12273,19 +13014,22 @@ fn Do_Func(lParse: &mut ParseData, this: *mut Node) {
                                 }
                                 if vector[i as usize] > 1 {
                                     pVals[i as usize].data.dbl =
-                                        *((*theParams[i as usize]).value.data.dblptr)
+                                        *((lParse.Nodes[theParams[i as usize]]).value.data.dblptr)
                                             .offset(elem as isize);
-                                    pNull[i as usize] = *((*theParams[i as usize]).value.undef)
-                                        .offset(elem as isize);
+                                    pNull[i as usize] =
+                                        *((lParse.Nodes[theParams[i as usize]]).value.undef)
+                                            .offset(elem as isize);
                                 } else if vector[i as usize] != 0 {
                                     pVals[i as usize].data.dbl =
-                                        *((*theParams[i as usize]).value.data.dblptr)
+                                        *((lParse.Nodes[theParams[i as usize]]).value.data.dblptr)
                                             .offset(row as isize);
-                                    pNull[i as usize] = *((*theParams[i as usize]).value.undef)
-                                        .offset(row as isize);
+                                    pNull[i as usize] =
+                                        *((lParse.Nodes[theParams[i as usize]]).value.undef)
+                                            .offset(row as isize);
                                 }
                             }
-                            let fresh180 = &mut *((*this).value.undef).offset(elem as isize);
+                            let fresh180 = &mut *((lParse.Nodes[this_node_idx]).value.undef)
+                                .offset(elem as isize);
                             *fresh180 = (pNull[0] as c_int != 0
                                 || pNull[1] as c_int != 0
                                 || pNull[2] as c_int != 0
@@ -12295,7 +13039,8 @@ fn Do_Func(lParse: &mut ParseData, this: *mut Node) {
                                 || pNull[6] as c_int != 0)
                                 as c_int as c_char;
                             if *fresh180 == 0 {
-                                *((*this).value.data.logptr).offset(elem as isize) = ellipse(
+                                *((lParse.Nodes[this_node_idx]).value.data.logptr)
+                                    .offset(elem as isize) = ellipse(
                                     pVals[0].data.dbl,
                                     pVals[1].data.dbl,
                                     pVals[2].data.dbl,
@@ -12307,14 +13052,14 @@ fn Do_Func(lParse: &mut ParseData, this: *mut Node) {
                             }
                         }
                     },
-                    1034 => match (*this).ntype {
-                        258 => loop {
+                    1034 => match (lParse.Nodes[this_node_idx]).ntype.into() {
+                        fits_parser_yytokentype::BOOLEAN => loop {
                             let fresh181 = row;
                             row -= 1;
                             if fresh181 == 0 {
                                 break;
                             }
-                            nelem = (*this).value.nelem;
+                            nelem = (lParse.Nodes[this_node_idx]).value.nelem;
                             loop {
                                 let fresh182 = nelem;
                                 nelem -= 1;
@@ -12322,17 +13067,20 @@ fn Do_Func(lParse: &mut ParseData, this: *mut Node) {
                                     break;
                                 }
                                 elem -= 1;
-                                elem;
                                 if vector[2] > 1 {
                                     pVals[2].data.log =
-                                        *((*theParams[2]).value.data.logptr).offset(elem as isize);
-                                    pNull[2] = *((*theParams[2]).value.undef).offset(elem as isize);
+                                        *((lParse.Nodes[theParams[2]]).value.data.logptr)
+                                            .offset(elem as isize);
+                                    pNull[2] = *((lParse.Nodes[theParams[2]]).value.undef)
+                                        .offset(elem as isize);
                                 } else if vector[2] != 0 {
                                     pVals[2].data.log =
-                                        *((*theParams[2]).value.data.logptr).offset(row as isize);
-                                    pNull[2] = *((*theParams[2]).value.undef).offset(row as isize);
+                                        *((lParse.Nodes[theParams[2]]).value.data.logptr)
+                                            .offset(row as isize);
+                                    pNull[2] = *((lParse.Nodes[theParams[2]]).value.undef)
+                                        .offset(row as isize);
                                 }
-                                i = 2 as c_int;
+                                i = 2;
                                 loop {
                                     let fresh183 = i;
                                     i -= 1;
@@ -12340,41 +13088,52 @@ fn Do_Func(lParse: &mut ParseData, this: *mut Node) {
                                         break;
                                     }
                                     if vector[i as usize] > 1 {
-                                        pVals[i as usize].data.log =
-                                            *((*theParams[i as usize]).value.data.logptr)
-                                                .offset(elem as isize);
-                                        pNull[i as usize] = *((*theParams[i as usize]).value.undef)
+                                        pVals[i as usize].data.log = *((lParse.Nodes
+                                            [theParams[i as usize]])
+                                            .value
+                                            .data
+                                            .logptr)
                                             .offset(elem as isize);
+                                        pNull[i as usize] =
+                                            *((lParse.Nodes[theParams[i as usize]]).value.undef)
+                                                .offset(elem as isize);
                                     } else if vector[i as usize] != 0 {
-                                        pVals[i as usize].data.log =
-                                            *((*theParams[i as usize]).value.data.logptr)
-                                                .offset(row as isize);
-                                        pNull[i as usize] = *((*theParams[i as usize]).value.undef)
+                                        pVals[i as usize].data.log = *((lParse.Nodes
+                                            [theParams[i as usize]])
+                                            .value
+                                            .data
+                                            .logptr)
                                             .offset(row as isize);
+                                        pNull[i as usize] =
+                                            *((lParse.Nodes[theParams[i as usize]]).value.undef)
+                                                .offset(row as isize);
                                     }
                                 }
-                                let fresh184 = &mut *((*this).value.undef).offset(elem as isize);
+                                let fresh184 = &mut *((lParse.Nodes[this_node_idx]).value.undef)
+                                    .offset(elem as isize);
                                 *fresh184 = pNull[2];
                                 if *fresh184 == 0 {
                                     if pVals[2].data.log != 0 {
-                                        *((*this).value.data.logptr).offset(elem as isize) =
-                                            pVals[0].data.log;
-                                        *((*this).value.undef).offset(elem as isize) = pNull[0];
+                                        *((lParse.Nodes[this_node_idx]).value.data.logptr)
+                                            .offset(elem as isize) = pVals[0].data.log;
+                                        *((lParse.Nodes[this_node_idx]).value.undef)
+                                            .offset(elem as isize) = pNull[0];
                                     } else {
-                                        *((*this).value.data.logptr).offset(elem as isize) =
-                                            pVals[1].data.log;
-                                        *((*this).value.undef).offset(elem as isize) = pNull[1];
+                                        *((lParse.Nodes[this_node_idx]).value.data.logptr)
+                                            .offset(elem as isize) = pVals[1].data.log;
+                                        *((lParse.Nodes[this_node_idx]).value.undef)
+                                            .offset(elem as isize) = pNull[1];
                                     }
                                 }
                             }
                         },
-                        259 => loop {
+                        fits_parser_yytokentype::LONG => loop {
                             let fresh185 = row;
                             row -= 1;
                             if fresh185 == 0 {
                                 break;
                             }
-                            nelem = (*this).value.nelem;
+                            nelem = (lParse.Nodes[this_node_idx]).value.nelem;
                             loop {
                                 let fresh186 = nelem;
                                 nelem -= 1;
@@ -12382,17 +13141,20 @@ fn Do_Func(lParse: &mut ParseData, this: *mut Node) {
                                     break;
                                 }
                                 elem -= 1;
-                                elem;
                                 if vector[2] > 1 {
                                     pVals[2].data.log =
-                                        *((*theParams[2]).value.data.logptr).offset(elem as isize);
-                                    pNull[2] = *((*theParams[2]).value.undef).offset(elem as isize);
+                                        *((lParse.Nodes[theParams[2]]).value.data.logptr)
+                                            .offset(elem as isize);
+                                    pNull[2] = *((lParse.Nodes[theParams[2]]).value.undef)
+                                        .offset(elem as isize);
                                 } else if vector[2] != 0 {
                                     pVals[2].data.log =
-                                        *((*theParams[2]).value.data.logptr).offset(row as isize);
-                                    pNull[2] = *((*theParams[2]).value.undef).offset(row as isize);
+                                        *((lParse.Nodes[theParams[2]]).value.data.logptr)
+                                            .offset(row as isize);
+                                    pNull[2] = *((lParse.Nodes[theParams[2]]).value.undef)
+                                        .offset(row as isize);
                                 }
-                                i = 2 as c_int;
+                                i = 2;
                                 loop {
                                     let fresh187 = i;
                                     i -= 1;
@@ -12400,41 +13162,52 @@ fn Do_Func(lParse: &mut ParseData, this: *mut Node) {
                                         break;
                                     }
                                     if vector[i as usize] > 1 {
-                                        pVals[i as usize].data.lng =
-                                            *((*theParams[i as usize]).value.data.lngptr)
-                                                .offset(elem as isize);
-                                        pNull[i as usize] = *((*theParams[i as usize]).value.undef)
+                                        pVals[i as usize].data.lng = *((lParse.Nodes
+                                            [theParams[i as usize]])
+                                            .value
+                                            .data
+                                            .lngptr)
                                             .offset(elem as isize);
+                                        pNull[i as usize] =
+                                            *((lParse.Nodes[theParams[i as usize]]).value.undef)
+                                                .offset(elem as isize);
                                     } else if vector[i as usize] != 0 {
-                                        pVals[i as usize].data.lng =
-                                            *((*theParams[i as usize]).value.data.lngptr)
-                                                .offset(row as isize);
-                                        pNull[i as usize] = *((*theParams[i as usize]).value.undef)
+                                        pVals[i as usize].data.lng = *((lParse.Nodes
+                                            [theParams[i as usize]])
+                                            .value
+                                            .data
+                                            .lngptr)
                                             .offset(row as isize);
+                                        pNull[i as usize] =
+                                            *((lParse.Nodes[theParams[i as usize]]).value.undef)
+                                                .offset(row as isize);
                                     }
                                 }
-                                let fresh188 = &mut *((*this).value.undef).offset(elem as isize);
+                                let fresh188 = &mut *((lParse.Nodes[this_node_idx]).value.undef)
+                                    .offset(elem as isize);
                                 *fresh188 = pNull[2];
                                 if *fresh188 == 0 {
                                     if pVals[2].data.log != 0 {
-                                        *((*this).value.data.lngptr).offset(elem as isize) =
-                                            pVals[0].data.lng;
-                                        *((*this).value.undef).offset(elem as isize) = pNull[0];
+                                        *((lParse.Nodes[this_node_idx]).value.data.lngptr)
+                                            .offset(elem as isize) = pVals[0].data.lng;
+                                        *((lParse.Nodes[this_node_idx]).value.undef)
+                                            .offset(elem as isize) = pNull[0];
                                     } else {
-                                        *((*this).value.data.lngptr).offset(elem as isize) =
-                                            pVals[1].data.lng;
-                                        *((*this).value.undef).offset(elem as isize) = pNull[1];
+                                        *((lParse.Nodes[this_node_idx]).value.data.lngptr)
+                                            .offset(elem as isize) = pVals[1].data.lng;
+                                        *((lParse.Nodes[this_node_idx]).value.undef)
+                                            .offset(elem as isize) = pNull[1];
                                     }
                                 }
                             }
                         },
-                        260 => loop {
+                        fits_parser_yytokentype::DOUBLE => loop {
                             let fresh189 = row;
                             row -= 1;
                             if fresh189 == 0 {
                                 break;
                             }
-                            nelem = (*this).value.nelem;
+                            nelem = (lParse.Nodes[this_node_idx]).value.nelem;
                             loop {
                                 let fresh190 = nelem;
                                 nelem -= 1;
@@ -12442,17 +13215,20 @@ fn Do_Func(lParse: &mut ParseData, this: *mut Node) {
                                     break;
                                 }
                                 elem -= 1;
-                                elem;
                                 if vector[2] > 1 {
                                     pVals[2].data.log =
-                                        *((*theParams[2]).value.data.logptr).offset(elem as isize);
-                                    pNull[2] = *((*theParams[2]).value.undef).offset(elem as isize);
+                                        *((lParse.Nodes[theParams[2]]).value.data.logptr)
+                                            .offset(elem as isize);
+                                    pNull[2] = *((lParse.Nodes[theParams[2]]).value.undef)
+                                        .offset(elem as isize);
                                 } else if vector[2] != 0 {
                                     pVals[2].data.log =
-                                        *((*theParams[2]).value.data.logptr).offset(row as isize);
-                                    pNull[2] = *((*theParams[2]).value.undef).offset(row as isize);
+                                        *((lParse.Nodes[theParams[2]]).value.data.logptr)
+                                            .offset(row as isize);
+                                    pNull[2] = *((lParse.Nodes[theParams[2]]).value.undef)
+                                        .offset(row as isize);
                                 }
-                                i = 2 as c_int;
+                                i = 2;
                                 loop {
                                     let fresh191 = i;
                                     i -= 1;
@@ -12460,35 +13236,46 @@ fn Do_Func(lParse: &mut ParseData, this: *mut Node) {
                                         break;
                                     }
                                     if vector[i as usize] > 1 {
-                                        pVals[i as usize].data.dbl =
-                                            *((*theParams[i as usize]).value.data.dblptr)
-                                                .offset(elem as isize);
-                                        pNull[i as usize] = *((*theParams[i as usize]).value.undef)
+                                        pVals[i as usize].data.dbl = *((lParse.Nodes
+                                            [theParams[i as usize]])
+                                            .value
+                                            .data
+                                            .dblptr)
                                             .offset(elem as isize);
+                                        pNull[i as usize] =
+                                            *((lParse.Nodes[theParams[i as usize]]).value.undef)
+                                                .offset(elem as isize);
                                     } else if vector[i as usize] != 0 {
-                                        pVals[i as usize].data.dbl =
-                                            *((*theParams[i as usize]).value.data.dblptr)
-                                                .offset(row as isize);
-                                        pNull[i as usize] = *((*theParams[i as usize]).value.undef)
+                                        pVals[i as usize].data.dbl = *((lParse.Nodes
+                                            [theParams[i as usize]])
+                                            .value
+                                            .data
+                                            .dblptr)
                                             .offset(row as isize);
+                                        pNull[i as usize] =
+                                            *((lParse.Nodes[theParams[i as usize]]).value.undef)
+                                                .offset(row as isize);
                                     }
                                 }
-                                let fresh192 = &mut *((*this).value.undef).offset(elem as isize);
+                                let fresh192 = &mut *((lParse.Nodes[this_node_idx]).value.undef)
+                                    .offset(elem as isize);
                                 *fresh192 = pNull[2];
                                 if *fresh192 == 0 {
                                     if pVals[2].data.log != 0 {
-                                        *((*this).value.data.dblptr).offset(elem as isize) =
-                                            pVals[0].data.dbl;
-                                        *((*this).value.undef).offset(elem as isize) = pNull[0];
+                                        *((lParse.Nodes[this_node_idx]).value.data.dblptr)
+                                            .offset(elem as isize) = pVals[0].data.dbl;
+                                        *((lParse.Nodes[this_node_idx]).value.undef)
+                                            .offset(elem as isize) = pNull[0];
                                     } else {
-                                        *((*this).value.data.dblptr).offset(elem as isize) =
-                                            pVals[1].data.dbl;
-                                        *((*this).value.undef).offset(elem as isize) = pNull[1];
+                                        *((lParse.Nodes[this_node_idx]).value.data.dblptr)
+                                            .offset(elem as isize) = pVals[1].data.dbl;
+                                        *((lParse.Nodes[this_node_idx]).value.undef)
+                                            .offset(elem as isize) = pNull[1];
                                     }
                                 }
                             }
                         },
-                        261 => loop {
+                        fits_parser_yytokentype::STRING => loop {
                             let fresh193 = row;
                             row -= 1;
                             if fresh193 == 0 {
@@ -12496,10 +13283,12 @@ fn Do_Func(lParse: &mut ParseData, this: *mut Node) {
                             }
                             if vector[2] != 0 {
                                 pVals[2].data.log =
-                                    *((*theParams[2]).value.data.logptr).offset(row as isize);
-                                pNull[2] = *((*theParams[2]).value.undef).offset(row as isize);
+                                    *((lParse.Nodes[theParams[2]]).value.data.logptr)
+                                        .offset(row as isize);
+                                pNull[2] = *((lParse.Nodes[theParams[2]]).value.undef)
+                                    .offset(row as isize);
                             }
-                            i = 2 as c_int;
+                            i = 2;
                             loop {
                                 let fresh194 = i;
                                 i -= 1;
@@ -12509,41 +13298,52 @@ fn Do_Func(lParse: &mut ParseData, this: *mut Node) {
                                 if vector[i as usize] != 0 {
                                     strcpy(
                                         (pVals[i as usize].data.astr).as_mut_ptr(),
-                                        *((*theParams[i as usize]).value.data.strptr)
+                                        *((lParse.Nodes[theParams[i as usize]]).value.data.strptr)
                                             .offset(row as isize),
                                     );
-                                    pNull[i as usize] = *((*theParams[i as usize]).value.undef)
-                                        .offset(row as isize);
+                                    pNull[i as usize] =
+                                        *((lParse.Nodes[theParams[i as usize]]).value.undef)
+                                            .offset(row as isize);
                                 }
                             }
-                            let fresh195 = &mut *((*this).value.undef).offset(row as isize);
+                            let fresh195 = &mut *((lParse.Nodes[this_node_idx]).value.undef)
+                                .offset(row as isize);
                             *fresh195 = pNull[2];
                             if *fresh195 == 0 {
                                 if pVals[2].data.log != 0 {
                                     strcpy(
-                                        *((*this).value.data.strptr).offset(row as isize),
+                                        *((lParse.Nodes[this_node_idx]).value.data.strptr)
+                                            .offset(row as isize),
                                         (pVals[0].data.astr).as_mut_ptr(),
                                     );
-                                    *((*this).value.undef).offset(row as isize) = pNull[0];
+                                    *((lParse.Nodes[this_node_idx]).value.undef)
+                                        .offset(row as isize) = pNull[0];
                                 } else {
                                     strcpy(
-                                        *((*this).value.data.strptr).offset(row as isize),
+                                        *((lParse.Nodes[this_node_idx]).value.data.strptr)
+                                            .offset(row as isize),
                                         (pVals[1].data.astr).as_mut_ptr(),
                                     );
-                                    *((*this).value.undef).offset(row as isize) = pNull[1];
+                                    *((lParse.Nodes[this_node_idx]).value.undef)
+                                        .offset(row as isize) = pNull[1];
                                 }
                             } else {
-                                *(*((*this).value.data.strptr).offset(row as isize)).offset(0) = 0;
+                                *(*((lParse.Nodes[this_node_idx]).value.data.strptr)
+                                    .offset(row as isize))
+                                .offset(0) = 0;
                             }
                         },
                         _ => {}
                     },
-                    1044 => {
-                        let strconst: c_int = ((*theParams[0]).operation == -1000) as c_int;
-                        let posconst: c_int = ((*theParams[1]).operation == -1000) as c_int;
-                        let lenconst: c_int = ((*theParams[2]).operation == -1000) as c_int;
-                        let dest_len: c_int = (*this).value.nelem as c_int;
-                        let mut src_len: c_int = (*theParams[0]).value.nelem as c_int;
+                    strmid_fct => {
+                        let strconst: c_int =
+                            ((lParse.Nodes[theParams[0]]).operation == CONST_OP) as c_int;
+                        let posconst: c_int =
+                            ((lParse.Nodes[theParams[1]]).operation == CONST_OP) as c_int;
+                        let lenconst: c_int =
+                            ((lParse.Nodes[theParams[2]]).operation == CONST_OP) as c_int;
+                        let dest_len: c_int = (lParse.Nodes[this_node_idx]).value.nelem as c_int;
+                        let mut src_len: c_int = (lParse.Nodes[theParams[0]]).value.nelem as c_int;
                         loop {
                             let fresh196 = row;
                             row -= 1;
@@ -12555,42 +13355,54 @@ fn Do_Func(lParse: &mut ParseData, this: *mut Node) {
                             let mut str: *mut c_char = ptr::null_mut();
                             let mut undef: c_int = 0;
                             if posconst != 0 {
-                                pos = (*theParams[1]).value.data.lng as c_int;
+                                pos = (lParse.Nodes[theParams[1]]).value.data.lng as c_int;
                             } else {
-                                pos = *((*theParams[1]).value.data.lngptr).offset(row as isize)
+                                pos = *((lParse.Nodes[theParams[1]]).value.data.lngptr)
+                                    .offset(row as isize)
                                     as c_int;
-                                if *((*theParams[1]).value.undef).offset(row as isize) != 0 {
+                                if *((lParse.Nodes[theParams[1]]).value.undef).offset(row as isize)
+                                    != 0
+                                {
                                     undef = 1;
                                 }
                             }
                             if strconst != 0 {
-                                str = ((*theParams[0]).value.data.astr).as_mut_ptr();
+                                str = ((lParse.Nodes[theParams[0]]).value.data.astr).as_mut_ptr();
                                 if src_len == 0 {
                                     src_len = strlen(str) as c_int;
                                 }
                             } else {
-                                str = *((*theParams[0]).value.data.strptr).offset(row as isize);
-                                if *((*theParams[0]).value.undef).offset(row as isize) != 0 {
+                                str = *((lParse.Nodes[theParams[0]]).value.data.strptr)
+                                    .offset(row as isize);
+                                if *((lParse.Nodes[theParams[0]]).value.undef).offset(row as isize)
+                                    != 0
+                                {
                                     undef = 1;
                                 }
                             }
                             if lenconst != 0 {
                                 len = dest_len;
                             } else {
-                                len = *((*theParams[2]).value.data.lngptr).offset(row as isize)
+                                len = *((lParse.Nodes[theParams[2]]).value.data.lngptr)
+                                    .offset(row as isize)
                                     as c_int;
-                                if *((*theParams[2]).value.undef).offset(row as isize) != 0 {
+                                if *((lParse.Nodes[theParams[2]]).value.undef).offset(row as isize)
+                                    != 0
+                                {
                                     undef = 1;
                                 }
                             }
-                            *(*((*this).value.data.strptr).offset(row as isize)).offset(0) = 0;
+                            *(*((lParse.Nodes[this_node_idx]).value.data.strptr)
+                                .offset(row as isize))
+                            .offset(0) = 0;
                             if pos == 0 {
                                 undef = 1;
                             }
                             if undef == 0
                                 && cstrmid(
                                     lParse,
-                                    *((*this).value.data.strptr).offset(row as isize),
+                                    *((lParse.Nodes[this_node_idx]).value.data.strptr)
+                                        .offset(row as isize),
                                     len,
                                     str,
                                     src_len,
@@ -12599,12 +13411,15 @@ fn Do_Func(lParse: &mut ParseData, this: *mut Node) {
                             {
                                 break;
                             }
-                            *((*this).value.undef).offset(row as isize) = undef as c_char;
+                            *((lParse.Nodes[this_node_idx]).value.undef).offset(row as isize) =
+                                undef as c_char;
                         }
                     }
                     1045 => {
-                        let const1: c_int = ((*theParams[0]).operation == -1000) as c_int;
-                        let const2: c_int = ((*theParams[1]).operation == -1000) as c_int;
+                        let const1: c_int =
+                            ((lParse.Nodes[theParams[0]]).operation == CONST_OP) as c_int;
+                        let const2: c_int =
+                            ((lParse.Nodes[theParams[1]]).operation == CONST_OP) as c_int;
                         loop {
                             let fresh197 = row;
                             row -= 1;
@@ -12615,56 +13430,67 @@ fn Do_Func(lParse: &mut ParseData, this: *mut Node) {
                             let mut str2: *mut c_char = ptr::null_mut();
                             let mut undef_0: c_int = 0;
                             if const1 != 0 {
-                                str1 = ((*theParams[0]).value.data.astr).as_mut_ptr();
+                                str1 = ((lParse.Nodes[theParams[0]]).value.data.astr).as_mut_ptr();
                             } else {
-                                str1 = *((*theParams[0]).value.data.strptr).offset(row as isize);
-                                if *((*theParams[0]).value.undef).offset(row as isize) != 0 {
+                                str1 = *((lParse.Nodes[theParams[0]]).value.data.strptr)
+                                    .offset(row as isize);
+                                if *((lParse.Nodes[theParams[0]]).value.undef).offset(row as isize)
+                                    != 0
+                                {
                                     undef_0 = 1;
                                 }
                             }
                             if const2 != 0 {
-                                str2 = ((*theParams[1]).value.data.astr).as_mut_ptr();
+                                str2 = ((lParse.Nodes[theParams[1]]).value.data.astr).as_mut_ptr();
                             } else {
-                                str2 = *((*theParams[1]).value.data.strptr).offset(row as isize);
-                                if *((*theParams[1]).value.undef).offset(row as isize) != 0 {
+                                str2 = *((lParse.Nodes[theParams[1]]).value.data.strptr)
+                                    .offset(row as isize);
+                                if *((lParse.Nodes[theParams[1]]).value.undef).offset(row as isize)
+                                    != 0
+                                {
                                     undef_0 = 1;
                                 }
                             }
-                            *((*this).value.data.lngptr).offset(row as isize) = 0;
+                            *((lParse.Nodes[this_node_idx]).value.data.lngptr)
+                                .offset(row as isize) = 0;
                             if undef_0 == 0 {
                                 let res_0: *mut c_char = strstr(str1, str2);
                                 if res_0.is_null() {
                                     undef_0 = 1;
-                                    *((*this).value.data.lngptr).offset(row as isize) = 0;
+                                    *((lParse.Nodes[this_node_idx]).value.data.lngptr)
+                                        .offset(row as isize) = 0;
                                 } else {
-                                    *((*this).value.data.lngptr).offset(row as isize) =
+                                    *((lParse.Nodes[this_node_idx]).value.data.lngptr)
+                                        .offset(row as isize) =
                                         res_0.offset_from(str1) as c_long + 1;
                                 }
                             }
-                            *((*this).value.undef).offset(row as isize) = undef_0 as c_char;
+                            *((lParse.Nodes[this_node_idx]).value.undef).offset(row as isize) =
+                                undef_0 as c_char;
                         }
                     }
                     _ => {}
                 }
             }
         }
-        i = (*this).nSubNodes;
+        i = (lParse.Nodes[this_node_idx]).nSubNodes;
         loop {
             let fresh198 = i;
             i -= 1;
             if fresh198 == 0 {
                 break;
             }
-            if (*theParams[i as usize]).operation > 0 {
-                free((*theParams[i as usize]).value.data.ptr);
+            if (lParse.Nodes[theParams[i as usize]]).operation > 0 {
+                free((lParse.Nodes[theParams[i as usize]]).value.data.ptr);
             }
         }
     }
 }
-fn Do_Deref(lParse: &mut ParseData, this: *mut Node) {
+
+fn Do_Deref(lParse: &mut ParseData, this_node_idx: usize) {
     unsafe {
-        let mut theVar: *mut Node = std::ptr::null_mut::<Node>();
-        let mut theDims: [*mut Node; 5] = [std::ptr::null_mut::<Node>(); 5];
+        let mut theVar: &mut Node;
+        let mut theDims: [usize; 5] = [0; 5];
         let mut isConst: [c_int; 5] = [0; 5];
         let mut allConst: c_int = 0;
         let mut dimVals: [c_long; 5] = [0; 5];
@@ -12673,173 +13499,216 @@ fn Do_Deref(lParse: &mut ParseData, this: *mut Node) {
         let mut row: c_long = 0;
         let mut elem: c_long = 0;
         let mut dsize: c_long = 0;
-        theVar = &mut (lParse.Nodes)[(*this).SubNodes[0] as usize];
-        nDims = (*this).nSubNodes - 1;
+
+        let theVar = (lParse.Nodes[this_node_idx]).SubNodes[0];
+        nDims = (lParse.Nodes[this_node_idx]).nSubNodes - 1;
         i = nDims;
         allConst = 1;
+
         loop {
-            let fresh199 = i;
-            i -= 1;
-            if fresh199 == 0 {
+            if i == 0 {
                 break;
             }
-            theDims[i as usize] = &mut (lParse.Nodes)[(*this).SubNodes[(i + 1) as usize] as usize];
-            isConst[i as usize] = ((*theDims[i as usize]).operation == -1000) as c_int;
+            i -= 1;
+
+            theDims[i as usize] = (lParse.Nodes[this_node_idx]).SubNodes[(i + 1) as usize] as usize;
+            isConst[i as usize] =
+                ((lParse.Nodes[theDims[i as usize]]).operation == CONST_OP) as c_int;
             if isConst[i as usize] != 0 {
-                dimVals[i as usize] = (*theDims[i as usize]).value.data.lng;
+                dimVals[i as usize] = (lParse.Nodes[theDims[i as usize]]).value.data.lng;
             } else {
                 allConst = 0;
             }
         }
-        if (*this).ntype == fits_parser_yytokentype::DOUBLE as c_int {
+
+        if (lParse.Nodes[this_node_idx]).ntype == fits_parser_yytokentype::DOUBLE as c_int {
             dsize = ::core::mem::size_of::<c_double>() as c_ulong as c_long;
-        } else if (*this).ntype == fits_parser_yytokentype::LONG as c_int {
+        } else if (lParse.Nodes[this_node_idx]).ntype == fits_parser_yytokentype::LONG as c_int {
             dsize = ::core::mem::size_of::<c_long>() as c_ulong as c_long;
-        } else if (*this).ntype == fits_parser_yytokentype::BOOLEAN as c_int {
+        } else if (lParse.Nodes[this_node_idx]).ntype == fits_parser_yytokentype::BOOLEAN as c_int {
             dsize = ::core::mem::size_of::<c_char>() as c_ulong as c_long;
         } else {
             dsize = 0;
         }
-        Allocate_Ptrs(lParse, this);
+
+        Allocate_Ptrs(lParse, this_node_idx);
+
         if lParse.status == 0 {
-            if allConst != 0 && (*theVar).value.naxis == nDims {
+            if allConst != 0 && (lParse.Nodes[theVar]).value.naxis == nDims {
+                /* Dereference completely using constant indices */
                 elem = 0;
                 i = nDims;
                 loop {
-                    let fresh200 = i;
-                    i -= 1;
-                    if fresh200 == 0 {
+                    if i == 0 {
                         break;
                     }
+                    i -= 1;
+
                     if dimVals[i as usize] < 1
-                        || dimVals[i as usize] > (*theVar).value.naxes[i as usize]
+                        || dimVals[i as usize] > (lParse.Nodes[theVar]).value.naxes[i as usize]
                     {
                         break;
                     }
-                    elem = (*theVar).value.naxes[i as usize] * elem + dimVals[i as usize] - 1;
+
+                    elem = (lParse.Nodes[theVar]).value.naxes[i as usize] * elem
+                        + dimVals[i as usize]
+                        - 1;
                 }
+
                 if i < 0 {
                     row = 0;
                     while row < lParse.nRows {
-                        if (*this).ntype == fits_parser_yytokentype::STRING as c_int {
-                            *((*this).value.undef).offset(row as isize) =
-                                *((*theVar).value.undef).offset(row as isize);
-                        } else if (*this).ntype != fits_parser_yytokentype::BITSTR as c_int {
-                            *((*this).value.undef).offset(row as isize) =
-                                *((*theVar).value.undef).offset(elem as isize);
+                        if (lParse.Nodes[this_node_idx]).ntype
+                            == fits_parser_yytokentype::STRING as c_int
+                        {
+                            *((lParse.Nodes[this_node_idx]).value.undef).offset(row as isize) =
+                                *((lParse.Nodes[theVar]).value.undef).offset(row as isize);
+                        } else if (lParse.Nodes[this_node_idx]).ntype
+                            != fits_parser_yytokentype::BITSTR as c_int
+                        {
+                            *((lParse.Nodes[this_node_idx]).value.undef).offset(row as isize) =
+                                *((lParse.Nodes[theVar]).value.undef).offset(elem as isize);
+                            /* Dummy - BITSTRs do not have undefs */
                         }
-                        if (*this).ntype == fits_parser_yytokentype::DOUBLE as c_int {
-                            *((*this).value.data.dblptr).offset(row as isize) =
-                                *((*theVar).value.data.dblptr).offset(elem as isize);
-                        } else if (*this).ntype == fits_parser_yytokentype::LONG as c_int {
-                            *((*this).value.data.lngptr).offset(row as isize) =
-                                *((*theVar).value.data.lngptr).offset(elem as isize);
-                        } else if (*this).ntype == fits_parser_yytokentype::BOOLEAN as c_int {
-                            *((*this).value.data.logptr).offset(row as isize) =
-                                *((*theVar).value.data.logptr).offset(elem as isize);
+                        if (lParse.Nodes[this_node_idx]).ntype
+                            == fits_parser_yytokentype::DOUBLE as c_int
+                        {
+                            *((lParse.Nodes[this_node_idx]).value.data.dblptr)
+                                .offset(row as isize) =
+                                *((lParse.Nodes[theVar]).value.data.dblptr).offset(elem as isize);
+                        } else if (lParse.Nodes[this_node_idx]).ntype
+                            == fits_parser_yytokentype::LONG as c_int
+                        {
+                            *((lParse.Nodes[this_node_idx]).value.data.lngptr)
+                                .offset(row as isize) =
+                                *((lParse.Nodes[theVar]).value.data.lngptr).offset(elem as isize);
+                        } else if (lParse.Nodes[this_node_idx]).ntype
+                            == fits_parser_yytokentype::BOOLEAN as c_int
+                        {
+                            *((lParse.Nodes[this_node_idx]).value.data.logptr)
+                                .offset(row as isize) =
+                                *((lParse.Nodes[theVar]).value.data.logptr).offset(elem as isize);
                         } else {
-                            *(*((*this).value.data.strptr).offset(row as isize)).offset(0) =
-                                *(*((*theVar).value.data.strptr).offset(0))
-                                    .offset((elem + row) as isize);
-                            *(*((*this).value.data.strptr).offset(row as isize))
-                                .offset(1 as c_int as isize) = 0;
+                            /* XXX Note, the below expression uses knowledge of
+                            the layout of the string format, namely (nelem+1)
+                            characters per string, followed by (nelem+1)
+                            "undef" values. */
+
+                            *(*((lParse.Nodes[this_node_idx]).value.data.strptr)
+                                .offset(row as isize))
+                            .offset(0) = *(*((lParse.Nodes[theVar]).value.data.strptr).offset(0))
+                                .offset((elem + row) as isize);
+                            *(*((lParse.Nodes[this_node_idx]).value.data.strptr)
+                                .offset(row as isize))
+                            .offset(1 as c_int as isize) = 0; /* Null terminate */
                         }
-                        elem += (*theVar).value.nelem;
+                        elem += (lParse.Nodes[theVar]).value.nelem;
                         row += 1;
-                        row;
                     }
                 } else {
                     fits_parser_yyerror(lParse, cs!(c"Index out of range"));
-                    free((*this).value.data.ptr);
+                    free((lParse.Nodes[this_node_idx]).value.data.ptr);
                 }
             } else if allConst != 0 && nDims == 1 {
+                /* Reduce dimensions by 1, using a constant index */
+
                 if dimVals[0] < 1
-                    || dimVals[0] > (*theVar).value.naxes[((*theVar).value.naxis - 1) as usize]
+                    || dimVals[0]
+                        > (lParse.Nodes[theVar]).value.naxes
+                            [((lParse.Nodes[theVar]).value.naxis - 1) as usize]
                 {
                     fits_parser_yyerror(lParse, cs!(c"Index out of range"));
-                    free((*this).value.data.ptr);
-                } else if (*this).ntype == fits_parser_yytokentype::BITSTR as c_int
-                    || (*this).ntype == fits_parser_yytokentype::STRING as c_int
+                    free((lParse.Nodes[this_node_idx]).value.data.ptr);
+                } else if (lParse.Nodes[this_node_idx]).ntype
+                    == fits_parser_yytokentype::BITSTR as c_int
+                    || (lParse.Nodes[this_node_idx]).ntype
+                        == fits_parser_yytokentype::STRING as c_int
                 {
-                    elem = (*this).value.nelem * (dimVals[0] - 1);
+                    elem = (lParse.Nodes[this_node_idx]).value.nelem * (dimVals[0] - 1);
                     row = 0;
                     while row < lParse.nRows {
-                        if !((*this).value.undef).is_null() {
-                            *((*this).value.undef).offset(row as isize) =
-                                *((*theVar).value.undef).offset(row as isize);
+                        if !((lParse.Nodes[this_node_idx]).value.undef).is_null() {
+                            *((lParse.Nodes[this_node_idx]).value.undef).offset(row as isize) =
+                                *((lParse.Nodes[theVar]).value.undef).offset(row as isize);
                         }
                         memcpy(
-                            (*((*this).value.data.strptr).offset(0)).offset(
+                            (*((lParse.Nodes[this_node_idx]).value.data.strptr).offset(0)).offset(
                                 (row as c_ulong)
                                     .wrapping_mul(::core::mem::size_of::<c_char>() as c_ulong)
-                                    .wrapping_mul(((*this).value.nelem + 1) as c_ulong)
-                                    as isize,
+                                    .wrapping_mul(
+                                        ((lParse.Nodes[this_node_idx]).value.nelem + 1) as c_ulong,
+                                    ) as isize,
                             ) as *mut c_void,
-                            (*((*theVar).value.data.strptr).offset(0)).offset(
+                            (*((lParse.Nodes[theVar]).value.data.strptr).offset(0)).offset(
                                 (elem as c_ulong)
                                     .wrapping_mul(::core::mem::size_of::<c_char>() as c_ulong)
                                     as isize,
                             ) as *const c_void,
-                            ((*this).value.nelem as c_ulong)
+                            ((lParse.Nodes[this_node_idx]).value.nelem as c_ulong)
                                 .wrapping_mul(::core::mem::size_of::<c_char>() as c_ulong)
                                 .try_into()
                                 .unwrap(),
                         );
-                        *(*((*this).value.data.strptr).offset(row as isize))
-                            .offset((*this).value.nelem as isize) = 0;
-                        elem += (*theVar).value.nelem + 1;
+                        *(*((lParse.Nodes[this_node_idx]).value.data.strptr)
+                            .offset(row as isize))
+                        .offset((lParse.Nodes[this_node_idx]).value.nelem as isize) = 0; /* Null terminate */
+                        elem += (lParse.Nodes[theVar]).value.nelem + 1;
                         row += 1;
-                        row;
                     }
                 } else {
-                    elem = (*this).value.nelem * (dimVals[0] - 1);
+                    elem = (lParse.Nodes[this_node_idx]).value.nelem * (dimVals[0] - 1);
                     row = 0;
                     while row < lParse.nRows {
                         memcpy(
-                            ((*this).value.undef).offset((row * (*this).value.nelem) as isize)
+                            ((lParse.Nodes[this_node_idx]).value.undef)
+                                .offset((row * (lParse.Nodes[this_node_idx]).value.nelem) as isize)
                                 as *mut c_void,
-                            ((*theVar).value.undef).offset(elem as isize) as *const c_void,
-                            ((*this).value.nelem as c_ulong)
+                            ((lParse.Nodes[theVar]).value.undef).offset(elem as isize)
+                                as *const c_void,
+                            ((lParse.Nodes[this_node_idx]).value.nelem as c_ulong)
                                 .wrapping_mul(::core::mem::size_of::<c_char>() as c_ulong)
                                 .try_into()
                                 .unwrap(),
                         );
                         memcpy(
-                            ((*this).value.data.ptr as *mut c_char)
-                                .offset((row * dsize * (*this).value.nelem) as isize)
-                                as *mut c_void,
-                            ((*theVar).value.data.ptr as *mut c_char)
+                            ((lParse.Nodes[this_node_idx]).value.data.ptr as *mut c_char).offset(
+                                (row * dsize * (lParse.Nodes[this_node_idx]).value.nelem) as isize,
+                            ) as *mut c_void,
+                            ((lParse.Nodes[theVar]).value.data.ptr as *mut c_char)
                                 .offset((elem * dsize) as isize)
                                 as *const c_void,
-                            (((*this).value.nelem * dsize) as c_ulong)
+                            (((lParse.Nodes[this_node_idx]).value.nelem * dsize) as c_ulong)
                                 .try_into()
                                 .unwrap(),
                         );
-                        elem += (*theVar).value.nelem;
+                        elem += (lParse.Nodes[theVar]).value.nelem;
                         row += 1;
-                        row;
                     }
                 }
-            } else if (*theVar).value.naxis == nDims {
+            } else if (lParse.Nodes[theVar]).value.naxis == nDims {
+                /* Dereference completely using an expression for the indices */
                 row = 0;
                 while row < lParse.nRows {
                     i = 0;
                     while i < nDims {
                         if isConst[i as usize] == 0 {
-                            if *((*theDims[i as usize]).value.undef).offset(row as isize) != 0 {
+                            if *((lParse.Nodes[theDims[i as usize]]).value.undef)
+                                .offset(row as isize)
+                                != 0
+                            {
                                 fits_parser_yyerror(
                                     lParse,
                                     cs!(c"Null encountered as vector index"),
                                 );
-                                free((*this).value.data.ptr);
+                                free((lParse.Nodes[this_node_idx]).value.data.ptr);
                                 break;
                             } else {
-                                dimVals[i as usize] = *((*theDims[i as usize]).value.data.lngptr)
-                                    .offset(row as isize);
+                                dimVals[i as usize] =
+                                    *((lParse.Nodes[theDims[i as usize]]).value.data.lngptr)
+                                        .offset(row as isize);
                             }
                         }
                         i += 1;
-                        i;
                     }
                     if lParse.status != 0 {
                         break;
@@ -12853,140 +13722,176 @@ fn Do_Deref(lParse: &mut ParseData, this: *mut Node) {
                             break;
                         }
                         if dimVals[i as usize] < 1
-                            || dimVals[i as usize] > (*theVar).value.naxes[i as usize]
+                            || dimVals[i as usize] > (lParse.Nodes[theVar]).value.naxes[i as usize]
                         {
                             break;
                         }
-                        elem = (*theVar).value.naxes[i as usize] * elem + dimVals[i as usize] - 1;
+                        elem = (lParse.Nodes[theVar]).value.naxes[i as usize] * elem
+                            + dimVals[i as usize]
+                            - 1;
                     }
                     if i < 0 {
-                        elem += row * (*theVar).value.nelem;
-                        if (*this).ntype == fits_parser_yytokentype::STRING as c_int {
-                            *((*this).value.undef).offset(row as isize) =
-                                *((*theVar).value.undef).offset(row as isize);
-                        } else if (*this).ntype != fits_parser_yytokentype::BITSTR as c_int {
-                            *((*this).value.undef).offset(row as isize) =
-                                *((*theVar).value.undef).offset(elem as isize);
+                        elem += row * (lParse.Nodes[theVar]).value.nelem;
+                        if (lParse.Nodes[this_node_idx]).ntype
+                            == fits_parser_yytokentype::STRING as c_int
+                        {
+                            *((lParse.Nodes[this_node_idx]).value.undef).offset(row as isize) =
+                                *((lParse.Nodes[theVar]).value.undef).offset(row as isize);
+                        } else if (lParse.Nodes[this_node_idx]).ntype
+                            != fits_parser_yytokentype::BITSTR as c_int
+                        {
+                            /* Dummy - BITSTRs do not have undefs */
+                            *((lParse.Nodes[this_node_idx]).value.undef).offset(row as isize) =
+                                *((lParse.Nodes[theVar]).value.undef).offset(elem as isize);
                         }
-                        if (*this).ntype == fits_parser_yytokentype::DOUBLE as c_int {
-                            *((*this).value.data.dblptr).offset(row as isize) =
-                                *((*theVar).value.data.dblptr).offset(elem as isize);
-                        } else if (*this).ntype == fits_parser_yytokentype::LONG as c_int {
-                            *((*this).value.data.lngptr).offset(row as isize) =
-                                *((*theVar).value.data.lngptr).offset(elem as isize);
-                        } else if (*this).ntype == fits_parser_yytokentype::BOOLEAN as c_int {
-                            *((*this).value.data.logptr).offset(row as isize) =
-                                *((*theVar).value.data.logptr).offset(elem as isize);
+                        if (lParse.Nodes[this_node_idx]).ntype
+                            == fits_parser_yytokentype::DOUBLE as c_int
+                        {
+                            *((lParse.Nodes[this_node_idx]).value.data.dblptr)
+                                .offset(row as isize) =
+                                *((lParse.Nodes[theVar]).value.data.dblptr).offset(elem as isize);
+                        } else if (lParse.Nodes[this_node_idx]).ntype
+                            == fits_parser_yytokentype::LONG as c_int
+                        {
+                            *((lParse.Nodes[this_node_idx]).value.data.lngptr)
+                                .offset(row as isize) =
+                                *((lParse.Nodes[theVar]).value.data.lngptr).offset(elem as isize);
+                        } else if (lParse.Nodes[this_node_idx]).ntype
+                            == fits_parser_yytokentype::BOOLEAN as c_int
+                        {
+                            *((lParse.Nodes[this_node_idx]).value.data.logptr)
+                                .offset(row as isize) =
+                                *((lParse.Nodes[theVar]).value.data.logptr).offset(elem as isize);
                         } else {
-                            *(*((*this).value.data.strptr).offset(row as isize)).offset(0) =
-                                *(*((*theVar).value.data.strptr).offset(0))
-                                    .offset((elem + row) as isize);
-                            *(*((*this).value.data.strptr).offset(row as isize))
-                                .offset(1 as c_int as isize) = 0;
+                            /* XXX Note, the below expression uses knowledge of
+                            the layout of the string format, namely (nelem+1)
+                            characters per string, followed by (nelem+1)
+                            "undef" values. */
+                            *(*((lParse.Nodes[this_node_idx]).value.data.strptr)
+                                .offset(row as isize))
+                            .offset(0) = *(*((lParse.Nodes[theVar]).value.data.strptr).offset(0))
+                                .offset((elem + row) as isize);
+                            *(*((lParse.Nodes[this_node_idx]).value.data.strptr)
+                                .offset(row as isize))
+                            .offset(1 as c_int as isize) = 0; /* Null terminate */
                         }
                     } else {
                         fits_parser_yyerror(lParse, cs!(c"Index out of range"));
-                        free((*this).value.data.ptr);
+                        free((lParse.Nodes[this_node_idx]).value.data.ptr);
                     }
                     row += 1;
-                    row;
                 }
             } else {
+                /* Reduce dimensions by 1, using a nonconstant expression */
                 row = 0;
                 while row < lParse.nRows {
-                    if *((*theDims[0]).value.undef).offset(row as isize) != 0 {
+                    /* Index cannot be a constant */
+                    if *((lParse.Nodes[theDims[0]]).value.undef).offset(row as isize) != 0 {
                         fits_parser_yyerror(lParse, cs!(c"Null encountered as vector index"));
-                        free((*this).value.data.ptr);
+                        free((lParse.Nodes[this_node_idx]).value.data.ptr);
                         break;
                     } else {
-                        dimVals[0] = *((*theDims[0]).value.data.lngptr).offset(row as isize);
+                        dimVals[0] =
+                            *((lParse.Nodes[theDims[0]]).value.data.lngptr).offset(row as isize);
                         if dimVals[0] < 1
                             || dimVals[0]
-                                > (*theVar).value.naxes[((*theVar).value.naxis - 1) as usize]
+                                > (lParse.Nodes[theVar]).value.naxes
+                                    [((lParse.Nodes[theVar]).value.naxis - 1) as usize]
                         {
                             fits_parser_yyerror(lParse, cs!(c"Index out of range"));
-                            free((*this).value.data.ptr);
-                        } else if (*this).ntype == fits_parser_yytokentype::BITSTR as c_int
-                            || (*this).ntype == fits_parser_yytokentype::STRING as c_int
+                            free((lParse.Nodes[this_node_idx]).value.data.ptr);
+                        } else if (lParse.Nodes[this_node_idx]).ntype
+                            == fits_parser_yytokentype::BITSTR as c_int
+                            || (lParse.Nodes[this_node_idx]).ntype
+                                == fits_parser_yytokentype::STRING as c_int
                         {
-                            elem = (*this).value.nelem * (dimVals[0] - 1);
-                            elem += row * ((*theVar).value.nelem + 1);
-                            if !((*this).value.undef).is_null() {
-                                *((*this).value.undef).offset(row as isize) =
-                                    *((*theVar).value.undef).offset(row as isize);
+                            elem = (lParse.Nodes[this_node_idx]).value.nelem * (dimVals[0] - 1);
+                            elem += row * ((lParse.Nodes[theVar]).value.nelem + 1);
+                            if !((lParse.Nodes[this_node_idx]).value.undef).is_null() {
+                                *((lParse.Nodes[this_node_idx]).value.undef).offset(row as isize) =
+                                    *((lParse.Nodes[theVar]).value.undef).offset(row as isize);
                             }
                             memcpy(
-                                (*((*this).value.data.strptr).offset(0)).offset(
-                                    (row as c_ulong)
-                                        .wrapping_mul(::core::mem::size_of::<c_char>() as c_ulong)
-                                        .wrapping_mul(((*this).value.nelem + 1) as c_ulong)
-                                        as isize,
-                                ) as *mut c_void,
-                                (*((*theVar).value.data.strptr).offset(0)).offset(
+                                (*((lParse.Nodes[this_node_idx]).value.data.strptr).offset(0))
+                                    .offset(
+                                        (row as c_ulong)
+                                            .wrapping_mul(
+                                                ::core::mem::size_of::<c_char>() as c_ulong
+                                            )
+                                            .wrapping_mul(
+                                                ((lParse.Nodes[this_node_idx]).value.nelem + 1)
+                                                    as c_ulong,
+                                            ) as isize,
+                                    ) as *mut c_void,
+                                (*((lParse.Nodes[theVar]).value.data.strptr).offset(0)).offset(
                                     (elem as c_ulong)
                                         .wrapping_mul(::core::mem::size_of::<c_char>() as c_ulong)
                                         as isize,
                                 ) as *const c_void,
-                                ((*this).value.nelem as c_ulong)
+                                ((lParse.Nodes[this_node_idx]).value.nelem as c_ulong)
                                     .wrapping_mul(::core::mem::size_of::<c_char>() as c_ulong)
                                     .try_into()
                                     .unwrap(),
                             );
-                            *(*((*this).value.data.strptr).offset(row as isize))
-                                .offset((*this).value.nelem as isize) = 0;
+                            *(*((lParse.Nodes[this_node_idx]).value.data.strptr)
+                                .offset(row as isize))
+                            .offset((lParse.Nodes[this_node_idx]).value.nelem as isize) = 0; /* Null terminate */
                         } else {
-                            elem = (*this).value.nelem * (dimVals[0] - 1);
-                            elem += row * (*theVar).value.nelem;
+                            elem = (lParse.Nodes[this_node_idx]).value.nelem * (dimVals[0] - 1);
+                            elem += row * (lParse.Nodes[theVar]).value.nelem;
                             memcpy(
-                                ((*this).value.undef).offset((row * (*this).value.nelem) as isize)
-                                    as *mut c_void,
-                                ((*theVar).value.undef).offset(elem as isize) as *const c_void,
-                                ((*this).value.nelem as c_ulong)
+                                ((lParse.Nodes[this_node_idx]).value.undef).offset(
+                                    (row * (lParse.Nodes[this_node_idx]).value.nelem) as isize,
+                                ) as *mut c_void,
+                                ((lParse.Nodes[theVar]).value.undef).offset(elem as isize)
+                                    as *const c_void,
+                                ((lParse.Nodes[this_node_idx]).value.nelem as c_ulong)
                                     .wrapping_mul(::core::mem::size_of::<c_char>() as c_ulong)
                                     .try_into()
                                     .unwrap(),
                             );
                             memcpy(
-                                ((*this).value.data.ptr as *mut c_char)
-                                    .offset((row * dsize * (*this).value.nelem) as isize)
-                                    as *mut c_void,
-                                ((*theVar).value.data.ptr as *mut c_char)
+                                ((lParse.Nodes[this_node_idx]).value.data.ptr as *mut c_char)
+                                    .offset(
+                                        (row * dsize * (lParse.Nodes[this_node_idx]).value.nelem)
+                                            as isize,
+                                    ) as *mut c_void,
+                                ((lParse.Nodes[theVar]).value.data.ptr as *mut c_char)
                                     .offset((elem * dsize) as isize)
                                     as *const c_void,
-                                (((*this).value.nelem * dsize) as c_ulong)
+                                (((lParse.Nodes[this_node_idx]).value.nelem * dsize) as c_ulong)
                                     .try_into()
                                     .unwrap(),
                             );
                         }
                         row += 1;
-                        row;
                     }
                 }
             }
         }
-        if (*theVar).operation > 0 {
-            if (*theVar).ntype == fits_parser_yytokentype::STRING as c_int
-                || (*theVar).ntype == fits_parser_yytokentype::BITSTR as c_int
+        if (lParse.Nodes[theVar]).operation > 0 {
+            if (lParse.Nodes[theVar]).ntype == fits_parser_yytokentype::STRING as c_int
+                || (lParse.Nodes[theVar]).ntype == fits_parser_yytokentype::BITSTR as c_int
             {
-                free(*((*theVar).value.data.strptr).offset(0) as *mut c_void);
+                free(*((lParse.Nodes[theVar]).value.data.strptr).offset(0) as *mut c_void);
             } else {
-                free((*theVar).value.data.ptr);
+                free((lParse.Nodes[theVar]).value.data.ptr);
             }
         }
         i = 0;
         while i < nDims {
-            if (*theDims[i as usize]).operation > 0 {
-                free((*theDims[i as usize]).value.data.ptr);
+            if (lParse.Nodes[theDims[i as usize]]).operation > 0 {
+                free((lParse.Nodes[theDims[i as usize]]).value.data.ptr);
             }
             i += 1;
-            i;
         }
     }
 }
-fn Do_GTI(lParse: &mut ParseData, this: *mut Node) {
+
+fn Do_GTI(lParse: &mut ParseData, this_node_idx: usize) {
     unsafe {
-        let mut theExpr: *mut Node = std::ptr::null_mut::<Node>();
-        let mut theTimes: *mut Node = std::ptr::null_mut::<Node>();
+        let mut theExpr: &mut Node;
+        let mut theTimes: &mut Node;
         let mut start: *mut c_double = std::ptr::null_mut::<c_double>();
         let mut stop: *mut c_double = std::ptr::null_mut::<c_double>();
         let mut times: *mut c_double = std::ptr::null_mut::<c_double>();
@@ -12994,16 +13899,19 @@ fn Do_GTI(lParse: &mut ParseData, this: *mut Node) {
         let mut nGTI: c_long = 0;
         let mut gti: c_long = 0;
         let mut ordered: c_int = 0;
-        let dorow: c_int = ((*this).operation == gtifind_fct as c_int) as c_int;
-        theTimes = &mut (lParse.Nodes)[(*this).SubNodes[0] as usize];
-        theExpr = &mut (lParse.Nodes)[(*this).SubNodes[1] as usize];
-        nGTI = (*theTimes).value.nelem;
-        start = (*theTimes).value.data.dblptr;
-        stop = ((*theTimes).value.data.dblptr).offset(nGTI as isize);
-        ordered = (*theTimes).ntype;
-        if (*theExpr).operation == -1000 {
+        let dorow: c_int =
+            ((lParse.Nodes[this_node_idx]).operation == gtifind_fct as c_int) as c_int;
+
+        let theTimes = (lParse.Nodes[this_node_idx]).SubNodes[0];
+        let theExpr = (lParse.Nodes[this_node_idx]).SubNodes[1];
+
+        nGTI = (lParse.Nodes[theTimes]).value.nelem;
+        start = (lParse.Nodes[theTimes]).value.data.dblptr;
+        stop = ((lParse.Nodes[theTimes]).value.data.dblptr).offset(nGTI as isize);
+        ordered = (lParse.Nodes[theTimes]).ntype;
+        if (lParse.Nodes[theExpr]).operation == CONST_OP {
             gti = Search_GTI(
-                (*theExpr).value.data.dbl,
+                (lParse.Nodes[theExpr]).value.data.dbl,
                 nGTI,
                 start,
                 stop,
@@ -13011,16 +13919,17 @@ fn Do_GTI(lParse: &mut ParseData, this: *mut Node) {
                 std::ptr::null_mut::<c_long>(),
             );
             if dorow != 0 {
-                (*this).value.data.lng = if gti >= 0 { gti + 1 } else { -(1) as c_long };
+                (lParse.Nodes[this_node_idx]).value.data.lng =
+                    if gti >= 0 { gti + 1 } else { -(1) as c_long };
             } else {
-                (*this).value.data.log = if gti >= 0 { 1 } else { 0 };
+                (lParse.Nodes[this_node_idx]).value.data.log = if gti >= 0 { 1 } else { 0 };
             }
-            (*this).operation = -1000;
+            (lParse.Nodes[this_node_idx]).operation = CONST_OP;
         } else {
-            Allocate_Ptrs(lParse, this);
-            times = (*theExpr).value.data.dblptr;
+            Allocate_Ptrs(lParse, this_node_idx);
+            times = (lParse.Nodes[theExpr]).value.data.dblptr;
             if lParse.status == 0 {
-                elem = lParse.nRows * (*this).value.nelem;
+                elem = lParse.nRows * (lParse.Nodes[this_node_idx]).value.nelem;
                 if nGTI != 0 {
                     gti = -(1) as c_long;
                     loop {
@@ -13029,8 +13938,9 @@ fn Do_GTI(lParse: &mut ParseData, this: *mut Node) {
                         if fresh202 == 0 {
                             break;
                         }
-                        let fresh203 = &mut *((*this).value.undef).offset(elem as isize);
-                        *fresh203 = *((*theExpr).value.undef).offset(elem as isize);
+                        let fresh203 =
+                            &mut *((lParse.Nodes[this_node_idx]).value.undef).offset(elem as isize);
+                        *fresh203 = *((lParse.Nodes[theExpr]).value.undef).offset(elem as isize);
                         if *fresh203 != 0 {
                             continue;
                         }
@@ -13048,13 +13958,14 @@ fn Do_GTI(lParse: &mut ParseData, this: *mut Node) {
                             );
                         }
                         if dorow != 0 {
-                            *((*this).value.data.lngptr).offset(elem as isize) =
+                            *((lParse.Nodes[this_node_idx]).value.data.lngptr)
+                                .offset(elem as isize) =
                                 if gti >= 0 { gti + 1 } else { -(1) as c_long };
-                            *((*this).value.undef).offset(elem as isize) =
+                            *((lParse.Nodes[this_node_idx]).value.undef).offset(elem as isize) =
                                 (if gti >= 0 { 0 } else { 1 }) as c_char;
                         } else {
-                            *((*this).value.data.logptr).offset(elem as isize) =
-                                if gti >= 0 { 1 } else { 0 };
+                            *((lParse.Nodes[this_node_idx]).value.data.logptr)
+                                .offset(elem as isize) = if gti >= 0 { 1 } else { 0 };
                         }
                     }
                 } else if dorow != 0 {
@@ -13064,7 +13975,7 @@ fn Do_GTI(lParse: &mut ParseData, this: *mut Node) {
                         if fresh204 == 0 {
                             break;
                         }
-                        *((*this).value.undef).offset(elem as isize) = 1;
+                        *((lParse.Nodes[this_node_idx]).value.undef).offset(elem as isize) = 1;
                     }
                 } else {
                     loop {
@@ -13073,22 +13984,24 @@ fn Do_GTI(lParse: &mut ParseData, this: *mut Node) {
                         if fresh205 == 0 {
                             break;
                         }
-                        *((*this).value.data.logptr).offset(elem as isize) = 0;
-                        *((*this).value.undef).offset(elem as isize) = 0;
+                        *((lParse.Nodes[this_node_idx]).value.data.logptr).offset(elem as isize) =
+                            0;
+                        *((lParse.Nodes[this_node_idx]).value.undef).offset(elem as isize) = 0;
                     }
                 }
             }
         }
-        if (*theExpr).operation > 0 {
-            free((*theExpr).value.data.ptr);
+        if (lParse.Nodes[theExpr]).operation > 0 {
+            free((lParse.Nodes[theExpr]).value.data.ptr);
         }
     }
 }
-fn Do_GTI_Over(lParse: &mut ParseData, this: *mut Node) {
+
+fn Do_GTI_Over(lParse: &mut ParseData, this_node_idx: usize) {
     unsafe {
-        let mut theTimes: *mut Node = std::ptr::null_mut::<Node>();
-        let mut theStart: *mut Node = std::ptr::null_mut::<Node>();
-        let mut theStop: *mut Node = std::ptr::null_mut::<Node>();
+        let mut theTimes: &mut Node;
+        let mut theStart: &mut Node;
+        let mut theStop: &mut Node;
         let mut gtiStart: *mut c_double = std::ptr::null_mut::<c_double>();
         let mut gtiStop: *mut c_double = std::ptr::null_mut::<c_double>();
         let mut evtStart: *mut c_double = std::ptr::null_mut::<c_double>();
@@ -13098,38 +14011,44 @@ fn Do_GTI_Over(lParse: &mut ParseData, this: *mut Node) {
         let mut gti: c_long = 0;
         let nextGTI: c_long = 0;
         let ordered: c_int = 0;
-        theTimes = &mut (lParse.Nodes)[(*this).SubNodes[0] as usize];
-        theStop = &mut (lParse.Nodes)[(*this).SubNodes[2] as usize];
-        theStart = &mut (lParse.Nodes)[(*this).SubNodes[1] as usize];
-        nGTI = (*theTimes).value.nelem;
-        gtiStart = (*theTimes).value.data.dblptr;
-        gtiStop = ((*theTimes).value.data.dblptr).offset(nGTI as isize);
-        if (*theStart).operation == -1000 && (*theStop).operation == -1000 {
-            (*this).value.data.dbl = GTI_Over(
-                (*theStart).value.data.dbl,
-                (*theStop).value.data.dbl,
+
+        let theTimes = (lParse.Nodes[this_node_idx]).SubNodes[0];
+        let theStop = (lParse.Nodes[this_node_idx]).SubNodes[2];
+        let theStart = (lParse.Nodes[this_node_idx]).SubNodes[1];
+
+        nGTI = (lParse.Nodes[theTimes]).value.nelem;
+        gtiStart = (lParse.Nodes[theTimes]).value.data.dblptr;
+        gtiStop = ((lParse.Nodes[theTimes]).value.data.dblptr).offset(nGTI as isize);
+        if (lParse.Nodes[theStart]).operation == CONST_OP
+            && (lParse.Nodes[theStop]).operation == CONST_OP
+        {
+            (lParse.Nodes[this_node_idx]).value.data.dbl = GTI_Over(
+                (lParse.Nodes[theStart]).value.data.dbl,
+                (lParse.Nodes[theStop]).value.data.dbl,
                 nGTI,
                 gtiStart,
                 gtiStop,
                 &mut gti,
             );
-            (*this).operation = -1000;
+            (lParse.Nodes[this_node_idx]).operation = CONST_OP;
         } else {
             let mut undefStart: c_char = 0;
             let mut undefStop: c_char = 0;
             let mut uStart: c_double = 0.0;
             let mut uStop: c_double = 0.0;
-            if (*theStart).operation == -1000 {
-                uStart = (*theStart).value.data.dbl;
+            if (lParse.Nodes[theStart]).operation == CONST_OP {
+                uStart = (lParse.Nodes[theStart]).value.data.dbl;
             }
-            if (*theStop).operation == -1000 {
-                uStop = (*theStop).value.data.dbl;
+            if (lParse.Nodes[theStop]).operation == CONST_OP {
+                uStop = (lParse.Nodes[theStop]).value.data.dbl;
             }
-            Allocate_Ptrs(lParse, this);
-            evtStart = (*theStart).value.data.dblptr;
-            evtStop = (*theStop).value.data.dblptr;
+
+            Allocate_Ptrs(lParse, this_node_idx);
+
+            evtStart = (lParse.Nodes[theStart]).value.data.dblptr;
+            evtStop = (lParse.Nodes[theStop]).value.data.dblptr;
             if lParse.status == 0 {
-                elem = lParse.nRows * (*this).value.nelem;
+                elem = lParse.nRows * (lParse.Nodes[this_node_idx]).value.nelem;
                 if nGTI != 0 {
                     let mut toverlap: c_double = 0.0;
                     gti = -(1) as c_long;
@@ -13139,15 +14058,18 @@ fn Do_GTI_Over(lParse: &mut ParseData, this: *mut Node) {
                         if fresh206 == 0 {
                             break;
                         }
-                        if (*theStart).operation != -1000 {
-                            undefStart = *((*theStart).value.undef).offset(elem as isize);
+                        if (lParse.Nodes[theStart]).operation != CONST_OP {
+                            undefStart =
+                                *((lParse.Nodes[theStart]).value.undef).offset(elem as isize);
                             uStart = *evtStart.offset(elem as isize);
                         }
-                        if (*theStop).operation != -1000 {
-                            undefStop = *((*theStop).value.undef).offset(elem as isize);
+                        if (lParse.Nodes[theStop]).operation != CONST_OP {
+                            undefStop =
+                                *((lParse.Nodes[theStop]).value.undef).offset(elem as isize);
                             uStop = *evtStop.offset(elem as isize);
                         }
-                        let fresh207 = &mut *((*this).value.undef).offset(elem as isize);
+                        let fresh207 =
+                            &mut *((lParse.Nodes[this_node_idx]).value.undef).offset(elem as isize);
                         *fresh207 = if undefStart as c_int != 0 || undefStop as c_int != 0 {
                             1
                         } else {
@@ -13166,7 +14088,8 @@ fn Do_GTI_Over(lParse: &mut ParseData, this: *mut Node) {
                         } else {
                             toverlap = uStop - uStart;
                         }
-                        *((*this).value.data.dblptr).offset(elem as isize) = toverlap;
+                        *((lParse.Nodes[this_node_idx]).value.data.dblptr).offset(elem as isize) =
+                            toverlap;
                     }
                 } else {
                     loop {
@@ -13175,17 +14098,18 @@ fn Do_GTI_Over(lParse: &mut ParseData, this: *mut Node) {
                         if fresh208 == 0 {
                             break;
                         }
-                        *((*this).value.data.dblptr).offset(elem as isize) = 0.0;
-                        *((*this).value.undef).offset(elem as isize) = 0;
+                        *((lParse.Nodes[this_node_idx]).value.data.dblptr).offset(elem as isize) =
+                            0.0;
+                        *((lParse.Nodes[this_node_idx]).value.undef).offset(elem as isize) = 0;
                     }
                 }
             }
         }
-        if (*theStart).operation > 0 {
-            free((*theStart).value.data.ptr);
+        if (lParse.Nodes[theStart]).operation > 0 {
+            free((lParse.Nodes[theStart]).value.data.ptr);
         }
-        if (*theStop).operation > 0 {
-            free((*theStop).value.data.ptr);
+        if (lParse.Nodes[theStop]).operation > 0 {
+            free((lParse.Nodes[theStop]).value.data.ptr);
         }
     }
 }
@@ -13242,7 +14166,6 @@ fn GTI_Over(
             }
             overlap += stopi - starti;
             gti += 1;
-            gti;
         }
         overlap
     }
@@ -13319,11 +14242,11 @@ fn Search_GTI(
         gti
     }
 }
-fn Do_REG(lParse: &mut ParseData, this: *mut Node) {
+fn Do_REG(lParse: &mut ParseData, this_node_idx: usize) {
     unsafe {
-        let mut theRegion: *mut Node = std::ptr::null_mut::<Node>();
-        let mut theX: *mut Node = std::ptr::null_mut::<Node>();
-        let mut theY: *mut Node = std::ptr::null_mut::<Node>();
+        let mut theRegion: &mut Node;
+        let mut theX: &mut Node;
+        let mut theY: &mut Node;
         let mut Xval: c_double = 0.0;
         let mut Yval: c_double = 0.0;
         let mut Xnull: c_char = 0;
@@ -13333,38 +14256,40 @@ fn Do_REG(lParse: &mut ParseData, this: *mut Node) {
         let mut nelem: c_long = 0;
         let mut elem: c_long = 0;
         let mut rows: c_long = 0;
-        theRegion = &mut (lParse.Nodes)[(*this).SubNodes[0] as usize];
-        theX = &mut (lParse.Nodes)[(*this).SubNodes[1] as usize];
-        theY = &mut (lParse.Nodes)[(*this).SubNodes[2] as usize];
-        Xvector = ((*theX).operation != -1000) as c_int;
+
+        let theRegion = (lParse.Nodes[this_node_idx]).SubNodes[0];
+        let theX = (lParse.Nodes[this_node_idx]).SubNodes[1];
+        let theY = (lParse.Nodes[this_node_idx]).SubNodes[2];
+
+        Xvector = ((lParse.Nodes[theX]).operation != CONST_OP) as c_int;
         if Xvector != 0 {
-            Xvector = (*theX).value.nelem as c_int;
+            Xvector = (lParse.Nodes[theX]).value.nelem as c_int;
         } else {
-            Xval = (*theX).value.data.dbl;
+            Xval = (lParse.Nodes[theX]).value.data.dbl;
         }
-        Yvector = ((*theY).operation != -1000) as c_int;
+        Yvector = ((lParse.Nodes[theY]).operation != CONST_OP) as c_int;
         if Yvector != 0 {
-            Yvector = (*theY).value.nelem as c_int;
+            Yvector = (lParse.Nodes[theY]).value.nelem as c_int;
         } else {
-            Yval = (*theY).value.data.dbl;
+            Yval = (lParse.Nodes[theY]).value.data.dbl;
         }
         if Xvector == 0 && Yvector == 0 {
-            (*this).value.data.log = if fits_in_region(
+            (lParse.Nodes[this_node_idx]).value.data.log = if fits_in_region(
                 Xval,
                 Yval,
-                &mut *((*theRegion).value.data.ptr as *mut SAORegion),
+                &mut *((lParse.Nodes[theRegion]).value.data.ptr as *mut SAORegion),
             ) != 0
             {
                 1
             } else {
                 0
             };
-            (*this).operation = -1000;
+            (lParse.Nodes[this_node_idx]).operation = CONST_OP;
         } else {
-            Allocate_Ptrs(lParse, this);
+            Allocate_Ptrs(lParse, this_node_idx);
             if lParse.status == 0 {
                 rows = lParse.nRows;
-                nelem = (*this).value.nelem;
+                nelem = (lParse.Nodes[this_node_idx]).value.nelem;
                 elem = rows * nelem;
                 loop {
                     let fresh210 = rows;
@@ -13379,102 +14304,187 @@ fn Do_REG(lParse: &mut ParseData, this: *mut Node) {
                             break;
                         }
                         elem -= 1;
-                        elem;
                         if Xvector > 1 {
-                            Xval = *((*theX).value.data.dblptr).offset(elem as isize);
-                            Xnull = *((*theX).value.undef).offset(elem as isize);
+                            Xval = *((lParse.Nodes[theX]).value.data.dblptr).offset(elem as isize);
+                            Xnull = *((lParse.Nodes[theX]).value.undef).offset(elem as isize);
                         } else if Xvector != 0 {
-                            Xval = *((*theX).value.data.dblptr).offset(rows as isize);
-                            Xnull = *((*theX).value.undef).offset(rows as isize);
+                            Xval = *((lParse.Nodes[theX]).value.data.dblptr).offset(rows as isize);
+                            Xnull = *((lParse.Nodes[theX]).value.undef).offset(rows as isize);
                         }
                         if Yvector > 1 {
-                            Yval = *((*theY).value.data.dblptr).offset(elem as isize);
-                            Ynull = *((*theY).value.undef).offset(elem as isize);
+                            Yval = *((lParse.Nodes[theY]).value.data.dblptr).offset(elem as isize);
+                            Ynull = *((lParse.Nodes[theY]).value.undef).offset(elem as isize);
                         } else if Yvector != 0 {
-                            Yval = *((*theY).value.data.dblptr).offset(rows as isize);
-                            Ynull = *((*theY).value.undef).offset(rows as isize);
+                            Yval = *((lParse.Nodes[theY]).value.data.dblptr).offset(rows as isize);
+                            Ynull = *((lParse.Nodes[theY]).value.undef).offset(rows as isize);
                         }
-                        *((*this).value.undef).offset(elem as isize) =
+                        *((lParse.Nodes[this_node_idx]).value.undef).offset(elem as isize) =
                             if Xnull as c_int != 0 || Ynull as c_int != 0 {
                                 1
                             } else {
                                 0
                             };
-                        if *((*this).value.undef).offset(elem as isize) != 0 {
+                        if *((lParse.Nodes[this_node_idx]).value.undef).offset(elem as isize) != 0 {
                             continue;
                         }
-                        *((*this).value.data.logptr).offset(elem as isize) = if fits_in_region(
-                            Xval,
-                            Yval,
-                            &mut *((*theRegion).value.data.ptr as *mut SAORegion),
-                        ) != 0
-                        {
-                            1
-                        } else {
-                            0
-                        };
+                        *((lParse.Nodes[this_node_idx]).value.data.logptr).offset(elem as isize) =
+                            if fits_in_region(
+                                Xval,
+                                Yval,
+                                &mut *((lParse.Nodes[theRegion]).value.data.ptr as *mut SAORegion),
+                            ) != 0
+                            {
+                                1
+                            } else {
+                                0
+                            };
                     }
-                    nelem = (*this).value.nelem;
+                    nelem = (lParse.Nodes[this_node_idx]).value.nelem;
                 }
             }
         }
-        if (*theX).operation > 0 {
-            free((*theX).value.data.ptr);
+        if (lParse.Nodes[theX]).operation > 0 {
+            free((lParse.Nodes[theX]).value.data.ptr);
         }
-        if (*theY).operation > 0 {
-            free((*theY).value.data.ptr);
+        if (lParse.Nodes[theY]).operation > 0 {
+            free((lParse.Nodes[theY]).value.data.ptr);
         }
     }
 }
-fn Do_Vector(lParse: &mut ParseData, this: *mut Node) {
+
+fn get_this_that_nodes<T>(nodes: &mut [T], this_idx: usize, that_idx: usize) -> (&mut T, &mut T) {
+    // Example: nodes length = 5
+    // this_idx = 4 (i.e the last item)
+    // that_idx = 2
+    // left will contain items 0, 1, 2, 3 and right will contain items 4
+
+    let split_idx = cmp::max(this_idx, that_idx);
+    let (left, right) = nodes.split_at_mut(split_idx);
+    if this_idx < that_idx {
+        let this_node = &mut right[0];
+        let that_node = &mut left[this_idx];
+        (this_node, that_node)
+    } else {
+        let this_node = &mut right[0];
+        let that_node = &mut left[that_idx];
+        (this_node, that_node)
+    }
+}
+
+/*
+fn get_this_that1_that2_nodes<T>(
+    nodes: &mut [T],
+    this_idx: usize,
+    that1_idx: usize,
+    that2_idx: usize,
+) -> (&mut T, &mut T, &mut T) {
+    // Example: nodes length = 5
+    // this_idx = 4 (i.e the last item)
+    // that1_idx = 2
+    // that2_idx = 1
+    // `right` will contain items 4
+    // `mid` will contain items 2, 3
+    // `left` will contain items 0, 1
+
+    assert_ne!(this_idx, that1_idx);
+    assert_ne!(this_idx, that2_idx);
+    assert_ne!(that1_idx, that2_idx);
+
+    let mut indices = [this_idx, that1_idx, that2_idx];
+    indices.sort();
+
+    // Right will now contain one of the nodes at the 0 index
+    let (tmp, right) = nodes.split_at_mut(indices[2]);
+
+    // Mid will now contain one of the nodes at the 0 index
+    let (left, mid) = tmp.split_at_mut(indices[1]);
+
+    let a = &mut left[indices[0]];
+    let b = &mut mid[0];
+    let c = &mut right[0];
+
+    if this_idx < that1_idx && that1_idx < that2_idx {
+        return (a, b, c);
+    }
+
+    if this_idx < that1_idx && that1_idx > that2_idx {
+        return (a, c, b);
+    }
+
+    if that1_idx < this_idx && this_idx < that2_idx {
+        return (b, a, c);
+    }
+
+    if that1_idx < this_idx && this_idx > that2_idx {
+        return (c, a, b);
+    }
+
+    if that2_idx < this_idx && this_idx < that1_idx {
+        return (b, c, a);
+    }
+
+    if that2_idx < this_idx && this_idx > that1_idx {
+        return (c, b, a);
+    }
+
+    unreachable!()
+}
+*/
+
+fn Do_Vector(lParse: &mut ParseData, this_node_idx: usize) {
     unsafe {
-        let mut that: *mut Node = std::ptr::null_mut::<Node>();
+        let mut that: &mut Node;
         let mut row: c_long = 0;
         let mut elem: c_long = 0;
         let mut idx: c_long = 0;
         let mut jdx: c_long = 0;
         let mut offset: c_long = 0;
         let mut node: c_int = 0;
-        Allocate_Ptrs(lParse, this);
+
+        Allocate_Ptrs(lParse, this_node_idx);
+
         if lParse.status == 0 {
             node = 0;
-            while node < (*this).nSubNodes {
-                that = &mut (lParse.Nodes)[(*this).SubNodes[node as usize] as usize];
-                if (*that).operation == -1000 {
-                    idx = lParse.nRows * (*this).value.nelem + offset;
+            while node < (lParse.Nodes[this_node_idx]).nSubNodes {
+                let that_node_idx = (lParse.Nodes[this_node_idx]).SubNodes[node as usize];
+                let (this_node, that_node) =
+                    get_this_that_nodes(&mut lParse.Nodes, this_node_idx, that_node_idx);
+
+                if that_node.operation == CONST_OP {
+                    idx = lParse.nRows * (this_node).value.nelem + offset;
                     loop {
-                        idx -= (*this).value.nelem;
+                        idx -= (this_node).value.nelem;
                         if idx < 0 {
                             break;
                         }
-                        *((*this).value.undef).offset(idx as isize) = 0;
-                        match (*this).ntype {
-                            258 => {
-                                *((*this).value.data.logptr).offset(idx as isize) =
-                                    (*that).value.data.log;
+                        *((this_node).value.undef).offset(idx as isize) = 0;
+                        match (this_node).ntype.into() {
+                            fits_parser_yytokentype::BOOLEAN => {
+                                *((this_node).value.data.logptr).offset(idx as isize) =
+                                    that_node.value.data.log;
                             }
-                            259 => {
-                                *((*this).value.data.lngptr).offset(idx as isize) =
-                                    (*that).value.data.lng;
+                            fits_parser_yytokentype::LONG => {
+                                *((this_node).value.data.lngptr).offset(idx as isize) =
+                                    that_node.value.data.lng;
                             }
-                            260 => {
-                                *((*this).value.data.dblptr).offset(idx as isize) =
-                                    (*that).value.data.dbl;
+                            fits_parser_yytokentype::DOUBLE => {
+                                *((this_node).value.data.dblptr).offset(idx as isize) =
+                                    that_node.value.data.dbl;
                             }
                             _ => {}
                         }
                     }
                 } else {
                     row = lParse.nRows;
-                    idx = row * (*that).value.nelem;
+                    idx = row * that_node.value.nelem;
                     loop {
                         let fresh212 = row;
                         row -= 1;
                         if fresh212 == 0 {
                             break;
                         }
-                        elem = (*that).value.nelem;
-                        jdx = row * (*this).value.nelem + offset;
+                        elem = that_node.value.nelem;
+                        jdx = row * (this_node).value.nelem + offset;
                         loop {
                             let fresh213 = elem;
                             elem -= 1;
@@ -13482,151 +14492,162 @@ fn Do_Vector(lParse: &mut ParseData, this: *mut Node) {
                                 break;
                             }
                             idx -= 1;
-                            *((*this).value.undef).offset((jdx + elem) as isize) =
-                                *((*that).value.undef).offset(idx as isize);
-                            match (*this).ntype {
-                                258 => {
-                                    *((*this).value.data.logptr).offset((jdx + elem) as isize) =
-                                        *((*that).value.data.logptr).offset(idx as isize);
+                            *((this_node).value.undef).offset((jdx + elem) as isize) =
+                                *(that_node.value.undef).offset(idx as isize);
+                            match (this_node).ntype.into() {
+                                fits_parser_yytokentype::BOOLEAN => {
+                                    *((this_node).value.data.logptr)
+                                        .offset((jdx + elem) as isize) =
+                                        *(that_node.value.data.logptr).offset(idx as isize);
                                 }
-                                259 => {
-                                    *((*this).value.data.lngptr).offset((jdx + elem) as isize) =
-                                        *((*that).value.data.lngptr).offset(idx as isize);
+                                fits_parser_yytokentype::LONG => {
+                                    *((this_node).value.data.lngptr)
+                                        .offset((jdx + elem) as isize) =
+                                        *(that_node.value.data.lngptr).offset(idx as isize);
                                 }
-                                260 => {
-                                    *((*this).value.data.dblptr).offset((jdx + elem) as isize) =
-                                        *((*that).value.data.dblptr).offset(idx as isize);
+                                fits_parser_yytokentype::DOUBLE => {
+                                    *((this_node).value.data.dblptr)
+                                        .offset((jdx + elem) as isize) =
+                                        *(that_node.value.data.dblptr).offset(idx as isize);
                                 }
                                 _ => {}
                             }
                         }
                     }
                 }
-                offset += (*that).value.nelem;
+                offset += that_node.value.nelem;
                 node += 1;
-                node;
             }
         }
+
         node = 0;
-        while node < (*this).nSubNodes {
-            if ((lParse.Nodes)[(*this).SubNodes[node as usize] as usize]).operation > 0 {
+        while node < (lParse.Nodes[this_node_idx]).nSubNodes {
+            if ((lParse.Nodes)[(lParse.Nodes[this_node_idx]).SubNodes[node as usize] as usize])
+                .operation
+                > 0
+            {
                 free(
-                    ((lParse.Nodes)[(*this).SubNodes[node as usize] as usize])
+                    ((lParse.Nodes)
+                        [(lParse.Nodes[this_node_idx]).SubNodes[node as usize] as usize])
                         .value
                         .data
                         .ptr,
                 );
             }
             node += 1;
-            node;
         }
     }
 }
 
-fn Do_Array(lParse: &mut ParseData, this: *mut Node) {
+fn Do_Array(lParse: &mut ParseData, this_node_idx: usize) {
     unsafe {
-        let mut that: *mut Node = std::ptr::null_mut::<Node>();
+        let mut that: &mut Node;
         let mut row: c_long = 0;
         let mut elem: c_long = 0;
         let mut idx: c_long = 0;
         let jdx: c_long = 0;
         let offset: c_long = 0;
         let node: c_int = 0;
-        Allocate_Ptrs(lParse, this);
+
+        Allocate_Ptrs(lParse, this_node_idx);
+
+        let that_idx = (lParse.Nodes[this_node_idx]).SubNodes[0];
+        let (this_node, that_node) =
+            get_this_that_nodes(&mut lParse.Nodes, this_node_idx, that_idx);
+
         if lParse.status == 0 {
-            that = &mut (lParse.Nodes)[(*this).SubNodes[0] as usize];
-            if (*that).operation == -1000 {
-                idx = lParse.nRows * (*this).value.nelem + offset;
+            if (that_node).operation == CONST_OP {
+                idx = lParse.nRows * this_node.value.nelem + offset;
                 loop {
                     let fresh214 = idx;
                     idx -= 1;
                     if fresh214 == 0 {
                         break;
                     }
-                    *((*this).value.undef).offset(idx as isize) = 0;
-                    match (*this).ntype {
-                        258 => {
-                            *((*this).value.data.logptr).offset(idx as isize) =
-                                (*that).value.data.log;
+                    *(this_node.value.undef).offset(idx as isize) = 0;
+                    match this_node.ntype.into() {
+                        fits_parser_yytokentype::BOOLEAN => {
+                            *(this_node.value.data.logptr).offset(idx as isize) =
+                                (that_node).value.data.log;
                         }
-                        259 => {
-                            *((*this).value.data.lngptr).offset(idx as isize) =
-                                (*that).value.data.lng;
+                        fits_parser_yytokentype::LONG => {
+                            *(this_node.value.data.lngptr).offset(idx as isize) =
+                                (that_node).value.data.lng;
                         }
-                        260 => {
-                            *((*this).value.data.dblptr).offset(idx as isize) =
-                                (*that).value.data.dbl;
+                        fits_parser_yytokentype::DOUBLE => {
+                            *(this_node.value.data.dblptr).offset(idx as isize) =
+                                (that_node).value.data.dbl;
                         }
                         _ => {}
                     }
                 }
-            } else if (*that).value.nelem > 1 {
-                idx = lParse.nRows * (*this).value.nelem;
+            } else if (that_node).value.nelem > 1 {
+                idx = lParse.nRows * this_node.value.nelem;
                 loop {
                     let fresh215 = idx;
                     idx -= 1;
                     if fresh215 == 0 {
                         break;
                     }
-                    *((*this).value.undef).offset(idx as isize) =
-                        *((*that).value.undef).offset(idx as isize);
-                    match (*this).ntype {
-                        258 => {
-                            *((*this).value.data.logptr).offset(idx as isize) =
-                                *((*that).value.data.logptr).offset(idx as isize);
+                    *(this_node.value.undef).offset(idx as isize) =
+                        *((that_node).value.undef).offset(idx as isize);
+                    match this_node.ntype.into() {
+                        fits_parser_yytokentype::BOOLEAN => {
+                            *(this_node.value.data.logptr).offset(idx as isize) =
+                                *((that_node).value.data.logptr).offset(idx as isize);
                         }
-                        259 => {
-                            *((*this).value.data.lngptr).offset(idx as isize) =
-                                *((*that).value.data.lngptr).offset(idx as isize);
+                        fits_parser_yytokentype::LONG => {
+                            *(this_node.value.data.lngptr).offset(idx as isize) =
+                                *((that_node).value.data.lngptr).offset(idx as isize);
                         }
-                        260 => {
-                            *((*this).value.data.dblptr).offset(idx as isize) =
-                                *((*that).value.data.dblptr).offset(idx as isize);
+                        fits_parser_yytokentype::DOUBLE => {
+                            *(this_node.value.data.dblptr).offset(idx as isize) =
+                                *((that_node).value.data.dblptr).offset(idx as isize);
                         }
                         _ => {}
                     }
                 }
             } else {
                 row = lParse.nRows;
-                idx = row * (*this).value.nelem - 1;
+                idx = row * this_node.value.nelem - 1;
                 loop {
                     let fresh216 = row;
                     row -= 1;
                     if fresh216 == 0 {
                         break;
                     }
-                    elem = (*this).value.nelem;
+                    elem = this_node.value.nelem;
                     loop {
                         let fresh217 = elem;
                         elem -= 1;
                         if fresh217 == 0 {
                             break;
                         }
-                        *((*this).value.undef).offset(idx as isize) =
-                            *((*that).value.undef).offset(row as isize);
-                        match (*this).ntype {
-                            258 => {
-                                *((*this).value.data.logptr).offset(idx as isize) =
-                                    *((*that).value.data.logptr).offset(row as isize);
+                        *(this_node.value.undef).offset(idx as isize) =
+                            *((that_node).value.undef).offset(row as isize);
+                        match this_node.ntype.into() {
+                            fits_parser_yytokentype::BOOLEAN => {
+                                *(this_node.value.data.logptr).offset(idx as isize) =
+                                    *((that_node).value.data.logptr).offset(row as isize);
                             }
-                            259 => {
-                                *((*this).value.data.lngptr).offset(idx as isize) =
-                                    *((*that).value.data.lngptr).offset(row as isize);
+                            fits_parser_yytokentype::LONG => {
+                                *(this_node.value.data.lngptr).offset(idx as isize) =
+                                    *((that_node).value.data.lngptr).offset(row as isize);
                             }
-                            260 => {
-                                *((*this).value.data.dblptr).offset(idx as isize) =
-                                    *((*that).value.data.dblptr).offset(row as isize);
+                            fits_parser_yytokentype::DOUBLE => {
+                                *(this_node.value.data.dblptr).offset(idx as isize) =
+                                    *((that_node).value.data.dblptr).offset(row as isize);
                             }
                             _ => {}
                         }
                         idx -= 1;
-                        idx;
                     }
                 }
             }
-            if ((lParse.Nodes)[(*this).SubNodes[0] as usize]).operation > 0 {
+
+            if ((lParse.Nodes)[lParse.Nodes[this_node_idx].SubNodes[0]]).operation > 0 {
                 free(
-                    ((lParse.Nodes)[(*this).SubNodes[0] as usize])
+                    ((lParse.Nodes)[lParse.Nodes[this_node_idx].SubNodes[0]])
                         .value
                         .data
                         .ptr,
@@ -13736,7 +14757,7 @@ fn bitlgte(mut bits1: *mut c_char, oper: c_int, mut bits2: *mut c_char) -> c_cha
                 if chr2 as c_int == '1' as i32 {
                     val2 += nextbit;
                 }
-                nextbit *= 2 as c_int;
+                nextbit *= 2;
             }
         }
         result = 0;
@@ -13859,7 +14880,6 @@ fn bitand(mut result: *mut c_char, mut bitstrm1: *mut c_char, mut bitstrm2: *mut
                 *result = b'0' as c_char;
             }
             result = result.offset(1);
-            result;
         }
         free(stream as *mut c_void);
         *result = 0;
@@ -13957,7 +14977,6 @@ fn bitor(mut result: *mut c_char, mut bitstrm1: *mut c_char, mut bitstrm2: *mut 
                 *result = b'x' as c_char;
             }
             result = result.offset(1);
-            result;
         }
         free(stream as *mut c_void);
         *result = 0;

--- a/src/eval_y.rs
+++ b/src/eval_y.rs
@@ -1,1 +1,15211 @@
-// NOT IMPLEMENTED
+#![allow(
+    dead_code,
+    mutable_transmutes,
+    non_camel_case_types,
+    non_snake_case,
+    non_upper_case_globals,
+    unused_assignments,
+    unused_mut,
+    deprecated
+)]
+
+use std::ffi::CStr;
+use std::ptr;
+
+use bytemuck::cast_slice;
+use libc::{calloc, free, malloc, memcpy, memset, realloc, sprintf, time, time_t};
+
+// Math function wrappers
+fn sqrt(x: f64) -> f64 {
+    x.sqrt()
+}
+fn sin(x: f64) -> f64 {
+    x.sin()
+}
+fn cos(x: f64) -> f64 {
+    x.cos()
+}
+fn ceil(x: f64) -> f64 {
+    x.ceil()
+}
+fn floor(x: f64) -> f64 {
+    x.floor()
+}
+fn fabs(x: f64) -> f64 {
+    x.abs()
+}
+fn acos(x: f64) -> f64 {
+    x.acos()
+}
+fn asin(x: f64) -> f64 {
+    x.asin()
+}
+fn atan(x: f64) -> f64 {
+    x.atan()
+}
+fn atan2(y: f64, x: f64) -> f64 {
+    y.atan2(x)
+}
+fn cosh(x: f64) -> f64 {
+    x.cosh()
+}
+fn exp(x: f64) -> f64 {
+    x.exp()
+}
+fn log(x: f64) -> f64 {
+    x.ln()
+}
+fn log10(x: f64) -> f64 {
+    x.log10()
+}
+fn pow(x: f64, y: f64) -> f64 {
+    x.powf(y)
+}
+fn sinh(x: f64) -> f64 {
+    x.sinh()
+}
+fn tan(x: f64) -> f64 {
+    x.tan()
+}
+fn tanh(x: f64) -> f64 {
+    x.tanh()
+}
+
+use crate::atoi;
+use crate::c_types::{
+    c_char, c_double, c_int, c_long, c_schar, c_short, c_uchar, c_uint, c_ulong, c_void,
+};
+use crate::cfileio::{ffclos, ffexts, ffopen};
+use crate::eval_defs::{Node, ParseData, data_union, lval};
+use crate::eval_l::{fits_parser_yyGetVariable, fits_parser_yylex};
+use crate::eval_tab::{FITS_PARSER_YYSTYPE, fits_parser_yytokentype};
+use crate::fitscore::ffpmsg;
+use crate::fitscore::{ffgcno, ffghdn, ffmahd, ffmnhd, ffupch};
+use crate::fitsio::{LONGLONG, fitsfile};
+use crate::getcold::ffgcvd;
+use crate::getkey::{ffgkyd, ffgkyj, ffgkys};
+use crate::region::{SAORegion, WCSdata, fits_in_region, fits_read_rgnfile};
+use crate::simplerng::{
+    simplerng_getnorm, simplerng_getpoisson, simplerng_getuniform, simplerng_srand,
+};
+use crate::wcssub::ffgtcs;
+use crate::wrappers::strncpy;
+use crate::wrappers::{strcat, strcmp, strcpy, strlen, strstr};
+
+pub type yyscan_t = *mut c_void;
+
+pub type yy_state_t = yytype_int16;
+pub type yytype_int16 = c_short;
+pub type yysymbol_kind_t = c_int;
+pub const YYSYMBOL_sexpr: yysymbol_kind_t = 65;
+pub const YYSYMBOL_bits: yysymbol_kind_t = 64;
+pub const YYSYMBOL_bexpr: yysymbol_kind_t = 63;
+pub const YYSYMBOL_expr: yysymbol_kind_t = 62;
+pub const YYSYMBOL_vector: yysymbol_kind_t = 61;
+pub const YYSYMBOL_bvector: yysymbol_kind_t = 60;
+pub const YYSYMBOL_line: yysymbol_kind_t = 59;
+pub const YYSYMBOL_lines: yysymbol_kind_t = 58;
+pub const YYSYMBOL_YYACCEPT: yysymbol_kind_t = 57;
+pub const YYSYMBOL_56_: yysymbol_kind_t = 56;
+pub const YYSYMBOL_55_: yysymbol_kind_t = 55;
+pub const YYSYMBOL_54_: yysymbol_kind_t = 54;
+pub const YYSYMBOL_53_n_: yysymbol_kind_t = 53;
+pub const YYSYMBOL_DIFF: yysymbol_kind_t = 52;
+pub const YYSYMBOL_ACCUM: yysymbol_kind_t = 51;
+pub const YYSYMBOL_50_: yysymbol_kind_t = 50;
+pub const YYSYMBOL_UMINUS: yysymbol_kind_t = 49;
+pub const YYSYMBOL_FLTCAST: yysymbol_kind_t = 48;
+pub const YYSYMBOL_INTCAST: yysymbol_kind_t = 47;
+pub const YYSYMBOL_NOT: yysymbol_kind_t = 46;
+pub const YYSYMBOL_POWER: yysymbol_kind_t = 45;
+pub const YYSYMBOL_XOR: yysymbol_kind_t = 44;
+pub const YYSYMBOL_43_: yysymbol_kind_t = 43;
+pub const YYSYMBOL_42_: yysymbol_kind_t = 42;
+pub const YYSYMBOL_41_: yysymbol_kind_t = 41;
+pub const YYSYMBOL_40_: yysymbol_kind_t = 40;
+pub const YYSYMBOL_39_: yysymbol_kind_t = 39;
+pub const YYSYMBOL_38_: yysymbol_kind_t = 38;
+pub const YYSYMBOL_37_: yysymbol_kind_t = 37;
+pub const YYSYMBOL_GTE: yysymbol_kind_t = 36;
+pub const YYSYMBOL_LTE: yysymbol_kind_t = 35;
+pub const YYSYMBOL_LT: yysymbol_kind_t = 34;
+pub const YYSYMBOL_GT: yysymbol_kind_t = 33;
+pub const YYSYMBOL_32_: yysymbol_kind_t = 32;
+pub const YYSYMBOL_NE: yysymbol_kind_t = 31;
+pub const YYSYMBOL_EQ: yysymbol_kind_t = 30;
+pub const YYSYMBOL_AND: yysymbol_kind_t = 29;
+pub const YYSYMBOL_OR: yysymbol_kind_t = 28;
+pub const YYSYMBOL_27_: yysymbol_kind_t = 27;
+pub const YYSYMBOL_26_: yysymbol_kind_t = 26;
+pub const YYSYMBOL_25_: yysymbol_kind_t = 25;
+pub const YYSYMBOL_24_: yysymbol_kind_t = 24;
+pub const YYSYMBOL_23_: yysymbol_kind_t = 23;
+pub const YYSYMBOL_22_: yysymbol_kind_t = 22;
+pub const YYSYMBOL_SNULLREF: yysymbol_kind_t = 21;
+pub const YYSYMBOL_NULLREF: yysymbol_kind_t = 20;
+pub const YYSYMBOL_ROWREF: yysymbol_kind_t = 19;
+pub const YYSYMBOL_BITCOL: yysymbol_kind_t = 18;
+pub const YYSYMBOL_SCOLUMN: yysymbol_kind_t = 17;
+pub const YYSYMBOL_BCOLUMN: yysymbol_kind_t = 16;
+pub const YYSYMBOL_COLUMN: yysymbol_kind_t = 15;
+pub const YYSYMBOL_REGFILTER: yysymbol_kind_t = 14;
+pub const YYSYMBOL_GTIFIND: yysymbol_kind_t = 13;
+pub const YYSYMBOL_GTIOVERLAP: yysymbol_kind_t = 12;
+pub const YYSYMBOL_GTIFILTER: yysymbol_kind_t = 11;
+pub const YYSYMBOL_IFUNCTION: yysymbol_kind_t = 10;
+pub const YYSYMBOL_BFUNCTION: yysymbol_kind_t = 9;
+pub const YYSYMBOL_FUNCTION: yysymbol_kind_t = 8;
+pub const YYSYMBOL_BITSTR: yysymbol_kind_t = 7;
+pub const YYSYMBOL_STRING: yysymbol_kind_t = 6;
+pub const YYSYMBOL_DOUBLE: yysymbol_kind_t = 5;
+pub const YYSYMBOL_LONG: yysymbol_kind_t = 4;
+pub const YYSYMBOL_BOOLEAN: yysymbol_kind_t = 3;
+pub const YYSYMBOL_YYUNDEF: yysymbol_kind_t = 2;
+pub const YYSYMBOL_YYerror: yysymbol_kind_t = 1;
+pub const YYSYMBOL_YYEOF: yysymbol_kind_t = 0;
+pub const YYSYMBOL_YYEMPTY: yysymbol_kind_t = -2;
+pub type yytype_int8 = c_schar;
+pub type yy_state_fast_t = c_int;
+pub type funcOp = c_uint;
+pub const array_fct: funcOp = 1051;
+pub const axiselem_fct: funcOp = 1050;
+pub const elemnum_fct: funcOp = 1049;
+pub const gtifind_fct: funcOp = 1048;
+pub const gtiover_fct: funcOp = 1047;
+pub const setnull_fct: funcOp = 1046;
+pub const strpos_fct: funcOp = 1045;
+pub const strmid_fct: funcOp = 1044;
+pub const poirnd_fct: funcOp = 1043;
+pub const gasrnd_fct: funcOp = 1042;
+pub const angsep_fct: funcOp = 1041;
+pub const nonnull_fct: funcOp = 1040;
+pub const stddev_fct: funcOp = 1039;
+pub const average_fct: funcOp = 1038;
+pub const median_fct: funcOp = 1037;
+pub const null_fct: funcOp = 1036;
+pub const row_fct: funcOp = 1035;
+pub const ifthenelse_fct: funcOp = 1034;
+pub const regfilt_fct: funcOp = 1033;
+pub const gtifilt_fct: funcOp = 1032;
+pub const defnull_fct: funcOp = 1031;
+pub const isnull_fct: funcOp = 1030;
+pub const elps_fct: funcOp = 1029;
+pub const box_fct: funcOp = 1028;
+pub const circle_fct: funcOp = 1027;
+pub const near_fct: funcOp = 1026;
+pub const max2_fct: funcOp = 1025;
+pub const max1_fct: funcOp = 1024;
+pub const min2_fct: funcOp = 1023;
+pub const min1_fct: funcOp = 1022;
+pub const round_fct: funcOp = 1021;
+pub const floor_fct: funcOp = 1020;
+pub const ceil_fct: funcOp = 1019;
+pub const atan2_fct: funcOp = 1018;
+pub const abs_fct: funcOp = 1017;
+pub const sqrt_fct: funcOp = 1016;
+pub const log10_fct: funcOp = 1015;
+pub const log_fct: funcOp = 1014;
+pub const exp_fct: funcOp = 1013;
+pub const tanh_fct: funcOp = 1012;
+pub const cosh_fct: funcOp = 1011;
+pub const sinh_fct: funcOp = 1010;
+pub const atan_fct: funcOp = 1009;
+pub const acos_fct: funcOp = 1008;
+pub const asin_fct: funcOp = 1007;
+pub const tan_fct: funcOp = 1006;
+pub const cos_fct: funcOp = 1005;
+pub const sin_fct: funcOp = 1004;
+pub const nelem_fct: funcOp = 1003;
+pub const sum_fct: funcOp = 1002;
+pub const rnd_fct: funcOp = 1001;
+
+pub type shapeType = c_uint;
+pub const bpanda_rgn: shapeType = 14;
+pub const epanda_rgn: shapeType = 13;
+pub const panda_rgn: shapeType = 12;
+pub const poly_rgn: shapeType = 11;
+pub const sector_rgn: shapeType = 10;
+pub const diamond_rgn: shapeType = 9;
+pub const rectangle_rgn: shapeType = 8;
+pub const boxannulus_rgn: shapeType = 7;
+pub const box_rgn: shapeType = 6;
+pub const elliptannulus_rgn: shapeType = 5;
+pub const ellipse_rgn: shapeType = 4;
+pub const annulus_rgn: shapeType = 3;
+pub const circle_rgn: shapeType = 2;
+pub const line_rgn: shapeType = 1;
+pub const point_rgn: shapeType = 0;
+pub type yytype_uint8 = c_uchar;
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub union yyalloc {
+    pub yyss_alloc: yy_state_t,
+    pub yyvs_alloc: FITS_PARSER_YYSTYPE,
+}
+
+/* YYTRANSLATE[TOKEN-NUM] -- Symbol number corresponding to TOKEN-NUM
+as returned by yylex.  */
+static yytranslate: [yytype_int8; 293] = [
+    0, 2, 2, 2, 2, 2, 2, 2, 2, 2, 53, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+    2, 2, 2, 2, 2, 2, 39, 43, 2, 55, 56, 40, 37, 22, 38, 2, 41, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 24,
+    2, 2, 23, 2, 27, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+    2, 50, 2, 54, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+    2, 2, 25, 42, 26, 32, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+    2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+    2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+    2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+    2, 2, 2, 2, 2, 2, 2, 2, 2, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
+    20, 21, 28, 29, 30, 31, 33, 34, 35, 36, 44, 45, 46, 47, 48, 49, 51, 52,
+];
+
+/* YYPACT[STATE-NUM] -- Index in YYTABLE of the portion describing
+STATE-NUM.  */
+static yypact: [yytype_int16; 322] = [
+    -41, 316, -41, -40, -41, -41, -41, -41, -41, 369, 423, 423, -5, 15, -4, 27, 36, 38, 40, 41,
+    -41, -41, -41, 423, 423, 423, 423, 423, 423, -41, 423, -41, -7, 10, 1226, 81, 1646, 83, -41,
+    -41, 450, 116, 309, 12, 479, 185, 152, 222, 1593, 1673, 1675, -19, -41, 13, -18, -41, 6, 423,
+    423, 423, 423, 1593, 1673, 1684, 17, 17, 19, 24, 17, 19, 17, 19, 710, 1253, 1611, 365, 423,
+    -41, 423, -41, 423, 423, 423, 423, 423, 423, 423, 423, 423, 423, 423, 423, 423, 423, 423, 423,
+    423, 423, -41, 423, 423, 423, 423, 423, 423, 423, -41, -2, -2, -2, -2, -2, -2, -2, -2, -2, 423,
+    -41, 423, 423, 423, 423, 423, 423, 423, -41, 423, -41, 423, -41, -41, 423, -41, 423, -41, -41,
+    -41, 423, 423, -41, 423, 423, -41, 423, -41, 1455, 1478, 1501, 1524, -41, -41, -41, -41, 1593,
+    1673, 1593, 1673, 1547, 1712, 1712, 1712, 1726, 1726, 1726, 1726, 368, 368, 368, 28, 19, 28, 5,
+    5, 5, 5, 851, 1570, 425, 260, 128, -20, 14, 14, 28, 876, -2, -2, -25, -25, -25, -25, -25, -25,
+    -36, 24, 24, 901, 140, 140, 39, 39, 39, 39, -41, 508, 738, 1258, 1288, 1629, 1312, 1638, 537,
+    1336, 566, 1360, -41, -41, -41, -41, 423, 423, -41, 423, 423, 423, 423, -41, 24, 189, 423, -41,
+    423, -41, -41, -41, 423, -41, 423, -41, 93, -41, 423, 94, -41, 423, 1694, 926, 1694, 1673,
+    1694, 1673, 1684, 951, 976, 1384, 766, 595, 79, 624, 80, 653, 423, -41, 423, -41, 423, -41,
+    423, -41, 423, -41, 100, 101, -41, 117, 118, -41, 1001, 1026, 1051, 794, 1408, 72, 111, 85, 99,
+    423, -41, 423, -41, 423, -41, -41, 423, -41, 129, -41, -41, 1076, 1101, 1126, 682, 104, 423,
+    -41, 423, -41, 423, -41, 423, -41, -41, 1151, 1176, 1201, 1432, -41, -41, -41, 423, 822, -41,
+];
+
+/* YYDEFACT[STATE-NUM] -- Default reduction number in state STATE-NUM.
+Performed when YYTABLE does not specify something else to do.  Zero
+means the default is an error.  */
+static yydefact: [yytype_uint8; 322] = [
+    2, 0, 1, 0, 74, 31, 32, 127, 18, 0, 0, 0, 0, 0, 0, 0, 33, 75, 128, 19, 35, 36, 130, 0, 0, 0, 0,
+    0, 0, 4, 0, 3, 0, 0, 0, 0, 0, 0, 9, 54, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 109, 0, 0, 113, 0,
+    0, 0, 0, 0, 12, 10, 0, 46, 47, 125, 29, 70, 71, 72, 73, 0, 0, 0, 0, 0, 17, 0, 16, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 5, 0, 0, 0, 0, 0, 0, 0, 6, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 8, 0, 0, 0, 0, 0, 0, 0, 7, 0, 59, 0, 55, 58, 0, 57, 0, 102, 103, 104, 0, 0, 110, 0, 0, 114,
+    0, 117, 0, 0, 0, 0, 48, 126, 30, 131, 15, 11, 13, 14, 0, 88, 89, 87, 83, 84, 86, 85, 38, 39,
+    37, 40, 49, 41, 43, 42, 44, 45, 0, 0, 0, 0, 97, 96, 98, 99, 50, 0, 0, 0, 77, 78, 81, 79, 80,
+    82, 23, 22, 21, 0, 90, 91, 92, 94, 95, 93, 132, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 34, 76, 129,
+    20, 0, 0, 65, 0, 0, 0, 0, 120, 29, 0, 0, 24, 0, 61, 56, 105, 0, 134, 0, 60, 0, 111, 0, 0, 115,
+    0, 100, 0, 51, 53, 52, 101, 133, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 66, 0, 121, 0, 25, 0, 135, 0,
+    106, 0, 0, 63, 0, 0, 118, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 67, 0, 122, 0, 26, 62, 0, 112, 0, 116,
+    119, 0, 0, 0, 0, 0, 0, 68, 0, 123, 0, 27, 0, 107, 64, 0, 0, 0, 0, 69, 124, 28, 0, 0, 108,
+];
+
+/* YYPGOTO[NTERM-NUM].  */
+static yypgoto: [yytype_int16; 9] = [-41, -41, -41, -41, -41, -1, 170, 96, 30];
+
+/* YYDEFGOTO[NTERM-NUM].  */
+static yydefgoto: [yytype_int8; 9] = [0, 1, 31, 32, 33, 48, 49, 46, 63];
+
+/* YYTABLE[YYPACT[STATE-NUM]] -- What to do in state STATE-NUM.  If
+positive, shift that token.  If negative, reduce the rule whose
+number is the opposite.  If YYTABLE_NINF, syntax error.  */
+static yytable: [yytype_int16; 1777] = [
+    34, 51, 54, 138, 141, 8, 114, 115, 40, 44, 102, 103, 113, 38, 116, 76, 19, 114, 115, 77, 104,
+    53, 61, 64, 65, 116, 68, 70, 143, 72, 105, 37, 78, 56, 131, 140, 79, 139, 142, 43, 47, 50, 118,
+    119, 185, 120, 121, 122, 123, 124, 96, 52, 55, 186, 104, 97, 145, 146, 147, 148, 75, 57, 144,
+    58, 105, 59, 60, 97, 132, 105, 93, 94, 95, 96, 116, 153, 124, 155, 97, 157, 158, 159, 160, 161,
+    162, 163, 164, 165, 166, 167, 168, 170, 171, 172, 173, 174, 175, 36, 176, 257, 259, 271, 274,
+    183, 184, 42, 282, 283, 99, 100, 101, 102, 103, 118, 119, 196, 120, 121, 122, 123, 124, 104,
+    67, 284, 285, 204, 74, 205, 294, 178, 207, 105, 209, 295, 106, 302, 125, 211, 128, 212, 213,
+    296, 214, 99, 100, 101, 102, 103, 197, 198, 199, 200, 201, 202, 203, 297, 104, 101, 102, 103,
+    311, 208, 0, 0, 0, 0, 105, 210, 104, 0, 0, 35, 129, 120, 121, 122, 123, 124, 105, 41, 45, 0,
+    107, 108, 0, 109, 110, 111, 112, 113, 0, 0, 0, 62, 114, 115, 66, 69, 71, 0, 73, 0, 116, 187,
+    188, 189, 190, 191, 192, 193, 194, 195, 99, 100, 101, 102, 103, 0, 245, 246, 0, 247, 249, 0,
+    252, 104, 113, 0, 253, 0, 254, 114, 115, 0, 255, 105, 256, 0, 0, 116, 258, 135, 0, 260, 0, 151,
+    154, 0, 156, 0, 0, 0, 118, 119, 251, 120, 121, 122, 123, 124, 277, 169, 278, 0, 279, 0, 280, 0,
+    281, 177, 179, 180, 181, 182, 0, 0, 0, 0, 136, 0, 0, 227, 228, 0, 224, 298, 0, 299, 0, 300,
+    118, 119, 301, 120, 121, 122, 123, 124, 206, 0, 0, 0, 312, 0, 313, 0, 314, 0, 315, 0, 0, 0, 0,
+    0, 0, 0, 2, 3, 320, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 0,
+    107, 108, 23, 109, 110, 111, 112, 113, 0, 0, 0, 0, 114, 115, 24, 25, 0, 0, 0, 0, 116, 0, 0, 26,
+    27, 28, 130, 0, 0, 0, 29, 0, 30, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+    21, 22, 0, 248, 250, 23, 118, 119, 0, 120, 121, 122, 123, 124, 0, 0, 0, 24, 25, 91, 92, 93, 94,
+    95, 96, 0, 26, 27, 28, 97, 0, 0, 152, 0, 0, 30, 39, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
+    16, 17, 18, 19, 20, 21, 22, 0, 0, 0, 23, 223, 0, 0, 99, 100, 101, 102, 103, 0, 0, 0, 24, 25, 0,
+    0, 0, 104, 0, 0, 0, 26, 27, 28, 126, 80, 0, 105, 0, 0, 30, 0, 81, 82, 83, 84, 85, 86, 87, 88,
+    89, 90, 91, 92, 93, 94, 95, 96, 0, 0, 0, 0, 97, 133, 80, 0, 0, 0, 127, 0, 0, 81, 82, 83, 84,
+    85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 0, 0, 0, 0, 97, 231, 80, 0, 0, 0, 134, 0, 0,
+    81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 0, 0, 0, 0, 97, 239, 80, 0, 0,
+    0, 232, 0, 0, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 0, 0, 0, 0, 97,
+    242, 80, 0, 0, 0, 240, 0, 0, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 0,
+    0, 0, 0, 97, 269, 80, 0, 0, 0, 243, 0, 0, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93,
+    94, 95, 96, 0, 0, 0, 0, 97, 272, 80, 0, 0, 0, 270, 0, 0, 81, 82, 83, 84, 85, 86, 87, 88, 89,
+    90, 91, 92, 93, 94, 95, 96, 0, 0, 0, 0, 97, 275, 80, 0, 0, 0, 273, 0, 0, 81, 82, 83, 84, 85,
+    86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 0, 0, 0, 0, 97, 309, 80, 0, 0, 0, 276, 0, 0, 81,
+    82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 0, 0, 0, 0, 97, 80, 0, 0, 0, 0,
+    310, 0, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 0, 0, 0, 0, 97, 80, 0,
+    0, 0, 0, 149, 0, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 0, 0, 0, 0,
+    97, 80, 0, 0, 0, 0, 233, 0, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 0,
+    0, 0, 0, 97, 80, 0, 0, 0, 0, 268, 0, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94,
+    95, 96, 0, 0, 0, 0, 97, 80, 0, 0, 0, 0, 292, 0, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92,
+    93, 94, 95, 96, 0, 0, 0, 0, 97, 220, 80, 0, 0, 0, 321, 0, 0, 81, 82, 83, 84, 85, 86, 87, 88,
+    89, 90, 91, 92, 93, 94, 95, 96, 0, 225, 80, 0, 97, 0, 0, 0, 221, 81, 82, 83, 84, 85, 86, 87,
+    88, 89, 90, 91, 92, 93, 94, 95, 96, 0, 229, 80, 0, 97, 0, 0, 0, 226, 81, 82, 83, 84, 85, 86,
+    87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 0, 261, 80, 0, 97, 0, 0, 0, 230, 81, 82, 83, 84, 85,
+    86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 0, 263, 80, 0, 97, 0, 0, 0, 262, 81, 82, 83, 84,
+    85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 0, 265, 80, 0, 97, 0, 0, 0, 264, 81, 82, 83,
+    84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 0, 286, 80, 0, 97, 0, 0, 0, 266, 81, 82,
+    83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 0, 288, 80, 0, 97, 0, 0, 0, 287, 81,
+    82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 0, 290, 80, 0, 97, 0, 0, 0, 289,
+    81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 0, 303, 80, 0, 97, 0, 0, 0,
+    291, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 0, 305, 80, 0, 97, 0, 0,
+    0, 304, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 0, 307, 80, 0, 97, 0,
+    0, 0, 306, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 0, 0, 80, 0, 97, 0,
+    0, 0, 308, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 0, 0, 80, 0, 97, 0,
+    0, 0, 316, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 0, 0, 80, 0, 97, 0,
+    0, 0, 317, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 0, 0, 80, 0, 97, 0,
+    0, 0, 318, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 0, 0, 0, 0, 97, 0,
+    0, 98, 99, 100, 101, 102, 103, 99, 100, 101, 102, 103, 0, 0, 0, 104, 0, 0, 0, 0, 104, 0, 0, 0,
+    0, 105, 0, 0, 0, 0, 105, 150, 235, 80, 0, 0, 234, 0, 0, 0, 81, 82, 83, 84, 85, 86, 87, 88, 89,
+    90, 91, 92, 93, 94, 95, 96, 237, 80, 0, 0, 97, 0, 0, 0, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90,
+    91, 92, 93, 94, 95, 96, 241, 80, 0, 0, 97, 0, 0, 0, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91,
+    92, 93, 94, 95, 96, 244, 80, 0, 0, 97, 0, 0, 0, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92,
+    93, 94, 95, 96, 267, 80, 0, 0, 97, 0, 0, 0, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93,
+    94, 95, 96, 293, 80, 0, 0, 97, 0, 0, 0, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94,
+    95, 96, 319, 80, 0, 0, 97, 0, 0, 0, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95,
+    96, 80, 0, 0, 215, 97, 0, 0, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96,
+    80, 0, 0, 216, 97, 0, 0, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 80, 0,
+    0, 217, 97, 0, 0, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 80, 0, 0,
+    218, 97, 0, 0, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 80, 219, 0, 0,
+    97, 0, 0, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 80, 222, 0, 0, 97, 0,
+    0, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 80, 0, 0, 0, 97, 0, 0, 81,
+    82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 0, 0, 107, 108, 97, 109, 110, 111,
+    112, 113, 0, 0, 0, 0, 114, 115, 0, 0, 0, 0, 118, 119, 116, 120, 121, 122, 123, 124, 151, 118,
+    119, 0, 120, 121, 122, 123, 124, 107, 108, 0, 109, 110, 111, 112, 113, 0, 236, 0, 0, 114, 115,
+    0, 0, 0, 0, 238, 0, 116, 137, 0, 117, 99, 100, 101, 102, 103, 118, 119, 0, 120, 121, 122, 123,
+    124, 104, 118, 119, 0, 120, 121, 122, 123, 124, 0, 105, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90,
+    91, 92, 93, 94, 95, 96, 0, 0, 0, 0, 97, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 0,
+    0, 0, 0, 97, 88, 89, 90, 91, 92, 93, 94, 95, 96, 0, 0, 0, 0, 97,
+];
+
+static yycheck: [yytype_int16; 1777] = [
+    1, 6, 6, 22, 22, 7, 42, 43, 9, 10, 30, 31, 37, 53, 50, 22, 18, 42, 43, 26, 40, 6, 23, 24, 25,
+    50, 27, 28, 22, 30, 50, 1, 22, 6, 22, 22, 26, 56, 56, 9, 10, 11, 30, 31, 46, 33, 34, 35, 36,
+    37, 45, 56, 56, 55, 40, 50, 57, 58, 59, 60, 30, 25, 56, 25, 50, 25, 25, 50, 56, 50, 42, 43, 44,
+    45, 50, 76, 37, 78, 50, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97,
+    1, 99, 6, 6, 22, 22, 104, 105, 9, 6, 6, 27, 28, 29, 30, 31, 30, 31, 116, 33, 34, 35, 36, 37,
+    40, 26, 6, 6, 126, 30, 128, 56, 99, 131, 50, 133, 22, 53, 6, 53, 138, 22, 140, 141, 56, 143,
+    27, 28, 29, 30, 31, 118, 119, 120, 121, 122, 123, 124, 56, 40, 29, 30, 31, 56, 131, -1, -1, -1,
+    -1, 50, 137, 40, -1, -1, 1, 56, 33, 34, 35, 36, 37, 50, 9, 10, -1, 30, 31, -1, 33, 34, 35, 36,
+    37, -1, -1, -1, 23, 42, 43, 26, 27, 28, -1, 30, -1, 50, 107, 108, 109, 110, 111, 112, 113, 114,
+    115, 27, 28, 29, 30, 31, -1, 219, 220, -1, 222, 223, -1, 225, 40, 37, -1, 229, -1, 231, 42, 43,
+    -1, 235, 50, 237, -1, -1, 50, 241, 56, -1, 244, -1, 56, 76, -1, 78, -1, -1, -1, 30, 31, 224,
+    33, 34, 35, 36, 37, 261, 91, 263, -1, 265, -1, 267, -1, 269, 99, 100, 101, 102, 103, -1, -1,
+    -1, -1, 56, -1, -1, 185, 186, -1, 24, 286, -1, 288, -1, 290, 30, 31, 293, 33, 34, 35, 36, 37,
+    128, -1, -1, -1, 303, -1, 305, -1, 307, -1, 309, -1, -1, -1, -1, -1, -1, -1, 0, 1, 319, 3, 4,
+    5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, -1, 30, 31, 25, 33, 34, 35, 36,
+    37, -1, -1, -1, -1, 42, 43, 37, 38, -1, -1, -1, -1, 50, -1, -1, 46, 47, 48, 56, -1, -1, -1, 53,
+    -1, 55, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, -1, 222, 223, 25,
+    30, 31, -1, 33, 34, 35, 36, 37, -1, -1, -1, 37, 38, 40, 41, 42, 43, 44, 45, -1, 46, 47, 48, 50,
+    -1, -1, 56, -1, -1, 55, 56, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+    21, -1, -1, -1, 25, 24, -1, -1, 27, 28, 29, 30, 31, -1, -1, -1, 37, 38, -1, -1, -1, 40, -1, -1,
+    -1, 46, 47, 48, 22, 23, -1, 50, -1, -1, 55, -1, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41,
+    42, 43, 44, 45, -1, -1, -1, -1, 50, 22, 23, -1, -1, -1, 56, -1, -1, 30, 31, 32, 33, 34, 35, 36,
+    37, 38, 39, 40, 41, 42, 43, 44, 45, -1, -1, -1, -1, 50, 22, 23, -1, -1, -1, 56, -1, -1, 30, 31,
+    32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, -1, -1, -1, -1, 50, 22, 23, -1, -1, -1,
+    56, -1, -1, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, -1, -1, -1, -1, 50,
+    22, 23, -1, -1, -1, 56, -1, -1, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45,
+    -1, -1, -1, -1, 50, 22, 23, -1, -1, -1, 56, -1, -1, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40,
+    41, 42, 43, 44, 45, -1, -1, -1, -1, 50, 22, 23, -1, -1, -1, 56, -1, -1, 30, 31, 32, 33, 34, 35,
+    36, 37, 38, 39, 40, 41, 42, 43, 44, 45, -1, -1, -1, -1, 50, 22, 23, -1, -1, -1, 56, -1, -1, 30,
+    31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, -1, -1, -1, -1, 50, 22, 23, -1, -1,
+    -1, 56, -1, -1, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, -1, -1, -1, -1,
+    50, 23, -1, -1, -1, -1, 56, -1, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45,
+    -1, -1, -1, -1, 50, 23, -1, -1, -1, -1, 56, -1, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41,
+    42, 43, 44, 45, -1, -1, -1, -1, 50, 23, -1, -1, -1, -1, 56, -1, 30, 31, 32, 33, 34, 35, 36, 37,
+    38, 39, 40, 41, 42, 43, 44, 45, -1, -1, -1, -1, 50, 23, -1, -1, -1, -1, 56, -1, 30, 31, 32, 33,
+    34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, -1, -1, -1, -1, 50, 23, -1, -1, -1, -1, 56, -1,
+    30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, -1, -1, -1, -1, 50, 22, 23, -1,
+    -1, -1, 56, -1, -1, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, -1, 22, 23,
+    -1, 50, -1, -1, -1, 54, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, -1, 22,
+    23, -1, 50, -1, -1, -1, 54, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, -1,
+    22, 23, -1, 50, -1, -1, -1, 54, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45,
+    -1, 22, 23, -1, 50, -1, -1, -1, 54, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44,
+    45, -1, 22, 23, -1, 50, -1, -1, -1, 54, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43,
+    44, 45, -1, 22, 23, -1, 50, -1, -1, -1, 54, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42,
+    43, 44, 45, -1, 22, 23, -1, 50, -1, -1, -1, 54, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41,
+    42, 43, 44, 45, -1, 22, 23, -1, 50, -1, -1, -1, 54, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40,
+    41, 42, 43, 44, 45, -1, 22, 23, -1, 50, -1, -1, -1, 54, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39,
+    40, 41, 42, 43, 44, 45, -1, 22, 23, -1, 50, -1, -1, -1, 54, 30, 31, 32, 33, 34, 35, 36, 37, 38,
+    39, 40, 41, 42, 43, 44, 45, -1, 22, 23, -1, 50, -1, -1, -1, 54, 30, 31, 32, 33, 34, 35, 36, 37,
+    38, 39, 40, 41, 42, 43, 44, 45, -1, -1, 23, -1, 50, -1, -1, -1, 54, 30, 31, 32, 33, 34, 35, 36,
+    37, 38, 39, 40, 41, 42, 43, 44, 45, -1, -1, 23, -1, 50, -1, -1, -1, 54, 30, 31, 32, 33, 34, 35,
+    36, 37, 38, 39, 40, 41, 42, 43, 44, 45, -1, -1, 23, -1, 50, -1, -1, -1, 54, 30, 31, 32, 33, 34,
+    35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, -1, -1, 23, -1, 50, -1, -1, -1, 54, 30, 31, 32, 33,
+    34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, -1, -1, -1, -1, 50, -1, -1, 53, 27, 28, 29, 30,
+    31, 27, 28, 29, 30, 31, -1, -1, -1, 40, -1, -1, -1, -1, 40, -1, -1, -1, -1, 50, -1, -1, -1, -1,
+    50, 56, 22, 23, -1, -1, 56, -1, -1, -1, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43,
+    44, 45, 22, 23, -1, -1, 50, -1, -1, -1, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43,
+    44, 45, 22, 23, -1, -1, 50, -1, -1, -1, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43,
+    44, 45, 22, 23, -1, -1, 50, -1, -1, -1, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43,
+    44, 45, 22, 23, -1, -1, 50, -1, -1, -1, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43,
+    44, 45, 22, 23, -1, -1, 50, -1, -1, -1, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43,
+    44, 45, 22, 23, -1, -1, 50, -1, -1, -1, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43,
+    44, 45, 23, -1, -1, 26, 50, -1, -1, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44,
+    45, 23, -1, -1, 26, 50, -1, -1, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45,
+    23, -1, -1, 26, 50, -1, -1, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 23,
+    -1, -1, 26, 50, -1, -1, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 23, 24,
+    -1, -1, 50, -1, -1, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 23, 24, -1,
+    -1, 50, -1, -1, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 23, -1, -1, -1,
+    50, -1, -1, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, -1, -1, 30, 31, 50,
+    33, 34, 35, 36, 37, -1, -1, -1, -1, 42, 43, -1, -1, -1, -1, 30, 31, 50, 33, 34, 35, 36, 37, 56,
+    30, 31, -1, 33, 34, 35, 36, 37, 30, 31, -1, 33, 34, 35, 36, 37, -1, 56, -1, -1, 42, 43, -1, -1,
+    -1, -1, 56, -1, 50, 22, -1, 53, 27, 28, 29, 30, 31, 30, 31, -1, 33, 34, 35, 36, 37, 40, 30, 31,
+    -1, 33, 34, 35, 36, 37, -1, 50, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45,
+    -1, -1, -1, -1, 50, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, -1, -1, -1, -1, 50, 37,
+    38, 39, 40, 41, 42, 43, 44, 45, -1, -1, -1, -1, 50,
+];
+
+/* YYSTOS[STATE-NUM] -- The symbol kind of the accessing symbol of
+state STATE-NUM.  */
+static yystos: [yytype_int8; 322] = [
+    0, 58, 0, 1, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 25, 37, 38,
+    46, 47, 48, 53, 55, 59, 60, 61, 62, 63, 64, 65, 53, 56, 62, 63, 64, 65, 62, 63, 64, 65, 62, 63,
+    65, 6, 56, 6, 6, 56, 6, 25, 25, 25, 25, 62, 63, 65, 62, 62, 63, 64, 62, 63, 62, 63, 62, 63, 64,
+    65, 22, 26, 22, 26, 23, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 50, 53,
+    27, 28, 29, 30, 31, 40, 50, 53, 30, 31, 33, 34, 35, 36, 37, 42, 43, 50, 53, 30, 31, 33, 34, 35,
+    36, 37, 53, 22, 56, 22, 56, 56, 22, 56, 22, 56, 56, 56, 22, 22, 56, 22, 22, 56, 22, 56, 62, 62,
+    62, 62, 56, 56, 56, 56, 62, 63, 62, 63, 62, 62, 62, 62, 62, 62, 62, 62, 62, 62, 62, 62, 63, 62,
+    62, 62, 62, 62, 62, 62, 63, 65, 63, 63, 63, 63, 62, 62, 46, 55, 64, 64, 64, 64, 64, 64, 64, 64,
+    64, 62, 65, 65, 65, 65, 65, 65, 65, 62, 62, 63, 62, 65, 62, 65, 62, 62, 62, 62, 26, 26, 26, 26,
+    24, 22, 54, 24, 24, 24, 22, 54, 64, 64, 22, 54, 22, 56, 56, 56, 22, 56, 22, 56, 22, 56, 22, 22,
+    56, 22, 62, 62, 62, 63, 62, 63, 65, 62, 62, 62, 62, 62, 6, 62, 6, 62, 22, 54, 22, 54, 22, 54,
+    22, 56, 22, 56, 22, 22, 56, 22, 22, 56, 62, 62, 62, 62, 62, 6, 6, 6, 6, 22, 54, 22, 54, 22, 54,
+    56, 22, 56, 22, 56, 56, 62, 62, 62, 62, 6, 22, 54, 22, 54, 22, 54, 22, 56, 56, 62, 62, 62, 62,
+    54, 54, 54, 22, 62, 56,
+];
+
+/* YYR1[RULE-NUM] -- Symbol kind of the left-hand side of rule RULE-NUM.  */
+static yyr1: [yytype_int8; 136] = [
+    0, 57, 58, 58, 59, 59, 59, 59, 59, 59, 60, 60, 61, 61, 61, 61, 62, 63, 64, 64, 64, 64, 64, 64,
+    64, 64, 64, 64, 64, 64, 64, 62, 62, 62, 62, 62, 62, 62, 62, 62, 62, 62, 62, 62, 62, 62, 62, 62,
+    62, 62, 62, 62, 62, 62, 62, 62, 62, 62, 62, 62, 62, 62, 62, 62, 62, 62, 62, 62, 62, 62, 62, 62,
+    62, 62, 63, 63, 63, 63, 63, 63, 63, 63, 63, 63, 63, 63, 63, 63, 63, 63, 63, 63, 63, 63, 63, 63,
+    63, 63, 63, 63, 63, 63, 63, 63, 63, 63, 63, 63, 63, 63, 63, 63, 63, 63, 63, 63, 63, 63, 63, 63,
+    63, 63, 63, 63, 63, 63, 63, 65, 65, 65, 65, 65, 65, 65, 65, 65,
+];
+
+/* YYR2[RULE-NUM] -- Number of symbols on the right-hand side of rule RULE-NUM.  */
+static yyr2: [yytype_int8; 136] = [
+    0, 2, 0, 2, 1, 2, 2, 2, 2, 2, 2, 3, 2, 3, 3, 3, 2, 2, 1, 1, 4, 3, 3, 3, 4, 6, 8, 10, 12, 2, 3,
+    1, 1, 1, 4, 1, 1, 3, 3, 3, 3, 3, 3, 3, 3, 3, 2, 2, 3, 3, 3, 5, 5, 5, 2, 3, 5, 3, 3, 3, 5, 5, 9,
+    7, 11, 4, 6, 8, 10, 12, 2, 2, 2, 2, 1, 1, 4, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
+    3, 3, 3, 3, 3, 3, 5, 5, 3, 3, 3, 5, 7, 11, 15, 2, 3, 5, 9, 2, 3, 5, 9, 3, 7, 9, 4, 6, 8, 10,
+    12, 2, 3, 1, 1, 4, 1, 3, 3, 5, 5, 7,
+];
+
+unsafe fn Alloc_Node(mut lParse: *mut ParseData) -> c_int {
+    unsafe {
+        let mut newNodePtr: *mut Node = std::ptr::null_mut::<Node>();
+        if (*lParse).nNodes == (*lParse).nNodesAlloc {
+            if !((*lParse).Nodes).is_null() {
+                (*lParse).nNodesAlloc += (*lParse).nNodesAlloc;
+                newNodePtr = realloc(
+                    (*lParse).Nodes as *mut c_void,
+                    (::core::mem::size_of::<Node>() as c_ulong)
+                        .wrapping_mul((*lParse).nNodesAlloc as c_ulong)
+                        .try_into()
+                        .unwrap(),
+                ) as *mut Node;
+            } else {
+                (*lParse).nNodesAlloc = 100 as c_int;
+                newNodePtr = malloc(
+                    (::core::mem::size_of::<Node>() as c_ulong)
+                        .wrapping_mul((*lParse).nNodesAlloc as c_ulong)
+                        .try_into()
+                        .unwrap(),
+                ) as *mut Node;
+            }
+            if !newNodePtr.is_null() {
+                (*lParse).Nodes = newNodePtr;
+            } else {
+                (*lParse).status = 113 as c_int;
+                return -(1);
+            }
+        }
+        let fresh0 = (*lParse).nNodes;
+        (*lParse).nNodes += 1;
+        fresh0
+    }
+}
+unsafe fn Free_Last_Node(mut lParse: *mut ParseData) {
+    unsafe {
+        if (*lParse).nNodes != 0 {
+            (*lParse).nNodes -= 1;
+            (*lParse).nNodes;
+        }
+    }
+}
+unsafe fn New_Const(
+    mut lParse: *mut ParseData,
+    mut returnType: c_int,
+    mut value: *mut c_void,
+    mut len: c_long,
+) -> c_int {
+    unsafe {
+        let mut this: *mut Node = std::ptr::null_mut::<Node>();
+        let mut n: c_int = 0;
+        n = Alloc_Node(lParse);
+        if n >= 0 {
+            this = ((*lParse).Nodes).offset(n as isize);
+            (*this).operation = -(1000 as c_int);
+            (*this).DoOp = None;
+            (*this).nSubNodes = 0;
+            (*this).ntype = returnType;
+            memcpy(
+                &mut (*this).value.data as *const _ as *mut c_void,
+                value,
+                (len as c_ulong).try_into().unwrap(),
+            );
+            (*this).value.undef = ptr::null_mut();
+            (*this).value.nelem = 1;
+            (*this).value.naxis = 1;
+            (*this).value.naxes[0] = 1;
+        }
+        n
+    }
+}
+unsafe fn New_Column(mut lParse: *mut ParseData, mut ColNum: c_int) -> c_int {
+    unsafe {
+        let mut this: *mut Node = std::ptr::null_mut::<Node>();
+        let mut n: c_int = 0;
+        let mut i: c_int = 0;
+        n = Alloc_Node(lParse);
+        if n >= 0 {
+            this = ((*lParse).Nodes).offset(n as isize);
+            (*this).operation = -ColNum;
+            (*this).DoOp = None;
+            (*this).nSubNodes = 0;
+            (*this).ntype = (*((*lParse).varData).offset(ColNum as isize)).dtype;
+            (*this).value.nelem = (*((*lParse).varData).offset(ColNum as isize)).nelem;
+            (*this).value.naxis = (*((*lParse).varData).offset(ColNum as isize)).naxis;
+            i = 0;
+            while i < (*((*lParse).varData).offset(ColNum as isize)).naxis {
+                (*this).value.naxes[i as usize] =
+                    (*((*lParse).varData).offset(ColNum as isize)).naxes[i as usize];
+                i += 1;
+                i;
+            }
+        }
+        n
+    }
+}
+unsafe fn New_Offset(
+    mut lParse: *mut ParseData,
+    mut ColNum: c_int,
+    mut offsetNode: c_int,
+) -> c_int {
+    unsafe {
+        let mut this: *mut Node = std::ptr::null_mut::<Node>();
+        let mut n: c_int = 0;
+        let mut i: c_int = 0;
+        let mut colNode: c_int = 0;
+        colNode = New_Column(lParse, ColNum);
+        if colNode < 0 {
+            return -(1);
+        }
+        n = Alloc_Node(lParse);
+        if n >= 0 {
+            this = ((*lParse).Nodes).offset(n as isize);
+            (*this).operation = b'{' as i32;
+            (*this).DoOp = Some(Do_Offset);
+            (*this).nSubNodes = 2 as c_int;
+            (*this).SubNodes[0] = colNode;
+            (*this).SubNodes[1] = offsetNode;
+            (*this).ntype = (*((*lParse).varData).offset(ColNum as isize)).dtype;
+            (*this).value.nelem = (*((*lParse).varData).offset(ColNum as isize)).nelem;
+            (*this).value.naxis = (*((*lParse).varData).offset(ColNum as isize)).naxis;
+            i = 0;
+            while i < (*((*lParse).varData).offset(ColNum as isize)).naxis {
+                (*this).value.naxes[i as usize] =
+                    (*((*lParse).varData).offset(ColNum as isize)).naxes[i as usize];
+                i += 1;
+                i;
+            }
+        }
+        n
+    }
+}
+unsafe fn New_Unary(
+    mut lParse: *mut ParseData,
+    mut returnType: c_int,
+    mut Op: c_int,
+    mut Node1: c_int,
+) -> c_int {
+    unsafe {
+        let mut this: *mut Node = std::ptr::null_mut::<Node>();
+        let mut that: *mut Node = std::ptr::null_mut::<Node>();
+        let mut i: c_int = 0;
+        let mut n: c_int = 0;
+        if Node1 < 0 {
+            return -(1);
+        }
+        that = ((*lParse).Nodes).offset(Node1 as isize);
+        if Op == 0 {
+            Op = returnType;
+        }
+        if (Op == fits_parser_yytokentype::DOUBLE as c_int
+            || Op == fits_parser_yytokentype::FLTCAST as c_int)
+            && (*that).ntype == fits_parser_yytokentype::DOUBLE as c_int
+        {
+            return Node1;
+        }
+        if (Op == fits_parser_yytokentype::LONG as c_int
+            || Op == fits_parser_yytokentype::INTCAST as c_int)
+            && (*that).ntype == fits_parser_yytokentype::LONG as c_int
+        {
+            return Node1;
+        }
+        if Op == fits_parser_yytokentype::BOOLEAN as c_int
+            && (*that).ntype == fits_parser_yytokentype::BOOLEAN as c_int
+        {
+            return Node1;
+        }
+        n = Alloc_Node(lParse);
+        if n >= 0 {
+            this = ((*lParse).Nodes).offset(n as isize);
+            (*this).operation = Op;
+            (*this).DoOp = Some(Do_Unary);
+            (*this).nSubNodes = 1;
+            (*this).SubNodes[0] = Node1;
+            (*this).ntype = returnType;
+            that = ((*lParse).Nodes).offset(Node1 as isize);
+            (*this).value.nelem = (*that).value.nelem;
+            (*this).value.naxis = (*that).value.naxis;
+            i = 0;
+            while i < (*that).value.naxis {
+                (*this).value.naxes[i as usize] = (*that).value.naxes[i as usize];
+                i += 1;
+                i;
+            }
+            if (*that).operation == -(1000 as c_int) {
+                ((*this).DoOp).expect("non-null function pointer")(lParse, this);
+            }
+        }
+        n
+    }
+}
+unsafe fn New_BinOp(
+    mut lParse: *mut ParseData,
+    mut returnType: c_int,
+    mut Node1: c_int,
+    mut Op: c_int,
+    mut Node2: c_int,
+) -> c_int {
+    unsafe {
+        let mut this: *mut Node = std::ptr::null_mut::<Node>();
+        let mut that1: *mut Node = std::ptr::null_mut::<Node>();
+        let mut that2: *mut Node = std::ptr::null_mut::<Node>();
+        let mut n: c_int = 0;
+        let mut i: c_int = 0;
+        let mut constant: c_int = 0;
+        if Node1 < 0 || Node2 < 0 {
+            return -(1);
+        }
+        n = Alloc_Node(lParse);
+        if n >= 0 {
+            this = ((*lParse).Nodes).offset(n as isize);
+            (*this).operation = Op;
+            (*this).nSubNodes = 2 as c_int;
+            (*this).SubNodes[0] = Node1;
+            (*this).SubNodes[1] = Node2;
+            (*this).ntype = returnType;
+            that1 = ((*lParse).Nodes).offset(Node1 as isize);
+            that2 = ((*lParse).Nodes).offset(Node2 as isize);
+            constant = ((*that1).operation == -(1000 as c_int)
+                && (*that2).operation == -(1000 as c_int)) as c_int;
+            if (*that1).ntype != fits_parser_yytokentype::STRING as c_int
+                && (*that1).ntype != fits_parser_yytokentype::BITSTR as c_int
+                && Test_Dims(lParse, Node1, Node2) == 0
+            {
+                Free_Last_Node(lParse);
+                fits_parser_yyerror(
+                    0 as yyscan_t,
+                    lParse,
+                    b"Array sizes/dims do not match for binary operator\0" as *const u8
+                        as *const c_char as *mut c_char,
+                );
+                return -(1);
+            }
+            if (*that1).value.nelem == 1 {
+                that1 = that2;
+            }
+            (*this).value.nelem = (*that1).value.nelem;
+            (*this).value.naxis = (*that1).value.naxis;
+            i = 0;
+            while i < (*that1).value.naxis {
+                (*this).value.naxes[i as usize] = (*that1).value.naxes[i as usize];
+                i += 1;
+                i;
+            }
+            if Op == fits_parser_yytokentype::ACCUM as c_int
+                && (*that1).ntype == fits_parser_yytokentype::BITSTR as c_int
+            {
+                (*this).value.nelem = 1;
+                (*this).value.naxis = 1;
+                (*this).value.naxes[0] = 1;
+            }
+            match (*that1).ntype {
+                262 => {
+                    (*this).DoOp = Some(Do_BinOp_bit);
+                }
+                261 => {
+                    (*this).DoOp = Some(Do_BinOp_str);
+                }
+                258 => {
+                    (*this).DoOp = Some(Do_BinOp_log);
+                }
+                259 => {
+                    (*this).DoOp = Some(Do_BinOp_lng);
+                }
+                260 => {
+                    (*this).DoOp = Some(Do_BinOp_dbl);
+                }
+                _ => {}
+            }
+            if constant != 0 {
+                ((*this).DoOp).expect("non-null function pointer")(lParse, this);
+            }
+        }
+        n
+    }
+}
+unsafe fn New_Func(
+    mut lParse: *mut ParseData,
+    mut returnType: c_int,
+    mut Op: funcOp,
+    mut nNodes: c_int,
+    mut Node1: c_int,
+    mut Node2: c_int,
+    mut Node3: c_int,
+    mut Node4: c_int,
+    mut Node5: c_int,
+    mut Node6: c_int,
+    mut Node7: c_int,
+) -> c_int {
+    unsafe {
+        New_FuncSize(
+            lParse, returnType, Op, nNodes, Node1, Node2, Node3, Node4, Node5, Node6, Node7, 0,
+        )
+    }
+}
+unsafe fn yydestruct(
+    mut yymsg: *const c_char,
+    mut yykind: yysymbol_kind_t,
+    mut yyvaluep: *mut FITS_PARSER_YYSTYPE,
+    mut scanner: yyscan_t,
+    mut lParse: *mut ParseData,
+) {
+    if yymsg.is_null() {
+        yymsg = b"Deleting\0" as *const u8 as *const c_char;
+    }
+}
+unsafe fn New_FuncSize(
+    mut lParse: *mut ParseData,
+    mut returnType: c_int,
+    mut Op: funcOp,
+    mut nNodes: c_int,
+    mut Node1: c_int,
+    mut Node2: c_int,
+    mut Node3: c_int,
+    mut Node4: c_int,
+    mut Node5: c_int,
+    mut Node6: c_int,
+    mut Node7: c_int,
+    mut Size: c_int,
+) -> c_int {
+    unsafe {
+        let mut this: *mut Node = std::ptr::null_mut::<Node>();
+        let mut that: *mut Node = std::ptr::null_mut::<Node>();
+        let mut i: c_int = 0;
+        let mut n: c_int = 0;
+        let mut constant: c_int = 0;
+        if Node1 < 0 || Node2 < 0 || Node3 < 0 || Node4 < 0 || Node5 < 0 || Node6 < 0 || Node7 < 0 {
+            return -(1);
+        }
+        n = Alloc_Node(lParse);
+        if n >= 0 {
+            this = ((*lParse).Nodes).offset(n as isize);
+            (*this).operation = Op as c_int;
+            (*this).DoOp = Some(Do_Func);
+            (*this).nSubNodes = nNodes;
+            (*this).SubNodes[0] = Node1;
+            (*this).SubNodes[1] = Node2;
+            (*this).SubNodes[2] = Node3;
+            (*this).SubNodes[3] = Node4;
+            (*this).SubNodes[4] = Node5;
+            (*this).SubNodes[5] = Node6;
+            (*this).SubNodes[6] = Node7;
+            constant = nNodes;
+            i = constant;
+            if Op as c_uint == poirnd_fct as c_int as c_uint {
+                constant = 0;
+            }
+            loop {
+                let fresh1 = i;
+                i -= 1;
+                if fresh1 == 0 {
+                    break;
+                }
+                constant = (constant != 0
+                    && (*((*lParse).Nodes).offset((*this).SubNodes[i as usize] as isize)).operation
+                        == -(1000 as c_int)) as c_int;
+            }
+            if returnType != 0 {
+                (*this).ntype = returnType;
+                (*this).value.nelem = 1;
+                (*this).value.naxis = 1;
+                (*this).value.naxes[0] = 1;
+            } else {
+                that = ((*lParse).Nodes).offset(Node1 as isize);
+                (*this).ntype = (*that).ntype;
+                (*this).value.nelem = (*that).value.nelem;
+                (*this).value.naxis = (*that).value.naxis;
+                i = 0;
+                while i < (*that).value.naxis {
+                    (*this).value.naxes[i as usize] = (*that).value.naxes[i as usize];
+                    i += 1;
+                    i;
+                }
+            }
+            if Size > 0 {
+                (*this).value.nelem = Size as c_long;
+            }
+            if constant != 0 {
+                ((*this).DoOp).expect("non-null function pointer")(lParse, this);
+            }
+        }
+        n
+    }
+}
+
+pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseData) -> c_int {
+    unsafe {
+        let mut current_block: u64;
+        let mut yychar: c_int = 0;
+        static mut yyval_default: FITS_PARSER_YYSTYPE = FITS_PARSER_YYSTYPE { Node: 0 };
+        let mut yylval: FITS_PARSER_YYSTYPE = yyval_default;
+        let mut fits_parser_yynerrs: c_int = 0;
+        let mut yystate: yy_state_fast_t = 0;
+        let mut yyerrstatus: c_int = 0;
+        let mut yystacksize: c_long = 100 as c_long;
+        let mut yyssa: [yy_state_t; 100] = [0; 100];
+        let mut yyss: *mut yy_state_t = yyssa.as_mut_ptr();
+        let mut yyssp: *mut yy_state_t = yyss;
+        let mut yyvsa: [FITS_PARSER_YYSTYPE; 100] = [FITS_PARSER_YYSTYPE { Node: 0 }; 100];
+        let mut yyvs: *mut FITS_PARSER_YYSTYPE = yyvsa.as_mut_ptr();
+        let mut yyvsp: *mut FITS_PARSER_YYSTYPE = yyvs;
+        let mut yyn: c_int = 0;
+        let mut yyresult: c_int = 0;
+        let mut yytoken: yysymbol_kind_t = YYSYMBOL_YYEMPTY;
+        let mut yyval: FITS_PARSER_YYSTYPE = FITS_PARSER_YYSTYPE { Node: 0 };
+        let mut yylen: c_int = 0;
+        yychar = fits_parser_yytokentype::FITS_PARSER_YYEMPTY as c_int;
+        's_54: loop {
+            (0 as c_int != 0 && (0 as c_int <= yystate && yystate < 322 as c_int)) as c_int;
+            *yyssp = yystate as yy_state_t;
+            if yyss
+                .offset(yystacksize as isize)
+                .offset(-(1 as c_int as isize))
+                <= yyssp
+            {
+                let mut yysize: c_long = yyssp.offset_from(yyss) as c_long + 1;
+                if 10000 as c_long <= yystacksize {
+                    current_block = 11794367917084412820;
+                    break;
+                }
+                yystacksize *= 2 as c_long;
+                if (10000 as c_long) < yystacksize {
+                    yystacksize = 10000 as c_long;
+                }
+                let mut yyss1: *mut yy_state_t = yyss;
+                let mut yyptr: *mut yyalloc = malloc(
+                    ((yystacksize
+                        * (::core::mem::size_of::<yy_state_t>() as c_ulong as c_long
+                            + ::core::mem::size_of::<FITS_PARSER_YYSTYPE>() as c_ulong as c_long)
+                        + (::core::mem::size_of::<yyalloc>() as c_ulong as c_long - 1))
+                        as c_ulong)
+                        .try_into()
+                        .unwrap(),
+                ) as *mut yyalloc;
+                if yyptr.is_null() {
+                    current_block = 11794367917084412820;
+                    break;
+                }
+                let mut yynewbytes: c_long = 0;
+                libc::memcpy(
+                    &mut (*yyptr).yyss_alloc as *mut yy_state_t as *mut c_void,
+                    yyss as *const c_void,
+                    (yysize as c_ulong)
+                        .wrapping_mul(::core::mem::size_of::<yy_state_t>() as c_ulong)
+                        as libc::size_t,
+                );
+                yyss = &mut (*yyptr).yyss_alloc;
+                yynewbytes = yystacksize
+                    * ::core::mem::size_of::<yy_state_t>() as c_ulong as c_long
+                    + (::core::mem::size_of::<yyalloc>() as c_ulong as c_long - 1);
+                yyptr = yyptr.offset(
+                    (yynewbytes / ::core::mem::size_of::<yyalloc>() as c_ulong as c_long) as isize,
+                );
+                let mut yynewbytes_0: c_long = 0;
+                libc::memcpy(
+                    &mut (*yyptr).yyvs_alloc as *mut FITS_PARSER_YYSTYPE as *mut c_void,
+                    yyvs as *const c_void,
+                    (yysize as c_ulong)
+                        .wrapping_mul(::core::mem::size_of::<FITS_PARSER_YYSTYPE>() as c_ulong)
+                        as libc::size_t,
+                );
+                yyvs = &mut (*yyptr).yyvs_alloc;
+                yynewbytes_0 = yystacksize
+                    * ::core::mem::size_of::<FITS_PARSER_YYSTYPE>() as c_ulong as c_long
+                    + (::core::mem::size_of::<yyalloc>() as c_ulong as c_long - 1);
+                yyptr = yyptr.offset(
+                    (yynewbytes_0 / ::core::mem::size_of::<yyalloc>() as c_ulong as c_long)
+                        as isize,
+                );
+                if yyss1 != yyssa.as_mut_ptr() {
+                    free(yyss1 as *mut c_void);
+                }
+                yyssp = yyss.offset(yysize as isize).offset(-(1 as c_int as isize));
+                yyvsp = yyvs.offset(yysize as isize).offset(-(1 as c_int as isize));
+                if yyss
+                    .offset(yystacksize as isize)
+                    .offset(-(1 as c_int as isize))
+                    <= yyssp
+                {
+                    current_block = 3964311021479492664;
+                    break;
+                }
+            }
+            if yystate == 2 as c_int {
+                yyresult = 0;
+                current_block = 15864720325503947191;
+                break;
+            } else {
+                yyn = yypact[yystate as usize] as c_int;
+                if yyn == -(41 as c_int) {
+                    current_block = 5937473999264333383;
+                } else {
+                    if yychar == fits_parser_yytokentype::FITS_PARSER_YYEMPTY as c_int {
+                        yychar =
+                            fits_parser_yylex(&mut yylval as *mut FITS_PARSER_YYSTYPE, scanner);
+                    }
+                    if yychar <= fits_parser_yytokentype::FITS_PARSER_YYEOF as c_int {
+                        yychar = fits_parser_yytokentype::FITS_PARSER_YYEOF as c_int;
+                        yytoken = YYSYMBOL_YYEOF;
+                        current_block = 1924505913685386279;
+                    } else if yychar == fits_parser_yytokentype::FITS_PARSER_YYerror as c_int {
+                        yychar = fits_parser_yytokentype::FITS_PARSER_YYUNDEF as c_int;
+                        yytoken = YYSYMBOL_YYerror;
+                        current_block = 1774893048582444437;
+                    } else {
+                        yytoken = (if 0 <= yychar && yychar <= 292 as c_int {
+                            yytranslate[yychar as usize] as yysymbol_kind_t as c_int
+                        } else {
+                            YYSYMBOL_YYUNDEF as c_int
+                        }) as yysymbol_kind_t;
+                        current_block = 1924505913685386279;
+                    }
+                    match current_block {
+                        1774893048582444437 => {}
+                        _ => {
+                            yyn += yytoken as c_int;
+                            if yyn < 0
+                                || (1776 as c_int) < yyn
+                                || yycheck[yyn as usize] as c_int != yytoken as c_int
+                            {
+                                current_block = 5937473999264333383;
+                            } else {
+                                yyn = yytable[yyn as usize] as c_int;
+                                if yyn <= 0 {
+                                    yyn = -yyn;
+                                    current_block = 670225253387957849;
+                                } else {
+                                    if yyerrstatus != 0 {
+                                        yyerrstatus -= 1;
+                                        yyerrstatus;
+                                    }
+                                    yystate = yyn;
+                                    yyvsp = yyvsp.offset(1);
+                                    *yyvsp = yylval;
+                                    yychar = fits_parser_yytokentype::FITS_PARSER_YYEMPTY as c_int;
+                                    current_block = 7872030484262409139;
+                                }
+                            }
+                        }
+                    }
+                }
+                if current_block == 5937473999264333383 {
+                    yyn = yydefact[yystate as usize] as c_int;
+                    if yyn == 0 {
+                        yytoken =
+                            (if yychar == fits_parser_yytokentype::FITS_PARSER_YYEMPTY as c_int {
+                                YYSYMBOL_YYEMPTY as c_int
+                            } else if 0 <= yychar && yychar <= 292 as c_int {
+                                yytranslate[yychar as usize] as yysymbol_kind_t as c_int
+                            } else {
+                                YYSYMBOL_YYUNDEF as c_int
+                            }) as yysymbol_kind_t;
+                        if yyerrstatus == 0 {
+                            fits_parser_yynerrs += 1;
+                            fits_parser_yynerrs;
+                            fits_parser_yyerror(
+                                scanner,
+                                lParse,
+                                b"syntax error\0" as *const u8 as *const c_char as *mut c_char,
+                            );
+                        }
+                        if yyerrstatus == 3 as c_int {
+                            if yychar <= fits_parser_yytokentype::FITS_PARSER_YYEOF as c_int {
+                                if yychar == fits_parser_yytokentype::FITS_PARSER_YYEOF as c_int {
+                                    current_block = 3964311021479492664;
+                                    break;
+                                }
+                            } else {
+                                yydestruct(
+                                    b"Error: discarding\0" as *const u8 as *const c_char,
+                                    yytoken,
+                                    &mut yylval,
+                                    scanner,
+                                    lParse,
+                                );
+                                yychar = fits_parser_yytokentype::FITS_PARSER_YYEMPTY as c_int;
+                            }
+                        }
+                        current_block = 1774893048582444437;
+                    } else {
+                        current_block = 670225253387957849;
+                    }
+                }
+                if current_block == 670225253387957849 {
+                    yylen = yyr2[yyn as usize] as c_int;
+                    yyval = *yyvsp.offset((1 as c_int - yylen) as isize);
+                    match yyn {
+                        4 => {
+                            current_block = 17353983478346836848;
+                        }
+                        5 => {
+                            if (*yyvsp.offset(-1_isize)).Node < 0 {
+                                fits_parser_yyerror(
+                                    scanner,
+                                    lParse,
+                                    b"Couldn't build node structure: out of memory?\0" as *const u8
+                                        as *const c_char
+                                        as *mut c_char,
+                                );
+                                current_block = 4830776507462815627;
+                            } else {
+                                (*lParse).resultNode = (*yyvsp.offset(-1_isize)).Node;
+                                current_block = 17353983478346836848;
+                            }
+                        }
+                        6 => {
+                            if (*yyvsp.offset(-1_isize)).Node < 0 {
+                                fits_parser_yyerror(
+                                    scanner,
+                                    lParse,
+                                    b"Couldn't build node structure: out of memory?\0" as *const u8
+                                        as *const c_char
+                                        as *mut c_char,
+                                );
+                                current_block = 4830776507462815627;
+                            } else {
+                                (*lParse).resultNode = (*yyvsp.offset(-1_isize)).Node;
+                                current_block = 17353983478346836848;
+                            }
+                        }
+                        7 => {
+                            if (*yyvsp.offset(-1_isize)).Node < 0 {
+                                fits_parser_yyerror(
+                                    scanner,
+                                    lParse,
+                                    b"Couldn't build node structure: out of memory?\0" as *const u8
+                                        as *const c_char
+                                        as *mut c_char,
+                                );
+                                current_block = 4830776507462815627;
+                            } else {
+                                (*lParse).resultNode = (*yyvsp.offset(-1_isize)).Node;
+                                current_block = 17353983478346836848;
+                            }
+                        }
+                        8 => {
+                            if (*yyvsp.offset(-1_isize)).Node < 0 {
+                                fits_parser_yyerror(
+                                    scanner,
+                                    lParse,
+                                    b"Couldn't build node structure: out of memory?\0" as *const u8
+                                        as *const c_char
+                                        as *mut c_char,
+                                );
+                                current_block = 4830776507462815627;
+                            } else {
+                                (*lParse).resultNode = (*yyvsp.offset(-1_isize)).Node;
+                                current_block = 17353983478346836848;
+                            }
+                        }
+                        9 => {
+                            yyerrstatus = 0;
+                            current_block = 17353983478346836848;
+                        }
+                        10 => {
+                            yyval.Node = New_Vector(lParse, (*yyvsp.offset(0)).Node);
+                            if yyval.Node < 0 {
+                                current_block = 4830776507462815627;
+                            } else {
+                                current_block = 17353983478346836848;
+                            }
+                        }
+                        11 => {
+                            if (*((*lParse).Nodes).offset((*yyvsp.offset(-2_isize)).Node as isize))
+                                .nSubNodes
+                                >= 10 as c_int
+                            {
+                                (*yyvsp.offset(-2_isize)).Node =
+                                    Close_Vec(lParse, (*yyvsp.offset(-2_isize)).Node);
+                                if (*yyvsp.offset(-2_isize)).Node < 0 {
+                                    current_block = 4830776507462815627;
+                                } else {
+                                    yyval.Node = New_Vector(lParse, (*yyvsp.offset(-2_isize)).Node);
+                                    if yyval.Node < 0 {
+                                        current_block = 4830776507462815627;
+                                    } else {
+                                        current_block = 2616667235040759262;
+                                    }
+                                }
+                            } else {
+                                yyval.Node = (*yyvsp.offset(-2_isize)).Node;
+                                current_block = 2616667235040759262;
+                            }
+                            match current_block {
+                                4830776507462815627 => {}
+                                _ => {
+                                    let fresh2 = &mut (*((*lParse).Nodes)
+                                        .offset(yyval.Node as isize))
+                                    .nSubNodes;
+                                    let fresh3 = *fresh2;
+                                    *fresh2 += 1;
+                                    (*((*lParse).Nodes).offset(yyval.Node as isize)).SubNodes
+                                        [fresh3 as usize] = (*yyvsp.offset(0)).Node;
+                                    current_block = 17353983478346836848;
+                                }
+                            }
+                        }
+                        12 => {
+                            yyval.Node = New_Vector(lParse, (*yyvsp.offset(0)).Node);
+                            if yyval.Node < 0 {
+                                current_block = 4830776507462815627;
+                            } else {
+                                current_block = 17353983478346836848;
+                            }
+                        }
+                        13 => {
+                            if (*((*lParse).Nodes).offset((*yyvsp.offset(-2_isize)).Node as isize))
+                                .ntype
+                                < (*((*lParse).Nodes).offset((*yyvsp.offset(0)).Node as isize))
+                                    .ntype
+                            {
+                                (*((*lParse).Nodes)
+                                    .offset((*yyvsp.offset(-2_isize)).Node as isize))
+                                .ntype = (*((*lParse).Nodes)
+                                    .offset((*yyvsp.offset(0)).Node as isize))
+                                .ntype;
+                            }
+                            if (*((*lParse).Nodes).offset((*yyvsp.offset(-2_isize)).Node as isize))
+                                .nSubNodes
+                                >= 10 as c_int
+                            {
+                                (*yyvsp.offset(-2_isize)).Node =
+                                    Close_Vec(lParse, (*yyvsp.offset(-2_isize)).Node);
+                                if (*yyvsp.offset(-2_isize)).Node < 0 {
+                                    current_block = 4830776507462815627;
+                                } else {
+                                    yyval.Node = New_Vector(lParse, (*yyvsp.offset(-2_isize)).Node);
+                                    if yyval.Node < 0 {
+                                        current_block = 4830776507462815627;
+                                    } else {
+                                        current_block = 2904036176499606090;
+                                    }
+                                }
+                            } else {
+                                yyval.Node = (*yyvsp.offset(-2_isize)).Node;
+                                current_block = 2904036176499606090;
+                            }
+                            match current_block {
+                                4830776507462815627 => {}
+                                _ => {
+                                    let fresh4 = &mut (*((*lParse).Nodes)
+                                        .offset(yyval.Node as isize))
+                                    .nSubNodes;
+                                    let fresh5 = *fresh4;
+                                    *fresh4 += 1;
+                                    (*((*lParse).Nodes).offset(yyval.Node as isize)).SubNodes
+                                        [fresh5 as usize] = (*yyvsp.offset(0)).Node;
+                                    current_block = 17353983478346836848;
+                                }
+                            }
+                        }
+                        14 => {
+                            if (*((*lParse).Nodes).offset((*yyvsp.offset(-2_isize)).Node as isize))
+                                .nSubNodes
+                                >= 10 as c_int
+                            {
+                                (*yyvsp.offset(-2_isize)).Node =
+                                    Close_Vec(lParse, (*yyvsp.offset(-2_isize)).Node);
+                                if (*yyvsp.offset(-2_isize)).Node < 0 {
+                                    current_block = 4830776507462815627;
+                                } else {
+                                    yyval.Node = New_Vector(lParse, (*yyvsp.offset(-2_isize)).Node);
+                                    if yyval.Node < 0 {
+                                        current_block = 4830776507462815627;
+                                    } else {
+                                        current_block = 17702298541784679949;
+                                    }
+                                }
+                            } else {
+                                yyval.Node = (*yyvsp.offset(-2_isize)).Node;
+                                current_block = 17702298541784679949;
+                            }
+                            match current_block {
+                                4830776507462815627 => {}
+                                _ => {
+                                    let fresh6 = &mut (*((*lParse).Nodes)
+                                        .offset(yyval.Node as isize))
+                                    .nSubNodes;
+                                    let fresh7 = *fresh6;
+                                    *fresh6 += 1;
+                                    (*((*lParse).Nodes).offset(yyval.Node as isize)).SubNodes
+                                        [fresh7 as usize] = (*yyvsp.offset(0)).Node;
+                                    current_block = 17353983478346836848;
+                                }
+                            }
+                        }
+                        15 => {
+                            (*((*lParse).Nodes).offset((*yyvsp.offset(-2_isize)).Node as isize))
+                                .ntype =
+                                (*((*lParse).Nodes).offset((*yyvsp.offset(0)).Node as isize)).ntype;
+                            if (*((*lParse).Nodes).offset((*yyvsp.offset(-2_isize)).Node as isize))
+                                .nSubNodes
+                                >= 10 as c_int
+                            {
+                                (*yyvsp.offset(-2_isize)).Node =
+                                    Close_Vec(lParse, (*yyvsp.offset(-2_isize)).Node);
+                                if (*yyvsp.offset(-2_isize)).Node < 0 {
+                                    current_block = 4830776507462815627;
+                                } else {
+                                    yyval.Node = New_Vector(lParse, (*yyvsp.offset(-2_isize)).Node);
+                                    if yyval.Node < 0 {
+                                        current_block = 4830776507462815627;
+                                    } else {
+                                        current_block = 1069630499025798221;
+                                    }
+                                }
+                            } else {
+                                yyval.Node = (*yyvsp.offset(-2_isize)).Node;
+                                current_block = 1069630499025798221;
+                            }
+                            match current_block {
+                                4830776507462815627 => {}
+                                _ => {
+                                    let fresh8 = &mut (*((*lParse).Nodes)
+                                        .offset(yyval.Node as isize))
+                                    .nSubNodes;
+                                    let fresh9 = *fresh8;
+                                    *fresh8 += 1;
+                                    (*((*lParse).Nodes).offset(yyval.Node as isize)).SubNodes
+                                        [fresh9 as usize] = (*yyvsp.offset(0)).Node;
+                                    current_block = 17353983478346836848;
+                                }
+                            }
+                        }
+                        16 => {
+                            yyval.Node = Close_Vec(lParse, (*yyvsp.offset(-1_isize)).Node);
+                            if yyval.Node < 0 {
+                                current_block = 4830776507462815627;
+                            } else {
+                                current_block = 17353983478346836848;
+                            }
+                        }
+                        17 => {
+                            yyval.Node = Close_Vec(lParse, (*yyvsp.offset(-1_isize)).Node);
+                            if yyval.Node < 0 {
+                                current_block = 4830776507462815627;
+                            } else {
+                                current_block = 17353983478346836848;
+                            }
+                        }
+                        18 => {
+                            yyval.Node = New_Const(
+                                lParse,
+                                fits_parser_yytokentype::BITSTR as c_int,
+                                ((*yyvsp.offset(0)).astr).as_mut_ptr() as *mut c_void,
+                                (strlen(((*yyvsp.offset(0)).astr).as_mut_ptr()))
+                                    .wrapping_add((1 as c_int as c_ulong).try_into().unwrap())
+                                    as c_long,
+                            );
+                            if yyval.Node < 0 {
+                                current_block = 4830776507462815627;
+                            } else {
+                                ((*((*lParse).Nodes).offset(yyval.Node as isize)).value).nelem =
+                                    strlen(((*yyvsp.offset(0)).astr).as_mut_ptr()) as c_long;
+                                current_block = 17353983478346836848;
+                            }
+                        }
+                        19 => {
+                            yyval.Node = New_Column(lParse, (*yyvsp.offset(0)).lng as c_int);
+                            if yyval.Node < 0 {
+                                current_block = 4830776507462815627;
+                            } else {
+                                current_block = 17353983478346836848;
+                            }
+                        }
+                        20 => {
+                            if (*((*lParse).Nodes).offset((*yyvsp.offset(-1_isize)).Node as isize))
+                                .ntype
+                                != fits_parser_yytokentype::LONG as c_int
+                                || (*((*lParse).Nodes)
+                                    .offset((*yyvsp.offset(-1_isize)).Node as isize))
+                                .operation
+                                    != -(1000 as c_int)
+                            {
+                                fits_parser_yyerror(
+                                    scanner,
+                                    lParse,
+                                    b"Offset argument must be a constant integer\0" as *const u8
+                                        as *const c_char
+                                        as *mut c_char,
+                                );
+                                current_block = 4830776507462815627;
+                            } else {
+                                yyval.Node = New_Offset(
+                                    lParse,
+                                    (*yyvsp.offset(-3_isize)).lng as c_int,
+                                    (*yyvsp.offset(-1_isize)).Node,
+                                );
+                                if yyval.Node < 0 {
+                                    current_block = 4830776507462815627;
+                                } else {
+                                    current_block = 17353983478346836848;
+                                }
+                            }
+                        }
+                        21 => {
+                            yyval.Node = New_BinOp(
+                                lParse,
+                                fits_parser_yytokentype::BITSTR as c_int,
+                                (*yyvsp.offset(-2_isize)).Node,
+                                '&' as i32,
+                                (*yyvsp.offset(0)).Node,
+                            );
+                            if yyval.Node < 0 {
+                                current_block = 4830776507462815627;
+                            } else {
+                                ((*((*lParse).Nodes).offset(yyval.Node as isize)).value).nelem =
+                                    if ((*((*lParse).Nodes)
+                                        .offset((*yyvsp.offset(-2_isize)).Node as isize))
+                                    .value)
+                                        .nelem
+                                        > (*((*lParse).Nodes)
+                                            .offset((*yyvsp.offset(0)).Node as isize))
+                                        .value
+                                        .nelem
+                                    {
+                                        (*((*lParse).Nodes)
+                                            .offset((*yyvsp.offset(-2_isize)).Node as isize))
+                                        .value
+                                        .nelem
+                                    } else {
+                                        (*((*lParse).Nodes)
+                                            .offset((*yyvsp.offset(0)).Node as isize))
+                                        .value
+                                        .nelem
+                                    };
+                                current_block = 17353983478346836848;
+                            }
+                        }
+                        22 => {
+                            yyval.Node = New_BinOp(
+                                lParse,
+                                fits_parser_yytokentype::BITSTR as c_int,
+                                (*yyvsp.offset(-2_isize)).Node,
+                                '|' as i32,
+                                (*yyvsp.offset(0)).Node,
+                            );
+                            if yyval.Node < 0 {
+                                current_block = 4830776507462815627;
+                            } else {
+                                ((*((*lParse).Nodes).offset(yyval.Node as isize)).value).nelem =
+                                    if ((*((*lParse).Nodes)
+                                        .offset((*yyvsp.offset(-2_isize)).Node as isize))
+                                    .value)
+                                        .nelem
+                                        > (*((*lParse).Nodes)
+                                            .offset((*yyvsp.offset(0)).Node as isize))
+                                        .value
+                                        .nelem
+                                    {
+                                        (*((*lParse).Nodes)
+                                            .offset((*yyvsp.offset(-2_isize)).Node as isize))
+                                        .value
+                                        .nelem
+                                    } else {
+                                        (*((*lParse).Nodes)
+                                            .offset((*yyvsp.offset(0)).Node as isize))
+                                        .value
+                                        .nelem
+                                    };
+                                current_block = 17353983478346836848;
+                            }
+                        }
+                        23 => {
+                            if (*((*lParse).Nodes).offset((*yyvsp.offset(-2_isize)).Node as isize))
+                                .value
+                                .nelem
+                                + (*((*lParse).Nodes).offset((*yyvsp.offset(0)).Node as isize))
+                                    .value
+                                    .nelem
+                                >= 256 as c_long
+                            {
+                                fits_parser_yyerror(
+                                    scanner,
+                                    lParse,
+                                    b"Combined bit string size exceeds 255 bits\0" as *const u8
+                                        as *const c_char
+                                        as *mut c_char,
+                                );
+                                current_block = 4830776507462815627;
+                            } else {
+                                yyval.Node = New_BinOp(
+                                    lParse,
+                                    fits_parser_yytokentype::BITSTR as c_int,
+                                    (*yyvsp.offset(-2_isize)).Node,
+                                    '+' as i32,
+                                    (*yyvsp.offset(0)).Node,
+                                );
+                                if yyval.Node < 0 {
+                                    current_block = 4830776507462815627;
+                                } else {
+                                    ((*((*lParse).Nodes).offset(yyval.Node as isize)).value)
+                                        .nelem = (*((*lParse).Nodes)
+                                        .offset((*yyvsp.offset(-2_isize)).Node as isize))
+                                    .value
+                                    .nelem
+                                        + (*((*lParse).Nodes)
+                                            .offset((*yyvsp.offset(0)).Node as isize))
+                                        .value
+                                        .nelem;
+                                    current_block = 17353983478346836848;
+                                }
+                            }
+                        }
+                        24 => {
+                            yyval.Node = New_Deref(
+                                lParse,
+                                (*yyvsp.offset(-3_isize)).Node,
+                                1,
+                                (*yyvsp.offset(-1_isize)).Node,
+                                0,
+                                0,
+                                0,
+                                0,
+                            );
+                            if yyval.Node < 0 {
+                                current_block = 4830776507462815627;
+                            } else {
+                                current_block = 17353983478346836848;
+                            }
+                        }
+                        25 => {
+                            yyval.Node = New_Deref(
+                                lParse,
+                                (*yyvsp.offset(-(5))).Node,
+                                2 as c_int,
+                                (*yyvsp.offset(-3_isize)).Node,
+                                (*yyvsp.offset(-1_isize)).Node,
+                                0,
+                                0,
+                                0,
+                            );
+                            if yyval.Node < 0 {
+                                current_block = 4830776507462815627;
+                            } else {
+                                current_block = 17353983478346836848;
+                            }
+                        }
+                        26 => {
+                            yyval.Node = New_Deref(
+                                lParse,
+                                (*yyvsp.offset(-(7 as c_int) as isize)).Node,
+                                3 as c_int,
+                                (*yyvsp.offset(-(5))).Node,
+                                (*yyvsp.offset(-3_isize)).Node,
+                                (*yyvsp.offset(-1_isize)).Node,
+                                0,
+                                0,
+                            );
+                            if yyval.Node < 0 {
+                                current_block = 4830776507462815627;
+                            } else {
+                                current_block = 17353983478346836848;
+                            }
+                        }
+                        27 => {
+                            yyval.Node = New_Deref(
+                                lParse,
+                                (*yyvsp.offset(-(9 as c_int) as isize)).Node,
+                                4 as c_int,
+                                (*yyvsp.offset(-(7 as c_int) as isize)).Node,
+                                (*yyvsp.offset(-(5))).Node,
+                                (*yyvsp.offset(-3_isize)).Node,
+                                (*yyvsp.offset(-1_isize)).Node,
+                                0,
+                            );
+                            if yyval.Node < 0 {
+                                current_block = 4830776507462815627;
+                            } else {
+                                current_block = 17353983478346836848;
+                            }
+                        }
+                        28 => {
+                            yyval.Node = New_Deref(
+                                lParse,
+                                (*yyvsp.offset(-(11 as c_int) as isize)).Node,
+                                5 as c_int,
+                                (*yyvsp.offset(-(9 as c_int) as isize)).Node,
+                                (*yyvsp.offset(-(7 as c_int) as isize)).Node,
+                                (*yyvsp.offset(-(5))).Node,
+                                (*yyvsp.offset(-3_isize)).Node,
+                                (*yyvsp.offset(-1_isize)).Node,
+                            );
+                            if yyval.Node < 0 {
+                                current_block = 4830776507462815627;
+                            } else {
+                                current_block = 17353983478346836848;
+                            }
+                        }
+                        29 => {
+                            yyval.Node = New_Unary(
+                                lParse,
+                                fits_parser_yytokentype::BITSTR as c_int,
+                                fits_parser_yytokentype::NOT as c_int,
+                                (*yyvsp.offset(0)).Node,
+                            );
+                            if yyval.Node < 0 {
+                                current_block = 4830776507462815627;
+                            } else {
+                                current_block = 17353983478346836848;
+                            }
+                        }
+                        30 => {
+                            yyval.Node = (*yyvsp.offset(-1_isize)).Node;
+                            current_block = 17353983478346836848;
+                        }
+                        31 => {
+                            yyval.Node = New_Const(
+                                lParse,
+                                fits_parser_yytokentype::LONG as c_int,
+                                &mut (*yyvsp.offset(0)).lng as *mut c_long as *mut c_void,
+                                ::core::mem::size_of::<c_long>() as c_ulong as c_long,
+                            );
+                            if yyval.Node < 0 {
+                                current_block = 4830776507462815627;
+                            } else {
+                                current_block = 17353983478346836848;
+                            }
+                        }
+                        32 => {
+                            yyval.Node = New_Const(
+                                lParse,
+                                fits_parser_yytokentype::DOUBLE as c_int,
+                                &mut (*yyvsp.offset(0)).dbl as *mut c_double as *mut c_void,
+                                ::core::mem::size_of::<c_double>() as c_ulong as c_long,
+                            );
+                            if yyval.Node < 0 {
+                                current_block = 4830776507462815627;
+                            } else {
+                                current_block = 17353983478346836848;
+                            }
+                        }
+                        33 => {
+                            yyval.Node = New_Column(lParse, (*yyvsp.offset(0)).lng as c_int);
+                            if yyval.Node < 0 {
+                                current_block = 4830776507462815627;
+                            } else {
+                                current_block = 17353983478346836848;
+                            }
+                        }
+                        34 => {
+                            if (*((*lParse).Nodes).offset((*yyvsp.offset(-1_isize)).Node as isize))
+                                .ntype
+                                != fits_parser_yytokentype::LONG as c_int
+                                || (*((*lParse).Nodes)
+                                    .offset((*yyvsp.offset(-1_isize)).Node as isize))
+                                .operation
+                                    != -(1000 as c_int)
+                            {
+                                fits_parser_yyerror(
+                                    scanner,
+                                    lParse,
+                                    b"Offset argument must be a constant integer\0" as *const u8
+                                        as *const c_char
+                                        as *mut c_char,
+                                );
+                                current_block = 4830776507462815627;
+                            } else {
+                                yyval.Node = New_Offset(
+                                    lParse,
+                                    (*yyvsp.offset(-3_isize)).lng as c_int,
+                                    (*yyvsp.offset(-1_isize)).Node,
+                                );
+                                if yyval.Node < 0 {
+                                    current_block = 4830776507462815627;
+                                } else {
+                                    current_block = 17353983478346836848;
+                                }
+                            }
+                        }
+                        35 => {
+                            yyval.Node = New_Func(
+                                lParse,
+                                fits_parser_yytokentype::LONG as c_int,
+                                row_fct,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                            );
+                            current_block = 17353983478346836848;
+                        }
+                        36 => {
+                            yyval.Node = New_Func(
+                                lParse,
+                                fits_parser_yytokentype::LONG as c_int,
+                                null_fct,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                            );
+                            current_block = 17353983478346836848;
+                        }
+                        37 => {
+                            if (*((*lParse).Nodes).offset((*yyvsp.offset(-2_isize)).Node as isize))
+                                .ntype
+                                > (*((*lParse).Nodes).offset((*yyvsp.offset(0)).Node as isize))
+                                    .ntype
+                            {
+                                (*yyvsp.offset(0)).Node = New_Unary(
+                                    lParse,
+                                    (*((*lParse).Nodes)
+                                        .offset((*yyvsp.offset(-2_isize)).Node as isize))
+                                    .ntype,
+                                    0,
+                                    (*yyvsp.offset(0)).Node,
+                                );
+                            } else if (*((*lParse).Nodes)
+                                .offset((*yyvsp.offset(-2_isize)).Node as isize))
+                            .ntype
+                                < (*((*lParse).Nodes).offset((*yyvsp.offset(0)).Node as isize))
+                                    .ntype
+                            {
+                                (*yyvsp.offset(-2_isize)).Node = New_Unary(
+                                    lParse,
+                                    (*((*lParse).Nodes).offset((*yyvsp.offset(0)).Node as isize))
+                                        .ntype,
+                                    0,
+                                    (*yyvsp.offset(-2_isize)).Node,
+                                );
+                            }
+                            yyval.Node = New_BinOp(
+                                lParse,
+                                (*((*lParse).Nodes)
+                                    .offset((*yyvsp.offset(-2_isize)).Node as isize))
+                                .ntype,
+                                (*yyvsp.offset(-2_isize)).Node,
+                                '%' as i32,
+                                (*yyvsp.offset(0)).Node,
+                            );
+                            if yyval.Node < 0 {
+                                current_block = 4830776507462815627;
+                            } else {
+                                current_block = 17353983478346836848;
+                            }
+                        }
+                        38 => {
+                            if (*((*lParse).Nodes).offset((*yyvsp.offset(-2_isize)).Node as isize))
+                                .ntype
+                                > (*((*lParse).Nodes).offset((*yyvsp.offset(0)).Node as isize))
+                                    .ntype
+                            {
+                                (*yyvsp.offset(0)).Node = New_Unary(
+                                    lParse,
+                                    (*((*lParse).Nodes)
+                                        .offset((*yyvsp.offset(-2_isize)).Node as isize))
+                                    .ntype,
+                                    0,
+                                    (*yyvsp.offset(0)).Node,
+                                );
+                            } else if (*((*lParse).Nodes)
+                                .offset((*yyvsp.offset(-2_isize)).Node as isize))
+                            .ntype
+                                < (*((*lParse).Nodes).offset((*yyvsp.offset(0)).Node as isize))
+                                    .ntype
+                            {
+                                (*yyvsp.offset(-2_isize)).Node = New_Unary(
+                                    lParse,
+                                    (*((*lParse).Nodes).offset((*yyvsp.offset(0)).Node as isize))
+                                        .ntype,
+                                    0,
+                                    (*yyvsp.offset(-2_isize)).Node,
+                                );
+                            }
+                            yyval.Node = New_BinOp(
+                                lParse,
+                                (*((*lParse).Nodes)
+                                    .offset((*yyvsp.offset(-2_isize)).Node as isize))
+                                .ntype,
+                                (*yyvsp.offset(-2_isize)).Node,
+                                '+' as i32,
+                                (*yyvsp.offset(0)).Node,
+                            );
+                            if yyval.Node < 0 {
+                                current_block = 4830776507462815627;
+                            } else {
+                                current_block = 17353983478346836848;
+                            }
+                        }
+                        39 => {
+                            if (*((*lParse).Nodes).offset((*yyvsp.offset(-2_isize)).Node as isize))
+                                .ntype
+                                > (*((*lParse).Nodes).offset((*yyvsp.offset(0)).Node as isize))
+                                    .ntype
+                            {
+                                (*yyvsp.offset(0)).Node = New_Unary(
+                                    lParse,
+                                    (*((*lParse).Nodes)
+                                        .offset((*yyvsp.offset(-2_isize)).Node as isize))
+                                    .ntype,
+                                    0,
+                                    (*yyvsp.offset(0)).Node,
+                                );
+                            } else if (*((*lParse).Nodes)
+                                .offset((*yyvsp.offset(-2_isize)).Node as isize))
+                            .ntype
+                                < (*((*lParse).Nodes).offset((*yyvsp.offset(0)).Node as isize))
+                                    .ntype
+                            {
+                                (*yyvsp.offset(-2_isize)).Node = New_Unary(
+                                    lParse,
+                                    (*((*lParse).Nodes).offset((*yyvsp.offset(0)).Node as isize))
+                                        .ntype,
+                                    0,
+                                    (*yyvsp.offset(-2_isize)).Node,
+                                );
+                            }
+                            yyval.Node = New_BinOp(
+                                lParse,
+                                (*((*lParse).Nodes)
+                                    .offset((*yyvsp.offset(-2_isize)).Node as isize))
+                                .ntype,
+                                (*yyvsp.offset(-2_isize)).Node,
+                                '-' as i32,
+                                (*yyvsp.offset(0)).Node,
+                            );
+                            if yyval.Node < 0 {
+                                current_block = 4830776507462815627;
+                            } else {
+                                current_block = 17353983478346836848;
+                            }
+                        }
+                        40 => {
+                            if (*((*lParse).Nodes).offset((*yyvsp.offset(-2_isize)).Node as isize))
+                                .ntype
+                                > (*((*lParse).Nodes).offset((*yyvsp.offset(0)).Node as isize))
+                                    .ntype
+                            {
+                                (*yyvsp.offset(0)).Node = New_Unary(
+                                    lParse,
+                                    (*((*lParse).Nodes)
+                                        .offset((*yyvsp.offset(-2_isize)).Node as isize))
+                                    .ntype,
+                                    0,
+                                    (*yyvsp.offset(0)).Node,
+                                );
+                            } else if (*((*lParse).Nodes)
+                                .offset((*yyvsp.offset(-2_isize)).Node as isize))
+                            .ntype
+                                < (*((*lParse).Nodes).offset((*yyvsp.offset(0)).Node as isize))
+                                    .ntype
+                            {
+                                (*yyvsp.offset(-2_isize)).Node = New_Unary(
+                                    lParse,
+                                    (*((*lParse).Nodes).offset((*yyvsp.offset(0)).Node as isize))
+                                        .ntype,
+                                    0,
+                                    (*yyvsp.offset(-2_isize)).Node,
+                                );
+                            }
+                            yyval.Node = New_BinOp(
+                                lParse,
+                                (*((*lParse).Nodes)
+                                    .offset((*yyvsp.offset(-2_isize)).Node as isize))
+                                .ntype,
+                                (*yyvsp.offset(-2_isize)).Node,
+                                '*' as i32,
+                                (*yyvsp.offset(0)).Node,
+                            );
+                            if yyval.Node < 0 {
+                                current_block = 4830776507462815627;
+                            } else {
+                                current_block = 17353983478346836848;
+                            }
+                        }
+                        41 => {
+                            if (*((*lParse).Nodes).offset((*yyvsp.offset(-2_isize)).Node as isize))
+                                .ntype
+                                > (*((*lParse).Nodes).offset((*yyvsp.offset(0)).Node as isize))
+                                    .ntype
+                            {
+                                (*yyvsp.offset(0)).Node = New_Unary(
+                                    lParse,
+                                    (*((*lParse).Nodes)
+                                        .offset((*yyvsp.offset(-2_isize)).Node as isize))
+                                    .ntype,
+                                    0,
+                                    (*yyvsp.offset(0)).Node,
+                                );
+                            } else if (*((*lParse).Nodes)
+                                .offset((*yyvsp.offset(-2_isize)).Node as isize))
+                            .ntype
+                                < (*((*lParse).Nodes).offset((*yyvsp.offset(0)).Node as isize))
+                                    .ntype
+                            {
+                                (*yyvsp.offset(-2_isize)).Node = New_Unary(
+                                    lParse,
+                                    (*((*lParse).Nodes).offset((*yyvsp.offset(0)).Node as isize))
+                                        .ntype,
+                                    0,
+                                    (*yyvsp.offset(-2_isize)).Node,
+                                );
+                            }
+                            yyval.Node = New_BinOp(
+                                lParse,
+                                (*((*lParse).Nodes)
+                                    .offset((*yyvsp.offset(-2_isize)).Node as isize))
+                                .ntype,
+                                (*yyvsp.offset(-2_isize)).Node,
+                                '/' as i32,
+                                (*yyvsp.offset(0)).Node,
+                            );
+                            if yyval.Node < 0 {
+                                current_block = 4830776507462815627;
+                            } else {
+                                current_block = 17353983478346836848;
+                            }
+                        }
+                        42 => {
+                            if (*((*lParse).Nodes).offset((*yyvsp.offset(-2_isize)).Node as isize))
+                                .ntype
+                                != fits_parser_yytokentype::LONG as c_int
+                                || (*((*lParse).Nodes).offset((*yyvsp.offset(0)).Node as isize))
+                                    .ntype
+                                    != fits_parser_yytokentype::LONG as c_int
+                            {
+                                fits_parser_yyerror(
+                                scanner,
+                                lParse,
+                                b"Bitwise operations with incompatible types; only (bit OP bit) and (int OP int) are allowed\0"
+                                    as *const u8 as *const c_char
+                                    as *mut c_char,
+                            );
+                                current_block = 4830776507462815627;
+                            } else {
+                                yyval.Node = New_BinOp(
+                                    lParse,
+                                    (*((*lParse).Nodes)
+                                        .offset((*yyvsp.offset(-2_isize)).Node as isize))
+                                    .ntype,
+                                    (*yyvsp.offset(-2_isize)).Node,
+                                    '&' as i32,
+                                    (*yyvsp.offset(0)).Node,
+                                );
+                                current_block = 17353983478346836848;
+                            }
+                        }
+                        43 => {
+                            if (*((*lParse).Nodes).offset((*yyvsp.offset(-2_isize)).Node as isize))
+                                .ntype
+                                != fits_parser_yytokentype::LONG as c_int
+                                || (*((*lParse).Nodes).offset((*yyvsp.offset(0)).Node as isize))
+                                    .ntype
+                                    != fits_parser_yytokentype::LONG as c_int
+                            {
+                                fits_parser_yyerror(
+                                scanner,
+                                lParse,
+                                b"Bitwise operations with incompatible types; only (bit OP bit) and (int OP int) are allowed\0"
+                                    as *const u8 as *const c_char
+                                    as *mut c_char,
+                            );
+                                current_block = 4830776507462815627;
+                            } else {
+                                yyval.Node = New_BinOp(
+                                    lParse,
+                                    (*((*lParse).Nodes)
+                                        .offset((*yyvsp.offset(-2_isize)).Node as isize))
+                                    .ntype,
+                                    (*yyvsp.offset(-2_isize)).Node,
+                                    '|' as i32,
+                                    (*yyvsp.offset(0)).Node,
+                                );
+                                current_block = 17353983478346836848;
+                            }
+                        }
+                        44 => {
+                            if (*((*lParse).Nodes).offset((*yyvsp.offset(-2_isize)).Node as isize))
+                                .ntype
+                                != fits_parser_yytokentype::LONG as c_int
+                                || (*((*lParse).Nodes).offset((*yyvsp.offset(0)).Node as isize))
+                                    .ntype
+                                    != fits_parser_yytokentype::LONG as c_int
+                            {
+                                fits_parser_yyerror(
+                                scanner,
+                                lParse,
+                                b"Bitwise operations with incompatible types; only (bit OP bit) and (int OP int) are allowed\0"
+                                    as *const u8 as *const c_char
+                                    as *mut c_char,
+                            );
+                                current_block = 4830776507462815627;
+                            } else {
+                                yyval.Node = New_BinOp(
+                                    lParse,
+                                    (*((*lParse).Nodes)
+                                        .offset((*yyvsp.offset(-2_isize)).Node as isize))
+                                    .ntype,
+                                    (*yyvsp.offset(-2_isize)).Node,
+                                    '^' as i32,
+                                    (*yyvsp.offset(0)).Node,
+                                );
+                                current_block = 17353983478346836848;
+                            }
+                        }
+                        45 => {
+                            if (*((*lParse).Nodes).offset((*yyvsp.offset(-2_isize)).Node as isize))
+                                .ntype
+                                > (*((*lParse).Nodes).offset((*yyvsp.offset(0)).Node as isize))
+                                    .ntype
+                            {
+                                (*yyvsp.offset(0)).Node = New_Unary(
+                                    lParse,
+                                    (*((*lParse).Nodes)
+                                        .offset((*yyvsp.offset(-2_isize)).Node as isize))
+                                    .ntype,
+                                    0,
+                                    (*yyvsp.offset(0)).Node,
+                                );
+                            } else if (*((*lParse).Nodes)
+                                .offset((*yyvsp.offset(-2_isize)).Node as isize))
+                            .ntype
+                                < (*((*lParse).Nodes).offset((*yyvsp.offset(0)).Node as isize))
+                                    .ntype
+                            {
+                                (*yyvsp.offset(-2_isize)).Node = New_Unary(
+                                    lParse,
+                                    (*((*lParse).Nodes).offset((*yyvsp.offset(0)).Node as isize))
+                                        .ntype,
+                                    0,
+                                    (*yyvsp.offset(-2_isize)).Node,
+                                );
+                            }
+                            yyval.Node = New_BinOp(
+                                lParse,
+                                (*((*lParse).Nodes)
+                                    .offset((*yyvsp.offset(-2_isize)).Node as isize))
+                                .ntype,
+                                (*yyvsp.offset(-2_isize)).Node,
+                                fits_parser_yytokentype::POWER as c_int,
+                                (*yyvsp.offset(0)).Node,
+                            );
+                            if yyval.Node < 0 {
+                                current_block = 4830776507462815627;
+                            } else {
+                                current_block = 17353983478346836848;
+                            }
+                        }
+                        46 => {
+                            yyval.Node = (*yyvsp.offset(0)).Node;
+                            current_block = 17353983478346836848;
+                        }
+                        47 => {
+                            yyval.Node = New_Unary(
+                                lParse,
+                                (*((*lParse).Nodes).offset((*yyvsp.offset(0)).Node as isize)).ntype,
+                                fits_parser_yytokentype::UMINUS as c_int,
+                                (*yyvsp.offset(0)).Node,
+                            );
+                            if yyval.Node < 0 {
+                                current_block = 4830776507462815627;
+                            } else {
+                                current_block = 17353983478346836848;
+                            }
+                        }
+                        48 => {
+                            yyval.Node = (*yyvsp.offset(-1_isize)).Node;
+                            current_block = 17353983478346836848;
+                        }
+                        49 => {
+                            (*yyvsp.offset(0)).Node = New_Unary(
+                                lParse,
+                                (*((*lParse).Nodes)
+                                    .offset((*yyvsp.offset(-2_isize)).Node as isize))
+                                .ntype,
+                                0,
+                                (*yyvsp.offset(0)).Node,
+                            );
+                            yyval.Node = New_BinOp(
+                                lParse,
+                                (*((*lParse).Nodes)
+                                    .offset((*yyvsp.offset(-2_isize)).Node as isize))
+                                .ntype,
+                                (*yyvsp.offset(-2_isize)).Node,
+                                '*' as i32,
+                                (*yyvsp.offset(0)).Node,
+                            );
+                            if yyval.Node < 0 {
+                                current_block = 4830776507462815627;
+                            } else {
+                                current_block = 17353983478346836848;
+                            }
+                        }
+                        50 => {
+                            (*yyvsp.offset(-2_isize)).Node = New_Unary(
+                                lParse,
+                                (*((*lParse).Nodes).offset((*yyvsp.offset(0)).Node as isize)).ntype,
+                                0,
+                                (*yyvsp.offset(-2_isize)).Node,
+                            );
+                            yyval.Node = New_BinOp(
+                                lParse,
+                                (*((*lParse).Nodes).offset((*yyvsp.offset(0)).Node as isize)).ntype,
+                                (*yyvsp.offset(-2_isize)).Node,
+                                '*' as i32,
+                                (*yyvsp.offset(0)).Node,
+                            );
+                            if yyval.Node < 0 {
+                                current_block = 4830776507462815627;
+                            } else {
+                                current_block = 17353983478346836848;
+                            }
+                        }
+                        51 => {
+                            if (*((*lParse).Nodes).offset((*yyvsp.offset(-2_isize)).Node as isize))
+                                .ntype
+                                > (*((*lParse).Nodes).offset((*yyvsp.offset(0)).Node as isize))
+                                    .ntype
+                            {
+                                (*yyvsp.offset(0)).Node = New_Unary(
+                                    lParse,
+                                    (*((*lParse).Nodes)
+                                        .offset((*yyvsp.offset(-2_isize)).Node as isize))
+                                    .ntype,
+                                    0,
+                                    (*yyvsp.offset(0)).Node,
+                                );
+                            } else if (*((*lParse).Nodes)
+                                .offset((*yyvsp.offset(-2_isize)).Node as isize))
+                            .ntype
+                                < (*((*lParse).Nodes).offset((*yyvsp.offset(0)).Node as isize))
+                                    .ntype
+                            {
+                                (*yyvsp.offset(-2_isize)).Node = New_Unary(
+                                    lParse,
+                                    (*((*lParse).Nodes).offset((*yyvsp.offset(0)).Node as isize))
+                                        .ntype,
+                                    0,
+                                    (*yyvsp.offset(-2_isize)).Node,
+                                );
+                            }
+                            if Test_Dims(
+                                lParse,
+                                (*yyvsp.offset(-2_isize)).Node,
+                                (*yyvsp.offset(0)).Node,
+                            ) == 0
+                            {
+                                fits_parser_yyerror(
+                                    scanner,
+                                    lParse,
+                                    b"Incompatible dimensions in '?:' arguments\0" as *const u8
+                                        as *const c_char
+                                        as *mut c_char,
+                                );
+                                current_block = 4830776507462815627;
+                            } else {
+                                yyval.Node = New_Func(
+                                    lParse,
+                                    0,
+                                    ifthenelse_fct,
+                                    3 as c_int,
+                                    (*yyvsp.offset(-2_isize)).Node,
+                                    (*yyvsp.offset(0)).Node,
+                                    (*yyvsp.offset(-4_isize)).Node,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                );
+                                if yyval.Node < 0 {
+                                    current_block = 4830776507462815627;
+                                } else {
+                                    if (*((*lParse).Nodes)
+                                        .offset((*yyvsp.offset(-2_isize)).Node as isize))
+                                    .value
+                                    .nelem
+                                        < (*((*lParse).Nodes)
+                                            .offset((*yyvsp.offset(0)).Node as isize))
+                                        .value
+                                        .nelem
+                                    {
+                                        Copy_Dims(lParse, yyval.Node, (*yyvsp.offset(0)).Node);
+                                    }
+                                    (*((*lParse).Nodes)
+                                        .offset((*yyvsp.offset(-4_isize)).Node as isize))
+                                    .ntype = (*((*lParse).Nodes)
+                                        .offset((*yyvsp.offset(-2_isize)).Node as isize))
+                                    .ntype;
+                                    if Test_Dims(lParse, (*yyvsp.offset(-4_isize)).Node, yyval.Node)
+                                        == 0
+                                    {
+                                        fits_parser_yyerror(
+                                            scanner,
+                                            lParse,
+                                            b"Incompatible dimensions in '?:' condition\0"
+                                                as *const u8
+                                                as *const c_char
+                                                as *mut c_char,
+                                        );
+                                        current_block = 4830776507462815627;
+                                    } else {
+                                        (*((*lParse).Nodes)
+                                            .offset((*yyvsp.offset(-4_isize)).Node as isize))
+                                        .ntype = fits_parser_yytokentype::BOOLEAN as c_int;
+                                        if ((*((*lParse).Nodes).offset(yyval.Node as isize)).value)
+                                            .nelem
+                                            < (*((*lParse).Nodes)
+                                                .offset((*yyvsp.offset(-4_isize)).Node as isize))
+                                            .value
+                                            .nelem
+                                        {
+                                            Copy_Dims(
+                                                lParse,
+                                                yyval.Node,
+                                                (*yyvsp.offset(-4_isize)).Node,
+                                            );
+                                        }
+                                        current_block = 17353983478346836848;
+                                    }
+                                }
+                            }
+                        }
+                        52 => {
+                            if (*((*lParse).Nodes).offset((*yyvsp.offset(-2_isize)).Node as isize))
+                                .ntype
+                                > (*((*lParse).Nodes).offset((*yyvsp.offset(0)).Node as isize))
+                                    .ntype
+                            {
+                                (*yyvsp.offset(0)).Node = New_Unary(
+                                    lParse,
+                                    (*((*lParse).Nodes)
+                                        .offset((*yyvsp.offset(-2_isize)).Node as isize))
+                                    .ntype,
+                                    0,
+                                    (*yyvsp.offset(0)).Node,
+                                );
+                            } else if (*((*lParse).Nodes)
+                                .offset((*yyvsp.offset(-2_isize)).Node as isize))
+                            .ntype
+                                < (*((*lParse).Nodes).offset((*yyvsp.offset(0)).Node as isize))
+                                    .ntype
+                            {
+                                (*yyvsp.offset(-2_isize)).Node = New_Unary(
+                                    lParse,
+                                    (*((*lParse).Nodes).offset((*yyvsp.offset(0)).Node as isize))
+                                        .ntype,
+                                    0,
+                                    (*yyvsp.offset(-2_isize)).Node,
+                                );
+                            }
+                            if Test_Dims(
+                                lParse,
+                                (*yyvsp.offset(-2_isize)).Node,
+                                (*yyvsp.offset(0)).Node,
+                            ) == 0
+                            {
+                                fits_parser_yyerror(
+                                    scanner,
+                                    lParse,
+                                    b"Incompatible dimensions in '?:' arguments\0" as *const u8
+                                        as *const c_char
+                                        as *mut c_char,
+                                );
+                                current_block = 4830776507462815627;
+                            } else {
+                                yyval.Node = New_Func(
+                                    lParse,
+                                    0,
+                                    ifthenelse_fct,
+                                    3 as c_int,
+                                    (*yyvsp.offset(-2_isize)).Node,
+                                    (*yyvsp.offset(0)).Node,
+                                    (*yyvsp.offset(-4_isize)).Node,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                );
+                                if yyval.Node < 0 {
+                                    current_block = 4830776507462815627;
+                                } else {
+                                    if (*((*lParse).Nodes)
+                                        .offset((*yyvsp.offset(-2_isize)).Node as isize))
+                                    .value
+                                    .nelem
+                                        < (*((*lParse).Nodes)
+                                            .offset((*yyvsp.offset(0)).Node as isize))
+                                        .value
+                                        .nelem
+                                    {
+                                        Copy_Dims(lParse, yyval.Node, (*yyvsp.offset(0)).Node);
+                                    }
+                                    (*((*lParse).Nodes)
+                                        .offset((*yyvsp.offset(-4_isize)).Node as isize))
+                                    .ntype = (*((*lParse).Nodes)
+                                        .offset((*yyvsp.offset(-2_isize)).Node as isize))
+                                    .ntype;
+                                    if Test_Dims(lParse, (*yyvsp.offset(-4_isize)).Node, yyval.Node)
+                                        == 0
+                                    {
+                                        fits_parser_yyerror(
+                                            scanner,
+                                            lParse,
+                                            b"Incompatible dimensions in '?:' condition\0"
+                                                as *const u8
+                                                as *const c_char
+                                                as *mut c_char,
+                                        );
+                                        current_block = 4830776507462815627;
+                                    } else {
+                                        (*((*lParse).Nodes)
+                                            .offset((*yyvsp.offset(-4_isize)).Node as isize))
+                                        .ntype = fits_parser_yytokentype::BOOLEAN as c_int;
+                                        if ((*((*lParse).Nodes).offset(yyval.Node as isize)).value)
+                                            .nelem
+                                            < (*((*lParse).Nodes)
+                                                .offset((*yyvsp.offset(-4_isize)).Node as isize))
+                                            .value
+                                            .nelem
+                                        {
+                                            Copy_Dims(
+                                                lParse,
+                                                yyval.Node,
+                                                (*yyvsp.offset(-4_isize)).Node,
+                                            );
+                                        }
+                                        current_block = 17353983478346836848;
+                                    }
+                                }
+                            }
+                        }
+                        53 => {
+                            if (*((*lParse).Nodes).offset((*yyvsp.offset(-2_isize)).Node as isize))
+                                .ntype
+                                > (*((*lParse).Nodes).offset((*yyvsp.offset(0)).Node as isize))
+                                    .ntype
+                            {
+                                (*yyvsp.offset(0)).Node = New_Unary(
+                                    lParse,
+                                    (*((*lParse).Nodes)
+                                        .offset((*yyvsp.offset(-2_isize)).Node as isize))
+                                    .ntype,
+                                    0,
+                                    (*yyvsp.offset(0)).Node,
+                                );
+                            } else if (*((*lParse).Nodes)
+                                .offset((*yyvsp.offset(-2_isize)).Node as isize))
+                            .ntype
+                                < (*((*lParse).Nodes).offset((*yyvsp.offset(0)).Node as isize))
+                                    .ntype
+                            {
+                                (*yyvsp.offset(-2_isize)).Node = New_Unary(
+                                    lParse,
+                                    (*((*lParse).Nodes).offset((*yyvsp.offset(0)).Node as isize))
+                                        .ntype,
+                                    0,
+                                    (*yyvsp.offset(-2_isize)).Node,
+                                );
+                            }
+                            if Test_Dims(
+                                lParse,
+                                (*yyvsp.offset(-2_isize)).Node,
+                                (*yyvsp.offset(0)).Node,
+                            ) == 0
+                            {
+                                fits_parser_yyerror(
+                                    scanner,
+                                    lParse,
+                                    b"Incompatible dimensions in '?:' arguments\0" as *const u8
+                                        as *const c_char
+                                        as *mut c_char,
+                                );
+                                current_block = 4830776507462815627;
+                            } else {
+                                yyval.Node = New_Func(
+                                    lParse,
+                                    0,
+                                    ifthenelse_fct,
+                                    3 as c_int,
+                                    (*yyvsp.offset(-2_isize)).Node,
+                                    (*yyvsp.offset(0)).Node,
+                                    (*yyvsp.offset(-4_isize)).Node,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                );
+                                if yyval.Node < 0 {
+                                    current_block = 4830776507462815627;
+                                } else {
+                                    if (*((*lParse).Nodes)
+                                        .offset((*yyvsp.offset(-2_isize)).Node as isize))
+                                    .value
+                                    .nelem
+                                        < (*((*lParse).Nodes)
+                                            .offset((*yyvsp.offset(0)).Node as isize))
+                                        .value
+                                        .nelem
+                                    {
+                                        Copy_Dims(lParse, yyval.Node, (*yyvsp.offset(0)).Node);
+                                    }
+                                    (*((*lParse).Nodes)
+                                        .offset((*yyvsp.offset(-4_isize)).Node as isize))
+                                    .ntype = (*((*lParse).Nodes)
+                                        .offset((*yyvsp.offset(-2_isize)).Node as isize))
+                                    .ntype;
+                                    if Test_Dims(lParse, (*yyvsp.offset(-4_isize)).Node, yyval.Node)
+                                        == 0
+                                    {
+                                        fits_parser_yyerror(
+                                            scanner,
+                                            lParse,
+                                            b"Incompatible dimensions in '?:' condition\0"
+                                                as *const u8
+                                                as *const c_char
+                                                as *mut c_char,
+                                        );
+                                        current_block = 4830776507462815627;
+                                    } else {
+                                        (*((*lParse).Nodes)
+                                            .offset((*yyvsp.offset(-4_isize)).Node as isize))
+                                        .ntype = fits_parser_yytokentype::BOOLEAN as c_int;
+                                        if ((*((*lParse).Nodes).offset(yyval.Node as isize)).value)
+                                            .nelem
+                                            < (*((*lParse).Nodes)
+                                                .offset((*yyvsp.offset(-4_isize)).Node as isize))
+                                            .value
+                                            .nelem
+                                        {
+                                            Copy_Dims(
+                                                lParse,
+                                                yyval.Node,
+                                                (*yyvsp.offset(-4_isize)).Node,
+                                            );
+                                        }
+                                        current_block = 17353983478346836848;
+                                    }
+                                }
+                            }
+                        }
+                        54 => {
+                            if (if ((*yyvsp.offset(-1_isize)).astr[0] as c_int)
+                                < (*::core::mem::transmute::<&[u8; 8], &[c_char; 8]>(b"RANDOM(\0"))
+                                    [0] as c_int
+                            {
+                                -(1)
+                            } else if (*yyvsp.offset(-1_isize)).astr[0] as c_int
+                                > (*::core::mem::transmute::<&[u8; 8], &[c_char; 8]>(b"RANDOM(\0"))
+                                    [0] as c_int
+                            {
+                                1
+                            } else {
+                                strcmp(
+                                    ((*yyvsp.offset(-1_isize)).astr).as_mut_ptr(),
+                                    b"RANDOM(\0" as *const u8 as *const c_char,
+                                )
+                            }) == 0
+                            {
+                                yyval.Node = New_Func(
+                                    lParse,
+                                    fits_parser_yytokentype::DOUBLE as c_int,
+                                    rnd_fct,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                );
+                                current_block = 1297461190301222800;
+                            } else if (if ((*yyvsp.offset(-1_isize)).astr[0] as c_int)
+                                < (*::core::mem::transmute::<&[u8; 9], &[c_char; 9]>(b"RANDOMN(\0"))
+                                    [0] as c_int
+                            {
+                                -(1)
+                            } else if (*yyvsp.offset(-1_isize)).astr[0] as c_int
+                                > (*::core::mem::transmute::<&[u8; 9], &[c_char; 9]>(b"RANDOMN(\0"))
+                                    [0] as c_int
+                            {
+                                1
+                            } else {
+                                strcmp(
+                                    ((*yyvsp.offset(-1_isize)).astr).as_mut_ptr(),
+                                    b"RANDOMN(\0" as *const u8 as *const c_char,
+                                )
+                            }) == 0
+                            {
+                                yyval.Node = New_Func(
+                                    lParse,
+                                    fits_parser_yytokentype::DOUBLE as c_int,
+                                    gasrnd_fct,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                );
+                                current_block = 1297461190301222800;
+                            } else {
+                                fits_parser_yyerror(
+                                    scanner,
+                                    lParse,
+                                    b"Function() not supported\0" as *const u8 as *const c_char
+                                        as *mut c_char,
+                                );
+                                current_block = 4830776507462815627;
+                            }
+                            match current_block {
+                                4830776507462815627 => {}
+                                _ => {
+                                    if yyval.Node < 0 {
+                                        current_block = 4830776507462815627;
+                                    } else {
+                                        current_block = 17353983478346836848;
+                                    }
+                                }
+                            }
+                        }
+                        55 => {
+                            if (if ((*yyvsp.offset(-2_isize)).astr[0] as c_int)
+                                < (*::core::mem::transmute::<&[u8; 5], &[c_char; 5]>(b"SUM(\0"))[0]
+                                    as c_int
+                            {
+                                -(1)
+                            } else if (*yyvsp.offset(-2_isize)).astr[0] as c_int
+                                > (*::core::mem::transmute::<&[u8; 5], &[c_char; 5]>(b"SUM(\0"))[0]
+                                    as c_int
+                            {
+                                1
+                            } else {
+                                strcmp(
+                                    ((*yyvsp.offset(-2_isize)).astr).as_mut_ptr(),
+                                    b"SUM(\0" as *const u8 as *const c_char,
+                                )
+                            }) == 0
+                            {
+                                yyval.Node = New_Func(
+                                    lParse,
+                                    fits_parser_yytokentype::LONG as c_int,
+                                    sum_fct,
+                                    1,
+                                    (*yyvsp.offset(-1_isize)).Node,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                );
+                                current_block = 10848699504537784535;
+                            } else if (if ((*yyvsp.offset(-2_isize)).astr[0] as c_int)
+                                < (*::core::mem::transmute::<&[u8; 7], &[c_char; 7]>(b"NELEM(\0"))
+                                    [0] as c_int
+                            {
+                                -(1)
+                            } else if (*yyvsp.offset(-2_isize)).astr[0] as c_int
+                                > (*::core::mem::transmute::<&[u8; 7], &[c_char; 7]>(b"NELEM(\0"))
+                                    [0] as c_int
+                            {
+                                1
+                            } else {
+                                strcmp(
+                                    ((*yyvsp.offset(-2_isize)).astr).as_mut_ptr(),
+                                    b"NELEM(\0" as *const u8 as *const c_char,
+                                )
+                            }) == 0
+                            {
+                                yyval.Node = New_Const(
+                                    lParse,
+                                    fits_parser_yytokentype::LONG as c_int,
+                                    &mut (*((*lParse).Nodes)
+                                        .offset((*yyvsp.offset(-1_isize)).Node as isize))
+                                    .value
+                                    .nelem as *mut c_long
+                                        as *mut c_void,
+                                    ::core::mem::size_of::<c_long>() as c_ulong as c_long,
+                                );
+                                current_block = 10848699504537784535;
+                            } else if (if ((*yyvsp.offset(-2_isize)).astr[0] as c_int)
+                                < (*::core::mem::transmute::<&[u8; 7], &[c_char; 7]>(b"ACCUM(\0"))
+                                    [0] as c_int
+                            {
+                                -(1)
+                            } else if (*yyvsp.offset(-2_isize)).astr[0] as c_int
+                                > (*::core::mem::transmute::<&[u8; 7], &[c_char; 7]>(b"ACCUM(\0"))
+                                    [0] as c_int
+                            {
+                                1
+                            } else {
+                                strcmp(
+                                    ((*yyvsp.offset(-2_isize)).astr).as_mut_ptr(),
+                                    b"ACCUM(\0" as *const u8 as *const c_char,
+                                )
+                            }) == 0
+                            {
+                                let mut zero: c_long = 0;
+                                yyval.Node = New_BinOp(
+                                    lParse,
+                                    fits_parser_yytokentype::LONG as c_int,
+                                    (*yyvsp.offset(-1_isize)).Node,
+                                    fits_parser_yytokentype::ACCUM as c_int,
+                                    New_Const(
+                                        lParse,
+                                        fits_parser_yytokentype::LONG as c_int,
+                                        &mut zero as *mut c_long as *mut c_void,
+                                        ::core::mem::size_of::<c_long>() as c_ulong as c_long,
+                                    ),
+                                );
+                                current_block = 10848699504537784535;
+                            } else {
+                                fits_parser_yyerror(
+                                    scanner,
+                                    lParse,
+                                    b"Function(bool) not supported\0" as *const u8 as *const c_char
+                                        as *mut c_char,
+                                );
+                                current_block = 4830776507462815627;
+                            }
+                            match current_block {
+                                4830776507462815627 => {}
+                                _ => {
+                                    if yyval.Node < 0 {
+                                        current_block = 4830776507462815627;
+                                    } else {
+                                        current_block = 17353983478346836848;
+                                    }
+                                }
+                            }
+                        }
+                        56 => {
+                            if (if ((*yyvsp.offset(-4_isize)).astr[0] as c_int)
+                                < (*::core::mem::transmute::<&[u8; 10], &[c_char; 10]>(
+                                    b"AXISELEM(\0",
+                                ))[0] as c_int
+                            {
+                                -(1)
+                            } else if (*yyvsp.offset(-4_isize)).astr[0] as c_int
+                                > (*::core::mem::transmute::<&[u8; 10], &[c_char; 10]>(
+                                    b"AXISELEM(\0",
+                                ))[0] as c_int
+                            {
+                                1
+                            } else {
+                                strcmp(
+                                    ((*yyvsp.offset(-4_isize)).astr).as_mut_ptr(),
+                                    b"AXISELEM(\0" as *const u8 as *const c_char,
+                                )
+                            }) == 0
+                            {
+                                if (*((*lParse).Nodes)
+                                    .offset((*yyvsp.offset(-1_isize)).Node as isize))
+                                .operation
+                                    != -(1000 as c_int)
+                                    || (*((*lParse).Nodes)
+                                        .offset((*yyvsp.offset(-1_isize)).Node as isize))
+                                    .value
+                                    .nelem
+                                        != 1
+                                {
+                                    fits_parser_yyerror(
+                                        scanner,
+                                        lParse,
+                                        b"AXISELEM second argument must be a scalar constant\0"
+                                            as *const u8
+                                            as *const c_char
+                                            as *mut c_char,
+                                    );
+                                    current_block = 4830776507462815627;
+                                } else if (*((*lParse).Nodes)
+                                    .offset((*yyvsp.offset(-3_isize)).Node as isize))
+                                .operation
+                                    == -(1000 as c_int)
+                                {
+                                    let mut one: c_long = 1;
+                                    yyval.Node = New_Const(
+                                        lParse,
+                                        fits_parser_yytokentype::LONG as c_int,
+                                        &mut one as *mut c_long as *mut c_void,
+                                        ::core::mem::size_of::<c_long>() as c_ulong as c_long,
+                                    );
+                                    current_block = 13755523488868872559;
+                                } else {
+                                    if (*((*lParse).Nodes)
+                                        .offset((*yyvsp.offset(-1_isize)).Node as isize))
+                                    .ntype
+                                        != fits_parser_yytokentype::LONG as c_int
+                                    {
+                                        (*yyvsp.offset(-1_isize)).Node = New_Unary(
+                                            lParse,
+                                            fits_parser_yytokentype::LONG as c_int,
+                                            0,
+                                            (*yyvsp.offset(-1_isize)).Node,
+                                        );
+                                    }
+                                    yyval.Node = New_Func(
+                                        lParse,
+                                        0,
+                                        axiselem_fct,
+                                        2 as c_int,
+                                        (*yyvsp.offset(-3_isize)).Node,
+                                        (*yyvsp.offset(-1_isize)).Node,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                    );
+                                    if yyval.Node < 0 {
+                                        current_block = 4830776507462815627;
+                                    } else {
+                                        (*((*lParse).Nodes).offset(yyval.Node as isize)).ntype =
+                                            fits_parser_yytokentype::LONG as c_int;
+                                        current_block = 13755523488868872559;
+                                    }
+                                }
+                            } else if (if ((*yyvsp.offset(-4_isize)).astr[0] as c_int)
+                                < (*::core::mem::transmute::<&[u8; 7], &[c_char; 7]>(b"NAXES(\0"))
+                                    [0] as c_int
+                            {
+                                -(1)
+                            } else if (*yyvsp.offset(-4_isize)).astr[0] as c_int
+                                > (*::core::mem::transmute::<&[u8; 7], &[c_char; 7]>(b"NAXES(\0"))
+                                    [0] as c_int
+                            {
+                                1
+                            } else {
+                                strcmp(
+                                    ((*yyvsp.offset(-4_isize)).astr).as_mut_ptr(),
+                                    b"NAXES(\0" as *const u8 as *const c_char,
+                                )
+                            }) == 0
+                            {
+                                if (*((*lParse).Nodes)
+                                    .offset((*yyvsp.offset(-1_isize)).Node as isize))
+                                .operation
+                                    != -(1000 as c_int)
+                                    || (*((*lParse).Nodes)
+                                        .offset((*yyvsp.offset(-1_isize)).Node as isize))
+                                    .value
+                                    .nelem
+                                        != 1
+                                {
+                                    fits_parser_yyerror(
+                                        scanner,
+                                        lParse,
+                                        b"NAXES second argument must be a scalar constant\0"
+                                            as *const u8
+                                            as *const c_char
+                                            as *mut c_char,
+                                    );
+                                    current_block = 4830776507462815627;
+                                } else if (*((*lParse).Nodes)
+                                    .offset((*yyvsp.offset(-3_isize)).Node as isize))
+                                .operation
+                                    == -(1000 as c_int)
+                                {
+                                    let mut one_0: c_long = 1;
+                                    yyval.Node = New_Const(
+                                        lParse,
+                                        fits_parser_yytokentype::LONG as c_int,
+                                        &mut one_0 as *mut c_long as *mut c_void,
+                                        ::core::mem::size_of::<c_long>() as c_ulong as c_long,
+                                    );
+                                    current_block = 13755523488868872559;
+                                } else {
+                                    let mut iaxis: c_long = 0;
+                                    let mut naxis: c_int = 0;
+                                    if (*((*lParse).Nodes)
+                                        .offset((*yyvsp.offset(-1_isize)).Node as isize))
+                                    .ntype
+                                        != fits_parser_yytokentype::LONG as c_int
+                                    {
+                                        (*yyvsp.offset(-1_isize)).Node = New_Unary(
+                                            lParse,
+                                            fits_parser_yytokentype::LONG as c_int,
+                                            0,
+                                            (*yyvsp.offset(-1_isize)).Node,
+                                        );
+                                    }
+                                    iaxis = (*((*lParse).Nodes)
+                                        .offset((*yyvsp.offset(-1_isize)).Node as isize))
+                                    .value
+                                    .data
+                                    .lng;
+                                    naxis = (*((*lParse).Nodes)
+                                        .offset((*yyvsp.offset(-3_isize)).Node as isize))
+                                    .value
+                                    .naxis;
+                                    if iaxis == 0 {
+                                        iaxis = naxis as c_long;
+                                    } else if iaxis <= naxis as c_long {
+                                        iaxis = (*((*lParse).Nodes)
+                                            .offset((*yyvsp.offset(-3_isize)).Node as isize))
+                                        .value
+                                        .naxes[(iaxis - 1) as usize];
+                                    } else {
+                                        iaxis = 1;
+                                    }
+                                    yyval.Node = New_Const(
+                                        lParse,
+                                        fits_parser_yytokentype::LONG as c_int,
+                                        &mut iaxis as *mut c_long as *mut c_void,
+                                        ::core::mem::size_of::<c_long>() as c_ulong as c_long,
+                                    );
+                                    if yyval.Node < 0 {
+                                        current_block = 4830776507462815627;
+                                    } else {
+                                        current_block = 13755523488868872559;
+                                    }
+                                }
+                            } else if (if ((*yyvsp.offset(-4_isize)).astr[0] as c_int)
+                                < (*::core::mem::transmute::<&[u8; 7], &[c_char; 7]>(b"ARRAY(\0"))
+                                    [0] as c_int
+                            {
+                                -(1)
+                            } else if (*yyvsp.offset(-4_isize)).astr[0] as c_int
+                                > (*::core::mem::transmute::<&[u8; 7], &[c_char; 7]>(b"ARRAY(\0"))
+                                    [0] as c_int
+                            {
+                                1
+                            } else {
+                                strcmp(
+                                    ((*yyvsp.offset(-4_isize)).astr).as_mut_ptr(),
+                                    b"ARRAY(\0" as *const u8 as *const c_char,
+                                )
+                            }) == 0
+                            {
+                                yyval.Node = New_Array(
+                                    lParse,
+                                    (*yyvsp.offset(-3_isize)).Node,
+                                    (*yyvsp.offset(-1_isize)).Node,
+                                );
+                                if yyval.Node < 0 {
+                                    current_block = 4830776507462815627;
+                                } else {
+                                    current_block = 13755523488868872559;
+                                }
+                            } else {
+                                fits_parser_yyerror(
+                                    scanner,
+                                    lParse,
+                                    b"Function(bool,expr) not supported\0" as *const u8
+                                        as *const c_char
+                                        as *mut c_char,
+                                );
+                                current_block = 4830776507462815627;
+                            }
+                            match current_block {
+                                4830776507462815627 => {}
+                                _ => {
+                                    if yyval.Node < 0 {
+                                        current_block = 4830776507462815627;
+                                    } else {
+                                        current_block = 17353983478346836848;
+                                    }
+                                }
+                            }
+                        }
+                        57 => {
+                            if (if ((*yyvsp.offset(-2_isize)).astr[0] as c_int)
+                                < (*::core::mem::transmute::<&[u8; 7], &[c_char; 7]>(b"NELEM(\0"))
+                                    [0] as c_int
+                            {
+                                -(1)
+                            } else if (*yyvsp.offset(-2_isize)).astr[0] as c_int
+                                > (*::core::mem::transmute::<&[u8; 7], &[c_char; 7]>(b"NELEM(\0"))
+                                    [0] as c_int
+                            {
+                                1
+                            } else {
+                                strcmp(
+                                    ((*yyvsp.offset(-2_isize)).astr).as_mut_ptr(),
+                                    b"NELEM(\0" as *const u8 as *const c_char,
+                                )
+                            }) == 0
+                            {
+                                yyval.Node = New_Const(
+                                    lParse,
+                                    fits_parser_yytokentype::LONG as c_int,
+                                    &mut (*((*lParse).Nodes)
+                                        .offset((*yyvsp.offset(-1_isize)).Node as isize))
+                                    .value
+                                    .nelem as *mut c_long
+                                        as *mut c_void,
+                                    ::core::mem::size_of::<c_long>() as c_ulong as c_long,
+                                );
+                                current_block = 15752106442776732052;
+                            } else if (if ((*yyvsp.offset(-2_isize)).astr[0] as c_int)
+                                < (*::core::mem::transmute::<&[u8; 8], &[c_char; 8]>(b"NVALID(\0"))
+                                    [0] as c_int
+                            {
+                                -(1)
+                            } else if (*yyvsp.offset(-2_isize)).astr[0] as c_int
+                                > (*::core::mem::transmute::<&[u8; 8], &[c_char; 8]>(b"NVALID(\0"))
+                                    [0] as c_int
+                            {
+                                1
+                            } else {
+                                strcmp(
+                                    ((*yyvsp.offset(-2_isize)).astr).as_mut_ptr(),
+                                    b"NVALID(\0" as *const u8 as *const c_char,
+                                )
+                            }) == 0
+                            {
+                                yyval.Node = New_Func(
+                                    lParse,
+                                    fits_parser_yytokentype::LONG as c_int,
+                                    nonnull_fct,
+                                    1,
+                                    (*yyvsp.offset(-1_isize)).Node,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                );
+                                current_block = 15752106442776732052;
+                            } else {
+                                fits_parser_yyerror(
+                                    scanner,
+                                    lParse,
+                                    b"Function(str) not supported\0" as *const u8 as *const c_char
+                                        as *mut c_char,
+                                );
+                                current_block = 4830776507462815627;
+                            }
+                            match current_block {
+                                4830776507462815627 => {}
+                                _ => {
+                                    if yyval.Node < 0 {
+                                        current_block = 4830776507462815627;
+                                    } else {
+                                        current_block = 17353983478346836848;
+                                    }
+                                }
+                            }
+                        }
+                        58 => {
+                            if (if ((*yyvsp.offset(-2_isize)).astr[0] as c_int)
+                                < (*::core::mem::transmute::<&[u8; 7], &[c_char; 7]>(b"NELEM(\0"))
+                                    [0] as c_int
+                            {
+                                -(1)
+                            } else if (*yyvsp.offset(-2_isize)).astr[0] as c_int
+                                > (*::core::mem::transmute::<&[u8; 7], &[c_char; 7]>(b"NELEM(\0"))
+                                    [0] as c_int
+                            {
+                                1
+                            } else {
+                                strcmp(
+                                    ((*yyvsp.offset(-2_isize)).astr).as_mut_ptr(),
+                                    b"NELEM(\0" as *const u8 as *const c_char,
+                                )
+                            }) == 0
+                            {
+                                yyval.Node = New_Const(
+                                    lParse,
+                                    fits_parser_yytokentype::LONG as c_int,
+                                    &mut (*((*lParse).Nodes)
+                                        .offset((*yyvsp.offset(-1_isize)).Node as isize))
+                                    .value
+                                    .nelem as *mut c_long
+                                        as *mut c_void,
+                                    ::core::mem::size_of::<c_long>() as c_ulong as c_long,
+                                );
+                                current_block = 494012601817399562;
+                            } else if (if ((*yyvsp.offset(-2_isize)).astr[0] as c_int)
+                                < (*::core::mem::transmute::<&[u8; 8], &[c_char; 8]>(b"NVALID(\0"))
+                                    [0] as c_int
+                            {
+                                -(1)
+                            } else if (*yyvsp.offset(-2_isize)).astr[0] as c_int
+                                > (*::core::mem::transmute::<&[u8; 8], &[c_char; 8]>(b"NVALID(\0"))
+                                    [0] as c_int
+                            {
+                                1
+                            } else {
+                                strcmp(
+                                    ((*yyvsp.offset(-2_isize)).astr).as_mut_ptr(),
+                                    b"NVALID(\0" as *const u8 as *const c_char,
+                                )
+                            }) == 0
+                            {
+                                yyval.Node = New_Const(
+                                    lParse,
+                                    fits_parser_yytokentype::LONG as c_int,
+                                    &mut (*((*lParse).Nodes)
+                                        .offset((*yyvsp.offset(-1_isize)).Node as isize))
+                                    .value
+                                    .nelem as *mut c_long
+                                        as *mut c_void,
+                                    ::core::mem::size_of::<c_long>() as c_ulong as c_long,
+                                );
+                                current_block = 494012601817399562;
+                            } else if (if ((*yyvsp.offset(-2_isize)).astr[0] as c_int)
+                                < (*::core::mem::transmute::<&[u8; 5], &[c_char; 5]>(b"SUM(\0"))[0]
+                                    as c_int
+                            {
+                                -(1)
+                            } else if (*yyvsp.offset(-2_isize)).astr[0] as c_int
+                                > (*::core::mem::transmute::<&[u8; 5], &[c_char; 5]>(b"SUM(\0"))[0]
+                                    as c_int
+                            {
+                                1
+                            } else {
+                                strcmp(
+                                    ((*yyvsp.offset(-2_isize)).astr).as_mut_ptr(),
+                                    b"SUM(\0" as *const u8 as *const c_char,
+                                )
+                            }) == 0
+                            {
+                                yyval.Node = New_Func(
+                                    lParse,
+                                    fits_parser_yytokentype::LONG as c_int,
+                                    sum_fct,
+                                    1,
+                                    (*yyvsp.offset(-1_isize)).Node,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                );
+                                current_block = 494012601817399562;
+                            } else if (if ((*yyvsp.offset(-2_isize)).astr[0] as c_int)
+                                < (*::core::mem::transmute::<&[u8; 5], &[c_char; 5]>(b"MIN(\0"))[0]
+                                    as c_int
+                            {
+                                -(1)
+                            } else if (*yyvsp.offset(-2_isize)).astr[0] as c_int
+                                > (*::core::mem::transmute::<&[u8; 5], &[c_char; 5]>(b"MIN(\0"))[0]
+                                    as c_int
+                            {
+                                1
+                            } else {
+                                strcmp(
+                                    ((*yyvsp.offset(-2_isize)).astr).as_mut_ptr(),
+                                    b"MIN(\0" as *const u8 as *const c_char,
+                                )
+                            }) == 0
+                            {
+                                yyval.Node = New_Func(
+                                    lParse,
+                                    (*((*lParse).Nodes)
+                                        .offset((*yyvsp.offset(-1_isize)).Node as isize))
+                                    .ntype,
+                                    min1_fct,
+                                    1,
+                                    (*yyvsp.offset(-1_isize)).Node,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                );
+                                ((*((*lParse).Nodes).offset(yyval.Node as isize)).value).nelem = 1;
+                                current_block = 494012601817399562;
+                            } else if (if ((*yyvsp.offset(-2_isize)).astr[0] as c_int)
+                                < (*::core::mem::transmute::<&[u8; 7], &[c_char; 7]>(b"ACCUM(\0"))
+                                    [0] as c_int
+                            {
+                                -(1)
+                            } else if (*yyvsp.offset(-2_isize)).astr[0] as c_int
+                                > (*::core::mem::transmute::<&[u8; 7], &[c_char; 7]>(b"ACCUM(\0"))
+                                    [0] as c_int
+                            {
+                                1
+                            } else {
+                                strcmp(
+                                    ((*yyvsp.offset(-2_isize)).astr).as_mut_ptr(),
+                                    b"ACCUM(\0" as *const u8 as *const c_char,
+                                )
+                            }) == 0
+                            {
+                                let mut zero_0: c_long = 0;
+                                yyval.Node = New_BinOp(
+                                    lParse,
+                                    fits_parser_yytokentype::LONG as c_int,
+                                    (*yyvsp.offset(-1_isize)).Node,
+                                    fits_parser_yytokentype::ACCUM as c_int,
+                                    New_Const(
+                                        lParse,
+                                        fits_parser_yytokentype::LONG as c_int,
+                                        &mut zero_0 as *mut c_long as *mut c_void,
+                                        ::core::mem::size_of::<c_long>() as c_ulong as c_long,
+                                    ),
+                                );
+                                current_block = 494012601817399562;
+                            } else if (if ((*yyvsp.offset(-2_isize)).astr[0] as c_int)
+                                < (*::core::mem::transmute::<&[u8; 5], &[c_char; 5]>(b"MAX(\0"))[0]
+                                    as c_int
+                            {
+                                -(1)
+                            } else if (*yyvsp.offset(-2_isize)).astr[0] as c_int
+                                > (*::core::mem::transmute::<&[u8; 5], &[c_char; 5]>(b"MAX(\0"))[0]
+                                    as c_int
+                            {
+                                1
+                            } else {
+                                strcmp(
+                                    ((*yyvsp.offset(-2_isize)).astr).as_mut_ptr(),
+                                    b"MAX(\0" as *const u8 as *const c_char,
+                                )
+                            }) == 0
+                            {
+                                yyval.Node = New_Func(
+                                    lParse,
+                                    (*((*lParse).Nodes)
+                                        .offset((*yyvsp.offset(-1_isize)).Node as isize))
+                                    .ntype,
+                                    max1_fct,
+                                    1,
+                                    (*yyvsp.offset(-1_isize)).Node,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                );
+                                ((*((*lParse).Nodes).offset(yyval.Node as isize)).value).nelem = 1;
+                                current_block = 494012601817399562;
+                            } else {
+                                fits_parser_yyerror(
+                                    scanner,
+                                    lParse,
+                                    b"Function(bits) not supported\0" as *const u8 as *const c_char
+                                        as *mut c_char,
+                                );
+                                current_block = 4830776507462815627;
+                            }
+                            match current_block {
+                                4830776507462815627 => {}
+                                _ => {
+                                    if yyval.Node < 0 {
+                                        current_block = 4830776507462815627;
+                                    } else {
+                                        current_block = 17353983478346836848;
+                                    }
+                                }
+                            }
+                        }
+                        59 => {
+                            if (if ((*yyvsp.offset(-2_isize)).astr[0] as c_int)
+                                < (*::core::mem::transmute::<&[u8; 5], &[c_char; 5]>(b"SUM(\0"))[0]
+                                    as c_int
+                            {
+                                -(1)
+                            } else if (*yyvsp.offset(-2_isize)).astr[0] as c_int
+                                > (*::core::mem::transmute::<&[u8; 5], &[c_char; 5]>(b"SUM(\0"))[0]
+                                    as c_int
+                            {
+                                1
+                            } else {
+                                strcmp(
+                                    ((*yyvsp.offset(-2_isize)).astr).as_mut_ptr(),
+                                    b"SUM(\0" as *const u8 as *const c_char,
+                                )
+                            }) == 0
+                            {
+                                yyval.Node = New_Func(
+                                    lParse,
+                                    (*((*lParse).Nodes)
+                                        .offset((*yyvsp.offset(-1_isize)).Node as isize))
+                                    .ntype,
+                                    sum_fct,
+                                    1,
+                                    (*yyvsp.offset(-1_isize)).Node,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                );
+                                current_block = 7600445499126923600;
+                            } else if (if ((*yyvsp.offset(-2_isize)).astr[0] as c_int)
+                                < (*::core::mem::transmute::<&[u8; 9], &[c_char; 9]>(b"AVERAGE(\0"))
+                                    [0] as c_int
+                            {
+                                -(1)
+                            } else if (*yyvsp.offset(-2_isize)).astr[0] as c_int
+                                > (*::core::mem::transmute::<&[u8; 9], &[c_char; 9]>(b"AVERAGE(\0"))
+                                    [0] as c_int
+                            {
+                                1
+                            } else {
+                                strcmp(
+                                    ((*yyvsp.offset(-2_isize)).astr).as_mut_ptr(),
+                                    b"AVERAGE(\0" as *const u8 as *const c_char,
+                                )
+                            }) == 0
+                            {
+                                yyval.Node = New_Func(
+                                    lParse,
+                                    fits_parser_yytokentype::DOUBLE as c_int,
+                                    average_fct,
+                                    1,
+                                    (*yyvsp.offset(-1_isize)).Node,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                );
+                                current_block = 7600445499126923600;
+                            } else if (if ((*yyvsp.offset(-2_isize)).astr[0] as c_int)
+                                < (*::core::mem::transmute::<&[u8; 8], &[c_char; 8]>(b"STDDEV(\0"))
+                                    [0] as c_int
+                            {
+                                -(1)
+                            } else if (*yyvsp.offset(-2_isize)).astr[0] as c_int
+                                > (*::core::mem::transmute::<&[u8; 8], &[c_char; 8]>(b"STDDEV(\0"))
+                                    [0] as c_int
+                            {
+                                1
+                            } else {
+                                strcmp(
+                                    ((*yyvsp.offset(-2_isize)).astr).as_mut_ptr(),
+                                    b"STDDEV(\0" as *const u8 as *const c_char,
+                                )
+                            }) == 0
+                            {
+                                yyval.Node = New_Func(
+                                    lParse,
+                                    fits_parser_yytokentype::DOUBLE as c_int,
+                                    stddev_fct,
+                                    1,
+                                    (*yyvsp.offset(-1_isize)).Node,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                );
+                                current_block = 7600445499126923600;
+                            } else if (if ((*yyvsp.offset(-2_isize)).astr[0] as c_int)
+                                < (*::core::mem::transmute::<&[u8; 8], &[c_char; 8]>(b"MEDIAN(\0"))
+                                    [0] as c_int
+                            {
+                                -(1)
+                            } else if (*yyvsp.offset(-2_isize)).astr[0] as c_int
+                                > (*::core::mem::transmute::<&[u8; 8], &[c_char; 8]>(b"MEDIAN(\0"))
+                                    [0] as c_int
+                            {
+                                1
+                            } else {
+                                strcmp(
+                                    ((*yyvsp.offset(-2_isize)).astr).as_mut_ptr(),
+                                    b"MEDIAN(\0" as *const u8 as *const c_char,
+                                )
+                            }) == 0
+                            {
+                                yyval.Node = New_Func(
+                                    lParse,
+                                    (*((*lParse).Nodes)
+                                        .offset((*yyvsp.offset(-1_isize)).Node as isize))
+                                    .ntype,
+                                    median_fct,
+                                    1,
+                                    (*yyvsp.offset(-1_isize)).Node,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                );
+                                current_block = 7600445499126923600;
+                            } else if (if ((*yyvsp.offset(-2_isize)).astr[0] as c_int)
+                                < (*::core::mem::transmute::<&[u8; 7], &[c_char; 7]>(b"NELEM(\0"))
+                                    [0] as c_int
+                            {
+                                -(1)
+                            } else if (*yyvsp.offset(-2_isize)).astr[0] as c_int
+                                > (*::core::mem::transmute::<&[u8; 7], &[c_char; 7]>(b"NELEM(\0"))
+                                    [0] as c_int
+                            {
+                                1
+                            } else {
+                                strcmp(
+                                    ((*yyvsp.offset(-2_isize)).astr).as_mut_ptr(),
+                                    b"NELEM(\0" as *const u8 as *const c_char,
+                                )
+                            }) == 0
+                            {
+                                yyval.Node = New_Const(
+                                    lParse,
+                                    fits_parser_yytokentype::LONG as c_int,
+                                    &mut (*((*lParse).Nodes)
+                                        .offset((*yyvsp.offset(-1_isize)).Node as isize))
+                                    .value
+                                    .nelem as *mut c_long
+                                        as *mut c_void,
+                                    ::core::mem::size_of::<c_long>() as c_ulong as c_long,
+                                );
+                                current_block = 7600445499126923600;
+                            } else if (if ((*yyvsp.offset(-2_isize)).astr[0] as c_int)
+                                < (*::core::mem::transmute::<&[u8; 8], &[c_char; 8]>(b"NVALID(\0"))
+                                    [0] as c_int
+                            {
+                                -(1)
+                            } else if (*yyvsp.offset(-2_isize)).astr[0] as c_int
+                                > (*::core::mem::transmute::<&[u8; 8], &[c_char; 8]>(b"NVALID(\0"))
+                                    [0] as c_int
+                            {
+                                1
+                            } else {
+                                strcmp(
+                                    ((*yyvsp.offset(-2_isize)).astr).as_mut_ptr(),
+                                    b"NVALID(\0" as *const u8 as *const c_char,
+                                )
+                            }) == 0
+                            {
+                                yyval.Node = New_Func(
+                                    lParse,
+                                    fits_parser_yytokentype::LONG as c_int,
+                                    nonnull_fct,
+                                    1,
+                                    (*yyvsp.offset(-1_isize)).Node,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                );
+                                current_block = 7600445499126923600;
+                            } else if (if ((*yyvsp.offset(-2_isize)).astr[0] as c_int)
+                                < (*::core::mem::transmute::<&[u8; 7], &[c_char; 7]>(b"ACCUM(\0"))
+                                    [0] as c_int
+                            {
+                                -(1)
+                            } else if (*yyvsp.offset(-2_isize)).astr[0] as c_int
+                                > (*::core::mem::transmute::<&[u8; 7], &[c_char; 7]>(b"ACCUM(\0"))
+                                    [0] as c_int
+                            {
+                                1
+                            } else {
+                                strcmp(
+                                    ((*yyvsp.offset(-2_isize)).astr).as_mut_ptr(),
+                                    b"ACCUM(\0" as *const u8 as *const c_char,
+                                )
+                            }) == 0
+                                && (*((*lParse).Nodes)
+                                    .offset((*yyvsp.offset(-1_isize)).Node as isize))
+                                .ntype
+                                    == fits_parser_yytokentype::LONG as c_int
+                            {
+                                let mut zero_1: c_long = 0;
+                                yyval.Node = New_BinOp(
+                                    lParse,
+                                    fits_parser_yytokentype::LONG as c_int,
+                                    (*yyvsp.offset(-1_isize)).Node,
+                                    fits_parser_yytokentype::ACCUM as c_int,
+                                    New_Const(
+                                        lParse,
+                                        fits_parser_yytokentype::LONG as c_int,
+                                        &mut zero_1 as *mut c_long as *mut c_void,
+                                        ::core::mem::size_of::<c_long>() as c_ulong as c_long,
+                                    ),
+                                );
+                                current_block = 7600445499126923600;
+                            } else if (if ((*yyvsp.offset(-2_isize)).astr[0] as c_int)
+                                < (*::core::mem::transmute::<&[u8; 7], &[c_char; 7]>(b"ACCUM(\0"))
+                                    [0] as c_int
+                            {
+                                -(1)
+                            } else if (*yyvsp.offset(-2_isize)).astr[0] as c_int
+                                > (*::core::mem::transmute::<&[u8; 7], &[c_char; 7]>(b"ACCUM(\0"))
+                                    [0] as c_int
+                            {
+                                1
+                            } else {
+                                strcmp(
+                                    ((*yyvsp.offset(-2_isize)).astr).as_mut_ptr(),
+                                    b"ACCUM(\0" as *const u8 as *const c_char,
+                                )
+                            }) == 0
+                                && (*((*lParse).Nodes)
+                                    .offset((*yyvsp.offset(-1_isize)).Node as isize))
+                                .ntype
+                                    == fits_parser_yytokentype::DOUBLE as c_int
+                            {
+                                let mut zero_2: c_double = 0.0;
+                                yyval.Node = New_BinOp(
+                                    lParse,
+                                    fits_parser_yytokentype::DOUBLE as c_int,
+                                    (*yyvsp.offset(-1_isize)).Node,
+                                    fits_parser_yytokentype::ACCUM as c_int,
+                                    New_Const(
+                                        lParse,
+                                        fits_parser_yytokentype::DOUBLE as c_int,
+                                        &mut zero_2 as *mut c_double as *mut c_void,
+                                        ::core::mem::size_of::<c_double>() as c_ulong as c_long,
+                                    ),
+                                );
+                                current_block = 7600445499126923600;
+                            } else if (if ((*yyvsp.offset(-2_isize)).astr[0] as c_int)
+                                < (*::core::mem::transmute::<&[u8; 9], &[c_char; 9]>(b"SEQDIFF(\0"))
+                                    [0] as c_int
+                            {
+                                -(1)
+                            } else if (*yyvsp.offset(-2_isize)).astr[0] as c_int
+                                > (*::core::mem::transmute::<&[u8; 9], &[c_char; 9]>(b"SEQDIFF(\0"))
+                                    [0] as c_int
+                            {
+                                1
+                            } else {
+                                strcmp(
+                                    ((*yyvsp.offset(-2_isize)).astr).as_mut_ptr(),
+                                    b"SEQDIFF(\0" as *const u8 as *const c_char,
+                                )
+                            }) == 0
+                                && (*((*lParse).Nodes)
+                                    .offset((*yyvsp.offset(-1_isize)).Node as isize))
+                                .ntype
+                                    == fits_parser_yytokentype::LONG as c_int
+                            {
+                                let mut zero_3: c_long = 0;
+                                yyval.Node = New_BinOp(
+                                    lParse,
+                                    fits_parser_yytokentype::LONG as c_int,
+                                    (*yyvsp.offset(-1_isize)).Node,
+                                    fits_parser_yytokentype::DIFF as c_int,
+                                    New_Const(
+                                        lParse,
+                                        fits_parser_yytokentype::LONG as c_int,
+                                        &mut zero_3 as *mut c_long as *mut c_void,
+                                        ::core::mem::size_of::<c_long>() as c_ulong as c_long,
+                                    ),
+                                );
+                                current_block = 7600445499126923600;
+                            } else if (if ((*yyvsp.offset(-2_isize)).astr[0] as c_int)
+                                < (*::core::mem::transmute::<&[u8; 9], &[c_char; 9]>(b"SEQDIFF(\0"))
+                                    [0] as c_int
+                            {
+                                -(1)
+                            } else if (*yyvsp.offset(-2_isize)).astr[0] as c_int
+                                > (*::core::mem::transmute::<&[u8; 9], &[c_char; 9]>(b"SEQDIFF(\0"))
+                                    [0] as c_int
+                            {
+                                1
+                            } else {
+                                strcmp(
+                                    ((*yyvsp.offset(-2_isize)).astr).as_mut_ptr(),
+                                    b"SEQDIFF(\0" as *const u8 as *const c_char,
+                                )
+                            }) == 0
+                                && (*((*lParse).Nodes)
+                                    .offset((*yyvsp.offset(-1_isize)).Node as isize))
+                                .ntype
+                                    == fits_parser_yytokentype::DOUBLE as c_int
+                            {
+                                let mut zero_4: c_double = 0.0;
+                                yyval.Node = New_BinOp(
+                                    lParse,
+                                    fits_parser_yytokentype::DOUBLE as c_int,
+                                    (*yyvsp.offset(-1_isize)).Node,
+                                    fits_parser_yytokentype::DIFF as c_int,
+                                    New_Const(
+                                        lParse,
+                                        fits_parser_yytokentype::DOUBLE as c_int,
+                                        &mut zero_4 as *mut c_double as *mut c_void,
+                                        ::core::mem::size_of::<c_double>() as c_ulong as c_long,
+                                    ),
+                                );
+                                current_block = 7600445499126923600;
+                            } else if (if ((*yyvsp.offset(-2_isize)).astr[0] as c_int)
+                                < (*::core::mem::transmute::<&[u8; 5], &[c_char; 5]>(b"ABS(\0"))[0]
+                                    as c_int
+                            {
+                                -(1)
+                            } else if (*yyvsp.offset(-2_isize)).astr[0] as c_int
+                                > (*::core::mem::transmute::<&[u8; 5], &[c_char; 5]>(b"ABS(\0"))[0]
+                                    as c_int
+                            {
+                                1
+                            } else {
+                                strcmp(
+                                    ((*yyvsp.offset(-2_isize)).astr).as_mut_ptr(),
+                                    b"ABS(\0" as *const u8 as *const c_char,
+                                )
+                            }) == 0
+                            {
+                                yyval.Node = New_Func(
+                                    lParse,
+                                    0,
+                                    abs_fct,
+                                    1,
+                                    (*yyvsp.offset(-1_isize)).Node,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                );
+                                current_block = 7600445499126923600;
+                            } else if (if ((*yyvsp.offset(-2_isize)).astr[0] as c_int)
+                                < (*::core::mem::transmute::<&[u8; 5], &[c_char; 5]>(b"MIN(\0"))[0]
+                                    as c_int
+                            {
+                                -(1)
+                            } else if (*yyvsp.offset(-2_isize)).astr[0] as c_int
+                                > (*::core::mem::transmute::<&[u8; 5], &[c_char; 5]>(b"MIN(\0"))[0]
+                                    as c_int
+                            {
+                                1
+                            } else {
+                                strcmp(
+                                    ((*yyvsp.offset(-2_isize)).astr).as_mut_ptr(),
+                                    b"MIN(\0" as *const u8 as *const c_char,
+                                )
+                            }) == 0
+                            {
+                                yyval.Node = New_Func(
+                                    lParse,
+                                    (*((*lParse).Nodes)
+                                        .offset((*yyvsp.offset(-1_isize)).Node as isize))
+                                    .ntype,
+                                    min1_fct,
+                                    1,
+                                    (*yyvsp.offset(-1_isize)).Node,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                );
+                                current_block = 7600445499126923600;
+                            } else if (if ((*yyvsp.offset(-2_isize)).astr[0] as c_int)
+                                < (*::core::mem::transmute::<&[u8; 5], &[c_char; 5]>(b"MAX(\0"))[0]
+                                    as c_int
+                            {
+                                -(1)
+                            } else if (*yyvsp.offset(-2_isize)).astr[0] as c_int
+                                > (*::core::mem::transmute::<&[u8; 5], &[c_char; 5]>(b"MAX(\0"))[0]
+                                    as c_int
+                            {
+                                1
+                            } else {
+                                strcmp(
+                                    ((*yyvsp.offset(-2_isize)).astr).as_mut_ptr(),
+                                    b"MAX(\0" as *const u8 as *const c_char,
+                                )
+                            }) == 0
+                            {
+                                yyval.Node = New_Func(
+                                    lParse,
+                                    (*((*lParse).Nodes)
+                                        .offset((*yyvsp.offset(-1_isize)).Node as isize))
+                                    .ntype,
+                                    max1_fct,
+                                    1,
+                                    (*yyvsp.offset(-1_isize)).Node,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                );
+                                current_block = 7600445499126923600;
+                            } else if (if ((*yyvsp.offset(-2_isize)).astr[0] as c_int)
+                                < (*::core::mem::transmute::<&[u8; 8], &[c_char; 8]>(b"RANDOM(\0"))
+                                    [0] as c_int
+                            {
+                                -(1)
+                            } else if (*yyvsp.offset(-2_isize)).astr[0] as c_int
+                                > (*::core::mem::transmute::<&[u8; 8], &[c_char; 8]>(b"RANDOM(\0"))
+                                    [0] as c_int
+                            {
+                                1
+                            } else {
+                                strcmp(
+                                    ((*yyvsp.offset(-2_isize)).astr).as_mut_ptr(),
+                                    b"RANDOM(\0" as *const u8 as *const c_char,
+                                )
+                            }) == 0
+                            {
+                                yyval.Node = New_Func(
+                                    lParse,
+                                    0,
+                                    rnd_fct,
+                                    1,
+                                    (*yyvsp.offset(-1_isize)).Node,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                );
+                                if yyval.Node < 0 {
+                                    current_block = 4830776507462815627;
+                                } else {
+                                    (*((*lParse).Nodes).offset(yyval.Node as isize)).ntype =
+                                        fits_parser_yytokentype::DOUBLE as c_int;
+                                    current_block = 7600445499126923600;
+                                }
+                            } else if (if ((*yyvsp.offset(-2_isize)).astr[0] as c_int)
+                                < (*::core::mem::transmute::<&[u8; 9], &[c_char; 9]>(b"RANDOMN(\0"))
+                                    [0] as c_int
+                            {
+                                -(1)
+                            } else if (*yyvsp.offset(-2_isize)).astr[0] as c_int
+                                > (*::core::mem::transmute::<&[u8; 9], &[c_char; 9]>(b"RANDOMN(\0"))
+                                    [0] as c_int
+                            {
+                                1
+                            } else {
+                                strcmp(
+                                    ((*yyvsp.offset(-2_isize)).astr).as_mut_ptr(),
+                                    b"RANDOMN(\0" as *const u8 as *const c_char,
+                                )
+                            }) == 0
+                            {
+                                yyval.Node = New_Func(
+                                    lParse,
+                                    0,
+                                    gasrnd_fct,
+                                    1,
+                                    (*yyvsp.offset(-1_isize)).Node,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                );
+                                if yyval.Node < 0 {
+                                    current_block = 4830776507462815627;
+                                } else {
+                                    (*((*lParse).Nodes).offset(yyval.Node as isize)).ntype =
+                                        fits_parser_yytokentype::DOUBLE as c_int;
+                                    current_block = 7600445499126923600;
+                                }
+                            } else if (if ((*yyvsp.offset(-2_isize)).astr[0] as c_int)
+                                < (*::core::mem::transmute::<&[u8; 12], &[c_char; 12]>(
+                                    b"ELEMENTNUM(\0",
+                                ))[0] as c_int
+                            {
+                                -(1)
+                            } else if (*yyvsp.offset(-2_isize)).astr[0] as c_int
+                                > (*::core::mem::transmute::<&[u8; 12], &[c_char; 12]>(
+                                    b"ELEMENTNUM(\0",
+                                ))[0] as c_int
+                            {
+                                1
+                            } else {
+                                strcmp(
+                                    ((*yyvsp.offset(-2_isize)).astr).as_mut_ptr(),
+                                    b"ELEMENTNUM(\0" as *const u8 as *const c_char,
+                                )
+                            }) == 0
+                            {
+                                if (*((*lParse).Nodes)
+                                    .offset((*yyvsp.offset(-1_isize)).Node as isize))
+                                .operation
+                                    == -(1000 as c_int)
+                                {
+                                    let mut one_1: c_long = 1;
+                                    yyval.Node = New_Const(
+                                        lParse,
+                                        fits_parser_yytokentype::LONG as c_int,
+                                        &mut one_1 as *mut c_long as *mut c_void,
+                                        ::core::mem::size_of::<c_long>() as c_ulong as c_long,
+                                    );
+                                    current_block = 7600445499126923600;
+                                } else {
+                                    yyval.Node = New_Func(
+                                        lParse,
+                                        0,
+                                        elemnum_fct,
+                                        1,
+                                        (*yyvsp.offset(-1_isize)).Node,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                    );
+                                    if yyval.Node < 0 {
+                                        current_block = 4830776507462815627;
+                                    } else {
+                                        (*((*lParse).Nodes).offset(yyval.Node as isize)).ntype =
+                                            fits_parser_yytokentype::LONG as c_int;
+                                        current_block = 7600445499126923600;
+                                    }
+                                }
+                            } else if (if ((*yyvsp.offset(-2_isize)).astr[0] as c_int)
+                                < (*::core::mem::transmute::<&[u8; 7], &[c_char; 7]>(b"NAXIS(\0"))
+                                    [0] as c_int
+                            {
+                                -(1)
+                            } else if (*yyvsp.offset(-2_isize)).astr[0] as c_int
+                                > (*::core::mem::transmute::<&[u8; 7], &[c_char; 7]>(b"NAXIS(\0"))
+                                    [0] as c_int
+                            {
+                                1
+                            } else {
+                                strcmp(
+                                    ((*yyvsp.offset(-2_isize)).astr).as_mut_ptr(),
+                                    b"NAXIS(\0" as *const u8 as *const c_char,
+                                )
+                            }) == 0
+                            {
+                                if (*((*lParse).Nodes)
+                                    .offset((*yyvsp.offset(-1_isize)).Node as isize))
+                                .operation
+                                    == -(1000 as c_int)
+                                {
+                                    let mut one_2: c_long = 1;
+                                    yyval.Node = New_Const(
+                                        lParse,
+                                        fits_parser_yytokentype::LONG as c_int,
+                                        &mut one_2 as *mut c_long as *mut c_void,
+                                        ::core::mem::size_of::<c_long>() as c_ulong as c_long,
+                                    );
+                                    current_block = 7600445499126923600;
+                                } else {
+                                    let mut naxis_0: c_long = (*((*lParse).Nodes)
+                                        .offset((*yyvsp.offset(-1_isize)).Node as isize))
+                                    .value
+                                    .naxis
+                                        as c_long;
+                                    yyval.Node = New_Const(
+                                        lParse,
+                                        fits_parser_yytokentype::LONG as c_int,
+                                        &mut naxis_0 as *mut c_long as *mut c_void,
+                                        ::core::mem::size_of::<c_long>() as c_ulong as c_long,
+                                    );
+                                    if yyval.Node < 0 {
+                                        current_block = 4830776507462815627;
+                                    } else {
+                                        current_block = 7600445499126923600;
+                                    }
+                                }
+                            } else {
+                                if (*((*lParse).Nodes)
+                                    .offset((*yyvsp.offset(-1_isize)).Node as isize))
+                                .ntype
+                                    != fits_parser_yytokentype::DOUBLE as c_int
+                                {
+                                    (*yyvsp.offset(-1_isize)).Node = New_Unary(
+                                        lParse,
+                                        fits_parser_yytokentype::DOUBLE as c_int,
+                                        0,
+                                        (*yyvsp.offset(-1_isize)).Node,
+                                    );
+                                }
+                                if (if ((*yyvsp.offset(-2_isize)).astr[0] as c_int)
+                                    < (*::core::mem::transmute::<&[u8; 5], &[c_char; 5]>(b"SIN(\0"))
+                                        [0] as c_int
+                                {
+                                    -(1)
+                                } else if (*yyvsp.offset(-2_isize)).astr[0] as c_int
+                                    > (*::core::mem::transmute::<&[u8; 5], &[c_char; 5]>(b"SIN(\0"))
+                                        [0] as c_int
+                                {
+                                    1
+                                } else {
+                                    strcmp(
+                                        ((*yyvsp.offset(-2_isize)).astr).as_mut_ptr(),
+                                        b"SIN(\0" as *const u8 as *const c_char,
+                                    )
+                                }) == 0
+                                {
+                                    yyval.Node = New_Func(
+                                        lParse,
+                                        0,
+                                        sin_fct,
+                                        1,
+                                        (*yyvsp.offset(-1_isize)).Node,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                    );
+                                    current_block = 7600445499126923600;
+                                } else if (if ((*yyvsp.offset(-2_isize)).astr[0] as c_int)
+                                    < (*::core::mem::transmute::<&[u8; 5], &[c_char; 5]>(b"COS(\0"))
+                                        [0] as c_int
+                                {
+                                    -(1)
+                                } else if (*yyvsp.offset(-2_isize)).astr[0] as c_int
+                                    > (*::core::mem::transmute::<&[u8; 5], &[c_char; 5]>(b"COS(\0"))
+                                        [0] as c_int
+                                {
+                                    1
+                                } else {
+                                    strcmp(
+                                        ((*yyvsp.offset(-2_isize)).astr).as_mut_ptr(),
+                                        b"COS(\0" as *const u8 as *const c_char,
+                                    )
+                                }) == 0
+                                {
+                                    yyval.Node = New_Func(
+                                        lParse,
+                                        0,
+                                        cos_fct,
+                                        1,
+                                        (*yyvsp.offset(-1_isize)).Node,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                    );
+                                    current_block = 7600445499126923600;
+                                } else if (if ((*yyvsp.offset(-2_isize)).astr[0] as c_int)
+                                    < (*::core::mem::transmute::<&[u8; 5], &[c_char; 5]>(b"TAN(\0"))
+                                        [0] as c_int
+                                {
+                                    -(1)
+                                } else if (*yyvsp.offset(-2_isize)).astr[0] as c_int
+                                    > (*::core::mem::transmute::<&[u8; 5], &[c_char; 5]>(b"TAN(\0"))
+                                        [0] as c_int
+                                {
+                                    1
+                                } else {
+                                    strcmp(
+                                        ((*yyvsp.offset(-2_isize)).astr).as_mut_ptr(),
+                                        b"TAN(\0" as *const u8 as *const c_char,
+                                    )
+                                }) == 0
+                                {
+                                    yyval.Node = New_Func(
+                                        lParse,
+                                        0,
+                                        tan_fct,
+                                        1,
+                                        (*yyvsp.offset(-1_isize)).Node,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                    );
+                                    current_block = 7600445499126923600;
+                                } else if (if ((*yyvsp.offset(-2_isize)).astr[0] as c_int)
+                                    < (*::core::mem::transmute::<&[u8; 8], &[c_char; 8]>(
+                                        b"ARCSIN(\0",
+                                    ))[0] as c_int
+                                {
+                                    -(1)
+                                } else if (*yyvsp.offset(-2_isize)).astr[0] as c_int
+                                    > (*::core::mem::transmute::<&[u8; 8], &[c_char; 8]>(
+                                        b"ARCSIN(\0",
+                                    ))[0] as c_int
+                                {
+                                    1
+                                } else {
+                                    strcmp(
+                                        ((*yyvsp.offset(-2_isize)).astr).as_mut_ptr(),
+                                        b"ARCSIN(\0" as *const u8 as *const c_char,
+                                    )
+                                }) == 0
+                                    || (if ((*yyvsp.offset(-2_isize)).astr[0] as c_int)
+                                        < (*::core::mem::transmute::<&[u8; 6], &[c_char; 6]>(
+                                            b"ASIN(\0",
+                                        ))[0] as c_int
+                                    {
+                                        -(1)
+                                    } else if (*yyvsp.offset(-2_isize)).astr[0] as c_int
+                                        > (*::core::mem::transmute::<&[u8; 6], &[c_char; 6]>(
+                                            b"ASIN(\0",
+                                        ))[0] as c_int
+                                    {
+                                        1
+                                    } else {
+                                        strcmp(
+                                            ((*yyvsp.offset(-2_isize)).astr).as_mut_ptr(),
+                                            b"ASIN(\0" as *const u8 as *const c_char,
+                                        )
+                                    }) == 0
+                                {
+                                    yyval.Node = New_Func(
+                                        lParse,
+                                        0,
+                                        asin_fct,
+                                        1,
+                                        (*yyvsp.offset(-1_isize)).Node,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                    );
+                                    current_block = 7600445499126923600;
+                                } else if (if ((*yyvsp.offset(-2_isize)).astr[0] as c_int)
+                                    < (*::core::mem::transmute::<&[u8; 8], &[c_char; 8]>(
+                                        b"ARCCOS(\0",
+                                    ))[0] as c_int
+                                {
+                                    -(1)
+                                } else if (*yyvsp.offset(-2_isize)).astr[0] as c_int
+                                    > (*::core::mem::transmute::<&[u8; 8], &[c_char; 8]>(
+                                        b"ARCCOS(\0",
+                                    ))[0] as c_int
+                                {
+                                    1
+                                } else {
+                                    strcmp(
+                                        ((*yyvsp.offset(-2_isize)).astr).as_mut_ptr(),
+                                        b"ARCCOS(\0" as *const u8 as *const c_char,
+                                    )
+                                }) == 0
+                                    || (if ((*yyvsp.offset(-2_isize)).astr[0] as c_int)
+                                        < (*::core::mem::transmute::<&[u8; 6], &[c_char; 6]>(
+                                            b"ACOS(\0",
+                                        ))[0] as c_int
+                                    {
+                                        -(1)
+                                    } else if (*yyvsp.offset(-2_isize)).astr[0] as c_int
+                                        > (*::core::mem::transmute::<&[u8; 6], &[c_char; 6]>(
+                                            b"ACOS(\0",
+                                        ))[0] as c_int
+                                    {
+                                        1
+                                    } else {
+                                        strcmp(
+                                            ((*yyvsp.offset(-2_isize)).astr).as_mut_ptr(),
+                                            b"ACOS(\0" as *const u8 as *const c_char,
+                                        )
+                                    }) == 0
+                                {
+                                    yyval.Node = New_Func(
+                                        lParse,
+                                        0,
+                                        acos_fct,
+                                        1,
+                                        (*yyvsp.offset(-1_isize)).Node,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                    );
+                                    current_block = 7600445499126923600;
+                                } else if (if ((*yyvsp.offset(-2_isize)).astr[0] as c_int)
+                                    < (*::core::mem::transmute::<&[u8; 8], &[c_char; 8]>(
+                                        b"ARCTAN(\0",
+                                    ))[0] as c_int
+                                {
+                                    -(1)
+                                } else if (*yyvsp.offset(-2_isize)).astr[0] as c_int
+                                    > (*::core::mem::transmute::<&[u8; 8], &[c_char; 8]>(
+                                        b"ARCTAN(\0",
+                                    ))[0] as c_int
+                                {
+                                    1
+                                } else {
+                                    strcmp(
+                                        ((*yyvsp.offset(-2_isize)).astr).as_mut_ptr(),
+                                        b"ARCTAN(\0" as *const u8 as *const c_char,
+                                    )
+                                }) == 0
+                                    || (if ((*yyvsp.offset(-2_isize)).astr[0] as c_int)
+                                        < (*::core::mem::transmute::<&[u8; 6], &[c_char; 6]>(
+                                            b"ATAN(\0",
+                                        ))[0] as c_int
+                                    {
+                                        -(1)
+                                    } else if (*yyvsp.offset(-2_isize)).astr[0] as c_int
+                                        > (*::core::mem::transmute::<&[u8; 6], &[c_char; 6]>(
+                                            b"ATAN(\0",
+                                        ))[0] as c_int
+                                    {
+                                        1
+                                    } else {
+                                        strcmp(
+                                            ((*yyvsp.offset(-2_isize)).astr).as_mut_ptr(),
+                                            b"ATAN(\0" as *const u8 as *const c_char,
+                                        )
+                                    }) == 0
+                                {
+                                    yyval.Node = New_Func(
+                                        lParse,
+                                        0,
+                                        atan_fct,
+                                        1,
+                                        (*yyvsp.offset(-1_isize)).Node,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                    );
+                                    current_block = 7600445499126923600;
+                                } else if (if ((*yyvsp.offset(-2_isize)).astr[0] as c_int)
+                                    < (*::core::mem::transmute::<&[u8; 6], &[c_char; 6]>(
+                                        b"SINH(\0",
+                                    ))[0] as c_int
+                                {
+                                    -(1)
+                                } else if (*yyvsp.offset(-2_isize)).astr[0] as c_int
+                                    > (*::core::mem::transmute::<&[u8; 6], &[c_char; 6]>(
+                                        b"SINH(\0",
+                                    ))[0] as c_int
+                                {
+                                    1
+                                } else {
+                                    strcmp(
+                                        ((*yyvsp.offset(-2_isize)).astr).as_mut_ptr(),
+                                        b"SINH(\0" as *const u8 as *const c_char,
+                                    )
+                                }) == 0
+                                {
+                                    yyval.Node = New_Func(
+                                        lParse,
+                                        0,
+                                        sinh_fct,
+                                        1,
+                                        (*yyvsp.offset(-1_isize)).Node,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                    );
+                                    current_block = 7600445499126923600;
+                                } else if (if ((*yyvsp.offset(-2_isize)).astr[0] as c_int)
+                                    < (*::core::mem::transmute::<&[u8; 6], &[c_char; 6]>(
+                                        b"COSH(\0",
+                                    ))[0] as c_int
+                                {
+                                    -(1)
+                                } else if (*yyvsp.offset(-2_isize)).astr[0] as c_int
+                                    > (*::core::mem::transmute::<&[u8; 6], &[c_char; 6]>(
+                                        b"COSH(\0",
+                                    ))[0] as c_int
+                                {
+                                    1
+                                } else {
+                                    strcmp(
+                                        ((*yyvsp.offset(-2_isize)).astr).as_mut_ptr(),
+                                        b"COSH(\0" as *const u8 as *const c_char,
+                                    )
+                                }) == 0
+                                {
+                                    yyval.Node = New_Func(
+                                        lParse,
+                                        0,
+                                        cosh_fct,
+                                        1,
+                                        (*yyvsp.offset(-1_isize)).Node,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                    );
+                                    current_block = 7600445499126923600;
+                                } else if (if ((*yyvsp.offset(-2_isize)).astr[0] as c_int)
+                                    < (*::core::mem::transmute::<&[u8; 6], &[c_char; 6]>(
+                                        b"TANH(\0",
+                                    ))[0] as c_int
+                                {
+                                    -(1)
+                                } else if (*yyvsp.offset(-2_isize)).astr[0] as c_int
+                                    > (*::core::mem::transmute::<&[u8; 6], &[c_char; 6]>(
+                                        b"TANH(\0",
+                                    ))[0] as c_int
+                                {
+                                    1
+                                } else {
+                                    strcmp(
+                                        ((*yyvsp.offset(-2_isize)).astr).as_mut_ptr(),
+                                        b"TANH(\0" as *const u8 as *const c_char,
+                                    )
+                                }) == 0
+                                {
+                                    yyval.Node = New_Func(
+                                        lParse,
+                                        0,
+                                        tanh_fct,
+                                        1,
+                                        (*yyvsp.offset(-1_isize)).Node,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                    );
+                                    current_block = 7600445499126923600;
+                                } else if (if ((*yyvsp.offset(-2_isize)).astr[0] as c_int)
+                                    < (*::core::mem::transmute::<&[u8; 5], &[c_char; 5]>(b"EXP(\0"))
+                                        [0] as c_int
+                                {
+                                    -(1)
+                                } else if (*yyvsp.offset(-2_isize)).astr[0] as c_int
+                                    > (*::core::mem::transmute::<&[u8; 5], &[c_char; 5]>(b"EXP(\0"))
+                                        [0] as c_int
+                                {
+                                    1
+                                } else {
+                                    strcmp(
+                                        ((*yyvsp.offset(-2_isize)).astr).as_mut_ptr(),
+                                        b"EXP(\0" as *const u8 as *const c_char,
+                                    )
+                                }) == 0
+                                {
+                                    yyval.Node = New_Func(
+                                        lParse,
+                                        0,
+                                        exp_fct,
+                                        1,
+                                        (*yyvsp.offset(-1_isize)).Node,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                    );
+                                    current_block = 7600445499126923600;
+                                } else if (if ((*yyvsp.offset(-2_isize)).astr[0] as c_int)
+                                    < (*::core::mem::transmute::<&[u8; 5], &[c_char; 5]>(b"LOG(\0"))
+                                        [0] as c_int
+                                {
+                                    -(1)
+                                } else if (*yyvsp.offset(-2_isize)).astr[0] as c_int
+                                    > (*::core::mem::transmute::<&[u8; 5], &[c_char; 5]>(b"LOG(\0"))
+                                        [0] as c_int
+                                {
+                                    1
+                                } else {
+                                    strcmp(
+                                        ((*yyvsp.offset(-2_isize)).astr).as_mut_ptr(),
+                                        b"LOG(\0" as *const u8 as *const c_char,
+                                    )
+                                }) == 0
+                                {
+                                    yyval.Node = New_Func(
+                                        lParse,
+                                        0,
+                                        log_fct,
+                                        1,
+                                        (*yyvsp.offset(-1_isize)).Node,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                    );
+                                    current_block = 7600445499126923600;
+                                } else if (if ((*yyvsp.offset(-2_isize)).astr[0] as c_int)
+                                    < (*::core::mem::transmute::<&[u8; 7], &[c_char; 7]>(
+                                        b"LOG10(\0",
+                                    ))[0] as c_int
+                                {
+                                    -(1)
+                                } else if (*yyvsp.offset(-2_isize)).astr[0] as c_int
+                                    > (*::core::mem::transmute::<&[u8; 7], &[c_char; 7]>(
+                                        b"LOG10(\0",
+                                    ))[0] as c_int
+                                {
+                                    1
+                                } else {
+                                    strcmp(
+                                        ((*yyvsp.offset(-2_isize)).astr).as_mut_ptr(),
+                                        b"LOG10(\0" as *const u8 as *const c_char,
+                                    )
+                                }) == 0
+                                {
+                                    yyval.Node = New_Func(
+                                        lParse,
+                                        0,
+                                        log10_fct,
+                                        1,
+                                        (*yyvsp.offset(-1_isize)).Node,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                    );
+                                    current_block = 7600445499126923600;
+                                } else if (if ((*yyvsp.offset(-2_isize)).astr[0] as c_int)
+                                    < (*::core::mem::transmute::<&[u8; 6], &[c_char; 6]>(
+                                        b"SQRT(\0",
+                                    ))[0] as c_int
+                                {
+                                    -(1)
+                                } else if (*yyvsp.offset(-2_isize)).astr[0] as c_int
+                                    > (*::core::mem::transmute::<&[u8; 6], &[c_char; 6]>(
+                                        b"SQRT(\0",
+                                    ))[0] as c_int
+                                {
+                                    1
+                                } else {
+                                    strcmp(
+                                        ((*yyvsp.offset(-2_isize)).astr).as_mut_ptr(),
+                                        b"SQRT(\0" as *const u8 as *const c_char,
+                                    )
+                                }) == 0
+                                {
+                                    yyval.Node = New_Func(
+                                        lParse,
+                                        0,
+                                        sqrt_fct,
+                                        1,
+                                        (*yyvsp.offset(-1_isize)).Node,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                    );
+                                    current_block = 7600445499126923600;
+                                } else if (if ((*yyvsp.offset(-2_isize)).astr[0] as c_int)
+                                    < (*::core::mem::transmute::<&[u8; 7], &[c_char; 7]>(
+                                        b"ROUND(\0",
+                                    ))[0] as c_int
+                                {
+                                    -(1)
+                                } else if (*yyvsp.offset(-2_isize)).astr[0] as c_int
+                                    > (*::core::mem::transmute::<&[u8; 7], &[c_char; 7]>(
+                                        b"ROUND(\0",
+                                    ))[0] as c_int
+                                {
+                                    1
+                                } else {
+                                    strcmp(
+                                        ((*yyvsp.offset(-2_isize)).astr).as_mut_ptr(),
+                                        b"ROUND(\0" as *const u8 as *const c_char,
+                                    )
+                                }) == 0
+                                {
+                                    yyval.Node = New_Func(
+                                        lParse,
+                                        0,
+                                        round_fct,
+                                        1,
+                                        (*yyvsp.offset(-1_isize)).Node,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                    );
+                                    current_block = 7600445499126923600;
+                                } else if (if ((*yyvsp.offset(-2_isize)).astr[0] as c_int)
+                                    < (*::core::mem::transmute::<&[u8; 7], &[c_char; 7]>(
+                                        b"FLOOR(\0",
+                                    ))[0] as c_int
+                                {
+                                    -(1)
+                                } else if (*yyvsp.offset(-2_isize)).astr[0] as c_int
+                                    > (*::core::mem::transmute::<&[u8; 7], &[c_char; 7]>(
+                                        b"FLOOR(\0",
+                                    ))[0] as c_int
+                                {
+                                    1
+                                } else {
+                                    strcmp(
+                                        ((*yyvsp.offset(-2_isize)).astr).as_mut_ptr(),
+                                        b"FLOOR(\0" as *const u8 as *const c_char,
+                                    )
+                                }) == 0
+                                {
+                                    yyval.Node = New_Func(
+                                        lParse,
+                                        0,
+                                        floor_fct,
+                                        1,
+                                        (*yyvsp.offset(-1_isize)).Node,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                    );
+                                    current_block = 7600445499126923600;
+                                } else if (if ((*yyvsp.offset(-2_isize)).astr[0] as c_int)
+                                    < (*::core::mem::transmute::<&[u8; 6], &[c_char; 6]>(
+                                        b"CEIL(\0",
+                                    ))[0] as c_int
+                                {
+                                    -(1)
+                                } else if (*yyvsp.offset(-2_isize)).astr[0] as c_int
+                                    > (*::core::mem::transmute::<&[u8; 6], &[c_char; 6]>(
+                                        b"CEIL(\0",
+                                    ))[0] as c_int
+                                {
+                                    1
+                                } else {
+                                    strcmp(
+                                        ((*yyvsp.offset(-2_isize)).astr).as_mut_ptr(),
+                                        b"CEIL(\0" as *const u8 as *const c_char,
+                                    )
+                                }) == 0
+                                {
+                                    yyval.Node = New_Func(
+                                        lParse,
+                                        0,
+                                        ceil_fct,
+                                        1,
+                                        (*yyvsp.offset(-1_isize)).Node,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                    );
+                                    current_block = 7600445499126923600;
+                                } else if (if ((*yyvsp.offset(-2_isize)).astr[0] as c_int)
+                                    < (*::core::mem::transmute::<&[u8; 9], &[c_char; 9]>(
+                                        b"RANDOMP(\0",
+                                    ))[0] as c_int
+                                {
+                                    -(1)
+                                } else if (*yyvsp.offset(-2_isize)).astr[0] as c_int
+                                    > (*::core::mem::transmute::<&[u8; 9], &[c_char; 9]>(
+                                        b"RANDOMP(\0",
+                                    ))[0] as c_int
+                                {
+                                    1
+                                } else {
+                                    strcmp(
+                                        ((*yyvsp.offset(-2_isize)).astr).as_mut_ptr(),
+                                        b"RANDOMP(\0" as *const u8 as *const c_char,
+                                    )
+                                }) == 0
+                                {
+                                    yyval.Node = New_Func(
+                                        lParse,
+                                        0,
+                                        poirnd_fct,
+                                        1,
+                                        (*yyvsp.offset(-1_isize)).Node,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                    );
+                                    (*((*lParse).Nodes).offset(yyval.Node as isize)).ntype =
+                                        fits_parser_yytokentype::LONG as c_int;
+                                    current_block = 7600445499126923600;
+                                } else {
+                                    fits_parser_yyerror(
+                                        scanner,
+                                        lParse,
+                                        b"Function(expr) not supported\0" as *const u8
+                                            as *const c_char
+                                            as *mut c_char,
+                                    );
+                                    current_block = 4830776507462815627;
+                                }
+                            }
+                            match current_block {
+                                4830776507462815627 => {}
+                                _ => {
+                                    if yyval.Node < 0 {
+                                        current_block = 4830776507462815627;
+                                    } else {
+                                        current_block = 17353983478346836848;
+                                    }
+                                }
+                            }
+                        }
+                        60 => {
+                            if (if ((*yyvsp.offset(-4_isize)).astr[0] as c_int)
+                                < (*::core::mem::transmute::<&[u8; 8], &[c_char; 8]>(b"STRSTR(\0"))
+                                    [0] as c_int
+                            {
+                                -(1)
+                            } else if (*yyvsp.offset(-4_isize)).astr[0] as c_int
+                                > (*::core::mem::transmute::<&[u8; 8], &[c_char; 8]>(b"STRSTR(\0"))
+                                    [0] as c_int
+                            {
+                                1
+                            } else {
+                                strcmp(
+                                    ((*yyvsp.offset(-4_isize)).astr).as_mut_ptr(),
+                                    b"STRSTR(\0" as *const u8 as *const c_char,
+                                )
+                            }) == 0
+                            {
+                                yyval.Node = New_Func(
+                                    lParse,
+                                    fits_parser_yytokentype::LONG as c_int,
+                                    strpos_fct,
+                                    2 as c_int,
+                                    (*yyvsp.offset(-3_isize)).Node,
+                                    (*yyvsp.offset(-1_isize)).Node,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                );
+                                if yyval.Node < 0 {
+                                    current_block = 4830776507462815627;
+                                } else {
+                                    current_block = 12473999534294722905;
+                                }
+                            } else {
+                                current_block = 12473999534294722905;
+                            }
+                            match current_block {
+                                4830776507462815627 => {}
+                                _ => {
+                                    current_block = 17353983478346836848;
+                                }
+                            }
+                        }
+                        61 => {
+                            if (if ((*yyvsp.offset(-4_isize)).astr[0] as c_int)
+                                < (*::core::mem::transmute::<&[u8; 9], &[c_char; 9]>(b"DEFNULL(\0"))
+                                    [0] as c_int
+                            {
+                                -(1)
+                            } else if (*yyvsp.offset(-4_isize)).astr[0] as c_int
+                                > (*::core::mem::transmute::<&[u8; 9], &[c_char; 9]>(b"DEFNULL(\0"))
+                                    [0] as c_int
+                            {
+                                1
+                            } else {
+                                strcmp(
+                                    ((*yyvsp.offset(-4_isize)).astr).as_mut_ptr(),
+                                    b"DEFNULL(\0" as *const u8 as *const c_char,
+                                )
+                            }) == 0
+                            {
+                                if (*((*lParse).Nodes)
+                                    .offset((*yyvsp.offset(-3_isize)).Node as isize))
+                                .value
+                                .nelem
+                                    >= (*((*lParse).Nodes)
+                                        .offset((*yyvsp.offset(-1_isize)).Node as isize))
+                                    .value
+                                    .nelem
+                                    && Test_Dims(
+                                        lParse,
+                                        (*yyvsp.offset(-3_isize)).Node,
+                                        (*yyvsp.offset(-1_isize)).Node,
+                                    ) != 0
+                                {
+                                    if (*((*lParse).Nodes)
+                                        .offset((*yyvsp.offset(-3_isize)).Node as isize))
+                                    .ntype
+                                        > (*((*lParse).Nodes)
+                                            .offset((*yyvsp.offset(-1_isize)).Node as isize))
+                                        .ntype
+                                    {
+                                        (*yyvsp.offset(-1_isize)).Node = New_Unary(
+                                            lParse,
+                                            (*((*lParse).Nodes)
+                                                .offset((*yyvsp.offset(-3_isize)).Node as isize))
+                                            .ntype,
+                                            0,
+                                            (*yyvsp.offset(-1_isize)).Node,
+                                        );
+                                    } else if (*((*lParse).Nodes)
+                                        .offset((*yyvsp.offset(-3_isize)).Node as isize))
+                                    .ntype
+                                        < (*((*lParse).Nodes)
+                                            .offset((*yyvsp.offset(-1_isize)).Node as isize))
+                                        .ntype
+                                    {
+                                        (*yyvsp.offset(-3_isize)).Node = New_Unary(
+                                            lParse,
+                                            (*((*lParse).Nodes)
+                                                .offset((*yyvsp.offset(-1_isize)).Node as isize))
+                                            .ntype,
+                                            0,
+                                            (*yyvsp.offset(-3_isize)).Node,
+                                        );
+                                    }
+                                    yyval.Node = New_Func(
+                                        lParse,
+                                        0,
+                                        defnull_fct,
+                                        2 as c_int,
+                                        (*yyvsp.offset(-3_isize)).Node,
+                                        (*yyvsp.offset(-1_isize)).Node,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                    );
+                                    if yyval.Node < 0 {
+                                        current_block = 4830776507462815627;
+                                    } else {
+                                        current_block = 9966817879908499150;
+                                    }
+                                } else {
+                                    fits_parser_yyerror(
+                                        scanner,
+                                        lParse,
+                                        b"Dimensions of DEFNULL arguments are not compatible\0"
+                                            as *const u8
+                                            as *const c_char
+                                            as *mut c_char,
+                                    );
+                                    current_block = 4830776507462815627;
+                                }
+                            } else if (if ((*yyvsp.offset(-4_isize)).astr[0] as c_int)
+                                < (*::core::mem::transmute::<&[u8; 9], &[c_char; 9]>(b"ARCTAN2(\0"))
+                                    [0] as c_int
+                            {
+                                -(1)
+                            } else if (*yyvsp.offset(-4_isize)).astr[0] as c_int
+                                > (*::core::mem::transmute::<&[u8; 9], &[c_char; 9]>(b"ARCTAN2(\0"))
+                                    [0] as c_int
+                            {
+                                1
+                            } else {
+                                strcmp(
+                                    ((*yyvsp.offset(-4_isize)).astr).as_mut_ptr(),
+                                    b"ARCTAN2(\0" as *const u8 as *const c_char,
+                                )
+                            }) == 0
+                            {
+                                if (*((*lParse).Nodes)
+                                    .offset((*yyvsp.offset(-3_isize)).Node as isize))
+                                .ntype
+                                    != fits_parser_yytokentype::DOUBLE as c_int
+                                {
+                                    (*yyvsp.offset(-3_isize)).Node = New_Unary(
+                                        lParse,
+                                        fits_parser_yytokentype::DOUBLE as c_int,
+                                        0,
+                                        (*yyvsp.offset(-3_isize)).Node,
+                                    );
+                                }
+                                if (*((*lParse).Nodes)
+                                    .offset((*yyvsp.offset(-1_isize)).Node as isize))
+                                .ntype
+                                    != fits_parser_yytokentype::DOUBLE as c_int
+                                {
+                                    (*yyvsp.offset(-1_isize)).Node = New_Unary(
+                                        lParse,
+                                        fits_parser_yytokentype::DOUBLE as c_int,
+                                        0,
+                                        (*yyvsp.offset(-1_isize)).Node,
+                                    );
+                                }
+                                if Test_Dims(
+                                    lParse,
+                                    (*yyvsp.offset(-3_isize)).Node,
+                                    (*yyvsp.offset(-1_isize)).Node,
+                                ) != 0
+                                {
+                                    yyval.Node = New_Func(
+                                        lParse,
+                                        0,
+                                        atan2_fct,
+                                        2 as c_int,
+                                        (*yyvsp.offset(-3_isize)).Node,
+                                        (*yyvsp.offset(-1_isize)).Node,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                    );
+                                    if yyval.Node < 0 {
+                                        current_block = 4830776507462815627;
+                                    } else {
+                                        if (*((*lParse).Nodes)
+                                            .offset((*yyvsp.offset(-3_isize)).Node as isize))
+                                        .value
+                                        .nelem
+                                            < (*((*lParse).Nodes)
+                                                .offset((*yyvsp.offset(-1_isize)).Node as isize))
+                                            .value
+                                            .nelem
+                                        {
+                                            Copy_Dims(
+                                                lParse,
+                                                yyval.Node,
+                                                (*yyvsp.offset(-1_isize)).Node,
+                                            );
+                                        }
+                                        current_block = 9966817879908499150;
+                                    }
+                                } else {
+                                    fits_parser_yyerror(
+                                        scanner,
+                                        lParse,
+                                        b"Dimensions of arctan2 arguments are not compatible\0"
+                                            as *const u8
+                                            as *const c_char
+                                            as *mut c_char,
+                                    );
+                                    current_block = 4830776507462815627;
+                                }
+                            } else if (if ((*yyvsp.offset(-4_isize)).astr[0] as c_int)
+                                < (*::core::mem::transmute::<&[u8; 5], &[c_char; 5]>(b"MIN(\0"))[0]
+                                    as c_int
+                            {
+                                -(1)
+                            } else if (*yyvsp.offset(-4_isize)).astr[0] as c_int
+                                > (*::core::mem::transmute::<&[u8; 5], &[c_char; 5]>(b"MIN(\0"))[0]
+                                    as c_int
+                            {
+                                1
+                            } else {
+                                strcmp(
+                                    ((*yyvsp.offset(-4_isize)).astr).as_mut_ptr(),
+                                    b"MIN(\0" as *const u8 as *const c_char,
+                                )
+                            }) == 0
+                            {
+                                if (*((*lParse).Nodes)
+                                    .offset((*yyvsp.offset(-3_isize)).Node as isize))
+                                .ntype
+                                    > (*((*lParse).Nodes)
+                                        .offset((*yyvsp.offset(-1_isize)).Node as isize))
+                                    .ntype
+                                {
+                                    (*yyvsp.offset(-1_isize)).Node = New_Unary(
+                                        lParse,
+                                        (*((*lParse).Nodes)
+                                            .offset((*yyvsp.offset(-3_isize)).Node as isize))
+                                        .ntype,
+                                        0,
+                                        (*yyvsp.offset(-1_isize)).Node,
+                                    );
+                                } else if (*((*lParse).Nodes)
+                                    .offset((*yyvsp.offset(-3_isize)).Node as isize))
+                                .ntype
+                                    < (*((*lParse).Nodes)
+                                        .offset((*yyvsp.offset(-1_isize)).Node as isize))
+                                    .ntype
+                                {
+                                    (*yyvsp.offset(-3_isize)).Node = New_Unary(
+                                        lParse,
+                                        (*((*lParse).Nodes)
+                                            .offset((*yyvsp.offset(-1_isize)).Node as isize))
+                                        .ntype,
+                                        0,
+                                        (*yyvsp.offset(-3_isize)).Node,
+                                    );
+                                }
+                                if Test_Dims(
+                                    lParse,
+                                    (*yyvsp.offset(-3_isize)).Node,
+                                    (*yyvsp.offset(-1_isize)).Node,
+                                ) != 0
+                                {
+                                    yyval.Node = New_Func(
+                                        lParse,
+                                        0,
+                                        min2_fct,
+                                        2 as c_int,
+                                        (*yyvsp.offset(-3_isize)).Node,
+                                        (*yyvsp.offset(-1_isize)).Node,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                    );
+                                    if yyval.Node < 0 {
+                                        current_block = 4830776507462815627;
+                                    } else {
+                                        if (*((*lParse).Nodes)
+                                            .offset((*yyvsp.offset(-3_isize)).Node as isize))
+                                        .value
+                                        .nelem
+                                            < (*((*lParse).Nodes)
+                                                .offset((*yyvsp.offset(-1_isize)).Node as isize))
+                                            .value
+                                            .nelem
+                                        {
+                                            Copy_Dims(
+                                                lParse,
+                                                yyval.Node,
+                                                (*yyvsp.offset(-1_isize)).Node,
+                                            );
+                                        }
+                                        current_block = 9966817879908499150;
+                                    }
+                                } else {
+                                    fits_parser_yyerror(
+                                        scanner,
+                                        lParse,
+                                        b"Dimensions of min(a,b) arguments are not compatible\0"
+                                            as *const u8
+                                            as *const c_char
+                                            as *mut c_char,
+                                    );
+                                    current_block = 4830776507462815627;
+                                }
+                            } else if (if ((*yyvsp.offset(-4_isize)).astr[0] as c_int)
+                                < (*::core::mem::transmute::<&[u8; 5], &[c_char; 5]>(b"MAX(\0"))[0]
+                                    as c_int
+                            {
+                                -(1)
+                            } else if (*yyvsp.offset(-4_isize)).astr[0] as c_int
+                                > (*::core::mem::transmute::<&[u8; 5], &[c_char; 5]>(b"MAX(\0"))[0]
+                                    as c_int
+                            {
+                                1
+                            } else {
+                                strcmp(
+                                    ((*yyvsp.offset(-4_isize)).astr).as_mut_ptr(),
+                                    b"MAX(\0" as *const u8 as *const c_char,
+                                )
+                            }) == 0
+                            {
+                                if (*((*lParse).Nodes)
+                                    .offset((*yyvsp.offset(-3_isize)).Node as isize))
+                                .ntype
+                                    > (*((*lParse).Nodes)
+                                        .offset((*yyvsp.offset(-1_isize)).Node as isize))
+                                    .ntype
+                                {
+                                    (*yyvsp.offset(-1_isize)).Node = New_Unary(
+                                        lParse,
+                                        (*((*lParse).Nodes)
+                                            .offset((*yyvsp.offset(-3_isize)).Node as isize))
+                                        .ntype,
+                                        0,
+                                        (*yyvsp.offset(-1_isize)).Node,
+                                    );
+                                } else if (*((*lParse).Nodes)
+                                    .offset((*yyvsp.offset(-3_isize)).Node as isize))
+                                .ntype
+                                    < (*((*lParse).Nodes)
+                                        .offset((*yyvsp.offset(-1_isize)).Node as isize))
+                                    .ntype
+                                {
+                                    (*yyvsp.offset(-3_isize)).Node = New_Unary(
+                                        lParse,
+                                        (*((*lParse).Nodes)
+                                            .offset((*yyvsp.offset(-1_isize)).Node as isize))
+                                        .ntype,
+                                        0,
+                                        (*yyvsp.offset(-3_isize)).Node,
+                                    );
+                                }
+                                if Test_Dims(
+                                    lParse,
+                                    (*yyvsp.offset(-3_isize)).Node,
+                                    (*yyvsp.offset(-1_isize)).Node,
+                                ) != 0
+                                {
+                                    yyval.Node = New_Func(
+                                        lParse,
+                                        0,
+                                        max2_fct,
+                                        2 as c_int,
+                                        (*yyvsp.offset(-3_isize)).Node,
+                                        (*yyvsp.offset(-1_isize)).Node,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                    );
+                                    if yyval.Node < 0 {
+                                        current_block = 4830776507462815627;
+                                    } else {
+                                        if (*((*lParse).Nodes)
+                                            .offset((*yyvsp.offset(-3_isize)).Node as isize))
+                                        .value
+                                        .nelem
+                                            < (*((*lParse).Nodes)
+                                                .offset((*yyvsp.offset(-1_isize)).Node as isize))
+                                            .value
+                                            .nelem
+                                        {
+                                            Copy_Dims(
+                                                lParse,
+                                                yyval.Node,
+                                                (*yyvsp.offset(-1_isize)).Node,
+                                            );
+                                        }
+                                        current_block = 9966817879908499150;
+                                    }
+                                } else {
+                                    fits_parser_yyerror(
+                                        scanner,
+                                        lParse,
+                                        b"Dimensions of max(a,b) arguments are not compatible\0"
+                                            as *const u8
+                                            as *const c_char
+                                            as *mut c_char,
+                                    );
+                                    current_block = 4830776507462815627;
+                                }
+                            } else if (if ((*yyvsp.offset(-4_isize)).astr[0] as c_int)
+                                < (*::core::mem::transmute::<&[u8; 9], &[c_char; 9]>(b"SETNULL(\0"))
+                                    [0] as c_int
+                            {
+                                -(1)
+                            } else if (*yyvsp.offset(-4_isize)).astr[0] as c_int
+                                > (*::core::mem::transmute::<&[u8; 9], &[c_char; 9]>(b"SETNULL(\0"))
+                                    [0] as c_int
+                            {
+                                1
+                            } else {
+                                strcmp(
+                                    ((*yyvsp.offset(-4_isize)).astr).as_mut_ptr(),
+                                    b"SETNULL(\0" as *const u8 as *const c_char,
+                                )
+                            }) == 0
+                            {
+                                if (*((*lParse).Nodes)
+                                    .offset((*yyvsp.offset(-3_isize)).Node as isize))
+                                .operation
+                                    != -(1000 as c_int)
+                                    || (*((*lParse).Nodes)
+                                        .offset((*yyvsp.offset(-3_isize)).Node as isize))
+                                    .value
+                                    .nelem
+                                        != 1
+                                {
+                                    fits_parser_yyerror(
+                                        scanner,
+                                        lParse,
+                                        b"SETNULL first argument must be a scalar constant\0"
+                                            as *const u8
+                                            as *const c_char
+                                            as *mut c_char,
+                                    );
+                                    current_block = 4830776507462815627;
+                                } else {
+                                    if (*((*lParse).Nodes)
+                                        .offset((*yyvsp.offset(-3_isize)).Node as isize))
+                                    .ntype
+                                        != (*((*lParse).Nodes)
+                                            .offset((*yyvsp.offset(-1_isize)).Node as isize))
+                                        .ntype
+                                    {
+                                        (*yyvsp.offset(-3_isize)).Node = New_Unary(
+                                            lParse,
+                                            (*((*lParse).Nodes)
+                                                .offset((*yyvsp.offset(-1_isize)).Node as isize))
+                                            .ntype,
+                                            0,
+                                            (*yyvsp.offset(-3_isize)).Node,
+                                        );
+                                    }
+                                    yyval.Node = New_Func(
+                                        lParse,
+                                        0,
+                                        setnull_fct,
+                                        2 as c_int,
+                                        (*yyvsp.offset(-1_isize)).Node,
+                                        (*yyvsp.offset(-3_isize)).Node,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                    );
+                                    current_block = 9966817879908499150;
+                                }
+                            } else if (if ((*yyvsp.offset(-4_isize)).astr[0] as c_int)
+                                < (*::core::mem::transmute::<&[u8; 10], &[c_char; 10]>(
+                                    b"AXISELEM(\0",
+                                ))[0] as c_int
+                            {
+                                -(1)
+                            } else if (*yyvsp.offset(-4_isize)).astr[0] as c_int
+                                > (*::core::mem::transmute::<&[u8; 10], &[c_char; 10]>(
+                                    b"AXISELEM(\0",
+                                ))[0] as c_int
+                            {
+                                1
+                            } else {
+                                strcmp(
+                                    ((*yyvsp.offset(-4_isize)).astr).as_mut_ptr(),
+                                    b"AXISELEM(\0" as *const u8 as *const c_char,
+                                )
+                            }) == 0
+                            {
+                                if (*((*lParse).Nodes)
+                                    .offset((*yyvsp.offset(-1_isize)).Node as isize))
+                                .operation
+                                    != -(1000 as c_int)
+                                    || (*((*lParse).Nodes)
+                                        .offset((*yyvsp.offset(-1_isize)).Node as isize))
+                                    .value
+                                    .nelem
+                                        != 1
+                                {
+                                    fits_parser_yyerror(
+                                        scanner,
+                                        lParse,
+                                        b"AXISELEM second argument must be a scalar constant\0"
+                                            as *const u8
+                                            as *const c_char
+                                            as *mut c_char,
+                                    );
+                                    current_block = 4830776507462815627;
+                                } else if (*((*lParse).Nodes)
+                                    .offset((*yyvsp.offset(-3_isize)).Node as isize))
+                                .operation
+                                    == -(1000 as c_int)
+                                {
+                                    let mut one_3: c_long = 1;
+                                    yyval.Node = New_Const(
+                                        lParse,
+                                        fits_parser_yytokentype::LONG as c_int,
+                                        &mut one_3 as *mut c_long as *mut c_void,
+                                        ::core::mem::size_of::<c_long>() as c_ulong as c_long,
+                                    );
+                                    current_block = 9966817879908499150;
+                                } else {
+                                    if (*((*lParse).Nodes)
+                                        .offset((*yyvsp.offset(-1_isize)).Node as isize))
+                                    .ntype
+                                        != fits_parser_yytokentype::LONG as c_int
+                                    {
+                                        (*yyvsp.offset(-1_isize)).Node = New_Unary(
+                                            lParse,
+                                            fits_parser_yytokentype::LONG as c_int,
+                                            0,
+                                            (*yyvsp.offset(-1_isize)).Node,
+                                        );
+                                    }
+                                    yyval.Node = New_Func(
+                                        lParse,
+                                        0,
+                                        axiselem_fct,
+                                        2 as c_int,
+                                        (*yyvsp.offset(-3_isize)).Node,
+                                        (*yyvsp.offset(-1_isize)).Node,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                    );
+                                    if yyval.Node < 0 {
+                                        current_block = 4830776507462815627;
+                                    } else {
+                                        (*((*lParse).Nodes).offset(yyval.Node as isize)).ntype =
+                                            fits_parser_yytokentype::LONG as c_int;
+                                        current_block = 9966817879908499150;
+                                    }
+                                }
+                            } else if (if ((*yyvsp.offset(-4_isize)).astr[0] as c_int)
+                                < (*::core::mem::transmute::<&[u8; 7], &[c_char; 7]>(b"NAXES(\0"))
+                                    [0] as c_int
+                            {
+                                -(1)
+                            } else if (*yyvsp.offset(-4_isize)).astr[0] as c_int
+                                > (*::core::mem::transmute::<&[u8; 7], &[c_char; 7]>(b"NAXES(\0"))
+                                    [0] as c_int
+                            {
+                                1
+                            } else {
+                                strcmp(
+                                    ((*yyvsp.offset(-4_isize)).astr).as_mut_ptr(),
+                                    b"NAXES(\0" as *const u8 as *const c_char,
+                                )
+                            }) == 0
+                            {
+                                if (*((*lParse).Nodes)
+                                    .offset((*yyvsp.offset(-1_isize)).Node as isize))
+                                .operation
+                                    != -(1000 as c_int)
+                                    || (*((*lParse).Nodes)
+                                        .offset((*yyvsp.offset(-1_isize)).Node as isize))
+                                    .value
+                                    .nelem
+                                        != 1
+                                {
+                                    fits_parser_yyerror(
+                                        scanner,
+                                        lParse,
+                                        b"NAXES second argument must be a scalar constant\0"
+                                            as *const u8
+                                            as *const c_char
+                                            as *mut c_char,
+                                    );
+                                    current_block = 4830776507462815627;
+                                } else if (*((*lParse).Nodes)
+                                    .offset((*yyvsp.offset(-3_isize)).Node as isize))
+                                .operation
+                                    == -(1000 as c_int)
+                                {
+                                    let mut one_4: c_long = 1;
+                                    yyval.Node = New_Const(
+                                        lParse,
+                                        fits_parser_yytokentype::LONG as c_int,
+                                        &mut one_4 as *mut c_long as *mut c_void,
+                                        ::core::mem::size_of::<c_long>() as c_ulong as c_long,
+                                    );
+                                    current_block = 9966817879908499150;
+                                } else {
+                                    let mut iaxis_0: c_long = 0;
+                                    let mut naxis_1: c_int = 0;
+                                    if (*((*lParse).Nodes)
+                                        .offset((*yyvsp.offset(-1_isize)).Node as isize))
+                                    .ntype
+                                        != fits_parser_yytokentype::LONG as c_int
+                                    {
+                                        (*yyvsp.offset(-1_isize)).Node = New_Unary(
+                                            lParse,
+                                            fits_parser_yytokentype::LONG as c_int,
+                                            0,
+                                            (*yyvsp.offset(-1_isize)).Node,
+                                        );
+                                    }
+                                    iaxis_0 = (*((*lParse).Nodes)
+                                        .offset((*yyvsp.offset(-1_isize)).Node as isize))
+                                    .value
+                                    .data
+                                    .lng;
+                                    naxis_1 = (*((*lParse).Nodes)
+                                        .offset((*yyvsp.offset(-3_isize)).Node as isize))
+                                    .value
+                                    .naxis;
+                                    if iaxis_0 == 0 {
+                                        iaxis_0 = naxis_1 as c_long;
+                                    } else if iaxis_0 <= naxis_1 as c_long {
+                                        iaxis_0 = (*((*lParse).Nodes)
+                                            .offset((*yyvsp.offset(-3_isize)).Node as isize))
+                                        .value
+                                        .naxes[(iaxis_0 - 1) as usize];
+                                    } else {
+                                        iaxis_0 = 1;
+                                    }
+                                    yyval.Node = New_Const(
+                                        lParse,
+                                        fits_parser_yytokentype::LONG as c_int,
+                                        &mut iaxis_0 as *mut c_long as *mut c_void,
+                                        ::core::mem::size_of::<c_long>() as c_ulong as c_long,
+                                    );
+                                    if yyval.Node < 0 {
+                                        current_block = 4830776507462815627;
+                                    } else {
+                                        current_block = 9966817879908499150;
+                                    }
+                                }
+                            } else if (if ((*yyvsp.offset(-4_isize)).astr[0] as c_int)
+                                < (*::core::mem::transmute::<&[u8; 7], &[c_char; 7]>(b"ARRAY(\0"))
+                                    [0] as c_int
+                            {
+                                -(1)
+                            } else if (*yyvsp.offset(-4_isize)).astr[0] as c_int
+                                > (*::core::mem::transmute::<&[u8; 7], &[c_char; 7]>(b"ARRAY(\0"))
+                                    [0] as c_int
+                            {
+                                1
+                            } else {
+                                strcmp(
+                                    ((*yyvsp.offset(-4_isize)).astr).as_mut_ptr(),
+                                    b"ARRAY(\0" as *const u8 as *const c_char,
+                                )
+                            }) == 0
+                            {
+                                yyval.Node = New_Array(
+                                    lParse,
+                                    (*yyvsp.offset(-3_isize)).Node,
+                                    (*yyvsp.offset(-1_isize)).Node,
+                                );
+                                if yyval.Node < 0 {
+                                    current_block = 4830776507462815627;
+                                } else {
+                                    current_block = 9966817879908499150;
+                                }
+                            } else {
+                                fits_parser_yyerror(
+                                    scanner,
+                                    lParse,
+                                    b"Function(expr,expr) not supported\0" as *const u8
+                                        as *const c_char
+                                        as *mut c_char,
+                                );
+                                current_block = 4830776507462815627;
+                            }
+                            match current_block {
+                                4830776507462815627 => {}
+                                _ => {
+                                    current_block = 17353983478346836848;
+                                }
+                            }
+                        }
+                        62 => {
+                            if (if ((*yyvsp.offset(-(8 as c_int) as isize)).astr[0] as c_int)
+                                < (*::core::mem::transmute::<&[u8; 8], &[c_char; 8]>(b"ANGSEP(\0"))
+                                    [0] as c_int
+                            {
+                                -(1)
+                            } else if (*yyvsp.offset(-(8 as c_int) as isize)).astr[0] as c_int
+                                > (*::core::mem::transmute::<&[u8; 8], &[c_char; 8]>(b"ANGSEP(\0"))
+                                    [0] as c_int
+                            {
+                                1
+                            } else {
+                                strcmp(
+                                    ((*yyvsp.offset(-(8 as c_int) as isize)).astr).as_mut_ptr(),
+                                    b"ANGSEP(\0" as *const u8 as *const c_char,
+                                )
+                            }) == 0
+                            {
+                                if (*((*lParse).Nodes)
+                                    .offset((*yyvsp.offset(-(7 as c_int) as isize)).Node as isize))
+                                .ntype
+                                    != fits_parser_yytokentype::DOUBLE as c_int
+                                {
+                                    (*yyvsp.offset(-(7 as c_int) as isize)).Node = New_Unary(
+                                        lParse,
+                                        fits_parser_yytokentype::DOUBLE as c_int,
+                                        0,
+                                        (*yyvsp.offset(-(7 as c_int) as isize)).Node,
+                                    );
+                                }
+                                if (*((*lParse).Nodes).offset((*yyvsp.offset(-(5))).Node as isize))
+                                    .ntype
+                                    != fits_parser_yytokentype::DOUBLE as c_int
+                                {
+                                    (*yyvsp.offset(-(5))).Node = New_Unary(
+                                        lParse,
+                                        fits_parser_yytokentype::DOUBLE as c_int,
+                                        0,
+                                        (*yyvsp.offset(-(5))).Node,
+                                    );
+                                }
+                                if (*((*lParse).Nodes)
+                                    .offset((*yyvsp.offset(-3_isize)).Node as isize))
+                                .ntype
+                                    != fits_parser_yytokentype::DOUBLE as c_int
+                                {
+                                    (*yyvsp.offset(-3_isize)).Node = New_Unary(
+                                        lParse,
+                                        fits_parser_yytokentype::DOUBLE as c_int,
+                                        0,
+                                        (*yyvsp.offset(-3_isize)).Node,
+                                    );
+                                }
+                                if (*((*lParse).Nodes)
+                                    .offset((*yyvsp.offset(-1_isize)).Node as isize))
+                                .ntype
+                                    != fits_parser_yytokentype::DOUBLE as c_int
+                                {
+                                    (*yyvsp.offset(-1_isize)).Node = New_Unary(
+                                        lParse,
+                                        fits_parser_yytokentype::DOUBLE as c_int,
+                                        0,
+                                        (*yyvsp.offset(-1_isize)).Node,
+                                    );
+                                }
+                                if Test_Dims(
+                                    lParse,
+                                    (*yyvsp.offset(-(7 as c_int) as isize)).Node,
+                                    (*yyvsp.offset(-(5))).Node,
+                                ) != 0
+                                    && Test_Dims(
+                                        lParse,
+                                        (*yyvsp.offset(-(5))).Node,
+                                        (*yyvsp.offset(-3_isize)).Node,
+                                    ) != 0
+                                    && Test_Dims(
+                                        lParse,
+                                        (*yyvsp.offset(-3_isize)).Node,
+                                        (*yyvsp.offset(-1_isize)).Node,
+                                    ) != 0
+                                {
+                                    yyval.Node = New_Func(
+                                        lParse,
+                                        0,
+                                        angsep_fct,
+                                        4 as c_int,
+                                        (*yyvsp.offset(-(7 as c_int) as isize)).Node,
+                                        (*yyvsp.offset(-(5))).Node,
+                                        (*yyvsp.offset(-3_isize)).Node,
+                                        (*yyvsp.offset(-1_isize)).Node,
+                                        0,
+                                        0,
+                                        0,
+                                    );
+                                    if yyval.Node < 0 {
+                                        current_block = 4830776507462815627;
+                                    } else {
+                                        if (*((*lParse).Nodes).offset(
+                                            (*yyvsp.offset(-(7 as c_int) as isize)).Node as isize,
+                                        ))
+                                        .value
+                                        .nelem
+                                            < (*((*lParse).Nodes)
+                                                .offset((*yyvsp.offset(-(5))).Node as isize))
+                                            .value
+                                            .nelem
+                                        {
+                                            Copy_Dims(
+                                                lParse,
+                                                yyval.Node,
+                                                (*yyvsp.offset(-(5))).Node,
+                                            );
+                                        }
+                                        if (*((*lParse).Nodes)
+                                            .offset((*yyvsp.offset(-(5))).Node as isize))
+                                        .value
+                                        .nelem
+                                            < (*((*lParse).Nodes)
+                                                .offset((*yyvsp.offset(-3_isize)).Node as isize))
+                                            .value
+                                            .nelem
+                                        {
+                                            Copy_Dims(
+                                                lParse,
+                                                yyval.Node,
+                                                (*yyvsp.offset(-3_isize)).Node,
+                                            );
+                                        }
+                                        if (*((*lParse).Nodes)
+                                            .offset((*yyvsp.offset(-3_isize)).Node as isize))
+                                        .value
+                                        .nelem
+                                            < (*((*lParse).Nodes)
+                                                .offset((*yyvsp.offset(-1_isize)).Node as isize))
+                                            .value
+                                            .nelem
+                                        {
+                                            Copy_Dims(
+                                                lParse,
+                                                yyval.Node,
+                                                (*yyvsp.offset(-1_isize)).Node,
+                                            );
+                                        }
+                                        current_block = 17353983478346836848;
+                                    }
+                                } else {
+                                    fits_parser_yyerror(
+                                        scanner,
+                                        lParse,
+                                        b"Dimensions of ANGSEP arguments are not compatible\0"
+                                            as *const u8
+                                            as *const c_char
+                                            as *mut c_char,
+                                    );
+                                    current_block = 4830776507462815627;
+                                }
+                            } else {
+                                fits_parser_yyerror(
+                                    scanner,
+                                    lParse,
+                                    b"Function(expr,expr,expr,expr) not supported\0" as *const u8
+                                        as *const c_char
+                                        as *mut c_char,
+                                );
+                                current_block = 4830776507462815627;
+                            }
+                        }
+                        63 => {
+                            yyval.Node = New_GTI(
+                                lParse,
+                                gtiover_fct,
+                                ((*yyvsp.offset(-(5))).astr).as_mut_ptr(),
+                                (*yyvsp.offset(-3_isize)).Node,
+                                (*yyvsp.offset(-1_isize)).Node,
+                                b"*START*\0" as *const u8 as *const c_char as *mut c_char,
+                                b"*STOP*\0" as *const u8 as *const c_char as *mut c_char,
+                            );
+                            if yyval.Node < 0 {
+                                current_block = 4830776507462815627;
+                            } else {
+                                current_block = 17353983478346836848;
+                            }
+                        }
+                        64 => {
+                            yyval.Node = New_GTI(
+                                lParse,
+                                gtiover_fct,
+                                ((*yyvsp.offset(-(9 as c_int) as isize)).astr).as_mut_ptr(),
+                                (*yyvsp.offset(-(7 as c_int) as isize)).Node,
+                                (*yyvsp.offset(-(5))).Node,
+                                ((*yyvsp.offset(-3_isize)).astr).as_mut_ptr(),
+                                ((*yyvsp.offset(-1_isize)).astr).as_mut_ptr(),
+                            );
+                            if yyval.Node < 0 {
+                                current_block = 4830776507462815627;
+                            } else {
+                                current_block = 17353983478346836848;
+                            }
+                        }
+                        65 => {
+                            yyval.Node = New_Deref(
+                                lParse,
+                                (*yyvsp.offset(-3_isize)).Node,
+                                1,
+                                (*yyvsp.offset(-1_isize)).Node,
+                                0,
+                                0,
+                                0,
+                                0,
+                            );
+                            if yyval.Node < 0 {
+                                current_block = 4830776507462815627;
+                            } else {
+                                current_block = 17353983478346836848;
+                            }
+                        }
+                        66 => {
+                            yyval.Node = New_Deref(
+                                lParse,
+                                (*yyvsp.offset(-(5))).Node,
+                                2 as c_int,
+                                (*yyvsp.offset(-3_isize)).Node,
+                                (*yyvsp.offset(-1_isize)).Node,
+                                0,
+                                0,
+                                0,
+                            );
+                            if yyval.Node < 0 {
+                                current_block = 4830776507462815627;
+                            } else {
+                                current_block = 17353983478346836848;
+                            }
+                        }
+                        67 => {
+                            yyval.Node = New_Deref(
+                                lParse,
+                                (*yyvsp.offset(-(7 as c_int) as isize)).Node,
+                                3 as c_int,
+                                (*yyvsp.offset(-(5))).Node,
+                                (*yyvsp.offset(-3_isize)).Node,
+                                (*yyvsp.offset(-1_isize)).Node,
+                                0,
+                                0,
+                            );
+                            if yyval.Node < 0 {
+                                current_block = 4830776507462815627;
+                            } else {
+                                current_block = 17353983478346836848;
+                            }
+                        }
+                        68 => {
+                            yyval.Node = New_Deref(
+                                lParse,
+                                (*yyvsp.offset(-(9 as c_int) as isize)).Node,
+                                4 as c_int,
+                                (*yyvsp.offset(-(7 as c_int) as isize)).Node,
+                                (*yyvsp.offset(-(5))).Node,
+                                (*yyvsp.offset(-3_isize)).Node,
+                                (*yyvsp.offset(-1_isize)).Node,
+                                0,
+                            );
+                            if yyval.Node < 0 {
+                                current_block = 4830776507462815627;
+                            } else {
+                                current_block = 17353983478346836848;
+                            }
+                        }
+                        69 => {
+                            yyval.Node = New_Deref(
+                                lParse,
+                                (*yyvsp.offset(-(11 as c_int) as isize)).Node,
+                                5 as c_int,
+                                (*yyvsp.offset(-(9 as c_int) as isize)).Node,
+                                (*yyvsp.offset(-(7 as c_int) as isize)).Node,
+                                (*yyvsp.offset(-(5))).Node,
+                                (*yyvsp.offset(-3_isize)).Node,
+                                (*yyvsp.offset(-1_isize)).Node,
+                            );
+                            if yyval.Node < 0 {
+                                current_block = 4830776507462815627;
+                            } else {
+                                current_block = 17353983478346836848;
+                            }
+                        }
+                        70 => {
+                            yyval.Node = New_Unary(
+                                lParse,
+                                fits_parser_yytokentype::LONG as c_int,
+                                fits_parser_yytokentype::INTCAST as c_int,
+                                (*yyvsp.offset(0)).Node,
+                            );
+                            if yyval.Node < 0 {
+                                current_block = 4830776507462815627;
+                            } else {
+                                current_block = 17353983478346836848;
+                            }
+                        }
+                        71 => {
+                            yyval.Node = New_Unary(
+                                lParse,
+                                fits_parser_yytokentype::LONG as c_int,
+                                fits_parser_yytokentype::INTCAST as c_int,
+                                (*yyvsp.offset(0)).Node,
+                            );
+                            if yyval.Node < 0 {
+                                current_block = 4830776507462815627;
+                            } else {
+                                current_block = 17353983478346836848;
+                            }
+                        }
+                        72 => {
+                            yyval.Node = New_Unary(
+                                lParse,
+                                fits_parser_yytokentype::DOUBLE as c_int,
+                                fits_parser_yytokentype::FLTCAST as c_int,
+                                (*yyvsp.offset(0)).Node,
+                            );
+                            if yyval.Node < 0 {
+                                current_block = 4830776507462815627;
+                            } else {
+                                current_block = 17353983478346836848;
+                            }
+                        }
+                        73 => {
+                            yyval.Node = New_Unary(
+                                lParse,
+                                fits_parser_yytokentype::DOUBLE as c_int,
+                                fits_parser_yytokentype::FLTCAST as c_int,
+                                (*yyvsp.offset(0)).Node,
+                            );
+                            if yyval.Node < 0 {
+                                current_block = 4830776507462815627;
+                            } else {
+                                current_block = 17353983478346836848;
+                            }
+                        }
+                        74 => {
+                            yyval.Node = New_Const(
+                                lParse,
+                                fits_parser_yytokentype::BOOLEAN as c_int,
+                                &mut (*yyvsp.offset(0)).log as *mut c_char as *mut c_void,
+                                ::core::mem::size_of::<c_char>() as c_ulong as c_long,
+                            );
+                            if yyval.Node < 0 {
+                                current_block = 4830776507462815627;
+                            } else {
+                                current_block = 17353983478346836848;
+                            }
+                        }
+                        75 => {
+                            yyval.Node = New_Column(lParse, (*yyvsp.offset(0)).lng as c_int);
+                            if yyval.Node < 0 {
+                                current_block = 4830776507462815627;
+                            } else {
+                                current_block = 17353983478346836848;
+                            }
+                        }
+                        76 => {
+                            if (*((*lParse).Nodes).offset((*yyvsp.offset(-1_isize)).Node as isize))
+                                .ntype
+                                != fits_parser_yytokentype::LONG as c_int
+                                || (*((*lParse).Nodes)
+                                    .offset((*yyvsp.offset(-1_isize)).Node as isize))
+                                .operation
+                                    != -(1000 as c_int)
+                            {
+                                fits_parser_yyerror(
+                                    scanner,
+                                    lParse,
+                                    b"Offset argument must be a constant integer\0" as *const u8
+                                        as *const c_char
+                                        as *mut c_char,
+                                );
+                                current_block = 4830776507462815627;
+                            } else {
+                                yyval.Node = New_Offset(
+                                    lParse,
+                                    (*yyvsp.offset(-3_isize)).lng as c_int,
+                                    (*yyvsp.offset(-1_isize)).Node,
+                                );
+                                if yyval.Node < 0 {
+                                    current_block = 4830776507462815627;
+                                } else {
+                                    current_block = 17353983478346836848;
+                                }
+                            }
+                        }
+                        77 => {
+                            yyval.Node = New_BinOp(
+                                lParse,
+                                fits_parser_yytokentype::BOOLEAN as c_int,
+                                (*yyvsp.offset(-2_isize)).Node,
+                                fits_parser_yytokentype::EQ as c_int,
+                                (*yyvsp.offset(0)).Node,
+                            );
+                            if yyval.Node < 0 {
+                                current_block = 4830776507462815627;
+                            } else {
+                                ((*((*lParse).Nodes).offset(yyval.Node as isize)).value).nelem = 1;
+                                current_block = 17353983478346836848;
+                            }
+                        }
+                        78 => {
+                            yyval.Node = New_BinOp(
+                                lParse,
+                                fits_parser_yytokentype::BOOLEAN as c_int,
+                                (*yyvsp.offset(-2_isize)).Node,
+                                fits_parser_yytokentype::NE as c_int,
+                                (*yyvsp.offset(0)).Node,
+                            );
+                            if yyval.Node < 0 {
+                                current_block = 4830776507462815627;
+                            } else {
+                                ((*((*lParse).Nodes).offset(yyval.Node as isize)).value).nelem = 1;
+                                current_block = 17353983478346836848;
+                            }
+                        }
+                        79 => {
+                            yyval.Node = New_BinOp(
+                                lParse,
+                                fits_parser_yytokentype::BOOLEAN as c_int,
+                                (*yyvsp.offset(-2_isize)).Node,
+                                fits_parser_yytokentype::LT as c_int,
+                                (*yyvsp.offset(0)).Node,
+                            );
+                            if yyval.Node < 0 {
+                                current_block = 4830776507462815627;
+                            } else {
+                                ((*((*lParse).Nodes).offset(yyval.Node as isize)).value).nelem = 1;
+                                current_block = 17353983478346836848;
+                            }
+                        }
+                        80 => {
+                            yyval.Node = New_BinOp(
+                                lParse,
+                                fits_parser_yytokentype::BOOLEAN as c_int,
+                                (*yyvsp.offset(-2_isize)).Node,
+                                fits_parser_yytokentype::LTE as c_int,
+                                (*yyvsp.offset(0)).Node,
+                            );
+                            if yyval.Node < 0 {
+                                current_block = 4830776507462815627;
+                            } else {
+                                ((*((*lParse).Nodes).offset(yyval.Node as isize)).value).nelem = 1;
+                                current_block = 17353983478346836848;
+                            }
+                        }
+                        81 => {
+                            yyval.Node = New_BinOp(
+                                lParse,
+                                fits_parser_yytokentype::BOOLEAN as c_int,
+                                (*yyvsp.offset(-2_isize)).Node,
+                                fits_parser_yytokentype::GT as c_int,
+                                (*yyvsp.offset(0)).Node,
+                            );
+                            if yyval.Node < 0 {
+                                current_block = 4830776507462815627;
+                            } else {
+                                ((*((*lParse).Nodes).offset(yyval.Node as isize)).value).nelem = 1;
+                                current_block = 17353983478346836848;
+                            }
+                        }
+                        82 => {
+                            yyval.Node = New_BinOp(
+                                lParse,
+                                fits_parser_yytokentype::BOOLEAN as c_int,
+                                (*yyvsp.offset(-2_isize)).Node,
+                                fits_parser_yytokentype::GTE as c_int,
+                                (*yyvsp.offset(0)).Node,
+                            );
+                            if yyval.Node < 0 {
+                                current_block = 4830776507462815627;
+                            } else {
+                                ((*((*lParse).Nodes).offset(yyval.Node as isize)).value).nelem = 1;
+                                current_block = 17353983478346836848;
+                            }
+                        }
+                        83 => {
+                            if (*((*lParse).Nodes).offset((*yyvsp.offset(-2_isize)).Node as isize))
+                                .ntype
+                                > (*((*lParse).Nodes).offset((*yyvsp.offset(0)).Node as isize))
+                                    .ntype
+                            {
+                                (*yyvsp.offset(0)).Node = New_Unary(
+                                    lParse,
+                                    (*((*lParse).Nodes)
+                                        .offset((*yyvsp.offset(-2_isize)).Node as isize))
+                                    .ntype,
+                                    0,
+                                    (*yyvsp.offset(0)).Node,
+                                );
+                            } else if (*((*lParse).Nodes)
+                                .offset((*yyvsp.offset(-2_isize)).Node as isize))
+                            .ntype
+                                < (*((*lParse).Nodes).offset((*yyvsp.offset(0)).Node as isize))
+                                    .ntype
+                            {
+                                (*yyvsp.offset(-2_isize)).Node = New_Unary(
+                                    lParse,
+                                    (*((*lParse).Nodes).offset((*yyvsp.offset(0)).Node as isize))
+                                        .ntype,
+                                    0,
+                                    (*yyvsp.offset(-2_isize)).Node,
+                                );
+                            }
+                            yyval.Node = New_BinOp(
+                                lParse,
+                                fits_parser_yytokentype::BOOLEAN as c_int,
+                                (*yyvsp.offset(-2_isize)).Node,
+                                fits_parser_yytokentype::GT as c_int,
+                                (*yyvsp.offset(0)).Node,
+                            );
+                            if yyval.Node < 0 {
+                                current_block = 4830776507462815627;
+                            } else {
+                                current_block = 17353983478346836848;
+                            }
+                        }
+                        84 => {
+                            if (*((*lParse).Nodes).offset((*yyvsp.offset(-2_isize)).Node as isize))
+                                .ntype
+                                > (*((*lParse).Nodes).offset((*yyvsp.offset(0)).Node as isize))
+                                    .ntype
+                            {
+                                (*yyvsp.offset(0)).Node = New_Unary(
+                                    lParse,
+                                    (*((*lParse).Nodes)
+                                        .offset((*yyvsp.offset(-2_isize)).Node as isize))
+                                    .ntype,
+                                    0,
+                                    (*yyvsp.offset(0)).Node,
+                                );
+                            } else if (*((*lParse).Nodes)
+                                .offset((*yyvsp.offset(-2_isize)).Node as isize))
+                            .ntype
+                                < (*((*lParse).Nodes).offset((*yyvsp.offset(0)).Node as isize))
+                                    .ntype
+                            {
+                                (*yyvsp.offset(-2_isize)).Node = New_Unary(
+                                    lParse,
+                                    (*((*lParse).Nodes).offset((*yyvsp.offset(0)).Node as isize))
+                                        .ntype,
+                                    0,
+                                    (*yyvsp.offset(-2_isize)).Node,
+                                );
+                            }
+                            yyval.Node = New_BinOp(
+                                lParse,
+                                fits_parser_yytokentype::BOOLEAN as c_int,
+                                (*yyvsp.offset(-2_isize)).Node,
+                                fits_parser_yytokentype::LT as c_int,
+                                (*yyvsp.offset(0)).Node,
+                            );
+                            if yyval.Node < 0 {
+                                current_block = 4830776507462815627;
+                            } else {
+                                current_block = 17353983478346836848;
+                            }
+                        }
+                        85 => {
+                            if (*((*lParse).Nodes).offset((*yyvsp.offset(-2_isize)).Node as isize))
+                                .ntype
+                                > (*((*lParse).Nodes).offset((*yyvsp.offset(0)).Node as isize))
+                                    .ntype
+                            {
+                                (*yyvsp.offset(0)).Node = New_Unary(
+                                    lParse,
+                                    (*((*lParse).Nodes)
+                                        .offset((*yyvsp.offset(-2_isize)).Node as isize))
+                                    .ntype,
+                                    0,
+                                    (*yyvsp.offset(0)).Node,
+                                );
+                            } else if (*((*lParse).Nodes)
+                                .offset((*yyvsp.offset(-2_isize)).Node as isize))
+                            .ntype
+                                < (*((*lParse).Nodes).offset((*yyvsp.offset(0)).Node as isize))
+                                    .ntype
+                            {
+                                (*yyvsp.offset(-2_isize)).Node = New_Unary(
+                                    lParse,
+                                    (*((*lParse).Nodes).offset((*yyvsp.offset(0)).Node as isize))
+                                        .ntype,
+                                    0,
+                                    (*yyvsp.offset(-2_isize)).Node,
+                                );
+                            }
+                            yyval.Node = New_BinOp(
+                                lParse,
+                                fits_parser_yytokentype::BOOLEAN as c_int,
+                                (*yyvsp.offset(-2_isize)).Node,
+                                fits_parser_yytokentype::GTE as c_int,
+                                (*yyvsp.offset(0)).Node,
+                            );
+                            if yyval.Node < 0 {
+                                current_block = 4830776507462815627;
+                            } else {
+                                current_block = 17353983478346836848;
+                            }
+                        }
+                        86 => {
+                            if (*((*lParse).Nodes).offset((*yyvsp.offset(-2_isize)).Node as isize))
+                                .ntype
+                                > (*((*lParse).Nodes).offset((*yyvsp.offset(0)).Node as isize))
+                                    .ntype
+                            {
+                                (*yyvsp.offset(0)).Node = New_Unary(
+                                    lParse,
+                                    (*((*lParse).Nodes)
+                                        .offset((*yyvsp.offset(-2_isize)).Node as isize))
+                                    .ntype,
+                                    0,
+                                    (*yyvsp.offset(0)).Node,
+                                );
+                            } else if (*((*lParse).Nodes)
+                                .offset((*yyvsp.offset(-2_isize)).Node as isize))
+                            .ntype
+                                < (*((*lParse).Nodes).offset((*yyvsp.offset(0)).Node as isize))
+                                    .ntype
+                            {
+                                (*yyvsp.offset(-2_isize)).Node = New_Unary(
+                                    lParse,
+                                    (*((*lParse).Nodes).offset((*yyvsp.offset(0)).Node as isize))
+                                        .ntype,
+                                    0,
+                                    (*yyvsp.offset(-2_isize)).Node,
+                                );
+                            }
+                            yyval.Node = New_BinOp(
+                                lParse,
+                                fits_parser_yytokentype::BOOLEAN as c_int,
+                                (*yyvsp.offset(-2_isize)).Node,
+                                fits_parser_yytokentype::LTE as c_int,
+                                (*yyvsp.offset(0)).Node,
+                            );
+                            if yyval.Node < 0 {
+                                current_block = 4830776507462815627;
+                            } else {
+                                current_block = 17353983478346836848;
+                            }
+                        }
+                        87 => {
+                            if (*((*lParse).Nodes).offset((*yyvsp.offset(-2_isize)).Node as isize))
+                                .ntype
+                                > (*((*lParse).Nodes).offset((*yyvsp.offset(0)).Node as isize))
+                                    .ntype
+                            {
+                                (*yyvsp.offset(0)).Node = New_Unary(
+                                    lParse,
+                                    (*((*lParse).Nodes)
+                                        .offset((*yyvsp.offset(-2_isize)).Node as isize))
+                                    .ntype,
+                                    0,
+                                    (*yyvsp.offset(0)).Node,
+                                );
+                            } else if (*((*lParse).Nodes)
+                                .offset((*yyvsp.offset(-2_isize)).Node as isize))
+                            .ntype
+                                < (*((*lParse).Nodes).offset((*yyvsp.offset(0)).Node as isize))
+                                    .ntype
+                            {
+                                (*yyvsp.offset(-2_isize)).Node = New_Unary(
+                                    lParse,
+                                    (*((*lParse).Nodes).offset((*yyvsp.offset(0)).Node as isize))
+                                        .ntype,
+                                    0,
+                                    (*yyvsp.offset(-2_isize)).Node,
+                                );
+                            }
+                            yyval.Node = New_BinOp(
+                                lParse,
+                                fits_parser_yytokentype::BOOLEAN as c_int,
+                                (*yyvsp.offset(-2_isize)).Node,
+                                '~' as i32,
+                                (*yyvsp.offset(0)).Node,
+                            );
+                            if yyval.Node < 0 {
+                                current_block = 4830776507462815627;
+                            } else {
+                                current_block = 17353983478346836848;
+                            }
+                        }
+                        88 => {
+                            if (*((*lParse).Nodes).offset((*yyvsp.offset(-2_isize)).Node as isize))
+                                .ntype
+                                > (*((*lParse).Nodes).offset((*yyvsp.offset(0)).Node as isize))
+                                    .ntype
+                            {
+                                (*yyvsp.offset(0)).Node = New_Unary(
+                                    lParse,
+                                    (*((*lParse).Nodes)
+                                        .offset((*yyvsp.offset(-2_isize)).Node as isize))
+                                    .ntype,
+                                    0,
+                                    (*yyvsp.offset(0)).Node,
+                                );
+                            } else if (*((*lParse).Nodes)
+                                .offset((*yyvsp.offset(-2_isize)).Node as isize))
+                            .ntype
+                                < (*((*lParse).Nodes).offset((*yyvsp.offset(0)).Node as isize))
+                                    .ntype
+                            {
+                                (*yyvsp.offset(-2_isize)).Node = New_Unary(
+                                    lParse,
+                                    (*((*lParse).Nodes).offset((*yyvsp.offset(0)).Node as isize))
+                                        .ntype,
+                                    0,
+                                    (*yyvsp.offset(-2_isize)).Node,
+                                );
+                            }
+                            yyval.Node = New_BinOp(
+                                lParse,
+                                fits_parser_yytokentype::BOOLEAN as c_int,
+                                (*yyvsp.offset(-2_isize)).Node,
+                                fits_parser_yytokentype::EQ as c_int,
+                                (*yyvsp.offset(0)).Node,
+                            );
+                            if yyval.Node < 0 {
+                                current_block = 4830776507462815627;
+                            } else {
+                                current_block = 17353983478346836848;
+                            }
+                        }
+                        89 => {
+                            if (*((*lParse).Nodes).offset((*yyvsp.offset(-2_isize)).Node as isize))
+                                .ntype
+                                > (*((*lParse).Nodes).offset((*yyvsp.offset(0)).Node as isize))
+                                    .ntype
+                            {
+                                (*yyvsp.offset(0)).Node = New_Unary(
+                                    lParse,
+                                    (*((*lParse).Nodes)
+                                        .offset((*yyvsp.offset(-2_isize)).Node as isize))
+                                    .ntype,
+                                    0,
+                                    (*yyvsp.offset(0)).Node,
+                                );
+                            } else if (*((*lParse).Nodes)
+                                .offset((*yyvsp.offset(-2_isize)).Node as isize))
+                            .ntype
+                                < (*((*lParse).Nodes).offset((*yyvsp.offset(0)).Node as isize))
+                                    .ntype
+                            {
+                                (*yyvsp.offset(-2_isize)).Node = New_Unary(
+                                    lParse,
+                                    (*((*lParse).Nodes).offset((*yyvsp.offset(0)).Node as isize))
+                                        .ntype,
+                                    0,
+                                    (*yyvsp.offset(-2_isize)).Node,
+                                );
+                            }
+                            yyval.Node = New_BinOp(
+                                lParse,
+                                fits_parser_yytokentype::BOOLEAN as c_int,
+                                (*yyvsp.offset(-2_isize)).Node,
+                                fits_parser_yytokentype::NE as c_int,
+                                (*yyvsp.offset(0)).Node,
+                            );
+                            if yyval.Node < 0 {
+                                current_block = 4830776507462815627;
+                            } else {
+                                current_block = 17353983478346836848;
+                            }
+                        }
+                        90 => {
+                            yyval.Node = New_BinOp(
+                                lParse,
+                                fits_parser_yytokentype::BOOLEAN as c_int,
+                                (*yyvsp.offset(-2_isize)).Node,
+                                fits_parser_yytokentype::EQ as c_int,
+                                (*yyvsp.offset(0)).Node,
+                            );
+                            if yyval.Node < 0 {
+                                current_block = 4830776507462815627;
+                            } else {
+                                ((*((*lParse).Nodes).offset(yyval.Node as isize)).value).nelem = 1;
+                                current_block = 17353983478346836848;
+                            }
+                        }
+                        91 => {
+                            yyval.Node = New_BinOp(
+                                lParse,
+                                fits_parser_yytokentype::BOOLEAN as c_int,
+                                (*yyvsp.offset(-2_isize)).Node,
+                                fits_parser_yytokentype::NE as c_int,
+                                (*yyvsp.offset(0)).Node,
+                            );
+                            if yyval.Node < 0 {
+                                current_block = 4830776507462815627;
+                            } else {
+                                ((*((*lParse).Nodes).offset(yyval.Node as isize)).value).nelem = 1;
+                                current_block = 17353983478346836848;
+                            }
+                        }
+                        92 => {
+                            yyval.Node = New_BinOp(
+                                lParse,
+                                fits_parser_yytokentype::BOOLEAN as c_int,
+                                (*yyvsp.offset(-2_isize)).Node,
+                                fits_parser_yytokentype::GT as c_int,
+                                (*yyvsp.offset(0)).Node,
+                            );
+                            if yyval.Node < 0 {
+                                current_block = 4830776507462815627;
+                            } else {
+                                ((*((*lParse).Nodes).offset(yyval.Node as isize)).value).nelem = 1;
+                                current_block = 17353983478346836848;
+                            }
+                        }
+                        93 => {
+                            yyval.Node = New_BinOp(
+                                lParse,
+                                fits_parser_yytokentype::BOOLEAN as c_int,
+                                (*yyvsp.offset(-2_isize)).Node,
+                                fits_parser_yytokentype::GTE as c_int,
+                                (*yyvsp.offset(0)).Node,
+                            );
+                            if yyval.Node < 0 {
+                                current_block = 4830776507462815627;
+                            } else {
+                                ((*((*lParse).Nodes).offset(yyval.Node as isize)).value).nelem = 1;
+                                current_block = 17353983478346836848;
+                            }
+                        }
+                        94 => {
+                            yyval.Node = New_BinOp(
+                                lParse,
+                                fits_parser_yytokentype::BOOLEAN as c_int,
+                                (*yyvsp.offset(-2_isize)).Node,
+                                fits_parser_yytokentype::LT as c_int,
+                                (*yyvsp.offset(0)).Node,
+                            );
+                            if yyval.Node < 0 {
+                                current_block = 4830776507462815627;
+                            } else {
+                                ((*((*lParse).Nodes).offset(yyval.Node as isize)).value).nelem = 1;
+                                current_block = 17353983478346836848;
+                            }
+                        }
+                        95 => {
+                            yyval.Node = New_BinOp(
+                                lParse,
+                                fits_parser_yytokentype::BOOLEAN as c_int,
+                                (*yyvsp.offset(-2_isize)).Node,
+                                fits_parser_yytokentype::LTE as c_int,
+                                (*yyvsp.offset(0)).Node,
+                            );
+                            if yyval.Node < 0 {
+                                current_block = 4830776507462815627;
+                            } else {
+                                ((*((*lParse).Nodes).offset(yyval.Node as isize)).value).nelem = 1;
+                                current_block = 17353983478346836848;
+                            }
+                        }
+                        96 => {
+                            yyval.Node = New_BinOp(
+                                lParse,
+                                fits_parser_yytokentype::BOOLEAN as c_int,
+                                (*yyvsp.offset(-2_isize)).Node,
+                                fits_parser_yytokentype::AND as c_int,
+                                (*yyvsp.offset(0)).Node,
+                            );
+                            if yyval.Node < 0 {
+                                current_block = 4830776507462815627;
+                            } else {
+                                current_block = 17353983478346836848;
+                            }
+                        }
+                        97 => {
+                            yyval.Node = New_BinOp(
+                                lParse,
+                                fits_parser_yytokentype::BOOLEAN as c_int,
+                                (*yyvsp.offset(-2_isize)).Node,
+                                fits_parser_yytokentype::OR as c_int,
+                                (*yyvsp.offset(0)).Node,
+                            );
+                            if yyval.Node < 0 {
+                                current_block = 4830776507462815627;
+                            } else {
+                                current_block = 17353983478346836848;
+                            }
+                        }
+                        98 => {
+                            yyval.Node = New_BinOp(
+                                lParse,
+                                fits_parser_yytokentype::BOOLEAN as c_int,
+                                (*yyvsp.offset(-2_isize)).Node,
+                                fits_parser_yytokentype::EQ as c_int,
+                                (*yyvsp.offset(0)).Node,
+                            );
+                            if yyval.Node < 0 {
+                                current_block = 4830776507462815627;
+                            } else {
+                                current_block = 17353983478346836848;
+                            }
+                        }
+                        99 => {
+                            yyval.Node = New_BinOp(
+                                lParse,
+                                fits_parser_yytokentype::BOOLEAN as c_int,
+                                (*yyvsp.offset(-2_isize)).Node,
+                                fits_parser_yytokentype::NE as c_int,
+                                (*yyvsp.offset(0)).Node,
+                            );
+                            if yyval.Node < 0 {
+                                current_block = 4830776507462815627;
+                            } else {
+                                current_block = 17353983478346836848;
+                            }
+                        }
+                        100 => {
+                            if (*((*lParse).Nodes).offset((*yyvsp.offset(-4_isize)).Node as isize))
+                                .ntype
+                                > (*((*lParse).Nodes)
+                                    .offset((*yyvsp.offset(-2_isize)).Node as isize))
+                                .ntype
+                            {
+                                (*yyvsp.offset(-2_isize)).Node = New_Unary(
+                                    lParse,
+                                    (*((*lParse).Nodes)
+                                        .offset((*yyvsp.offset(-4_isize)).Node as isize))
+                                    .ntype,
+                                    0,
+                                    (*yyvsp.offset(-2_isize)).Node,
+                                );
+                            } else if (*((*lParse).Nodes)
+                                .offset((*yyvsp.offset(-4_isize)).Node as isize))
+                            .ntype
+                                < (*((*lParse).Nodes)
+                                    .offset((*yyvsp.offset(-2_isize)).Node as isize))
+                                .ntype
+                            {
+                                (*yyvsp.offset(-4_isize)).Node = New_Unary(
+                                    lParse,
+                                    (*((*lParse).Nodes)
+                                        .offset((*yyvsp.offset(-2_isize)).Node as isize))
+                                    .ntype,
+                                    0,
+                                    (*yyvsp.offset(-4_isize)).Node,
+                                );
+                            }
+                            if (*((*lParse).Nodes).offset((*yyvsp.offset(-4_isize)).Node as isize))
+                                .ntype
+                                > (*((*lParse).Nodes).offset((*yyvsp.offset(0)).Node as isize))
+                                    .ntype
+                            {
+                                (*yyvsp.offset(0)).Node = New_Unary(
+                                    lParse,
+                                    (*((*lParse).Nodes)
+                                        .offset((*yyvsp.offset(-4_isize)).Node as isize))
+                                    .ntype,
+                                    0,
+                                    (*yyvsp.offset(0)).Node,
+                                );
+                            } else if (*((*lParse).Nodes)
+                                .offset((*yyvsp.offset(-4_isize)).Node as isize))
+                            .ntype
+                                < (*((*lParse).Nodes).offset((*yyvsp.offset(0)).Node as isize))
+                                    .ntype
+                            {
+                                (*yyvsp.offset(-4_isize)).Node = New_Unary(
+                                    lParse,
+                                    (*((*lParse).Nodes).offset((*yyvsp.offset(0)).Node as isize))
+                                        .ntype,
+                                    0,
+                                    (*yyvsp.offset(-4_isize)).Node,
+                                );
+                            }
+                            if (*((*lParse).Nodes).offset((*yyvsp.offset(-2_isize)).Node as isize))
+                                .ntype
+                                > (*((*lParse).Nodes).offset((*yyvsp.offset(0)).Node as isize))
+                                    .ntype
+                            {
+                                (*yyvsp.offset(0)).Node = New_Unary(
+                                    lParse,
+                                    (*((*lParse).Nodes)
+                                        .offset((*yyvsp.offset(-2_isize)).Node as isize))
+                                    .ntype,
+                                    0,
+                                    (*yyvsp.offset(0)).Node,
+                                );
+                            } else if (*((*lParse).Nodes)
+                                .offset((*yyvsp.offset(-2_isize)).Node as isize))
+                            .ntype
+                                < (*((*lParse).Nodes).offset((*yyvsp.offset(0)).Node as isize))
+                                    .ntype
+                            {
+                                (*yyvsp.offset(-2_isize)).Node = New_Unary(
+                                    lParse,
+                                    (*((*lParse).Nodes).offset((*yyvsp.offset(0)).Node as isize))
+                                        .ntype,
+                                    0,
+                                    (*yyvsp.offset(-2_isize)).Node,
+                                );
+                            }
+                            (*yyvsp.offset(-2_isize)).Node = New_BinOp(
+                                lParse,
+                                fits_parser_yytokentype::BOOLEAN as c_int,
+                                (*yyvsp.offset(-2_isize)).Node,
+                                fits_parser_yytokentype::LTE as c_int,
+                                (*yyvsp.offset(-4_isize)).Node,
+                            );
+                            (*yyvsp.offset(0)).Node = New_BinOp(
+                                lParse,
+                                fits_parser_yytokentype::BOOLEAN as c_int,
+                                (*yyvsp.offset(-4_isize)).Node,
+                                fits_parser_yytokentype::LTE as c_int,
+                                (*yyvsp.offset(0)).Node,
+                            );
+                            yyval.Node = New_BinOp(
+                                lParse,
+                                fits_parser_yytokentype::BOOLEAN as c_int,
+                                (*yyvsp.offset(-2_isize)).Node,
+                                fits_parser_yytokentype::AND as c_int,
+                                (*yyvsp.offset(0)).Node,
+                            );
+                            if yyval.Node < 0 {
+                                current_block = 4830776507462815627;
+                            } else {
+                                current_block = 17353983478346836848;
+                            }
+                        }
+                        101 => {
+                            if Test_Dims(
+                                lParse,
+                                (*yyvsp.offset(-2_isize)).Node,
+                                (*yyvsp.offset(0)).Node,
+                            ) == 0
+                            {
+                                fits_parser_yyerror(
+                                    scanner,
+                                    lParse,
+                                    b"Incompatible dimensions in '?:' arguments\0" as *const u8
+                                        as *const c_char
+                                        as *mut c_char,
+                                );
+                                current_block = 4830776507462815627;
+                            } else {
+                                yyval.Node = New_Func(
+                                    lParse,
+                                    0,
+                                    ifthenelse_fct,
+                                    3 as c_int,
+                                    (*yyvsp.offset(-2_isize)).Node,
+                                    (*yyvsp.offset(0)).Node,
+                                    (*yyvsp.offset(-4_isize)).Node,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                );
+                                if yyval.Node < 0 {
+                                    current_block = 4830776507462815627;
+                                } else {
+                                    if (*((*lParse).Nodes)
+                                        .offset((*yyvsp.offset(-2_isize)).Node as isize))
+                                    .value
+                                    .nelem
+                                        < (*((*lParse).Nodes)
+                                            .offset((*yyvsp.offset(0)).Node as isize))
+                                        .value
+                                        .nelem
+                                    {
+                                        Copy_Dims(lParse, yyval.Node, (*yyvsp.offset(0)).Node);
+                                    }
+                                    if Test_Dims(lParse, (*yyvsp.offset(-4_isize)).Node, yyval.Node)
+                                        == 0
+                                    {
+                                        fits_parser_yyerror(
+                                            scanner,
+                                            lParse,
+                                            b"Incompatible dimensions in '?:' condition\0"
+                                                as *const u8
+                                                as *const c_char
+                                                as *mut c_char,
+                                        );
+                                        current_block = 4830776507462815627;
+                                    } else {
+                                        if ((*((*lParse).Nodes).offset(yyval.Node as isize)).value)
+                                            .nelem
+                                            < (*((*lParse).Nodes)
+                                                .offset((*yyvsp.offset(-4_isize)).Node as isize))
+                                            .value
+                                            .nelem
+                                        {
+                                            Copy_Dims(
+                                                lParse,
+                                                yyval.Node,
+                                                (*yyvsp.offset(-4_isize)).Node,
+                                            );
+                                        }
+                                        current_block = 17353983478346836848;
+                                    }
+                                }
+                            }
+                        }
+                        102 => {
+                            if (if ((*yyvsp.offset(-2_isize)).astr[0] as c_int)
+                                < (*::core::mem::transmute::<&[u8; 8], &[c_char; 8]>(b"ISNULL(\0"))
+                                    [0] as c_int
+                            {
+                                -(1)
+                            } else if (*yyvsp.offset(-2_isize)).astr[0] as c_int
+                                > (*::core::mem::transmute::<&[u8; 8], &[c_char; 8]>(b"ISNULL(\0"))
+                                    [0] as c_int
+                            {
+                                1
+                            } else {
+                                strcmp(
+                                    ((*yyvsp.offset(-2_isize)).astr).as_mut_ptr(),
+                                    b"ISNULL(\0" as *const u8 as *const c_char,
+                                )
+                            }) == 0
+                            {
+                                yyval.Node = New_Func(
+                                    lParse,
+                                    0,
+                                    isnull_fct,
+                                    1,
+                                    (*yyvsp.offset(-1_isize)).Node,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                );
+                                if yyval.Node < 0 {
+                                    current_block = 4830776507462815627;
+                                } else {
+                                    (*((*lParse).Nodes).offset(yyval.Node as isize)).ntype =
+                                        fits_parser_yytokentype::BOOLEAN as c_int;
+                                    current_block = 17353983478346836848;
+                                }
+                            } else {
+                                fits_parser_yyerror(
+                                    scanner,
+                                    lParse,
+                                    b"Boolean Function(expr) not supported\0" as *const u8
+                                        as *const c_char
+                                        as *mut c_char,
+                                );
+                                current_block = 4830776507462815627;
+                            }
+                        }
+                        103 => {
+                            if (if ((*yyvsp.offset(-2_isize)).astr[0] as c_int)
+                                < (*::core::mem::transmute::<&[u8; 8], &[c_char; 8]>(b"ISNULL(\0"))
+                                    [0] as c_int
+                            {
+                                -(1)
+                            } else if (*yyvsp.offset(-2_isize)).astr[0] as c_int
+                                > (*::core::mem::transmute::<&[u8; 8], &[c_char; 8]>(b"ISNULL(\0"))
+                                    [0] as c_int
+                            {
+                                1
+                            } else {
+                                strcmp(
+                                    ((*yyvsp.offset(-2_isize)).astr).as_mut_ptr(),
+                                    b"ISNULL(\0" as *const u8 as *const c_char,
+                                )
+                            }) == 0
+                            {
+                                yyval.Node = New_Func(
+                                    lParse,
+                                    0,
+                                    isnull_fct,
+                                    1,
+                                    (*yyvsp.offset(-1_isize)).Node,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                );
+                                if yyval.Node < 0 {
+                                    current_block = 4830776507462815627;
+                                } else {
+                                    (*((*lParse).Nodes).offset(yyval.Node as isize)).ntype =
+                                        fits_parser_yytokentype::BOOLEAN as c_int;
+                                    current_block = 17353983478346836848;
+                                }
+                            } else {
+                                fits_parser_yyerror(
+                                    scanner,
+                                    lParse,
+                                    b"Boolean Function(expr) not supported\0" as *const u8
+                                        as *const c_char
+                                        as *mut c_char,
+                                );
+                                current_block = 4830776507462815627;
+                            }
+                        }
+                        104 => {
+                            if (if ((*yyvsp.offset(-2_isize)).astr[0] as c_int)
+                                < (*::core::mem::transmute::<&[u8; 8], &[c_char; 8]>(b"ISNULL(\0"))
+                                    [0] as c_int
+                            {
+                                -(1)
+                            } else if (*yyvsp.offset(-2_isize)).astr[0] as c_int
+                                > (*::core::mem::transmute::<&[u8; 8], &[c_char; 8]>(b"ISNULL(\0"))
+                                    [0] as c_int
+                            {
+                                1
+                            } else {
+                                strcmp(
+                                    ((*yyvsp.offset(-2_isize)).astr).as_mut_ptr(),
+                                    b"ISNULL(\0" as *const u8 as *const c_char,
+                                )
+                            }) == 0
+                            {
+                                yyval.Node = New_Func(
+                                    lParse,
+                                    fits_parser_yytokentype::BOOLEAN as c_int,
+                                    isnull_fct,
+                                    1,
+                                    (*yyvsp.offset(-1_isize)).Node,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                );
+                                if yyval.Node < 0 {
+                                    current_block = 4830776507462815627;
+                                } else {
+                                    current_block = 17353983478346836848;
+                                }
+                            } else {
+                                fits_parser_yyerror(
+                                    scanner,
+                                    lParse,
+                                    b"Boolean Function(expr) not supported\0" as *const u8
+                                        as *const c_char
+                                        as *mut c_char,
+                                );
+                                current_block = 4830776507462815627;
+                            }
+                        }
+                        105 => {
+                            if (if ((*yyvsp.offset(-4_isize)).astr[0] as c_int)
+                                < (*::core::mem::transmute::<&[u8; 9], &[c_char; 9]>(b"DEFNULL(\0"))
+                                    [0] as c_int
+                            {
+                                -(1)
+                            } else if (*yyvsp.offset(-4_isize)).astr[0] as c_int
+                                > (*::core::mem::transmute::<&[u8; 9], &[c_char; 9]>(b"DEFNULL(\0"))
+                                    [0] as c_int
+                            {
+                                1
+                            } else {
+                                strcmp(
+                                    ((*yyvsp.offset(-4_isize)).astr).as_mut_ptr(),
+                                    b"DEFNULL(\0" as *const u8 as *const c_char,
+                                )
+                            }) == 0
+                            {
+                                if (*((*lParse).Nodes)
+                                    .offset((*yyvsp.offset(-3_isize)).Node as isize))
+                                .value
+                                .nelem
+                                    >= (*((*lParse).Nodes)
+                                        .offset((*yyvsp.offset(-1_isize)).Node as isize))
+                                    .value
+                                    .nelem
+                                    && Test_Dims(
+                                        lParse,
+                                        (*yyvsp.offset(-3_isize)).Node,
+                                        (*yyvsp.offset(-1_isize)).Node,
+                                    ) != 0
+                                {
+                                    yyval.Node = New_Func(
+                                        lParse,
+                                        0,
+                                        defnull_fct,
+                                        2 as c_int,
+                                        (*yyvsp.offset(-3_isize)).Node,
+                                        (*yyvsp.offset(-1_isize)).Node,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                    );
+                                    if yyval.Node < 0 {
+                                        current_block = 4830776507462815627;
+                                    } else {
+                                        current_block = 17353983478346836848;
+                                    }
+                                } else {
+                                    fits_parser_yyerror(
+                                        scanner,
+                                        lParse,
+                                        b"Dimensions of DEFNULL arguments are not compatible\0"
+                                            as *const u8
+                                            as *const c_char
+                                            as *mut c_char,
+                                    );
+                                    current_block = 4830776507462815627;
+                                }
+                            } else {
+                                fits_parser_yyerror(
+                                    scanner,
+                                    lParse,
+                                    b"Boolean Function(expr,expr) not supported\0" as *const u8
+                                        as *const c_char
+                                        as *mut c_char,
+                                );
+                                current_block = 4830776507462815627;
+                            }
+                        }
+                        106 => {
+                            if (*((*lParse).Nodes).offset((*yyvsp.offset(-(5))).Node as isize))
+                                .ntype
+                                != fits_parser_yytokentype::DOUBLE as c_int
+                            {
+                                (*yyvsp.offset(-(5))).Node = New_Unary(
+                                    lParse,
+                                    fits_parser_yytokentype::DOUBLE as c_int,
+                                    0,
+                                    (*yyvsp.offset(-(5))).Node,
+                                );
+                            }
+                            if (*((*lParse).Nodes).offset((*yyvsp.offset(-3_isize)).Node as isize))
+                                .ntype
+                                != fits_parser_yytokentype::DOUBLE as c_int
+                            {
+                                (*yyvsp.offset(-3_isize)).Node = New_Unary(
+                                    lParse,
+                                    fits_parser_yytokentype::DOUBLE as c_int,
+                                    0,
+                                    (*yyvsp.offset(-3_isize)).Node,
+                                );
+                            }
+                            if (*((*lParse).Nodes).offset((*yyvsp.offset(-1_isize)).Node as isize))
+                                .ntype
+                                != fits_parser_yytokentype::DOUBLE as c_int
+                            {
+                                (*yyvsp.offset(-1_isize)).Node = New_Unary(
+                                    lParse,
+                                    fits_parser_yytokentype::DOUBLE as c_int,
+                                    0,
+                                    (*yyvsp.offset(-1_isize)).Node,
+                                );
+                            }
+                            if !(Test_Dims(
+                                lParse,
+                                (*yyvsp.offset(-(5))).Node,
+                                (*yyvsp.offset(-3_isize)).Node,
+                            ) != 0
+                                && Test_Dims(
+                                    lParse,
+                                    (*yyvsp.offset(-3_isize)).Node,
+                                    (*yyvsp.offset(-1_isize)).Node,
+                                ) != 0)
+                            {
+                                fits_parser_yyerror(
+                                    scanner,
+                                    lParse,
+                                    b"Dimensions of NEAR arguments are not compatible\0"
+                                        as *const u8
+                                        as *const c_char
+                                        as *mut c_char,
+                                );
+                                current_block = 4830776507462815627;
+                            } else if (if ((*yyvsp.offset(-(6 as c_int) as isize)).astr[0] as c_int)
+                                < (*::core::mem::transmute::<&[u8; 6], &[c_char; 6]>(b"NEAR(\0"))[0]
+                                    as c_int
+                            {
+                                -(1)
+                            } else if (*yyvsp.offset(-(6 as c_int) as isize)).astr[0] as c_int
+                                > (*::core::mem::transmute::<&[u8; 6], &[c_char; 6]>(b"NEAR(\0"))[0]
+                                    as c_int
+                            {
+                                1
+                            } else {
+                                strcmp(
+                                    ((*yyvsp.offset(-(6 as c_int) as isize)).astr).as_mut_ptr(),
+                                    b"NEAR(\0" as *const u8 as *const c_char,
+                                )
+                            }) == 0
+                            {
+                                yyval.Node = New_Func(
+                                    lParse,
+                                    fits_parser_yytokentype::BOOLEAN as c_int,
+                                    near_fct,
+                                    3 as c_int,
+                                    (*yyvsp.offset(-(5))).Node,
+                                    (*yyvsp.offset(-3_isize)).Node,
+                                    (*yyvsp.offset(-1_isize)).Node,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                );
+                                if yyval.Node < 0 {
+                                    current_block = 4830776507462815627;
+                                } else {
+                                    if ((*((*lParse).Nodes).offset(yyval.Node as isize)).value)
+                                        .nelem
+                                        < (*((*lParse).Nodes)
+                                            .offset((*yyvsp.offset(-(5))).Node as isize))
+                                        .value
+                                        .nelem
+                                    {
+                                        Copy_Dims(lParse, yyval.Node, (*yyvsp.offset(-(5))).Node);
+                                    }
+                                    if (*((*lParse).Nodes)
+                                        .offset((*yyvsp.offset(-(5))).Node as isize))
+                                    .value
+                                    .nelem
+                                        < (*((*lParse).Nodes)
+                                            .offset((*yyvsp.offset(-3_isize)).Node as isize))
+                                        .value
+                                        .nelem
+                                    {
+                                        Copy_Dims(
+                                            lParse,
+                                            yyval.Node,
+                                            (*yyvsp.offset(-3_isize)).Node,
+                                        );
+                                    }
+                                    if (*((*lParse).Nodes)
+                                        .offset((*yyvsp.offset(-3_isize)).Node as isize))
+                                    .value
+                                    .nelem
+                                        < (*((*lParse).Nodes)
+                                            .offset((*yyvsp.offset(-1_isize)).Node as isize))
+                                        .value
+                                        .nelem
+                                    {
+                                        Copy_Dims(
+                                            lParse,
+                                            yyval.Node,
+                                            (*yyvsp.offset(-1_isize)).Node,
+                                        );
+                                    }
+                                    current_block = 17353983478346836848;
+                                }
+                            } else {
+                                fits_parser_yyerror(
+                                    scanner,
+                                    lParse,
+                                    b"Boolean Function not supported\0" as *const u8
+                                        as *const c_char
+                                        as *mut c_char,
+                                );
+                                current_block = 4830776507462815627;
+                            }
+                        }
+                        107 => {
+                            if (*((*lParse).Nodes)
+                                .offset((*yyvsp.offset(-(9 as c_int) as isize)).Node as isize))
+                            .ntype
+                                != fits_parser_yytokentype::DOUBLE as c_int
+                            {
+                                (*yyvsp.offset(-(9 as c_int) as isize)).Node = New_Unary(
+                                    lParse,
+                                    fits_parser_yytokentype::DOUBLE as c_int,
+                                    0,
+                                    (*yyvsp.offset(-(9 as c_int) as isize)).Node,
+                                );
+                            }
+                            if (*((*lParse).Nodes)
+                                .offset((*yyvsp.offset(-(7 as c_int) as isize)).Node as isize))
+                            .ntype
+                                != fits_parser_yytokentype::DOUBLE as c_int
+                            {
+                                (*yyvsp.offset(-(7 as c_int) as isize)).Node = New_Unary(
+                                    lParse,
+                                    fits_parser_yytokentype::DOUBLE as c_int,
+                                    0,
+                                    (*yyvsp.offset(-(7 as c_int) as isize)).Node,
+                                );
+                            }
+                            if (*((*lParse).Nodes).offset((*yyvsp.offset(-(5))).Node as isize))
+                                .ntype
+                                != fits_parser_yytokentype::DOUBLE as c_int
+                            {
+                                (*yyvsp.offset(-(5))).Node = New_Unary(
+                                    lParse,
+                                    fits_parser_yytokentype::DOUBLE as c_int,
+                                    0,
+                                    (*yyvsp.offset(-(5))).Node,
+                                );
+                            }
+                            if (*((*lParse).Nodes).offset((*yyvsp.offset(-3_isize)).Node as isize))
+                                .ntype
+                                != fits_parser_yytokentype::DOUBLE as c_int
+                            {
+                                (*yyvsp.offset(-3_isize)).Node = New_Unary(
+                                    lParse,
+                                    fits_parser_yytokentype::DOUBLE as c_int,
+                                    0,
+                                    (*yyvsp.offset(-3_isize)).Node,
+                                );
+                            }
+                            if (*((*lParse).Nodes).offset((*yyvsp.offset(-1_isize)).Node as isize))
+                                .ntype
+                                != fits_parser_yytokentype::DOUBLE as c_int
+                            {
+                                (*yyvsp.offset(-1_isize)).Node = New_Unary(
+                                    lParse,
+                                    fits_parser_yytokentype::DOUBLE as c_int,
+                                    0,
+                                    (*yyvsp.offset(-1_isize)).Node,
+                                );
+                            }
+                            if !(Test_Dims(
+                                lParse,
+                                (*yyvsp.offset(-(9 as c_int) as isize)).Node,
+                                (*yyvsp.offset(-(7 as c_int) as isize)).Node,
+                            ) != 0
+                                && Test_Dims(
+                                    lParse,
+                                    (*yyvsp.offset(-(7 as c_int) as isize)).Node,
+                                    (*yyvsp.offset(-(5))).Node,
+                                ) != 0
+                                && Test_Dims(
+                                    lParse,
+                                    (*yyvsp.offset(-(5))).Node,
+                                    (*yyvsp.offset(-3_isize)).Node,
+                                ) != 0
+                                && Test_Dims(
+                                    lParse,
+                                    (*yyvsp.offset(-3_isize)).Node,
+                                    (*yyvsp.offset(-1_isize)).Node,
+                                ) != 0)
+                            {
+                                fits_parser_yyerror(
+                                    scanner,
+                                    lParse,
+                                    b"Dimensions of CIRCLE arguments are not compatible\0"
+                                        as *const u8
+                                        as *const c_char
+                                        as *mut c_char,
+                                );
+                                current_block = 4830776507462815627;
+                            } else if (if ((*yyvsp.offset(-(10 as c_int) as isize)).astr[0]
+                                as c_int)
+                                < (*::core::mem::transmute::<&[u8; 8], &[c_char; 8]>(b"CIRCLE(\0"))
+                                    [0] as c_int
+                            {
+                                -(1)
+                            } else if (*yyvsp.offset(-(10 as c_int) as isize)).astr[0] as c_int
+                                > (*::core::mem::transmute::<&[u8; 8], &[c_char; 8]>(b"CIRCLE(\0"))
+                                    [0] as c_int
+                            {
+                                1
+                            } else {
+                                strcmp(
+                                    ((*yyvsp.offset(-(10 as c_int) as isize)).astr).as_mut_ptr(),
+                                    b"CIRCLE(\0" as *const u8 as *const c_char,
+                                )
+                            }) == 0
+                            {
+                                yyval.Node = New_Func(
+                                    lParse,
+                                    fits_parser_yytokentype::BOOLEAN as c_int,
+                                    circle_fct,
+                                    5 as c_int,
+                                    (*yyvsp.offset(-(9 as c_int) as isize)).Node,
+                                    (*yyvsp.offset(-(7 as c_int) as isize)).Node,
+                                    (*yyvsp.offset(-(5))).Node,
+                                    (*yyvsp.offset(-3_isize)).Node,
+                                    (*yyvsp.offset(-1_isize)).Node,
+                                    0,
+                                    0,
+                                );
+                                if yyval.Node < 0 {
+                                    current_block = 4830776507462815627;
+                                } else {
+                                    if ((*((*lParse).Nodes).offset(yyval.Node as isize)).value)
+                                        .nelem
+                                        < (*((*lParse).Nodes).offset(
+                                            (*yyvsp.offset(-(9 as c_int) as isize)).Node as isize,
+                                        ))
+                                        .value
+                                        .nelem
+                                    {
+                                        Copy_Dims(
+                                            lParse,
+                                            yyval.Node,
+                                            (*yyvsp.offset(-(9 as c_int) as isize)).Node,
+                                        );
+                                    }
+                                    if (*((*lParse).Nodes).offset(
+                                        (*yyvsp.offset(-(9 as c_int) as isize)).Node as isize,
+                                    ))
+                                    .value
+                                    .nelem
+                                        < (*((*lParse).Nodes).offset(
+                                            (*yyvsp.offset(-(7 as c_int) as isize)).Node as isize,
+                                        ))
+                                        .value
+                                        .nelem
+                                    {
+                                        Copy_Dims(
+                                            lParse,
+                                            yyval.Node,
+                                            (*yyvsp.offset(-(7 as c_int) as isize)).Node,
+                                        );
+                                    }
+                                    if (*((*lParse).Nodes).offset(
+                                        (*yyvsp.offset(-(7 as c_int) as isize)).Node as isize,
+                                    ))
+                                    .value
+                                    .nelem
+                                        < (*((*lParse).Nodes)
+                                            .offset((*yyvsp.offset(-(5))).Node as isize))
+                                        .value
+                                        .nelem
+                                    {
+                                        Copy_Dims(lParse, yyval.Node, (*yyvsp.offset(-(5))).Node);
+                                    }
+                                    if (*((*lParse).Nodes)
+                                        .offset((*yyvsp.offset(-(5))).Node as isize))
+                                    .value
+                                    .nelem
+                                        < (*((*lParse).Nodes)
+                                            .offset((*yyvsp.offset(-3_isize)).Node as isize))
+                                        .value
+                                        .nelem
+                                    {
+                                        Copy_Dims(
+                                            lParse,
+                                            yyval.Node,
+                                            (*yyvsp.offset(-3_isize)).Node,
+                                        );
+                                    }
+                                    if (*((*lParse).Nodes)
+                                        .offset((*yyvsp.offset(-3_isize)).Node as isize))
+                                    .value
+                                    .nelem
+                                        < (*((*lParse).Nodes)
+                                            .offset((*yyvsp.offset(-1_isize)).Node as isize))
+                                        .value
+                                        .nelem
+                                    {
+                                        Copy_Dims(
+                                            lParse,
+                                            yyval.Node,
+                                            (*yyvsp.offset(-1_isize)).Node,
+                                        );
+                                    }
+                                    current_block = 17353983478346836848;
+                                }
+                            } else {
+                                fits_parser_yyerror(
+                                    scanner,
+                                    lParse,
+                                    b"Boolean Function not supported\0" as *const u8
+                                        as *const c_char
+                                        as *mut c_char,
+                                );
+                                current_block = 4830776507462815627;
+                            }
+                        }
+                        108 => {
+                            if (*((*lParse).Nodes)
+                                .offset((*yyvsp.offset(-(13 as c_int) as isize)).Node as isize))
+                            .ntype
+                                != fits_parser_yytokentype::DOUBLE as c_int
+                            {
+                                (*yyvsp.offset(-(13 as c_int) as isize)).Node = New_Unary(
+                                    lParse,
+                                    fits_parser_yytokentype::DOUBLE as c_int,
+                                    0,
+                                    (*yyvsp.offset(-(13 as c_int) as isize)).Node,
+                                );
+                            }
+                            if (*((*lParse).Nodes)
+                                .offset((*yyvsp.offset(-(11 as c_int) as isize)).Node as isize))
+                            .ntype
+                                != fits_parser_yytokentype::DOUBLE as c_int
+                            {
+                                (*yyvsp.offset(-(11 as c_int) as isize)).Node = New_Unary(
+                                    lParse,
+                                    fits_parser_yytokentype::DOUBLE as c_int,
+                                    0,
+                                    (*yyvsp.offset(-(11 as c_int) as isize)).Node,
+                                );
+                            }
+                            if (*((*lParse).Nodes)
+                                .offset((*yyvsp.offset(-(9 as c_int) as isize)).Node as isize))
+                            .ntype
+                                != fits_parser_yytokentype::DOUBLE as c_int
+                            {
+                                (*yyvsp.offset(-(9 as c_int) as isize)).Node = New_Unary(
+                                    lParse,
+                                    fits_parser_yytokentype::DOUBLE as c_int,
+                                    0,
+                                    (*yyvsp.offset(-(9 as c_int) as isize)).Node,
+                                );
+                            }
+                            if (*((*lParse).Nodes)
+                                .offset((*yyvsp.offset(-(7 as c_int) as isize)).Node as isize))
+                            .ntype
+                                != fits_parser_yytokentype::DOUBLE as c_int
+                            {
+                                (*yyvsp.offset(-(7 as c_int) as isize)).Node = New_Unary(
+                                    lParse,
+                                    fits_parser_yytokentype::DOUBLE as c_int,
+                                    0,
+                                    (*yyvsp.offset(-(7 as c_int) as isize)).Node,
+                                );
+                            }
+                            if (*((*lParse).Nodes).offset((*yyvsp.offset(-(5))).Node as isize))
+                                .ntype
+                                != fits_parser_yytokentype::DOUBLE as c_int
+                            {
+                                (*yyvsp.offset(-(5))).Node = New_Unary(
+                                    lParse,
+                                    fits_parser_yytokentype::DOUBLE as c_int,
+                                    0,
+                                    (*yyvsp.offset(-(5))).Node,
+                                );
+                            }
+                            if (*((*lParse).Nodes).offset((*yyvsp.offset(-3_isize)).Node as isize))
+                                .ntype
+                                != fits_parser_yytokentype::DOUBLE as c_int
+                            {
+                                (*yyvsp.offset(-3_isize)).Node = New_Unary(
+                                    lParse,
+                                    fits_parser_yytokentype::DOUBLE as c_int,
+                                    0,
+                                    (*yyvsp.offset(-3_isize)).Node,
+                                );
+                            }
+                            if (*((*lParse).Nodes).offset((*yyvsp.offset(-1_isize)).Node as isize))
+                                .ntype
+                                != fits_parser_yytokentype::DOUBLE as c_int
+                            {
+                                (*yyvsp.offset(-1_isize)).Node = New_Unary(
+                                    lParse,
+                                    fits_parser_yytokentype::DOUBLE as c_int,
+                                    0,
+                                    (*yyvsp.offset(-1_isize)).Node,
+                                );
+                            }
+                            if !(Test_Dims(
+                                lParse,
+                                (*yyvsp.offset(-(13 as c_int) as isize)).Node,
+                                (*yyvsp.offset(-(11 as c_int) as isize)).Node,
+                            ) != 0
+                                && Test_Dims(
+                                    lParse,
+                                    (*yyvsp.offset(-(11 as c_int) as isize)).Node,
+                                    (*yyvsp.offset(-(9 as c_int) as isize)).Node,
+                                ) != 0
+                                && Test_Dims(
+                                    lParse,
+                                    (*yyvsp.offset(-(9 as c_int) as isize)).Node,
+                                    (*yyvsp.offset(-(7 as c_int) as isize)).Node,
+                                ) != 0
+                                && Test_Dims(
+                                    lParse,
+                                    (*yyvsp.offset(-(7 as c_int) as isize)).Node,
+                                    (*yyvsp.offset(-(5))).Node,
+                                ) != 0
+                                && Test_Dims(
+                                    lParse,
+                                    (*yyvsp.offset(-(5))).Node,
+                                    (*yyvsp.offset(-3_isize)).Node,
+                                ) != 0
+                                && Test_Dims(
+                                    lParse,
+                                    (*yyvsp.offset(-3_isize)).Node,
+                                    (*yyvsp.offset(-1_isize)).Node,
+                                ) != 0)
+                            {
+                                fits_parser_yyerror(
+                                    scanner,
+                                    lParse,
+                                    b"Dimensions of BOX or ELLIPSE arguments are not compatible\0"
+                                        as *const u8
+                                        as *const c_char
+                                        as *mut c_char,
+                                );
+                                current_block = 4830776507462815627;
+                            } else {
+                                if (if ((*yyvsp.offset(-(14 as c_int) as isize)).astr[0] as c_int)
+                                    < (*::core::mem::transmute::<&[u8; 5], &[c_char; 5]>(b"BOX(\0"))
+                                        [0] as c_int
+                                {
+                                    -(1)
+                                } else if (*yyvsp.offset(-(14 as c_int) as isize)).astr[0] as c_int
+                                    > (*::core::mem::transmute::<&[u8; 5], &[c_char; 5]>(b"BOX(\0"))
+                                        [0] as c_int
+                                {
+                                    1
+                                } else {
+                                    strcmp(
+                                        ((*yyvsp.offset(-(14 as c_int) as isize)).astr)
+                                            .as_mut_ptr(),
+                                        b"BOX(\0" as *const u8 as *const c_char,
+                                    )
+                                }) == 0
+                                {
+                                    yyval.Node = New_Func(
+                                        lParse,
+                                        fits_parser_yytokentype::BOOLEAN as c_int,
+                                        box_fct,
+                                        7 as c_int,
+                                        (*yyvsp.offset(-(13 as c_int) as isize)).Node,
+                                        (*yyvsp.offset(-(11 as c_int) as isize)).Node,
+                                        (*yyvsp.offset(-(9 as c_int) as isize)).Node,
+                                        (*yyvsp.offset(-(7 as c_int) as isize)).Node,
+                                        (*yyvsp.offset(-(5))).Node,
+                                        (*yyvsp.offset(-3_isize)).Node,
+                                        (*yyvsp.offset(-1_isize)).Node,
+                                    );
+                                    current_block = 3023179740610631044;
+                                } else if (if ((*yyvsp.offset(-(14 as c_int) as isize)).astr[0]
+                                    as c_int)
+                                    < (*::core::mem::transmute::<&[u8; 9], &[c_char; 9]>(
+                                        b"ELLIPSE(\0",
+                                    ))[0] as c_int
+                                {
+                                    -(1)
+                                } else if (*yyvsp.offset(-(14 as c_int) as isize)).astr[0] as c_int
+                                    > (*::core::mem::transmute::<&[u8; 9], &[c_char; 9]>(
+                                        b"ELLIPSE(\0",
+                                    ))[0] as c_int
+                                {
+                                    1
+                                } else {
+                                    strcmp(
+                                        ((*yyvsp.offset(-(14 as c_int) as isize)).astr)
+                                            .as_mut_ptr(),
+                                        b"ELLIPSE(\0" as *const u8 as *const c_char,
+                                    )
+                                }) == 0
+                                {
+                                    yyval.Node = New_Func(
+                                        lParse,
+                                        fits_parser_yytokentype::BOOLEAN as c_int,
+                                        elps_fct,
+                                        7 as c_int,
+                                        (*yyvsp.offset(-(13 as c_int) as isize)).Node,
+                                        (*yyvsp.offset(-(11 as c_int) as isize)).Node,
+                                        (*yyvsp.offset(-(9 as c_int) as isize)).Node,
+                                        (*yyvsp.offset(-(7 as c_int) as isize)).Node,
+                                        (*yyvsp.offset(-(5))).Node,
+                                        (*yyvsp.offset(-3_isize)).Node,
+                                        (*yyvsp.offset(-1_isize)).Node,
+                                    );
+                                    current_block = 3023179740610631044;
+                                } else {
+                                    fits_parser_yyerror(
+                                        scanner,
+                                        lParse,
+                                        b"SAO Image Function not supported\0" as *const u8
+                                            as *const c_char
+                                            as *mut c_char,
+                                    );
+                                    current_block = 4830776507462815627;
+                                }
+                                match current_block {
+                                    4830776507462815627 => {}
+                                    _ => {
+                                        if yyval.Node < 0 {
+                                            current_block = 4830776507462815627;
+                                        } else {
+                                            if ((*((*lParse).Nodes).offset(yyval.Node as isize))
+                                                .value)
+                                                .nelem
+                                                < (*((*lParse).Nodes).offset(
+                                                    (*yyvsp.offset(-(13 as c_int) as isize)).Node
+                                                        as isize,
+                                                ))
+                                                .value
+                                                .nelem
+                                            {
+                                                Copy_Dims(
+                                                    lParse,
+                                                    yyval.Node,
+                                                    (*yyvsp.offset(-(13 as c_int) as isize)).Node,
+                                                );
+                                            }
+                                            if (*((*lParse).Nodes).offset(
+                                                (*yyvsp.offset(-(13 as c_int) as isize)).Node
+                                                    as isize,
+                                            ))
+                                            .value
+                                            .nelem
+                                                < (*((*lParse).Nodes).offset(
+                                                    (*yyvsp.offset(-(11 as c_int) as isize)).Node
+                                                        as isize,
+                                                ))
+                                                .value
+                                                .nelem
+                                            {
+                                                Copy_Dims(
+                                                    lParse,
+                                                    yyval.Node,
+                                                    (*yyvsp.offset(-(11 as c_int) as isize)).Node,
+                                                );
+                                            }
+                                            if (*((*lParse).Nodes).offset(
+                                                (*yyvsp.offset(-(11 as c_int) as isize)).Node
+                                                    as isize,
+                                            ))
+                                            .value
+                                            .nelem
+                                                < (*((*lParse).Nodes).offset(
+                                                    (*yyvsp.offset(-(9 as c_int) as isize)).Node
+                                                        as isize,
+                                                ))
+                                                .value
+                                                .nelem
+                                            {
+                                                Copy_Dims(
+                                                    lParse,
+                                                    yyval.Node,
+                                                    (*yyvsp.offset(-(9 as c_int) as isize)).Node,
+                                                );
+                                            }
+                                            if (*((*lParse).Nodes).offset(
+                                                (*yyvsp.offset(-(9 as c_int) as isize)).Node
+                                                    as isize,
+                                            ))
+                                            .value
+                                            .nelem
+                                                < (*((*lParse).Nodes).offset(
+                                                    (*yyvsp.offset(-(7 as c_int) as isize)).Node
+                                                        as isize,
+                                                ))
+                                                .value
+                                                .nelem
+                                            {
+                                                Copy_Dims(
+                                                    lParse,
+                                                    yyval.Node,
+                                                    (*yyvsp.offset(-(7 as c_int) as isize)).Node,
+                                                );
+                                            }
+                                            if (*((*lParse).Nodes).offset(
+                                                (*yyvsp.offset(-(7 as c_int) as isize)).Node
+                                                    as isize,
+                                            ))
+                                            .value
+                                            .nelem
+                                                < (*((*lParse).Nodes)
+                                                    .offset((*yyvsp.offset(-(5))).Node as isize))
+                                                .value
+                                                .nelem
+                                            {
+                                                Copy_Dims(
+                                                    lParse,
+                                                    yyval.Node,
+                                                    (*yyvsp.offset(-(5))).Node,
+                                                );
+                                            }
+                                            if (*((*lParse).Nodes)
+                                                .offset((*yyvsp.offset(-(5))).Node as isize))
+                                            .value
+                                            .nelem
+                                                < (*((*lParse).Nodes).offset(
+                                                    (*yyvsp.offset(-3_isize)).Node as isize,
+                                                ))
+                                                .value
+                                                .nelem
+                                            {
+                                                Copy_Dims(
+                                                    lParse,
+                                                    yyval.Node,
+                                                    (*yyvsp.offset(-3_isize)).Node,
+                                                );
+                                            }
+                                            if (*((*lParse).Nodes)
+                                                .offset((*yyvsp.offset(-3_isize)).Node as isize))
+                                            .value
+                                            .nelem
+                                                < (*((*lParse).Nodes).offset(
+                                                    (*yyvsp.offset(-1_isize)).Node as isize,
+                                                ))
+                                                .value
+                                                .nelem
+                                            {
+                                                Copy_Dims(
+                                                    lParse,
+                                                    yyval.Node,
+                                                    (*yyvsp.offset(-1_isize)).Node,
+                                                );
+                                            }
+                                            current_block = 17353983478346836848;
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        109 => {
+                            yyval.Node = New_GTI(
+                                lParse,
+                                gtifilt_fct,
+                                b"\0" as *const u8 as *const c_char as *mut c_char,
+                                -(99 as c_int),
+                                -(99 as c_int),
+                                b"*START*\0" as *const u8 as *const c_char as *mut c_char,
+                                b"*STOP*\0" as *const u8 as *const c_char as *mut c_char,
+                            );
+                            if yyval.Node < 0 {
+                                current_block = 4830776507462815627;
+                            } else {
+                                current_block = 17353983478346836848;
+                            }
+                        }
+                        110 => {
+                            yyval.Node = New_GTI(
+                                lParse,
+                                gtifilt_fct,
+                                ((*yyvsp.offset(-1_isize)).astr).as_mut_ptr(),
+                                -(99 as c_int),
+                                -(99 as c_int),
+                                b"*START*\0" as *const u8 as *const c_char as *mut c_char,
+                                b"*STOP*\0" as *const u8 as *const c_char as *mut c_char,
+                            );
+                            if yyval.Node < 0 {
+                                current_block = 4830776507462815627;
+                            } else {
+                                current_block = 17353983478346836848;
+                            }
+                        }
+                        111 => {
+                            yyval.Node = New_GTI(
+                                lParse,
+                                gtifilt_fct,
+                                ((*yyvsp.offset(-3_isize)).astr).as_mut_ptr(),
+                                (*yyvsp.offset(-1_isize)).Node,
+                                -(99 as c_int),
+                                b"*START*\0" as *const u8 as *const c_char as *mut c_char,
+                                b"*STOP*\0" as *const u8 as *const c_char as *mut c_char,
+                            );
+                            if yyval.Node < 0 {
+                                current_block = 4830776507462815627;
+                            } else {
+                                current_block = 17353983478346836848;
+                            }
+                        }
+                        112 => {
+                            yyval.Node = New_GTI(
+                                lParse,
+                                gtifilt_fct,
+                                ((*yyvsp.offset(-(7 as c_int) as isize)).astr).as_mut_ptr(),
+                                (*yyvsp.offset(-(5))).Node,
+                                -(99 as c_int),
+                                ((*yyvsp.offset(-3_isize)).astr).as_mut_ptr(),
+                                ((*yyvsp.offset(-1_isize)).astr).as_mut_ptr(),
+                            );
+                            if yyval.Node < 0 {
+                                current_block = 4830776507462815627;
+                            } else {
+                                current_block = 17353983478346836848;
+                            }
+                        }
+                        113 => {
+                            yyval.Node = New_GTI(
+                                lParse,
+                                gtifind_fct,
+                                b"\0" as *const u8 as *const c_char as *mut c_char,
+                                -(99 as c_int),
+                                -(99 as c_int),
+                                b"*START*\0" as *const u8 as *const c_char as *mut c_char,
+                                b"*STOP*\0" as *const u8 as *const c_char as *mut c_char,
+                            );
+                            if yyval.Node < 0 {
+                                current_block = 4830776507462815627;
+                            } else {
+                                current_block = 17353983478346836848;
+                            }
+                        }
+                        114 => {
+                            yyval.Node = New_GTI(
+                                lParse,
+                                gtifind_fct,
+                                ((*yyvsp.offset(-1_isize)).astr).as_mut_ptr(),
+                                -(99 as c_int),
+                                -(99 as c_int),
+                                b"*START*\0" as *const u8 as *const c_char as *mut c_char,
+                                b"*STOP*\0" as *const u8 as *const c_char as *mut c_char,
+                            );
+                            if yyval.Node < 0 {
+                                current_block = 4830776507462815627;
+                            } else {
+                                current_block = 17353983478346836848;
+                            }
+                        }
+                        115 => {
+                            yyval.Node = New_GTI(
+                                lParse,
+                                gtifind_fct,
+                                ((*yyvsp.offset(-3_isize)).astr).as_mut_ptr(),
+                                (*yyvsp.offset(-1_isize)).Node,
+                                -(99 as c_int),
+                                b"*START*\0" as *const u8 as *const c_char as *mut c_char,
+                                b"*STOP*\0" as *const u8 as *const c_char as *mut c_char,
+                            );
+                            if yyval.Node < 0 {
+                                current_block = 4830776507462815627;
+                            } else {
+                                current_block = 17353983478346836848;
+                            }
+                        }
+                        116 => {
+                            yyval.Node = New_GTI(
+                                lParse,
+                                gtifind_fct,
+                                ((*yyvsp.offset(-(7 as c_int) as isize)).astr).as_mut_ptr(),
+                                (*yyvsp.offset(-(5))).Node,
+                                -(99 as c_int),
+                                ((*yyvsp.offset(-3_isize)).astr).as_mut_ptr(),
+                                ((*yyvsp.offset(-1_isize)).astr).as_mut_ptr(),
+                            );
+                            if yyval.Node < 0 {
+                                current_block = 4830776507462815627;
+                            } else {
+                                current_block = 17353983478346836848;
+                            }
+                        }
+                        117 => {
+                            yyval.Node = New_REG(
+                                lParse,
+                                ((*yyvsp.offset(-1_isize)).astr).as_mut_ptr(),
+                                -(99 as c_int),
+                                -(99 as c_int),
+                                b"\0" as *const u8 as *const c_char as *mut c_char,
+                            );
+                            if yyval.Node < 0 {
+                                current_block = 4830776507462815627;
+                            } else {
+                                current_block = 17353983478346836848;
+                            }
+                        }
+                        118 => {
+                            yyval.Node = New_REG(
+                                lParse,
+                                ((*yyvsp.offset(-(5))).astr).as_mut_ptr(),
+                                (*yyvsp.offset(-3_isize)).Node,
+                                (*yyvsp.offset(-1_isize)).Node,
+                                b"\0" as *const u8 as *const c_char as *mut c_char,
+                            );
+                            if yyval.Node < 0 {
+                                current_block = 4830776507462815627;
+                            } else {
+                                current_block = 17353983478346836848;
+                            }
+                        }
+                        119 => {
+                            yyval.Node = New_REG(
+                                lParse,
+                                ((*yyvsp.offset(-(7 as c_int) as isize)).astr).as_mut_ptr(),
+                                (*yyvsp.offset(-(5))).Node,
+                                (*yyvsp.offset(-3_isize)).Node,
+                                ((*yyvsp.offset(-1_isize)).astr).as_mut_ptr(),
+                            );
+                            if yyval.Node < 0 {
+                                current_block = 4830776507462815627;
+                            } else {
+                                current_block = 17353983478346836848;
+                            }
+                        }
+                        120 => {
+                            yyval.Node = New_Deref(
+                                lParse,
+                                (*yyvsp.offset(-3_isize)).Node,
+                                1,
+                                (*yyvsp.offset(-1_isize)).Node,
+                                0,
+                                0,
+                                0,
+                                0,
+                            );
+                            if yyval.Node < 0 {
+                                current_block = 4830776507462815627;
+                            } else {
+                                current_block = 17353983478346836848;
+                            }
+                        }
+                        121 => {
+                            yyval.Node = New_Deref(
+                                lParse,
+                                (*yyvsp.offset(-(5))).Node,
+                                2 as c_int,
+                                (*yyvsp.offset(-3_isize)).Node,
+                                (*yyvsp.offset(-1_isize)).Node,
+                                0,
+                                0,
+                                0,
+                            );
+                            if yyval.Node < 0 {
+                                current_block = 4830776507462815627;
+                            } else {
+                                current_block = 17353983478346836848;
+                            }
+                        }
+                        122 => {
+                            yyval.Node = New_Deref(
+                                lParse,
+                                (*yyvsp.offset(-(7 as c_int) as isize)).Node,
+                                3 as c_int,
+                                (*yyvsp.offset(-(5))).Node,
+                                (*yyvsp.offset(-3_isize)).Node,
+                                (*yyvsp.offset(-1_isize)).Node,
+                                0,
+                                0,
+                            );
+                            if yyval.Node < 0 {
+                                current_block = 4830776507462815627;
+                            } else {
+                                current_block = 17353983478346836848;
+                            }
+                        }
+                        123 => {
+                            yyval.Node = New_Deref(
+                                lParse,
+                                (*yyvsp.offset(-(9 as c_int) as isize)).Node,
+                                4 as c_int,
+                                (*yyvsp.offset(-(7 as c_int) as isize)).Node,
+                                (*yyvsp.offset(-(5))).Node,
+                                (*yyvsp.offset(-3_isize)).Node,
+                                (*yyvsp.offset(-1_isize)).Node,
+                                0,
+                            );
+                            if yyval.Node < 0 {
+                                current_block = 4830776507462815627;
+                            } else {
+                                current_block = 17353983478346836848;
+                            }
+                        }
+                        124 => {
+                            yyval.Node = New_Deref(
+                                lParse,
+                                (*yyvsp.offset(-(11 as c_int) as isize)).Node,
+                                5 as c_int,
+                                (*yyvsp.offset(-(9 as c_int) as isize)).Node,
+                                (*yyvsp.offset(-(7 as c_int) as isize)).Node,
+                                (*yyvsp.offset(-(5))).Node,
+                                (*yyvsp.offset(-3_isize)).Node,
+                                (*yyvsp.offset(-1_isize)).Node,
+                            );
+                            if yyval.Node < 0 {
+                                current_block = 4830776507462815627;
+                            } else {
+                                current_block = 17353983478346836848;
+                            }
+                        }
+                        125 => {
+                            yyval.Node = New_Unary(
+                                lParse,
+                                fits_parser_yytokentype::BOOLEAN as c_int,
+                                fits_parser_yytokentype::NOT as c_int,
+                                (*yyvsp.offset(0)).Node,
+                            );
+                            if yyval.Node < 0 {
+                                current_block = 4830776507462815627;
+                            } else {
+                                current_block = 17353983478346836848;
+                            }
+                        }
+                        126 => {
+                            yyval.Node = (*yyvsp.offset(-1_isize)).Node;
+                            current_block = 17353983478346836848;
+                        }
+                        127 => {
+                            yyval.Node = New_Const(
+                                lParse,
+                                fits_parser_yytokentype::STRING as c_int,
+                                ((*yyvsp.offset(0)).astr).as_mut_ptr() as *mut c_void,
+                                (strlen(((*yyvsp.offset(0)).astr).as_mut_ptr()))
+                                    .wrapping_add((1 as c_int as c_ulong).try_into().unwrap())
+                                    as c_long,
+                            );
+                            if yyval.Node < 0 {
+                                current_block = 4830776507462815627;
+                            } else {
+                                ((*((*lParse).Nodes).offset(yyval.Node as isize)).value).nelem =
+                                    strlen(((*yyvsp.offset(0)).astr).as_mut_ptr()) as c_long;
+                                current_block = 17353983478346836848;
+                            }
+                        }
+                        128 => {
+                            yyval.Node = New_Column(lParse, (*yyvsp.offset(0)).lng as c_int);
+                            if yyval.Node < 0 {
+                                current_block = 4830776507462815627;
+                            } else {
+                                current_block = 17353983478346836848;
+                            }
+                        }
+                        129 => {
+                            if (*((*lParse).Nodes).offset((*yyvsp.offset(-1_isize)).Node as isize))
+                                .ntype
+                                != fits_parser_yytokentype::LONG as c_int
+                                || (*((*lParse).Nodes)
+                                    .offset((*yyvsp.offset(-1_isize)).Node as isize))
+                                .operation
+                                    != -(1000 as c_int)
+                            {
+                                fits_parser_yyerror(
+                                    scanner,
+                                    lParse,
+                                    b"Offset argument must be a constant integer\0" as *const u8
+                                        as *const c_char
+                                        as *mut c_char,
+                                );
+                                current_block = 4830776507462815627;
+                            } else {
+                                yyval.Node = New_Offset(
+                                    lParse,
+                                    (*yyvsp.offset(-3_isize)).lng as c_int,
+                                    (*yyvsp.offset(-1_isize)).Node,
+                                );
+                                if yyval.Node < 0 {
+                                    current_block = 4830776507462815627;
+                                } else {
+                                    current_block = 17353983478346836848;
+                                }
+                            }
+                        }
+                        130 => {
+                            yyval.Node = New_Func(
+                                lParse,
+                                fits_parser_yytokentype::STRING as c_int,
+                                null_fct,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                            );
+                            current_block = 17353983478346836848;
+                        }
+                        131 => {
+                            yyval.Node = (*yyvsp.offset(-1_isize)).Node;
+                            current_block = 17353983478346836848;
+                        }
+                        132 => {
+                            if (*((*lParse).Nodes).offset((*yyvsp.offset(-2_isize)).Node as isize))
+                                .value
+                                .nelem
+                                + (*((*lParse).Nodes).offset((*yyvsp.offset(0)).Node as isize))
+                                    .value
+                                    .nelem
+                                >= 256 as c_long
+                            {
+                                fits_parser_yyerror(
+                                    scanner,
+                                    lParse,
+                                    b"Combined string size exceeds 255 characters\0" as *const u8
+                                        as *const c_char
+                                        as *mut c_char,
+                                );
+                                current_block = 4830776507462815627;
+                            } else {
+                                yyval.Node = New_BinOp(
+                                    lParse,
+                                    fits_parser_yytokentype::STRING as c_int,
+                                    (*yyvsp.offset(-2_isize)).Node,
+                                    '+' as i32,
+                                    (*yyvsp.offset(0)).Node,
+                                );
+                                if yyval.Node < 0 {
+                                    current_block = 4830776507462815627;
+                                } else {
+                                    ((*((*lParse).Nodes).offset(yyval.Node as isize)).value)
+                                        .nelem = (*((*lParse).Nodes)
+                                        .offset((*yyvsp.offset(-2_isize)).Node as isize))
+                                    .value
+                                    .nelem
+                                        + (*((*lParse).Nodes)
+                                            .offset((*yyvsp.offset(0)).Node as isize))
+                                        .value
+                                        .nelem;
+                                    current_block = 17353983478346836848;
+                                }
+                            }
+                        }
+                        133 => {
+                            let mut outSize: c_int = 0;
+                            if (*((*lParse).Nodes).offset((*yyvsp.offset(-4_isize)).Node as isize))
+                                .value
+                                .nelem
+                                != 1
+                            {
+                                fits_parser_yyerror(
+                                    scanner,
+                                    lParse,
+                                    b"Cannot have a vector string column\0" as *const u8
+                                        as *const c_char
+                                        as *mut c_char,
+                                );
+                                current_block = 4830776507462815627;
+                            } else {
+                                outSize = ((*((*lParse).Nodes)
+                                    .offset((*yyvsp.offset(-2_isize)).Node as isize))
+                                .value)
+                                    .nelem as c_int;
+                                if (*((*lParse).Nodes).offset((*yyvsp.offset(0)).Node as isize))
+                                    .value
+                                    .nelem
+                                    > outSize as c_long
+                                {
+                                    outSize = (*((*lParse).Nodes)
+                                        .offset((*yyvsp.offset(0)).Node as isize))
+                                    .value
+                                    .nelem as c_int;
+                                }
+                                yyval.Node = New_FuncSize(
+                                    lParse,
+                                    0,
+                                    ifthenelse_fct,
+                                    3 as c_int,
+                                    (*yyvsp.offset(-2_isize)).Node,
+                                    (*yyvsp.offset(0)).Node,
+                                    (*yyvsp.offset(-4_isize)).Node,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    outSize,
+                                );
+                                if yyval.Node < 0 {
+                                    current_block = 4830776507462815627;
+                                } else {
+                                    if (*((*lParse).Nodes)
+                                        .offset((*yyvsp.offset(-2_isize)).Node as isize))
+                                    .value
+                                    .nelem
+                                        < (*((*lParse).Nodes)
+                                            .offset((*yyvsp.offset(0)).Node as isize))
+                                        .value
+                                        .nelem
+                                    {
+                                        Copy_Dims(lParse, yyval.Node, (*yyvsp.offset(0)).Node);
+                                    }
+                                    current_block = 17353983478346836848;
+                                }
+                            }
+                        }
+                        134 => {
+                            if (if ((*yyvsp.offset(-4_isize)).astr[0] as c_int)
+                                < (*::core::mem::transmute::<&[u8; 9], &[c_char; 9]>(b"DEFNULL(\0"))
+                                    [0] as c_int
+                            {
+                                -(1)
+                            } else if (*yyvsp.offset(-4_isize)).astr[0] as c_int
+                                > (*::core::mem::transmute::<&[u8; 9], &[c_char; 9]>(b"DEFNULL(\0"))
+                                    [0] as c_int
+                            {
+                                1
+                            } else {
+                                strcmp(
+                                    ((*yyvsp.offset(-4_isize)).astr).as_mut_ptr(),
+                                    b"DEFNULL(\0" as *const u8 as *const c_char,
+                                )
+                            }) == 0
+                            {
+                                let mut outSize_0: c_int = 0;
+                                outSize_0 = (*((*lParse).Nodes)
+                                    .offset((*yyvsp.offset(-3_isize)).Node as isize))
+                                .value
+                                .nelem as c_int;
+                                if (*((*lParse).Nodes)
+                                    .offset((*yyvsp.offset(-1_isize)).Node as isize))
+                                .value
+                                .nelem
+                                    > outSize_0 as c_long
+                                {
+                                    outSize_0 = (*((*lParse).Nodes)
+                                        .offset((*yyvsp.offset(-1_isize)).Node as isize))
+                                    .value
+                                    .nelem as c_int;
+                                }
+                                yyval.Node = New_FuncSize(
+                                    lParse,
+                                    0,
+                                    defnull_fct,
+                                    2 as c_int,
+                                    (*yyvsp.offset(-3_isize)).Node,
+                                    (*yyvsp.offset(-1_isize)).Node,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    outSize_0,
+                                );
+                                if yyval.Node < 0 {
+                                    current_block = 4830776507462815627;
+                                } else {
+                                    if (*((*lParse).Nodes)
+                                        .offset((*yyvsp.offset(-1_isize)).Node as isize))
+                                    .value
+                                    .nelem
+                                        > (*((*lParse).Nodes)
+                                            .offset((*yyvsp.offset(-3_isize)).Node as isize))
+                                        .value
+                                        .nelem
+                                    {
+                                        ((*((*lParse).Nodes).offset(yyval.Node as isize)).value)
+                                            .nelem = (*((*lParse).Nodes)
+                                            .offset((*yyvsp.offset(-1_isize)).Node as isize))
+                                        .value
+                                        .nelem;
+                                    }
+                                    current_block = 17353983478346836848;
+                                }
+                            } else {
+                                fits_parser_yyerror(
+                                    scanner,
+                                    lParse,
+                                    b"Function(string,string) not supported\0" as *const u8
+                                        as *const c_char
+                                        as *mut c_char,
+                                );
+                                current_block = 4830776507462815627;
+                            }
+                        }
+                        135 => {
+                            if (if ((*yyvsp.offset(-(6 as c_int) as isize)).astr[0] as c_int)
+                                < (*::core::mem::transmute::<&[u8; 8], &[c_char; 8]>(b"STRMID(\0"))
+                                    [0] as c_int
+                            {
+                                -(1)
+                            } else if (*yyvsp.offset(-(6 as c_int) as isize)).astr[0] as c_int
+                                > (*::core::mem::transmute::<&[u8; 8], &[c_char; 8]>(b"STRMID(\0"))
+                                    [0] as c_int
+                            {
+                                1
+                            } else {
+                                strcmp(
+                                    ((*yyvsp.offset(-(6 as c_int) as isize)).astr).as_mut_ptr(),
+                                    b"STRMID(\0" as *const u8 as *const c_char,
+                                )
+                            }) == 0
+                            {
+                                let mut len: c_int = 0;
+                                if (*((*lParse).Nodes)
+                                    .offset((*yyvsp.offset(-3_isize)).Node as isize))
+                                .ntype
+                                    != fits_parser_yytokentype::LONG as c_int
+                                    || (*((*lParse).Nodes)
+                                        .offset((*yyvsp.offset(-3_isize)).Node as isize))
+                                    .value
+                                    .nelem
+                                        != 1
+                                    || (*((*lParse).Nodes)
+                                        .offset((*yyvsp.offset(-1_isize)).Node as isize))
+                                    .ntype
+                                        != fits_parser_yytokentype::LONG as c_int
+                                    || (*((*lParse).Nodes)
+                                        .offset((*yyvsp.offset(-1_isize)).Node as isize))
+                                    .value
+                                    .nelem
+                                        != 1
+                                {
+                                    fits_parser_yyerror(
+                                    scanner,
+                                    lParse,
+                                    b"When using STRMID(S,P,N), P and N must be integers (and not vector columns)\0"
+                                        as *const u8 as *const c_char
+                                        as *mut c_char,
+                                );
+                                    current_block = 4830776507462815627;
+                                } else {
+                                    if (*((*lParse).Nodes)
+                                        .offset((*yyvsp.offset(-1_isize)).Node as isize))
+                                    .operation
+                                        == -(1000 as c_int)
+                                    {
+                                        len = (*((*lParse).Nodes)
+                                            .offset((*yyvsp.offset(-1_isize)).Node as isize))
+                                        .value
+                                        .data
+                                        .lng as c_int;
+                                    } else {
+                                        len = (*((*lParse).Nodes)
+                                            .offset((*yyvsp.offset(-(5))).Node as isize))
+                                        .value
+                                        .nelem
+                                            as c_int;
+                                    }
+                                    if len <= 0 || len >= 256 as c_int {
+                                        fits_parser_yyerror(
+                                            scanner,
+                                            lParse,
+                                            b"STRMID(S,P,N), N must be 1-255\0" as *const u8
+                                                as *const c_char
+                                                as *mut c_char,
+                                        );
+                                        current_block = 4830776507462815627;
+                                    } else {
+                                        yyval.Node = New_FuncSize(
+                                            lParse,
+                                            0,
+                                            strmid_fct,
+                                            3 as c_int,
+                                            (*yyvsp.offset(-(5))).Node,
+                                            (*yyvsp.offset(-3_isize)).Node,
+                                            (*yyvsp.offset(-1_isize)).Node,
+                                            0,
+                                            0,
+                                            0,
+                                            0,
+                                            len,
+                                        );
+                                        if yyval.Node < 0 {
+                                            current_block = 4830776507462815627;
+                                        } else {
+                                            current_block = 17353983478346836848;
+                                        }
+                                    }
+                                }
+                            } else {
+                                fits_parser_yyerror(
+                                    scanner,
+                                    lParse,
+                                    b"Function(string,expr,expr) not supported\0" as *const u8
+                                        as *const c_char
+                                        as *mut c_char,
+                                );
+                                current_block = 4830776507462815627;
+                            }
+                        }
+                        _ => {
+                            current_block = 17353983478346836848;
+                        }
+                    }
+                    match current_block {
+                        4830776507462815627 => {
+                            fits_parser_yynerrs += 1;
+                            fits_parser_yynerrs;
+                            yyvsp = yyvsp.offset(-(yylen as isize));
+                            yyssp = yyssp.offset(-(yylen as isize));
+                            yylen = 0;
+                            yystate = *yyssp as yy_state_fast_t;
+                            current_block = 1774893048582444437;
+                        }
+                        _ => {
+                            yyvsp = yyvsp.offset(-(yylen as isize));
+                            yyssp = yyssp.offset(-(yylen as isize));
+                            yylen = 0;
+                            yyvsp = yyvsp.offset(1);
+                            *yyvsp = yyval;
+                            let yylhs: c_int = yyr1[yyn as usize] as c_int - 57 as c_int;
+                            let yyi: c_int = yypgoto[yylhs as usize] as c_int + *yyssp as c_int;
+                            yystate = if 0 <= yyi
+                                && yyi <= 1776 as c_int
+                                && yycheck[yyi as usize] as c_int == *yyssp as c_int
+                            {
+                                yytable[yyi as usize] as c_int
+                            } else {
+                                yydefgoto[yylhs as usize] as c_int
+                            };
+                            current_block = 7872030484262409139;
+                        }
+                    }
+                }
+                if current_block == 1774893048582444437 {
+                    yyerrstatus = 3 as c_int;
+                    loop {
+                        yyn = yypact[yystate as usize] as c_int;
+                        if yyn != -(41 as c_int) {
+                            yyn += YYSYMBOL_YYerror as c_int;
+                            if 0 <= yyn
+                                && yyn <= 1776 as c_int
+                                && yycheck[yyn as usize] as c_int == YYSYMBOL_YYerror as c_int
+                            {
+                                yyn = yytable[yyn as usize] as c_int;
+                                if (0 as c_int) < yyn {
+                                    break;
+                                }
+                            }
+                        }
+                        if yyssp == yyss {
+                            current_block = 3964311021479492664;
+                            break 's_54;
+                        }
+                        yydestruct(
+                            b"Error: popping\0" as *const u8 as *const c_char,
+                            yystos[yystate as usize] as yysymbol_kind_t,
+                            yyvsp,
+                            scanner,
+                            lParse,
+                        );
+                        yyvsp = yyvsp.offset(-(1 as c_int as isize));
+                        yyssp = yyssp.offset(-(1 as c_int as isize));
+                        yystate = *yyssp as yy_state_fast_t;
+                    }
+                    yyvsp = yyvsp.offset(1);
+                    *yyvsp = yylval;
+                    yystate = yyn;
+                }
+                yyssp = yyssp.offset(1);
+                yyssp;
+            }
+        }
+        match current_block {
+            11794367917084412820 => {
+                fits_parser_yyerror(
+                    scanner,
+                    lParse,
+                    b"memory exhausted\0" as *const u8 as *const c_char as *mut c_char,
+                );
+                yyresult = 2 as c_int;
+            }
+            3964311021479492664 => {
+                yyresult = 1;
+            }
+            _ => {}
+        }
+        if yychar != fits_parser_yytokentype::FITS_PARSER_YYEMPTY as c_int {
+            yytoken = (if 0 <= yychar && yychar <= 292 as c_int {
+                yytranslate[yychar as usize] as yysymbol_kind_t as c_int
+            } else {
+                YYSYMBOL_YYUNDEF as c_int
+            }) as yysymbol_kind_t;
+            yydestruct(
+                b"Cleanup: discarding lookahead\0" as *const u8 as *const c_char,
+                yytoken,
+                &mut yylval,
+                scanner,
+                lParse,
+            );
+        }
+        yyvsp = yyvsp.offset(-(yylen as isize));
+        yyssp = yyssp.offset(-(yylen as isize));
+        while yyssp != yyss {
+            yydestruct(
+                b"Cleanup: popping\0" as *const u8 as *const c_char,
+                yystos[*yyssp as usize] as yysymbol_kind_t,
+                yyvsp,
+                scanner,
+                lParse,
+            );
+            yyvsp = yyvsp.offset(-(1 as c_int as isize));
+            yyssp = yyssp.offset(-(1 as c_int as isize));
+        }
+        if yyss != yyssa.as_mut_ptr() {
+            free(yyss as *mut c_void);
+        }
+        yyresult
+    }
+}
+unsafe fn New_Deref(
+    mut lParse: *mut ParseData,
+    mut Var: c_int,
+    mut nDim: c_int,
+    mut Dim1: c_int,
+    mut Dim2: c_int,
+    mut Dim3: c_int,
+    mut Dim4: c_int,
+    mut Dim5: c_int,
+) -> c_int {
+    unsafe {
+        let mut n: c_int = 0;
+        let mut idx: c_int = 0;
+        let mut constant: c_int = 0;
+        let mut elem: c_long = 0;
+        let mut this: *mut Node = std::ptr::null_mut::<Node>();
+        let mut theVar: *mut Node = std::ptr::null_mut::<Node>();
+        let mut theDim: [*mut Node; 5] = [std::ptr::null_mut::<Node>(); 5];
+        if Var < 0 || Dim1 < 0 || Dim2 < 0 || Dim3 < 0 || Dim4 < 0 || Dim5 < 0 {
+            return -(1);
+        }
+        theVar = ((*lParse).Nodes).offset(Var as isize);
+        if (*theVar).operation == -(1000 as c_int) || (*theVar).value.nelem == 1 {
+            fits_parser_yyerror(
+                0 as yyscan_t,
+                lParse,
+                b"Cannot index a scalar value\0" as *const u8 as *const c_char as *mut c_char,
+            );
+            return -(1);
+        }
+        n = Alloc_Node(lParse);
+        if n >= 0 {
+            this = ((*lParse).Nodes).offset(n as isize);
+            (*this).nSubNodes = nDim + 1;
+            (*this).SubNodes[0] = Var;
+            theVar = ((*lParse).Nodes).offset((*this).SubNodes[0] as isize);
+            (*this).SubNodes[1] = Dim1;
+            theDim[0] = ((*lParse).Nodes).offset((*this).SubNodes[1] as isize);
+            (*this).SubNodes[2] = Dim2;
+            theDim[1] = ((*lParse).Nodes).offset((*this).SubNodes[2] as isize);
+            (*this).SubNodes[3] = Dim3;
+            theDim[2] = ((*lParse).Nodes).offset((*this).SubNodes[3] as isize);
+            (*this).SubNodes[4] = Dim4;
+            theDim[3] = ((*lParse).Nodes).offset((*this).SubNodes[4] as isize);
+            (*this).SubNodes[5] = Dim5;
+            theDim[4] = ((*lParse).Nodes).offset((*this).SubNodes[5] as isize);
+            constant = ((*theVar).operation == -(1000 as c_int)) as c_int;
+            idx = 0;
+            while idx < nDim {
+                constant = (constant != 0 && (*theDim[idx as usize]).operation == -(1000 as c_int))
+                    as c_int;
+                idx += 1;
+                idx;
+            }
+            idx = 0;
+            while idx < nDim {
+                if (*theDim[idx as usize]).value.nelem > 1 {
+                    Free_Last_Node(lParse);
+                    fits_parser_yyerror(
+                        0 as yyscan_t,
+                        lParse,
+                        b"Cannot use an array as an index value\0" as *const u8 as *const c_char
+                            as *mut c_char,
+                    );
+                    return -(1);
+                } else if (*theDim[idx as usize]).ntype != fits_parser_yytokentype::LONG as c_int {
+                    Free_Last_Node(lParse);
+                    fits_parser_yyerror(
+                        0 as yyscan_t,
+                        lParse,
+                        b"Index value must be an integer type\0" as *const u8 as *const c_char
+                            as *mut c_char,
+                    );
+                    return -(1);
+                }
+                idx += 1;
+                idx;
+            }
+            (*this).operation = '[' as i32;
+            (*this).DoOp = Some(Do_Deref);
+            (*this).ntype = (*theVar).ntype;
+            if (*theVar).value.naxis == nDim {
+                (*this).value.nelem = 1;
+                (*this).value.naxis = 1;
+                (*this).value.naxes[0] = 1;
+            } else if nDim == 1 {
+                elem = 1;
+                (*this).value.naxis = (*theVar).value.naxis - 1;
+                idx = 0;
+                while idx < (*this).value.naxis {
+                    (*this).value.naxes[idx as usize] = (*theVar).value.naxes[idx as usize];
+                    elem *= (*this).value.naxes[idx as usize];
+                    idx += 1;
+                    idx;
+                }
+                (*this).value.nelem = elem;
+            } else {
+                Free_Last_Node(lParse);
+                fits_parser_yyerror(
+                    0 as yyscan_t,
+                    lParse,
+                    b"Must specify just one or all indices for vector\0" as *const u8
+                        as *const c_char as *mut c_char,
+                );
+                return -(1);
+            }
+            if constant != 0 {
+                ((*this).DoOp).expect("non-null function pointer")(lParse, this);
+            }
+        }
+        n
+    }
+}
+unsafe fn New_GTI(
+    mut lParse: *mut ParseData,
+    mut Op: funcOp,
+    mut fname: *mut c_char,
+    mut Node1: c_int,
+    mut Node2: c_int,
+    mut start: *mut c_char,
+    mut stop: *mut c_char,
+) -> c_int {
+    unsafe {
+        let mut fptr: *mut fitsfile = std::ptr::null_mut();
+        let mut this: *mut Node = std::ptr::null_mut::<Node>();
+        let mut that0: *mut Node = std::ptr::null_mut::<Node>();
+        let mut that1: *mut Node = std::ptr::null_mut::<Node>();
+        let mut that2: *mut Node = std::ptr::null_mut::<Node>();
+        let mut type_0: c_int = 0;
+        let mut i: c_int = 0;
+        let mut n: c_int = 0;
+        let mut startCol: c_int = 0;
+        let mut stopCol: c_int = 0;
+        let mut Node0: c_int = 0;
+        let mut hdutype: c_int = 0;
+        let mut hdunum: c_int = 0;
+        let mut evthdu: c_int = 0;
+        let mut samefile: c_int = 0;
+        let mut extvers: c_int = 0;
+        let mut movetotype: c_int = 0;
+        let mut tstat: c_int = 0;
+        let mut extname: [c_char; 100] = [0; 100];
+        let mut nrows: c_long = 0;
+        let mut timeZeroI: [c_double; 2] = [0.; 2];
+        let mut timeZeroF: [c_double; 2] = [0.; 2];
+        let mut dt: c_double = 0.;
+        let mut timeSpan: c_double = 0.;
+        let mut xcol: [c_char; 20] = [0; 20];
+        let mut xexpr: [c_char; 20] = [0; 20];
+        let mut colVal: FITS_PARSER_YYSTYPE = FITS_PARSER_YYSTYPE { Node: 0 };
+        if (Op as c_uint == gtifilt_fct as c_int as c_uint
+            || Op as c_uint == gtifind_fct as c_int as c_uint)
+            && Node1 == -(99 as c_int)
+        {
+            type_0 = fits_parser_yyGetVariable(
+                lParse,
+                b"TIME\0" as *const u8 as *const c_char as *mut c_char,
+                &mut colVal,
+            );
+            if type_0 == fits_parser_yytokentype::COLUMN as c_int {
+                Node1 = New_Column(lParse, colVal.lng as c_int);
+            } else {
+                fits_parser_yyerror(
+                    0 as yyscan_t,
+                    lParse,
+                    b"Could not build TIME column for GTIFILTER/GTIFIND\0" as *const u8
+                        as *const c_char as *mut c_char,
+                );
+                return -(1);
+            }
+        }
+        if Op as c_uint == gtiover_fct as c_int as c_uint {
+            if Node1 == -(99 as c_int) || Node2 == -(99 as c_int) {
+                fits_parser_yyerror(
+                    0 as yyscan_t,
+                    lParse,
+                    b"startExpr and stopExpr values must be defined for GTIOVERLAP\0" as *const u8
+                        as *const c_char as *mut c_char,
+                );
+                return -(1);
+            }
+            Node2 = New_Unary(lParse, fits_parser_yytokentype::DOUBLE as c_int, 0, Node2);
+            if Node2 < 0 {
+                return -(1);
+            }
+        }
+        Node1 = New_Unary(lParse, fits_parser_yytokentype::DOUBLE as c_int, 0, Node1);
+        Node0 = Alloc_Node(lParse);
+        if Node1 < 0 || Node0 < 0 {
+            return -(1);
+        }
+        fptr = (*lParse).def_fptr;
+        ffghdn(fptr, &mut evthdu);
+        tstat = 0;
+        if ffgkyd(
+            fptr,
+            b"TIMEZERO\0" as *const u8 as *const c_char,
+            timeZeroI.as_mut_ptr(),
+            std::ptr::null_mut::<c_char>(),
+            &mut tstat,
+        ) != 0
+        {
+            tstat = 0;
+            if ffgkyd(
+                fptr,
+                b"TIMEZERI\0" as *const u8 as *const c_char,
+                timeZeroI.as_mut_ptr(),
+                std::ptr::null_mut::<c_char>(),
+                &mut tstat,
+            ) != 0
+            {
+                timeZeroF[0] = 0.0f64;
+                timeZeroI[0] = timeZeroF[0];
+            } else if ffgkyd(
+                fptr,
+                b"TIMEZERF\0" as *const u8 as *const c_char,
+                timeZeroF.as_mut_ptr(),
+                std::ptr::null_mut::<c_char>(),
+                &mut tstat,
+            ) != 0
+            {
+                timeZeroF[0] = 0.0f64;
+            }
+        } else {
+            timeZeroF[0] = 0.0f64;
+        }
+        match *fname.offset(0) as c_int {
+            0 => {
+                samefile = 1;
+                hdunum = 1;
+            }
+            91 => {
+                samefile = 1;
+                i = 1;
+                while *fname.offset(i as isize) as c_int != 0_i32
+                    && *fname.offset(i as isize) as c_int != ']' as i32
+                {
+                    i += 1;
+                    i;
+                }
+                if *fname.offset(i as isize) != 0 {
+                    *fname.offset(i as isize) = 0;
+                    fname = fname.offset(1);
+                    fname;
+                    ffexts(
+                        fname,
+                        &mut hdunum,
+                        extname.as_mut_ptr(),
+                        &mut extvers,
+                        &mut movetotype,
+                        xcol.as_mut_ptr(),
+                        xexpr.as_mut_ptr(),
+                        &mut (*lParse).status,
+                    );
+                    if *extname.as_mut_ptr() != 0 {
+                        ffmnhd(
+                            fptr,
+                            movetotype,
+                            extname.as_mut_ptr(),
+                            extvers,
+                            &mut (*lParse).status,
+                        );
+                        ffghdn(fptr, &mut hdunum);
+                    } else if hdunum != 0 {
+                        hdunum += 1;
+                        ffmahd(fptr, hdunum, &mut hdutype, &mut (*lParse).status);
+                    } else if (*lParse).status == 0 {
+                        fits_parser_yyerror(
+                            0 as yyscan_t,
+                            lParse,
+                            b"Cannot use primary array for GTI filter\0" as *const u8
+                                as *const c_char as *mut c_char,
+                        );
+                        return -(1);
+                    }
+                } else {
+                    fits_parser_yyerror(
+                        0 as yyscan_t,
+                        lParse,
+                        b"File extension specifier lacks closing ']'\0" as *const u8
+                            as *const c_char as *mut c_char,
+                    );
+                    return -(1);
+                }
+            }
+            43 => {
+                samefile = 1;
+                hdunum =
+                    atoi(std::ffi::CStr::from_ptr(fname).to_str().unwrap_or("0")).unwrap_or(0) + 1;
+                if hdunum > 1 {
+                    ffmahd(fptr, hdunum, &mut hdutype, &mut (*lParse).status);
+                } else {
+                    fits_parser_yyerror(
+                        0 as yyscan_t,
+                        lParse,
+                        b"Cannot use primary array for GTI filter / GTIFIND\0" as *const u8
+                            as *const c_char as *mut c_char,
+                    );
+                    return -(1);
+                }
+            }
+            _ => {
+                samefile = 0;
+                let mut fptr_tmp: *mut Option<Box<fitsfile>> =
+                    &mut None as *mut Option<Box<fitsfile>>;
+                if ffopen(fptr_tmp, fname, 0, &mut (*lParse).status) == 0 {
+                    ffghdn(fptr, &mut hdunum);
+                }
+            }
+        }
+        if (*lParse).status != 0 {
+            return -(1);
+        }
+        if hdunum == 1 {
+            loop {
+                hdunum += 1;
+                hdunum;
+                if ffmahd(fptr, hdunum, &mut hdutype, &mut (*lParse).status) != 0 {
+                    break;
+                }
+                if hdutype == 0 {
+                    continue;
+                }
+                tstat = 0;
+                if ffgkys(
+                    fptr,
+                    b"EXTNAME\0" as *const u8 as *const c_char,
+                    extname.as_mut_ptr(),
+                    std::ptr::null_mut::<c_char>(),
+                    &mut tstat,
+                ) != 0
+                {
+                    continue;
+                }
+                ffupch(extname.as_mut_ptr());
+                if !(strstr(extname.as_mut_ptr(), b"GTI\0" as *const u8 as *const c_char)).is_null()
+                {
+                    break;
+                }
+            }
+            if (*lParse).status != 0 {
+                if (*lParse).status == 107 as c_int {
+                    fits_parser_yyerror(
+                        0 as yyscan_t,
+                        lParse,
+                        b"GTI extension not found in this file\0" as *const u8 as *const c_char
+                            as *mut c_char,
+                    );
+                }
+                return -(1);
+            }
+        }
+        ffgcno(fptr, 0, start, &mut startCol, &mut (*lParse).status);
+        ffgcno(fptr, 0, stop, &mut stopCol, &mut (*lParse).status);
+        if (*lParse).status != 0 {
+            return -(1);
+        }
+        tstat = 0;
+        if ffgkyd(
+            fptr,
+            b"TIMEZERO\0" as *const u8 as *const c_char,
+            timeZeroI.as_mut_ptr().offset(1 as c_int as isize),
+            std::ptr::null_mut::<c_char>(),
+            &mut tstat,
+        ) != 0
+        {
+            tstat = 0;
+            if ffgkyd(
+                fptr,
+                b"TIMEZERI\0" as *const u8 as *const c_char,
+                timeZeroI.as_mut_ptr().offset(1 as c_int as isize),
+                std::ptr::null_mut::<c_char>(),
+                &mut tstat,
+            ) != 0
+            {
+                timeZeroF[1] = 0.0f64;
+                timeZeroI[1] = timeZeroF[1];
+            } else if ffgkyd(
+                fptr,
+                b"TIMEZERF\0" as *const u8 as *const c_char,
+                timeZeroF.as_mut_ptr().offset(1 as c_int as isize),
+                std::ptr::null_mut::<c_char>(),
+                &mut tstat,
+            ) != 0
+            {
+                timeZeroF[1] = 0.0f64;
+            }
+        } else {
+            timeZeroF[1] = 0.0f64;
+        }
+        n = Alloc_Node(lParse);
+        if n >= 0 {
+            this = ((*lParse).Nodes).offset(n as isize);
+            (*this).SubNodes[1] = Node1;
+            (*this).operation = Op as c_int;
+            if Op as c_uint == gtifilt_fct as c_int as c_uint {
+                (*this).nSubNodes = 2 as c_int;
+                (*this).DoOp = Some(Do_GTI);
+                (*this).ntype = fits_parser_yytokentype::BOOLEAN as c_int;
+            } else if Op as c_uint == gtifind_fct as c_int as c_uint {
+                (*this).nSubNodes = 2 as c_int;
+                (*this).DoOp = Some(Do_GTI);
+                (*this).ntype = fits_parser_yytokentype::LONG as c_int;
+            } else {
+                (*this).nSubNodes = 3 as c_int;
+                (*this).DoOp = Some(Do_GTI_Over);
+                (*this).ntype = fits_parser_yytokentype::DOUBLE as c_int;
+            }
+            that1 = ((*lParse).Nodes).offset(Node1 as isize);
+            (*this).value.nelem = (*that1).value.nelem;
+            (*this).value.naxis = (*that1).value.naxis;
+            i = 0;
+            while i < (*that1).value.naxis {
+                (*this).value.naxes[i as usize] = (*that1).value.naxes[i as usize];
+                i += 1;
+                i;
+            }
+            if Op as c_uint == gtiover_fct as c_int as c_uint {
+                (*this).SubNodes[2] = Node2;
+                that2 = ((*lParse).Nodes).offset(Node2 as isize);
+                if (*that1).value.nelem != (*that2).value.nelem {
+                    fits_parser_yyerror(
+                        0 as yyscan_t,
+                        lParse,
+                        b"Dimensions of TIME and TIME_STOP must match for GTIOVERLAP\0" as *const u8
+                            as *const c_char as *mut c_char,
+                    );
+                    return -(1);
+                }
+            }
+            (*this).SubNodes[0] = Node0;
+            that0 = ((*lParse).Nodes).offset(Node0 as isize);
+            (*that0).operation = -(1000 as c_int);
+            (*that0).DoOp = None;
+            (*that0).value.data.ptr = std::ptr::null_mut::<c_void>();
+            if ffgkyj(
+                fptr,
+                b"NAXIS2\0" as *const u8 as *const c_char,
+                &mut nrows,
+                std::ptr::null_mut::<c_char>(),
+                &mut (*lParse).status,
+            ) != 0
+            {
+                return -(1);
+            }
+            (*that0).value.nelem = nrows;
+            if nrows != 0 {
+                let mut startptr: *mut c_double = std::ptr::null_mut::<c_double>();
+                let mut stopptr: *mut c_double = std::ptr::null_mut::<c_double>();
+                (*that0).value.data.dblptr = malloc(
+                    ((2 as c_long * nrows) as c_ulong)
+                        .wrapping_mul(::core::mem::size_of::<c_double>() as c_ulong)
+                        .try_into()
+                        .unwrap(),
+                ) as *mut c_double;
+                if ((*that0).value.data.dblptr).is_null() {
+                    (*lParse).status = 113 as c_int;
+                    return -(1);
+                }
+                startptr = (*that0).value.data.dblptr;
+                stopptr = ((*that0).value.data.dblptr).offset(nrows as isize);
+                ffgcvd(
+                    fptr,
+                    startCol,
+                    1 as LONGLONG,
+                    1 as LONGLONG,
+                    nrows as LONGLONG,
+                    0.0f64,
+                    startptr,
+                    &mut i,
+                    &mut (*lParse).status,
+                );
+                ffgcvd(
+                    fptr,
+                    stopCol,
+                    1 as LONGLONG,
+                    1 as LONGLONG,
+                    nrows as LONGLONG,
+                    0.0f64,
+                    stopptr,
+                    &mut i,
+                    &mut (*lParse).status,
+                );
+                if (*lParse).status != 0 {
+                    free((*that0).value.data.dblptr as *mut c_void);
+                    return -(1);
+                }
+                (*that0).ntype = 1;
+                i = nrows as c_int;
+                loop {
+                    i -= 1;
+                    if i == 0 {
+                        break;
+                    }
+                    if !(*startptr.offset(i as isize) > *stopptr.offset(i as isize)
+                        || *startptr.offset(i as isize) < *stopptr.offset((i - 1) as isize))
+                    {
+                        continue;
+                    }
+                    (*that0).ntype = 0;
+                    break;
+                }
+                if (*that0).ntype != 1 && Op as c_uint == gtiover_fct as c_int as c_uint {
+                    let mut errmsg: [c_char; 120] = [0; 120];
+                    sprintf(
+                        errmsg.as_mut_ptr(),
+                        b"Input GTI must be time-ordered for GTIOVERLAP (row %ld)\0" as *const u8
+                            as *const c_char,
+                        i + 1,
+                    );
+                    fits_parser_yyerror(0 as yyscan_t, lParse, errmsg.as_mut_ptr());
+                    return -(1);
+                }
+                dt = timeZeroI[1] - timeZeroI[0] + (timeZeroF[1] - timeZeroF[0]);
+                timeSpan = *stopptr.offset((nrows - 1) as isize) - *startptr.offset(0);
+                if timeSpan == 0.0 {
+                    timeSpan = 1.0f64;
+                }
+                if fabs(dt / timeSpan) > 1e-12f64 {
+                    i = 0;
+                    while (i as c_long) < nrows {
+                        *startptr.offset(i as isize) += dt;
+                        *stopptr.offset(i as isize) += dt;
+                        i += 1;
+                        i;
+                    }
+                }
+            }
+            if (*((*lParse).Nodes).offset(Node1 as isize)).operation == -(1000 as c_int)
+                && (Op as c_uint == gtifilt_fct as c_int as c_uint
+                    || (*((*lParse).Nodes).offset(Node2 as isize)).operation == -(1000 as c_int))
+            {
+                ((*this).DoOp).expect("non-null function pointer")(lParse, this);
+            }
+        }
+        if samefile != 0 {
+            ffmahd(fptr, evthdu, &mut hdutype, &mut (*lParse).status);
+        } else {
+            ffclos(Some(Box::from_raw(fptr)), &mut (*lParse).status);
+        }
+        n
+    }
+}
+
+unsafe fn New_REG(
+    mut lParse: *mut ParseData,
+    mut fname: *mut c_char,
+    mut NodeX: c_int,
+    mut NodeY: c_int,
+    mut colNames: *mut c_char,
+) -> c_int {
+    unsafe {
+        let mut this: *mut Node = std::ptr::null_mut::<Node>();
+        let mut that0: *mut Node = std::ptr::null_mut::<Node>();
+        let mut type_0: c_int = 0;
+        let mut n: c_int = 0;
+        let mut Node0: c_int = 0;
+        let mut Xcol: c_int = 0;
+        let mut Ycol: c_int = 0;
+        let mut tstat: c_int = 0;
+        let mut wcs: WCSdata = WCSdata {
+            exists: false,
+            xrefval: 0.,
+            yrefval: 0.,
+            xrefpix: 0.,
+            yrefpix: 0.,
+            xinc: 0.,
+            yinc: 0.,
+            rot: 0.,
+            dtype: [0; 5],
+        };
+        let mut Rgn: *mut SAORegion = ptr::null_mut();
+        let mut cX: *mut c_char = ptr::null_mut();
+        let mut cY: *mut c_char = ptr::null_mut();
+        let mut colVal: FITS_PARSER_YYSTYPE = FITS_PARSER_YYSTYPE { Node: 0 };
+        if NodeX == -(99 as c_int) {
+            type_0 = fits_parser_yyGetVariable(
+                lParse,
+                b"X\0" as *const u8 as *const c_char as *mut c_char,
+                &mut colVal,
+            );
+            if type_0 == fits_parser_yytokentype::COLUMN as c_int {
+                NodeX = New_Column(lParse, colVal.lng as c_int);
+            } else {
+                fits_parser_yyerror(
+                    0 as yyscan_t,
+                    lParse,
+                    b"Could not build X column for REGFILTER\0" as *const u8 as *const c_char
+                        as *mut c_char,
+                );
+                return -(1);
+            }
+        }
+        if NodeY == -(99 as c_int) {
+            type_0 = fits_parser_yyGetVariable(
+                lParse,
+                b"Y\0" as *const u8 as *const c_char as *mut c_char,
+                &mut colVal,
+            );
+            if type_0 == fits_parser_yytokentype::COLUMN as c_int {
+                NodeY = New_Column(lParse, colVal.lng as c_int);
+            } else {
+                fits_parser_yyerror(
+                    0 as yyscan_t,
+                    lParse,
+                    b"Could not build Y column for REGFILTER\0" as *const u8 as *const c_char
+                        as *mut c_char,
+                );
+                return -(1);
+            }
+        }
+        NodeX = New_Unary(lParse, fits_parser_yytokentype::DOUBLE as c_int, 0, NodeX);
+        NodeY = New_Unary(lParse, fits_parser_yytokentype::DOUBLE as c_int, 0, NodeY);
+        Node0 = Alloc_Node(lParse);
+        if NodeX < 0 || NodeY < 0 || Node0 < 0 {
+            return -(1);
+        }
+        if Test_Dims(lParse, NodeX, NodeY) == 0 {
+            fits_parser_yyerror(
+                0 as yyscan_t,
+                lParse,
+                b"Dimensions of REGFILTER arguments are not compatible\0" as *const u8
+                    as *const c_char as *mut c_char,
+            );
+            return -(1);
+        }
+        n = Alloc_Node(lParse);
+        if n >= 0 {
+            this = ((*lParse).Nodes).offset(n as isize);
+            (*this).nSubNodes = 3 as c_int;
+            (*this).SubNodes[0] = Node0;
+            (*this).SubNodes[1] = NodeX;
+            (*this).SubNodes[2] = NodeY;
+            (*this).operation = regfilt_fct as c_int;
+            (*this).DoOp = Some(Do_REG);
+            (*this).ntype = fits_parser_yytokentype::BOOLEAN as c_int;
+            (*this).value.nelem = 1;
+            (*this).value.naxis = 1;
+            (*this).value.naxes[0] = 1;
+            Copy_Dims(lParse, n, NodeX);
+            if ((*((*lParse).Nodes).offset(NodeX as isize)).value).nelem
+                < ((*((*lParse).Nodes).offset(NodeY as isize)).value).nelem
+            {
+                Copy_Dims(lParse, n, NodeY);
+            }
+            that0 = ((*lParse).Nodes).offset(Node0 as isize);
+            (*that0).operation = -(1000 as c_int);
+            (*that0).DoOp = None;
+            Ycol = 0;
+            Xcol = Ycol;
+            if *colNames != 0 {
+                while *colNames as c_int == ' ' as i32 {
+                    colNames = colNames.offset(1);
+                    colNames;
+                }
+                cY = colNames;
+                cX = cY;
+                while *cY as c_int != 0 && *cY as c_int != ' ' as i32 && *cY as c_int != ',' as i32
+                {
+                    cY = cY.offset(1);
+                    cY;
+                }
+                if *cY != 0 {
+                    let fresh10 = cY;
+                    cY = cY.offset(1);
+                    *fresh10 = 0;
+                }
+                while *cY as c_int == ' ' as i32 {
+                    cY = cY.offset(1);
+                    cY;
+                }
+                if *cY == 0 {
+                    fits_parser_yyerror(
+                        0 as yyscan_t,
+                        lParse,
+                        b"Could not extract valid pair of column names from REGFILTER\0"
+                            as *const u8 as *const c_char as *mut c_char,
+                    );
+                    Free_Last_Node(lParse);
+                    return -(1);
+                }
+                ffgcno((*lParse).def_fptr, 0, cX, &mut Xcol, &mut (*lParse).status);
+                ffgcno((*lParse).def_fptr, 0, cY, &mut Ycol, &mut (*lParse).status);
+                if (*lParse).status != 0 {
+                    fits_parser_yyerror(
+                        0 as yyscan_t,
+                        lParse,
+                        b"Could not locate columns indicated for WCS info\0" as *const u8
+                            as *const c_char as *mut c_char,
+                    );
+                    Free_Last_Node(lParse);
+                    return -(1);
+                }
+            } else {
+                Xcol = Locate_Col(lParse, ((*lParse).Nodes).offset(NodeX as isize));
+                Ycol = Locate_Col(lParse, ((*lParse).Nodes).offset(NodeY as isize));
+                if Xcol < 0 || Ycol < 0 {
+                    fits_parser_yyerror(
+                        0 as yyscan_t,
+                        lParse,
+                        b"Found multiple X/Y column references in REGFILTER\0" as *const u8
+                            as *const c_char as *mut c_char,
+                    );
+                    Free_Last_Node(lParse);
+                    return -(1);
+                }
+            }
+            wcs.exists = false;
+            if Xcol > 0 && Ycol > 0 {
+                tstat = 0;
+                ffgtcs(
+                    (*lParse).def_fptr,
+                    Xcol,
+                    Ycol,
+                    &mut wcs.xrefval,
+                    &mut wcs.yrefval,
+                    &mut wcs.xrefpix,
+                    &mut wcs.yrefpix,
+                    &mut wcs.xinc,
+                    &mut wcs.yinc,
+                    &mut wcs.rot,
+                    &mut (wcs.dtype),
+                    &mut tstat,
+                );
+                if tstat == 505 as c_int {
+                    wcs.exists = false;
+                } else if tstat != 0 {
+                    (*lParse).status = tstat;
+                    Free_Last_Node(lParse);
+                    return -(1);
+                } else {
+                    wcs.exists = true;
+                }
+            }
+
+            let fname_slice = CStr::from_ptr(fname);
+            let rgn_box = Box::from_raw(Rgn);
+            fits_read_rgnfile(
+                cast_slice(fname_slice.to_bytes_with_nul()),
+                &mut wcs,
+                &mut Some(rgn_box),
+                &mut (*lParse).status,
+            );
+            if (*lParse).status != 0 {
+                Free_Last_Node(lParse);
+                return -(1);
+            }
+            (*that0).value.data.ptr = Rgn as *mut c_void;
+            if (*((*lParse).Nodes).offset(NodeX as isize)).operation == -(1000 as c_int)
+                && (*((*lParse).Nodes).offset(NodeY as isize)).operation == -(1000 as c_int)
+            {
+                ((*this).DoOp).expect("non-null function pointer")(lParse, this);
+            }
+        }
+        n
+    }
+}
+unsafe fn New_Vector(mut lParse: *mut ParseData, mut subNode: c_int) -> c_int {
+    unsafe {
+        let mut this: *mut Node = std::ptr::null_mut::<Node>();
+        let mut that: *mut Node = std::ptr::null_mut::<Node>();
+        let mut n: c_int = 0;
+        n = Alloc_Node(lParse);
+        if n >= 0 {
+            this = ((*lParse).Nodes).offset(n as isize);
+            that = ((*lParse).Nodes).offset(subNode as isize);
+            (*this).ntype = (*that).ntype;
+            (*this).nSubNodes = 1;
+            (*this).SubNodes[0] = subNode;
+            (*this).operation = '{' as i32;
+            (*this).DoOp = Some(Do_Vector);
+        }
+        n
+    }
+}
+unsafe fn Close_Vec(mut lParse: *mut ParseData, mut vecNode: c_int) -> c_int {
+    unsafe {
+        let mut this: *mut Node = std::ptr::null_mut::<Node>();
+        let mut n: c_int = 0;
+        let mut nelem: c_int = 0;
+        this = ((*lParse).Nodes).offset(vecNode as isize);
+        n = 0;
+        while n < (*this).nSubNodes {
+            if (*((*lParse).Nodes).offset((*this).SubNodes[n as usize] as isize)).ntype
+                != (*this).ntype
+            {
+                (*this).SubNodes[n as usize] =
+                    New_Unary(lParse, (*this).ntype, 0, (*this).SubNodes[n as usize]);
+                if (*this).SubNodes[n as usize] < 0 {
+                    return -(1);
+                }
+            }
+            nelem = (nelem as c_long
+                + (*((*lParse).Nodes).offset((*this).SubNodes[n as usize] as isize))
+                    .value
+                    .nelem) as c_int;
+            n += 1;
+            n;
+        }
+        (*this).value.naxis = 1;
+        (*this).value.nelem = nelem as c_long;
+        (*this).value.naxes[0] = nelem as c_long;
+        vecNode
+    }
+}
+unsafe fn New_Array(mut lParse: *mut ParseData, mut valueNode: c_int, mut dimNode: c_int) -> c_int {
+    unsafe {
+        let mut dims: *mut Node = std::ptr::null_mut::<Node>();
+        let mut naxis: c_long = 0;
+        let mut nelem: c_long = 0;
+        let mut naxes: [c_long; 5] = [0; 5];
+        let mut this: *mut Node = std::ptr::null_mut::<Node>();
+        let mut n: c_int = 0;
+        let mut i: c_int = 0;
+        if valueNode < 0 || dimNode < 0 {
+            return -(1);
+        }
+        dims = &mut *((*lParse).Nodes).offset(dimNode as isize) as *mut Node;
+        i = 0;
+        while i < 5 as c_int {
+            naxes[i as usize] = 1;
+            i += 1;
+            i;
+        }
+        if (*((*lParse).Nodes).offset(dimNode as isize)).operation == -(1000 as c_int) {
+            if (*((*lParse).Nodes).offset(dimNode as isize)).ntype
+                != fits_parser_yytokentype::LONG as c_int
+            {
+                dimNode = New_Unary(lParse, fits_parser_yytokentype::LONG as c_int, 0, dimNode);
+            }
+            if dimNode < 0 {
+                return -(1);
+            }
+            naxis = 1;
+            naxes[0] = ((*((*lParse).Nodes).offset(dimNode as isize)).value)
+                .data
+                .lng;
+        } else if (*((*lParse).Nodes).offset(dimNode as isize)).operation == '{' as i32 {
+            if (*dims).nSubNodes > 5 as c_int {
+                fits_parser_yyerror(
+                    0 as yyscan_t,
+                    lParse,
+                    b"ARRAY(V,{...}) number of dimensions must not exceed 5\0" as *const u8
+                        as *const c_char as *mut c_char,
+                );
+                return -(1);
+            }
+            naxis = (*dims).nSubNodes as c_long;
+            i = 0;
+            while i < (*dims).nSubNodes {
+                if (*((*lParse).Nodes).offset((*dims).SubNodes[i as usize] as isize)).ntype
+                    != fits_parser_yytokentype::LONG as c_int
+                {
+                    (*dims).SubNodes[i as usize] = New_Unary(
+                        lParse,
+                        fits_parser_yytokentype::LONG as c_int,
+                        0,
+                        (*dims).SubNodes[i as usize],
+                    );
+                    if (*dims).SubNodes[i as usize] < 0 {
+                        return -(1);
+                    }
+                }
+                naxes[i as usize] = (*((*lParse).Nodes)
+                    .offset((*dims).SubNodes[i as usize] as isize))
+                .value
+                .data
+                .lng;
+                i += 1;
+                i;
+            }
+        } else {
+            fits_parser_yyerror(
+                0 as yyscan_t,
+                lParse,
+                b"ARRAY(V,dims) dims must be either integer or const vector\0" as *const u8
+                    as *const c_char as *mut c_char,
+            );
+            return -(1);
+        }
+        nelem = 1;
+        i = 0;
+        while (i as c_long) < naxis {
+            if naxes[i as usize] <= 0 {
+                fits_parser_yyerror(
+                    0 as yyscan_t,
+                    lParse,
+                    b"ARRAY(V,dims) must have positive dimensions\0" as *const u8 as *const c_char
+                        as *mut c_char,
+                );
+                return -(1);
+            }
+            nelem *= naxes[i as usize];
+            i += 1;
+            i;
+        }
+        if !(((*((*lParse).Nodes).offset(valueNode as isize)).value).nelem == nelem && nelem > 1) {
+            if ((*((*lParse).Nodes).offset(valueNode as isize)).value).nelem > 1 && nelem > 1 {
+                fits_parser_yyerror(
+                    0 as yyscan_t,
+                    lParse,
+                    b"ARRAY(V,d) mismatch between number of elements in V and d\0" as *const u8
+                        as *const c_char as *mut c_char,
+                );
+                return -(1);
+            } else if ((*((*lParse).Nodes).offset(valueNode as isize)).value).nelem > 1 {
+                fits_parser_yyerror(
+                    0 as yyscan_t,
+                    lParse,
+                    b"ARRAY(V,n) value V must have vector dimension of 1\0" as *const u8
+                        as *const c_char as *mut c_char,
+                );
+                return -(1);
+            }
+        }
+        n = Alloc_Node(lParse);
+        if n >= 0 {
+            this = ((*lParse).Nodes).offset(n as isize);
+            (*this).operation = array_fct as c_int;
+            (*this).nSubNodes = 1;
+            (*this).SubNodes[0] = valueNode;
+            (*this).ntype = (*((*lParse).Nodes).offset(valueNode as isize)).ntype;
+            (*this).value.nelem = nelem;
+            (*this).value.naxis = naxis as c_int;
+            i = 0;
+            while (i as c_long) < naxis {
+                (*this).value.naxes[i as usize] = naxes[i as usize];
+                i += 1;
+                i;
+            }
+            (*this).DoOp = Some(Do_Array);
+        }
+        n
+    }
+}
+unsafe fn Locate_Col(mut lParse: *mut ParseData, mut this: *mut Node) -> c_int {
+    unsafe {
+        let mut that: *mut Node = std::ptr::null_mut::<Node>();
+        let mut i: c_int = 0;
+        let mut col: c_int = 0;
+        let mut newCol: c_int = 0;
+        let mut nfound: c_int = 0;
+        if (*this).nSubNodes == 0 && (*this).operation <= 0 && (*this).operation != -(1000 as c_int)
+        {
+            return (*((*lParse).colData).offset(-(*this).operation as isize)).colnum;
+        }
+        i = 0;
+        while i < (*this).nSubNodes {
+            that = ((*lParse).Nodes).offset((*this).SubNodes[i as usize] as isize);
+            if (*that).operation > 0 {
+                newCol = Locate_Col(lParse, that);
+                if newCol <= 0 {
+                    nfound += -newCol;
+                } else if nfound == 0 {
+                    col = newCol;
+                    nfound += 1;
+                    nfound;
+                } else if col != newCol {
+                    nfound += 1;
+                    nfound;
+                }
+            } else if (*that).operation != -(1000 as c_int) {
+                newCol = (*((*lParse).colData).offset(-(*that).operation as isize)).colnum;
+                if nfound == 0 {
+                    col = newCol;
+                    nfound += 1;
+                    nfound;
+                } else if col != newCol {
+                    nfound += 1;
+                    nfound;
+                }
+            }
+            i += 1;
+            i;
+        }
+        if nfound != 1 { -nfound } else { col }
+    }
+}
+unsafe fn Test_Dims(mut lParse: *mut ParseData, mut Node1: c_int, mut Node2: c_int) -> c_int {
+    unsafe {
+        let mut that1: *mut Node = std::ptr::null_mut::<Node>();
+        let mut that2: *mut Node = std::ptr::null_mut::<Node>();
+        let mut valid: c_int = 0;
+        let mut i: c_int = 0;
+        if Node1 < 0 || Node2 < 0 {
+            return 0;
+        }
+        that1 = ((*lParse).Nodes).offset(Node1 as isize);
+        that2 = ((*lParse).Nodes).offset(Node2 as isize);
+        if (*that1).value.nelem == 1 || (*that2).value.nelem == 1 {
+            valid = 1;
+        } else if (*that1).ntype == (*that2).ntype
+            && (*that1).value.nelem == (*that2).value.nelem
+            && (*that1).value.naxis == (*that2).value.naxis
+        {
+            valid = 1;
+            i = 0;
+            while i < (*that1).value.naxis {
+                if (*that1).value.naxes[i as usize] != (*that2).value.naxes[i as usize] {
+                    valid = 0;
+                }
+                i += 1;
+                i;
+            }
+        } else {
+            valid = 0;
+        }
+        valid
+    }
+}
+unsafe fn Copy_Dims(mut lParse: *mut ParseData, mut Node1: c_int, mut Node2: c_int) {
+    unsafe {
+        let mut that1: *mut Node = std::ptr::null_mut::<Node>();
+        let mut that2: *mut Node = std::ptr::null_mut::<Node>();
+        let mut i: c_int = 0;
+        if Node1 < 0 || Node2 < 0 {
+            return;
+        }
+        that1 = ((*lParse).Nodes).offset(Node1 as isize);
+        that2 = ((*lParse).Nodes).offset(Node2 as isize);
+        (*that1).value.nelem = (*that2).value.nelem;
+        (*that1).value.naxis = (*that2).value.naxis;
+        i = 0;
+        while i < (*that2).value.naxis {
+            (*that1).value.naxes[i as usize] = (*that2).value.naxes[i as usize];
+            i += 1;
+            i;
+        }
+    }
+}
+
+pub unsafe fn Evaluate_Parser(mut lParse: *mut ParseData, mut firstRow: c_long, mut nRows: c_long) {
+    unsafe {
+        let mut i: c_int = 0;
+        let mut column: c_int = 0;
+        let mut offset: c_long = 0;
+        let mut rowOffset: c_long = 0;
+        static mut rand_initialized: c_int = 0;
+        if rand_initialized == 0 {
+            simplerng_srand(time(std::ptr::null_mut::<time_t>()) as c_uint);
+            rand_initialized = 1;
+        }
+        (*lParse).firstRow = firstRow;
+        (*lParse).nRows = nRows;
+        rowOffset = firstRow - (*lParse).firstDataRow;
+        i = 0;
+        while i < (*lParse).nNodes {
+            if !((*((*lParse).Nodes).offset(i as isize)).operation > 0
+                || (*((*lParse).Nodes).offset(i as isize)).operation == -(1000 as c_int))
+            {
+                column = -(*((*lParse).Nodes).offset(i as isize)).operation;
+                offset = (*((*lParse).varData).offset(column as isize)).nelem * rowOffset;
+                let fresh11 = &mut ((*((*lParse).Nodes).offset(i as isize)).value).undef;
+                *fresh11 =
+                    ((*((*lParse).varData).offset(column as isize)).undef).offset(offset as isize);
+                match (*((*lParse).Nodes).offset(i as isize)).ntype {
+                    262 => {
+                        let fresh12 =
+                            &mut ((*((*lParse).Nodes).offset(i as isize)).value).data.strptr;
+                        *fresh12 = ((*((*lParse).varData).offset(column as isize)).data
+                            as *mut *mut c_char)
+                            .offset(rowOffset as isize);
+                        let fresh13 = &mut ((*((*lParse).Nodes).offset(i as isize)).value).undef;
+                        *fresh13 = ptr::null_mut();
+                    }
+                    261 => {
+                        let fresh14 =
+                            &mut ((*((*lParse).Nodes).offset(i as isize)).value).data.strptr;
+                        *fresh14 = ((*((*lParse).varData).offset(column as isize)).data
+                            as *mut *mut c_char)
+                            .offset(rowOffset as isize);
+                        let fresh15 = &mut ((*((*lParse).Nodes).offset(i as isize)).value).undef;
+                        *fresh15 = ((*((*lParse).varData).offset(column as isize)).undef)
+                            .offset(rowOffset as isize);
+                    }
+                    258 => {
+                        let fresh16 =
+                            &mut ((*((*lParse).Nodes).offset(i as isize)).value).data.logptr;
+                        *fresh16 = ((*((*lParse).varData).offset(column as isize)).data as *const _
+                            as *mut c_char)
+                            .offset(offset as isize);
+                    }
+                    259 => {
+                        let fresh17 =
+                            &mut ((*((*lParse).Nodes).offset(i as isize)).value).data.lngptr;
+                        *fresh17 = ((*((*lParse).varData).offset(column as isize)).data as *const _
+                            as *mut c_long)
+                            .offset(offset as isize);
+                    }
+                    260 => {
+                        let fresh18 =
+                            &mut ((*((*lParse).Nodes).offset(i as isize)).value).data.dblptr;
+                        *fresh18 = ((*((*lParse).varData).offset(column as isize)).data as *const _
+                            as *mut c_double)
+                            .offset(offset as isize);
+                    }
+                    _ => {}
+                }
+            }
+            i += 1;
+            i;
+        }
+        Evaluate_Node(lParse, (*lParse).resultNode);
+    }
+}
+unsafe fn Evaluate_Node(mut lParse: *mut ParseData, mut thisNode: c_int) {
+    unsafe {
+        let mut this: *mut Node = std::ptr::null_mut::<Node>();
+        let mut i: c_int = 0;
+        if (*lParse).status != 0 {
+            return;
+        }
+        this = ((*lParse).Nodes).offset(thisNode as isize);
+        if (*this).operation > 0 {
+            i = (*this).nSubNodes;
+            loop {
+                let fresh19 = i;
+                i -= 1;
+                if fresh19 == 0 {
+                    break;
+                }
+                Evaluate_Node(lParse, (*this).SubNodes[i as usize]);
+                if (*lParse).status != 0 {
+                    return;
+                }
+            }
+            ((*this).DoOp).expect("non-null function pointer")(lParse, this);
+        }
+    }
+}
+unsafe fn Allocate_Ptrs(mut lParse: *mut ParseData, mut this: *mut Node) {
+    unsafe {
+        let mut elem: c_long = 0;
+        let mut row: c_long = 0;
+        let mut size: c_long = 0;
+        if (*this).ntype == fits_parser_yytokentype::BITSTR as c_int
+            || (*this).ntype == fits_parser_yytokentype::STRING as c_int
+        {
+            (*this).value.data.strptr = malloc(
+                ((*lParse).nRows as c_ulong)
+                    .wrapping_mul(::core::mem::size_of::<*mut c_char>() as c_ulong)
+                    .try_into()
+                    .unwrap(),
+            ) as *mut *mut c_char;
+            if !((*this).value.data.strptr).is_null() {
+                let fresh20 = &mut *((*this).value.data.strptr).offset(0);
+                *fresh20 = malloc(
+                    (((*lParse).nRows * ((*this).value.nelem + 2 as c_long)) as c_ulong)
+                        .wrapping_mul(::core::mem::size_of::<c_char>() as c_ulong)
+                        .try_into()
+                        .unwrap(),
+                ) as *mut c_char;
+                if !(*((*this).value.data.strptr).offset(0)).is_null() {
+                    row = 0;
+                    loop {
+                        row += 1;
+                        if row >= (*lParse).nRows {
+                            break;
+                        }
+                        let fresh21 = &mut *((*this).value.data.strptr).offset(row as isize);
+                        *fresh21 = (*((*this).value.data.strptr).offset((row - 1) as isize))
+                            .offset((*this).value.nelem as isize)
+                            .offset(1 as c_int as isize);
+                    }
+                    if (*this).ntype == fits_parser_yytokentype::STRING as c_int {
+                        (*this).value.undef = (*((*this).value.data.strptr)
+                            .offset((row - 1) as isize))
+                        .offset((*this).value.nelem as isize)
+                        .offset(1 as c_int as isize);
+                    } else {
+                        (*this).value.undef = ptr::null_mut();
+                    }
+                } else {
+                    (*lParse).status = 113 as c_int;
+                    free((*this).value.data.strptr as *mut c_void);
+                }
+            } else {
+                (*lParse).status = 113 as c_int;
+            }
+        } else {
+            elem = (*this).value.nelem * (*lParse).nRows;
+            match (*this).ntype {
+                260 => {
+                    size = ::core::mem::size_of::<c_double>() as c_ulong as c_long;
+                }
+                259 => {
+                    size = ::core::mem::size_of::<c_long>() as c_ulong as c_long;
+                }
+                258 => {
+                    size = ::core::mem::size_of::<c_char>() as c_ulong as c_long;
+                }
+                _ => {
+                    size = 1;
+                }
+            }
+            (*this).value.data.ptr = calloc(
+                ((size + 1) as c_ulong).try_into().unwrap(),
+                (elem as c_ulong).try_into().unwrap(),
+            );
+            if ((*this).value.data.ptr).is_null() {
+                (*lParse).status = 113 as c_int;
+            } else {
+                (*this).value.undef =
+                    ((*this).value.data.ptr as *mut c_char).offset((elem * size) as isize);
+            }
+        };
+    }
+}
+unsafe fn Do_Unary(mut lParse: *mut ParseData, mut this: *mut Node) {
+    unsafe {
+        let mut that: *mut Node = std::ptr::null_mut::<Node>();
+        let mut elem: c_long = 0;
+        that = ((*lParse).Nodes).offset((*this).SubNodes[0] as isize);
+        if (*that).operation == -(1000 as c_int) {
+            match (*this).operation {
+                x if x == fits_parser_yytokentype::DOUBLE as c_int
+                    || x == fits_parser_yytokentype::FLTCAST as c_int =>
+                {
+                    if (*that).ntype == fits_parser_yytokentype::LONG as c_int {
+                        (*this).value.data.dbl = (*that).value.data.lng as c_double;
+                    } else if (*that).ntype == fits_parser_yytokentype::BOOLEAN as c_int {
+                        (*this).value.data.dbl = if (*that).value.data.log as c_int != 0 {
+                            1.0f64
+                        } else {
+                            0.0f64
+                        };
+                    }
+                }
+                x if x == fits_parser_yytokentype::LONG as c_int
+                    || x == fits_parser_yytokentype::INTCAST as c_int =>
+                {
+                    if (*that).ntype == fits_parser_yytokentype::DOUBLE as c_int {
+                        (*this).value.data.lng = (*that).value.data.dbl as c_long;
+                    } else if (*that).ntype == fits_parser_yytokentype::BOOLEAN as c_int {
+                        (*this).value.data.lng = if (*that).value.data.log as c_int != 0 {
+                            1
+                        } else {
+                            0
+                        };
+                    }
+                }
+                x if x == fits_parser_yytokentype::BOOLEAN as c_int => {
+                    if (*that).ntype == fits_parser_yytokentype::DOUBLE as c_int {
+                        (*this).value.data.log = if (*that).value.data.dbl != 0.0f64 {
+                            1
+                        } else {
+                            0
+                        };
+                    } else if (*that).ntype == fits_parser_yytokentype::LONG as c_int {
+                        (*this).value.data.log = if (*that).value.data.lng != 0 { 1 } else { 0 };
+                    }
+                }
+                x if x == fits_parser_yytokentype::UMINUS as c_int => {
+                    if (*that).ntype == fits_parser_yytokentype::DOUBLE as c_int {
+                        (*this).value.data.dbl = -(*that).value.data.dbl;
+                    } else if (*that).ntype == fits_parser_yytokentype::LONG as c_int {
+                        (*this).value.data.lng = -(*that).value.data.lng;
+                    }
+                }
+                x if x == fits_parser_yytokentype::NOT as c_int => {
+                    if (*that).ntype == fits_parser_yytokentype::BOOLEAN as c_int {
+                        (*this).value.data.log = if (*that).value.data.log == 0 { 1 } else { 0 };
+                    } else if (*that).ntype == fits_parser_yytokentype::BITSTR as c_int {
+                        bitnot(
+                            ((*this).value.data.astr).as_mut_ptr(),
+                            ((*that).value.data.astr).as_mut_ptr(),
+                        );
+                    }
+                }
+                _ => {}
+            }
+            (*this).operation = -(1000 as c_int);
+        } else {
+            Allocate_Ptrs(lParse, this);
+            if (*lParse).status == 0 {
+                if (*this).ntype != fits_parser_yytokentype::BITSTR as c_int {
+                    elem = (*lParse).nRows;
+                    if (*this).ntype != fits_parser_yytokentype::STRING as c_int {
+                        elem *= (*this).value.nelem;
+                    }
+                    loop {
+                        let fresh22 = elem;
+                        elem -= 1;
+                        if fresh22 == 0 {
+                            break;
+                        }
+                        *((*this).value.undef).offset(elem as isize) =
+                            *((*that).value.undef).offset(elem as isize);
+                    }
+                }
+                elem = (*lParse).nRows * (*this).value.nelem;
+                match (*this).operation {
+                    258 => {
+                        if (*that).ntype == fits_parser_yytokentype::DOUBLE as c_int {
+                            loop {
+                                let fresh23 = elem;
+                                elem -= 1;
+                                if fresh23 == 0 {
+                                    break;
+                                }
+                                *((*this).value.data.logptr).offset(elem as isize) =
+                                    if *((*that).value.data.dblptr).offset(elem as isize) != 0.0f64
+                                    {
+                                        1
+                                    } else {
+                                        0
+                                    };
+                            }
+                        } else if (*that).ntype == fits_parser_yytokentype::LONG as c_int {
+                            loop {
+                                let fresh24 = elem;
+                                elem -= 1;
+                                if fresh24 == 0 {
+                                    break;
+                                }
+                                *((*this).value.data.logptr).offset(elem as isize) =
+                                    if *((*that).value.data.lngptr).offset(elem as isize) != 0 {
+                                        1
+                                    } else {
+                                        0
+                                    };
+                            }
+                        }
+                    }
+                    260 | 289 => {
+                        if (*that).ntype == fits_parser_yytokentype::LONG as c_int {
+                            loop {
+                                let fresh25 = elem;
+                                elem -= 1;
+                                if fresh25 == 0 {
+                                    break;
+                                }
+                                *((*this).value.data.dblptr).offset(elem as isize) =
+                                    *((*that).value.data.lngptr).offset(elem as isize) as c_double;
+                            }
+                        } else if (*that).ntype == fits_parser_yytokentype::BOOLEAN as c_int {
+                            loop {
+                                let fresh26 = elem;
+                                elem -= 1;
+                                if fresh26 == 0 {
+                                    break;
+                                }
+                                *((*this).value.data.dblptr).offset(elem as isize) =
+                                    if *((*that).value.data.logptr).offset(elem as isize) as c_int
+                                        != 0
+                                    {
+                                        1.0f64
+                                    } else {
+                                        0.0f64
+                                    };
+                            }
+                        }
+                    }
+                    259 | 288 => {
+                        if (*that).ntype == fits_parser_yytokentype::DOUBLE as c_int {
+                            loop {
+                                let fresh27 = elem;
+                                elem -= 1;
+                                if fresh27 == 0 {
+                                    break;
+                                }
+                                *((*this).value.data.lngptr).offset(elem as isize) =
+                                    *((*that).value.data.dblptr).offset(elem as isize) as c_long;
+                            }
+                        } else if (*that).ntype == fits_parser_yytokentype::BOOLEAN as c_int {
+                            loop {
+                                let fresh28 = elem;
+                                elem -= 1;
+                                if fresh28 == 0 {
+                                    break;
+                                }
+                                *((*this).value.data.lngptr).offset(elem as isize) =
+                                    if *((*that).value.data.logptr).offset(elem as isize) as c_int
+                                        != 0
+                                    {
+                                        1
+                                    } else {
+                                        0
+                                    };
+                            }
+                        }
+                    }
+                    290 => {
+                        if (*that).ntype == fits_parser_yytokentype::DOUBLE as c_int {
+                            loop {
+                                let fresh29 = elem;
+                                elem -= 1;
+                                if fresh29 == 0 {
+                                    break;
+                                }
+                                *((*this).value.data.dblptr).offset(elem as isize) =
+                                    -*((*that).value.data.dblptr).offset(elem as isize);
+                            }
+                        } else if (*that).ntype == fits_parser_yytokentype::LONG as c_int {
+                            loop {
+                                let fresh30 = elem;
+                                elem -= 1;
+                                if fresh30 == 0 {
+                                    break;
+                                }
+                                *((*this).value.data.lngptr).offset(elem as isize) =
+                                    -*((*that).value.data.lngptr).offset(elem as isize);
+                            }
+                        }
+                    }
+                    287 => {
+                        if (*that).ntype == fits_parser_yytokentype::BOOLEAN as c_int {
+                            loop {
+                                let fresh31 = elem;
+                                elem -= 1;
+                                if fresh31 == 0 {
+                                    break;
+                                }
+                                *((*this).value.data.logptr).offset(elem as isize) =
+                                    (*((*that).value.data.logptr).offset(elem as isize) == 0)
+                                        as c_int as c_char;
+                            }
+                        } else if (*that).ntype == fits_parser_yytokentype::BITSTR as c_int {
+                            elem = (*lParse).nRows;
+                            loop {
+                                let fresh32 = elem;
+                                elem -= 1;
+                                if fresh32 == 0 {
+                                    break;
+                                }
+                                bitnot(
+                                    *((*this).value.data.strptr).offset(elem as isize),
+                                    *((*that).value.data.strptr).offset(elem as isize),
+                                );
+                            }
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        }
+        if (*that).operation > 0 {
+            free((*that).value.data.ptr);
+        }
+    }
+}
+unsafe fn Do_Offset(mut lParse: *mut ParseData, mut this: *mut Node) {
+    unsafe {
+        let mut col: *mut Node = std::ptr::null_mut::<Node>();
+        let mut fRow: c_long = 0;
+        let mut nRowOverlap: c_long = 0;
+        let mut nRowReload: c_long = 0;
+        let mut rowOffset: c_long = 0;
+        let mut nelem: c_long = 0;
+        let mut elem: c_long = 0;
+        let mut offset: c_long = 0;
+        let mut nRealElem: c_long = 0;
+        let mut status: c_int = 0;
+        col = ((*lParse).Nodes).offset((*this).SubNodes[0] as isize);
+        rowOffset = (*((*lParse).Nodes).offset((*this).SubNodes[1] as isize))
+            .value
+            .data
+            .lng;
+        Allocate_Ptrs(lParse, this);
+        fRow = (*lParse).firstRow + rowOffset;
+        if (*this).ntype == fits_parser_yytokentype::STRING as c_int
+            || (*this).ntype == fits_parser_yytokentype::BITSTR as c_int
+        {
+            nRealElem = 1;
+        } else {
+            nRealElem = (*this).value.nelem;
+        }
+        nelem = nRealElem;
+        if fRow < (*lParse).firstDataRow {
+            nRowReload = (*lParse).firstDataRow - fRow;
+            if nRowReload > (*lParse).nRows {
+                nRowReload = (*lParse).nRows;
+            }
+            nRowOverlap = (*lParse).nRows - nRowReload;
+            offset = 0;
+            while fRow < 1 && nRowReload > 0 {
+                if (*this).ntype == fits_parser_yytokentype::BITSTR as c_int {
+                    nelem = (*this).value.nelem;
+                    *(*((*this).value.data.strptr).offset(offset as isize))
+                        .offset(nelem as isize) = 0;
+                    loop {
+                        let fresh33 = nelem;
+                        nelem -= 1;
+                        if fresh33 == 0 {
+                            break;
+                        }
+                        *(*((*this).value.data.strptr).offset(offset as isize))
+                            .offset(nelem as isize) = b'0' as c_char;
+                    }
+                    offset += 1;
+                    offset;
+                } else {
+                    loop {
+                        let fresh34 = nelem;
+                        nelem -= 1;
+                        if fresh34 == 0 {
+                            break;
+                        }
+                        let fresh35 = offset;
+                        offset += 1;
+                        *((*this).value.undef).offset(fresh35 as isize) = 1;
+                    }
+                }
+                nelem = nRealElem;
+                fRow += 1;
+                fRow;
+                nRowReload -= 1;
+                nRowReload;
+            }
+        } else if fRow + (*lParse).nRows > (*lParse).firstDataRow + (*lParse).nDataRows {
+            nRowReload = fRow + (*lParse).nRows - ((*lParse).firstDataRow + (*lParse).nDataRows);
+            if nRowReload > (*lParse).nRows {
+                nRowReload = (*lParse).nRows;
+            } else {
+                fRow = (*lParse).firstDataRow + (*lParse).nDataRows;
+            }
+            nRowOverlap = (*lParse).nRows - nRowReload;
+            offset = nRowOverlap * nelem;
+            elem = (*lParse).nRows * nelem;
+            while fRow + nRowReload > (*lParse).totalRows && nRowReload > 0 {
+                if (*this).ntype == fits_parser_yytokentype::BITSTR as c_int {
+                    nelem = (*this).value.nelem;
+                    elem -= 1;
+                    elem;
+                    *(*((*this).value.data.strptr).offset(elem as isize)).offset(nelem as isize) =
+                        0;
+                    loop {
+                        let fresh36 = nelem;
+                        nelem -= 1;
+                        if fresh36 == 0 {
+                            break;
+                        }
+                        *(*((*this).value.data.strptr).offset(elem as isize))
+                            .offset(nelem as isize) = b'0' as c_char;
+                    }
+                } else {
+                    loop {
+                        let fresh37 = nelem;
+                        nelem -= 1;
+                        if fresh37 == 0 {
+                            break;
+                        }
+                        elem -= 1;
+                        *((*this).value.undef).offset(elem as isize) = 1;
+                    }
+                }
+                nelem = nRealElem;
+                nRowReload -= 1;
+                nRowReload;
+            }
+        } else {
+            nRowReload = 0;
+            nRowOverlap = (*lParse).nRows;
+            offset = 0;
+        }
+        if nRowReload > 0 {
+            match (*this).ntype {
+                262 | 261 => {
+                    status = ((*lParse).loadData).expect("non-null function pointer")(
+                        lParse,
+                        -(*col).operation,
+                        fRow,
+                        nRowReload,
+                        ((*this).value.data.strptr).offset(offset as isize) as *mut c_void,
+                        ((*this).value.undef).offset(offset as isize),
+                    );
+                }
+                258 => {
+                    status = ((*lParse).loadData).expect("non-null function pointer")(
+                        lParse,
+                        -(*col).operation,
+                        fRow,
+                        nRowReload,
+                        ((*this).value.data.logptr).offset(offset as isize) as *mut c_void,
+                        ((*this).value.undef).offset(offset as isize),
+                    );
+                }
+                259 => {
+                    status = ((*lParse).loadData).expect("non-null function pointer")(
+                        lParse,
+                        -(*col).operation,
+                        fRow,
+                        nRowReload,
+                        ((*this).value.data.lngptr).offset(offset as isize) as *mut c_void,
+                        ((*this).value.undef).offset(offset as isize),
+                    );
+                }
+                260 => {
+                    status = ((*lParse).loadData).expect("non-null function pointer")(
+                        lParse,
+                        -(*col).operation,
+                        fRow,
+                        nRowReload,
+                        ((*this).value.data.dblptr).offset(offset as isize) as *mut c_void,
+                        ((*this).value.undef).offset(offset as isize),
+                    );
+                }
+                _ => {}
+            }
+        }
+        if nRowOverlap <= 0 {
+            return;
+        }
+        if rowOffset > 0 {
+            elem = nRowOverlap * nelem;
+        } else {
+            elem = (*lParse).nRows * nelem;
+        }
+        offset = nelem * rowOffset;
+        loop {
+            let fresh38 = nRowOverlap;
+            nRowOverlap -= 1;
+            if !(fresh38 != 0 && (*lParse).status == 0) {
+                break;
+            }
+            loop {
+                let fresh39 = nelem;
+                nelem -= 1;
+                if !(fresh39 != 0 && (*lParse).status == 0) {
+                    break;
+                }
+                elem -= 1;
+                elem;
+                if (*this).ntype != fits_parser_yytokentype::BITSTR as c_int {
+                    *((*this).value.undef).offset(elem as isize) =
+                        *((*col).value.undef).offset((elem + offset) as isize);
+                }
+                match (*this).ntype {
+                    262 => {
+                        strcpy(
+                            *((*this).value.data.strptr).offset(elem as isize),
+                            *((*col).value.data.strptr).offset((elem + offset) as isize),
+                        );
+                    }
+                    261 => {
+                        strcpy(
+                            *((*this).value.data.strptr).offset(elem as isize),
+                            *((*col).value.data.strptr).offset((elem + offset) as isize),
+                        );
+                    }
+                    258 => {
+                        *((*this).value.data.logptr).offset(elem as isize) =
+                            *((*col).value.data.logptr).offset((elem + offset) as isize);
+                    }
+                    259 => {
+                        *((*this).value.data.lngptr).offset(elem as isize) =
+                            *((*col).value.data.lngptr).offset((elem + offset) as isize);
+                    }
+                    260 => {
+                        *((*this).value.data.dblptr).offset(elem as isize) =
+                            *((*col).value.data.dblptr).offset((elem + offset) as isize);
+                    }
+                    _ => {}
+                }
+            }
+            nelem = nRealElem;
+        }
+    }
+}
+unsafe fn Do_BinOp_bit(mut lParse: *mut ParseData, mut this: *mut Node) {
+    unsafe {
+        let mut that1: *mut Node = std::ptr::null_mut::<Node>();
+        let mut that2: *mut Node = std::ptr::null_mut::<Node>();
+        let mut sptr1: *mut c_char = ptr::null_mut();
+        let mut sptr2: *mut c_char = ptr::null_mut();
+        let mut const1: c_int = 0;
+        let mut const2: c_int = 0;
+        let mut rows: c_long = 0;
+        that1 = ((*lParse).Nodes).offset((*this).SubNodes[0] as isize);
+        that2 = ((*lParse).Nodes).offset((*this).SubNodes[1] as isize);
+        const1 = ((*that1).operation == -(1000 as c_int)) as c_int;
+        const2 = ((*that2).operation == -(1000 as c_int)) as c_int;
+        sptr1 = if const1 != 0 {
+            ((*that1).value.data.astr).as_mut_ptr()
+        } else {
+            std::ptr::null_mut::<c_char>()
+        };
+        sptr2 = if const2 != 0 {
+            ((*that2).value.data.astr).as_mut_ptr()
+        } else {
+            std::ptr::null_mut::<c_char>()
+        };
+        if const1 != 0 && const2 != 0 {
+            match (*this).operation {
+                280 => {
+                    (*this).value.data.log = if bitcmp(sptr1, sptr2) == 0 { 1 } else { 0 };
+                }
+                279 => {
+                    (*this).value.data.log = bitcmp(sptr1, sptr2);
+                }
+                281..=284 => {
+                    (*this).value.data.log = bitlgte(sptr1, (*this).operation, sptr2);
+                }
+                124 => {
+                    bitor(((*this).value.data.astr).as_mut_ptr(), sptr1, sptr2);
+                }
+                38 => {
+                    bitand(((*this).value.data.astr).as_mut_ptr(), sptr1, sptr2);
+                }
+                43 => {
+                    strcpy(((*this).value.data.astr).as_mut_ptr(), sptr1);
+                    strcat(((*this).value.data.astr).as_mut_ptr(), sptr2);
+                }
+                291 => {
+                    (*this).value.data.lng = 0;
+                    while *sptr1 != 0 {
+                        if *sptr1 as c_int == '1' as i32 {
+                            (*this).value.data.lng += 1;
+                            (*this).value.data.lng;
+                        }
+                        sptr1 = sptr1.offset(1);
+                        sptr1;
+                    }
+                }
+                _ => {}
+            }
+            (*this).operation = -(1000 as c_int);
+        } else {
+            Allocate_Ptrs(lParse, this);
+            if (*lParse).status == 0 {
+                rows = (*lParse).nRows;
+                match (*this).operation {
+                    279..=284 => loop {
+                        let fresh40 = rows;
+                        rows -= 1;
+                        if fresh40 == 0 {
+                            break;
+                        }
+                        if const1 == 0 {
+                            sptr1 = *((*that1).value.data.strptr).offset(rows as isize);
+                        }
+                        if const2 == 0 {
+                            sptr2 = *((*that2).value.data.strptr).offset(rows as isize);
+                        }
+                        match (*this).operation {
+                            280 => {
+                                *((*this).value.data.logptr).offset(rows as isize) =
+                                    if bitcmp(sptr1, sptr2) == 0 { 1 } else { 0 };
+                            }
+                            279 => {
+                                *((*this).value.data.logptr).offset(rows as isize) =
+                                    bitcmp(sptr1, sptr2);
+                            }
+                            281..=284 => {
+                                *((*this).value.data.logptr).offset(rows as isize) =
+                                    bitlgte(sptr1, (*this).operation, sptr2);
+                            }
+                            _ => {}
+                        }
+                        *((*this).value.undef).offset(rows as isize) = 0;
+                    },
+                    124 | 38 | 43 => loop {
+                        let fresh41 = rows;
+                        rows -= 1;
+                        if fresh41 == 0 {
+                            break;
+                        }
+                        if const1 == 0 {
+                            sptr1 = *((*that1).value.data.strptr).offset(rows as isize);
+                        }
+                        if const2 == 0 {
+                            sptr2 = *((*that2).value.data.strptr).offset(rows as isize);
+                        }
+                        if (*this).operation == '|' as i32 {
+                            bitor(
+                                *((*this).value.data.strptr).offset(rows as isize),
+                                sptr1,
+                                sptr2,
+                            );
+                        } else if (*this).operation == '&' as i32 {
+                            bitand(
+                                *((*this).value.data.strptr).offset(rows as isize),
+                                sptr1,
+                                sptr2,
+                            );
+                        } else {
+                            strcpy(*((*this).value.data.strptr).offset(rows as isize), sptr1);
+                            strcat(*((*this).value.data.strptr).offset(rows as isize), sptr2);
+                        }
+                    },
+                    291 => {
+                        let mut i: c_long = 0;
+                        let mut previous: c_long = 0;
+                        let mut curr: c_long = 0;
+                        previous = (*that2).value.data.lng;
+                        i = 0;
+                        while i < rows {
+                            sptr1 = *((*that1).value.data.strptr).offset(i as isize);
+                            curr = 0;
+                            while *sptr1 != 0 {
+                                if *sptr1 as c_int == '1' as i32 {
+                                    curr += 1;
+                                    curr;
+                                }
+                                sptr1 = sptr1.offset(1);
+                                sptr1;
+                            }
+                            previous += curr;
+                            *((*this).value.data.lngptr).offset(i as isize) = previous;
+                            *((*this).value.undef).offset(i as isize) = 0;
+                            i += 1;
+                            i;
+                        }
+                        (*that2).value.data.lng = previous;
+                    }
+                    _ => {}
+                }
+            }
+        }
+        if (*that1).operation > 0 {
+            free(*((*that1).value.data.strptr).offset(0) as *mut c_void);
+            free((*that1).value.data.strptr as *mut c_void);
+        }
+        if (*that2).operation > 0 {
+            free(*((*that2).value.data.strptr).offset(0) as *mut c_void);
+            free((*that2).value.data.strptr as *mut c_void);
+        }
+    }
+}
+unsafe fn Do_BinOp_str(mut lParse: *mut ParseData, mut this: *mut Node) {
+    unsafe {
+        let mut that1: *mut Node = std::ptr::null_mut::<Node>();
+        let mut that2: *mut Node = std::ptr::null_mut::<Node>();
+        let mut sptr1: *mut c_char = ptr::null_mut();
+        let mut sptr2: *mut c_char = ptr::null_mut();
+        let mut null1: c_char = 0;
+        let mut null2: c_char = 0;
+        let mut const1: c_int = 0;
+        let mut const2: c_int = 0;
+        let mut val: c_int = 0;
+        let mut rows: c_long = 0;
+        that1 = ((*lParse).Nodes).offset((*this).SubNodes[0] as isize);
+        that2 = ((*lParse).Nodes).offset((*this).SubNodes[1] as isize);
+        const1 = ((*that1).operation == -(1000 as c_int)) as c_int;
+        const2 = ((*that2).operation == -(1000 as c_int)) as c_int;
+        sptr1 = if const1 != 0 {
+            ((*that1).value.data.astr).as_mut_ptr()
+        } else {
+            std::ptr::null_mut::<c_char>()
+        };
+        sptr2 = if const2 != 0 {
+            ((*that2).value.data.astr).as_mut_ptr()
+        } else {
+            std::ptr::null_mut::<c_char>()
+        };
+        if const1 != 0 && const2 != 0 {
+            match (*this).operation {
+                280 | 279 => {
+                    val = ((if (*sptr1.offset(0) as c_int) < *sptr2.offset(0) as c_int {
+                        -(1)
+                    } else if *sptr1.offset(0) as c_int > *sptr2.offset(0) as c_int {
+                        1
+                    } else {
+                        strcmp(sptr1, sptr2)
+                    }) == 0) as c_int;
+                    (*this).value.data.log =
+                        (if (*this).operation == fits_parser_yytokentype::EQ as c_int {
+                            val
+                        } else {
+                            (val == 0) as c_int
+                        }) as c_char;
+                }
+                281 => {
+                    (*this).value.data.log =
+                        if (if (*sptr1.offset(0) as c_int) < *sptr2.offset(0) as c_int {
+                            -(1)
+                        } else if *sptr1.offset(0) as c_int > *sptr2.offset(0) as c_int {
+                            1
+                        } else {
+                            strcmp(sptr1, sptr2)
+                        }) > 0
+                        {
+                            1
+                        } else {
+                            0
+                        };
+                }
+                282 => {
+                    (*this).value.data.log =
+                        if (if (*sptr1.offset(0) as c_int) < *sptr2.offset(0) as c_int {
+                            -(1)
+                        } else if *sptr1.offset(0) as c_int > *sptr2.offset(0) as c_int {
+                            1
+                        } else {
+                            strcmp(sptr1, sptr2)
+                        }) < 0
+                        {
+                            1
+                        } else {
+                            0
+                        };
+                }
+                284 => {
+                    (*this).value.data.log =
+                        if (if (*sptr1.offset(0) as c_int) < *sptr2.offset(0) as c_int {
+                            -(1)
+                        } else if *sptr1.offset(0) as c_int > *sptr2.offset(0) as c_int {
+                            1
+                        } else {
+                            strcmp(sptr1, sptr2)
+                        }) >= 0
+                        {
+                            1
+                        } else {
+                            0
+                        };
+                }
+                283 => {
+                    (*this).value.data.log =
+                        if (if (*sptr1.offset(0) as c_int) < *sptr2.offset(0) as c_int {
+                            -(1)
+                        } else if *sptr1.offset(0) as c_int > *sptr2.offset(0) as c_int {
+                            1
+                        } else {
+                            strcmp(sptr1, sptr2)
+                        }) <= 0
+                        {
+                            1
+                        } else {
+                            0
+                        };
+                }
+                43 => {
+                    strcpy(((*this).value.data.astr).as_mut_ptr(), sptr1);
+                    strcat(((*this).value.data.astr).as_mut_ptr(), sptr2);
+                }
+                _ => {}
+            }
+            (*this).operation = -(1000 as c_int);
+        } else {
+            Allocate_Ptrs(lParse, this);
+            if (*lParse).status == 0 {
+                rows = (*lParse).nRows;
+                match (*this).operation {
+                    280 | 279 => loop {
+                        let fresh42 = rows;
+                        rows -= 1;
+                        if fresh42 == 0 {
+                            break;
+                        }
+                        if const1 == 0 {
+                            null1 = *((*that1).value.undef).offset(rows as isize);
+                        }
+                        if const2 == 0 {
+                            null2 = *((*that2).value.undef).offset(rows as isize);
+                        }
+                        *((*this).value.undef).offset(rows as isize) =
+                            if null1 as c_int != 0 || null2 as c_int != 0 {
+                                1
+                            } else {
+                                0
+                            };
+                        if *((*this).value.undef).offset(rows as isize) == 0 {
+                            if const1 == 0 {
+                                sptr1 = *((*that1).value.data.strptr).offset(rows as isize);
+                            }
+                            if const2 == 0 {
+                                sptr2 = *((*that2).value.data.strptr).offset(rows as isize);
+                            }
+                            val = ((if (*sptr1.offset(0) as c_int) < *sptr2.offset(0) as c_int {
+                                -(1)
+                            } else if *sptr1.offset(0) as c_int > *sptr2.offset(0) as c_int {
+                                1
+                            } else {
+                                strcmp(sptr1, sptr2)
+                            }) == 0) as c_int;
+                            *((*this).value.data.logptr).offset(rows as isize) =
+                                (if (*this).operation == fits_parser_yytokentype::EQ as c_int {
+                                    val
+                                } else {
+                                    (val == 0) as c_int
+                                }) as c_char;
+                        }
+                    },
+                    281 | 282 => loop {
+                        let fresh43 = rows;
+                        rows -= 1;
+                        if fresh43 == 0 {
+                            break;
+                        }
+                        if const1 == 0 {
+                            null1 = *((*that1).value.undef).offset(rows as isize);
+                        }
+                        if const2 == 0 {
+                            null2 = *((*that2).value.undef).offset(rows as isize);
+                        }
+                        *((*this).value.undef).offset(rows as isize) =
+                            if null1 as c_int != 0 || null2 as c_int != 0 {
+                                1
+                            } else {
+                                0
+                            };
+                        if *((*this).value.undef).offset(rows as isize) == 0 {
+                            if const1 == 0 {
+                                sptr1 = *((*that1).value.data.strptr).offset(rows as isize);
+                            }
+                            if const2 == 0 {
+                                sptr2 = *((*that2).value.data.strptr).offset(rows as isize);
+                            }
+                            val = if (*sptr1.offset(0) as c_int) < *sptr2.offset(0) as c_int {
+                                -(1)
+                            } else if *sptr1.offset(0) as c_int > *sptr2.offset(0) as c_int {
+                                1
+                            } else {
+                                strcmp(sptr1, sptr2)
+                            };
+                            *((*this).value.data.logptr).offset(rows as isize) =
+                                (if (*this).operation == fits_parser_yytokentype::GT as c_int {
+                                    (val > 0) as c_int
+                                } else {
+                                    (val < 0) as c_int
+                                }) as c_char;
+                        }
+                    },
+                    284 | 283 => loop {
+                        let fresh44 = rows;
+                        rows -= 1;
+                        if fresh44 == 0 {
+                            break;
+                        }
+                        if const1 == 0 {
+                            null1 = *((*that1).value.undef).offset(rows as isize);
+                        }
+                        if const2 == 0 {
+                            null2 = *((*that2).value.undef).offset(rows as isize);
+                        }
+                        *((*this).value.undef).offset(rows as isize) =
+                            if null1 as c_int != 0 || null2 as c_int != 0 {
+                                1
+                            } else {
+                                0
+                            };
+                        if *((*this).value.undef).offset(rows as isize) == 0 {
+                            if const1 == 0 {
+                                sptr1 = *((*that1).value.data.strptr).offset(rows as isize);
+                            }
+                            if const2 == 0 {
+                                sptr2 = *((*that2).value.data.strptr).offset(rows as isize);
+                            }
+                            val = if (*sptr1.offset(0) as c_int) < *sptr2.offset(0) as c_int {
+                                -(1)
+                            } else if *sptr1.offset(0) as c_int > *sptr2.offset(0) as c_int {
+                                1
+                            } else {
+                                strcmp(sptr1, sptr2)
+                            };
+                            *((*this).value.data.logptr).offset(rows as isize) =
+                                (if (*this).operation == fits_parser_yytokentype::GTE as c_int {
+                                    (val >= 0) as c_int
+                                } else {
+                                    (val <= 0) as c_int
+                                }) as c_char;
+                        }
+                    },
+                    43 => loop {
+                        let fresh45 = rows;
+                        rows -= 1;
+                        if fresh45 == 0 {
+                            break;
+                        }
+                        if const1 == 0 {
+                            null1 = *((*that1).value.undef).offset(rows as isize);
+                        }
+                        if const2 == 0 {
+                            null2 = *((*that2).value.undef).offset(rows as isize);
+                        }
+                        *((*this).value.undef).offset(rows as isize) =
+                            if null1 as c_int != 0 || null2 as c_int != 0 {
+                                1
+                            } else {
+                                0
+                            };
+                        if *((*this).value.undef).offset(rows as isize) == 0 {
+                            if const1 == 0 {
+                                sptr1 = *((*that1).value.data.strptr).offset(rows as isize);
+                            }
+                            if const2 == 0 {
+                                sptr2 = *((*that2).value.data.strptr).offset(rows as isize);
+                            }
+                            strcpy(*((*this).value.data.strptr).offset(rows as isize), sptr1);
+                            strcat(*((*this).value.data.strptr).offset(rows as isize), sptr2);
+                        }
+                    },
+                    _ => {}
+                }
+            }
+        }
+        if (*that1).operation > 0 {
+            free(*((*that1).value.data.strptr).offset(0) as *mut c_void);
+            free((*that1).value.data.strptr as *mut c_void);
+        }
+        if (*that2).operation > 0 {
+            free(*((*that2).value.data.strptr).offset(0) as *mut c_void);
+            free((*that2).value.data.strptr as *mut c_void);
+        }
+    }
+}
+unsafe fn Do_BinOp_log(mut lParse: *mut ParseData, mut this: *mut Node) {
+    unsafe {
+        let mut that1: *mut Node = std::ptr::null_mut::<Node>();
+        let mut that2: *mut Node = std::ptr::null_mut::<Node>();
+        let mut vector1: c_int = 0;
+        let mut vector2: c_int = 0;
+        let mut val1: c_char = 0;
+        let mut val2: c_char = 0;
+        let mut null1: c_char = 0;
+        let mut null2: c_char = 0;
+        let mut rows: c_long = 0;
+        let mut nelem: c_long = 0;
+        let mut elem: c_long = 0;
+        that1 = ((*lParse).Nodes).offset((*this).SubNodes[0] as isize);
+        that2 = ((*lParse).Nodes).offset((*this).SubNodes[1] as isize);
+        vector1 = ((*that1).operation != -(1000 as c_int)) as c_int;
+        if vector1 != 0 {
+            vector1 = (*that1).value.nelem as c_int;
+        } else {
+            val1 = (*that1).value.data.log;
+        }
+        vector2 = ((*that2).operation != -(1000 as c_int)) as c_int;
+        if vector2 != 0 {
+            vector2 = (*that2).value.nelem as c_int;
+        } else {
+            val2 = (*that2).value.data.log;
+        }
+        if vector1 == 0 && vector2 == 0 {
+            match (*this).operation {
+                277 => {
+                    (*this).value.data.log = if val1 as c_int != 0 || val2 as c_int != 0 {
+                        1
+                    } else {
+                        0
+                    };
+                }
+                278 => {
+                    (*this).value.data.log = if val1 as c_int != 0 && val2 as c_int != 0 {
+                        1
+                    } else {
+                        0
+                    };
+                }
+                279 => {
+                    (*this).value.data.log = (val1 as c_int != 0 && val2 as c_int != 0
+                        || val1 == 0 && val2 == 0)
+                        as c_int as c_char;
+                }
+                280 => {
+                    (*this).value.data.log =
+                        if val1 as c_int != 0 && val2 == 0 || val1 == 0 && val2 as c_int != 0 {
+                            1
+                        } else {
+                            0
+                        };
+                }
+                291 => {
+                    (*this).value.data.lng = val1 as c_long;
+                }
+                _ => {}
+            }
+            (*this).operation = -(1000 as c_int);
+        } else if (*this).operation == fits_parser_yytokentype::ACCUM as c_int {
+            let mut i: c_long = 0;
+            let mut previous: c_long = 0;
+            let mut curr: c_long = 0;
+            rows = (*lParse).nRows;
+            nelem = (*this).value.nelem;
+            elem = (*this).value.nelem * rows;
+            Allocate_Ptrs(lParse, this);
+            if (*lParse).status == 0 {
+                previous = (*that2).value.data.lng;
+                i = 0;
+                while i < elem {
+                    if *((*that1).value.undef).offset(i as isize) == 0 {
+                        curr = *((*that1).value.data.logptr).offset(i as isize) as c_long;
+                        previous += curr;
+                    }
+                    *((*this).value.data.lngptr).offset(i as isize) = previous;
+                    *((*this).value.undef).offset(i as isize) = 0;
+                    i += 1;
+                    i;
+                }
+                (*that2).value.data.lng = previous;
+            }
+        } else {
+            rows = (*lParse).nRows;
+            nelem = (*this).value.nelem;
+            elem = (*this).value.nelem * rows;
+            Allocate_Ptrs(lParse, this);
+            if (*lParse).status == 0 {
+                if (*this).operation == fits_parser_yytokentype::ACCUM as c_int {
+                    let mut i_0: c_long = 0;
+                    let mut previous_0: c_long = 0;
+                    let mut curr_0: c_long = 0;
+                    previous_0 = (*that2).value.data.lng;
+                    i_0 = 0;
+                    while i_0 < elem {
+                        if *((*that1).value.undef).offset(i_0 as isize) == 0 {
+                            curr_0 = *((*that1).value.data.logptr).offset(i_0 as isize) as c_long;
+                            previous_0 += curr_0;
+                        }
+                        *((*this).value.data.lngptr).offset(i_0 as isize) = previous_0;
+                        *((*this).value.undef).offset(i_0 as isize) = 0;
+                        i_0 += 1;
+                        i_0;
+                    }
+                    (*that2).value.data.lng = previous_0;
+                }
+                loop {
+                    let fresh46 = rows;
+                    rows -= 1;
+                    if fresh46 == 0 {
+                        break;
+                    }
+                    loop {
+                        let fresh47 = nelem;
+                        nelem -= 1;
+                        if fresh47 == 0 {
+                            break;
+                        }
+                        elem -= 1;
+                        elem;
+                        if vector1 > 1 {
+                            val1 = *((*that1).value.data.logptr).offset(elem as isize);
+                            null1 = *((*that1).value.undef).offset(elem as isize);
+                        } else if vector1 != 0 {
+                            val1 = *((*that1).value.data.logptr).offset(rows as isize);
+                            null1 = *((*that1).value.undef).offset(rows as isize);
+                        }
+                        if vector2 > 1 {
+                            val2 = *((*that2).value.data.logptr).offset(elem as isize);
+                            null2 = *((*that2).value.undef).offset(elem as isize);
+                        } else if vector2 != 0 {
+                            val2 = *((*that2).value.data.logptr).offset(rows as isize);
+                            null2 = *((*that2).value.undef).offset(rows as isize);
+                        }
+                        *((*this).value.undef).offset(elem as isize) =
+                            if null1 as c_int != 0 || null2 as c_int != 0 {
+                                1
+                            } else {
+                                0
+                            };
+                        match (*this).operation {
+                            277 => {
+                                if null1 == 0 && null2 == 0 {
+                                    *((*this).value.data.logptr).offset(elem as isize) =
+                                        if val1 as c_int != 0 || val2 as c_int != 0 {
+                                            1
+                                        } else {
+                                            0
+                                        };
+                                } else if null1 as c_int != 0 && null2 == 0 && val2 as c_int != 0
+                                    || null1 == 0 && null2 as c_int != 0 && val1 as c_int != 0
+                                {
+                                    *((*this).value.data.logptr).offset(elem as isize) = 1;
+                                    *((*this).value.undef).offset(elem as isize) = 0;
+                                }
+                            }
+                            278 => {
+                                if null1 == 0 && null2 == 0 {
+                                    *((*this).value.data.logptr).offset(elem as isize) =
+                                        if val1 as c_int != 0 && val2 as c_int != 0 {
+                                            1
+                                        } else {
+                                            0
+                                        };
+                                } else if null1 as c_int != 0 && null2 == 0 && val2 == 0
+                                    || null1 == 0 && null2 as c_int != 0 && val1 == 0
+                                {
+                                    *((*this).value.data.logptr).offset(elem as isize) = 0;
+                                    *((*this).value.undef).offset(elem as isize) = 0;
+                                }
+                            }
+                            279 => {
+                                *((*this).value.data.logptr).offset(elem as isize) =
+                                    (val1 as c_int != 0 && val2 as c_int != 0
+                                        || val1 == 0 && val2 == 0)
+                                        as c_int as c_char;
+                            }
+                            280 => {
+                                *((*this).value.data.logptr).offset(elem as isize) =
+                                    (val1 as c_int != 0 && val2 == 0
+                                        || val1 == 0 && val2 as c_int != 0)
+                                        as c_int as c_char;
+                            }
+                            _ => {}
+                        }
+                    }
+                    nelem = (*this).value.nelem;
+                }
+            }
+        }
+        if (*that1).operation > 0 {
+            free((*that1).value.data.ptr);
+        }
+        if (*that2).operation > 0 {
+            free((*that2).value.data.ptr);
+        }
+    }
+}
+unsafe fn Do_BinOp_lng(mut lParse: *mut ParseData, mut this: *mut Node) {
+    unsafe {
+        let mut that1: *mut Node = std::ptr::null_mut::<Node>();
+        let mut that2: *mut Node = std::ptr::null_mut::<Node>();
+        let mut vector1: c_int = 0;
+        let mut vector2: c_int = 0;
+        let mut val1: c_long = 0;
+        let mut val2: c_long = 0;
+        let mut null1: c_char = 0;
+        let mut null2: c_char = 0;
+        let mut rows: c_long = 0;
+        let mut nelem: c_long = 0;
+        let mut elem: c_long = 0;
+        that1 = ((*lParse).Nodes).offset((*this).SubNodes[0] as isize);
+        that2 = ((*lParse).Nodes).offset((*this).SubNodes[1] as isize);
+        vector1 = ((*that1).operation != -(1000 as c_int)) as c_int;
+        if vector1 != 0 {
+            vector1 = (*that1).value.nelem as c_int;
+        } else {
+            val1 = (*that1).value.data.lng;
+        }
+        vector2 = ((*that2).operation != -(1000 as c_int)) as c_int;
+        if vector2 != 0 {
+            vector2 = (*that2).value.nelem as c_int;
+        } else {
+            val2 = (*that2).value.data.lng;
+        }
+        if vector1 == 0 && vector2 == 0 {
+            match (*this).operation {
+                126 | 279 => {
+                    (*this).value.data.log = if val1 == val2 { 1 } else { 0 };
+                }
+                280 => {
+                    (*this).value.data.log = if val1 != val2 { 1 } else { 0 };
+                }
+                281 => {
+                    (*this).value.data.log = if val1 > val2 { 1 } else { 0 };
+                }
+                282 => {
+                    (*this).value.data.log = if val1 < val2 { 1 } else { 0 };
+                }
+                283 => {
+                    (*this).value.data.log = if val1 <= val2 { 1 } else { 0 };
+                }
+                284 => {
+                    (*this).value.data.log = if val1 >= val2 { 1 } else { 0 };
+                }
+                43 => {
+                    (*this).value.data.lng = val1 + val2;
+                }
+                45 => {
+                    (*this).value.data.lng = val1 - val2;
+                }
+                42 => {
+                    (*this).value.data.lng = val1 * val2;
+                }
+                38 => {
+                    (*this).value.data.lng = val1 & val2;
+                }
+                124 => {
+                    (*this).value.data.lng = val1 | val2;
+                }
+                94 => {
+                    (*this).value.data.lng = val1 ^ val2;
+                }
+                37 => {
+                    if val2 != 0 {
+                        (*this).value.data.lng = val1 % val2;
+                    } else {
+                        fits_parser_yyerror(
+                            0 as yyscan_t,
+                            lParse,
+                            b"Divide by Zero\0" as *const u8 as *const c_char as *mut c_char,
+                        );
+                    }
+                }
+                47 => {
+                    if val2 != 0 {
+                        (*this).value.data.lng = val1 / val2;
+                    } else {
+                        fits_parser_yyerror(
+                            0 as yyscan_t,
+                            lParse,
+                            b"Divide by Zero\0" as *const u8 as *const c_char as *mut c_char,
+                        );
+                    }
+                }
+                286 => {
+                    (*this).value.data.lng = pow(val1 as c_double, val2 as c_double) as c_long;
+                }
+                291 => {
+                    (*this).value.data.lng = val1;
+                }
+                292 => {
+                    (*this).value.data.lng = 0;
+                }
+                _ => {}
+            }
+            (*this).operation = -(1000 as c_int);
+        } else if (*this).operation == fits_parser_yytokentype::ACCUM as c_int
+            || (*this).operation == fits_parser_yytokentype::DIFF as c_int
+        {
+            let mut i: c_long = 0;
+            let mut previous: c_long = 0;
+            let mut curr: c_long = 0;
+            let mut undef: c_long = 0;
+            rows = (*lParse).nRows;
+            nelem = (*this).value.nelem;
+            elem = (*this).value.nelem * rows;
+            Allocate_Ptrs(lParse, this);
+            if (*lParse).status == 0 {
+                previous = (*that2).value.data.lng;
+                undef = *(*that2).value.undef as c_long;
+                if (*this).operation == fits_parser_yytokentype::ACCUM as c_int {
+                    i = 0;
+                    while i < elem {
+                        if *((*that1).value.undef).offset(i as isize) == 0 {
+                            curr = *((*that1).value.data.lngptr).offset(i as isize);
+                            previous += curr;
+                        }
+                        *((*this).value.data.lngptr).offset(i as isize) = previous;
+                        *((*this).value.undef).offset(i as isize) = 0;
+                        i += 1;
+                        i;
+                    }
+                } else {
+                    i = 0;
+                    while i < elem {
+                        curr = *((*that1).value.data.lngptr).offset(i as isize);
+                        if *((*that1).value.undef).offset(i as isize) as c_int != 0 || undef != 0 {
+                            *((*this).value.data.lngptr).offset(i as isize) = 0;
+                            *((*this).value.undef).offset(i as isize) = 1;
+                        } else {
+                            *((*this).value.data.lngptr).offset(i as isize) = curr - previous;
+                            *((*this).value.undef).offset(i as isize) = 0;
+                        }
+                        previous = curr;
+                        undef = *((*that1).value.undef).offset(i as isize) as c_long;
+                        i += 1;
+                        i;
+                    }
+                }
+                (*that2).value.data.lng = previous;
+                (*that2).value.undef = undef as *mut c_char;
+            }
+        } else {
+            rows = (*lParse).nRows;
+            nelem = (*this).value.nelem;
+            elem = (*this).value.nelem * rows;
+            Allocate_Ptrs(lParse, this);
+            loop {
+                let fresh48 = rows;
+                rows -= 1;
+                if !(fresh48 != 0 && (*lParse).status == 0) {
+                    break;
+                }
+                loop {
+                    let fresh49 = nelem;
+                    nelem -= 1;
+                    if !(fresh49 != 0 && (*lParse).status == 0) {
+                        break;
+                    }
+                    elem -= 1;
+                    elem;
+                    if vector1 > 1 {
+                        val1 = *((*that1).value.data.lngptr).offset(elem as isize);
+                        null1 = *((*that1).value.undef).offset(elem as isize);
+                    } else if vector1 != 0 {
+                        val1 = *((*that1).value.data.lngptr).offset(rows as isize);
+                        null1 = *((*that1).value.undef).offset(rows as isize);
+                    }
+                    if vector2 > 1 {
+                        val2 = *((*that2).value.data.lngptr).offset(elem as isize);
+                        null2 = *((*that2).value.undef).offset(elem as isize);
+                    } else if vector2 != 0 {
+                        val2 = *((*that2).value.data.lngptr).offset(rows as isize);
+                        null2 = *((*that2).value.undef).offset(rows as isize);
+                    }
+                    *((*this).value.undef).offset(elem as isize) =
+                        if null1 as c_int != 0 || null2 as c_int != 0 {
+                            1
+                        } else {
+                            0
+                        };
+                    match (*this).operation {
+                        126 | 279 => {
+                            *((*this).value.data.logptr).offset(elem as isize) =
+                                if val1 == val2 { 1 } else { 0 };
+                        }
+                        280 => {
+                            *((*this).value.data.logptr).offset(elem as isize) =
+                                if val1 != val2 { 1 } else { 0 };
+                        }
+                        281 => {
+                            *((*this).value.data.logptr).offset(elem as isize) =
+                                if val1 > val2 { 1 } else { 0 };
+                        }
+                        282 => {
+                            *((*this).value.data.logptr).offset(elem as isize) =
+                                if val1 < val2 { 1 } else { 0 };
+                        }
+                        283 => {
+                            *((*this).value.data.logptr).offset(elem as isize) =
+                                if val1 <= val2 { 1 } else { 0 };
+                        }
+                        284 => {
+                            *((*this).value.data.logptr).offset(elem as isize) =
+                                if val1 >= val2 { 1 } else { 0 };
+                        }
+                        43 => {
+                            *((*this).value.data.lngptr).offset(elem as isize) = val1 + val2;
+                        }
+                        45 => {
+                            *((*this).value.data.lngptr).offset(elem as isize) = val1 - val2;
+                        }
+                        42 => {
+                            *((*this).value.data.lngptr).offset(elem as isize) = val1 * val2;
+                        }
+                        38 => {
+                            *((*this).value.data.lngptr).offset(elem as isize) = val1 & val2;
+                        }
+                        124 => {
+                            *((*this).value.data.lngptr).offset(elem as isize) = val1 | val2;
+                        }
+                        94 => {
+                            *((*this).value.data.lngptr).offset(elem as isize) = val1 ^ val2;
+                        }
+                        37 => {
+                            if val2 != 0 {
+                                *((*this).value.data.lngptr).offset(elem as isize) = val1 % val2;
+                            } else {
+                                *((*this).value.data.lngptr).offset(elem as isize) = 0;
+                                *((*this).value.undef).offset(elem as isize) = 1;
+                            }
+                        }
+                        47 => {
+                            if val2 != 0 {
+                                *((*this).value.data.lngptr).offset(elem as isize) = val1 / val2;
+                            } else {
+                                *((*this).value.data.lngptr).offset(elem as isize) = 0;
+                                *((*this).value.undef).offset(elem as isize) = 1;
+                            }
+                        }
+                        286 => {
+                            *((*this).value.data.lngptr).offset(elem as isize) =
+                                pow(val1 as c_double, val2 as c_double) as c_long;
+                        }
+                        _ => {}
+                    }
+                }
+                nelem = (*this).value.nelem;
+            }
+        }
+        if (*that1).operation > 0 {
+            free((*that1).value.data.ptr);
+        }
+        if (*that2).operation > 0 {
+            free((*that2).value.data.ptr);
+        }
+    }
+}
+unsafe fn Do_BinOp_dbl(mut lParse: *mut ParseData, mut this: *mut Node) {
+    unsafe {
+        let mut that1: *mut Node = std::ptr::null_mut::<Node>();
+        let mut that2: *mut Node = std::ptr::null_mut::<Node>();
+        let mut vector1: c_int = 0;
+        let mut vector2: c_int = 0;
+        let mut val1: c_double = 0.0f64;
+        let mut val2: c_double = 0.0f64;
+        let mut null1: c_char = 0;
+        let mut null2: c_char = 0;
+        let mut rows: c_long = 0;
+        let mut nelem: c_long = 0;
+        let mut elem: c_long = 0;
+        that1 = ((*lParse).Nodes).offset((*this).SubNodes[0] as isize);
+        that2 = ((*lParse).Nodes).offset((*this).SubNodes[1] as isize);
+        vector1 = ((*that1).operation != -(1000 as c_int)) as c_int;
+        if vector1 != 0 {
+            vector1 = (*that1).value.nelem as c_int;
+        } else {
+            val1 = (*that1).value.data.dbl;
+        }
+        vector2 = ((*that2).operation != -(1000 as c_int)) as c_int;
+        if vector2 != 0 {
+            vector2 = (*that2).value.nelem as c_int;
+        } else {
+            val2 = (*that2).value.data.dbl;
+        }
+        if vector1 == 0 && vector2 == 0 {
+            match (*this).operation {
+                126 => {
+                    (*this).value.data.log = if fabs(val1 - val2) < 1.0e-7f64 { 1 } else { 0 };
+                }
+                279 => {
+                    (*this).value.data.log = if val1 == val2 { 1 } else { 0 };
+                }
+                280 => {
+                    (*this).value.data.log = if val1 != val2 { 1 } else { 0 };
+                }
+                281 => {
+                    (*this).value.data.log = if val1 > val2 { 1 } else { 0 };
+                }
+                282 => {
+                    (*this).value.data.log = if val1 < val2 { 1 } else { 0 };
+                }
+                283 => {
+                    (*this).value.data.log = if val1 <= val2 { 1 } else { 0 };
+                }
+                284 => {
+                    (*this).value.data.log = if val1 >= val2 { 1 } else { 0 };
+                }
+                43 => {
+                    (*this).value.data.dbl = val1 + val2;
+                }
+                45 => {
+                    (*this).value.data.dbl = val1 - val2;
+                }
+                42 => {
+                    (*this).value.data.dbl = val1 * val2;
+                }
+                37 => {
+                    if val2 != 0. {
+                        (*this).value.data.dbl = val1 - val2 * (val1 / val2) as c_int as c_double;
+                    } else {
+                        fits_parser_yyerror(
+                            0 as yyscan_t,
+                            lParse,
+                            b"Divide by Zero\0" as *const u8 as *const c_char as *mut c_char,
+                        );
+                    }
+                }
+                47 => {
+                    if val2 != 0. {
+                        (*this).value.data.dbl = val1 / val2;
+                    } else {
+                        fits_parser_yyerror(
+                            0 as yyscan_t,
+                            lParse,
+                            b"Divide by Zero\0" as *const u8 as *const c_char as *mut c_char,
+                        );
+                    }
+                }
+                286 => {
+                    (*this).value.data.dbl = pow(val1, val2);
+                }
+                291 => {
+                    (*this).value.data.dbl = val1;
+                }
+                292 => {
+                    (*this).value.data.dbl = 0.0;
+                }
+                _ => {}
+            }
+            (*this).operation = -(1000 as c_int);
+        } else if (*this).operation == fits_parser_yytokentype::ACCUM as c_int
+            || (*this).operation == fits_parser_yytokentype::DIFF as c_int
+        {
+            let mut i: c_long = 0;
+            let mut undef: c_long = 0;
+            let mut previous: c_double = 0.;
+            let mut curr: c_double = 0.;
+            rows = (*lParse).nRows;
+            nelem = (*this).value.nelem;
+            elem = (*this).value.nelem * rows;
+            Allocate_Ptrs(lParse, this);
+            if (*lParse).status == 0 {
+                previous = (*that2).value.data.dbl;
+                undef = *(*that2).value.undef as c_long;
+                if (*this).operation == fits_parser_yytokentype::ACCUM as c_int {
+                    i = 0;
+                    while i < elem {
+                        if *((*that1).value.undef).offset(i as isize) == 0 {
+                            curr = *((*that1).value.data.dblptr).offset(i as isize);
+                            previous += curr;
+                        }
+                        *((*this).value.data.dblptr).offset(i as isize) = previous;
+                        *((*this).value.undef).offset(i as isize) = 0;
+                        i += 1;
+                        i;
+                    }
+                } else {
+                    i = 0;
+                    while i < elem {
+                        curr = *((*that1).value.data.dblptr).offset(i as isize);
+                        if *((*that1).value.undef).offset(i as isize) as c_int != 0 || undef != 0 {
+                            *((*this).value.data.dblptr).offset(i as isize) = 0.0;
+                            *((*this).value.undef).offset(i as isize) = 1;
+                        } else {
+                            *((*this).value.data.dblptr).offset(i as isize) = curr - previous;
+                            *((*this).value.undef).offset(i as isize) = 0;
+                        }
+                        previous = curr;
+                        undef = *((*that1).value.undef).offset(i as isize) as c_long;
+                        i += 1;
+                        i;
+                    }
+                }
+                (*that2).value.data.dbl = previous;
+                (*that2).value.undef = undef as *mut c_char;
+            }
+        } else {
+            rows = (*lParse).nRows;
+            nelem = (*this).value.nelem;
+            elem = (*this).value.nelem * rows;
+            Allocate_Ptrs(lParse, this);
+            loop {
+                let fresh50 = rows;
+                rows -= 1;
+                if !(fresh50 != 0 && (*lParse).status == 0) {
+                    break;
+                }
+                loop {
+                    let fresh51 = nelem;
+                    nelem -= 1;
+                    if !(fresh51 != 0 && (*lParse).status == 0) {
+                        break;
+                    }
+                    elem -= 1;
+                    elem;
+                    if vector1 > 1 {
+                        val1 = *((*that1).value.data.dblptr).offset(elem as isize);
+                        null1 = *((*that1).value.undef).offset(elem as isize);
+                    } else if vector1 != 0 {
+                        val1 = *((*that1).value.data.dblptr).offset(rows as isize);
+                        null1 = *((*that1).value.undef).offset(rows as isize);
+                    }
+                    if vector2 > 1 {
+                        val2 = *((*that2).value.data.dblptr).offset(elem as isize);
+                        null2 = *((*that2).value.undef).offset(elem as isize);
+                    } else if vector2 != 0 {
+                        val2 = *((*that2).value.data.dblptr).offset(rows as isize);
+                        null2 = *((*that2).value.undef).offset(rows as isize);
+                    }
+                    *((*this).value.undef).offset(elem as isize) =
+                        if null1 as c_int != 0 || null2 as c_int != 0 {
+                            1
+                        } else {
+                            0
+                        };
+                    match (*this).operation {
+                        126 => {
+                            *((*this).value.data.logptr).offset(elem as isize) =
+                                if fabs(val1 - val2) < 1.0e-7f64 { 1 } else { 0 };
+                        }
+                        279 => {
+                            *((*this).value.data.logptr).offset(elem as isize) =
+                                if val1 == val2 { 1 } else { 0 };
+                        }
+                        280 => {
+                            *((*this).value.data.logptr).offset(elem as isize) =
+                                if val1 != val2 { 1 } else { 0 };
+                        }
+                        281 => {
+                            *((*this).value.data.logptr).offset(elem as isize) =
+                                if val1 > val2 { 1 } else { 0 };
+                        }
+                        282 => {
+                            *((*this).value.data.logptr).offset(elem as isize) =
+                                if val1 < val2 { 1 } else { 0 };
+                        }
+                        283 => {
+                            *((*this).value.data.logptr).offset(elem as isize) =
+                                if val1 <= val2 { 1 } else { 0 };
+                        }
+                        284 => {
+                            *((*this).value.data.logptr).offset(elem as isize) =
+                                if val1 >= val2 { 1 } else { 0 };
+                        }
+                        43 => {
+                            *((*this).value.data.dblptr).offset(elem as isize) = val1 + val2;
+                        }
+                        45 => {
+                            *((*this).value.data.dblptr).offset(elem as isize) = val1 - val2;
+                        }
+                        42 => {
+                            *((*this).value.data.dblptr).offset(elem as isize) = val1 * val2;
+                        }
+                        37 => {
+                            if val2 != 0. {
+                                *((*this).value.data.dblptr).offset(elem as isize) =
+                                    val1 - val2 * (val1 / val2) as c_int as c_double;
+                            } else {
+                                *((*this).value.data.dblptr).offset(elem as isize) = 0.0f64;
+                                *((*this).value.undef).offset(elem as isize) = 1;
+                            }
+                        }
+                        47 => {
+                            if val2 != 0. {
+                                *((*this).value.data.dblptr).offset(elem as isize) = val1 / val2;
+                            } else {
+                                *((*this).value.data.dblptr).offset(elem as isize) = 0.0f64;
+                                *((*this).value.undef).offset(elem as isize) = 1;
+                            }
+                        }
+                        286 => {
+                            *((*this).value.data.dblptr).offset(elem as isize) = pow(val1, val2);
+                        }
+                        _ => {}
+                    }
+                }
+                nelem = (*this).value.nelem;
+            }
+        }
+        if (*that1).operation > 0 {
+            free((*that1).value.data.ptr);
+        }
+        if (*that2).operation > 0 {
+            free((*that2).value.data.ptr);
+        }
+    }
+}
+
+pub unsafe fn qselect_median_lng(mut arr: *mut c_long, mut n: c_int) -> c_long {
+    unsafe {
+        let mut low: c_int = 0;
+        let mut high: c_int = 0;
+        let mut median: c_int = 0;
+        let mut middle: c_int = 0;
+        let mut ll: c_int = 0;
+        let mut hh: c_int = 0;
+        low = 0;
+        high = n - 1;
+        median = (low + high) / 2 as c_int;
+        loop {
+            if high <= low {
+                return *arr.offset(median as isize);
+            }
+            if high == low + 1 {
+                if *arr.offset(low as isize) > *arr.offset(high as isize) {
+                    let mut t: c_long = *arr.offset(low as isize);
+                    *arr.offset(low as isize) = *arr.offset(high as isize);
+                    *arr.offset(high as isize) = t;
+                }
+                return *arr.offset(median as isize);
+            }
+            middle = (low + high) / 2 as c_int;
+            if *arr.offset(middle as isize) > *arr.offset(high as isize) {
+                let mut t_0: c_long = *arr.offset(middle as isize);
+                *arr.offset(middle as isize) = *arr.offset(high as isize);
+                *arr.offset(high as isize) = t_0;
+            }
+            if *arr.offset(low as isize) > *arr.offset(high as isize) {
+                let mut t_1: c_long = *arr.offset(low as isize);
+                *arr.offset(low as isize) = *arr.offset(high as isize);
+                *arr.offset(high as isize) = t_1;
+            }
+            if *arr.offset(middle as isize) > *arr.offset(low as isize) {
+                let mut t_2: c_long = *arr.offset(middle as isize);
+                *arr.offset(middle as isize) = *arr.offset(low as isize);
+                *arr.offset(low as isize) = t_2;
+            }
+            let mut t_3: c_long = *arr.offset(middle as isize);
+            *arr.offset(middle as isize) = *arr.offset((low + 1) as isize);
+            *arr.offset((low + 1) as isize) = t_3;
+            ll = low + 1;
+            hh = high;
+            loop {
+                loop {
+                    ll += 1;
+                    ll;
+                    if *arr.offset(low as isize) <= *arr.offset(ll as isize) {
+                        break;
+                    }
+                }
+                loop {
+                    hh -= 1;
+                    hh;
+                    if *arr.offset(hh as isize) <= *arr.offset(low as isize) {
+                        break;
+                    }
+                }
+                if hh < ll {
+                    break;
+                }
+                let mut t_4: c_long = *arr.offset(ll as isize);
+                *arr.offset(ll as isize) = *arr.offset(hh as isize);
+                *arr.offset(hh as isize) = t_4;
+            }
+            let mut t_5: c_long = *arr.offset(low as isize);
+            *arr.offset(low as isize) = *arr.offset(hh as isize);
+            *arr.offset(hh as isize) = t_5;
+            if hh <= median {
+                low = ll;
+            }
+            if hh >= median {
+                high = hh - 1;
+            }
+        }
+    }
+}
+
+pub unsafe fn qselect_median_dbl(mut arr: *mut c_double, mut n: c_int) -> c_double {
+    unsafe {
+        let mut low: c_int = 0;
+        let mut high: c_int = 0;
+        let mut median: c_int = 0;
+        let mut middle: c_int = 0;
+        let mut ll: c_int = 0;
+        let mut hh: c_int = 0;
+        low = 0;
+        high = n - 1;
+        median = (low + high) / 2 as c_int;
+        loop {
+            if high <= low {
+                return *arr.offset(median as isize);
+            }
+            if high == low + 1 {
+                if *arr.offset(low as isize) > *arr.offset(high as isize) {
+                    let mut t: c_double = *arr.offset(low as isize);
+                    *arr.offset(low as isize) = *arr.offset(high as isize);
+                    *arr.offset(high as isize) = t;
+                }
+                return *arr.offset(median as isize);
+            }
+            middle = (low + high) / 2 as c_int;
+            if *arr.offset(middle as isize) > *arr.offset(high as isize) {
+                let mut t_0: c_double = *arr.offset(middle as isize);
+                *arr.offset(middle as isize) = *arr.offset(high as isize);
+                *arr.offset(high as isize) = t_0;
+            }
+            if *arr.offset(low as isize) > *arr.offset(high as isize) {
+                let mut t_1: c_double = *arr.offset(low as isize);
+                *arr.offset(low as isize) = *arr.offset(high as isize);
+                *arr.offset(high as isize) = t_1;
+            }
+            if *arr.offset(middle as isize) > *arr.offset(low as isize) {
+                let mut t_2: c_double = *arr.offset(middle as isize);
+                *arr.offset(middle as isize) = *arr.offset(low as isize);
+                *arr.offset(low as isize) = t_2;
+            }
+            let mut t_3: c_double = *arr.offset(middle as isize);
+            *arr.offset(middle as isize) = *arr.offset((low + 1) as isize);
+            *arr.offset((low + 1) as isize) = t_3;
+            ll = low + 1;
+            hh = high;
+            loop {
+                loop {
+                    ll += 1;
+                    ll;
+                    if !(*arr.offset(low as isize) > *arr.offset(ll as isize)) {
+                        break;
+                    }
+                }
+                loop {
+                    hh -= 1;
+                    hh;
+                    if !(*arr.offset(hh as isize) > *arr.offset(low as isize)) {
+                        break;
+                    }
+                }
+                if hh < ll {
+                    break;
+                }
+                let mut t_4: c_double = *arr.offset(ll as isize);
+                *arr.offset(ll as isize) = *arr.offset(hh as isize);
+                *arr.offset(hh as isize) = t_4;
+            }
+            let mut t_5: c_double = *arr.offset(low as isize);
+            *arr.offset(low as isize) = *arr.offset(hh as isize);
+            *arr.offset(hh as isize) = t_5;
+            if hh <= median {
+                low = ll;
+            }
+            if hh >= median {
+                high = hh - 1;
+            }
+        }
+    }
+}
+
+pub unsafe fn angsep_calc(
+    mut ra1: c_double,
+    mut dec1: c_double,
+    mut ra2: c_double,
+    mut dec2: c_double,
+) -> c_double {
+    unsafe {
+        static mut deg: c_double = 0.0;
+        let mut a: c_double = 0.;
+        let mut sdec: c_double = 0.;
+        let mut sra: c_double = 0.;
+        if deg == 0.0 {
+            deg = 4.0 * atan(1.0) / 180.0;
+        }
+        sra = ((ra2 - ra1) * deg / 2.0).sin();
+        sdec = ((dec2 - dec1) * deg / 2.0).sin();
+        a = sdec * sdec + (dec1 * deg).cos() * cos(dec2 * deg) * sra * sra;
+        if a < 0.0 {
+            a = 0.0;
+        }
+        if a > 1 as c_double {
+            a = 1 as c_double;
+        }
+        2.0f64 * atan2((a).sqrt(), (1.0f64 - a).sqrt()) / deg
+    }
+}
+unsafe fn Do_Func(mut lParse: *mut ParseData, mut this: *mut Node) {
+    unsafe {
+        let mut theParams: [*mut Node; 10] = [std::ptr::null_mut::<Node>(); 10];
+        let mut vector: [c_int; 10] = [0; 10];
+        let mut allConst: c_int = 0;
+        let mut pVals: [lval; 10] = [lval {
+            nelem: 0,
+            naxis: 0,
+            naxes: [0; 5],
+            undef: std::ptr::null_mut::<c_char>(),
+            data: data_union { dbl: 0. },
+        }; 10];
+        let mut pNull: [c_char; 10] = [0; 10];
+        let mut ival: c_long = 0;
+        let mut dval: c_double = 0.;
+        let mut i: c_int = 0;
+        let mut valInit: c_int = 0;
+        let mut row: c_long = 0;
+        let mut elem: c_long = 0;
+        let mut nelem: c_long = 0;
+        i = (*this).nSubNodes;
+        allConst = 1;
+        loop {
+            let fresh52 = i;
+            i -= 1;
+            if fresh52 == 0 {
+                break;
+            }
+            theParams[i as usize] = ((*lParse).Nodes).offset((*this).SubNodes[i as usize] as isize);
+            vector[i as usize] = ((*theParams[i as usize]).operation != -(1000 as c_int)) as c_int;
+            if vector[i as usize] != 0 {
+                allConst = 0;
+                vector[i as usize] = (*theParams[i as usize]).value.nelem as c_int;
+            } else {
+                if (*theParams[i as usize]).ntype == fits_parser_yytokentype::DOUBLE as c_int {
+                    pVals[i as usize].data.dbl = (*theParams[i as usize]).value.data.dbl;
+                } else if (*theParams[i as usize]).ntype == fits_parser_yytokentype::LONG as c_int {
+                    pVals[i as usize].data.lng = (*theParams[i as usize]).value.data.lng;
+                } else if (*theParams[i as usize]).ntype
+                    == fits_parser_yytokentype::BOOLEAN as c_int
+                {
+                    pVals[i as usize].data.log = (*theParams[i as usize]).value.data.log;
+                } else {
+                    strcpy(
+                        (pVals[i as usize].data.astr).as_mut_ptr(),
+                        ((*theParams[i as usize]).value.data.astr).as_mut_ptr(),
+                    );
+                }
+                pNull[i as usize] = 0;
+            }
+        }
+        if (*this).nSubNodes == 0 {
+            allConst = 0;
+        }
+        if (*this).operation == poirnd_fct as c_int {
+            allConst = 0;
+        }
+        if (*this).operation == gasrnd_fct as c_int {
+            allConst = 0;
+        }
+        if (*this).operation == rnd_fct as c_int {
+            allConst = 0;
+        }
+        if allConst != 0 {
+            let mut current_block_139: u64;
+            match (*this).operation {
+                1002 => {
+                    if (*theParams[0]).ntype == fits_parser_yytokentype::BOOLEAN as c_int {
+                        (*this).value.data.lng = (if pVals[0].data.log as c_int != 0 {
+                            1
+                        } else {
+                            0
+                        }) as c_long;
+                    } else if (*theParams[0]).ntype == fits_parser_yytokentype::LONG as c_int {
+                        (*this).value.data.lng = pVals[0].data.lng;
+                    } else if (*theParams[0]).ntype == fits_parser_yytokentype::DOUBLE as c_int {
+                        (*this).value.data.dbl = pVals[0].data.dbl;
+                    } else if (*theParams[0]).ntype == fits_parser_yytokentype::BITSTR as c_int {
+                        strcpy(
+                            ((*this).value.data.astr).as_mut_ptr(),
+                            (pVals[0].data.astr).as_mut_ptr(),
+                        );
+                    }
+                    current_block_139 = 7627602990488000394;
+                }
+                1038 => {
+                    if (*theParams[0]).ntype == fits_parser_yytokentype::LONG as c_int {
+                        (*this).value.data.dbl = pVals[0].data.lng as c_double;
+                    } else if (*theParams[0]).ntype == fits_parser_yytokentype::DOUBLE as c_int {
+                        (*this).value.data.dbl = pVals[0].data.dbl;
+                    }
+                    current_block_139 = 7627602990488000394;
+                }
+                1039 => {
+                    (*this).value.data.dbl = 0.0;
+                    current_block_139 = 7627602990488000394;
+                }
+                1037 => {
+                    if (*theParams[0]).ntype == fits_parser_yytokentype::BOOLEAN as c_int {
+                        (*this).value.data.lng = (if pVals[0].data.log as c_int != 0 {
+                            1
+                        } else {
+                            0
+                        }) as c_long;
+                    } else if (*theParams[0]).ntype == fits_parser_yytokentype::LONG as c_int {
+                        (*this).value.data.lng = pVals[0].data.lng;
+                    } else {
+                        (*this).value.data.dbl = pVals[0].data.dbl;
+                    }
+                    current_block_139 = 7627602990488000394;
+                }
+                1043 => {
+                    if (*theParams[0]).ntype == fits_parser_yytokentype::DOUBLE as c_int {
+                        (*this).value.data.lng = simplerng_getpoisson(pVals[0].data.dbl) as c_long;
+                    } else {
+                        (*this).value.data.lng =
+                            simplerng_getpoisson(pVals[0].data.lng as c_double) as c_long;
+                    }
+                    current_block_139 = 7627602990488000394;
+                }
+                1017 => {
+                    if (*theParams[0]).ntype == fits_parser_yytokentype::DOUBLE as c_int {
+                        dval = pVals[0].data.dbl;
+                        (*this).value.data.dbl = if dval > 0.0f64 { dval } else { -dval };
+                    } else {
+                        ival = pVals[0].data.lng;
+                        (*this).value.data.lng = if ival > 0 { ival } else { -ival };
+                    }
+                    current_block_139 = 7627602990488000394;
+                }
+                1040 => {
+                    (*this).value.data.lng = 1;
+                    current_block_139 = 7627602990488000394;
+                }
+                1030 => {
+                    (*this).value.data.log = 0;
+                    current_block_139 = 7627602990488000394;
+                }
+                1031 => {
+                    if (*this).ntype == fits_parser_yytokentype::BOOLEAN as c_int {
+                        (*this).value.data.log = pVals[0].data.log;
+                    } else if (*this).ntype == fits_parser_yytokentype::LONG as c_int {
+                        (*this).value.data.lng = pVals[0].data.lng;
+                    } else if (*this).ntype == fits_parser_yytokentype::DOUBLE as c_int {
+                        (*this).value.data.dbl = pVals[0].data.dbl;
+                    } else if (*this).ntype == fits_parser_yytokentype::STRING as c_int {
+                        strcpy(
+                            ((*this).value.data.astr).as_mut_ptr(),
+                            (pVals[0].data.astr).as_mut_ptr(),
+                        );
+                    }
+                    current_block_139 = 7627602990488000394;
+                }
+                1046 => {
+                    if (*this).ntype == fits_parser_yytokentype::LONG as c_int {
+                        (*this).value.data.lng = pVals[0].data.lng;
+                    } else if (*this).ntype == fits_parser_yytokentype::DOUBLE as c_int {
+                        (*this).value.data.dbl = pVals[0].data.dbl;
+                    }
+                    current_block_139 = 7627602990488000394;
+                }
+                1004 => {
+                    (*this).value.data.dbl = sin(pVals[0].data.dbl);
+                    current_block_139 = 7627602990488000394;
+                }
+                1005 => {
+                    (*this).value.data.dbl = cos(pVals[0].data.dbl);
+                    current_block_139 = 7627602990488000394;
+                }
+                1006 => {
+                    (*this).value.data.dbl = tan(pVals[0].data.dbl);
+                    current_block_139 = 7627602990488000394;
+                }
+                1007 => {
+                    dval = pVals[0].data.dbl;
+                    if dval < -1.0f64 || dval > 1.0f64 {
+                        fits_parser_yyerror(
+                            0 as yyscan_t,
+                            lParse,
+                            b"Out of range argument to arcsin\0" as *const u8 as *const c_char
+                                as *mut c_char,
+                        );
+                    } else {
+                        (*this).value.data.dbl = asin(dval);
+                    }
+                    current_block_139 = 7627602990488000394;
+                }
+                1008 => {
+                    dval = pVals[0].data.dbl;
+                    if dval < -1.0f64 || dval > 1.0f64 {
+                        fits_parser_yyerror(
+                            0 as yyscan_t,
+                            lParse,
+                            b"Out of range argument to arccos\0" as *const u8 as *const c_char
+                                as *mut c_char,
+                        );
+                    } else {
+                        (*this).value.data.dbl = acos(dval);
+                    }
+                    current_block_139 = 7627602990488000394;
+                }
+                1009 => {
+                    (*this).value.data.dbl = atan(pVals[0].data.dbl);
+                    current_block_139 = 7627602990488000394;
+                }
+                1010 => {
+                    (*this).value.data.dbl = sinh(pVals[0].data.dbl);
+                    current_block_139 = 7627602990488000394;
+                }
+                1011 => {
+                    (*this).value.data.dbl = cosh(pVals[0].data.dbl);
+                    current_block_139 = 7627602990488000394;
+                }
+                1012 => {
+                    (*this).value.data.dbl = tanh(pVals[0].data.dbl);
+                    current_block_139 = 7627602990488000394;
+                }
+                1013 => {
+                    (*this).value.data.dbl = exp(pVals[0].data.dbl);
+                    current_block_139 = 7627602990488000394;
+                }
+                1014 => {
+                    dval = pVals[0].data.dbl;
+                    if dval <= 0.0f64 {
+                        fits_parser_yyerror(
+                            0 as yyscan_t,
+                            lParse,
+                            b"Out of range argument to log\0" as *const u8 as *const c_char
+                                as *mut c_char,
+                        );
+                    } else {
+                        (*this).value.data.dbl = log(dval);
+                    }
+                    current_block_139 = 7627602990488000394;
+                }
+                1015 => {
+                    dval = pVals[0].data.dbl;
+                    if dval <= 0.0f64 {
+                        fits_parser_yyerror(
+                            0 as yyscan_t,
+                            lParse,
+                            b"Out of range argument to log10\0" as *const u8 as *const c_char
+                                as *mut c_char,
+                        );
+                    } else {
+                        (*this).value.data.dbl = log10(dval);
+                    }
+                    current_block_139 = 7627602990488000394;
+                }
+                1016 => {
+                    dval = pVals[0].data.dbl;
+                    if dval < 0.0f64 {
+                        fits_parser_yyerror(
+                            0 as yyscan_t,
+                            lParse,
+                            b"Out of range argument to sqrt\0" as *const u8 as *const c_char
+                                as *mut c_char,
+                        );
+                    } else {
+                        (*this).value.data.dbl = sqrt(dval);
+                    }
+                    current_block_139 = 7627602990488000394;
+                }
+                1019 => {
+                    (*this).value.data.dbl = ceil(pVals[0].data.dbl);
+                    current_block_139 = 7627602990488000394;
+                }
+                1020 => {
+                    (*this).value.data.dbl = floor(pVals[0].data.dbl);
+                    current_block_139 = 7627602990488000394;
+                }
+                1021 => {
+                    (*this).value.data.dbl = floor(pVals[0].data.dbl + 0.5f64);
+                    current_block_139 = 7627602990488000394;
+                }
+                1018 => {
+                    (*this).value.data.dbl = atan2(pVals[0].data.dbl, pVals[1].data.dbl);
+                    current_block_139 = 7627602990488000394;
+                }
+                1041 => {
+                    (*this).value.data.dbl = angsep_calc(
+                        pVals[0].data.dbl,
+                        pVals[1].data.dbl,
+                        pVals[2].data.dbl,
+                        pVals[3].data.dbl,
+                    );
+                    current_block_139 = 15934000668868306918;
+                }
+                1022 => {
+                    current_block_139 = 15934000668868306918;
+                }
+                1023 => {
+                    if (*this).ntype == fits_parser_yytokentype::DOUBLE as c_int {
+                        (*this).value.data.dbl = if pVals[0].data.dbl < pVals[1].data.dbl {
+                            pVals[0].data.dbl
+                        } else {
+                            pVals[1].data.dbl
+                        };
+                    } else if (*this).ntype == fits_parser_yytokentype::LONG as c_int {
+                        (*this).value.data.lng = if pVals[0].data.lng < pVals[1].data.lng {
+                            pVals[0].data.lng
+                        } else {
+                            pVals[1].data.lng
+                        };
+                    }
+                    current_block_139 = 7627602990488000394;
+                }
+                1024 => {
+                    if (*this).ntype == fits_parser_yytokentype::DOUBLE as c_int {
+                        (*this).value.data.dbl = pVals[0].data.dbl;
+                    } else if (*this).ntype == fits_parser_yytokentype::LONG as c_int {
+                        (*this).value.data.lng = pVals[0].data.lng;
+                    } else if (*this).ntype == fits_parser_yytokentype::BITSTR as c_int {
+                        strcpy(
+                            ((*this).value.data.astr).as_mut_ptr(),
+                            (pVals[0].data.astr).as_mut_ptr(),
+                        );
+                    }
+                    current_block_139 = 7627602990488000394;
+                }
+                1025 => {
+                    if (*this).ntype == fits_parser_yytokentype::DOUBLE as c_int {
+                        (*this).value.data.dbl = if pVals[0].data.dbl > pVals[1].data.dbl {
+                            pVals[0].data.dbl
+                        } else {
+                            pVals[1].data.dbl
+                        };
+                    } else if (*this).ntype == fits_parser_yytokentype::LONG as c_int {
+                        (*this).value.data.lng = if pVals[0].data.lng > pVals[1].data.lng {
+                            pVals[0].data.lng
+                        } else {
+                            pVals[1].data.lng
+                        };
+                    }
+                    current_block_139 = 7627602990488000394;
+                }
+                1026 => {
+                    (*this).value.data.log =
+                        bnear(pVals[0].data.dbl, pVals[1].data.dbl, pVals[2].data.dbl);
+                    current_block_139 = 7627602990488000394;
+                }
+                1027 => {
+                    (*this).value.data.log = circle(
+                        pVals[0].data.dbl,
+                        pVals[1].data.dbl,
+                        pVals[2].data.dbl,
+                        pVals[3].data.dbl,
+                        pVals[4].data.dbl,
+                    );
+                    current_block_139 = 7627602990488000394;
+                }
+                1028 => {
+                    (*this).value.data.log = saobox(
+                        pVals[0].data.dbl,
+                        pVals[1].data.dbl,
+                        pVals[2].data.dbl,
+                        pVals[3].data.dbl,
+                        pVals[4].data.dbl,
+                        pVals[5].data.dbl,
+                        pVals[6].data.dbl,
+                    );
+                    current_block_139 = 7627602990488000394;
+                }
+                1029 => {
+                    (*this).value.data.log = ellipse(
+                        pVals[0].data.dbl,
+                        pVals[1].data.dbl,
+                        pVals[2].data.dbl,
+                        pVals[3].data.dbl,
+                        pVals[4].data.dbl,
+                        pVals[5].data.dbl,
+                        pVals[6].data.dbl,
+                    );
+                    current_block_139 = 7627602990488000394;
+                }
+                1034 => {
+                    match (*this).ntype {
+                        258 => {
+                            (*this).value.data.log = (if pVals[2].data.log as c_int != 0 {
+                                pVals[0].data.log as c_int
+                            } else {
+                                pVals[1].data.log as c_int
+                            }) as c_char;
+                        }
+                        259 => {
+                            (*this).value.data.lng = if pVals[2].data.log as c_int != 0 {
+                                pVals[0].data.lng
+                            } else {
+                                pVals[1].data.lng
+                            };
+                        }
+                        260 => {
+                            (*this).value.data.dbl = if pVals[2].data.log as c_int != 0 {
+                                pVals[0].data.dbl
+                            } else {
+                                pVals[1].data.dbl
+                            };
+                        }
+                        261 => {
+                            strcpy(
+                                ((*this).value.data.astr).as_mut_ptr(),
+                                if pVals[2].data.log as c_int != 0 {
+                                    (pVals[0].data.astr).as_mut_ptr()
+                                } else {
+                                    (pVals[1].data.astr).as_mut_ptr()
+                                },
+                            );
+                        }
+                        _ => {}
+                    }
+                    current_block_139 = 7627602990488000394;
+                }
+                1044 => {
+                    cstrmid(
+                        lParse,
+                        ((*this).value.data.astr).as_mut_ptr(),
+                        (*this).value.nelem as c_int,
+                        (pVals[0].data.astr).as_mut_ptr(),
+                        pVals[0].nelem as c_int,
+                        pVals[1].data.lng as c_int,
+                    );
+                    current_block_139 = 7627602990488000394;
+                }
+                1045 => {
+                    let mut res: *mut c_char = strstr(
+                        (pVals[0].data.astr).as_mut_ptr(),
+                        (pVals[1].data.astr).as_mut_ptr(),
+                    );
+                    if res.is_null() {
+                        (*this).value.data.lng = 0;
+                    } else {
+                        (*this).value.data.lng =
+                            res.offset_from((pVals[0].data.astr).as_mut_ptr()) as c_long + 1;
+                    }
+                    current_block_139 = 7627602990488000394;
+                }
+                _ => {
+                    current_block_139 = 7627602990488000394;
+                }
+            }
+            if current_block_139 == 15934000668868306918 {
+                if (*this).ntype == fits_parser_yytokentype::DOUBLE as c_int {
+                    (*this).value.data.dbl = pVals[0].data.dbl;
+                } else if (*this).ntype == fits_parser_yytokentype::LONG as c_int {
+                    (*this).value.data.lng = pVals[0].data.lng;
+                } else if (*this).ntype == fits_parser_yytokentype::BITSTR as c_int {
+                    strcpy(
+                        ((*this).value.data.astr).as_mut_ptr(),
+                        (pVals[0].data.astr).as_mut_ptr(),
+                    );
+                }
+            }
+            (*this).operation = -(1000 as c_int);
+        } else {
+            Allocate_Ptrs(lParse, this);
+            row = (*lParse).nRows;
+            elem = row * (*this).value.nelem;
+            if (*lParse).status == 0 {
+                match (*this).operation {
+                    1035 => loop {
+                        let fresh53 = row;
+                        row -= 1;
+                        if fresh53 == 0 {
+                            break;
+                        }
+                        *((*this).value.data.lngptr).offset(row as isize) =
+                            (*lParse).firstRow + row;
+                        *((*this).value.undef).offset(row as isize) = 0;
+                    },
+                    1036 => {
+                        if (*this).ntype == fits_parser_yytokentype::LONG as c_int {
+                            loop {
+                                let fresh54 = row;
+                                row -= 1;
+                                if fresh54 == 0 {
+                                    break;
+                                }
+                                *((*this).value.data.lngptr).offset(row as isize) = 0;
+                                *((*this).value.undef).offset(row as isize) = 1;
+                            }
+                        } else if (*this).ntype == fits_parser_yytokentype::STRING as c_int {
+                            loop {
+                                let fresh55 = row;
+                                row -= 1;
+                                if fresh55 == 0 {
+                                    break;
+                                }
+                                *(*((*this).value.data.strptr).offset(row as isize)).offset(0) = 0;
+                                *((*this).value.undef).offset(row as isize) = 1;
+                            }
+                        }
+                    }
+                    1050 => {
+                        let mut ielem: c_long = 0;
+                        let mut iaxis: [c_long; 5] = [1, 1, 1, 1, 1];
+                        let mut ipos: c_long = pVals[1].data.lng - 1;
+                        let mut naxis: c_int = (*this).value.naxis;
+                        let mut j: c_int = 0;
+                        if ipos < 0 || ipos >= 5 as c_long {
+                            fits_parser_yyerror(
+                                0 as yyscan_t,
+                                lParse,
+                                b"AXISELEM(V,n) n value exceeded maximum dimension\0" as *const u8
+                                    as *const c_char as *mut c_char,
+                            );
+                            free((*this).value.data.ptr);
+                        } else {
+                            ielem = 0;
+                            while ielem < elem {
+                                *((*this).value.data.lngptr).offset(ielem as isize) =
+                                    iaxis[ipos as usize];
+                                *((*this).value.undef).offset(ielem as isize) = 0;
+                                iaxis[0] += 1;
+                                iaxis[0];
+                                j = 0;
+                                while j < naxis {
+                                    if iaxis[j as usize] <= (*this).value.naxes[j as usize] {
+                                        break;
+                                    }
+                                    iaxis[j as usize] = 1;
+                                    if j < naxis - 1 {
+                                        iaxis[(j + 1) as usize] += 1;
+                                        iaxis[(j + 1) as usize];
+                                    }
+                                    j += 1;
+                                    j;
+                                }
+                                ielem += 1;
+                                ielem;
+                            }
+                        }
+                    }
+                    1049 => {
+                        let mut ielem_0: c_long = 0;
+                        let mut elemnum: c_long = 1;
+                        let mut j_0: c_int = 0;
+                        ielem_0 = 0;
+                        while ielem_0 < elem {
+                            *((*this).value.data.lngptr).offset(ielem_0 as isize) = elemnum;
+                            *((*this).value.undef).offset(ielem_0 as isize) = 0;
+                            elemnum += 1;
+                            elemnum;
+                            if elemnum > (*this).value.nelem {
+                                elemnum = 1;
+                            }
+                            ielem_0 += 1;
+                            ielem_0;
+                        }
+                    }
+                    1001 => loop {
+                        let fresh56 = elem;
+                        elem -= 1;
+                        if fresh56 == 0 {
+                            break;
+                        }
+                        *((*this).value.data.dblptr).offset(elem as isize) = simplerng_getuniform();
+                        *((*this).value.undef).offset(elem as isize) = 0;
+                    },
+                    1042 => loop {
+                        let fresh57 = elem;
+                        elem -= 1;
+                        if fresh57 == 0 {
+                            break;
+                        }
+                        *((*this).value.data.dblptr).offset(elem as isize) = simplerng_getnorm();
+                        *((*this).value.undef).offset(elem as isize) = 0;
+                    },
+                    1043 => {
+                        if (*theParams[0]).ntype == fits_parser_yytokentype::DOUBLE as c_int {
+                            if (*theParams[0]).operation == -(1000 as c_int) {
+                                loop {
+                                    let fresh58 = elem;
+                                    elem -= 1;
+                                    if fresh58 == 0 {
+                                        break;
+                                    }
+                                    *((*this).value.undef).offset(elem as isize) =
+                                        if pVals[0].data.dbl < 0.0 { 1 } else { 0 };
+                                    if *((*this).value.undef).offset(elem as isize) == 0 {
+                                        *((*this).value.data.lngptr).offset(elem as isize) =
+                                            simplerng_getpoisson(pVals[0].data.dbl) as c_long;
+                                    }
+                                }
+                            } else {
+                                loop {
+                                    let fresh59 = elem;
+                                    elem -= 1;
+                                    if fresh59 == 0 {
+                                        break;
+                                    }
+                                    *((*this).value.undef).offset(elem as isize) =
+                                        *((*theParams[0]).value.undef).offset(elem as isize);
+                                    if *((*theParams[0]).value.data.dblptr).offset(elem as isize)
+                                        < 0.0
+                                    {
+                                        *((*this).value.undef).offset(elem as isize) = 1;
+                                    }
+                                    if *((*this).value.undef).offset(elem as isize) == 0 {
+                                        *((*this).value.data.lngptr).offset(elem as isize) =
+                                            simplerng_getpoisson(
+                                                *((*theParams[0]).value.data.dblptr)
+                                                    .offset(elem as isize),
+                                            ) as c_long;
+                                    }
+                                }
+                            }
+                        } else if (*theParams[0]).operation == -(1000 as c_int) {
+                            loop {
+                                let fresh60 = elem;
+                                elem -= 1;
+                                if fresh60 == 0 {
+                                    break;
+                                }
+                                *((*this).value.undef).offset(elem as isize) =
+                                    if pVals[0].data.lng < 0 { 1 } else { 0 };
+                                if *((*this).value.undef).offset(elem as isize) == 0 {
+                                    *((*this).value.data.lngptr).offset(elem as isize) =
+                                        simplerng_getpoisson(pVals[0].data.lng as c_double)
+                                            as c_long;
+                                }
+                            }
+                        } else {
+                            loop {
+                                let fresh61 = elem;
+                                elem -= 1;
+                                if fresh61 == 0 {
+                                    break;
+                                }
+                                *((*this).value.undef).offset(elem as isize) =
+                                    *((*theParams[0]).value.undef).offset(elem as isize);
+                                if *((*theParams[0]).value.data.lngptr).offset(elem as isize) < 0 {
+                                    *((*this).value.undef).offset(elem as isize) = 1;
+                                }
+                                if *((*this).value.undef).offset(elem as isize) == 0 {
+                                    *((*this).value.data.lngptr).offset(elem as isize) =
+                                        simplerng_getpoisson(
+                                            *((*theParams[0]).value.data.lngptr)
+                                                .offset(elem as isize)
+                                                as c_double,
+                                        ) as c_long;
+                                }
+                            }
+                        }
+                    }
+                    1002 => {
+                        elem = row * (*theParams[0]).value.nelem;
+                        if (*theParams[0]).ntype == fits_parser_yytokentype::BOOLEAN as c_int {
+                            loop {
+                                let fresh62 = row;
+                                row -= 1;
+                                if fresh62 == 0 {
+                                    break;
+                                }
+                                *((*this).value.data.lngptr).offset(row as isize) = 0;
+                                *((*this).value.undef).offset(row as isize) = 1;
+                                nelem = (*theParams[0]).value.nelem;
+                                loop {
+                                    let fresh63 = nelem;
+                                    nelem -= 1;
+                                    if fresh63 == 0 {
+                                        break;
+                                    }
+                                    elem -= 1;
+                                    elem;
+                                    if *((*theParams[0]).value.undef).offset(elem as isize) == 0 {
+                                        *((*this).value.data.lngptr).offset(row as isize) +=
+                                            (if *((*theParams[0]).value.data.logptr)
+                                                .offset(elem as isize)
+                                                as c_int
+                                                != 0
+                                            {
+                                                1
+                                            } else {
+                                                0
+                                            })
+                                                as c_long;
+                                        *((*this).value.undef).offset(row as isize) = 0;
+                                    }
+                                }
+                            }
+                        } else if (*theParams[0]).ntype == fits_parser_yytokentype::LONG as c_int {
+                            loop {
+                                let fresh64 = row;
+                                row -= 1;
+                                if fresh64 == 0 {
+                                    break;
+                                }
+                                *((*this).value.data.lngptr).offset(row as isize) = 0;
+                                *((*this).value.undef).offset(row as isize) = 1;
+                                nelem = (*theParams[0]).value.nelem;
+                                loop {
+                                    let fresh65 = nelem;
+                                    nelem -= 1;
+                                    if fresh65 == 0 {
+                                        break;
+                                    }
+                                    elem -= 1;
+                                    elem;
+                                    if *((*theParams[0]).value.undef).offset(elem as isize) == 0 {
+                                        *((*this).value.data.lngptr).offset(row as isize) +=
+                                            *((*theParams[0]).value.data.lngptr)
+                                                .offset(elem as isize);
+                                        *((*this).value.undef).offset(row as isize) = 0;
+                                    }
+                                }
+                            }
+                        } else if (*theParams[0]).ntype == fits_parser_yytokentype::DOUBLE as c_int
+                        {
+                            loop {
+                                let fresh66 = row;
+                                row -= 1;
+                                if fresh66 == 0 {
+                                    break;
+                                }
+                                *((*this).value.data.dblptr).offset(row as isize) = 0.0f64;
+                                *((*this).value.undef).offset(row as isize) = 1;
+                                nelem = (*theParams[0]).value.nelem;
+                                loop {
+                                    let fresh67 = nelem;
+                                    nelem -= 1;
+                                    if fresh67 == 0 {
+                                        break;
+                                    }
+                                    elem -= 1;
+                                    elem;
+                                    if *((*theParams[0]).value.undef).offset(elem as isize) == 0 {
+                                        *((*this).value.data.dblptr).offset(row as isize) +=
+                                            *((*theParams[0]).value.data.dblptr)
+                                                .offset(elem as isize);
+                                        *((*this).value.undef).offset(row as isize) = 0;
+                                    }
+                                }
+                            }
+                        } else {
+                            nelem = (*theParams[0]).value.nelem;
+                            loop {
+                                let fresh68 = row;
+                                row -= 1;
+                                if fresh68 == 0 {
+                                    break;
+                                }
+                                let mut sptr1: *mut c_char =
+                                    *((*theParams[0]).value.data.strptr).offset(row as isize);
+                                *((*this).value.data.lngptr).offset(row as isize) = 0;
+                                *((*this).value.undef).offset(row as isize) = 0;
+                                while *sptr1 != 0 {
+                                    if *sptr1 as c_int == '1' as i32 {
+                                        let fresh69 =
+                                            &mut *((*this).value.data.lngptr).offset(row as isize);
+                                        *fresh69 += 1;
+                                        *fresh69;
+                                    }
+                                    sptr1 = sptr1.offset(1);
+                                    sptr1;
+                                }
+                            }
+                        }
+                    }
+                    1038 => {
+                        elem = row * (*theParams[0]).value.nelem;
+                        if (*theParams[0]).ntype == fits_parser_yytokentype::LONG as c_int {
+                            loop {
+                                let fresh70 = row;
+                                row -= 1;
+                                if fresh70 == 0 {
+                                    break;
+                                }
+                                let mut count: c_int = 0;
+                                *((*this).value.data.dblptr).offset(row as isize) = 0.0;
+                                nelem = (*theParams[0]).value.nelem;
+                                loop {
+                                    let fresh71 = nelem;
+                                    nelem -= 1;
+                                    if fresh71 == 0 {
+                                        break;
+                                    }
+                                    elem -= 1;
+                                    elem;
+                                    if *((*theParams[0]).value.undef).offset(elem as isize) as c_int
+                                        == 0
+                                    {
+                                        *((*this).value.data.dblptr).offset(row as isize) +=
+                                            *((*theParams[0]).value.data.lngptr)
+                                                .offset(elem as isize)
+                                                as c_double;
+                                        count += 1;
+                                        count;
+                                    }
+                                }
+                                if count == 0 {
+                                    *((*this).value.undef).offset(row as isize) = 1;
+                                } else {
+                                    *((*this).value.undef).offset(row as isize) = 0;
+                                    *((*this).value.data.dblptr).offset(row as isize) /=
+                                        count as c_double;
+                                }
+                            }
+                        } else if (*theParams[0]).ntype == fits_parser_yytokentype::DOUBLE as c_int
+                        {
+                            loop {
+                                let fresh72 = row;
+                                row -= 1;
+                                if fresh72 == 0 {
+                                    break;
+                                }
+                                let mut count_0: c_int = 0;
+                                *((*this).value.data.dblptr).offset(row as isize) = 0.0;
+                                nelem = (*theParams[0]).value.nelem;
+                                loop {
+                                    let fresh73 = nelem;
+                                    nelem -= 1;
+                                    if fresh73 == 0 {
+                                        break;
+                                    }
+                                    elem -= 1;
+                                    elem;
+                                    if *((*theParams[0]).value.undef).offset(elem as isize) as c_int
+                                        == 0
+                                    {
+                                        *((*this).value.data.dblptr).offset(row as isize) +=
+                                            *((*theParams[0]).value.data.dblptr)
+                                                .offset(elem as isize);
+                                        count_0 += 1;
+                                        count_0;
+                                    }
+                                }
+                                if count_0 == 0 {
+                                    *((*this).value.undef).offset(row as isize) = 1;
+                                } else {
+                                    *((*this).value.undef).offset(row as isize) = 0;
+                                    *((*this).value.data.dblptr).offset(row as isize) /=
+                                        count_0 as c_double;
+                                }
+                            }
+                        }
+                    }
+                    1039 => {
+                        elem = row * (*theParams[0]).value.nelem;
+                        if (*theParams[0]).ntype == fits_parser_yytokentype::LONG as c_int {
+                            loop {
+                                let fresh74 = row;
+                                row -= 1;
+                                if fresh74 == 0 {
+                                    break;
+                                }
+                                let mut count_1: c_int = 0;
+                                let mut sum: c_double = 0.0;
+                                let mut sum2: c_double = 0.0;
+                                nelem = (*theParams[0]).value.nelem;
+                                loop {
+                                    let fresh75 = nelem;
+                                    nelem -= 1;
+                                    if fresh75 == 0 {
+                                        break;
+                                    }
+                                    elem -= 1;
+                                    elem;
+                                    if *((*theParams[0]).value.undef).offset(elem as isize) as c_int
+                                        == 0
+                                    {
+                                        sum += *((*theParams[0]).value.data.lngptr)
+                                            .offset(elem as isize)
+                                            as c_double;
+                                        count_1 += 1;
+                                        count_1;
+                                    }
+                                }
+                                if count_1 > 1 {
+                                    sum /= count_1 as c_double;
+                                    nelem = (*theParams[0]).value.nelem;
+                                    elem += nelem;
+                                    loop {
+                                        let fresh76 = nelem;
+                                        nelem -= 1;
+                                        if fresh76 == 0 {
+                                            break;
+                                        }
+                                        elem -= 1;
+                                        elem;
+                                        if *((*theParams[0]).value.undef).offset(elem as isize)
+                                            as c_int
+                                            == 0
+                                        {
+                                            let mut dx: c_double =
+                                                *((*theParams[0]).value.data.lngptr)
+                                                    .offset(elem as isize)
+                                                    as c_double
+                                                    - sum;
+                                            sum2 += dx * dx;
+                                        }
+                                    }
+                                    sum2 /= count_1 as c_double - 1 as c_double;
+                                    *((*this).value.undef).offset(row as isize) = 0;
+                                    *((*this).value.data.dblptr).offset(row as isize) = sqrt(sum2);
+                                } else {
+                                    *((*this).value.undef).offset(row as isize) = 0;
+                                    *((*this).value.data.dblptr).offset(row as isize) = 0.0;
+                                }
+                            }
+                        } else if (*theParams[0]).ntype == fits_parser_yytokentype::DOUBLE as c_int
+                        {
+                            loop {
+                                let fresh77 = row;
+                                row -= 1;
+                                if fresh77 == 0 {
+                                    break;
+                                }
+                                let mut count_2: c_int = 0;
+                                let mut sum_0: c_double = 0.0;
+                                let mut sum2_0: c_double = 0.0;
+                                nelem = (*theParams[0]).value.nelem;
+                                loop {
+                                    let fresh78 = nelem;
+                                    nelem -= 1;
+                                    if fresh78 == 0 {
+                                        break;
+                                    }
+                                    elem -= 1;
+                                    elem;
+                                    if *((*theParams[0]).value.undef).offset(elem as isize) as c_int
+                                        == 0
+                                    {
+                                        sum_0 += *((*theParams[0]).value.data.dblptr)
+                                            .offset(elem as isize);
+                                        count_2 += 1;
+                                        count_2;
+                                    }
+                                }
+                                if count_2 > 1 {
+                                    sum_0 /= count_2 as c_double;
+                                    nelem = (*theParams[0]).value.nelem;
+                                    elem += nelem;
+                                    loop {
+                                        let fresh79 = nelem;
+                                        nelem -= 1;
+                                        if fresh79 == 0 {
+                                            break;
+                                        }
+                                        elem -= 1;
+                                        elem;
+                                        if *((*theParams[0]).value.undef).offset(elem as isize)
+                                            as c_int
+                                            == 0
+                                        {
+                                            let mut dx_0: c_double =
+                                                *((*theParams[0]).value.data.dblptr)
+                                                    .offset(elem as isize)
+                                                    - sum_0;
+                                            sum2_0 += dx_0 * dx_0;
+                                        }
+                                    }
+                                    sum2_0 /= count_2 as c_double - 1 as c_double;
+                                    *((*this).value.undef).offset(row as isize) = 0;
+                                    *((*this).value.data.dblptr).offset(row as isize) =
+                                        sqrt(sum2_0);
+                                } else {
+                                    *((*this).value.undef).offset(row as isize) = 0;
+                                    *((*this).value.data.dblptr).offset(row as isize) = 0.0;
+                                }
+                            }
+                        }
+                    }
+                    1037 => {
+                        elem = row * (*theParams[0]).value.nelem;
+                        nelem = (*theParams[0]).value.nelem;
+                        if (*theParams[0]).ntype == fits_parser_yytokentype::LONG as c_int {
+                            let mut dptr: *mut c_long = (*theParams[0]).value.data.lngptr;
+                            let mut uptr: *mut c_char = (*theParams[0]).value.undef;
+                            let mut mptr: *mut c_long = malloc(
+                                (::core::mem::size_of::<c_long>() as c_ulong)
+                                    .wrapping_mul(nelem as c_ulong)
+                                    .try_into()
+                                    .unwrap(),
+                            )
+                                as *mut c_long;
+                            let mut irow: c_int = 0;
+                            if mptr.is_null() {
+                                fits_parser_yyerror(
+                                    0 as yyscan_t,
+                                    lParse,
+                                    b"Could not allocate temporary memory in median function\0"
+                                        as *const u8
+                                        as *const c_char
+                                        as *mut c_char,
+                                );
+                                free((*this).value.data.ptr);
+                            } else {
+                                irow = 0;
+                                while (irow as c_long) < row {
+                                    let mut p: *mut c_long = mptr;
+                                    let mut nelem1: c_int = nelem as c_int;
+                                    loop {
+                                        let fresh80 = nelem1;
+                                        nelem1 -= 1;
+                                        if fresh80 == 0 {
+                                            break;
+                                        }
+                                        if *uptr as c_int == 0 {
+                                            let fresh81 = p;
+                                            p = p.offset(1);
+                                            *fresh81 = *dptr;
+                                        }
+                                        dptr = dptr.offset(1);
+                                        dptr;
+                                        uptr = uptr.offset(1);
+                                        uptr;
+                                    }
+                                    nelem1 = p.offset_from(mptr) as c_long as c_int;
+                                    if nelem1 > 0 {
+                                        *((*this).value.undef).offset(irow as isize) = 0;
+                                        *((*this).value.data.lngptr).offset(irow as isize) =
+                                            qselect_median_lng(mptr, nelem1);
+                                    } else {
+                                        *((*this).value.undef).offset(irow as isize) = 1;
+                                        *((*this).value.data.lngptr).offset(irow as isize) = 0;
+                                    }
+                                    irow += 1;
+                                    irow;
+                                }
+                                free(mptr as *mut c_void);
+                            }
+                        } else {
+                            let mut dptr_0: *mut c_double = (*theParams[0]).value.data.dblptr;
+                            let mut uptr_0: *mut c_char = (*theParams[0]).value.undef;
+                            let mut mptr_0: *mut c_double = malloc(
+                                (::core::mem::size_of::<c_double>() as c_ulong)
+                                    .wrapping_mul(nelem as c_ulong)
+                                    .try_into()
+                                    .unwrap(),
+                            )
+                                as *mut c_double;
+                            let mut irow_0: c_int = 0;
+                            if mptr_0.is_null() {
+                                fits_parser_yyerror(
+                                    0 as yyscan_t,
+                                    lParse,
+                                    b"Could not allocate temporary memory in median function\0"
+                                        as *const u8
+                                        as *const c_char
+                                        as *mut c_char,
+                                );
+                                free((*this).value.data.ptr);
+                            } else {
+                                irow_0 = 0;
+                                while (irow_0 as c_long) < row {
+                                    let mut p_0: *mut c_double = mptr_0;
+                                    let mut nelem1_0: c_int = nelem as c_int;
+                                    loop {
+                                        let fresh82 = nelem1_0;
+                                        nelem1_0 -= 1;
+                                        if fresh82 == 0 {
+                                            break;
+                                        }
+                                        if *uptr_0 as c_int == 0 {
+                                            let fresh83 = p_0;
+                                            p_0 = p_0.offset(1);
+                                            *fresh83 = *dptr_0;
+                                        }
+                                        dptr_0 = dptr_0.offset(1);
+                                        dptr_0;
+                                        uptr_0 = uptr_0.offset(1);
+                                        uptr_0;
+                                    }
+                                    nelem1_0 = p_0.offset_from(mptr_0) as c_long as c_int;
+                                    if nelem1_0 > 0 {
+                                        *((*this).value.undef).offset(irow_0 as isize) = 0;
+                                        *((*this).value.data.dblptr).offset(irow_0 as isize) =
+                                            qselect_median_dbl(mptr_0, nelem1_0);
+                                    } else {
+                                        *((*this).value.undef).offset(irow_0 as isize) = 1;
+                                        *((*this).value.data.dblptr).offset(irow_0 as isize) = 0.0;
+                                    }
+                                    irow_0 += 1;
+                                    irow_0;
+                                }
+                                free(mptr_0 as *mut c_void);
+                            }
+                        }
+                    }
+                    1017 => {
+                        if (*theParams[0]).ntype == fits_parser_yytokentype::DOUBLE as c_int {
+                            loop {
+                                let fresh84 = elem;
+                                elem -= 1;
+                                if fresh84 == 0 {
+                                    break;
+                                }
+                                dval = *((*theParams[0]).value.data.dblptr).offset(elem as isize);
+                                *((*this).value.data.dblptr).offset(elem as isize) =
+                                    if dval > 0.0f64 { dval } else { -dval };
+                                *((*this).value.undef).offset(elem as isize) =
+                                    *((*theParams[0]).value.undef).offset(elem as isize);
+                            }
+                        } else {
+                            loop {
+                                let fresh85 = elem;
+                                elem -= 1;
+                                if fresh85 == 0 {
+                                    break;
+                                }
+                                ival = *((*theParams[0]).value.data.lngptr).offset(elem as isize);
+                                *((*this).value.data.lngptr).offset(elem as isize) =
+                                    if ival > 0 { ival } else { -ival };
+                                *((*this).value.undef).offset(elem as isize) =
+                                    *((*theParams[0]).value.undef).offset(elem as isize);
+                            }
+                        }
+                    }
+                    1040 => {
+                        nelem = (*theParams[0]).value.nelem;
+                        if (*theParams[0]).ntype == fits_parser_yytokentype::STRING as c_int {
+                            nelem = 1;
+                        }
+                        elem = row * nelem;
+                        loop {
+                            let fresh86 = row;
+                            row -= 1;
+                            if fresh86 == 0 {
+                                break;
+                            }
+                            let mut nelem1_1: c_int = nelem as c_int;
+                            *((*this).value.undef).offset(row as isize) = 0;
+                            *((*this).value.data.lngptr).offset(row as isize) = 0;
+                            loop {
+                                let fresh87 = nelem1_1;
+                                nelem1_1 -= 1;
+                                if fresh87 == 0 {
+                                    break;
+                                }
+                                elem -= 1;
+                                elem;
+                                if *((*theParams[0]).value.undef).offset(elem as isize) as c_int
+                                    == 0
+                                {
+                                    let fresh88 =
+                                        &mut *((*this).value.data.lngptr).offset(row as isize);
+                                    *fresh88 += 1;
+                                    *fresh88;
+                                }
+                            }
+                        }
+                    }
+                    1030 => {
+                        if (*theParams[0]).ntype == fits_parser_yytokentype::STRING as c_int {
+                            elem = row;
+                        }
+                        loop {
+                            let fresh89 = elem;
+                            elem -= 1;
+                            if fresh89 == 0 {
+                                break;
+                            }
+                            *((*this).value.data.logptr).offset(elem as isize) =
+                                *((*theParams[0]).value.undef).offset(elem as isize);
+                            *((*this).value.undef).offset(elem as isize) = 0;
+                        }
+                    }
+                    1031 => match (*this).ntype {
+                        258 => loop {
+                            let fresh90 = row;
+                            row -= 1;
+                            if fresh90 == 0 {
+                                break;
+                            }
+                            nelem = (*this).value.nelem;
+                            loop {
+                                let fresh91 = nelem;
+                                nelem -= 1;
+                                if fresh91 == 0 {
+                                    break;
+                                }
+                                elem -= 1;
+                                elem;
+                                i = 2 as c_int;
+                                loop {
+                                    let fresh92 = i;
+                                    i -= 1;
+                                    if fresh92 == 0 {
+                                        break;
+                                    }
+                                    if vector[i as usize] > 1 {
+                                        pNull[i as usize] = *((*theParams[i as usize]).value.undef)
+                                            .offset(elem as isize);
+                                        pVals[i as usize].data.log =
+                                            *((*theParams[i as usize]).value.data.logptr)
+                                                .offset(elem as isize);
+                                    } else if vector[i as usize] != 0 {
+                                        pNull[i as usize] = *((*theParams[i as usize]).value.undef)
+                                            .offset(row as isize);
+                                        pVals[i as usize].data.log =
+                                            *((*theParams[i as usize]).value.data.logptr)
+                                                .offset(row as isize);
+                                    }
+                                }
+                                if pNull[0] != 0 {
+                                    *((*this).value.undef).offset(elem as isize) = pNull[1];
+                                    *((*this).value.data.logptr).offset(elem as isize) =
+                                        pVals[1].data.log;
+                                } else {
+                                    *((*this).value.undef).offset(elem as isize) = 0;
+                                    *((*this).value.data.logptr).offset(elem as isize) =
+                                        pVals[0].data.log;
+                                }
+                            }
+                        },
+                        259 => loop {
+                            let fresh93 = row;
+                            row -= 1;
+                            if fresh93 == 0 {
+                                break;
+                            }
+                            nelem = (*this).value.nelem;
+                            loop {
+                                let fresh94 = nelem;
+                                nelem -= 1;
+                                if fresh94 == 0 {
+                                    break;
+                                }
+                                elem -= 1;
+                                elem;
+                                i = 2 as c_int;
+                                loop {
+                                    let fresh95 = i;
+                                    i -= 1;
+                                    if fresh95 == 0 {
+                                        break;
+                                    }
+                                    if vector[i as usize] > 1 {
+                                        pNull[i as usize] = *((*theParams[i as usize]).value.undef)
+                                            .offset(elem as isize);
+                                        pVals[i as usize].data.lng =
+                                            *((*theParams[i as usize]).value.data.lngptr)
+                                                .offset(elem as isize);
+                                    } else if vector[i as usize] != 0 {
+                                        pNull[i as usize] = *((*theParams[i as usize]).value.undef)
+                                            .offset(row as isize);
+                                        pVals[i as usize].data.lng =
+                                            *((*theParams[i as usize]).value.data.lngptr)
+                                                .offset(row as isize);
+                                    }
+                                }
+                                if pNull[0] != 0 {
+                                    *((*this).value.undef).offset(elem as isize) = pNull[1];
+                                    *((*this).value.data.lngptr).offset(elem as isize) =
+                                        pVals[1].data.lng;
+                                } else {
+                                    *((*this).value.undef).offset(elem as isize) = 0;
+                                    *((*this).value.data.lngptr).offset(elem as isize) =
+                                        pVals[0].data.lng;
+                                }
+                            }
+                        },
+                        260 => loop {
+                            let fresh96 = row;
+                            row -= 1;
+                            if fresh96 == 0 {
+                                break;
+                            }
+                            nelem = (*this).value.nelem;
+                            loop {
+                                let fresh97 = nelem;
+                                nelem -= 1;
+                                if fresh97 == 0 {
+                                    break;
+                                }
+                                elem -= 1;
+                                elem;
+                                i = 2 as c_int;
+                                loop {
+                                    let fresh98 = i;
+                                    i -= 1;
+                                    if fresh98 == 0 {
+                                        break;
+                                    }
+                                    if vector[i as usize] > 1 {
+                                        pNull[i as usize] = *((*theParams[i as usize]).value.undef)
+                                            .offset(elem as isize);
+                                        pVals[i as usize].data.dbl =
+                                            *((*theParams[i as usize]).value.data.dblptr)
+                                                .offset(elem as isize);
+                                    } else if vector[i as usize] != 0 {
+                                        pNull[i as usize] = *((*theParams[i as usize]).value.undef)
+                                            .offset(row as isize);
+                                        pVals[i as usize].data.dbl =
+                                            *((*theParams[i as usize]).value.data.dblptr)
+                                                .offset(row as isize);
+                                    }
+                                }
+                                if pNull[0] != 0 {
+                                    *((*this).value.undef).offset(elem as isize) = pNull[1];
+                                    *((*this).value.data.dblptr).offset(elem as isize) =
+                                        pVals[1].data.dbl;
+                                } else {
+                                    *((*this).value.undef).offset(elem as isize) = 0;
+                                    *((*this).value.data.dblptr).offset(elem as isize) =
+                                        pVals[0].data.dbl;
+                                }
+                            }
+                        },
+                        261 => loop {
+                            let fresh99 = row;
+                            row -= 1;
+                            if fresh99 == 0 {
+                                break;
+                            }
+                            i = 2 as c_int;
+                            loop {
+                                let fresh100 = i;
+                                i -= 1;
+                                if fresh100 == 0 {
+                                    break;
+                                }
+                                if vector[i as usize] != 0 {
+                                    pNull[i as usize] = *((*theParams[i as usize]).value.undef)
+                                        .offset(row as isize);
+                                    strcpy(
+                                        (pVals[i as usize].data.astr).as_mut_ptr(),
+                                        *((*theParams[i as usize]).value.data.strptr)
+                                            .offset(row as isize),
+                                    );
+                                }
+                            }
+                            if pNull[0] != 0 {
+                                *((*this).value.undef).offset(row as isize) = pNull[1];
+                                strcpy(
+                                    *((*this).value.data.strptr).offset(row as isize),
+                                    (pVals[1].data.astr).as_mut_ptr(),
+                                );
+                            } else {
+                                *((*this).value.undef).offset(elem as isize) = 0;
+                                strcpy(
+                                    *((*this).value.data.strptr).offset(row as isize),
+                                    (pVals[0].data.astr).as_mut_ptr(),
+                                );
+                            }
+                        },
+                        _ => {}
+                    },
+                    1046 => match (*this).ntype {
+                        259 => loop {
+                            let fresh101 = elem;
+                            elem -= 1;
+                            if fresh101 == 0 {
+                                break;
+                            }
+                            if (*theParams[1]).value.data.lng
+                                == *((*theParams[0]).value.data.lngptr).offset(elem as isize)
+                            {
+                                *((*this).value.data.lngptr).offset(elem as isize) = 0;
+                                *((*this).value.undef).offset(elem as isize) = 1;
+                            } else {
+                                *((*this).value.data.lngptr).offset(elem as isize) =
+                                    *((*theParams[0]).value.data.lngptr).offset(elem as isize);
+                                *((*this).value.undef).offset(elem as isize) =
+                                    *((*theParams[0]).value.undef).offset(elem as isize);
+                            }
+                        },
+                        260 => loop {
+                            let fresh102 = elem;
+                            elem -= 1;
+                            if fresh102 == 0 {
+                                break;
+                            }
+                            if (*theParams[1]).value.data.dbl
+                                == *((*theParams[0]).value.data.dblptr).offset(elem as isize)
+                            {
+                                *((*this).value.data.dblptr).offset(elem as isize) = 0.0;
+                                *((*this).value.undef).offset(elem as isize) = 1;
+                            } else {
+                                *((*this).value.data.dblptr).offset(elem as isize) =
+                                    *((*theParams[0]).value.data.dblptr).offset(elem as isize);
+                                *((*this).value.undef).offset(elem as isize) =
+                                    *((*theParams[0]).value.undef).offset(elem as isize);
+                            }
+                        },
+                        _ => {}
+                    },
+                    1004 => loop {
+                        let fresh103 = elem;
+                        elem -= 1;
+                        if fresh103 == 0 {
+                            break;
+                        }
+                        let fresh104 = &mut *((*this).value.undef).offset(elem as isize);
+                        *fresh104 = *((*theParams[0]).value.undef).offset(elem as isize);
+                        if *fresh104 == 0 {
+                            *((*this).value.data.dblptr).offset(elem as isize) =
+                                sin(*((*theParams[0]).value.data.dblptr).offset(elem as isize));
+                        }
+                    },
+                    1005 => loop {
+                        let fresh105 = elem;
+                        elem -= 1;
+                        if fresh105 == 0 {
+                            break;
+                        }
+                        let fresh106 = &mut *((*this).value.undef).offset(elem as isize);
+                        *fresh106 = *((*theParams[0]).value.undef).offset(elem as isize);
+                        if *fresh106 == 0 {
+                            *((*this).value.data.dblptr).offset(elem as isize) =
+                                cos(*((*theParams[0]).value.data.dblptr).offset(elem as isize));
+                        }
+                    },
+                    1006 => loop {
+                        let fresh107 = elem;
+                        elem -= 1;
+                        if fresh107 == 0 {
+                            break;
+                        }
+                        let fresh108 = &mut *((*this).value.undef).offset(elem as isize);
+                        *fresh108 = *((*theParams[0]).value.undef).offset(elem as isize);
+                        if *fresh108 == 0 {
+                            *((*this).value.data.dblptr).offset(elem as isize) =
+                                tan(*((*theParams[0]).value.data.dblptr).offset(elem as isize));
+                        }
+                    },
+                    1007 => loop {
+                        let fresh109 = elem;
+                        elem -= 1;
+                        if fresh109 == 0 {
+                            break;
+                        }
+                        let fresh110 = &mut *((*this).value.undef).offset(elem as isize);
+                        *fresh110 = *((*theParams[0]).value.undef).offset(elem as isize);
+                        if *fresh110 == 0 {
+                            dval = *((*theParams[0]).value.data.dblptr).offset(elem as isize);
+                            if dval < -1.0f64 || dval > 1.0f64 {
+                                *((*this).value.data.dblptr).offset(elem as isize) = 0.0f64;
+                                *((*this).value.undef).offset(elem as isize) = 1;
+                            } else {
+                                *((*this).value.data.dblptr).offset(elem as isize) = asin(dval);
+                            }
+                        }
+                    },
+                    1008 => loop {
+                        let fresh111 = elem;
+                        elem -= 1;
+                        if fresh111 == 0 {
+                            break;
+                        }
+                        let fresh112 = &mut *((*this).value.undef).offset(elem as isize);
+                        *fresh112 = *((*theParams[0]).value.undef).offset(elem as isize);
+                        if *fresh112 == 0 {
+                            dval = *((*theParams[0]).value.data.dblptr).offset(elem as isize);
+                            if dval < -1.0f64 || dval > 1.0f64 {
+                                *((*this).value.data.dblptr).offset(elem as isize) = 0.0f64;
+                                *((*this).value.undef).offset(elem as isize) = 1;
+                            } else {
+                                *((*this).value.data.dblptr).offset(elem as isize) = acos(dval);
+                            }
+                        }
+                    },
+                    1009 => loop {
+                        let fresh113 = elem;
+                        elem -= 1;
+                        if fresh113 == 0 {
+                            break;
+                        }
+                        let fresh114 = &mut *((*this).value.undef).offset(elem as isize);
+                        *fresh114 = *((*theParams[0]).value.undef).offset(elem as isize);
+                        if *fresh114 == 0 {
+                            dval = *((*theParams[0]).value.data.dblptr).offset(elem as isize);
+                            *((*this).value.data.dblptr).offset(elem as isize) = atan(dval);
+                        }
+                    },
+                    1010 => loop {
+                        let fresh115 = elem;
+                        elem -= 1;
+                        if fresh115 == 0 {
+                            break;
+                        }
+                        let fresh116 = &mut *((*this).value.undef).offset(elem as isize);
+                        *fresh116 = *((*theParams[0]).value.undef).offset(elem as isize);
+                        if *fresh116 == 0 {
+                            *((*this).value.data.dblptr).offset(elem as isize) =
+                                sinh(*((*theParams[0]).value.data.dblptr).offset(elem as isize));
+                        }
+                    },
+                    1011 => loop {
+                        let fresh117 = elem;
+                        elem -= 1;
+                        if fresh117 == 0 {
+                            break;
+                        }
+                        let fresh118 = &mut *((*this).value.undef).offset(elem as isize);
+                        *fresh118 = *((*theParams[0]).value.undef).offset(elem as isize);
+                        if *fresh118 == 0 {
+                            *((*this).value.data.dblptr).offset(elem as isize) =
+                                cosh(*((*theParams[0]).value.data.dblptr).offset(elem as isize));
+                        }
+                    },
+                    1012 => loop {
+                        let fresh119 = elem;
+                        elem -= 1;
+                        if fresh119 == 0 {
+                            break;
+                        }
+                        let fresh120 = &mut *((*this).value.undef).offset(elem as isize);
+                        *fresh120 = *((*theParams[0]).value.undef).offset(elem as isize);
+                        if *fresh120 == 0 {
+                            *((*this).value.data.dblptr).offset(elem as isize) =
+                                tanh(*((*theParams[0]).value.data.dblptr).offset(elem as isize));
+                        }
+                    },
+                    1013 => loop {
+                        let fresh121 = elem;
+                        elem -= 1;
+                        if fresh121 == 0 {
+                            break;
+                        }
+                        let fresh122 = &mut *((*this).value.undef).offset(elem as isize);
+                        *fresh122 = *((*theParams[0]).value.undef).offset(elem as isize);
+                        if *fresh122 == 0 {
+                            dval = *((*theParams[0]).value.data.dblptr).offset(elem as isize);
+                            *((*this).value.data.dblptr).offset(elem as isize) = exp(dval);
+                        }
+                    },
+                    1014 => loop {
+                        let fresh123 = elem;
+                        elem -= 1;
+                        if fresh123 == 0 {
+                            break;
+                        }
+                        let fresh124 = &mut *((*this).value.undef).offset(elem as isize);
+                        *fresh124 = *((*theParams[0]).value.undef).offset(elem as isize);
+                        if *fresh124 == 0 {
+                            dval = *((*theParams[0]).value.data.dblptr).offset(elem as isize);
+                            if dval <= 0.0f64 {
+                                *((*this).value.data.dblptr).offset(elem as isize) = 0.0f64;
+                                *((*this).value.undef).offset(elem as isize) = 1;
+                            } else {
+                                *((*this).value.data.dblptr).offset(elem as isize) = log(dval);
+                            }
+                        }
+                    },
+                    1015 => loop {
+                        let fresh125 = elem;
+                        elem -= 1;
+                        if fresh125 == 0 {
+                            break;
+                        }
+                        let fresh126 = &mut *((*this).value.undef).offset(elem as isize);
+                        *fresh126 = *((*theParams[0]).value.undef).offset(elem as isize);
+                        if *fresh126 == 0 {
+                            dval = *((*theParams[0]).value.data.dblptr).offset(elem as isize);
+                            if dval <= 0.0f64 {
+                                *((*this).value.data.dblptr).offset(elem as isize) = 0.0f64;
+                                *((*this).value.undef).offset(elem as isize) = 1;
+                            } else {
+                                *((*this).value.data.dblptr).offset(elem as isize) = log10(dval);
+                            }
+                        }
+                    },
+                    1016 => loop {
+                        let fresh127 = elem;
+                        elem -= 1;
+                        if fresh127 == 0 {
+                            break;
+                        }
+                        let fresh128 = &mut *((*this).value.undef).offset(elem as isize);
+                        *fresh128 = *((*theParams[0]).value.undef).offset(elem as isize);
+                        if *fresh128 == 0 {
+                            dval = *((*theParams[0]).value.data.dblptr).offset(elem as isize);
+                            if dval < 0.0f64 {
+                                *((*this).value.data.dblptr).offset(elem as isize) = 0.0f64;
+                                *((*this).value.undef).offset(elem as isize) = 1;
+                            } else {
+                                *((*this).value.data.dblptr).offset(elem as isize) = sqrt(dval);
+                            }
+                        }
+                    },
+                    1019 => loop {
+                        let fresh129 = elem;
+                        elem -= 1;
+                        if fresh129 == 0 {
+                            break;
+                        }
+                        let fresh130 = &mut *((*this).value.undef).offset(elem as isize);
+                        *fresh130 = *((*theParams[0]).value.undef).offset(elem as isize);
+                        if *fresh130 == 0 {
+                            *((*this).value.data.dblptr).offset(elem as isize) =
+                                ceil(*((*theParams[0]).value.data.dblptr).offset(elem as isize));
+                        }
+                    },
+                    1020 => loop {
+                        let fresh131 = elem;
+                        elem -= 1;
+                        if fresh131 == 0 {
+                            break;
+                        }
+                        let fresh132 = &mut *((*this).value.undef).offset(elem as isize);
+                        *fresh132 = *((*theParams[0]).value.undef).offset(elem as isize);
+                        if *fresh132 == 0 {
+                            *((*this).value.data.dblptr).offset(elem as isize) =
+                                floor(*((*theParams[0]).value.data.dblptr).offset(elem as isize));
+                        }
+                    },
+                    1021 => loop {
+                        let fresh133 = elem;
+                        elem -= 1;
+                        if fresh133 == 0 {
+                            break;
+                        }
+                        let fresh134 = &mut *((*this).value.undef).offset(elem as isize);
+                        *fresh134 = *((*theParams[0]).value.undef).offset(elem as isize);
+                        if *fresh134 == 0 {
+                            *((*this).value.data.dblptr).offset(elem as isize) = floor(
+                                *((*theParams[0]).value.data.dblptr).offset(elem as isize) + 0.5f64,
+                            );
+                        }
+                    },
+                    1018 => loop {
+                        let fresh135 = row;
+                        row -= 1;
+                        if fresh135 == 0 {
+                            break;
+                        }
+                        nelem = (*this).value.nelem;
+                        loop {
+                            let fresh136 = nelem;
+                            nelem -= 1;
+                            if fresh136 == 0 {
+                                break;
+                            }
+                            elem -= 1;
+                            elem;
+                            i = 2 as c_int;
+                            loop {
+                                let fresh137 = i;
+                                i -= 1;
+                                if fresh137 == 0 {
+                                    break;
+                                }
+                                if vector[i as usize] > 1 {
+                                    pVals[i as usize].data.dbl =
+                                        *((*theParams[i as usize]).value.data.dblptr)
+                                            .offset(elem as isize);
+                                    pNull[i as usize] = *((*theParams[i as usize]).value.undef)
+                                        .offset(elem as isize);
+                                } else if vector[i as usize] != 0 {
+                                    pVals[i as usize].data.dbl =
+                                        *((*theParams[i as usize]).value.data.dblptr)
+                                            .offset(row as isize);
+                                    pNull[i as usize] = *((*theParams[i as usize]).value.undef)
+                                        .offset(row as isize);
+                                }
+                            }
+                            let fresh138 = &mut *((*this).value.undef).offset(elem as isize);
+                            *fresh138 = if pNull[0] as c_int != 0 || pNull[1] as c_int != 0 {
+                                1
+                            } else {
+                                0
+                            };
+                            if *fresh138 == 0 {
+                                *((*this).value.data.dblptr).offset(elem as isize) =
+                                    atan2(pVals[0].data.dbl, pVals[1].data.dbl);
+                            }
+                        }
+                    },
+                    1041 => loop {
+                        let fresh139 = row;
+                        row -= 1;
+                        if fresh139 == 0 {
+                            break;
+                        }
+                        nelem = (*this).value.nelem;
+                        loop {
+                            let fresh140 = nelem;
+                            nelem -= 1;
+                            if fresh140 == 0 {
+                                break;
+                            }
+                            elem -= 1;
+                            elem;
+                            i = 4 as c_int;
+                            loop {
+                                let fresh141 = i;
+                                i -= 1;
+                                if fresh141 == 0 {
+                                    break;
+                                }
+                                if vector[i as usize] > 1 {
+                                    pVals[i as usize].data.dbl =
+                                        *((*theParams[i as usize]).value.data.dblptr)
+                                            .offset(elem as isize);
+                                    pNull[i as usize] = *((*theParams[i as usize]).value.undef)
+                                        .offset(elem as isize);
+                                } else if vector[i as usize] != 0 {
+                                    pVals[i as usize].data.dbl =
+                                        *((*theParams[i as usize]).value.data.dblptr)
+                                            .offset(row as isize);
+                                    pNull[i as usize] = *((*theParams[i as usize]).value.undef)
+                                        .offset(row as isize);
+                                }
+                            }
+                            let fresh142 = &mut *((*this).value.undef).offset(elem as isize);
+                            *fresh142 = (pNull[0] as c_int != 0
+                                || pNull[1] as c_int != 0
+                                || pNull[2] as c_int != 0
+                                || pNull[3] as c_int != 0)
+                                as c_int as c_char;
+                            if *fresh142 == 0 {
+                                *((*this).value.data.dblptr).offset(elem as isize) = angsep_calc(
+                                    pVals[0].data.dbl,
+                                    pVals[1].data.dbl,
+                                    pVals[2].data.dbl,
+                                    pVals[3].data.dbl,
+                                );
+                            }
+                        }
+                    },
+                    1022 => {
+                        elem = row * (*theParams[0]).value.nelem;
+                        if (*this).ntype == fits_parser_yytokentype::LONG as c_int {
+                            let mut minVal: c_long = 0;
+                            loop {
+                                let fresh143 = row;
+                                row -= 1;
+                                if fresh143 == 0 {
+                                    break;
+                                }
+                                valInit = 1;
+                                *((*this).value.undef).offset(row as isize) = 1;
+                                nelem = (*theParams[0]).value.nelem;
+                                loop {
+                                    let fresh144 = nelem;
+                                    nelem -= 1;
+                                    if fresh144 == 0 {
+                                        break;
+                                    }
+                                    elem -= 1;
+                                    elem;
+                                    if *((*theParams[0]).value.undef).offset(elem as isize) == 0 {
+                                        if valInit != 0 {
+                                            valInit = 0;
+                                            minVal = *((*theParams[0]).value.data.lngptr)
+                                                .offset(elem as isize);
+                                        } else {
+                                            minVal = if minVal
+                                                < *((*theParams[0]).value.data.lngptr)
+                                                    .offset(elem as isize)
+                                            {
+                                                minVal
+                                            } else {
+                                                *((*theParams[0]).value.data.lngptr)
+                                                    .offset(elem as isize)
+                                            };
+                                        }
+                                        *((*this).value.undef).offset(row as isize) = 0;
+                                    }
+                                }
+                                *((*this).value.data.lngptr).offset(row as isize) = minVal;
+                            }
+                        } else if (*this).ntype == fits_parser_yytokentype::DOUBLE as c_int {
+                            let mut minVal_0: c_double = 0.0f64;
+                            loop {
+                                let fresh145 = row;
+                                row -= 1;
+                                if fresh145 == 0 {
+                                    break;
+                                }
+                                valInit = 1;
+                                *((*this).value.undef).offset(row as isize) = 1;
+                                nelem = (*theParams[0]).value.nelem;
+                                loop {
+                                    let fresh146 = nelem;
+                                    nelem -= 1;
+                                    if fresh146 == 0 {
+                                        break;
+                                    }
+                                    elem -= 1;
+                                    elem;
+                                    if *((*theParams[0]).value.undef).offset(elem as isize) == 0 {
+                                        if valInit != 0 {
+                                            valInit = 0;
+                                            minVal_0 = *((*theParams[0]).value.data.dblptr)
+                                                .offset(elem as isize);
+                                        } else {
+                                            minVal_0 = if minVal_0
+                                                < *((*theParams[0]).value.data.dblptr)
+                                                    .offset(elem as isize)
+                                            {
+                                                minVal_0
+                                            } else {
+                                                *((*theParams[0]).value.data.dblptr)
+                                                    .offset(elem as isize)
+                                            };
+                                        }
+                                        *((*this).value.undef).offset(row as isize) = 0;
+                                    }
+                                }
+                                *((*this).value.data.dblptr).offset(row as isize) = minVal_0;
+                            }
+                        } else if (*this).ntype == fits_parser_yytokentype::BITSTR as c_int {
+                            let mut minVal_1: c_char = 0;
+                            loop {
+                                let fresh147 = row;
+                                row -= 1;
+                                if fresh147 == 0 {
+                                    break;
+                                }
+                                let mut sptr1_0: *mut c_char =
+                                    *((*theParams[0]).value.data.strptr).offset(row as isize);
+                                minVal_1 = b'1' as c_char;
+                                while *sptr1_0 != 0 {
+                                    if *sptr1_0 as c_int == '0' as i32 {
+                                        minVal_1 = b'0' as c_char;
+                                    }
+                                    sptr1_0 = sptr1_0.offset(1);
+                                    sptr1_0;
+                                }
+                                *(*((*this).value.data.strptr).offset(row as isize)).offset(0) =
+                                    minVal_1;
+                                *(*((*this).value.data.strptr).offset(row as isize))
+                                    .offset(1 as c_int as isize) = 0;
+                            }
+                        }
+                    }
+                    1023 => {
+                        if (*this).ntype == fits_parser_yytokentype::LONG as c_int {
+                            loop {
+                                let fresh148 = row;
+                                row -= 1;
+                                if fresh148 == 0 {
+                                    break;
+                                }
+                                nelem = (*this).value.nelem;
+                                loop {
+                                    let fresh149 = nelem;
+                                    nelem -= 1;
+                                    if fresh149 == 0 {
+                                        break;
+                                    }
+                                    elem -= 1;
+                                    elem;
+                                    i = 2 as c_int;
+                                    loop {
+                                        let fresh150 = i;
+                                        i -= 1;
+                                        if fresh150 == 0 {
+                                            break;
+                                        }
+                                        if vector[i as usize] > 1 {
+                                            pVals[i as usize].data.lng =
+                                                *((*theParams[i as usize]).value.data.lngptr)
+                                                    .offset(elem as isize);
+                                            pNull[i as usize] =
+                                                *((*theParams[i as usize]).value.undef)
+                                                    .offset(elem as isize);
+                                        } else if vector[i as usize] != 0 {
+                                            pVals[i as usize].data.lng =
+                                                *((*theParams[i as usize]).value.data.lngptr)
+                                                    .offset(row as isize);
+                                            pNull[i as usize] =
+                                                *((*theParams[i as usize]).value.undef)
+                                                    .offset(row as isize);
+                                        }
+                                    }
+                                    if pNull[0] as c_int != 0 && pNull[1] as c_int != 0 {
+                                        *((*this).value.undef).offset(elem as isize) = 1;
+                                        *((*this).value.data.lngptr).offset(elem as isize) = 0;
+                                    } else if pNull[0] != 0 {
+                                        *((*this).value.undef).offset(elem as isize) = 0;
+                                        *((*this).value.data.lngptr).offset(elem as isize) =
+                                            pVals[1].data.lng;
+                                    } else if pNull[1] != 0 {
+                                        *((*this).value.undef).offset(elem as isize) = 0;
+                                        *((*this).value.data.lngptr).offset(elem as isize) =
+                                            pVals[0].data.lng;
+                                    } else {
+                                        *((*this).value.undef).offset(elem as isize) = 0;
+                                        *((*this).value.data.lngptr).offset(elem as isize) =
+                                            if pVals[0].data.lng < pVals[1].data.lng {
+                                                pVals[0].data.lng
+                                            } else {
+                                                pVals[1].data.lng
+                                            };
+                                    }
+                                }
+                            }
+                        } else if (*this).ntype == fits_parser_yytokentype::DOUBLE as c_int {
+                            loop {
+                                let fresh151 = row;
+                                row -= 1;
+                                if fresh151 == 0 {
+                                    break;
+                                }
+                                nelem = (*this).value.nelem;
+                                loop {
+                                    let fresh152 = nelem;
+                                    nelem -= 1;
+                                    if fresh152 == 0 {
+                                        break;
+                                    }
+                                    elem -= 1;
+                                    elem;
+                                    i = 2 as c_int;
+                                    loop {
+                                        let fresh153 = i;
+                                        i -= 1;
+                                        if fresh153 == 0 {
+                                            break;
+                                        }
+                                        if vector[i as usize] > 1 {
+                                            pVals[i as usize].data.dbl =
+                                                *((*theParams[i as usize]).value.data.dblptr)
+                                                    .offset(elem as isize);
+                                            pNull[i as usize] =
+                                                *((*theParams[i as usize]).value.undef)
+                                                    .offset(elem as isize);
+                                        } else if vector[i as usize] != 0 {
+                                            pVals[i as usize].data.dbl =
+                                                *((*theParams[i as usize]).value.data.dblptr)
+                                                    .offset(row as isize);
+                                            pNull[i as usize] =
+                                                *((*theParams[i as usize]).value.undef)
+                                                    .offset(row as isize);
+                                        }
+                                    }
+                                    if pNull[0] as c_int != 0 && pNull[1] as c_int != 0 {
+                                        *((*this).value.undef).offset(elem as isize) = 1;
+                                        *((*this).value.data.dblptr).offset(elem as isize) = 0.0;
+                                    } else if pNull[0] != 0 {
+                                        *((*this).value.undef).offset(elem as isize) = 0;
+                                        *((*this).value.data.dblptr).offset(elem as isize) =
+                                            pVals[1].data.dbl;
+                                    } else if pNull[1] != 0 {
+                                        *((*this).value.undef).offset(elem as isize) = 0;
+                                        *((*this).value.data.dblptr).offset(elem as isize) =
+                                            pVals[0].data.dbl;
+                                    } else {
+                                        *((*this).value.undef).offset(elem as isize) = 0;
+                                        *((*this).value.data.dblptr).offset(elem as isize) =
+                                            if pVals[0].data.dbl < pVals[1].data.dbl {
+                                                pVals[0].data.dbl
+                                            } else {
+                                                pVals[1].data.dbl
+                                            };
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    1024 => {
+                        elem = row * (*theParams[0]).value.nelem;
+                        if (*this).ntype == fits_parser_yytokentype::LONG as c_int {
+                            let mut maxVal: c_long = 0;
+                            loop {
+                                let fresh154 = row;
+                                row -= 1;
+                                if fresh154 == 0 {
+                                    break;
+                                }
+                                valInit = 1;
+                                *((*this).value.undef).offset(row as isize) = 1;
+                                nelem = (*theParams[0]).value.nelem;
+                                loop {
+                                    let fresh155 = nelem;
+                                    nelem -= 1;
+                                    if fresh155 == 0 {
+                                        break;
+                                    }
+                                    elem -= 1;
+                                    elem;
+                                    if *((*theParams[0]).value.undef).offset(elem as isize) == 0 {
+                                        if valInit != 0 {
+                                            valInit = 0;
+                                            maxVal = *((*theParams[0]).value.data.lngptr)
+                                                .offset(elem as isize);
+                                        } else {
+                                            maxVal = if maxVal
+                                                > *((*theParams[0]).value.data.lngptr)
+                                                    .offset(elem as isize)
+                                            {
+                                                maxVal
+                                            } else {
+                                                *((*theParams[0]).value.data.lngptr)
+                                                    .offset(elem as isize)
+                                            };
+                                        }
+                                        *((*this).value.undef).offset(row as isize) = 0;
+                                    }
+                                }
+                                *((*this).value.data.lngptr).offset(row as isize) = maxVal;
+                            }
+                        } else if (*this).ntype == fits_parser_yytokentype::DOUBLE as c_int {
+                            let mut maxVal_0: c_double = 0.0f64;
+                            loop {
+                                let fresh156 = row;
+                                row -= 1;
+                                if fresh156 == 0 {
+                                    break;
+                                }
+                                valInit = 1;
+                                *((*this).value.undef).offset(row as isize) = 1;
+                                nelem = (*theParams[0]).value.nelem;
+                                loop {
+                                    let fresh157 = nelem;
+                                    nelem -= 1;
+                                    if fresh157 == 0 {
+                                        break;
+                                    }
+                                    elem -= 1;
+                                    elem;
+                                    if *((*theParams[0]).value.undef).offset(elem as isize) == 0 {
+                                        if valInit != 0 {
+                                            valInit = 0;
+                                            maxVal_0 = *((*theParams[0]).value.data.dblptr)
+                                                .offset(elem as isize);
+                                        } else {
+                                            maxVal_0 = if maxVal_0
+                                                > *((*theParams[0]).value.data.dblptr)
+                                                    .offset(elem as isize)
+                                            {
+                                                maxVal_0
+                                            } else {
+                                                *((*theParams[0]).value.data.dblptr)
+                                                    .offset(elem as isize)
+                                            };
+                                        }
+                                        *((*this).value.undef).offset(row as isize) = 0;
+                                    }
+                                }
+                                *((*this).value.data.dblptr).offset(row as isize) = maxVal_0;
+                            }
+                        } else if (*this).ntype == fits_parser_yytokentype::BITSTR as c_int {
+                            let mut maxVal_1: c_char = 0;
+                            loop {
+                                let fresh158 = row;
+                                row -= 1;
+                                if fresh158 == 0 {
+                                    break;
+                                }
+                                let mut sptr1_1: *mut c_char =
+                                    *((*theParams[0]).value.data.strptr).offset(row as isize);
+                                maxVal_1 = b'0' as c_char;
+                                while *sptr1_1 != 0 {
+                                    if *sptr1_1 as c_int == '1' as i32 {
+                                        maxVal_1 = b'1' as c_char;
+                                    }
+                                    sptr1_1 = sptr1_1.offset(1);
+                                    sptr1_1;
+                                }
+                                *(*((*this).value.data.strptr).offset(row as isize)).offset(0) =
+                                    maxVal_1;
+                                *(*((*this).value.data.strptr).offset(row as isize))
+                                    .offset(1 as c_int as isize) = 0;
+                            }
+                        }
+                    }
+                    1025 => {
+                        if (*this).ntype == fits_parser_yytokentype::LONG as c_int {
+                            loop {
+                                let fresh159 = row;
+                                row -= 1;
+                                if fresh159 == 0 {
+                                    break;
+                                }
+                                nelem = (*this).value.nelem;
+                                loop {
+                                    let fresh160 = nelem;
+                                    nelem -= 1;
+                                    if fresh160 == 0 {
+                                        break;
+                                    }
+                                    elem -= 1;
+                                    elem;
+                                    i = 2 as c_int;
+                                    loop {
+                                        let fresh161 = i;
+                                        i -= 1;
+                                        if fresh161 == 0 {
+                                            break;
+                                        }
+                                        if vector[i as usize] > 1 {
+                                            pVals[i as usize].data.lng =
+                                                *((*theParams[i as usize]).value.data.lngptr)
+                                                    .offset(elem as isize);
+                                            pNull[i as usize] =
+                                                *((*theParams[i as usize]).value.undef)
+                                                    .offset(elem as isize);
+                                        } else if vector[i as usize] != 0 {
+                                            pVals[i as usize].data.lng =
+                                                *((*theParams[i as usize]).value.data.lngptr)
+                                                    .offset(row as isize);
+                                            pNull[i as usize] =
+                                                *((*theParams[i as usize]).value.undef)
+                                                    .offset(row as isize);
+                                        }
+                                    }
+                                    if pNull[0] as c_int != 0 && pNull[1] as c_int != 0 {
+                                        *((*this).value.undef).offset(elem as isize) = 1;
+                                        *((*this).value.data.lngptr).offset(elem as isize) = 0;
+                                    } else if pNull[0] != 0 {
+                                        *((*this).value.undef).offset(elem as isize) = 0;
+                                        *((*this).value.data.lngptr).offset(elem as isize) =
+                                            pVals[1].data.lng;
+                                    } else if pNull[1] != 0 {
+                                        *((*this).value.undef).offset(elem as isize) = 0;
+                                        *((*this).value.data.lngptr).offset(elem as isize) =
+                                            pVals[0].data.lng;
+                                    } else {
+                                        *((*this).value.undef).offset(elem as isize) = 0;
+                                        *((*this).value.data.lngptr).offset(elem as isize) =
+                                            if pVals[0].data.lng > pVals[1].data.lng {
+                                                pVals[0].data.lng
+                                            } else {
+                                                pVals[1].data.lng
+                                            };
+                                    }
+                                }
+                            }
+                        } else if (*this).ntype == fits_parser_yytokentype::DOUBLE as c_int {
+                            loop {
+                                let fresh162 = row;
+                                row -= 1;
+                                if fresh162 == 0 {
+                                    break;
+                                }
+                                nelem = (*this).value.nelem;
+                                loop {
+                                    let fresh163 = nelem;
+                                    nelem -= 1;
+                                    if fresh163 == 0 {
+                                        break;
+                                    }
+                                    elem -= 1;
+                                    elem;
+                                    i = 2 as c_int;
+                                    loop {
+                                        let fresh164 = i;
+                                        i -= 1;
+                                        if fresh164 == 0 {
+                                            break;
+                                        }
+                                        if vector[i as usize] > 1 {
+                                            pVals[i as usize].data.dbl =
+                                                *((*theParams[i as usize]).value.data.dblptr)
+                                                    .offset(elem as isize);
+                                            pNull[i as usize] =
+                                                *((*theParams[i as usize]).value.undef)
+                                                    .offset(elem as isize);
+                                        } else if vector[i as usize] != 0 {
+                                            pVals[i as usize].data.dbl =
+                                                *((*theParams[i as usize]).value.data.dblptr)
+                                                    .offset(row as isize);
+                                            pNull[i as usize] =
+                                                *((*theParams[i as usize]).value.undef)
+                                                    .offset(row as isize);
+                                        }
+                                    }
+                                    if pNull[0] as c_int != 0 && pNull[1] as c_int != 0 {
+                                        *((*this).value.undef).offset(elem as isize) = 1;
+                                        *((*this).value.data.dblptr).offset(elem as isize) = 0.0;
+                                    } else if pNull[0] != 0 {
+                                        *((*this).value.undef).offset(elem as isize) = 0;
+                                        *((*this).value.data.dblptr).offset(elem as isize) =
+                                            pVals[1].data.dbl;
+                                    } else if pNull[1] != 0 {
+                                        *((*this).value.undef).offset(elem as isize) = 0;
+                                        *((*this).value.data.dblptr).offset(elem as isize) =
+                                            pVals[0].data.dbl;
+                                    } else {
+                                        *((*this).value.undef).offset(elem as isize) = 0;
+                                        *((*this).value.data.dblptr).offset(elem as isize) =
+                                            if pVals[0].data.dbl > pVals[1].data.dbl {
+                                                pVals[0].data.dbl
+                                            } else {
+                                                pVals[1].data.dbl
+                                            };
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    1026 => loop {
+                        let fresh165 = row;
+                        row -= 1;
+                        if fresh165 == 0 {
+                            break;
+                        }
+                        nelem = (*this).value.nelem;
+                        loop {
+                            let fresh166 = nelem;
+                            nelem -= 1;
+                            if fresh166 == 0 {
+                                break;
+                            }
+                            elem -= 1;
+                            elem;
+                            i = 3 as c_int;
+                            loop {
+                                let fresh167 = i;
+                                i -= 1;
+                                if fresh167 == 0 {
+                                    break;
+                                }
+                                if vector[i as usize] > 1 {
+                                    pVals[i as usize].data.dbl =
+                                        *((*theParams[i as usize]).value.data.dblptr)
+                                            .offset(elem as isize);
+                                    pNull[i as usize] = *((*theParams[i as usize]).value.undef)
+                                        .offset(elem as isize);
+                                } else if vector[i as usize] != 0 {
+                                    pVals[i as usize].data.dbl =
+                                        *((*theParams[i as usize]).value.data.dblptr)
+                                            .offset(row as isize);
+                                    pNull[i as usize] = *((*theParams[i as usize]).value.undef)
+                                        .offset(row as isize);
+                                }
+                            }
+                            let fresh168 = &mut *((*this).value.undef).offset(elem as isize);
+                            *fresh168 = (pNull[0] as c_int != 0
+                                || pNull[1] as c_int != 0
+                                || pNull[2] as c_int != 0)
+                                as c_int as c_char;
+                            if *fresh168 == 0 {
+                                *((*this).value.data.logptr).offset(elem as isize) =
+                                    bnear(pVals[0].data.dbl, pVals[1].data.dbl, pVals[2].data.dbl);
+                            }
+                        }
+                    },
+                    1027 => loop {
+                        let fresh169 = row;
+                        row -= 1;
+                        if fresh169 == 0 {
+                            break;
+                        }
+                        nelem = (*this).value.nelem;
+                        loop {
+                            let fresh170 = nelem;
+                            nelem -= 1;
+                            if fresh170 == 0 {
+                                break;
+                            }
+                            elem -= 1;
+                            elem;
+                            i = 5 as c_int;
+                            loop {
+                                let fresh171 = i;
+                                i -= 1;
+                                if fresh171 == 0 {
+                                    break;
+                                }
+                                if vector[i as usize] > 1 {
+                                    pVals[i as usize].data.dbl =
+                                        *((*theParams[i as usize]).value.data.dblptr)
+                                            .offset(elem as isize);
+                                    pNull[i as usize] = *((*theParams[i as usize]).value.undef)
+                                        .offset(elem as isize);
+                                } else if vector[i as usize] != 0 {
+                                    pVals[i as usize].data.dbl =
+                                        *((*theParams[i as usize]).value.data.dblptr)
+                                            .offset(row as isize);
+                                    pNull[i as usize] = *((*theParams[i as usize]).value.undef)
+                                        .offset(row as isize);
+                                }
+                            }
+                            let fresh172 = &mut *((*this).value.undef).offset(elem as isize);
+                            *fresh172 = (pNull[0] as c_int != 0
+                                || pNull[1] as c_int != 0
+                                || pNull[2] as c_int != 0
+                                || pNull[3] as c_int != 0
+                                || pNull[4] as c_int != 0)
+                                as c_int as c_char;
+                            if *fresh172 == 0 {
+                                *((*this).value.data.logptr).offset(elem as isize) = circle(
+                                    pVals[0].data.dbl,
+                                    pVals[1].data.dbl,
+                                    pVals[2].data.dbl,
+                                    pVals[3].data.dbl,
+                                    pVals[4].data.dbl,
+                                );
+                            }
+                        }
+                    },
+                    1028 => loop {
+                        let fresh173 = row;
+                        row -= 1;
+                        if fresh173 == 0 {
+                            break;
+                        }
+                        nelem = (*this).value.nelem;
+                        loop {
+                            let fresh174 = nelem;
+                            nelem -= 1;
+                            if fresh174 == 0 {
+                                break;
+                            }
+                            elem -= 1;
+                            elem;
+                            i = 7 as c_int;
+                            loop {
+                                let fresh175 = i;
+                                i -= 1;
+                                if fresh175 == 0 {
+                                    break;
+                                }
+                                if vector[i as usize] > 1 {
+                                    pVals[i as usize].data.dbl =
+                                        *((*theParams[i as usize]).value.data.dblptr)
+                                            .offset(elem as isize);
+                                    pNull[i as usize] = *((*theParams[i as usize]).value.undef)
+                                        .offset(elem as isize);
+                                } else if vector[i as usize] != 0 {
+                                    pVals[i as usize].data.dbl =
+                                        *((*theParams[i as usize]).value.data.dblptr)
+                                            .offset(row as isize);
+                                    pNull[i as usize] = *((*theParams[i as usize]).value.undef)
+                                        .offset(row as isize);
+                                }
+                            }
+                            let fresh176 = &mut *((*this).value.undef).offset(elem as isize);
+                            *fresh176 = (pNull[0] as c_int != 0
+                                || pNull[1] as c_int != 0
+                                || pNull[2] as c_int != 0
+                                || pNull[3] as c_int != 0
+                                || pNull[4] as c_int != 0
+                                || pNull[5] as c_int != 0
+                                || pNull[6] as c_int != 0)
+                                as c_int as c_char;
+                            if *fresh176 == 0 {
+                                *((*this).value.data.logptr).offset(elem as isize) = saobox(
+                                    pVals[0].data.dbl,
+                                    pVals[1].data.dbl,
+                                    pVals[2].data.dbl,
+                                    pVals[3].data.dbl,
+                                    pVals[4].data.dbl,
+                                    pVals[5].data.dbl,
+                                    pVals[6].data.dbl,
+                                );
+                            }
+                        }
+                    },
+                    1029 => loop {
+                        let fresh177 = row;
+                        row -= 1;
+                        if fresh177 == 0 {
+                            break;
+                        }
+                        nelem = (*this).value.nelem;
+                        loop {
+                            let fresh178 = nelem;
+                            nelem -= 1;
+                            if fresh178 == 0 {
+                                break;
+                            }
+                            elem -= 1;
+                            elem;
+                            i = 7 as c_int;
+                            loop {
+                                let fresh179 = i;
+                                i -= 1;
+                                if fresh179 == 0 {
+                                    break;
+                                }
+                                if vector[i as usize] > 1 {
+                                    pVals[i as usize].data.dbl =
+                                        *((*theParams[i as usize]).value.data.dblptr)
+                                            .offset(elem as isize);
+                                    pNull[i as usize] = *((*theParams[i as usize]).value.undef)
+                                        .offset(elem as isize);
+                                } else if vector[i as usize] != 0 {
+                                    pVals[i as usize].data.dbl =
+                                        *((*theParams[i as usize]).value.data.dblptr)
+                                            .offset(row as isize);
+                                    pNull[i as usize] = *((*theParams[i as usize]).value.undef)
+                                        .offset(row as isize);
+                                }
+                            }
+                            let fresh180 = &mut *((*this).value.undef).offset(elem as isize);
+                            *fresh180 = (pNull[0] as c_int != 0
+                                || pNull[1] as c_int != 0
+                                || pNull[2] as c_int != 0
+                                || pNull[3] as c_int != 0
+                                || pNull[4] as c_int != 0
+                                || pNull[5] as c_int != 0
+                                || pNull[6] as c_int != 0)
+                                as c_int as c_char;
+                            if *fresh180 == 0 {
+                                *((*this).value.data.logptr).offset(elem as isize) = ellipse(
+                                    pVals[0].data.dbl,
+                                    pVals[1].data.dbl,
+                                    pVals[2].data.dbl,
+                                    pVals[3].data.dbl,
+                                    pVals[4].data.dbl,
+                                    pVals[5].data.dbl,
+                                    pVals[6].data.dbl,
+                                );
+                            }
+                        }
+                    },
+                    1034 => match (*this).ntype {
+                        258 => loop {
+                            let fresh181 = row;
+                            row -= 1;
+                            if fresh181 == 0 {
+                                break;
+                            }
+                            nelem = (*this).value.nelem;
+                            loop {
+                                let fresh182 = nelem;
+                                nelem -= 1;
+                                if fresh182 == 0 {
+                                    break;
+                                }
+                                elem -= 1;
+                                elem;
+                                if vector[2] > 1 {
+                                    pVals[2].data.log =
+                                        *((*theParams[2]).value.data.logptr).offset(elem as isize);
+                                    pNull[2] = *((*theParams[2]).value.undef).offset(elem as isize);
+                                } else if vector[2] != 0 {
+                                    pVals[2].data.log =
+                                        *((*theParams[2]).value.data.logptr).offset(row as isize);
+                                    pNull[2] = *((*theParams[2]).value.undef).offset(row as isize);
+                                }
+                                i = 2 as c_int;
+                                loop {
+                                    let fresh183 = i;
+                                    i -= 1;
+                                    if fresh183 == 0 {
+                                        break;
+                                    }
+                                    if vector[i as usize] > 1 {
+                                        pVals[i as usize].data.log =
+                                            *((*theParams[i as usize]).value.data.logptr)
+                                                .offset(elem as isize);
+                                        pNull[i as usize] = *((*theParams[i as usize]).value.undef)
+                                            .offset(elem as isize);
+                                    } else if vector[i as usize] != 0 {
+                                        pVals[i as usize].data.log =
+                                            *((*theParams[i as usize]).value.data.logptr)
+                                                .offset(row as isize);
+                                        pNull[i as usize] = *((*theParams[i as usize]).value.undef)
+                                            .offset(row as isize);
+                                    }
+                                }
+                                let fresh184 = &mut *((*this).value.undef).offset(elem as isize);
+                                *fresh184 = pNull[2];
+                                if *fresh184 == 0 {
+                                    if pVals[2].data.log != 0 {
+                                        *((*this).value.data.logptr).offset(elem as isize) =
+                                            pVals[0].data.log;
+                                        *((*this).value.undef).offset(elem as isize) = pNull[0];
+                                    } else {
+                                        *((*this).value.data.logptr).offset(elem as isize) =
+                                            pVals[1].data.log;
+                                        *((*this).value.undef).offset(elem as isize) = pNull[1];
+                                    }
+                                }
+                            }
+                        },
+                        259 => loop {
+                            let fresh185 = row;
+                            row -= 1;
+                            if fresh185 == 0 {
+                                break;
+                            }
+                            nelem = (*this).value.nelem;
+                            loop {
+                                let fresh186 = nelem;
+                                nelem -= 1;
+                                if fresh186 == 0 {
+                                    break;
+                                }
+                                elem -= 1;
+                                elem;
+                                if vector[2] > 1 {
+                                    pVals[2].data.log =
+                                        *((*theParams[2]).value.data.logptr).offset(elem as isize);
+                                    pNull[2] = *((*theParams[2]).value.undef).offset(elem as isize);
+                                } else if vector[2] != 0 {
+                                    pVals[2].data.log =
+                                        *((*theParams[2]).value.data.logptr).offset(row as isize);
+                                    pNull[2] = *((*theParams[2]).value.undef).offset(row as isize);
+                                }
+                                i = 2 as c_int;
+                                loop {
+                                    let fresh187 = i;
+                                    i -= 1;
+                                    if fresh187 == 0 {
+                                        break;
+                                    }
+                                    if vector[i as usize] > 1 {
+                                        pVals[i as usize].data.lng =
+                                            *((*theParams[i as usize]).value.data.lngptr)
+                                                .offset(elem as isize);
+                                        pNull[i as usize] = *((*theParams[i as usize]).value.undef)
+                                            .offset(elem as isize);
+                                    } else if vector[i as usize] != 0 {
+                                        pVals[i as usize].data.lng =
+                                            *((*theParams[i as usize]).value.data.lngptr)
+                                                .offset(row as isize);
+                                        pNull[i as usize] = *((*theParams[i as usize]).value.undef)
+                                            .offset(row as isize);
+                                    }
+                                }
+                                let fresh188 = &mut *((*this).value.undef).offset(elem as isize);
+                                *fresh188 = pNull[2];
+                                if *fresh188 == 0 {
+                                    if pVals[2].data.log != 0 {
+                                        *((*this).value.data.lngptr).offset(elem as isize) =
+                                            pVals[0].data.lng;
+                                        *((*this).value.undef).offset(elem as isize) = pNull[0];
+                                    } else {
+                                        *((*this).value.data.lngptr).offset(elem as isize) =
+                                            pVals[1].data.lng;
+                                        *((*this).value.undef).offset(elem as isize) = pNull[1];
+                                    }
+                                }
+                            }
+                        },
+                        260 => loop {
+                            let fresh189 = row;
+                            row -= 1;
+                            if fresh189 == 0 {
+                                break;
+                            }
+                            nelem = (*this).value.nelem;
+                            loop {
+                                let fresh190 = nelem;
+                                nelem -= 1;
+                                if fresh190 == 0 {
+                                    break;
+                                }
+                                elem -= 1;
+                                elem;
+                                if vector[2] > 1 {
+                                    pVals[2].data.log =
+                                        *((*theParams[2]).value.data.logptr).offset(elem as isize);
+                                    pNull[2] = *((*theParams[2]).value.undef).offset(elem as isize);
+                                } else if vector[2] != 0 {
+                                    pVals[2].data.log =
+                                        *((*theParams[2]).value.data.logptr).offset(row as isize);
+                                    pNull[2] = *((*theParams[2]).value.undef).offset(row as isize);
+                                }
+                                i = 2 as c_int;
+                                loop {
+                                    let fresh191 = i;
+                                    i -= 1;
+                                    if fresh191 == 0 {
+                                        break;
+                                    }
+                                    if vector[i as usize] > 1 {
+                                        pVals[i as usize].data.dbl =
+                                            *((*theParams[i as usize]).value.data.dblptr)
+                                                .offset(elem as isize);
+                                        pNull[i as usize] = *((*theParams[i as usize]).value.undef)
+                                            .offset(elem as isize);
+                                    } else if vector[i as usize] != 0 {
+                                        pVals[i as usize].data.dbl =
+                                            *((*theParams[i as usize]).value.data.dblptr)
+                                                .offset(row as isize);
+                                        pNull[i as usize] = *((*theParams[i as usize]).value.undef)
+                                            .offset(row as isize);
+                                    }
+                                }
+                                let fresh192 = &mut *((*this).value.undef).offset(elem as isize);
+                                *fresh192 = pNull[2];
+                                if *fresh192 == 0 {
+                                    if pVals[2].data.log != 0 {
+                                        *((*this).value.data.dblptr).offset(elem as isize) =
+                                            pVals[0].data.dbl;
+                                        *((*this).value.undef).offset(elem as isize) = pNull[0];
+                                    } else {
+                                        *((*this).value.data.dblptr).offset(elem as isize) =
+                                            pVals[1].data.dbl;
+                                        *((*this).value.undef).offset(elem as isize) = pNull[1];
+                                    }
+                                }
+                            }
+                        },
+                        261 => loop {
+                            let fresh193 = row;
+                            row -= 1;
+                            if fresh193 == 0 {
+                                break;
+                            }
+                            if vector[2] != 0 {
+                                pVals[2].data.log =
+                                    *((*theParams[2]).value.data.logptr).offset(row as isize);
+                                pNull[2] = *((*theParams[2]).value.undef).offset(row as isize);
+                            }
+                            i = 2 as c_int;
+                            loop {
+                                let fresh194 = i;
+                                i -= 1;
+                                if fresh194 == 0 {
+                                    break;
+                                }
+                                if vector[i as usize] != 0 {
+                                    strcpy(
+                                        (pVals[i as usize].data.astr).as_mut_ptr(),
+                                        *((*theParams[i as usize]).value.data.strptr)
+                                            .offset(row as isize),
+                                    );
+                                    pNull[i as usize] = *((*theParams[i as usize]).value.undef)
+                                        .offset(row as isize);
+                                }
+                            }
+                            let fresh195 = &mut *((*this).value.undef).offset(row as isize);
+                            *fresh195 = pNull[2];
+                            if *fresh195 == 0 {
+                                if pVals[2].data.log != 0 {
+                                    strcpy(
+                                        *((*this).value.data.strptr).offset(row as isize),
+                                        (pVals[0].data.astr).as_mut_ptr(),
+                                    );
+                                    *((*this).value.undef).offset(row as isize) = pNull[0];
+                                } else {
+                                    strcpy(
+                                        *((*this).value.data.strptr).offset(row as isize),
+                                        (pVals[1].data.astr).as_mut_ptr(),
+                                    );
+                                    *((*this).value.undef).offset(row as isize) = pNull[1];
+                                }
+                            } else {
+                                *(*((*this).value.data.strptr).offset(row as isize)).offset(0) = 0;
+                            }
+                        },
+                        _ => {}
+                    },
+                    1044 => {
+                        let mut strconst: c_int =
+                            ((*theParams[0]).operation == -(1000 as c_int)) as c_int;
+                        let mut posconst: c_int =
+                            ((*theParams[1]).operation == -(1000 as c_int)) as c_int;
+                        let mut lenconst: c_int =
+                            ((*theParams[2]).operation == -(1000 as c_int)) as c_int;
+                        let mut dest_len: c_int = (*this).value.nelem as c_int;
+                        let mut src_len: c_int = (*theParams[0]).value.nelem as c_int;
+                        loop {
+                            let fresh196 = row;
+                            row -= 1;
+                            if fresh196 == 0 {
+                                break;
+                            }
+                            let mut pos: c_int = 0;
+                            let mut len: c_int = 0;
+                            let mut str: *mut c_char = ptr::null_mut();
+                            let mut undef: c_int = 0;
+                            if posconst != 0 {
+                                pos = (*theParams[1]).value.data.lng as c_int;
+                            } else {
+                                pos = *((*theParams[1]).value.data.lngptr).offset(row as isize)
+                                    as c_int;
+                                if *((*theParams[1]).value.undef).offset(row as isize) != 0 {
+                                    undef = 1;
+                                }
+                            }
+                            if strconst != 0 {
+                                str = ((*theParams[0]).value.data.astr).as_mut_ptr();
+                                if src_len == 0 {
+                                    src_len = strlen(str) as c_int;
+                                }
+                            } else {
+                                str = *((*theParams[0]).value.data.strptr).offset(row as isize);
+                                if *((*theParams[0]).value.undef).offset(row as isize) != 0 {
+                                    undef = 1;
+                                }
+                            }
+                            if lenconst != 0 {
+                                len = dest_len;
+                            } else {
+                                len = *((*theParams[2]).value.data.lngptr).offset(row as isize)
+                                    as c_int;
+                                if *((*theParams[2]).value.undef).offset(row as isize) != 0 {
+                                    undef = 1;
+                                }
+                            }
+                            *(*((*this).value.data.strptr).offset(row as isize)).offset(0) = 0;
+                            if pos == 0 {
+                                undef = 1;
+                            }
+                            if undef == 0
+                                && cstrmid(
+                                    lParse,
+                                    *((*this).value.data.strptr).offset(row as isize),
+                                    len,
+                                    str,
+                                    src_len,
+                                    pos,
+                                ) < 0
+                            {
+                                break;
+                            }
+                            *((*this).value.undef).offset(row as isize) = undef as c_char;
+                        }
+                    }
+                    1045 => {
+                        let mut const1: c_int =
+                            ((*theParams[0]).operation == -(1000 as c_int)) as c_int;
+                        let mut const2: c_int =
+                            ((*theParams[1]).operation == -(1000 as c_int)) as c_int;
+                        loop {
+                            let fresh197 = row;
+                            row -= 1;
+                            if fresh197 == 0 {
+                                break;
+                            }
+                            let mut str1: *mut c_char = ptr::null_mut();
+                            let mut str2: *mut c_char = ptr::null_mut();
+                            let mut undef_0: c_int = 0;
+                            if const1 != 0 {
+                                str1 = ((*theParams[0]).value.data.astr).as_mut_ptr();
+                            } else {
+                                str1 = *((*theParams[0]).value.data.strptr).offset(row as isize);
+                                if *((*theParams[0]).value.undef).offset(row as isize) != 0 {
+                                    undef_0 = 1;
+                                }
+                            }
+                            if const2 != 0 {
+                                str2 = ((*theParams[1]).value.data.astr).as_mut_ptr();
+                            } else {
+                                str2 = *((*theParams[1]).value.data.strptr).offset(row as isize);
+                                if *((*theParams[1]).value.undef).offset(row as isize) != 0 {
+                                    undef_0 = 1;
+                                }
+                            }
+                            *((*this).value.data.lngptr).offset(row as isize) = 0;
+                            if undef_0 == 0 {
+                                let mut res_0: *mut c_char = strstr(str1, str2);
+                                if res_0.is_null() {
+                                    undef_0 = 1;
+                                    *((*this).value.data.lngptr).offset(row as isize) = 0;
+                                } else {
+                                    *((*this).value.data.lngptr).offset(row as isize) =
+                                        res_0.offset_from(str1) as c_long + 1;
+                                }
+                            }
+                            *((*this).value.undef).offset(row as isize) = undef_0 as c_char;
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        }
+        i = (*this).nSubNodes;
+        loop {
+            let fresh198 = i;
+            i -= 1;
+            if fresh198 == 0 {
+                break;
+            }
+            if (*theParams[i as usize]).operation > 0 {
+                free((*theParams[i as usize]).value.data.ptr);
+            }
+        }
+    }
+}
+unsafe fn Do_Deref(mut lParse: *mut ParseData, mut this: *mut Node) {
+    unsafe {
+        let mut theVar: *mut Node = std::ptr::null_mut::<Node>();
+        let mut theDims: [*mut Node; 5] = [std::ptr::null_mut::<Node>(); 5];
+        let mut isConst: [c_int; 5] = [0; 5];
+        let mut allConst: c_int = 0;
+        let mut dimVals: [c_long; 5] = [0; 5];
+        let mut i: c_int = 0;
+        let mut nDims: c_int = 0;
+        let mut row: c_long = 0;
+        let mut elem: c_long = 0;
+        let mut dsize: c_long = 0;
+        theVar = ((*lParse).Nodes).offset((*this).SubNodes[0] as isize);
+        nDims = (*this).nSubNodes - 1;
+        i = nDims;
+        allConst = 1;
+        loop {
+            let fresh199 = i;
+            i -= 1;
+            if fresh199 == 0 {
+                break;
+            }
+            theDims[i as usize] =
+                ((*lParse).Nodes).offset((*this).SubNodes[(i + 1) as usize] as isize);
+            isConst[i as usize] = ((*theDims[i as usize]).operation == -(1000 as c_int)) as c_int;
+            if isConst[i as usize] != 0 {
+                dimVals[i as usize] = (*theDims[i as usize]).value.data.lng;
+            } else {
+                allConst = 0;
+            }
+        }
+        if (*this).ntype == fits_parser_yytokentype::DOUBLE as c_int {
+            dsize = ::core::mem::size_of::<c_double>() as c_ulong as c_long;
+        } else if (*this).ntype == fits_parser_yytokentype::LONG as c_int {
+            dsize = ::core::mem::size_of::<c_long>() as c_ulong as c_long;
+        } else if (*this).ntype == fits_parser_yytokentype::BOOLEAN as c_int {
+            dsize = ::core::mem::size_of::<c_char>() as c_ulong as c_long;
+        } else {
+            dsize = 0;
+        }
+        Allocate_Ptrs(lParse, this);
+        if (*lParse).status == 0 {
+            if allConst != 0 && (*theVar).value.naxis == nDims {
+                elem = 0;
+                i = nDims;
+                loop {
+                    let fresh200 = i;
+                    i -= 1;
+                    if fresh200 == 0 {
+                        break;
+                    }
+                    if dimVals[i as usize] < 1
+                        || dimVals[i as usize] > (*theVar).value.naxes[i as usize]
+                    {
+                        break;
+                    }
+                    elem = (*theVar).value.naxes[i as usize] * elem + dimVals[i as usize] - 1;
+                }
+                if i < 0 {
+                    row = 0;
+                    while row < (*lParse).nRows {
+                        if (*this).ntype == fits_parser_yytokentype::STRING as c_int {
+                            *((*this).value.undef).offset(row as isize) =
+                                *((*theVar).value.undef).offset(row as isize);
+                        } else if (*this).ntype != fits_parser_yytokentype::BITSTR as c_int {
+                            *((*this).value.undef).offset(row as isize) =
+                                *((*theVar).value.undef).offset(elem as isize);
+                        }
+                        if (*this).ntype == fits_parser_yytokentype::DOUBLE as c_int {
+                            *((*this).value.data.dblptr).offset(row as isize) =
+                                *((*theVar).value.data.dblptr).offset(elem as isize);
+                        } else if (*this).ntype == fits_parser_yytokentype::LONG as c_int {
+                            *((*this).value.data.lngptr).offset(row as isize) =
+                                *((*theVar).value.data.lngptr).offset(elem as isize);
+                        } else if (*this).ntype == fits_parser_yytokentype::BOOLEAN as c_int {
+                            *((*this).value.data.logptr).offset(row as isize) =
+                                *((*theVar).value.data.logptr).offset(elem as isize);
+                        } else {
+                            *(*((*this).value.data.strptr).offset(row as isize)).offset(0) =
+                                *(*((*theVar).value.data.strptr).offset(0))
+                                    .offset((elem + row) as isize);
+                            *(*((*this).value.data.strptr).offset(row as isize))
+                                .offset(1 as c_int as isize) = 0;
+                        }
+                        elem += (*theVar).value.nelem;
+                        row += 1;
+                        row;
+                    }
+                } else {
+                    fits_parser_yyerror(
+                        0 as yyscan_t,
+                        lParse,
+                        b"Index out of range\0" as *const u8 as *const c_char as *mut c_char,
+                    );
+                    free((*this).value.data.ptr);
+                }
+            } else if allConst != 0 && nDims == 1 {
+                if dimVals[0] < 1
+                    || dimVals[0] > (*theVar).value.naxes[((*theVar).value.naxis - 1) as usize]
+                {
+                    fits_parser_yyerror(
+                        0 as yyscan_t,
+                        lParse,
+                        b"Index out of range\0" as *const u8 as *const c_char as *mut c_char,
+                    );
+                    free((*this).value.data.ptr);
+                } else if (*this).ntype == fits_parser_yytokentype::BITSTR as c_int
+                    || (*this).ntype == fits_parser_yytokentype::STRING as c_int
+                {
+                    elem = (*this).value.nelem * (dimVals[0] - 1);
+                    row = 0;
+                    while row < (*lParse).nRows {
+                        if !((*this).value.undef).is_null() {
+                            *((*this).value.undef).offset(row as isize) =
+                                *((*theVar).value.undef).offset(row as isize);
+                        }
+                        memcpy(
+                            (*((*this).value.data.strptr).offset(0)).offset(
+                                (row as c_ulong)
+                                    .wrapping_mul(::core::mem::size_of::<c_char>() as c_ulong)
+                                    .wrapping_mul(((*this).value.nelem + 1) as c_ulong)
+                                    as isize,
+                            ) as *mut c_void,
+                            (*((*theVar).value.data.strptr).offset(0)).offset(
+                                (elem as c_ulong)
+                                    .wrapping_mul(::core::mem::size_of::<c_char>() as c_ulong)
+                                    as isize,
+                            ) as *const c_void,
+                            ((*this).value.nelem as c_ulong)
+                                .wrapping_mul(::core::mem::size_of::<c_char>() as c_ulong)
+                                .try_into()
+                                .unwrap(),
+                        );
+                        *(*((*this).value.data.strptr).offset(row as isize))
+                            .offset((*this).value.nelem as isize) = 0;
+                        elem += (*theVar).value.nelem + 1;
+                        row += 1;
+                        row;
+                    }
+                } else {
+                    elem = (*this).value.nelem * (dimVals[0] - 1);
+                    row = 0;
+                    while row < (*lParse).nRows {
+                        memcpy(
+                            ((*this).value.undef).offset((row * (*this).value.nelem) as isize)
+                                as *mut c_void,
+                            ((*theVar).value.undef).offset(elem as isize) as *const c_void,
+                            ((*this).value.nelem as c_ulong)
+                                .wrapping_mul(::core::mem::size_of::<c_char>() as c_ulong)
+                                .try_into()
+                                .unwrap(),
+                        );
+                        memcpy(
+                            ((*this).value.data.ptr as *mut c_char)
+                                .offset((row * dsize * (*this).value.nelem) as isize)
+                                as *mut c_void,
+                            ((*theVar).value.data.ptr as *mut c_char)
+                                .offset((elem * dsize) as isize)
+                                as *const c_void,
+                            (((*this).value.nelem * dsize) as c_ulong)
+                                .try_into()
+                                .unwrap(),
+                        );
+                        elem += (*theVar).value.nelem;
+                        row += 1;
+                        row;
+                    }
+                }
+            } else if (*theVar).value.naxis == nDims {
+                row = 0;
+                while row < (*lParse).nRows {
+                    i = 0;
+                    while i < nDims {
+                        if isConst[i as usize] == 0 {
+                            if *((*theDims[i as usize]).value.undef).offset(row as isize) != 0 {
+                                fits_parser_yyerror(
+                                    0 as yyscan_t,
+                                    lParse,
+                                    b"Null encountered as vector index\0" as *const u8
+                                        as *const c_char
+                                        as *mut c_char,
+                                );
+                                free((*this).value.data.ptr);
+                                break;
+                            } else {
+                                dimVals[i as usize] = *((*theDims[i as usize]).value.data.lngptr)
+                                    .offset(row as isize);
+                            }
+                        }
+                        i += 1;
+                        i;
+                    }
+                    if (*lParse).status != 0 {
+                        break;
+                    }
+                    elem = 0;
+                    i = nDims;
+                    loop {
+                        let fresh201 = i;
+                        i -= 1;
+                        if fresh201 == 0 {
+                            break;
+                        }
+                        if dimVals[i as usize] < 1
+                            || dimVals[i as usize] > (*theVar).value.naxes[i as usize]
+                        {
+                            break;
+                        }
+                        elem = (*theVar).value.naxes[i as usize] * elem + dimVals[i as usize] - 1;
+                    }
+                    if i < 0 {
+                        elem += row * (*theVar).value.nelem;
+                        if (*this).ntype == fits_parser_yytokentype::STRING as c_int {
+                            *((*this).value.undef).offset(row as isize) =
+                                *((*theVar).value.undef).offset(row as isize);
+                        } else if (*this).ntype != fits_parser_yytokentype::BITSTR as c_int {
+                            *((*this).value.undef).offset(row as isize) =
+                                *((*theVar).value.undef).offset(elem as isize);
+                        }
+                        if (*this).ntype == fits_parser_yytokentype::DOUBLE as c_int {
+                            *((*this).value.data.dblptr).offset(row as isize) =
+                                *((*theVar).value.data.dblptr).offset(elem as isize);
+                        } else if (*this).ntype == fits_parser_yytokentype::LONG as c_int {
+                            *((*this).value.data.lngptr).offset(row as isize) =
+                                *((*theVar).value.data.lngptr).offset(elem as isize);
+                        } else if (*this).ntype == fits_parser_yytokentype::BOOLEAN as c_int {
+                            *((*this).value.data.logptr).offset(row as isize) =
+                                *((*theVar).value.data.logptr).offset(elem as isize);
+                        } else {
+                            *(*((*this).value.data.strptr).offset(row as isize)).offset(0) =
+                                *(*((*theVar).value.data.strptr).offset(0))
+                                    .offset((elem + row) as isize);
+                            *(*((*this).value.data.strptr).offset(row as isize))
+                                .offset(1 as c_int as isize) = 0;
+                        }
+                    } else {
+                        fits_parser_yyerror(
+                            0 as yyscan_t,
+                            lParse,
+                            b"Index out of range\0" as *const u8 as *const c_char as *mut c_char,
+                        );
+                        free((*this).value.data.ptr);
+                    }
+                    row += 1;
+                    row;
+                }
+            } else {
+                row = 0;
+                while row < (*lParse).nRows {
+                    if *((*theDims[0]).value.undef).offset(row as isize) != 0 {
+                        fits_parser_yyerror(
+                            0 as yyscan_t,
+                            lParse,
+                            b"Null encountered as vector index\0" as *const u8 as *const c_char
+                                as *mut c_char,
+                        );
+                        free((*this).value.data.ptr);
+                        break;
+                    } else {
+                        dimVals[0] = *((*theDims[0]).value.data.lngptr).offset(row as isize);
+                        if dimVals[0] < 1
+                            || dimVals[0]
+                                > (*theVar).value.naxes[((*theVar).value.naxis - 1) as usize]
+                        {
+                            fits_parser_yyerror(
+                                0 as yyscan_t,
+                                lParse,
+                                b"Index out of range\0" as *const u8 as *const c_char
+                                    as *mut c_char,
+                            );
+                            free((*this).value.data.ptr);
+                        } else if (*this).ntype == fits_parser_yytokentype::BITSTR as c_int
+                            || (*this).ntype == fits_parser_yytokentype::STRING as c_int
+                        {
+                            elem = (*this).value.nelem * (dimVals[0] - 1);
+                            elem += row * ((*theVar).value.nelem + 1);
+                            if !((*this).value.undef).is_null() {
+                                *((*this).value.undef).offset(row as isize) =
+                                    *((*theVar).value.undef).offset(row as isize);
+                            }
+                            memcpy(
+                                (*((*this).value.data.strptr).offset(0)).offset(
+                                    (row as c_ulong)
+                                        .wrapping_mul(::core::mem::size_of::<c_char>() as c_ulong)
+                                        .wrapping_mul(((*this).value.nelem + 1) as c_ulong)
+                                        as isize,
+                                ) as *mut c_void,
+                                (*((*theVar).value.data.strptr).offset(0)).offset(
+                                    (elem as c_ulong)
+                                        .wrapping_mul(::core::mem::size_of::<c_char>() as c_ulong)
+                                        as isize,
+                                ) as *const c_void,
+                                ((*this).value.nelem as c_ulong)
+                                    .wrapping_mul(::core::mem::size_of::<c_char>() as c_ulong)
+                                    .try_into()
+                                    .unwrap(),
+                            );
+                            *(*((*this).value.data.strptr).offset(row as isize))
+                                .offset((*this).value.nelem as isize) = 0;
+                        } else {
+                            elem = (*this).value.nelem * (dimVals[0] - 1);
+                            elem += row * (*theVar).value.nelem;
+                            memcpy(
+                                ((*this).value.undef).offset((row * (*this).value.nelem) as isize)
+                                    as *mut c_void,
+                                ((*theVar).value.undef).offset(elem as isize) as *const c_void,
+                                ((*this).value.nelem as c_ulong)
+                                    .wrapping_mul(::core::mem::size_of::<c_char>() as c_ulong)
+                                    .try_into()
+                                    .unwrap(),
+                            );
+                            memcpy(
+                                ((*this).value.data.ptr as *mut c_char)
+                                    .offset((row * dsize * (*this).value.nelem) as isize)
+                                    as *mut c_void,
+                                ((*theVar).value.data.ptr as *mut c_char)
+                                    .offset((elem * dsize) as isize)
+                                    as *const c_void,
+                                (((*this).value.nelem * dsize) as c_ulong)
+                                    .try_into()
+                                    .unwrap(),
+                            );
+                        }
+                        row += 1;
+                        row;
+                    }
+                }
+            }
+        }
+        if (*theVar).operation > 0 {
+            if (*theVar).ntype == fits_parser_yytokentype::STRING as c_int
+                || (*theVar).ntype == fits_parser_yytokentype::BITSTR as c_int
+            {
+                free(*((*theVar).value.data.strptr).offset(0) as *mut c_void);
+            } else {
+                free((*theVar).value.data.ptr);
+            }
+        }
+        i = 0;
+        while i < nDims {
+            if (*theDims[i as usize]).operation > 0 {
+                free((*theDims[i as usize]).value.data.ptr);
+            }
+            i += 1;
+            i;
+        }
+    }
+}
+unsafe fn Do_GTI(mut lParse: *mut ParseData, mut this: *mut Node) {
+    unsafe {
+        let mut theExpr: *mut Node = std::ptr::null_mut::<Node>();
+        let mut theTimes: *mut Node = std::ptr::null_mut::<Node>();
+        let mut start: *mut c_double = std::ptr::null_mut::<c_double>();
+        let mut stop: *mut c_double = std::ptr::null_mut::<c_double>();
+        let mut times: *mut c_double = std::ptr::null_mut::<c_double>();
+        let mut elem: c_long = 0;
+        let mut nGTI: c_long = 0;
+        let mut gti: c_long = 0;
+        let mut ordered: c_int = 0;
+        let mut dorow: c_int = ((*this).operation == gtifind_fct as c_int) as c_int;
+        theTimes = ((*lParse).Nodes).offset((*this).SubNodes[0] as isize);
+        theExpr = ((*lParse).Nodes).offset((*this).SubNodes[1] as isize);
+        nGTI = (*theTimes).value.nelem;
+        start = (*theTimes).value.data.dblptr;
+        stop = ((*theTimes).value.data.dblptr).offset(nGTI as isize);
+        ordered = (*theTimes).ntype;
+        if (*theExpr).operation == -(1000 as c_int) {
+            gti = Search_GTI(
+                (*theExpr).value.data.dbl,
+                nGTI,
+                start,
+                stop,
+                ordered,
+                std::ptr::null_mut::<c_long>(),
+            );
+            if dorow != 0 {
+                (*this).value.data.lng = if gti >= 0 { gti + 1 } else { -(1) as c_long };
+            } else {
+                (*this).value.data.log = if gti >= 0 { 1 } else { 0 };
+            }
+            (*this).operation = -(1000 as c_int);
+        } else {
+            Allocate_Ptrs(lParse, this);
+            times = (*theExpr).value.data.dblptr;
+            if (*lParse).status == 0 {
+                elem = (*lParse).nRows * (*this).value.nelem;
+                if nGTI != 0 {
+                    gti = -(1) as c_long;
+                    loop {
+                        let fresh202 = elem;
+                        elem -= 1;
+                        if fresh202 == 0 {
+                            break;
+                        }
+                        let fresh203 = &mut *((*this).value.undef).offset(elem as isize);
+                        *fresh203 = *((*theExpr).value.undef).offset(elem as isize);
+                        if *fresh203 != 0 {
+                            continue;
+                        }
+                        if gti < 0
+                            || *times.offset(elem as isize) < *start.offset(gti as isize)
+                            || *times.offset(elem as isize) > *stop.offset(gti as isize)
+                        {
+                            gti = Search_GTI(
+                                *times.offset(elem as isize),
+                                nGTI,
+                                start,
+                                stop,
+                                ordered,
+                                std::ptr::null_mut::<c_long>(),
+                            );
+                        }
+                        if dorow != 0 {
+                            *((*this).value.data.lngptr).offset(elem as isize) =
+                                if gti >= 0 { gti + 1 } else { -(1) as c_long };
+                            *((*this).value.undef).offset(elem as isize) =
+                                (if gti >= 0 { 0 } else { 1 }) as c_char;
+                        } else {
+                            *((*this).value.data.logptr).offset(elem as isize) =
+                                if gti >= 0 { 1 } else { 0 };
+                        }
+                    }
+                } else if dorow != 0 {
+                    loop {
+                        let fresh204 = elem;
+                        elem -= 1;
+                        if fresh204 == 0 {
+                            break;
+                        }
+                        *((*this).value.undef).offset(elem as isize) = 1;
+                    }
+                } else {
+                    loop {
+                        let fresh205 = elem;
+                        elem -= 1;
+                        if fresh205 == 0 {
+                            break;
+                        }
+                        *((*this).value.data.logptr).offset(elem as isize) = 0;
+                        *((*this).value.undef).offset(elem as isize) = 0;
+                    }
+                }
+            }
+        }
+        if (*theExpr).operation > 0 {
+            free((*theExpr).value.data.ptr);
+        }
+    }
+}
+unsafe fn Do_GTI_Over(mut lParse: *mut ParseData, mut this: *mut Node) {
+    unsafe {
+        let mut theTimes: *mut Node = std::ptr::null_mut::<Node>();
+        let mut theStart: *mut Node = std::ptr::null_mut::<Node>();
+        let mut theStop: *mut Node = std::ptr::null_mut::<Node>();
+        let mut gtiStart: *mut c_double = std::ptr::null_mut::<c_double>();
+        let mut gtiStop: *mut c_double = std::ptr::null_mut::<c_double>();
+        let mut evtStart: *mut c_double = std::ptr::null_mut::<c_double>();
+        let mut evtStop: *mut c_double = std::ptr::null_mut::<c_double>();
+        let mut elem: c_long = 0;
+        let mut nGTI: c_long = 0;
+        let mut gti: c_long = 0;
+        let mut nextGTI: c_long = 0;
+        let mut ordered: c_int = 0;
+        theTimes = ((*lParse).Nodes).offset((*this).SubNodes[0] as isize);
+        theStop = ((*lParse).Nodes).offset((*this).SubNodes[2] as isize);
+        theStart = ((*lParse).Nodes).offset((*this).SubNodes[1] as isize);
+        nGTI = (*theTimes).value.nelem;
+        gtiStart = (*theTimes).value.data.dblptr;
+        gtiStop = ((*theTimes).value.data.dblptr).offset(nGTI as isize);
+        if (*theStart).operation == -(1000 as c_int) && (*theStop).operation == -(1000 as c_int) {
+            (*this).value.data.dbl = GTI_Over(
+                (*theStart).value.data.dbl,
+                (*theStop).value.data.dbl,
+                nGTI,
+                gtiStart,
+                gtiStop,
+                &mut gti,
+            );
+            (*this).operation = -(1000 as c_int);
+        } else {
+            let mut undefStart: c_char = 0;
+            let mut undefStop: c_char = 0;
+            let mut uStart: c_double = 0.;
+            let mut uStop: c_double = 0.;
+            if (*theStart).operation == -(1000 as c_int) {
+                uStart = (*theStart).value.data.dbl;
+            }
+            if (*theStop).operation == -(1000 as c_int) {
+                uStop = (*theStop).value.data.dbl;
+            }
+            Allocate_Ptrs(lParse, this);
+            evtStart = (*theStart).value.data.dblptr;
+            evtStop = (*theStop).value.data.dblptr;
+            if (*lParse).status == 0 {
+                elem = (*lParse).nRows * (*this).value.nelem;
+                if nGTI != 0 {
+                    let mut toverlap: c_double = 0.0f64;
+                    gti = -(1) as c_long;
+                    loop {
+                        let fresh206 = elem;
+                        elem -= 1;
+                        if fresh206 == 0 {
+                            break;
+                        }
+                        if (*theStart).operation != -(1000 as c_int) {
+                            undefStart = *((*theStart).value.undef).offset(elem as isize);
+                            uStart = *evtStart.offset(elem as isize);
+                        }
+                        if (*theStop).operation != -(1000 as c_int) {
+                            undefStop = *((*theStop).value.undef).offset(elem as isize);
+                            uStop = *evtStop.offset(elem as isize);
+                        }
+                        let fresh207 = &mut *((*this).value.undef).offset(elem as isize);
+                        *fresh207 = if undefStart as c_int != 0 || undefStop as c_int != 0 {
+                            1
+                        } else {
+                            0
+                        };
+                        if *fresh207 != 0 {
+                            continue;
+                        }
+                        if gti < 0
+                            || uStart < *gtiStart.offset(gti as isize)
+                            || uStart > *gtiStop.offset(gti as isize)
+                            || uStop < *gtiStart.offset(gti as isize)
+                            || uStop > *gtiStop.offset(gti as isize)
+                        {
+                            toverlap = GTI_Over(uStart, uStop, nGTI, gtiStart, gtiStop, &mut gti);
+                        } else {
+                            toverlap = uStop - uStart;
+                        }
+                        *((*this).value.data.dblptr).offset(elem as isize) = toverlap;
+                    }
+                } else {
+                    loop {
+                        let fresh208 = elem;
+                        elem -= 1;
+                        if fresh208 == 0 {
+                            break;
+                        }
+                        *((*this).value.data.dblptr).offset(elem as isize) = 0.0f64;
+                        *((*this).value.undef).offset(elem as isize) = 0;
+                    }
+                }
+            }
+        }
+        if (*theStart).operation > 0 {
+            free((*theStart).value.data.ptr);
+        }
+        if (*theStop).operation > 0 {
+            free((*theStop).value.data.ptr);
+        }
+    }
+}
+unsafe fn GTI_Over(
+    mut evtStart: c_double,
+    mut evtStop: c_double,
+    mut nGTI: c_long,
+    mut start: *mut c_double,
+    mut stop: *mut c_double,
+    mut gtiout: *mut c_long,
+) -> c_double {
+    unsafe {
+        let mut gti1: c_long = 0;
+        let mut gti2: c_long = 0;
+        let mut nextGTI1: c_long = 0;
+        let mut nextGTI2: c_long = 0;
+        let mut gti: c_long = 0;
+        let mut nMax: c_long = 0;
+        let mut overlap: c_double = 0.0f64;
+        *gtiout = -(1 as c_long);
+        if evtStop <= evtStart {
+            return 0.0f64;
+        }
+        gti1 = Search_GTI(evtStart, nGTI, start, stop, 1, &mut nextGTI1);
+        gti2 = Search_GTI(evtStop, nGTI, start, stop, 1, &mut nextGTI2);
+        if gti1 >= 0 {
+            *gtiout = gti1;
+        }
+        if nextGTI1 < 0 && nextGTI2 < 0 {
+            return 0.0f64;
+        }
+        if gti1 < 0 && gti2 < 0 && nextGTI1 == nextGTI2 {
+            return 0.0f64;
+        }
+        if gti1 >= 0 && gti1 == gti2 {
+            return evtStop - evtStart;
+        }
+        if nextGTI2 < 0 {
+            nMax = nGTI - 1;
+        } else if gti2 >= 0 {
+            nMax = nextGTI2;
+        } else {
+            nMax = nextGTI2 - 1;
+        }
+        gti = nextGTI1;
+        while gti <= nMax {
+            let mut starti: c_double = *start.offset(gti as isize);
+            let mut stopi: c_double = *stop.offset(gti as isize);
+            if evtStart > starti {
+                starti = evtStart;
+            }
+            if evtStop < stopi {
+                stopi = evtStop;
+            }
+            overlap += stopi - starti;
+            gti += 1;
+            gti;
+        }
+        overlap
+    }
+}
+unsafe fn Search_GTI(
+    mut evtTime: c_double,
+    mut nGTI: c_long,
+    mut start: *mut c_double,
+    mut stop: *mut c_double,
+    mut ordered: c_int,
+    mut nextGTI0: *mut c_long,
+) -> c_long {
+    unsafe {
+        let mut gti: c_long = 0;
+        let mut nextGTI: c_long = -(1 as c_long);
+        let mut step: c_long = 0;
+        if ordered != 0 && nGTI > 15 as c_long {
+            if evtTime >= *start.offset(0) && evtTime <= *stop.offset((nGTI - 1) as isize) {
+                step = nGTI >> 1;
+                gti = step;
+                loop {
+                    if step > 1 {
+                        step >>= 1;
+                    }
+                    if evtTime > *stop.offset(gti as isize) {
+                        if evtTime >= *start.offset((gti + 1) as isize) {
+                            gti += step;
+                        } else {
+                            nextGTI = gti + 1;
+                            gti = -(1 as c_long);
+                            break;
+                        }
+                    } else if evtTime < *start.offset(gti as isize) {
+                        if evtTime <= *stop.offset((gti - 1) as isize) {
+                            gti -= step;
+                        } else {
+                            nextGTI = gti;
+                            gti = -(1 as c_long);
+                            break;
+                        }
+                    } else {
+                        nextGTI = gti;
+                        break;
+                    }
+                }
+            } else {
+                if *start.offset(0) > evtTime {
+                    nextGTI = 0;
+                }
+                gti = -(1 as c_long);
+            }
+        } else {
+            gti = nGTI;
+            loop {
+                let fresh209 = gti;
+                gti -= 1;
+                if fresh209 == 0 {
+                    break;
+                }
+                if *stop.offset(gti as isize) >= evtTime {
+                    nextGTI = gti;
+                }
+                if evtTime >= *start.offset(gti as isize) && evtTime <= *stop.offset(gti as isize) {
+                    break;
+                }
+            }
+        }
+        if nextGTI >= nGTI {
+            nextGTI = -(1) as c_long;
+        }
+        if !nextGTI0.is_null() {
+            *nextGTI0 = nextGTI;
+        }
+        gti
+    }
+}
+unsafe fn Do_REG(mut lParse: *mut ParseData, mut this: *mut Node) {
+    unsafe {
+        let mut theRegion: *mut Node = std::ptr::null_mut::<Node>();
+        let mut theX: *mut Node = std::ptr::null_mut::<Node>();
+        let mut theY: *mut Node = std::ptr::null_mut::<Node>();
+        let mut Xval: c_double = 0.0f64;
+        let mut Yval: c_double = 0.0f64;
+        let mut Xnull: c_char = 0;
+        let mut Ynull: c_char = 0;
+        let mut Xvector: c_int = 0;
+        let mut Yvector: c_int = 0;
+        let mut nelem: c_long = 0;
+        let mut elem: c_long = 0;
+        let mut rows: c_long = 0;
+        theRegion = ((*lParse).Nodes).offset((*this).SubNodes[0] as isize);
+        theX = ((*lParse).Nodes).offset((*this).SubNodes[1] as isize);
+        theY = ((*lParse).Nodes).offset((*this).SubNodes[2] as isize);
+        Xvector = ((*theX).operation != -(1000 as c_int)) as c_int;
+        if Xvector != 0 {
+            Xvector = (*theX).value.nelem as c_int;
+        } else {
+            Xval = (*theX).value.data.dbl;
+        }
+        Yvector = ((*theY).operation != -(1000 as c_int)) as c_int;
+        if Yvector != 0 {
+            Yvector = (*theY).value.nelem as c_int;
+        } else {
+            Yval = (*theY).value.data.dbl;
+        }
+        if Xvector == 0 && Yvector == 0 {
+            (*this).value.data.log = if fits_in_region(
+                Xval,
+                Yval,
+                &mut *((*theRegion).value.data.ptr as *mut SAORegion),
+            ) != 0
+            {
+                1
+            } else {
+                0
+            };
+            (*this).operation = -(1000 as c_int);
+        } else {
+            Allocate_Ptrs(lParse, this);
+            if (*lParse).status == 0 {
+                rows = (*lParse).nRows;
+                nelem = (*this).value.nelem;
+                elem = rows * nelem;
+                loop {
+                    let fresh210 = rows;
+                    rows -= 1;
+                    if fresh210 == 0 {
+                        break;
+                    }
+                    loop {
+                        let fresh211 = nelem;
+                        nelem -= 1;
+                        if fresh211 == 0 {
+                            break;
+                        }
+                        elem -= 1;
+                        elem;
+                        if Xvector > 1 {
+                            Xval = *((*theX).value.data.dblptr).offset(elem as isize);
+                            Xnull = *((*theX).value.undef).offset(elem as isize);
+                        } else if Xvector != 0 {
+                            Xval = *((*theX).value.data.dblptr).offset(rows as isize);
+                            Xnull = *((*theX).value.undef).offset(rows as isize);
+                        }
+                        if Yvector > 1 {
+                            Yval = *((*theY).value.data.dblptr).offset(elem as isize);
+                            Ynull = *((*theY).value.undef).offset(elem as isize);
+                        } else if Yvector != 0 {
+                            Yval = *((*theY).value.data.dblptr).offset(rows as isize);
+                            Ynull = *((*theY).value.undef).offset(rows as isize);
+                        }
+                        *((*this).value.undef).offset(elem as isize) =
+                            if Xnull as c_int != 0 || Ynull as c_int != 0 {
+                                1
+                            } else {
+                                0
+                            };
+                        if *((*this).value.undef).offset(elem as isize) != 0 {
+                            continue;
+                        }
+                        *((*this).value.data.logptr).offset(elem as isize) = if fits_in_region(
+                            Xval,
+                            Yval,
+                            &mut *((*theRegion).value.data.ptr as *mut SAORegion),
+                        ) != 0
+                        {
+                            1
+                        } else {
+                            0
+                        };
+                    }
+                    nelem = (*this).value.nelem;
+                }
+            }
+        }
+        if (*theX).operation > 0 {
+            free((*theX).value.data.ptr);
+        }
+        if (*theY).operation > 0 {
+            free((*theY).value.data.ptr);
+        }
+    }
+}
+unsafe fn Do_Vector(mut lParse: *mut ParseData, mut this: *mut Node) {
+    unsafe {
+        let mut that: *mut Node = std::ptr::null_mut::<Node>();
+        let mut row: c_long = 0;
+        let mut elem: c_long = 0;
+        let mut idx: c_long = 0;
+        let mut jdx: c_long = 0;
+        let mut offset: c_long = 0;
+        let mut node: c_int = 0;
+        Allocate_Ptrs(lParse, this);
+        if (*lParse).status == 0 {
+            node = 0;
+            while node < (*this).nSubNodes {
+                that = ((*lParse).Nodes).offset((*this).SubNodes[node as usize] as isize);
+                if (*that).operation == -(1000 as c_int) {
+                    idx = (*lParse).nRows * (*this).value.nelem + offset;
+                    loop {
+                        idx -= (*this).value.nelem;
+                        if idx < 0 {
+                            break;
+                        }
+                        *((*this).value.undef).offset(idx as isize) = 0;
+                        match (*this).ntype {
+                            258 => {
+                                *((*this).value.data.logptr).offset(idx as isize) =
+                                    (*that).value.data.log;
+                            }
+                            259 => {
+                                *((*this).value.data.lngptr).offset(idx as isize) =
+                                    (*that).value.data.lng;
+                            }
+                            260 => {
+                                *((*this).value.data.dblptr).offset(idx as isize) =
+                                    (*that).value.data.dbl;
+                            }
+                            _ => {}
+                        }
+                    }
+                } else {
+                    row = (*lParse).nRows;
+                    idx = row * (*that).value.nelem;
+                    loop {
+                        let fresh212 = row;
+                        row -= 1;
+                        if fresh212 == 0 {
+                            break;
+                        }
+                        elem = (*that).value.nelem;
+                        jdx = row * (*this).value.nelem + offset;
+                        loop {
+                            let fresh213 = elem;
+                            elem -= 1;
+                            if fresh213 == 0 {
+                                break;
+                            }
+                            idx -= 1;
+                            *((*this).value.undef).offset((jdx + elem) as isize) =
+                                *((*that).value.undef).offset(idx as isize);
+                            match (*this).ntype {
+                                258 => {
+                                    *((*this).value.data.logptr).offset((jdx + elem) as isize) =
+                                        *((*that).value.data.logptr).offset(idx as isize);
+                                }
+                                259 => {
+                                    *((*this).value.data.lngptr).offset((jdx + elem) as isize) =
+                                        *((*that).value.data.lngptr).offset(idx as isize);
+                                }
+                                260 => {
+                                    *((*this).value.data.dblptr).offset((jdx + elem) as isize) =
+                                        *((*that).value.data.dblptr).offset(idx as isize);
+                                }
+                                _ => {}
+                            }
+                        }
+                    }
+                }
+                offset += (*that).value.nelem;
+                node += 1;
+                node;
+            }
+        }
+        node = 0;
+        while node < (*this).nSubNodes {
+            if (*((*lParse).Nodes).offset((*this).SubNodes[node as usize] as isize)).operation > 0 {
+                free(
+                    (*((*lParse).Nodes).offset((*this).SubNodes[node as usize] as isize))
+                        .value
+                        .data
+                        .ptr,
+                );
+            }
+            node += 1;
+            node;
+        }
+    }
+}
+
+unsafe fn Do_Array(mut lParse: *mut ParseData, mut this: *mut Node) {
+    unsafe {
+        let mut that: *mut Node = std::ptr::null_mut::<Node>();
+        let mut row: c_long = 0;
+        let mut elem: c_long = 0;
+        let mut idx: c_long = 0;
+        let mut jdx: c_long = 0;
+        let mut offset: c_long = 0;
+        let mut node: c_int = 0;
+        Allocate_Ptrs(lParse, this);
+        if (*lParse).status == 0 {
+            that = ((*lParse).Nodes).offset((*this).SubNodes[0] as isize);
+            if (*that).operation == -(1000 as c_int) {
+                idx = (*lParse).nRows * (*this).value.nelem + offset;
+                loop {
+                    let fresh214 = idx;
+                    idx -= 1;
+                    if fresh214 == 0 {
+                        break;
+                    }
+                    *((*this).value.undef).offset(idx as isize) = 0;
+                    match (*this).ntype {
+                        258 => {
+                            *((*this).value.data.logptr).offset(idx as isize) =
+                                (*that).value.data.log;
+                        }
+                        259 => {
+                            *((*this).value.data.lngptr).offset(idx as isize) =
+                                (*that).value.data.lng;
+                        }
+                        260 => {
+                            *((*this).value.data.dblptr).offset(idx as isize) =
+                                (*that).value.data.dbl;
+                        }
+                        _ => {}
+                    }
+                }
+            } else if (*that).value.nelem > 1 {
+                idx = (*lParse).nRows * (*this).value.nelem;
+                loop {
+                    let fresh215 = idx;
+                    idx -= 1;
+                    if fresh215 == 0 {
+                        break;
+                    }
+                    *((*this).value.undef).offset(idx as isize) =
+                        *((*that).value.undef).offset(idx as isize);
+                    match (*this).ntype {
+                        258 => {
+                            *((*this).value.data.logptr).offset(idx as isize) =
+                                *((*that).value.data.logptr).offset(idx as isize);
+                        }
+                        259 => {
+                            *((*this).value.data.lngptr).offset(idx as isize) =
+                                *((*that).value.data.lngptr).offset(idx as isize);
+                        }
+                        260 => {
+                            *((*this).value.data.dblptr).offset(idx as isize) =
+                                *((*that).value.data.dblptr).offset(idx as isize);
+                        }
+                        _ => {}
+                    }
+                }
+            } else {
+                row = (*lParse).nRows;
+                idx = row * (*this).value.nelem - 1;
+                loop {
+                    let fresh216 = row;
+                    row -= 1;
+                    if fresh216 == 0 {
+                        break;
+                    }
+                    elem = (*this).value.nelem;
+                    loop {
+                        let fresh217 = elem;
+                        elem -= 1;
+                        if fresh217 == 0 {
+                            break;
+                        }
+                        *((*this).value.undef).offset(idx as isize) =
+                            *((*that).value.undef).offset(row as isize);
+                        match (*this).ntype {
+                            258 => {
+                                *((*this).value.data.logptr).offset(idx as isize) =
+                                    *((*that).value.data.logptr).offset(row as isize);
+                            }
+                            259 => {
+                                *((*this).value.data.lngptr).offset(idx as isize) =
+                                    *((*that).value.data.lngptr).offset(row as isize);
+                            }
+                            260 => {
+                                *((*this).value.data.dblptr).offset(idx as isize) =
+                                    *((*that).value.data.dblptr).offset(row as isize);
+                            }
+                            _ => {}
+                        }
+                        idx -= 1;
+                        idx;
+                    }
+                }
+            }
+            if (*((*lParse).Nodes).offset((*this).SubNodes[0] as isize)).operation > 0 {
+                free(
+                    (*((*lParse).Nodes).offset((*this).SubNodes[0] as isize))
+                        .value
+                        .data
+                        .ptr,
+                );
+            }
+        }
+    }
+}
+
+unsafe fn bitlgte(mut bits1: *mut c_char, mut oper: c_int, mut bits2: *mut c_char) -> c_char {
+    unsafe {
+        let mut val1: c_int = 0;
+        let mut val2: c_int = 0;
+        let mut nextbit: c_int = 0;
+        let mut result: c_char = 0;
+        let mut i: c_int = 0;
+        let mut l1: c_int = 0;
+        let mut l2: c_int = 0;
+        let mut length: c_int = 0;
+        let mut ldiff: c_int = 0;
+        let mut stream: *mut c_char = ptr::null_mut();
+        let mut chr1: c_char = 0;
+        let mut chr2: c_char = 0;
+        l1 = strlen(bits1) as c_int;
+        l2 = strlen(bits2) as c_int;
+        length = if l1 > l2 { l1 } else { l2 };
+        stream = malloc(
+            (::core::mem::size_of::<c_char>() as c_ulong)
+                .wrapping_mul((length + 1) as c_ulong)
+                .try_into()
+                .unwrap(),
+        ) as *mut c_char;
+        if l1 < l2 {
+            ldiff = l2 - l1;
+            i = 0;
+            loop {
+                let fresh218 = ldiff;
+                ldiff -= 1;
+                if fresh218 == 0 {
+                    break;
+                }
+                let fresh219 = i;
+                i += 1;
+                *stream.offset(fresh219 as isize) = b'0' as c_char;
+            }
+            loop {
+                let fresh220 = l1;
+                l1 -= 1;
+                if fresh220 == 0 {
+                    break;
+                }
+                let fresh221 = bits1;
+                bits1 = bits1.offset(1);
+                let fresh222 = i;
+                i += 1;
+                *stream.offset(fresh222 as isize) = *fresh221;
+            }
+            *stream.offset(i as isize) = 0;
+            bits1 = stream;
+        } else if l2 < l1 {
+            ldiff = l1 - l2;
+            i = 0;
+            loop {
+                let fresh223 = ldiff;
+                ldiff -= 1;
+                if fresh223 == 0 {
+                    break;
+                }
+                let fresh224 = i;
+                i += 1;
+                *stream.offset(fresh224 as isize) = b'0' as c_char;
+            }
+            loop {
+                let fresh225 = l2;
+                l2 -= 1;
+                if fresh225 == 0 {
+                    break;
+                }
+                let fresh226 = bits2;
+                bits2 = bits2.offset(1);
+                let fresh227 = i;
+                i += 1;
+                *stream.offset(fresh227 as isize) = *fresh226;
+            }
+            *stream.offset(i as isize) = 0;
+            bits2 = stream;
+        }
+        val2 = 0;
+        val1 = val2;
+        nextbit = 1;
+        loop {
+            let fresh228 = length;
+            length -= 1;
+            if fresh228 == 0 {
+                break;
+            }
+            chr1 = *bits1.offset(length as isize);
+            chr2 = *bits2.offset(length as isize);
+            if chr1 as c_int != 'x' as i32
+                && chr1 as c_int != 'X' as i32
+                && chr2 as c_int != 'x' as i32
+                && chr2 as c_int != 'X' as i32
+            {
+                if chr1 as c_int == '1' as i32 {
+                    val1 += nextbit;
+                }
+                if chr2 as c_int == '1' as i32 {
+                    val2 += nextbit;
+                }
+                nextbit *= 2 as c_int;
+            }
+        }
+        result = 0;
+        match oper {
+            282 => {
+                if val1 < val2 {
+                    result = 1;
+                }
+            }
+            283 => {
+                if val1 <= val2 {
+                    result = 1;
+                }
+            }
+            281 => {
+                if val1 > val2 {
+                    result = 1;
+                }
+            }
+            284 => {
+                if val1 >= val2 {
+                    result = 1;
+                }
+            }
+            _ => {}
+        }
+        free(stream as *mut c_void);
+        result
+    }
+}
+unsafe fn bitand(mut result: *mut c_char, mut bitstrm1: *mut c_char, mut bitstrm2: *mut c_char) {
+    unsafe {
+        let mut i: c_int = 0;
+        let mut l1: c_int = 0;
+        let mut l2: c_int = 0;
+        let mut ldiff: c_int = 0;
+        let mut largestStream: c_int = 0;
+        let mut stream: *mut c_char = ptr::null_mut();
+        let mut chr1: c_char = 0;
+        let mut chr2: c_char = 0;
+        l1 = strlen(bitstrm1) as c_int;
+        l2 = strlen(bitstrm2) as c_int;
+        largestStream = if l1 > l2 { l1 } else { l2 };
+        stream = malloc(
+            (::core::mem::size_of::<c_char>() as c_ulong)
+                .wrapping_mul((largestStream + 1) as c_ulong)
+                .try_into()
+                .unwrap(),
+        ) as *mut c_char;
+        if l1 < l2 {
+            ldiff = l2 - l1;
+            i = 0;
+            loop {
+                let fresh229 = ldiff;
+                ldiff -= 1;
+                if fresh229 == 0 {
+                    break;
+                }
+                let fresh230 = i;
+                i += 1;
+                *stream.offset(fresh230 as isize) = b'0' as c_char;
+            }
+            loop {
+                let fresh231 = l1;
+                l1 -= 1;
+                if fresh231 == 0 {
+                    break;
+                }
+                let fresh232 = bitstrm1;
+                bitstrm1 = bitstrm1.offset(1);
+                let fresh233 = i;
+                i += 1;
+                *stream.offset(fresh233 as isize) = *fresh232;
+            }
+            *stream.offset(i as isize) = 0;
+            bitstrm1 = stream;
+        } else if l2 < l1 {
+            ldiff = l1 - l2;
+            i = 0;
+            loop {
+                let fresh234 = ldiff;
+                ldiff -= 1;
+                if fresh234 == 0 {
+                    break;
+                }
+                let fresh235 = i;
+                i += 1;
+                *stream.offset(fresh235 as isize) = b'0' as c_char;
+            }
+            loop {
+                let fresh236 = l2;
+                l2 -= 1;
+                if fresh236 == 0 {
+                    break;
+                }
+                let fresh237 = bitstrm2;
+                bitstrm2 = bitstrm2.offset(1);
+                let fresh238 = i;
+                i += 1;
+                *stream.offset(fresh238 as isize) = *fresh237;
+            }
+            *stream.offset(i as isize) = 0;
+            bitstrm2 = stream;
+        }
+        loop {
+            let fresh239 = bitstrm1;
+            bitstrm1 = bitstrm1.offset(1);
+            chr1 = *fresh239;
+            if chr1 == 0 {
+                break;
+            }
+            let fresh240 = bitstrm2;
+            bitstrm2 = bitstrm2.offset(1);
+            chr2 = *fresh240;
+            if chr1 as c_int == 'x' as i32 || chr2 as c_int == 'x' as i32 {
+                *result = b'x' as c_char;
+            } else if chr1 as c_int == '1' as i32 && chr2 as c_int == '1' as i32 {
+                *result = b'1' as c_char;
+            } else {
+                *result = b'0' as c_char;
+            }
+            result = result.offset(1);
+            result;
+        }
+        free(stream as *mut c_void);
+        *result = 0;
+    }
+}
+unsafe fn bitor(mut result: *mut c_char, mut bitstrm1: *mut c_char, mut bitstrm2: *mut c_char) {
+    unsafe {
+        let mut i: c_int = 0;
+        let mut l1: c_int = 0;
+        let mut l2: c_int = 0;
+        let mut ldiff: c_int = 0;
+        let mut largestStream: c_int = 0;
+        let mut stream: *mut c_char = ptr::null_mut();
+        let mut chr1: c_char = 0;
+        let mut chr2: c_char = 0;
+        l1 = strlen(bitstrm1) as c_int;
+        l2 = strlen(bitstrm2) as c_int;
+        largestStream = if l1 > l2 { l1 } else { l2 };
+        stream = malloc(
+            (::core::mem::size_of::<c_char>() as c_ulong)
+                .wrapping_mul((largestStream + 1) as c_ulong)
+                .try_into()
+                .unwrap(),
+        ) as *mut c_char;
+        if l1 < l2 {
+            ldiff = l2 - l1;
+            i = 0;
+            loop {
+                let fresh241 = ldiff;
+                ldiff -= 1;
+                if fresh241 == 0 {
+                    break;
+                }
+                let fresh242 = i;
+                i += 1;
+                *stream.offset(fresh242 as isize) = b'0' as c_char;
+            }
+            loop {
+                let fresh243 = l1;
+                l1 -= 1;
+                if fresh243 == 0 {
+                    break;
+                }
+                let fresh244 = bitstrm1;
+                bitstrm1 = bitstrm1.offset(1);
+                let fresh245 = i;
+                i += 1;
+                *stream.offset(fresh245 as isize) = *fresh244;
+            }
+            *stream.offset(i as isize) = 0;
+            bitstrm1 = stream;
+        } else if l2 < l1 {
+            ldiff = l1 - l2;
+            i = 0;
+            loop {
+                let fresh246 = ldiff;
+                ldiff -= 1;
+                if fresh246 == 0 {
+                    break;
+                }
+                let fresh247 = i;
+                i += 1;
+                *stream.offset(fresh247 as isize) = b'0' as c_char;
+            }
+            loop {
+                let fresh248 = l2;
+                l2 -= 1;
+                if fresh248 == 0 {
+                    break;
+                }
+                let fresh249 = bitstrm2;
+                bitstrm2 = bitstrm2.offset(1);
+                let fresh250 = i;
+                i += 1;
+                *stream.offset(fresh250 as isize) = *fresh249;
+            }
+            *stream.offset(i as isize) = 0;
+            bitstrm2 = stream;
+        }
+        loop {
+            let fresh251 = bitstrm1;
+            bitstrm1 = bitstrm1.offset(1);
+            chr1 = *fresh251;
+            if chr1 == 0 {
+                break;
+            }
+            let fresh252 = bitstrm2;
+            bitstrm2 = bitstrm2.offset(1);
+            chr2 = *fresh252;
+            if chr1 as c_int == '1' as i32 || chr2 as c_int == '1' as i32 {
+                *result = b'1' as c_char;
+            } else if chr1 as c_int == '0' as i32 || chr2 as c_int == '0' as i32 {
+                *result = b'0' as c_char;
+            } else {
+                *result = b'x' as c_char;
+            }
+            result = result.offset(1);
+            result;
+        }
+        free(stream as *mut c_void);
+        *result = 0;
+    }
+}
+unsafe fn bitnot(mut result: *mut c_char, mut bits: *mut c_char) {
+    unsafe {
+        let mut length: c_int = 0;
+        let mut chr: c_char = 0;
+        length = strlen(bits) as c_int;
+        loop {
+            let fresh253 = length;
+            length -= 1;
+            if fresh253 == 0 {
+                break;
+            }
+            let fresh254 = bits;
+            bits = bits.offset(1);
+            chr = *fresh254;
+            let fresh255 = result;
+            result = result.offset(1);
+            *fresh255 = (if chr as c_int == '1' as i32 {
+                '0' as i32
+            } else if chr as c_int == '0' as i32 {
+                '1' as i32
+            } else {
+                chr as c_int
+            }) as c_char;
+        }
+        *result = 0;
+    }
+}
+unsafe fn bitcmp(mut bitstrm1: *mut c_char, mut bitstrm2: *mut c_char) -> c_char {
+    unsafe {
+        let mut i: c_int = 0;
+        let mut l1: c_int = 0;
+        let mut l2: c_int = 0;
+        let mut ldiff: c_int = 0;
+        let mut largestStream: c_int = 0;
+        let mut stream: *mut c_char = ptr::null_mut();
+        let mut chr1: c_char = 0;
+        let mut chr2: c_char = 0;
+        l1 = strlen(bitstrm1) as c_int;
+        l2 = strlen(bitstrm2) as c_int;
+        largestStream = if l1 > l2 { l1 } else { l2 };
+        stream = malloc(
+            (::core::mem::size_of::<c_char>() as c_ulong)
+                .wrapping_mul((largestStream + 1) as c_ulong)
+                .try_into()
+                .unwrap(),
+        ) as *mut c_char;
+        if l1 < l2 {
+            ldiff = l2 - l1;
+            i = 0;
+            loop {
+                let fresh256 = ldiff;
+                ldiff -= 1;
+                if fresh256 == 0 {
+                    break;
+                }
+                let fresh257 = i;
+                i += 1;
+                *stream.offset(fresh257 as isize) = b'0' as c_char;
+            }
+            loop {
+                let fresh258 = l1;
+                l1 -= 1;
+                if fresh258 == 0 {
+                    break;
+                }
+                let fresh259 = bitstrm1;
+                bitstrm1 = bitstrm1.offset(1);
+                let fresh260 = i;
+                i += 1;
+                *stream.offset(fresh260 as isize) = *fresh259;
+            }
+            *stream.offset(i as isize) = 0;
+            bitstrm1 = stream;
+        } else if l2 < l1 {
+            ldiff = l1 - l2;
+            i = 0;
+            loop {
+                let fresh261 = ldiff;
+                ldiff -= 1;
+                if fresh261 == 0 {
+                    break;
+                }
+                let fresh262 = i;
+                i += 1;
+                *stream.offset(fresh262 as isize) = b'0' as c_char;
+            }
+            loop {
+                let fresh263 = l2;
+                l2 -= 1;
+                if fresh263 == 0 {
+                    break;
+                }
+                let fresh264 = bitstrm2;
+                bitstrm2 = bitstrm2.offset(1);
+                let fresh265 = i;
+                i += 1;
+                *stream.offset(fresh265 as isize) = *fresh264;
+            }
+            *stream.offset(i as isize) = 0;
+            bitstrm2 = stream;
+        }
+        loop {
+            let fresh266 = bitstrm1;
+            bitstrm1 = bitstrm1.offset(1);
+            chr1 = *fresh266;
+            if chr1 == 0 {
+                break;
+            }
+            let fresh267 = bitstrm2;
+            bitstrm2 = bitstrm2.offset(1);
+            chr2 = *fresh267;
+            if chr1 as c_int == '0' as i32 && chr2 as c_int == '1' as i32
+                || chr1 as c_int == '1' as i32 && chr2 as c_int == '0' as i32
+            {
+                free(stream as *mut c_void);
+                return 0;
+            }
+        }
+        free(stream as *mut c_void);
+        1
+    }
+}
+unsafe fn bnear(mut x: c_double, mut y: c_double, mut tolerance: c_double) -> c_char {
+    if fabs(x - y) < tolerance { 1 } else { 0 }
+}
+unsafe fn saobox(
+    mut xcen: c_double,
+    mut ycen: c_double,
+    mut xwid: c_double,
+    mut ywid: c_double,
+    mut rot: c_double,
+    mut xcol: c_double,
+    mut ycol: c_double,
+) -> c_char {
+    let mut x: c_double = 0.;
+    let mut y: c_double = 0.;
+    let mut xprime: c_double = 0.;
+    let mut yprime: c_double = 0.;
+    let mut xmin: c_double = 0.;
+    let mut xmax: c_double = 0.;
+    let mut ymin: c_double = 0.;
+    let mut ymax: c_double = 0.;
+    let mut theta: c_double = 0.;
+    theta = rot / 180.0f64 * 3.141_592_653_589_793_f64;
+    xprime = xcol - xcen;
+    yprime = ycol - ycen;
+    x = xprime * cos(theta) + yprime * sin(theta);
+    y = -xprime * sin(theta) + yprime * cos(theta);
+    xmin = -0.5f64 * xwid;
+    xmax = 0.5f64 * xwid;
+    ymin = -0.5f64 * ywid;
+    ymax = 0.5f64 * ywid;
+    if x >= xmin && x <= xmax && y >= ymin && y <= ymax {
+        1
+    } else {
+        0
+    }
+}
+unsafe fn circle(
+    mut xcen: c_double,
+    mut ycen: c_double,
+    mut rad: c_double,
+    mut xcol: c_double,
+    mut ycol: c_double,
+) -> c_char {
+    let mut r2: c_double = 0.;
+    let mut dx: c_double = 0.;
+    let mut dy: c_double = 0.;
+    let mut dlen: c_double = 0.;
+    dx = xcol - xcen;
+    dy = ycol - ycen;
+    dx *= dx;
+    dy *= dy;
+    dlen = dx + dy;
+    r2 = rad * rad;
+    if dlen <= r2 { 1 } else { 0 }
+}
+unsafe fn ellipse(
+    mut xcen: c_double,
+    mut ycen: c_double,
+    mut xrad: c_double,
+    mut yrad: c_double,
+    mut rot: c_double,
+    mut xcol: c_double,
+    mut ycol: c_double,
+) -> c_char {
+    let mut x: c_double = 0.;
+    let mut y: c_double = 0.;
+    let mut xprime: c_double = 0.;
+    let mut yprime: c_double = 0.;
+    let mut dx: c_double = 0.;
+    let mut dy: c_double = 0.;
+    let mut dlen: c_double = 0.;
+    let mut theta: c_double = 0.;
+    theta = rot / 180.0f64 * 3.141_592_653_589_793_f64;
+    xprime = xcol - xcen;
+    yprime = ycol - ycen;
+    x = xprime * cos(theta) + yprime * sin(theta);
+    y = -xprime * sin(theta) + yprime * cos(theta);
+    dx = x / xrad;
+    dy = y / yrad;
+    dx *= dx;
+    dy *= dy;
+    dlen = dx + dy;
+    if dlen <= 1.0f64 { 1 } else { 0 }
+}
+unsafe fn cstrmid(
+    mut lParse: *mut ParseData,
+    mut dest_str: *mut c_char,
+    mut dest_len: c_int,
+    mut src_str: *mut c_char,
+    mut src_len: c_int,
+    mut pos: c_int,
+) -> c_int {
+    unsafe {
+        let mut fill_char: c_char = 0;
+        if src_len == 0 {
+            src_len = strlen(src_str) as c_int;
+        }
+        if pos < 0 {
+            fits_parser_yyerror(
+                0 as yyscan_t,
+                lParse,
+                b"STRMID(S,P,N) P must be 0 or greater\0" as *const u8 as *const c_char
+                    as *mut c_char,
+            );
+            return -(1);
+        }
+        if pos > src_len || pos == 0 {
+            memset(
+                dest_str as *mut c_void,
+                fill_char as c_int,
+                (dest_len as c_ulong).try_into().unwrap(),
+            );
+        } else if pos + dest_len > src_len {
+            let mut nsub: c_int = src_len - pos + 1;
+            let mut npad: c_int = dest_len - nsub;
+            memcpy(
+                dest_str as *mut c_void,
+                src_str.offset(pos as isize).offset(-(1 as c_int as isize)) as *const c_void,
+                (nsub as c_ulong).try_into().unwrap(),
+            );
+            memset(
+                dest_str.offset(nsub as isize) as *mut c_void,
+                fill_char as c_int,
+                (npad as c_ulong).try_into().unwrap(),
+            );
+        } else {
+            memcpy(
+                dest_str as *mut c_void,
+                src_str.offset(pos as isize).offset(-(1 as c_int as isize)) as *const c_void,
+                (dest_len as c_ulong).try_into().unwrap(),
+            );
+        }
+        *dest_str.offset(dest_len as isize) = 0;
+        0
+    }
+}
+unsafe fn fits_parser_yyerror(
+    mut scanner: yyscan_t,
+    mut lParse: *mut ParseData,
+    mut s: *mut c_char,
+) {
+    unsafe {
+        let mut msg: [c_char; 80] = [0; 80];
+        if (*lParse).status == 0 {
+            (*lParse).status = 431 as c_int;
+        }
+        strncpy(
+            msg.as_mut_ptr(),
+            s,
+            (80 as c_int as c_ulong).try_into().unwrap(),
+        );
+        msg[79] = 0;
+        ffpmsg(msg.as_mut_ptr());
+    }
+}

--- a/src/eval_y.rs
+++ b/src/eval_y.rs
@@ -1,4 +1,3 @@
-#![deny(dead_code)]
 
 use std::ffi::CStr;
 use std::rc::Rc;
@@ -67,7 +66,7 @@ use crate::c_types::{
     c_char, c_double, c_int, c_long, c_schar, c_short, c_uchar, c_uint, c_ulong, c_void,
 };
 use crate::cfileio::{ffclos_safer, ffexts_safer, ffopen_safer};
-use crate::eval_defs::{CONST_OP, MAXDIMS, Node, ParseData, data_union, lval, yyscan_t};
+use crate::eval_defs::{data_union, lval, yyscan_t, Node, ParseData, CONST_OP, MAXDIMS, MAXSUBS};
 use crate::eval_l::{fits_parser_yyGetVariable, fits_parser_yylex, yyguts_t};
 use crate::eval_tab::{FITS_PARSER_YYSTYPE, fits_parser_yytokentype};
 use crate::fitscore::ffpmsg_slice;
@@ -233,8 +232,25 @@ pub union yyalloc {
     pub yyvs_alloc: FITS_PARSER_YYSTYPE,
 }
 
-/* YYTRANSLATE[TOKEN-NUM] -- Symbol number corresponding to TOKEN-NUM
-as returned by yylex.  */
+/* YYFINAL -- State number of the termination state.  */
+const YYFINAL: usize= 2;
+/* YYLAST -- Last index in YYTABLE.  */
+const YYLAST: usize= 1776;
+
+/* YYNTOKENS -- Number of terminals.  */
+const YYNTOKENS: usize= 57;
+/* YYNNTS -- Number of nonterminals.  */
+const YYNNTS: usize= 9;
+/* YYNRULES -- Number of rules.  */
+const YYNRULES: usize= 135;
+/* YYNSTATES -- Number of states.  */
+const YYNSTATES: usize= 322;
+
+/* YYMAXUTOK -- Last valid token kind.  */
+const YYMAXUTOK: usize= 292;
+
+
+/* YYTRANSLATE[TOKEN-NUM] -- Symbol number corresponding to TOKEN-NUM as returned by yylex.  */
 static YYTRANSLATE: [yytype_int8; 293] = [
     0, 2, 2, 2, 2, 2, 2, 2, 2, 2, 53, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
     2, 2, 2, 2, 2, 2, 39, 43, 2, 55, 56, 40, 37, 22, 38, 2, 41, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 24,
@@ -247,6 +263,15 @@ static YYTRANSLATE: [yytype_int8; 293] = [
     2, 2, 2, 2, 2, 2, 2, 2, 2, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
     20, 21, 28, 29, 30, 31, 33, 34, 35, 36, 44, 45, 46, 47, 48, 49, 51, 52,
 ];
+
+/* YYRLINE[YYN] -- Source line where rule number YYN was defined.  */
+static YYRLINE: [yytype_int16; 136] = [0,    266,  266,  267,  270,  271,  277,  283,  289,  295,  298,  300,  313,  315,  328,  339,  353,  357,  361,  365,  367,  376,  379,
+                                       382,  391,  393,  395,  397,  399,  401,  404,  408,  410,  412,  414,  423,  425,  427,  430,  433,  436,  439,  442,  451,  460,  469,
+                                       472,  474,  476,  478,  482,  486,  505,  524,  543,  554,  568,  617,  629,  660,  774,  782,  885,  911,  914,  918,  920,  922,  924,
+                                       926,  928,  930,  932,  934,  938,  940,  942,  951,  954,  957,  960,  963,  966,  969,  972,  975,  978,  981,  984,  987,  990,  993,
+                                       996,  999,  1002, 1005, 1008, 1010, 1012, 1014, 1017, 1024, 1041, 1054, 1067, 1078, 1094, 1118, 1146, 1183, 1187, 1191, 1194, 1200, 1204,
+                                       1208, 1211, 1216, 1220, 1223, 1227, 1229, 1231, 1233, 1235, 1237, 1239, 1243, 1246, 1248, 1257, 1259, 1261, 1270, 1289, 1308];
+
 
 /* YYPACT[STATE-NUM] -- Index in YYTABLE of the portion describing
 STATE-NUM.  */
@@ -491,6 +516,10 @@ static YYR2: [yytype_int8; 136] = [
     12, 2, 3, 1, 1, 4, 1, 3, 3, 5, 5, 7,
 ];
 
+
+
+
+
 fn Alloc_Node(lParse: &mut ParseData) -> c_int {
     // If number of nodes == number allocated, then realloc
     if lParse.nNodes == lParse.nNodesAlloc {
@@ -516,7 +545,7 @@ fn Alloc_Node(lParse: &mut ParseData) -> c_int {
     }
 
     lParse.nNodes += 1;
-    lParse.nNodes
+    (lParse.nNodes-1)
 }
 
 fn Free_Last_Node(lParse: &mut ParseData) {
@@ -686,7 +715,6 @@ fn New_BinOp(
     Node2: c_int,
 ) -> c_int {
     let mut n: c_int = 0;
-    let mut i: c_int = 0;
     let mut constant: c_int = 0;
 
     if Node1 < 0 || Node2 < 0 {
@@ -696,7 +724,7 @@ fn New_BinOp(
     n = Alloc_Node(lParse);
 
     if n >= 0 {
-        let that1_idx = Node1 as usize;
+        let mut that1_idx = Node1 as usize;
         let that2_idx = Node2 as usize;
         let this_node_idx = n as usize;
 
@@ -722,16 +750,15 @@ fn New_BinOp(
         }
 
         if (lParse.Nodes[that1_idx]).value.nelem == 1 {
-            (lParse.Nodes[that1_idx]) = lParse.Nodes[that2_idx];
+            that1_idx = that2_idx;
         }
 
         (lParse.Nodes[this_node_idx]).value.nelem = (lParse.Nodes[that1_idx]).value.nelem;
         (lParse.Nodes[this_node_idx]).value.naxis = (lParse.Nodes[that1_idx]).value.naxis;
 
-        while i < (lParse.Nodes[that1_idx]).value.naxis {
+        for i in 0..lParse.Nodes[that1_idx].value.naxis as usize {
             (lParse.Nodes[this_node_idx]).value.naxes[i as usize] =
                 (lParse.Nodes[that1_idx]).value.naxes[i as usize];
-            i += 1;
         }
 
         if Op == fits_parser_yytokentype::ACCUM as c_int
@@ -789,6 +816,205 @@ fn New_Func(
         lParse, returnType, Op, nNodes, Node1, Node2, Node3, Node4, Node5, Node6, Node7, 0,
     )
 }
+
+macro_rules! YY_SYMBOL_PRINT {
+    ($title:expr, $kind:expr, $value:expr, $scanner:expr, $lParse:expr) => {
+        {
+            if YYDEBUG {
+                eprintln!("{}", $title);
+                yy_symbol_print($kind, $value, $scanner, $lParse);
+                eprintln!();
+            }
+        }
+    };
+}
+
+
+fn yysymbol_name(yykind: yysymbol_kind_t) -> &'static str {
+    YYTNAME[yykind as usize]
+}
+
+/* YYTNAME[SYMBOL-NUM] -- String name of the symbol SYMBOL-NUM.
+   First, the terminals, then, starting at YYNTOKENS, nonterminals.  */
+static YYTNAME: [&str; 67] = ["\"end of file\"",
+                                      "error",
+                                      "\"invalid token\"",
+                                      "BOOLEAN",
+                                      "LONG",
+                                      "DOUBLE",
+                                      "STRING",
+                                      "BITSTR",
+                                      "FUNCTION",
+                                      "BFUNCTION",
+                                      "IFUNCTION",
+                                      "GTIFILTER",
+                                      "GTIOVERLAP",
+                                      "GTIFIND",
+                                      "REGFILTER",
+                                      "COLUMN",
+                                      "BCOLUMN",
+                                      "SCOLUMN",
+                                      "BITCOL",
+                                      "ROWREF",
+                                      "NULLREF",
+                                      "SNULLREF",
+                                      "','",
+                                      "'='",
+                                      "':'",
+                                      "'{'",
+                                      "'}'",
+                                      "'?'",
+                                      "OR",
+                                      "AND",
+                                      "EQ",
+                                      "NE",
+                                      "'~'",
+                                      "GT",
+                                      "LT",
+                                      "LTE",
+                                      "GTE",
+                                      "'+'",
+                                      "'-'",
+                                      "'%'",
+                                      "'*'",
+                                      "'/'",
+                                      "'|'",
+                                      "'&'",
+                                      "XOR",
+                                      "POWER",
+                                      "NOT",
+                                      "INTCAST",
+                                      "FLTCAST",
+                                      "UMINUS",
+                                      "'['",
+                                      "ACCUM",
+                                      "DIFF",
+                                      "'\\n'",
+                                      "']'",
+                                      "'('",
+                                      "')'",
+                                      "$accept",
+                                      "lines",
+                                      "line",
+                                      "bvector",
+                                      "vector",
+                                      "expr",
+                                      "bexpr",
+                                      "bits",
+                                      "sexpr",
+                                      "NULL PTR"];
+
+
+/*-----------------------------------.
+| Print this symbol's value on YYO.  |
+`-----------------------------------*/
+
+fn yy_symbol_value_print(
+    yykind: yysymbol_kind_t,
+    yyvaluep: *const FITS_PARSER_YYSTYPE,
+    _scanner: yyscan_t,
+    _lParse: &mut ParseData,
+) {
+    return
+}
+
+
+/*---------------------------.
+| Print this symbol on YYO.  |
+`---------------------------*/
+
+fn yy_symbol_print(
+    yykind: yysymbol_kind_t,
+    yyvaluep: *const FITS_PARSER_YYSTYPE,
+    scanner: yyscan_t,
+    lParse: &mut ParseData,
+) {
+    unsafe {
+        eprint!("{} {} (", if (yykind as usize) < YYNTOKENS { "token" } else { "nterm" }, yysymbol_name(yykind));
+        yy_symbol_value_print(yykind, yyvaluep, scanner, lParse);
+        eprintln!(")");
+    }
+}
+
+/*------------------------------------------------------------------.
+| yy_stack_print -- Print the state stack from its BOTTOM up to its |
+| TOP (included).                                                   |
+`------------------------------------------------------------------*/
+
+fn yy_stackprint(
+    yybottom: *const yy_state_t,
+    yytop: *const yy_state_t,
+) {
+    unsafe {
+        eprint!("Stack now");
+        let mut ptr = yybottom;
+        while ptr <= yytop {
+            let yybot = *ptr;
+            eprint!(" {}", yybot);
+            ptr = ptr.add(1);
+        }
+        eprintln!();
+    }
+}
+
+macro_rules! YY_STACK_PRINT {
+    ($bottom:expr, $top:expr) => {
+        {
+            if YYDEBUG {
+                yy_stackprint($bottom, $top);
+            }
+        }
+    };
+}
+
+
+/*------------------------------------------------.
+| Report that the YYRULE is going to be reduced.  |
+`------------------------------------------------*/
+
+fn yy_reduce_print(
+    yyssp: *const yy_state_t,
+    yyvsp: *const FITS_PARSER_YYSTYPE,
+    yyrule: c_int,
+    scanner: yyscan_t,
+    lParse: &mut ParseData,
+) {
+    unsafe {
+        let yylno = YYRLINE[yyrule as usize];
+        let yynrhs = YYR2[yyrule as usize];
+        eprintln!("Reducing stack by rule {} (line {}):", yyrule - 1, yylno);
+        /* The symbols being reduced.  */
+        for yyi in 0..yynrhs {
+            eprint!("   ${} = ", yyi + 1);
+            yy_symbol_print(
+                (YYSTOS[(*yyssp.add((yyi + 1 - yynrhs) as usize)) as usize]).into(),
+                yyvsp.add((yyi + 1 - yynrhs) as usize),
+                scanner,
+                lParse,
+            );
+            eprintln!();
+        }
+    }
+}
+
+
+const YYDEBUG: bool = false;
+
+/* YYINITDEPTH -- initial size of the parser's stacks.  */
+const YYINITDEPTH: usize = 200;
+
+/* YYMAXDEPTH -- maximum size the stacks can grow to (effective only
+   if the built-in stack extension method is used).
+
+   Do not make this value too large; the results are undefined if
+   YYSTACK_ALLOC_MAXIMUM < YYSTACK_BYTES (YYMAXDEPTH)
+   evaluated with infinite-precision integer arithmetic.  */
+
+const YYMAXDEPTH: usize = 10000;
+
+/*-----------------------------------------------.
+| Release the memory associated to this symbol.  |
+`-----------------------------------------------*/
 
 fn yydestruct(
     mut yymsg: *const c_char,
@@ -862,31 +1088,29 @@ fn New_FuncSize(
                     == CONST_OP) as c_int;
         }
 
-        let (this_node, that_node) =
-            get_this_that_nodes(&mut lParse.Nodes, n as usize, Node1 as usize);
-
+        
         if returnType != 0 {
-            (this_node).ntype = returnType;
-            (this_node).value.nelem = 1;
-            (this_node).value.naxis = 1;
-            (this_node).value.naxes[0] = 1;
+            (lParse.Nodes[n as usize]).ntype = returnType;
+            (lParse.Nodes[n as usize]).value.nelem = 1;
+            (lParse.Nodes[n as usize]).value.naxis = 1;
+            (lParse.Nodes[n as usize]).value.naxes[0] = 1;
         } else {
-            (this_node).ntype = (that_node).ntype;
-            (this_node).value.nelem = (that_node).value.nelem;
-            (this_node).value.naxis = (that_node).value.naxis;
+            (lParse.Nodes[n as usize]).ntype = (lParse.Nodes[Node1 as usize]).ntype;
+            (lParse.Nodes[n as usize]).value.nelem = (lParse.Nodes[Node1 as usize]).value.nelem;
+            (lParse.Nodes[n as usize]).value.naxis = (lParse.Nodes[Node1 as usize]).value.naxis;
             i = 0;
-            while i < (that_node).value.naxis {
-                (this_node).value.naxes[i as usize] = (that_node).value.naxes[i as usize];
+            while i < (lParse.Nodes[Node1 as usize]).value.naxis {
+                (lParse.Nodes[n as usize]).value.naxes[i as usize] = (lParse.Nodes[Node1 as usize]).value.naxes[i as usize];
                 i += 1;
             }
         }
 
         if Size > 0 {
-            (this_node).value.nelem = Size as c_long;
+            (lParse.Nodes[n as usize]).value.nelem = Size as c_long;
         }
 
         if constant != 0 {
-            ((this_node).DoOp).expect("non-null function pointer")(lParse, n as usize);
+            ((lParse.Nodes[n as usize]).DoOp).expect("non-null function pointer")(lParse, n as usize);
         }
     }
     n
@@ -915,21 +1139,30 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
         let mut yylen: c_int = 0;
         yychar = fits_parser_yytokentype::FITS_PARSER_YYEMPTY as c_int;
         's_54: loop {
-            (0 as c_int != 0 && (0 as c_int <= yystate && yystate < 322 as c_int)) as c_int;
+            /*--------------------------------------------------------------------.
+            | yysetstate -- set current state (the top of the stack) to yystate.  |
+            `--------------------------------------------------------------------*/
+            if YYDEBUG {
+                eprintln!("Entering state {}", yystate);
+            }
+            assert!((0 <= yystate && yystate < YYNSTATES as c_int));
+            YY_STACK_PRINT!(yyss, yyssp);
+
             *yyssp = yystate as yy_state_t;
             if yyss
                 .offset(yystacksize as isize)
-                .offset(-(1 as c_int as isize))
+                .offset(-1)
                 <= yyssp
             {
+                 /* Get the current used size of the three stacks, in elements.  */
                 let yysize: c_long = yyssp.offset_from(yyss) as c_long + 1;
-                if 10000 as c_long <= yystacksize {
-                    current_block = 11794367917084412820;
+                if YYMAXDEPTH as c_long <= yystacksize {
+                    current_block = 11794367917084412820; // goto yyexhaustedlab;
                     break;
                 }
                 yystacksize *= 2 as c_long;
-                if (10000 as c_long) < yystacksize {
-                    yystacksize = 10000 as c_long;
+                if (YYMAXDEPTH as c_long) < yystacksize { /* Extend the stack our own way.  */
+                    yystacksize = YYMAXDEPTH as c_long;
                 }
                 let yyss1: *mut yy_state_t = yyss;
                 let mut yyptr: *mut yyalloc = malloc(
@@ -942,7 +1175,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         .unwrap(),
                 ) as *mut yyalloc;
                 if yyptr.is_null() {
-                    current_block = 11794367917084412820;
+                    current_block = 11794367917084412820; // goto yyexhaustedlab;
                     break;
                 }
                 let mut yynewbytes: c_long = 0;
@@ -979,43 +1212,67 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                 if yyss1 != yyssa.as_mut_ptr() {
                     free(yyss1 as *mut c_void);
                 }
-                yyssp = yyss.offset(yysize as isize).offset(-(1 as c_int as isize));
-                yyvsp = yyvs.offset(yysize as isize).offset(-(1 as c_int as isize));
+                yyssp = yyss.offset(yysize as isize).offset(-1);
+                yyvsp = yyvs.offset(yysize as isize).offset(-1);
                 if yyss
                     .offset(yystacksize as isize)
-                    .offset(-(1 as c_int as isize))
+                    .offset(-1)
                     <= yyssp
                 {
-                    current_block = 3964311021479492664;
+                    current_block = 3964311021479492664; // goto yyabortlab;
                     break;
                 }
             }
-            if yystate == 2 {
+            if yystate == YYFINAL as c_int{
                 yyresult = 0;
-                current_block = 15864720325503947191;
+                current_block = 15864720325503947191; // goto yyacceptlab;
                 break;
-            } else {
+            } else { 
+
+                /*-----------.
+                | yybackup.  |
+                `-----------*/
+                 /* Do appropriate processing given the current state.  Read a
+                lookahead token if we need one and don't already have one.  */
+
+                /* First try to decide what to do without reference to lookahead token.  */
                 yyn = YYPACT[yystate as usize] as c_int;
-                if yyn == -(41 as c_int) {
-                    current_block = 5937473999264333383;
+                if yyn == -41 {
+                    current_block = 5937473999264333383; // goto yydefault;
                 } else {
+
+                    /* Not known => get a lookahead token if don't already have one.  */
+
+                    /* YYCHAR is either empty, or end-of-input, or a valid lookahead.  */
+
                     if yychar == fits_parser_yytokentype::FITS_PARSER_YYEMPTY as c_int {
+                        if YYDEBUG {
+                            eprintln!("Read a token");
+                        }
                         yychar = fits_parser_yylex(&mut yylval, scanner);
                     }
+
                     if yychar <= fits_parser_yytokentype::FITS_PARSER_YYEOF as c_int {
                         yychar = fits_parser_yytokentype::FITS_PARSER_YYEOF as c_int;
                         yytoken = YYSYMBOL_YYEOF;
+                        if YYDEBUG {
+                            eprintln!("Now at end of input.");
+                        }
                         current_block = 1924505913685386279;
                     } else if yychar == fits_parser_yytokentype::FITS_PARSER_YYerror as c_int {
+                        /* The scanner already issued an error message, process directly
+                        to error recovery.  But do not keep the error token as
+                        lookahead, it is too special and may lead us to an endless
+                        loop in error recovery. */
                         yychar = fits_parser_yytokentype::FITS_PARSER_YYUNDEF as c_int;
                         yytoken = YYSYMBOL_YYerror;
-                        current_block = 1774893048582444437;
+                        current_block = 1774893048582444437; // goto yyerrlab1;
                     } else {
                         yytoken = (if 0 <= yychar && yychar <= 292 as c_int {
                             YYTRANSLATE[yychar as usize] as yysymbol_kind_t as c_int
                         } else {
                             YYSYMBOL_YYUNDEF as c_int
-                        }) as yysymbol_kind_t;
+                        }) as yysymbol_kind_t; YY_SYMBOL_PRINT!("Next token is", yytoken, &yylval, scanner, lParse);
                         current_block = 1924505913685386279;
                     }
                     match current_block {
@@ -1023,7 +1280,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         _ => {
                             yyn += yytoken as c_int;
                             if yyn < 0
-                                || (1776 as c_int) < yyn
+                                || (YYLAST as c_int) < yyn
                                 || YYCHECK[yyn as usize] as c_int != yytoken as c_int
                             {
                                 current_block = 5937473999264333383;
@@ -1032,23 +1289,28 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 if yyn <= 0 {
                                     yyn = -yyn;
                                     current_block = 670225253387957849;
-                                } else {
+                                } else { /* Count tokens shifted since error; after three, turn off error status.  */
                                     if yyerrstatus != 0 {
                                         yyerrstatus -= 1;
-                                    }
+                                    } /* Shift the lookahead token.  */ YY_SYMBOL_PRINT!("Shifting", yytoken, &yylval, scanner, lParse);
                                     yystate = yyn;
                                     yyvsp = yyvsp.offset(1);
                                     *yyvsp = yylval;
-                                    yychar = fits_parser_yytokentype::FITS_PARSER_YYEMPTY as c_int;
+                                    yychar = fits_parser_yytokentype::FITS_PARSER_YYEMPTY as c_int; /* Discard the shifted token.  */
                                     current_block = 7872030484262409139;
                                 }
                             }
                         }
                     }
                 }
+
                 if current_block == 5937473999264333383 {
+                     /*-----------------------------------------------------------.
+                    | yydefault -- do the default action for the current state.  |
+                    `-----------------------------------------------------------*/
+
                     yyn = YYDEFACT[yystate as usize] as c_int;
-                    if yyn == 0 {
+                    if yyn == 0 { // goto yyerrlab;
                         yytoken =
                             (if yychar == fits_parser_yytokentype::FITS_PARSER_YYEMPTY as c_int {
                                 YYSYMBOL_YYEMPTY as c_int
@@ -1080,17 +1342,36 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         }
                         current_block = 1774893048582444437;
                     } else {
-                        current_block = 670225253387957849;
+                        current_block = 670225253387957849; // goto yyreduce;
                     }
                 }
                 if current_block == 670225253387957849 {
+                    /*-----------------------------.
+                    | yyreduce -- do a reduction.  |
+                    `-----------------------------*/
+
+                    /* yyn is the number of a rule to reduce with.  */
                     yylen = YYR2[yyn as usize] as c_int;
-                    yyval = *yyvsp.offset((1 as c_int - yylen) as isize);
+
+                    /* If YYLEN is nonzero, implement the default value of the action:
+       '$$ = $1'.
+
+       Otherwise, the following line sets YYVAL to garbage.
+       This behavior is undocumented and Bison
+       users should not rely upon it.  Assigning to YYVAL
+       unconditionally makes the parser a bit smaller, and it avoids a
+       GCC warning that YYVAL may be used uninitialized.  */
+                    yyval = *yyvsp.offset((1  - yylen) as isize);
+
+                    if YYDEBUG {
+                        yy_reduce_print(yyssp, yyvsp, yyn, scanner, lParse);
+                    }
+
                     match yyn {
-                        4 => {
+                        4 => { /* line: '\n'  */
                             current_block = 17353983478346836848;
                         }
-                        5 => {
+                        5 => { /* line: expr '\n'  */
                             if (*yyvsp.offset(-1)).Node < 0 {
                                 fits_parser_yyerror(
                                     lParse,
@@ -1102,7 +1383,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        6 => {
+                        6 => { /* line: bexpr '\n'  */
                             if (*yyvsp.offset(-1)).Node < 0 {
                                 fits_parser_yyerror(
                                     lParse,
@@ -1114,7 +1395,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        7 => {
+                        7 => { /* line: sexpr '\n'  */
                             if (*yyvsp.offset(-1)).Node < 0 {
                                 fits_parser_yyerror(
                                     lParse,
@@ -1126,7 +1407,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        8 => {
+                        8 => { /* line: bits '\n'  */
                             if (*yyvsp.offset(-1)).Node < 0 {
                                 fits_parser_yyerror(
                                     lParse,
@@ -1138,11 +1419,11 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        9 => {
+                        9 => { /* line: error '\n'  */
                             yyerrstatus = 0;
                             current_block = 17353983478346836848;
                         }
-                        10 => {
+                        10 => { /* bvector: '{' bexpr  */
                             yyval.Node = New_Vector(lParse, (*yyvsp.offset(0)).Node);
                             if yyval.Node < 0 {
                                 current_block = 4830776507462815627;
@@ -1150,7 +1431,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        11 => {
+                        11 => { /* bvector: bvector ',' bexpr  */
                             if (lParse.Nodes[(*yyvsp.offset(-2)).Node as usize]).nSubNodes
                                 >= 10 as c_int
                             {
@@ -1184,7 +1465,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 }
                             }
                         }
-                        12 => {
+                        12 => {  /* vector: '{' expr  */
                             yyval.Node = New_Vector(lParse, (*yyvsp.offset(0)).Node);
                             if yyval.Node < 0 {
                                 current_block = 4830776507462815627;
@@ -1192,7 +1473,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        13 => {
+                        13 => { /* vector: vector ',' expr  */
                             if (lParse.Nodes[(*yyvsp.offset(-2)).Node as usize]).ntype
                                 < (lParse.Nodes[(*yyvsp.offset(0)).Node as usize]).ntype
                             {
@@ -1232,9 +1513,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 }
                             }
                         }
-                        14 => {
+                        14 => { /* vector: vector ',' bexpr  */
                             if (lParse.Nodes[(*yyvsp.offset(-2)).Node as usize]).nSubNodes
-                                >= 10 as c_int
+                                >= MAXSUBS as c_int
                             {
                                 (*yyvsp.offset(-2)).Node =
                                     Close_Vec(lParse, (*yyvsp.offset(-2)).Node);
@@ -1266,7 +1547,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 }
                             }
                         }
-                        15 => {
+                        15 => { /* vector: bvector ',' expr  */
                             (lParse.Nodes[(*yyvsp.offset(-2)).Node as usize]).ntype =
                                 (lParse.Nodes[(*yyvsp.offset(0)).Node as usize]).ntype;
                             if (lParse.Nodes[(*yyvsp.offset(-2)).Node as usize]).nSubNodes
@@ -1302,7 +1583,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 }
                             }
                         }
-                        16 => {
+                        16 => {/* expr: vector '}'  */
                             yyval.Node = Close_Vec(lParse, (*yyvsp.offset(-1)).Node);
                             if yyval.Node < 0 {
                                 current_block = 4830776507462815627;
@@ -1310,7 +1591,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        17 => {
+                        17 => {/* bexpr: bvector '}'  */
                             yyval.Node = Close_Vec(lParse, (*yyvsp.offset(-1)).Node);
                             if yyval.Node < 0 {
                                 current_block = 4830776507462815627;
@@ -1318,13 +1599,13 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        18 => {
+                        18 => {/* bits: BITSTR  */
                             yyval.Node = New_Const(
                                 lParse,
                                 fits_parser_yytokentype::BITSTR as c_int,
                                 ((*yyvsp.offset(0)).astr).as_mut_ptr() as *mut c_void,
                                 (strlen(((*yyvsp.offset(0)).astr).as_mut_ptr()))
-                                    .wrapping_add((1 as c_int as c_ulong).try_into().unwrap())
+                                    .wrapping_add((1).try_into().unwrap())
                                     as c_long,
                             );
                             if yyval.Node < 0 {
@@ -1335,7 +1616,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        19 => {
+                        19 => {/* bits: BITCOL  */
                             yyval.Node = New_Column(lParse, (*yyvsp.offset(0)).lng as c_int);
                             if yyval.Node < 0 {
                                 current_block = 4830776507462815627;
@@ -1343,7 +1624,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        20 => {
+                        20 => {/* bits: BITCOL '{' expr '}'  */
                             if ((lParse.Nodes)[(*yyvsp.offset(-1)).Node as usize]).ntype
                                 != fits_parser_yytokentype::LONG as c_int
                                 || ((lParse.Nodes)[(*yyvsp.offset(-1)).Node as usize]).operation
@@ -1367,7 +1648,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 }
                             }
                         }
-                        21 => {
+                        21 => {/* bits: bits '&' bits  */
                             yyval.Node = New_BinOp(
                                 lParse,
                                 fits_parser_yytokentype::BITSTR as c_int,
@@ -1394,7 +1675,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        22 => {
+                        22 => {/* bits: bits '|' bits  */
                             yyval.Node = New_BinOp(
                                 lParse,
                                 fits_parser_yytokentype::BITSTR as c_int,
@@ -1421,7 +1702,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        23 => {
+                        23 => {/* bits: bits '+' bits  */
                             if (lParse.Nodes[(*yyvsp.offset(-2)).Node as usize])
                                 .value
                                 .nelem
@@ -1455,7 +1736,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 }
                             }
                         }
-                        24 => {
+                        24 => {/* bits: bits '[' expr ']'  */
                             yyval.Node = New_Deref(
                                 lParse,
                                 (*yyvsp.offset(-3)).Node,
@@ -1472,7 +1753,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        25 => {
+                        25 => {/* bits: bits '[' expr ',' expr ']'  */
                             yyval.Node = New_Deref(
                                 lParse,
                                 (*yyvsp.offset(-(5))).Node,
@@ -1489,7 +1770,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        26 => {
+                        26 => {/* bits: bits '[' expr ',' expr ',' expr ']'  */
                             yyval.Node = New_Deref(
                                 lParse,
                                 (*yyvsp.offset(-7)).Node,
@@ -1506,7 +1787,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        27 => {
+                        27 => { /* bits: bits '[' expr ',' expr ',' expr ',' expr ']'  */
                             yyval.Node = New_Deref(
                                 lParse,
                                 (*yyvsp.offset(-9)).Node,
@@ -1523,7 +1804,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        28 => {
+                        28 => {/* bits: bits '[' expr ',' expr ',' expr ',' expr ',' expr ']'  */
                             yyval.Node = New_Deref(
                                 lParse,
                                 (*yyvsp.offset(-11)).Node,
@@ -1540,7 +1821,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        29 => {
+                        29 => {/* bits: NOT bits  */
                             yyval.Node = New_Unary(
                                 lParse,
                                 fits_parser_yytokentype::BITSTR as c_int,
@@ -1553,11 +1834,11 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        30 => {
+                        30 => { /* bits: '(' bits ')'  */
                             yyval.Node = (*yyvsp.offset(-1)).Node;
                             current_block = 17353983478346836848;
                         }
-                        31 => {
+                        31 => {/* expr: LONG  */
                             yyval.Node = New_Const(
                                 lParse,
                                 fits_parser_yytokentype::LONG as c_int,
@@ -1570,7 +1851,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        32 => {
+                        32 => { /* expr: DOUBLE  */
                             yyval.Node = New_Const(
                                 lParse,
                                 fits_parser_yytokentype::DOUBLE as c_int,
@@ -1583,7 +1864,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        33 => {
+                        33 => {/* expr: COLUMN  */
                             yyval.Node = New_Column(lParse, (*yyvsp.offset(0)).lng as c_int);
                             if yyval.Node < 0 {
                                 current_block = 4830776507462815627;
@@ -1591,7 +1872,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        34 => {
+                        34 => {/* expr: COLUMN '{' expr '}'  */
                             if ((lParse.Nodes)[(*yyvsp.offset(-1)).Node as usize]).ntype
                                 != fits_parser_yytokentype::LONG as c_int
                                 || ((lParse.Nodes)[(*yyvsp.offset(-1)).Node as usize]).operation
@@ -1615,7 +1896,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 }
                             }
                         }
-                        35 => {
+                        35 => {/* expr: ROWREF  */
                             yyval.Node = New_Func(
                                 lParse,
                                 fits_parser_yytokentype::LONG as c_int,
@@ -1631,7 +1912,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             );
                             current_block = 17353983478346836848;
                         }
-                        36 => {
+                        36 => { /* expr: NULLREF  */
                             yyval.Node = New_Func(
                                 lParse,
                                 fits_parser_yytokentype::LONG as c_int,
@@ -1647,7 +1928,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             );
                             current_block = 17353983478346836848;
                         }
-                        37 => {
+                        37 => {/* expr: expr '%' expr  */
                             if (lParse.Nodes[(*yyvsp.offset(-2)).Node as usize]).ntype
                                 > (lParse.Nodes[(*yyvsp.offset(0)).Node as usize]).ntype
                             {
@@ -1680,7 +1961,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        38 => {
+                        38 => { /* expr: expr '+' expr  */
                             if (lParse.Nodes[(*yyvsp.offset(-2)).Node as usize]).ntype
                                 > (lParse.Nodes[(*yyvsp.offset(0)).Node as usize]).ntype
                             {
@@ -1713,7 +1994,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        39 => {
+                        39 => {/* expr: expr '-' expr  */
                             if (lParse.Nodes[(*yyvsp.offset(-2)).Node as usize]).ntype
                                 > (lParse.Nodes[(*yyvsp.offset(0)).Node as usize]).ntype
                             {
@@ -1746,7 +2027,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        40 => {
+                        40 => {/* expr: expr '*' expr  */
                             if (lParse.Nodes[(*yyvsp.offset(-2)).Node as usize]).ntype
                                 > (lParse.Nodes[(*yyvsp.offset(0)).Node as usize]).ntype
                             {
@@ -1779,7 +2060,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        41 => {
+                        41 => {/* expr: expr '/' expr  */
                             if (lParse.Nodes[(*yyvsp.offset(-2)).Node as usize]).ntype
                                 > (lParse.Nodes[(*yyvsp.offset(0)).Node as usize]).ntype
                             {
@@ -1812,7 +2093,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        42 => {
+                        42 => { /* expr: expr '&' expr  */
                             if (lParse.Nodes[(*yyvsp.offset(-2)).Node as usize]).ntype
                                 != fits_parser_yytokentype::LONG as c_int
                                 || (lParse.Nodes[(*yyvsp.offset(0)).Node as usize]).ntype
@@ -1834,7 +2115,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        43 => {
+                        43 => {/* expr: expr '|' expr  */
                             if (lParse.Nodes[(*yyvsp.offset(-2)).Node as usize]).ntype
                                 != fits_parser_yytokentype::LONG as c_int
                                 || (lParse.Nodes[(*yyvsp.offset(0)).Node as usize]).ntype
@@ -1856,7 +2137,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        44 => {
+                        44 => {/* expr: expr XOR expr  */
                             if (lParse.Nodes[(*yyvsp.offset(-2)).Node as usize]).ntype
                                 != fits_parser_yytokentype::LONG as c_int
                                 || (lParse.Nodes[(*yyvsp.offset(0)).Node as usize]).ntype
@@ -1878,7 +2159,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        45 => {
+                        45 => { /* expr: expr POWER expr  */
                             if (lParse.Nodes[(*yyvsp.offset(-2)).Node as usize]).ntype
                                 > (lParse.Nodes[(*yyvsp.offset(0)).Node as usize]).ntype
                             {
@@ -1911,11 +2192,11 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        46 => {
+                        46 => {/* expr: '+' expr  */
                             yyval.Node = (*yyvsp.offset(0)).Node;
                             current_block = 17353983478346836848;
                         }
-                        47 => {
+                        47 => {/* expr: '-' expr  */
                             yyval.Node = New_Unary(
                                 lParse,
                                 (lParse.Nodes[(*yyvsp.offset(0)).Node as usize]).ntype,
@@ -1928,11 +2209,11 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        48 => {
+                        48 => {/* expr: '(' expr ')'  */
                             yyval.Node = (*yyvsp.offset(-1)).Node;
                             current_block = 17353983478346836848;
                         }
-                        49 => {
+                        49 => { /* expr: expr '*' bexpr  */
                             (*yyvsp.offset(0)).Node = New_Unary(
                                 lParse,
                                 (lParse.Nodes[(*yyvsp.offset(-2)).Node as usize]).ntype,
@@ -1952,7 +2233,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        50 => {
+                        50 => {/* expr: bexpr '*' expr  */
                             (*yyvsp.offset(-2)).Node = New_Unary(
                                 lParse,
                                 (lParse.Nodes[(*yyvsp.offset(0)).Node as usize]).ntype,
@@ -1972,7 +2253,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        51 => {
+                        51 => {/* expr: bexpr '?' expr ':' expr  */
                             if (lParse.Nodes[(*yyvsp.offset(-2)).Node as usize]).ntype
                                 > (lParse.Nodes[(*yyvsp.offset(0)).Node as usize]).ntype
                             {
@@ -2050,7 +2331,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 }
                             }
                         }
-                        52 => {
+                        52 => {/* expr: bexpr '?' bexpr ':' expr  */
                             if (lParse.Nodes[(*yyvsp.offset(-2)).Node as usize]).ntype
                                 > (lParse.Nodes[(*yyvsp.offset(0)).Node as usize]).ntype
                             {
@@ -2128,7 +2409,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 }
                             }
                         }
-                        53 => {
+                        53 => { /* expr: bexpr '?' expr ':' bexpr  */
                             if (lParse.Nodes[(*yyvsp.offset(-2)).Node as usize]).ntype
                                 > (lParse.Nodes[(*yyvsp.offset(0)).Node as usize]).ntype
                             {
@@ -2206,7 +2487,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 }
                             }
                         }
-                        54 => {
+                        54 => { /* expr: FUNCTION ')'  */
                             if (if ((*yyvsp.offset(-1)).astr[0] as c_int)
                                 < (*::core::mem::transmute::<&[u8; 8], &[c_char; 8]>(b"RANDOM(\0"))
                                     [0] as c_int
@@ -2284,7 +2565,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 }
                             }
                         }
-                        55 => {
+                        55 => {/* expr: FUNCTION bexpr ')'  */
                             if (if ((*yyvsp.offset(-2)).astr[0] as c_int)
                                 < (*::core::mem::transmute::<&[u8; 5], &[c_char; 5]>(b"SUM(\0"))[0]
                                     as c_int
@@ -2391,7 +2672,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 }
                             }
                         }
-                        56 => {
+                        56 => {/* expr: FUNCTION bexpr ',' expr ')'  */
                             if (if ((*yyvsp.offset(-4)).astr[0] as c_int)
                                 < (*::core::mem::transmute::<&[u8; 10], &[c_char; 10]>(
                                     b"AXISELEM(\0",
@@ -2595,7 +2876,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 }
                             }
                         }
-                        57 => {
+                        57 => {/* expr: FUNCTION sexpr ')'  */
                             if (if ((*yyvsp.offset(-2)).astr[0] as c_int)
                                 < (*::core::mem::transmute::<&[u8; 7], &[c_char; 7]>(b"NELEM(\0"))
                                     [0] as c_int
@@ -2669,7 +2950,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 }
                             }
                         }
-                        58 => {
+                        58 => { /* expr: FUNCTION bits ')'  */
                             if (if ((*yyvsp.offset(-2)).astr[0] as c_int)
                                 < (*::core::mem::transmute::<&[u8; 7], &[c_char; 7]>(b"NELEM(\0"))
                                     [0] as c_int
@@ -2867,7 +3148,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 }
                             }
                         }
-                        59 => {
+                        59 => {/* expr: FUNCTION expr ')'  */
                             if (if ((*yyvsp.offset(-2)).astr[0] as c_int)
                                 < (*::core::mem::transmute::<&[u8; 5], &[c_char; 5]>(b"SUM(\0"))[0]
                                     as c_int
@@ -4095,7 +4376,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 }
                             }
                         }
-                        60 => {
+                        60 => {/* expr: IFUNCTION sexpr ',' sexpr ')'  */
                             if (if ((*yyvsp.offset(-4)).astr[0] as c_int)
                                 < (*::core::mem::transmute::<&[u8; 8], &[c_char; 8]>(b"STRSTR(\0"))
                                     [0] as c_int
@@ -4141,7 +4422,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 }
                             }
                         }
-                        61 => {
+                        61 => {/* expr: FUNCTION expr ',' expr ')'  */
                             if (if ((*yyvsp.offset(-4)).astr[0] as c_int)
                                 < (*::core::mem::transmute::<&[u8; 9], &[c_char; 9]>(b"DEFNULL(\0"))
                                     [0] as c_int
@@ -4703,7 +4984,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 }
                             }
                         }
-                        62 => {
+                        62 => {/* expr: FUNCTION expr ',' expr ',' expr ',' expr ')'  */
                             if (if ((*yyvsp.offset(-8)).astr[0] as c_int)
                                 < (*::core::mem::transmute::<&[u8; 8], &[c_char; 8]>(b"ANGSEP(\0"))
                                     [0] as c_int
@@ -4841,7 +5122,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 4830776507462815627;
                             }
                         }
-                        63 => {
+                        63 => {/* expr: GTIOVERLAP STRING ',' expr ',' expr ')'  */
                             yyval.Node = New_GTI(
                                 lParse,
                                 gtiover_fct,
@@ -4857,7 +5138,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        64 => {
+                        64 => {/* expr: GTIOVERLAP STRING ',' expr ',' expr ',' STRING ',' STRING ')'  */
                             yyval.Node = New_GTI(
                                 lParse,
                                 gtiover_fct,
@@ -4873,7 +5154,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        65 => {
+                        65 => {/* expr: expr '[' expr ']'  */
                             yyval.Node = New_Deref(
                                 lParse,
                                 (*yyvsp.offset(-3)).Node,
@@ -4890,7 +5171,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        66 => {
+                        66 => {/* expr: expr '[' expr ',' expr ']'  */
                             yyval.Node = New_Deref(
                                 lParse,
                                 (*yyvsp.offset(-(5))).Node,
@@ -4907,7 +5188,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        67 => {
+                        67 => {/* expr: expr '[' expr ',' expr ',' expr ']'  */
                             yyval.Node = New_Deref(
                                 lParse,
                                 (*yyvsp.offset(-7)).Node,
@@ -4924,7 +5205,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        68 => {
+                        68 => {/* expr: expr '[' expr ',' expr ',' expr ',' expr ']'  */
                             yyval.Node = New_Deref(
                                 lParse,
                                 (*yyvsp.offset(-9)).Node,
@@ -4941,7 +5222,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        69 => {
+                        69 => {/* expr: expr '[' expr ',' expr ',' expr ',' expr ',' expr ']'  */
                             yyval.Node = New_Deref(
                                 lParse,
                                 (*yyvsp.offset(-11)).Node,
@@ -4958,7 +5239,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        70 => {
+                        70 => {/* expr: INTCAST expr  */
                             yyval.Node = New_Unary(
                                 lParse,
                                 fits_parser_yytokentype::LONG as c_int,
@@ -4971,7 +5252,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        71 => {
+                        71 => {/* expr: INTCAST bexpr  */
                             yyval.Node = New_Unary(
                                 lParse,
                                 fits_parser_yytokentype::LONG as c_int,
@@ -4984,7 +5265,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        72 => {
+                        72 => { /* expr: FLTCAST expr  */
                             yyval.Node = New_Unary(
                                 lParse,
                                 fits_parser_yytokentype::DOUBLE as c_int,
@@ -4997,7 +5278,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        73 => {
+                        73 => {/* expr: FLTCAST bexpr  */
                             yyval.Node = New_Unary(
                                 lParse,
                                 fits_parser_yytokentype::DOUBLE as c_int,
@@ -5010,7 +5291,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        74 => {
+                        74 => {/* bexpr: BOOLEAN  */
                             yyval.Node = New_Const(
                                 lParse,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
@@ -5023,7 +5304,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        75 => {
+                        75 => {/* bexpr: BCOLUMN  */
                             yyval.Node = New_Column(lParse, (*yyvsp.offset(0)).lng as c_int);
                             if yyval.Node < 0 {
                                 current_block = 4830776507462815627;
@@ -5031,7 +5312,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        76 => {
+                        76 => {/* bexpr: BCOLUMN '{' expr '}'  */
                             if ((lParse.Nodes)[(*yyvsp.offset(-1)).Node as usize]).ntype
                                 != fits_parser_yytokentype::LONG as c_int
                                 || ((lParse.Nodes)[(*yyvsp.offset(-1)).Node as usize]).operation
@@ -5055,7 +5336,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 }
                             }
                         }
-                        77 => {
+                        77 => {/* bexpr: bits EQ bits  */
                             yyval.Node = New_BinOp(
                                 lParse,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
@@ -5070,7 +5351,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        78 => {
+                        78 => { /* bexpr: bits NE bits  */
                             yyval.Node = New_BinOp(
                                 lParse,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
@@ -5085,7 +5366,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        79 => {
+                        79 => {/* bexpr: bits LT bits  */
                             yyval.Node = New_BinOp(
                                 lParse,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
@@ -5100,7 +5381,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        80 => {
+                        80 => { /* bexpr: bits LTE bits  */
                             yyval.Node = New_BinOp(
                                 lParse,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
@@ -5115,7 +5396,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        81 => {
+                        81 => {/* bexpr: bits GT bits  */
                             yyval.Node = New_BinOp(
                                 lParse,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
@@ -5130,7 +5411,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        82 => {
+                        82 => {/* bexpr: bits GTE bits  */
                             yyval.Node = New_BinOp(
                                 lParse,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
@@ -5145,7 +5426,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        83 => {
+                        83 => {/* bexpr: expr GT expr  */
                             if (lParse.Nodes[(*yyvsp.offset(-2)).Node as usize]).ntype
                                 > (lParse.Nodes[(*yyvsp.offset(0)).Node as usize]).ntype
                             {
@@ -5178,7 +5459,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        84 => {
+                        84 => { /* bexpr: expr LT expr  */
                             if (lParse.Nodes[(*yyvsp.offset(-2)).Node as usize]).ntype
                                 > (lParse.Nodes[(*yyvsp.offset(0)).Node as usize]).ntype
                             {
@@ -5211,7 +5492,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        85 => {
+                        85 => {/* bexpr: expr GTE expr  */
                             if (lParse.Nodes[(*yyvsp.offset(-2)).Node as usize]).ntype
                                 > (lParse.Nodes[(*yyvsp.offset(0)).Node as usize]).ntype
                             {
@@ -5244,7 +5525,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        86 => {
+                        86 => {/* bexpr: expr LTE expr  */
                             if (lParse.Nodes[(*yyvsp.offset(-2)).Node as usize]).ntype
                                 > (lParse.Nodes[(*yyvsp.offset(0)).Node as usize]).ntype
                             {
@@ -5277,7 +5558,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        87 => {
+                        87 => {/* bexpr: expr '~' expr  */
                             if (lParse.Nodes[(*yyvsp.offset(-2)).Node as usize]).ntype
                                 > (lParse.Nodes[(*yyvsp.offset(0)).Node as usize]).ntype
                             {
@@ -5310,7 +5591,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        88 => {
+                        88 => { /* bexpr: expr EQ expr  */
                             if (lParse.Nodes[(*yyvsp.offset(-2)).Node as usize]).ntype
                                 > (lParse.Nodes[(*yyvsp.offset(0)).Node as usize]).ntype
                             {
@@ -5343,7 +5624,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        89 => {
+                        89 => { /* bexpr: expr NE expr  */
                             if (lParse.Nodes[(*yyvsp.offset(-2)).Node as usize]).ntype
                                 > (lParse.Nodes[(*yyvsp.offset(0)).Node as usize]).ntype
                             {
@@ -5376,7 +5657,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        90 => {
+                        90 => {/* bexpr: sexpr EQ sexpr  */
                             yyval.Node = New_BinOp(
                                 lParse,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
@@ -5391,7 +5672,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        91 => {
+                        91 => {/* bexpr: sexpr NE sexpr  */
                             yyval.Node = New_BinOp(
                                 lParse,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
@@ -5406,7 +5687,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        92 => {
+                        92 => {/* bexpr: sexpr GT sexpr  */
                             yyval.Node = New_BinOp(
                                 lParse,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
@@ -5421,7 +5702,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        93 => {
+                        93 => {/* bexpr: sexpr GTE sexpr  */
                             yyval.Node = New_BinOp(
                                 lParse,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
@@ -5436,7 +5717,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        94 => {
+                        94 => {/* bexpr: sexpr LT sexpr  */
                             yyval.Node = New_BinOp(
                                 lParse,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
@@ -5451,7 +5732,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        95 => {
+                        95 => {/* bexpr: sexpr LTE sexpr  */
                             yyval.Node = New_BinOp(
                                 lParse,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
@@ -5466,7 +5747,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        96 => {
+                        96 => { /* bexpr: bexpr AND bexpr  */
                             yyval.Node = New_BinOp(
                                 lParse,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
@@ -5480,7 +5761,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        97 => {
+                        97 => {/* bexpr: bexpr OR bexpr  */
                             yyval.Node = New_BinOp(
                                 lParse,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
@@ -5494,7 +5775,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        98 => {
+                        98 => {/* bexpr: bexpr EQ bexpr  */
                             yyval.Node = New_BinOp(
                                 lParse,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
@@ -5508,7 +5789,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        99 => {
+                        99 => {/* bexpr: bexpr NE bexpr  */
                             yyval.Node = New_BinOp(
                                 lParse,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
@@ -5522,7 +5803,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        100 => {
+                        100 => {/* bexpr: expr '=' expr ':' expr  */
                             if ((lParse.Nodes)[(*yyvsp.offset(-4)).Node as usize]).ntype
                                 > (lParse.Nodes[(*yyvsp.offset(-2)).Node as usize]).ntype
                             {
@@ -5607,7 +5888,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        101 => {
+                        101 => { /* bexpr: bexpr '?' bexpr ':' bexpr  */
                             if Test_Dims(lParse, (*yyvsp.offset(-2)).Node, (*yyvsp.offset(0)).Node)
                                 == 0
                             {
@@ -5662,7 +5943,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 }
                             }
                         }
-                        102 => {
+                        102 => {/* bexpr: BFUNCTION expr ')'  */
                             if (if ((*yyvsp.offset(-2)).astr[0] as c_int)
                                 < (*::core::mem::transmute::<&[u8; 8], &[c_char; 8]>(b"ISNULL(\0"))
                                     [0] as c_int
@@ -5708,7 +5989,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 4830776507462815627;
                             }
                         }
-                        103 => {
+                        103 => {/* bexpr: BFUNCTION bexpr ')'  */
                             if (if ((*yyvsp.offset(-2)).astr[0] as c_int)
                                 < (*::core::mem::transmute::<&[u8; 8], &[c_char; 8]>(b"ISNULL(\0"))
                                     [0] as c_int
@@ -5754,7 +6035,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 4830776507462815627;
                             }
                         }
-                        104 => {
+                        104 => { /* bexpr: BFUNCTION sexpr ')'  */
                             if (if ((*yyvsp.offset(-2)).astr[0] as c_int)
                                 < (*::core::mem::transmute::<&[u8; 8], &[c_char; 8]>(b"ISNULL(\0"))
                                     [0] as c_int
@@ -5798,7 +6079,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 4830776507462815627;
                             }
                         }
-                        105 => {
+                        105 => {/* bexpr: FUNCTION bexpr ',' bexpr ')'  */
                             if (if ((*yyvsp.offset(-4)).astr[0] as c_int)
                                 < (*::core::mem::transmute::<&[u8; 9], &[c_char; 9]>(b"DEFNULL(\0"))
                                     [0] as c_int
@@ -5861,7 +6142,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 4830776507462815627;
                             }
                         }
-                        106 => {
+                        106 => { /* bexpr: BFUNCTION expr ',' expr ',' expr ')'  */
                             if ((lParse.Nodes)[(*yyvsp.offset(-(5))).Node as usize]).ntype
                                 != fits_parser_yytokentype::DOUBLE as c_int
                             {
@@ -5973,7 +6254,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 4830776507462815627;
                             }
                         }
-                        107 => {
+                        107 => {/* bexpr: BFUNCTION expr ',' expr ',' expr ',' expr ',' expr ')'  */
                             if ((lParse.Nodes)[(*yyvsp.offset(-9)).Node as usize]).ntype
                                 != fits_parser_yytokentype::DOUBLE as c_int
                             {
@@ -6133,7 +6414,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 4830776507462815627;
                             }
                         }
-                        108 => {
+                        108 => { /* bexpr: BFUNCTION expr ',' expr ',' expr ',' expr ',' expr ',' expr ',' expr ')'  */
                             if ((lParse.Nodes)[(*yyvsp.offset(-13)).Node as usize]).ntype
                                 != fits_parser_yytokentype::DOUBLE as c_int
                             {
@@ -6420,7 +6701,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 }
                             }
                         }
-                        109 => {
+                        109 => {/* bexpr: GTIFILTER ')'  */  /* Use defaults for all elements */
                             yyval.Node = New_GTI(
                                 lParse,
                                 gtifilt_fct,
@@ -6436,7 +6717,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        110 => {
+                        110 => {/* bexpr: GTIFILTER STRING ')'  */  /* Use defaults for all except filename */
                             yyval.Node = New_GTI(
                                 lParse,
                                 gtifilt_fct,
@@ -6452,7 +6733,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        111 => {
+                        111 => {/* bexpr: GTIFILTER STRING ',' expr ')'  */
                             yyval.Node = New_GTI(
                                 lParse,
                                 gtifilt_fct,
@@ -6468,7 +6749,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        112 => {
+                        112 => {/* bexpr: GTIFILTER STRING ',' expr ',' STRING ',' STRING ')'  */
                             yyval.Node = New_GTI(
                                 lParse,
                                 gtifilt_fct,
@@ -6484,7 +6765,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        113 => {
+                        113 => {/* bexpr: GTIFIND ')'  */ /* Use defaults for all elements */
                             yyval.Node = New_GTI(
                                 lParse,
                                 gtifind_fct,
@@ -6500,7 +6781,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        114 => {
+                        114 => { /* bexpr: GTIFIND STRING ')'  *//* Use defaults for all except filename */
                             yyval.Node = New_GTI(
                                 lParse,
                                 gtifind_fct,
@@ -6516,7 +6797,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        115 => {
+                        115 => {/* bexpr: GTIFIND STRING ',' expr ')'  */
                             yyval.Node = New_GTI(
                                 lParse,
                                 gtifind_fct,
@@ -6532,7 +6813,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        116 => {
+                        116 => {/* bexpr: GTIFIND STRING ',' expr ',' STRING ',' STRING ')'  */
                             yyval.Node = New_GTI(
                                 lParse,
                                 gtifind_fct,
@@ -6548,7 +6829,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        117 => {
+                        117 => {/* bexpr: REGFILTER STRING ')'  *//* Use defaults for all except filename */
                             let mut dummy = [0];
                             yyval.Node = New_REG(
                                 lParse,
@@ -6563,7 +6844,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        118 => {
+                        118 => {/* bexpr: REGFILTER STRING ',' expr ',' expr ')'  */
                             let mut dummy = [0];
                             yyval.Node = New_REG(
                                 lParse,
@@ -6578,7 +6859,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        119 => {
+                        119 => {/* bexpr: REGFILTER STRING ',' expr ',' expr ',' STRING ')'  */
                             yyval.Node = New_REG(
                                 lParse,
                                 ((*yyvsp.offset(-7)).astr).as_mut_ptr(),
@@ -6592,7 +6873,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        120 => {
+                        120 => {/* bexpr: bexpr '[' expr ']'  */
                             yyval.Node = New_Deref(
                                 lParse,
                                 (*yyvsp.offset(-3)).Node,
@@ -6609,7 +6890,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        121 => {
+                        121 => { /* bexpr: bexpr '[' expr ',' expr ']'  */
                             yyval.Node = New_Deref(
                                 lParse,
                                 (*yyvsp.offset(-(5))).Node,
@@ -6626,7 +6907,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        122 => {
+                        122 => {/* bexpr: bexpr '[' expr ',' expr ',' expr ']'  */
                             yyval.Node = New_Deref(
                                 lParse,
                                 (*yyvsp.offset(-7)).Node,
@@ -6643,7 +6924,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        123 => {
+                        123 => {/* bexpr: bexpr '[' expr ',' expr ',' expr ',' expr ']'  */
                             yyval.Node = New_Deref(
                                 lParse,
                                 (*yyvsp.offset(-9)).Node,
@@ -6660,7 +6941,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        124 => {
+                        124 => {/* bexpr: bexpr '[' expr ',' expr ',' expr ',' expr ',' expr ']'  */
                             yyval.Node = New_Deref(
                                 lParse,
                                 (*yyvsp.offset(-11)).Node,
@@ -6677,7 +6958,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        125 => {
+                        125 => { /* bexpr: NOT bexpr  */
                             yyval.Node = New_Unary(
                                 lParse,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
@@ -6690,17 +6971,17 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        126 => {
+                        126 => {/* bexpr: '(' bexpr ')'  */
                             yyval.Node = (*yyvsp.offset(-1)).Node;
                             current_block = 17353983478346836848;
                         }
-                        127 => {
+                        127 => {/* sexpr: STRING  */
                             yyval.Node = New_Const(
                                 lParse,
                                 fits_parser_yytokentype::STRING as c_int,
                                 ((*yyvsp.offset(0)).astr).as_mut_ptr() as *mut c_void,
                                 (strlen(((*yyvsp.offset(0)).astr).as_mut_ptr()))
-                                    .wrapping_add((1 as c_int as c_ulong).try_into().unwrap())
+                                    .wrapping_add((1).try_into().unwrap())
                                     as c_long,
                             );
                             if yyval.Node < 0 {
@@ -6711,7 +6992,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        128 => {
+                        128 => {/* sexpr: SCOLUMN  */
                             yyval.Node = New_Column(lParse, (*yyvsp.offset(0)).lng as c_int);
                             if yyval.Node < 0 {
                                 current_block = 4830776507462815627;
@@ -6719,7 +7000,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 17353983478346836848;
                             }
                         }
-                        129 => {
+                        129 => {/* sexpr: SCOLUMN '{' expr '}'  */
                             if ((lParse.Nodes)[(*yyvsp.offset(-1)).Node as usize]).ntype
                                 != fits_parser_yytokentype::LONG as c_int
                                 || ((lParse.Nodes)[(*yyvsp.offset(-1)).Node as usize]).operation
@@ -6743,7 +7024,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 }
                             }
                         }
-                        130 => {
+                        130 => { /* sexpr: SNULLREF  */
                             yyval.Node = New_Func(
                                 lParse,
                                 fits_parser_yytokentype::STRING as c_int,
@@ -6759,11 +7040,11 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             );
                             current_block = 17353983478346836848;
                         }
-                        131 => {
+                        131 => { /* sexpr: '(' sexpr ')'  */
                             yyval.Node = (*yyvsp.offset(-1)).Node;
                             current_block = 17353983478346836848;
                         }
-                        132 => {
+                        132 => {/* sexpr: sexpr '+' sexpr  */
                             if (lParse.Nodes[(*yyvsp.offset(-2)).Node as usize])
                                 .value
                                 .nelem
@@ -6797,7 +7078,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 }
                             }
                         }
-                        133 => {
+                        133 => { /* sexpr: bexpr '?' sexpr ':' sexpr  */
                             let mut outSize: c_int = 0;
                             if ((lParse.Nodes)[(*yyvsp.offset(-4)).Node as usize])
                                 .value
@@ -6808,8 +7089,12 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     lParse,
                                     cs!(c"Cannot have a vector string column"),
                                 );
-                                current_block = 4830776507462815627;
+                                current_block = 4830776507462815627; // goto yyerrorlab
                             } else {
+                                 /* Since the output can be calculated now, as a constant
+                                    scalar, we must precalculate the output size, in
+                                    order to avoid an overflow. */
+
                                 outSize = (((lParse.Nodes)[(*yyvsp.offset(-2)).Node as usize])
                                     .value)
                                     .nelem as c_int;
@@ -6851,7 +7136,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 }
                             }
                         }
-                        134 => {
+                        134 => { /* sexpr: FUNCTION sexpr ',' sexpr ')'  */
                             if (if ((*yyvsp.offset(-4)).astr[0] as c_int)
                                 < (*::core::mem::transmute::<&[u8; 9], &[c_char; 9]>(b"DEFNULL(\0"))
                                     [0] as c_int
@@ -6869,6 +7154,10 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 )
                             }) == 0
                             {
+                                 /* Since the output can be calculated now, as a constant
+                                scalar, we must precalculate the output size, in
+                                order to avoid an overflow. */
+
                                 let mut outSize_0: c_int = 0;
                                 outSize_0 = ((lParse.Nodes)[(*yyvsp.offset(-3)).Node as usize])
                                     .value
@@ -6922,7 +7211,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = 4830776507462815627;
                             }
                         }
-                        135 => {
+                        135 => {/* sexpr: FUNCTION sexpr ',' expr ',' expr ')'  */
                             if (if ((*yyvsp.offset(-6)).astr[0] as c_int)
                                 < (*::core::mem::transmute::<&[u8; 8], &[c_char; 8]>(b"STRMID(\0"))
                                     [0] as c_int
@@ -6964,12 +7253,14 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     if ((lParse.Nodes)[(*yyvsp.offset(-1)).Node as usize]).operation
                                         == CONST_OP
                                     {
+                                        /* Constant value: use that directly */
                                         len = ((lParse.Nodes)[(*yyvsp.offset(-1)).Node as usize])
                                             .value
                                             .data
                                             .lng
                                             as c_int;
                                     } else {
+                                          /* Variable value: use the maximum possible (from $2) */
                                         len = ((lParse.Nodes)[(*yyvsp.offset(-(5))).Node as usize])
                                             .value
                                             .nelem
@@ -7015,6 +7306,22 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             current_block = 17353983478346836848;
                         }
                     }
+
+                    /* User semantic actions sometimes alter yychar, and that requires
+                    that yytoken be updated with the new translation.  We take the
+                    approach of translating immediately before every use of yytoken.
+                    One alternative is translating here after every semantic action,
+                    but that translation would be missed if the semantic action invokes
+                    YYABORT, YYACCEPT, or YYERROR immediately after altering yychar or
+                    if it invokes YYBACKUP.  In the case of YYABORT or YYACCEPT, an
+                    incorrect destructor might then be invoked immediately.  In the
+                    case of YYERROR or YYBACKUP, subsequent parser actions might lead
+                    to an incorrect destructor call or verbose syntax error message
+                    before the lookahead is translated.  */
+
+
+                        YY_SYMBOL_PRINT!("-> $$ =", YYR1[yyn as usize] as yysymbol_kind_t, &yyval,  scanner, lParse);
+
                     match current_block {
                         4830776507462815627 => {
                             fits_parser_yynerrs += 1;
@@ -7030,25 +7337,31 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             yylen = 0;
                             yyvsp = yyvsp.offset(1);
                             *yyvsp = yyval;
-                            let yylhs: c_int = YYR1[yyn as usize] as c_int - 57 as c_int;
+
+                            /* Now 'shift' the result of the reduction.  Determine what state
+                            that goes to, based on the state we popped back to and the rule
+                            number reduced by.  */
+
+                            let yylhs: c_int = YYR1[yyn as usize] as c_int - YYNTOKENS as c_int;
                             let yyi: c_int = YYPGOTO[yylhs as usize] as c_int + *yyssp as c_int;
                             yystate = if 0 <= yyi
-                                && yyi <= 1776 as c_int
+                                && yyi <= YYLAST as c_int
                                 && YYCHECK[yyi as usize] as c_int == *yyssp as c_int
                             {
                                 YYTABLE[yyi as usize] as c_int
                             } else {
                                 YYDEFGOTO[yylhs as usize] as c_int
                             };
-                            current_block = 7872030484262409139;
+                            current_block = 7872030484262409139; // goto yynewstate;
                         }
                     }
                 }
+
                 if current_block == 1774893048582444437 {
                     yyerrstatus = 3 as c_int;
                     loop {
                         yyn = YYPACT[yystate as usize] as c_int;
-                        if yyn != -(41 as c_int) {
+                        if yyn != -41 {
                             yyn += YYSYMBOL_YYerror as c_int;
                             if 0 <= yyn
                                 && yyn <= 1776 as c_int
@@ -7071,15 +7384,22 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             scanner,
                             lParse,
                         );
-                        yyvsp = yyvsp.offset(-(1 as c_int as isize));
-                        yyssp = yyssp.offset(-(1 as c_int as isize));
+                        yyvsp = yyvsp.offset(-1);
+                        yyssp = yyssp.offset(-1);
                         yystate = *yyssp as yy_state_fast_t;
                     }
                     yyvsp = yyvsp.offset(1);
                     *yyvsp = yylval;
                     yystate = yyn;
                 }
+
+                /*------------------------------------------------------------.
+                | yynewstate -- push a new state, which is found in yystate.  |
+                `------------------------------------------------------------*/
                 yyssp = yyssp.offset(1);
+                /* In all cases, when you get here, the value and location stacks
+                have just been pushed.  So pushing a state here evens the stacks.  */
+
             }
         }
         match current_block {
@@ -7116,8 +7436,8 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                 scanner,
                 lParse,
             );
-            yyvsp = yyvsp.offset(-(1 as c_int as isize));
-            yyssp = yyssp.offset(-(1 as c_int as isize));
+            yyvsp = yyvsp.offset(-1);
+            yyssp = yyssp.offset(-1);
         }
         if yyss != yyssa.as_mut_ptr() {
             free(yyss as *mut c_void);
@@ -8284,7 +8604,7 @@ fn Allocate_Ptrs(lParse: &mut ParseData, this_node_idx: usize) {
                         *fresh21 = (*((lParse.Nodes[this_node_idx]).value.data.strptr)
                             .offset((row - 1) as isize))
                         .offset((lParse.Nodes[this_node_idx]).value.nelem as isize)
-                        .offset(1 as c_int as isize);
+                        .offset(1);
                     }
                     if (lParse.Nodes[this_node_idx]).ntype
                         == fits_parser_yytokentype::STRING as c_int
@@ -8293,7 +8613,7 @@ fn Allocate_Ptrs(lParse: &mut ParseData, this_node_idx: usize) {
                             (*((lParse.Nodes[this_node_idx]).value.data.strptr)
                                 .offset((row - 1) as isize))
                             .offset((lParse.Nodes[this_node_idx]).value.nelem as isize)
-                            .offset(1 as c_int as isize);
+                            .offset(1);
                     } else {
                         (lParse.Nodes[this_node_idx]).value.undef = ptr::null_mut(); /* BITSTRs don't use undef array */
                     }
@@ -12386,7 +12706,7 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                                 .offset(0) = minVal_1;
                                 *(*((lParse.Nodes[this_node_idx]).value.data.strptr)
                                     .offset(row as isize))
-                                .offset(1 as c_int as isize) = 0;
+                                .offset(1) = 0;
                             }
                         }
                     }
@@ -12672,7 +12992,7 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                                 .offset(0) = maxVal_1;
                                 *(*((lParse.Nodes[this_node_idx]).value.data.strptr)
                                     .offset(row as isize))
-                                .offset(1 as c_int as isize) = 0;
+                                .offset(1) = 0;
                             }
                         }
                     }
@@ -13612,7 +13932,7 @@ fn Do_Deref(lParse: &mut ParseData, this_node_idx: usize) {
                                 .offset((elem + row) as isize);
                             *(*((lParse.Nodes[this_node_idx]).value.data.strptr)
                                 .offset(row as isize))
-                            .offset(1 as c_int as isize) = 0; /* Null terminate */
+                            .offset(1) = 0; /* Null terminate */
                         }
                         elem += (lParse.Nodes[theVar]).value.nelem;
                         row += 1;
@@ -13785,7 +14105,7 @@ fn Do_Deref(lParse: &mut ParseData, this_node_idx: usize) {
                                 .offset((elem + row) as isize);
                             *(*((lParse.Nodes[this_node_idx]).value.data.strptr)
                                 .offset(row as isize))
-                            .offset(1 as c_int as isize) = 0; /* Null terminate */
+                            .offset(1) = 0; /* Null terminate */
                         }
                     } else {
                         fits_parser_yyerror(lParse, cs!(c"Index out of range"));
@@ -14373,8 +14693,8 @@ fn get_this_that_nodes<T>(nodes: &mut [T], this_idx: usize, that_idx: usize) -> 
     let split_idx = cmp::max(this_idx, that_idx);
     let (left, right) = nodes.split_at_mut(split_idx);
     if this_idx < that_idx {
-        let this_node = &mut right[0];
-        let that_node = &mut left[this_idx];
+        let that_node = &mut right[0];
+        let this_node = &mut left[this_idx];
         (this_node, that_node)
     } else {
         let this_node = &mut right[0];

--- a/src/eval_y.rs
+++ b/src/eval_y.rs
@@ -10,10 +10,11 @@
 )]
 
 use std::ffi::CStr;
-use std::ptr;
+use std::rc::Rc;
+use std::{cmp, ptr};
 
 use bytemuck::cast_slice;
-use libc::{calloc, free, malloc, memcpy, memset, realloc, sprintf, time, time_t};
+use libc::{calloc, free, malloc, memcpy, sprintf, time, time_t};
 
 // Math function wrappers
 fn sqrt(x: f64) -> f64 {
@@ -71,28 +72,26 @@ fn tanh(x: f64) -> f64 {
     x.tanh()
 }
 
-use crate::atoi;
 use crate::c_types::{
     c_char, c_double, c_int, c_long, c_schar, c_short, c_uchar, c_uint, c_ulong, c_void,
 };
 use crate::cfileio::{ffclos, ffexts, ffopen};
-use crate::eval_defs::{Node, ParseData, data_union, lval};
+use crate::eval_defs::{Node, ParseData, data_union, lval, yyscan_t};
 use crate::eval_l::{fits_parser_yyGetVariable, fits_parser_yylex};
 use crate::eval_tab::{FITS_PARSER_YYSTYPE, fits_parser_yytokentype};
-use crate::fitscore::ffpmsg;
+use crate::fitscore::ffpmsg_slice;
 use crate::fitscore::{ffgcno, ffghdn, ffmahd, ffmnhd, ffupch};
-use crate::fitsio::{LONGLONG, fitsfile};
+use crate::fitsio::{LONGLONG, MEMORY_ALLOCATION, PARSE_SYNTAX_ERR, fitsfile};
 use crate::getcold::ffgcvd;
 use crate::getkey::{ffgkyd, ffgkyj, ffgkys};
-use crate::region::{SAORegion, WCSdata, fits_in_region, fits_read_rgnfile};
+use crate::region::{MY_PI, SAORegion, WCSdata, fits_in_region, fits_read_rgnfile};
 use crate::simplerng::{
     simplerng_getnorm, simplerng_getpoisson, simplerng_getuniform, simplerng_srand,
 };
 use crate::wcssub::ffgtcs;
-use crate::wrappers::strncpy;
+use crate::wrappers::strncpy_safe;
 use crate::wrappers::{strcat, strcmp, strcpy, strlen, strstr};
-
-pub type yyscan_t = *mut c_void;
+use crate::{atoi, cs};
 
 pub type yy_state_t = yytype_int16;
 pub type yytype_int16 = c_short;
@@ -501,95 +500,83 @@ static yyr2: [yytype_int8; 136] = [
     12, 2, 3, 1, 1, 4, 1, 3, 3, 5, 5, 7,
 ];
 
-unsafe fn Alloc_Node(mut lParse: *mut ParseData) -> c_int {
-    unsafe {
-        let mut newNodePtr: *mut Node = std::ptr::null_mut::<Node>();
-        if (*lParse).nNodes == (*lParse).nNodesAlloc {
-            if !((*lParse).Nodes).is_null() {
-                (*lParse).nNodesAlloc += (*lParse).nNodesAlloc;
-                newNodePtr = realloc(
-                    (*lParse).Nodes as *mut c_void,
-                    (::core::mem::size_of::<Node>() as c_ulong)
-                        .wrapping_mul((*lParse).nNodesAlloc as c_ulong)
-                        .try_into()
-                        .unwrap(),
-                ) as *mut Node;
-            } else {
-                (*lParse).nNodesAlloc = 100 as c_int;
-                newNodePtr = malloc(
-                    (::core::mem::size_of::<Node>() as c_ulong)
-                        .wrapping_mul((*lParse).nNodesAlloc as c_ulong)
-                        .try_into()
-                        .unwrap(),
-                ) as *mut Node;
-            }
-            if !newNodePtr.is_null() {
-                (*lParse).Nodes = newNodePtr;
-            } else {
-                (*lParse).status = 113 as c_int;
-                return -(1);
-            }
+fn Alloc_Node(lParse: &mut ParseData) -> c_int {
+    // If number of nodes == number allocated, then realloc
+    if lParse.nNodes == lParse.nNodesAlloc {
+        if lParse
+            .Nodes
+            .try_reserve_exact(lParse.nNodesAlloc as usize)
+            .is_err()
+        {
+            lParse.status = MEMORY_ALLOCATION;
+            return -(1);
+        } else {
+            lParse.nNodesAlloc *= 2;
+            lParse
+                .Nodes
+                .resize(lParse.nNodesAlloc as usize, Node::default());
         }
-        let fresh0 = (*lParse).nNodes;
-        (*lParse).nNodes += 1;
-        fresh0
     }
+
+    lParse.nNodes += 1;
+    lParse.nNodes
 }
-unsafe fn Free_Last_Node(mut lParse: *mut ParseData) {
+
+unsafe fn Free_Last_Node(lParse: &mut ParseData) {
     unsafe {
-        if (*lParse).nNodes != 0 {
-            (*lParse).nNodes -= 1;
-            (*lParse).nNodes;
+        if lParse.nNodes != 0 {
+            lParse.nNodes -= 1;
+            lParse.nNodes;
         }
     }
 }
+
 unsafe fn New_Const(
-    mut lParse: *mut ParseData,
-    mut returnType: c_int,
-    mut value: *mut c_void,
-    mut len: c_long,
+    lParse: &mut ParseData,
+    returnType: c_int,
+    value: *const c_void,
+    len: c_long,
 ) -> c_int {
     unsafe {
-        let mut this: *mut Node = std::ptr::null_mut::<Node>();
         let mut n: c_int = 0;
         n = Alloc_Node(lParse);
         if n >= 0 {
-            this = ((*lParse).Nodes).offset(n as isize);
-            (*this).operation = -(1000 as c_int);
-            (*this).DoOp = None;
-            (*this).nSubNodes = 0;
-            (*this).ntype = returnType;
+            let this = &mut (lParse.Nodes)[n as usize];
+            this.operation = -1000;
+            this.DoOp = None;
+            this.nSubNodes = 0;
+            this.ntype = returnType;
             memcpy(
-                &mut (*this).value.data as *const _ as *mut c_void,
+                &mut this.value.data as *const _ as *mut c_void,
                 value,
                 (len as c_ulong).try_into().unwrap(),
             );
-            (*this).value.undef = ptr::null_mut();
-            (*this).value.nelem = 1;
-            (*this).value.naxis = 1;
-            (*this).value.naxes[0] = 1;
+            this.value.undef = ptr::null_mut();
+            this.value.nelem = 1;
+            this.value.naxis = 1;
+            this.value.naxes[0] = 1;
         }
         n
     }
 }
-unsafe fn New_Column(mut lParse: *mut ParseData, mut ColNum: c_int) -> c_int {
+unsafe fn New_Column(lParse: &mut ParseData, mut ColNum: c_int) -> c_int {
     unsafe {
         let mut this: *mut Node = std::ptr::null_mut::<Node>();
         let mut n: c_int = 0;
         let mut i: c_int = 0;
         n = Alloc_Node(lParse);
         if n >= 0 {
-            this = ((*lParse).Nodes).offset(n as isize);
+            this = &mut (lParse.Nodes)[n as usize];
             (*this).operation = -ColNum;
             (*this).DoOp = None;
             (*this).nSubNodes = 0;
-            (*this).ntype = (*((*lParse).varData).offset(ColNum as isize)).dtype;
-            (*this).value.nelem = (*((*lParse).varData).offset(ColNum as isize)).nelem;
-            (*this).value.naxis = (*((*lParse).varData).offset(ColNum as isize)).naxis;
+            (*this).ntype = (*(lParse.varData).offset(ColNum as isize)).dtype;
+            (*this).value.nelem = (*(lParse.varData).offset(ColNum as isize)).nelem;
+            (*this).value.naxis = (*(lParse.varData).offset(ColNum as isize)).naxis;
             i = 0;
-            while i < (*((*lParse).varData).offset(ColNum as isize)).naxis {
+            while i < (*(lParse.varData).offset(ColNum as isize)).naxis {
                 (*this).value.naxes[i as usize] =
-                    (*((*lParse).varData).offset(ColNum as isize)).naxes[i as usize];
+                    (*(lParse.varData).offset(ColNum as isize)).naxes[i as usize];
                 i += 1;
                 i;
             }
@@ -597,11 +584,7 @@ unsafe fn New_Column(mut lParse: *mut ParseData, mut ColNum: c_int) -> c_int {
         n
     }
 }
-unsafe fn New_Offset(
-    mut lParse: *mut ParseData,
-    mut ColNum: c_int,
-    mut offsetNode: c_int,
-) -> c_int {
+unsafe fn New_Offset(lParse: &mut ParseData, mut ColNum: c_int, mut offsetNode: c_int) -> c_int {
     unsafe {
         let mut this: *mut Node = std::ptr::null_mut::<Node>();
         let mut n: c_int = 0;
@@ -613,19 +596,19 @@ unsafe fn New_Offset(
         }
         n = Alloc_Node(lParse);
         if n >= 0 {
-            this = ((*lParse).Nodes).offset(n as isize);
+            this = &mut (lParse.Nodes)[n as usize];
             (*this).operation = b'{' as i32;
             (*this).DoOp = Some(Do_Offset);
             (*this).nSubNodes = 2 as c_int;
             (*this).SubNodes[0] = colNode;
             (*this).SubNodes[1] = offsetNode;
-            (*this).ntype = (*((*lParse).varData).offset(ColNum as isize)).dtype;
-            (*this).value.nelem = (*((*lParse).varData).offset(ColNum as isize)).nelem;
-            (*this).value.naxis = (*((*lParse).varData).offset(ColNum as isize)).naxis;
+            (*this).ntype = (*(lParse.varData).offset(ColNum as isize)).dtype;
+            (*this).value.nelem = (*(lParse.varData).offset(ColNum as isize)).nelem;
+            (*this).value.naxis = (*(lParse.varData).offset(ColNum as isize)).naxis;
             i = 0;
-            while i < (*((*lParse).varData).offset(ColNum as isize)).naxis {
+            while i < (*(lParse.varData).offset(ColNum as isize)).naxis {
                 (*this).value.naxes[i as usize] =
-                    (*((*lParse).varData).offset(ColNum as isize)).naxes[i as usize];
+                    (*(lParse.varData).offset(ColNum as isize)).naxes[i as usize];
                 i += 1;
                 i;
             }
@@ -634,7 +617,7 @@ unsafe fn New_Offset(
     }
 }
 unsafe fn New_Unary(
-    mut lParse: *mut ParseData,
+    lParse: &mut ParseData,
     mut returnType: c_int,
     mut Op: c_int,
     mut Node1: c_int,
@@ -647,7 +630,7 @@ unsafe fn New_Unary(
         if Node1 < 0 {
             return -(1);
         }
-        that = ((*lParse).Nodes).offset(Node1 as isize);
+        that = &mut (lParse.Nodes)[Node1 as usize];
         if Op == 0 {
             Op = returnType;
         }
@@ -670,13 +653,13 @@ unsafe fn New_Unary(
         }
         n = Alloc_Node(lParse);
         if n >= 0 {
-            this = ((*lParse).Nodes).offset(n as isize);
+            this = &mut (lParse.Nodes)[n as usize];
             (*this).operation = Op;
             (*this).DoOp = Some(Do_Unary);
             (*this).nSubNodes = 1;
             (*this).SubNodes[0] = Node1;
             (*this).ntype = returnType;
-            that = ((*lParse).Nodes).offset(Node1 as isize);
+            that = &mut (lParse.Nodes)[Node1 as usize];
             (*this).value.nelem = (*that).value.nelem;
             (*this).value.naxis = (*that).value.naxis;
             i = 0;
@@ -685,7 +668,7 @@ unsafe fn New_Unary(
                 i += 1;
                 i;
             }
-            if (*that).operation == -(1000 as c_int) {
+            if (*that).operation == -1000 {
                 ((*this).DoOp).expect("non-null function pointer")(lParse, this);
             }
         }
@@ -693,7 +676,7 @@ unsafe fn New_Unary(
     }
 }
 unsafe fn New_BinOp(
-    mut lParse: *mut ParseData,
+    lParse: &mut ParseData,
     mut returnType: c_int,
     mut Node1: c_int,
     mut Op: c_int,
@@ -711,26 +694,24 @@ unsafe fn New_BinOp(
         }
         n = Alloc_Node(lParse);
         if n >= 0 {
-            this = ((*lParse).Nodes).offset(n as isize);
+            this = &mut (lParse.Nodes)[n as usize];
             (*this).operation = Op;
             (*this).nSubNodes = 2 as c_int;
             (*this).SubNodes[0] = Node1;
             (*this).SubNodes[1] = Node2;
             (*this).ntype = returnType;
-            that1 = ((*lParse).Nodes).offset(Node1 as isize);
-            that2 = ((*lParse).Nodes).offset(Node2 as isize);
-            constant = ((*that1).operation == -(1000 as c_int)
-                && (*that2).operation == -(1000 as c_int)) as c_int;
+            that1 = &mut (lParse.Nodes)[Node1 as usize];
+            that2 = &mut (lParse.Nodes)[Node2 as usize];
+            constant = ((*that1).operation == -1000 && (*that2).operation == -1000) as c_int;
             if (*that1).ntype != fits_parser_yytokentype::STRING as c_int
                 && (*that1).ntype != fits_parser_yytokentype::BITSTR as c_int
                 && Test_Dims(lParse, Node1, Node2) == 0
             {
                 Free_Last_Node(lParse);
                 fits_parser_yyerror(
-                    0 as yyscan_t,
+                    ptr::null_mut(),
                     lParse,
-                    b"Array sizes/dims do not match for binary operator\0" as *const u8
-                        as *const c_char as *mut c_char,
+                    cs!(c"Array sizes/dims do not match for binary operator"),
                 );
                 return -(1);
             }
@@ -778,7 +759,7 @@ unsafe fn New_BinOp(
     }
 }
 unsafe fn New_Func(
-    mut lParse: *mut ParseData,
+    lParse: &mut ParseData,
     mut returnType: c_int,
     mut Op: funcOp,
     mut nNodes: c_int,
@@ -801,14 +782,14 @@ unsafe fn yydestruct(
     mut yykind: yysymbol_kind_t,
     mut yyvaluep: *mut FITS_PARSER_YYSTYPE,
     mut scanner: yyscan_t,
-    mut lParse: *mut ParseData,
+    lParse: &mut ParseData,
 ) {
     if yymsg.is_null() {
         yymsg = b"Deleting\0" as *const u8 as *const c_char;
     }
 }
 unsafe fn New_FuncSize(
-    mut lParse: *mut ParseData,
+    lParse: &mut ParseData,
     mut returnType: c_int,
     mut Op: funcOp,
     mut nNodes: c_int,
@@ -832,7 +813,7 @@ unsafe fn New_FuncSize(
         }
         n = Alloc_Node(lParse);
         if n >= 0 {
-            this = ((*lParse).Nodes).offset(n as isize);
+            this = &mut (lParse.Nodes)[n as usize];
             (*this).operation = Op as c_int;
             (*this).DoOp = Some(Do_Func);
             (*this).nSubNodes = nNodes;
@@ -855,8 +836,8 @@ unsafe fn New_FuncSize(
                     break;
                 }
                 constant = (constant != 0
-                    && (*((*lParse).Nodes).offset((*this).SubNodes[i as usize] as isize)).operation
-                        == -(1000 as c_int)) as c_int;
+                    && ((lParse.Nodes)[(*this).SubNodes[i as usize] as usize]).operation == -1000)
+                    as c_int;
             }
             if returnType != 0 {
                 (*this).ntype = returnType;
@@ -864,7 +845,7 @@ unsafe fn New_FuncSize(
                 (*this).value.naxis = 1;
                 (*this).value.naxes[0] = 1;
             } else {
-                that = ((*lParse).Nodes).offset(Node1 as isize);
+                that = &mut (lParse.Nodes)[Node1 as usize];
                 (*this).ntype = (*that).ntype;
                 (*this).value.nelem = (*that).value.nelem;
                 (*this).value.naxis = (*that).value.naxis;
@@ -886,7 +867,7 @@ unsafe fn New_FuncSize(
     }
 }
 
-pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseData) -> c_int {
+pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, lParse: &mut ParseData) -> c_int {
     unsafe {
         let mut current_block: u64;
         let mut yychar: c_int = 0;
@@ -1056,11 +1037,7 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                         if yyerrstatus == 0 {
                             fits_parser_yynerrs += 1;
                             fits_parser_yynerrs;
-                            fits_parser_yyerror(
-                                scanner,
-                                lParse,
-                                b"syntax error\0" as *const u8 as *const c_char as *mut c_char,
-                            );
+                            fits_parser_yyerror(scanner, lParse, cs!(c"syntax error"));
                         }
                         if yyerrstatus == 3 as c_int {
                             if yychar <= fits_parser_yytokentype::FITS_PARSER_YYEOF as c_int {
@@ -1092,62 +1069,54 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                             current_block = 17353983478346836848;
                         }
                         5 => {
-                            if (*yyvsp.offset(-1_isize)).Node < 0 {
+                            if (*yyvsp.offset(-1)).Node < 0 {
                                 fits_parser_yyerror(
                                     scanner,
                                     lParse,
-                                    b"Couldn't build node structure: out of memory?\0" as *const u8
-                                        as *const c_char
-                                        as *mut c_char,
+                                    cs!(c"Couldn't build node structure: out of memory?"),
                                 );
                                 current_block = 4830776507462815627;
                             } else {
-                                (*lParse).resultNode = (*yyvsp.offset(-1_isize)).Node;
+                                lParse.resultNode = (*yyvsp.offset(-1)).Node;
                                 current_block = 17353983478346836848;
                             }
                         }
                         6 => {
-                            if (*yyvsp.offset(-1_isize)).Node < 0 {
+                            if (*yyvsp.offset(-1)).Node < 0 {
                                 fits_parser_yyerror(
                                     scanner,
                                     lParse,
-                                    b"Couldn't build node structure: out of memory?\0" as *const u8
-                                        as *const c_char
-                                        as *mut c_char,
+                                    cs!(c"Couldn't build node structure: out of memory?"),
                                 );
                                 current_block = 4830776507462815627;
                             } else {
-                                (*lParse).resultNode = (*yyvsp.offset(-1_isize)).Node;
+                                lParse.resultNode = (*yyvsp.offset(-1)).Node;
                                 current_block = 17353983478346836848;
                             }
                         }
                         7 => {
-                            if (*yyvsp.offset(-1_isize)).Node < 0 {
+                            if (*yyvsp.offset(-1)).Node < 0 {
                                 fits_parser_yyerror(
                                     scanner,
                                     lParse,
-                                    b"Couldn't build node structure: out of memory?\0" as *const u8
-                                        as *const c_char
-                                        as *mut c_char,
+                                    cs!(c"Couldn't build node structure: out of memory?"),
                                 );
                                 current_block = 4830776507462815627;
                             } else {
-                                (*lParse).resultNode = (*yyvsp.offset(-1_isize)).Node;
+                                lParse.resultNode = (*yyvsp.offset(-1)).Node;
                                 current_block = 17353983478346836848;
                             }
                         }
                         8 => {
-                            if (*yyvsp.offset(-1_isize)).Node < 0 {
+                            if (*yyvsp.offset(-1)).Node < 0 {
                                 fits_parser_yyerror(
                                     scanner,
                                     lParse,
-                                    b"Couldn't build node structure: out of memory?\0" as *const u8
-                                        as *const c_char
-                                        as *mut c_char,
+                                    cs!(c"Couldn't build node structure: out of memory?"),
                                 );
                                 current_block = 4830776507462815627;
                             } else {
-                                (*lParse).resultNode = (*yyvsp.offset(-1_isize)).Node;
+                                lParse.resultNode = (*yyvsp.offset(-1)).Node;
                                 current_block = 17353983478346836848;
                             }
                         }
@@ -1164,16 +1133,15 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                             }
                         }
                         11 => {
-                            if (*((*lParse).Nodes).offset((*yyvsp.offset(-2_isize)).Node as isize))
-                                .nSubNodes
+                            if (lParse.Nodes[(*yyvsp.offset(-2)).Node as usize]).nSubNodes
                                 >= 10 as c_int
                             {
-                                (*yyvsp.offset(-2_isize)).Node =
-                                    Close_Vec(lParse, (*yyvsp.offset(-2_isize)).Node);
-                                if (*yyvsp.offset(-2_isize)).Node < 0 {
+                                (*yyvsp.offset(-2)).Node =
+                                    Close_Vec(lParse, (*yyvsp.offset(-2)).Node);
+                                if (*yyvsp.offset(-2)).Node < 0 {
                                     current_block = 4830776507462815627;
                                 } else {
-                                    yyval.Node = New_Vector(lParse, (*yyvsp.offset(-2_isize)).Node);
+                                    yyval.Node = New_Vector(lParse, (*yyvsp.offset(-2)).Node);
                                     if yyval.Node < 0 {
                                         current_block = 4830776507462815627;
                                     } else {
@@ -1181,18 +1149,17 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                     }
                                 }
                             } else {
-                                yyval.Node = (*yyvsp.offset(-2_isize)).Node;
+                                yyval.Node = (*yyvsp.offset(-2)).Node;
                                 current_block = 2616667235040759262;
                             }
                             match current_block {
                                 4830776507462815627 => {}
                                 _ => {
-                                    let fresh2 = &mut (*((*lParse).Nodes)
-                                        .offset(yyval.Node as isize))
-                                    .nSubNodes;
+                                    let fresh2 =
+                                        &mut ((lParse.Nodes)[yyval.Node as usize]).nSubNodes;
                                     let fresh3 = *fresh2;
                                     *fresh2 += 1;
-                                    (*((*lParse).Nodes).offset(yyval.Node as isize)).SubNodes
+                                    ((lParse.Nodes)[yyval.Node as usize]).SubNodes
                                         [fresh3 as usize] = (*yyvsp.offset(0)).Node;
                                     current_block = 17353983478346836848;
                                 }
@@ -1207,27 +1174,21 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                             }
                         }
                         13 => {
-                            if (*((*lParse).Nodes).offset((*yyvsp.offset(-2_isize)).Node as isize))
-                                .ntype
-                                < (*((*lParse).Nodes).offset((*yyvsp.offset(0)).Node as isize))
-                                    .ntype
+                            if (lParse.Nodes[(*yyvsp.offset(-2)).Node as usize]).ntype
+                                < (lParse.Nodes[(*yyvsp.offset(0)).Node as usize]).ntype
                             {
-                                (*((*lParse).Nodes)
-                                    .offset((*yyvsp.offset(-2_isize)).Node as isize))
-                                .ntype = (*((*lParse).Nodes)
-                                    .offset((*yyvsp.offset(0)).Node as isize))
-                                .ntype;
+                                (lParse.Nodes[(*yyvsp.offset(-2)).Node as usize]).ntype =
+                                    ((lParse.Nodes)[(*yyvsp.offset(0)).Node as usize]).ntype;
                             }
-                            if (*((*lParse).Nodes).offset((*yyvsp.offset(-2_isize)).Node as isize))
-                                .nSubNodes
+                            if (lParse.Nodes[(*yyvsp.offset(-2)).Node as usize]).nSubNodes
                                 >= 10 as c_int
                             {
-                                (*yyvsp.offset(-2_isize)).Node =
-                                    Close_Vec(lParse, (*yyvsp.offset(-2_isize)).Node);
-                                if (*yyvsp.offset(-2_isize)).Node < 0 {
+                                (*yyvsp.offset(-2)).Node =
+                                    Close_Vec(lParse, (*yyvsp.offset(-2)).Node);
+                                if (*yyvsp.offset(-2)).Node < 0 {
                                     current_block = 4830776507462815627;
                                 } else {
-                                    yyval.Node = New_Vector(lParse, (*yyvsp.offset(-2_isize)).Node);
+                                    yyval.Node = New_Vector(lParse, (*yyvsp.offset(-2)).Node);
                                     if yyval.Node < 0 {
                                         current_block = 4830776507462815627;
                                     } else {
@@ -1235,34 +1196,32 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                     }
                                 }
                             } else {
-                                yyval.Node = (*yyvsp.offset(-2_isize)).Node;
+                                yyval.Node = (*yyvsp.offset(-2)).Node;
                                 current_block = 2904036176499606090;
                             }
                             match current_block {
                                 4830776507462815627 => {}
                                 _ => {
-                                    let fresh4 = &mut (*((*lParse).Nodes)
-                                        .offset(yyval.Node as isize))
-                                    .nSubNodes;
+                                    let fresh4 =
+                                        &mut ((lParse.Nodes)[yyval.Node as usize]).nSubNodes;
                                     let fresh5 = *fresh4;
                                     *fresh4 += 1;
-                                    (*((*lParse).Nodes).offset(yyval.Node as isize)).SubNodes
+                                    ((lParse.Nodes)[yyval.Node as usize]).SubNodes
                                         [fresh5 as usize] = (*yyvsp.offset(0)).Node;
                                     current_block = 17353983478346836848;
                                 }
                             }
                         }
                         14 => {
-                            if (*((*lParse).Nodes).offset((*yyvsp.offset(-2_isize)).Node as isize))
-                                .nSubNodes
+                            if (lParse.Nodes[(*yyvsp.offset(-2)).Node as usize]).nSubNodes
                                 >= 10 as c_int
                             {
-                                (*yyvsp.offset(-2_isize)).Node =
-                                    Close_Vec(lParse, (*yyvsp.offset(-2_isize)).Node);
-                                if (*yyvsp.offset(-2_isize)).Node < 0 {
+                                (*yyvsp.offset(-2)).Node =
+                                    Close_Vec(lParse, (*yyvsp.offset(-2)).Node);
+                                if (*yyvsp.offset(-2)).Node < 0 {
                                     current_block = 4830776507462815627;
                                 } else {
-                                    yyval.Node = New_Vector(lParse, (*yyvsp.offset(-2_isize)).Node);
+                                    yyval.Node = New_Vector(lParse, (*yyvsp.offset(-2)).Node);
                                     if yyval.Node < 0 {
                                         current_block = 4830776507462815627;
                                     } else {
@@ -1270,37 +1229,34 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                     }
                                 }
                             } else {
-                                yyval.Node = (*yyvsp.offset(-2_isize)).Node;
+                                yyval.Node = (*yyvsp.offset(-2)).Node;
                                 current_block = 17702298541784679949;
                             }
                             match current_block {
                                 4830776507462815627 => {}
                                 _ => {
-                                    let fresh6 = &mut (*((*lParse).Nodes)
-                                        .offset(yyval.Node as isize))
-                                    .nSubNodes;
+                                    let fresh6 =
+                                        &mut ((lParse.Nodes)[yyval.Node as usize]).nSubNodes;
                                     let fresh7 = *fresh6;
                                     *fresh6 += 1;
-                                    (*((*lParse).Nodes).offset(yyval.Node as isize)).SubNodes
+                                    ((lParse.Nodes)[yyval.Node as usize]).SubNodes
                                         [fresh7 as usize] = (*yyvsp.offset(0)).Node;
                                     current_block = 17353983478346836848;
                                 }
                             }
                         }
                         15 => {
-                            (*((*lParse).Nodes).offset((*yyvsp.offset(-2_isize)).Node as isize))
-                                .ntype =
-                                (*((*lParse).Nodes).offset((*yyvsp.offset(0)).Node as isize)).ntype;
-                            if (*((*lParse).Nodes).offset((*yyvsp.offset(-2_isize)).Node as isize))
-                                .nSubNodes
+                            (lParse.Nodes[(*yyvsp.offset(-2)).Node as usize]).ntype =
+                                (lParse.Nodes[(*yyvsp.offset(0)).Node as usize]).ntype;
+                            if (lParse.Nodes[(*yyvsp.offset(-2)).Node as usize]).nSubNodes
                                 >= 10 as c_int
                             {
-                                (*yyvsp.offset(-2_isize)).Node =
-                                    Close_Vec(lParse, (*yyvsp.offset(-2_isize)).Node);
-                                if (*yyvsp.offset(-2_isize)).Node < 0 {
+                                (*yyvsp.offset(-2)).Node =
+                                    Close_Vec(lParse, (*yyvsp.offset(-2)).Node);
+                                if (*yyvsp.offset(-2)).Node < 0 {
                                     current_block = 4830776507462815627;
                                 } else {
-                                    yyval.Node = New_Vector(lParse, (*yyvsp.offset(-2_isize)).Node);
+                                    yyval.Node = New_Vector(lParse, (*yyvsp.offset(-2)).Node);
                                     if yyval.Node < 0 {
                                         current_block = 4830776507462815627;
                                     } else {
@@ -1308,25 +1264,24 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                     }
                                 }
                             } else {
-                                yyval.Node = (*yyvsp.offset(-2_isize)).Node;
+                                yyval.Node = (*yyvsp.offset(-2)).Node;
                                 current_block = 1069630499025798221;
                             }
                             match current_block {
                                 4830776507462815627 => {}
                                 _ => {
-                                    let fresh8 = &mut (*((*lParse).Nodes)
-                                        .offset(yyval.Node as isize))
-                                    .nSubNodes;
+                                    let fresh8 =
+                                        &mut ((lParse.Nodes)[yyval.Node as usize]).nSubNodes;
                                     let fresh9 = *fresh8;
                                     *fresh8 += 1;
-                                    (*((*lParse).Nodes).offset(yyval.Node as isize)).SubNodes
+                                    ((lParse.Nodes)[yyval.Node as usize]).SubNodes
                                         [fresh9 as usize] = (*yyvsp.offset(0)).Node;
                                     current_block = 17353983478346836848;
                                 }
                             }
                         }
                         16 => {
-                            yyval.Node = Close_Vec(lParse, (*yyvsp.offset(-1_isize)).Node);
+                            yyval.Node = Close_Vec(lParse, (*yyvsp.offset(-1)).Node);
                             if yyval.Node < 0 {
                                 current_block = 4830776507462815627;
                             } else {
@@ -1334,7 +1289,7 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                             }
                         }
                         17 => {
-                            yyval.Node = Close_Vec(lParse, (*yyvsp.offset(-1_isize)).Node);
+                            yyval.Node = Close_Vec(lParse, (*yyvsp.offset(-1)).Node);
                             if yyval.Node < 0 {
                                 current_block = 4830776507462815627;
                             } else {
@@ -1353,7 +1308,7 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                             if yyval.Node < 0 {
                                 current_block = 4830776507462815627;
                             } else {
-                                ((*((*lParse).Nodes).offset(yyval.Node as isize)).value).nelem =
+                                (((lParse.Nodes)[yyval.Node as usize]).value).nelem =
                                     strlen(((*yyvsp.offset(0)).astr).as_mut_ptr()) as c_long;
                                 current_block = 17353983478346836848;
                             }
@@ -1367,27 +1322,22 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                             }
                         }
                         20 => {
-                            if (*((*lParse).Nodes).offset((*yyvsp.offset(-1_isize)).Node as isize))
-                                .ntype
+                            if ((lParse.Nodes)[(*yyvsp.offset(-1)).Node as usize]).ntype
                                 != fits_parser_yytokentype::LONG as c_int
-                                || (*((*lParse).Nodes)
-                                    .offset((*yyvsp.offset(-1_isize)).Node as isize))
-                                .operation
-                                    != -(1000 as c_int)
+                                || ((lParse.Nodes)[(*yyvsp.offset(-1)).Node as usize]).operation
+                                    != -1000
                             {
                                 fits_parser_yyerror(
                                     scanner,
                                     lParse,
-                                    b"Offset argument must be a constant integer\0" as *const u8
-                                        as *const c_char
-                                        as *mut c_char,
+                                    cs!(c"Offset argument must be a constant integer"),
                                 );
                                 current_block = 4830776507462815627;
                             } else {
                                 yyval.Node = New_Offset(
                                     lParse,
-                                    (*yyvsp.offset(-3_isize)).lng as c_int,
-                                    (*yyvsp.offset(-1_isize)).Node,
+                                    (*yyvsp.offset(-3)).lng as c_int,
+                                    (*yyvsp.offset(-1)).Node,
                                 );
                                 if yyval.Node < 0 {
                                     current_block = 4830776507462815627;
@@ -1400,32 +1350,25 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                             yyval.Node = New_BinOp(
                                 lParse,
                                 fits_parser_yytokentype::BITSTR as c_int,
-                                (*yyvsp.offset(-2_isize)).Node,
+                                (*yyvsp.offset(-2)).Node,
                                 '&' as i32,
                                 (*yyvsp.offset(0)).Node,
                             );
                             if yyval.Node < 0 {
                                 current_block = 4830776507462815627;
                             } else {
-                                ((*((*lParse).Nodes).offset(yyval.Node as isize)).value).nelem =
-                                    if ((*((*lParse).Nodes)
-                                        .offset((*yyvsp.offset(-2_isize)).Node as isize))
-                                    .value)
+                                (((lParse.Nodes)[yyval.Node as usize]).value).nelem =
+                                    if (((lParse.Nodes)[(*yyvsp.offset(-2)).Node as usize]).value)
                                         .nelem
-                                        > (*((*lParse).Nodes)
-                                            .offset((*yyvsp.offset(0)).Node as isize))
-                                        .value
-                                        .nelem
+                                        > (lParse.Nodes[(*yyvsp.offset(0)).Node as usize])
+                                            .value
+                                            .nelem
                                     {
-                                        (*((*lParse).Nodes)
-                                            .offset((*yyvsp.offset(-2_isize)).Node as isize))
-                                        .value
-                                        .nelem
+                                        ((lParse.Nodes)[(*yyvsp.offset(-2)).Node as usize])
+                                            .value
+                                            .nelem
                                     } else {
-                                        (*((*lParse).Nodes)
-                                            .offset((*yyvsp.offset(0)).Node as isize))
-                                        .value
-                                        .nelem
+                                        (lParse.Nodes[(*yyvsp.offset(0)).Node as usize]).value.nelem
                                     };
                                 current_block = 17353983478346836848;
                             }
@@ -1434,73 +1377,60 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                             yyval.Node = New_BinOp(
                                 lParse,
                                 fits_parser_yytokentype::BITSTR as c_int,
-                                (*yyvsp.offset(-2_isize)).Node,
+                                (*yyvsp.offset(-2)).Node,
                                 '|' as i32,
                                 (*yyvsp.offset(0)).Node,
                             );
                             if yyval.Node < 0 {
                                 current_block = 4830776507462815627;
                             } else {
-                                ((*((*lParse).Nodes).offset(yyval.Node as isize)).value).nelem =
-                                    if ((*((*lParse).Nodes)
-                                        .offset((*yyvsp.offset(-2_isize)).Node as isize))
-                                    .value)
+                                (((lParse.Nodes)[yyval.Node as usize]).value).nelem =
+                                    if (((lParse.Nodes)[(*yyvsp.offset(-2)).Node as usize]).value)
                                         .nelem
-                                        > (*((*lParse).Nodes)
-                                            .offset((*yyvsp.offset(0)).Node as isize))
-                                        .value
-                                        .nelem
+                                        > (lParse.Nodes[(*yyvsp.offset(0)).Node as usize])
+                                            .value
+                                            .nelem
                                     {
-                                        (*((*lParse).Nodes)
-                                            .offset((*yyvsp.offset(-2_isize)).Node as isize))
-                                        .value
-                                        .nelem
+                                        ((lParse.Nodes)[(*yyvsp.offset(-2)).Node as usize])
+                                            .value
+                                            .nelem
                                     } else {
-                                        (*((*lParse).Nodes)
-                                            .offset((*yyvsp.offset(0)).Node as isize))
-                                        .value
-                                        .nelem
+                                        (lParse.Nodes[(*yyvsp.offset(0)).Node as usize]).value.nelem
                                     };
                                 current_block = 17353983478346836848;
                             }
                         }
                         23 => {
-                            if (*((*lParse).Nodes).offset((*yyvsp.offset(-2_isize)).Node as isize))
+                            if (lParse.Nodes[(*yyvsp.offset(-2)).Node as usize])
                                 .value
                                 .nelem
-                                + (*((*lParse).Nodes).offset((*yyvsp.offset(0)).Node as isize))
-                                    .value
-                                    .nelem
+                                + (lParse.Nodes[(*yyvsp.offset(0)).Node as usize]).value.nelem
                                 >= 256 as c_long
                             {
                                 fits_parser_yyerror(
                                     scanner,
                                     lParse,
-                                    b"Combined bit string size exceeds 255 bits\0" as *const u8
-                                        as *const c_char
-                                        as *mut c_char,
+                                    cs!(c"Combined bit string size exceeds 255 bits"),
                                 );
                                 current_block = 4830776507462815627;
                             } else {
                                 yyval.Node = New_BinOp(
                                     lParse,
                                     fits_parser_yytokentype::BITSTR as c_int,
-                                    (*yyvsp.offset(-2_isize)).Node,
+                                    (*yyvsp.offset(-2)).Node,
                                     '+' as i32,
                                     (*yyvsp.offset(0)).Node,
                                 );
                                 if yyval.Node < 0 {
                                     current_block = 4830776507462815627;
                                 } else {
-                                    ((*((*lParse).Nodes).offset(yyval.Node as isize)).value)
-                                        .nelem = (*((*lParse).Nodes)
-                                        .offset((*yyvsp.offset(-2_isize)).Node as isize))
-                                    .value
-                                    .nelem
-                                        + (*((*lParse).Nodes)
-                                            .offset((*yyvsp.offset(0)).Node as isize))
-                                        .value
-                                        .nelem;
+                                    (((lParse.Nodes)[yyval.Node as usize]).value).nelem =
+                                        ((lParse.Nodes)[(*yyvsp.offset(-2)).Node as usize])
+                                            .value
+                                            .nelem
+                                            + ((lParse.Nodes)[(*yyvsp.offset(0)).Node as usize])
+                                                .value
+                                                .nelem;
                                     current_block = 17353983478346836848;
                                 }
                             }
@@ -1508,9 +1438,9 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                         24 => {
                             yyval.Node = New_Deref(
                                 lParse,
-                                (*yyvsp.offset(-3_isize)).Node,
+                                (*yyvsp.offset(-3)).Node,
                                 1,
-                                (*yyvsp.offset(-1_isize)).Node,
+                                (*yyvsp.offset(-1)).Node,
                                 0,
                                 0,
                                 0,
@@ -1527,8 +1457,8 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                 lParse,
                                 (*yyvsp.offset(-(5))).Node,
                                 2 as c_int,
-                                (*yyvsp.offset(-3_isize)).Node,
-                                (*yyvsp.offset(-1_isize)).Node,
+                                (*yyvsp.offset(-3)).Node,
+                                (*yyvsp.offset(-1)).Node,
                                 0,
                                 0,
                                 0,
@@ -1542,11 +1472,11 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                         26 => {
                             yyval.Node = New_Deref(
                                 lParse,
-                                (*yyvsp.offset(-(7 as c_int) as isize)).Node,
+                                (*yyvsp.offset(-7)).Node,
                                 3 as c_int,
                                 (*yyvsp.offset(-(5))).Node,
-                                (*yyvsp.offset(-3_isize)).Node,
-                                (*yyvsp.offset(-1_isize)).Node,
+                                (*yyvsp.offset(-3)).Node,
+                                (*yyvsp.offset(-1)).Node,
                                 0,
                                 0,
                             );
@@ -1559,12 +1489,12 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                         27 => {
                             yyval.Node = New_Deref(
                                 lParse,
-                                (*yyvsp.offset(-(9 as c_int) as isize)).Node,
+                                (*yyvsp.offset(-9)).Node,
                                 4 as c_int,
-                                (*yyvsp.offset(-(7 as c_int) as isize)).Node,
+                                (*yyvsp.offset(-7)).Node,
                                 (*yyvsp.offset(-(5))).Node,
-                                (*yyvsp.offset(-3_isize)).Node,
-                                (*yyvsp.offset(-1_isize)).Node,
+                                (*yyvsp.offset(-3)).Node,
+                                (*yyvsp.offset(-1)).Node,
                                 0,
                             );
                             if yyval.Node < 0 {
@@ -1576,13 +1506,13 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                         28 => {
                             yyval.Node = New_Deref(
                                 lParse,
-                                (*yyvsp.offset(-(11 as c_int) as isize)).Node,
+                                (*yyvsp.offset(-11)).Node,
                                 5 as c_int,
-                                (*yyvsp.offset(-(9 as c_int) as isize)).Node,
-                                (*yyvsp.offset(-(7 as c_int) as isize)).Node,
+                                (*yyvsp.offset(-9)).Node,
+                                (*yyvsp.offset(-7)).Node,
                                 (*yyvsp.offset(-(5))).Node,
-                                (*yyvsp.offset(-3_isize)).Node,
-                                (*yyvsp.offset(-1_isize)).Node,
+                                (*yyvsp.offset(-3)).Node,
+                                (*yyvsp.offset(-1)).Node,
                             );
                             if yyval.Node < 0 {
                                 current_block = 4830776507462815627;
@@ -1604,7 +1534,7 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                             }
                         }
                         30 => {
-                            yyval.Node = (*yyvsp.offset(-1_isize)).Node;
+                            yyval.Node = (*yyvsp.offset(-1)).Node;
                             current_block = 17353983478346836848;
                         }
                         31 => {
@@ -1642,27 +1572,22 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                             }
                         }
                         34 => {
-                            if (*((*lParse).Nodes).offset((*yyvsp.offset(-1_isize)).Node as isize))
-                                .ntype
+                            if ((lParse.Nodes)[(*yyvsp.offset(-1)).Node as usize]).ntype
                                 != fits_parser_yytokentype::LONG as c_int
-                                || (*((*lParse).Nodes)
-                                    .offset((*yyvsp.offset(-1_isize)).Node as isize))
-                                .operation
-                                    != -(1000 as c_int)
+                                || ((lParse.Nodes)[(*yyvsp.offset(-1)).Node as usize]).operation
+                                    != -1000
                             {
                                 fits_parser_yyerror(
                                     scanner,
                                     lParse,
-                                    b"Offset argument must be a constant integer\0" as *const u8
-                                        as *const c_char
-                                        as *mut c_char,
+                                    cs!(c"Offset argument must be a constant integer"),
                                 );
                                 current_block = 4830776507462815627;
                             } else {
                                 yyval.Node = New_Offset(
                                     lParse,
-                                    (*yyvsp.offset(-3_isize)).lng as c_int,
-                                    (*yyvsp.offset(-1_isize)).Node,
+                                    (*yyvsp.offset(-3)).lng as c_int,
+                                    (*yyvsp.offset(-1)).Node,
                                 );
                                 if yyval.Node < 0 {
                                     current_block = 4830776507462815627;
@@ -1704,39 +1629,29 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                             current_block = 17353983478346836848;
                         }
                         37 => {
-                            if (*((*lParse).Nodes).offset((*yyvsp.offset(-2_isize)).Node as isize))
-                                .ntype
-                                > (*((*lParse).Nodes).offset((*yyvsp.offset(0)).Node as isize))
-                                    .ntype
+                            if (lParse.Nodes[(*yyvsp.offset(-2)).Node as usize]).ntype
+                                > (lParse.Nodes[(*yyvsp.offset(0)).Node as usize]).ntype
                             {
                                 (*yyvsp.offset(0)).Node = New_Unary(
                                     lParse,
-                                    (*((*lParse).Nodes)
-                                        .offset((*yyvsp.offset(-2_isize)).Node as isize))
-                                    .ntype,
+                                    ((lParse.Nodes)[(*yyvsp.offset(-2)).Node as usize]).ntype,
                                     0,
                                     (*yyvsp.offset(0)).Node,
                                 );
-                            } else if (*((*lParse).Nodes)
-                                .offset((*yyvsp.offset(-2_isize)).Node as isize))
-                            .ntype
-                                < (*((*lParse).Nodes).offset((*yyvsp.offset(0)).Node as isize))
-                                    .ntype
+                            } else if ((lParse.Nodes)[(*yyvsp.offset(-2)).Node as usize]).ntype
+                                < (lParse.Nodes[(*yyvsp.offset(0)).Node as usize]).ntype
                             {
-                                (*yyvsp.offset(-2_isize)).Node = New_Unary(
+                                (*yyvsp.offset(-2)).Node = New_Unary(
                                     lParse,
-                                    (*((*lParse).Nodes).offset((*yyvsp.offset(0)).Node as isize))
-                                        .ntype,
+                                    (lParse.Nodes[(*yyvsp.offset(0)).Node as usize]).ntype,
                                     0,
-                                    (*yyvsp.offset(-2_isize)).Node,
+                                    (*yyvsp.offset(-2)).Node,
                                 );
                             }
                             yyval.Node = New_BinOp(
                                 lParse,
-                                (*((*lParse).Nodes)
-                                    .offset((*yyvsp.offset(-2_isize)).Node as isize))
-                                .ntype,
-                                (*yyvsp.offset(-2_isize)).Node,
+                                (lParse.Nodes[(*yyvsp.offset(-2)).Node as usize]).ntype,
+                                (*yyvsp.offset(-2)).Node,
                                 '%' as i32,
                                 (*yyvsp.offset(0)).Node,
                             );
@@ -1747,39 +1662,29 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                             }
                         }
                         38 => {
-                            if (*((*lParse).Nodes).offset((*yyvsp.offset(-2_isize)).Node as isize))
-                                .ntype
-                                > (*((*lParse).Nodes).offset((*yyvsp.offset(0)).Node as isize))
-                                    .ntype
+                            if (lParse.Nodes[(*yyvsp.offset(-2)).Node as usize]).ntype
+                                > (lParse.Nodes[(*yyvsp.offset(0)).Node as usize]).ntype
                             {
                                 (*yyvsp.offset(0)).Node = New_Unary(
                                     lParse,
-                                    (*((*lParse).Nodes)
-                                        .offset((*yyvsp.offset(-2_isize)).Node as isize))
-                                    .ntype,
+                                    ((lParse.Nodes)[(*yyvsp.offset(-2)).Node as usize]).ntype,
                                     0,
                                     (*yyvsp.offset(0)).Node,
                                 );
-                            } else if (*((*lParse).Nodes)
-                                .offset((*yyvsp.offset(-2_isize)).Node as isize))
-                            .ntype
-                                < (*((*lParse).Nodes).offset((*yyvsp.offset(0)).Node as isize))
-                                    .ntype
+                            } else if ((lParse.Nodes)[(*yyvsp.offset(-2)).Node as usize]).ntype
+                                < (lParse.Nodes[(*yyvsp.offset(0)).Node as usize]).ntype
                             {
-                                (*yyvsp.offset(-2_isize)).Node = New_Unary(
+                                (*yyvsp.offset(-2)).Node = New_Unary(
                                     lParse,
-                                    (*((*lParse).Nodes).offset((*yyvsp.offset(0)).Node as isize))
-                                        .ntype,
+                                    (lParse.Nodes[(*yyvsp.offset(0)).Node as usize]).ntype,
                                     0,
-                                    (*yyvsp.offset(-2_isize)).Node,
+                                    (*yyvsp.offset(-2)).Node,
                                 );
                             }
                             yyval.Node = New_BinOp(
                                 lParse,
-                                (*((*lParse).Nodes)
-                                    .offset((*yyvsp.offset(-2_isize)).Node as isize))
-                                .ntype,
-                                (*yyvsp.offset(-2_isize)).Node,
+                                (lParse.Nodes[(*yyvsp.offset(-2)).Node as usize]).ntype,
+                                (*yyvsp.offset(-2)).Node,
                                 '+' as i32,
                                 (*yyvsp.offset(0)).Node,
                             );
@@ -1790,39 +1695,29 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                             }
                         }
                         39 => {
-                            if (*((*lParse).Nodes).offset((*yyvsp.offset(-2_isize)).Node as isize))
-                                .ntype
-                                > (*((*lParse).Nodes).offset((*yyvsp.offset(0)).Node as isize))
-                                    .ntype
+                            if (lParse.Nodes[(*yyvsp.offset(-2)).Node as usize]).ntype
+                                > (lParse.Nodes[(*yyvsp.offset(0)).Node as usize]).ntype
                             {
                                 (*yyvsp.offset(0)).Node = New_Unary(
                                     lParse,
-                                    (*((*lParse).Nodes)
-                                        .offset((*yyvsp.offset(-2_isize)).Node as isize))
-                                    .ntype,
+                                    ((lParse.Nodes)[(*yyvsp.offset(-2)).Node as usize]).ntype,
                                     0,
                                     (*yyvsp.offset(0)).Node,
                                 );
-                            } else if (*((*lParse).Nodes)
-                                .offset((*yyvsp.offset(-2_isize)).Node as isize))
-                            .ntype
-                                < (*((*lParse).Nodes).offset((*yyvsp.offset(0)).Node as isize))
-                                    .ntype
+                            } else if ((lParse.Nodes)[(*yyvsp.offset(-2)).Node as usize]).ntype
+                                < (lParse.Nodes[(*yyvsp.offset(0)).Node as usize]).ntype
                             {
-                                (*yyvsp.offset(-2_isize)).Node = New_Unary(
+                                (*yyvsp.offset(-2)).Node = New_Unary(
                                     lParse,
-                                    (*((*lParse).Nodes).offset((*yyvsp.offset(0)).Node as isize))
-                                        .ntype,
+                                    (lParse.Nodes[(*yyvsp.offset(0)).Node as usize]).ntype,
                                     0,
-                                    (*yyvsp.offset(-2_isize)).Node,
+                                    (*yyvsp.offset(-2)).Node,
                                 );
                             }
                             yyval.Node = New_BinOp(
                                 lParse,
-                                (*((*lParse).Nodes)
-                                    .offset((*yyvsp.offset(-2_isize)).Node as isize))
-                                .ntype,
-                                (*yyvsp.offset(-2_isize)).Node,
+                                (lParse.Nodes[(*yyvsp.offset(-2)).Node as usize]).ntype,
+                                (*yyvsp.offset(-2)).Node,
                                 '-' as i32,
                                 (*yyvsp.offset(0)).Node,
                             );
@@ -1833,39 +1728,29 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                             }
                         }
                         40 => {
-                            if (*((*lParse).Nodes).offset((*yyvsp.offset(-2_isize)).Node as isize))
-                                .ntype
-                                > (*((*lParse).Nodes).offset((*yyvsp.offset(0)).Node as isize))
-                                    .ntype
+                            if (lParse.Nodes[(*yyvsp.offset(-2)).Node as usize]).ntype
+                                > (lParse.Nodes[(*yyvsp.offset(0)).Node as usize]).ntype
                             {
                                 (*yyvsp.offset(0)).Node = New_Unary(
                                     lParse,
-                                    (*((*lParse).Nodes)
-                                        .offset((*yyvsp.offset(-2_isize)).Node as isize))
-                                    .ntype,
+                                    ((lParse.Nodes)[(*yyvsp.offset(-2)).Node as usize]).ntype,
                                     0,
                                     (*yyvsp.offset(0)).Node,
                                 );
-                            } else if (*((*lParse).Nodes)
-                                .offset((*yyvsp.offset(-2_isize)).Node as isize))
-                            .ntype
-                                < (*((*lParse).Nodes).offset((*yyvsp.offset(0)).Node as isize))
-                                    .ntype
+                            } else if ((lParse.Nodes)[(*yyvsp.offset(-2)).Node as usize]).ntype
+                                < (lParse.Nodes[(*yyvsp.offset(0)).Node as usize]).ntype
                             {
-                                (*yyvsp.offset(-2_isize)).Node = New_Unary(
+                                (*yyvsp.offset(-2)).Node = New_Unary(
                                     lParse,
-                                    (*((*lParse).Nodes).offset((*yyvsp.offset(0)).Node as isize))
-                                        .ntype,
+                                    (lParse.Nodes[(*yyvsp.offset(0)).Node as usize]).ntype,
                                     0,
-                                    (*yyvsp.offset(-2_isize)).Node,
+                                    (*yyvsp.offset(-2)).Node,
                                 );
                             }
                             yyval.Node = New_BinOp(
                                 lParse,
-                                (*((*lParse).Nodes)
-                                    .offset((*yyvsp.offset(-2_isize)).Node as isize))
-                                .ntype,
-                                (*yyvsp.offset(-2_isize)).Node,
+                                (lParse.Nodes[(*yyvsp.offset(-2)).Node as usize]).ntype,
+                                (*yyvsp.offset(-2)).Node,
                                 '*' as i32,
                                 (*yyvsp.offset(0)).Node,
                             );
@@ -1876,39 +1761,29 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                             }
                         }
                         41 => {
-                            if (*((*lParse).Nodes).offset((*yyvsp.offset(-2_isize)).Node as isize))
-                                .ntype
-                                > (*((*lParse).Nodes).offset((*yyvsp.offset(0)).Node as isize))
-                                    .ntype
+                            if (lParse.Nodes[(*yyvsp.offset(-2)).Node as usize]).ntype
+                                > (lParse.Nodes[(*yyvsp.offset(0)).Node as usize]).ntype
                             {
                                 (*yyvsp.offset(0)).Node = New_Unary(
                                     lParse,
-                                    (*((*lParse).Nodes)
-                                        .offset((*yyvsp.offset(-2_isize)).Node as isize))
-                                    .ntype,
+                                    ((lParse.Nodes)[(*yyvsp.offset(-2)).Node as usize]).ntype,
                                     0,
                                     (*yyvsp.offset(0)).Node,
                                 );
-                            } else if (*((*lParse).Nodes)
-                                .offset((*yyvsp.offset(-2_isize)).Node as isize))
-                            .ntype
-                                < (*((*lParse).Nodes).offset((*yyvsp.offset(0)).Node as isize))
-                                    .ntype
+                            } else if ((lParse.Nodes)[(*yyvsp.offset(-2)).Node as usize]).ntype
+                                < (lParse.Nodes[(*yyvsp.offset(0)).Node as usize]).ntype
                             {
-                                (*yyvsp.offset(-2_isize)).Node = New_Unary(
+                                (*yyvsp.offset(-2)).Node = New_Unary(
                                     lParse,
-                                    (*((*lParse).Nodes).offset((*yyvsp.offset(0)).Node as isize))
-                                        .ntype,
+                                    (lParse.Nodes[(*yyvsp.offset(0)).Node as usize]).ntype,
                                     0,
-                                    (*yyvsp.offset(-2_isize)).Node,
+                                    (*yyvsp.offset(-2)).Node,
                                 );
                             }
                             yyval.Node = New_BinOp(
                                 lParse,
-                                (*((*lParse).Nodes)
-                                    .offset((*yyvsp.offset(-2_isize)).Node as isize))
-                                .ntype,
-                                (*yyvsp.offset(-2_isize)).Node,
+                                (lParse.Nodes[(*yyvsp.offset(-2)).Node as usize]).ntype,
+                                (*yyvsp.offset(-2)).Node,
                                 '/' as i32,
                                 (*yyvsp.offset(0)).Node,
                             );
@@ -1919,28 +1794,22 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                             }
                         }
                         42 => {
-                            if (*((*lParse).Nodes).offset((*yyvsp.offset(-2_isize)).Node as isize))
-                                .ntype
+                            if (lParse.Nodes[(*yyvsp.offset(-2)).Node as usize]).ntype
                                 != fits_parser_yytokentype::LONG as c_int
-                                || (*((*lParse).Nodes).offset((*yyvsp.offset(0)).Node as isize))
-                                    .ntype
+                                || (lParse.Nodes[(*yyvsp.offset(0)).Node as usize]).ntype
                                     != fits_parser_yytokentype::LONG as c_int
                             {
                                 fits_parser_yyerror(
-                                scanner,
-                                lParse,
-                                b"Bitwise operations with incompatible types; only (bit OP bit) and (int OP int) are allowed\0"
-                                    as *const u8 as *const c_char
-                                    as *mut c_char,
-                            );
+                                    scanner,
+                                    lParse,
+                                    cs!(c"Bitwise operations with incompatible types; only (bit OP bit) and (int OP int) are allowed"),
+                                );
                                 current_block = 4830776507462815627;
                             } else {
                                 yyval.Node = New_BinOp(
                                     lParse,
-                                    (*((*lParse).Nodes)
-                                        .offset((*yyvsp.offset(-2_isize)).Node as isize))
-                                    .ntype,
-                                    (*yyvsp.offset(-2_isize)).Node,
+                                    ((lParse.Nodes)[(*yyvsp.offset(-2)).Node as usize]).ntype,
+                                    (*yyvsp.offset(-2)).Node,
                                     '&' as i32,
                                     (*yyvsp.offset(0)).Node,
                                 );
@@ -1948,28 +1817,22 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                             }
                         }
                         43 => {
-                            if (*((*lParse).Nodes).offset((*yyvsp.offset(-2_isize)).Node as isize))
-                                .ntype
+                            if (lParse.Nodes[(*yyvsp.offset(-2)).Node as usize]).ntype
                                 != fits_parser_yytokentype::LONG as c_int
-                                || (*((*lParse).Nodes).offset((*yyvsp.offset(0)).Node as isize))
-                                    .ntype
+                                || (lParse.Nodes[(*yyvsp.offset(0)).Node as usize]).ntype
                                     != fits_parser_yytokentype::LONG as c_int
                             {
                                 fits_parser_yyerror(
-                                scanner,
-                                lParse,
-                                b"Bitwise operations with incompatible types; only (bit OP bit) and (int OP int) are allowed\0"
-                                    as *const u8 as *const c_char
-                                    as *mut c_char,
-                            );
+                                    scanner,
+                                    lParse,
+                                    cs!(c"Bitwise operations with incompatible types; only (bit OP bit) and (int OP int) are allowed"),
+                                );
                                 current_block = 4830776507462815627;
                             } else {
                                 yyval.Node = New_BinOp(
                                     lParse,
-                                    (*((*lParse).Nodes)
-                                        .offset((*yyvsp.offset(-2_isize)).Node as isize))
-                                    .ntype,
-                                    (*yyvsp.offset(-2_isize)).Node,
+                                    ((lParse.Nodes)[(*yyvsp.offset(-2)).Node as usize]).ntype,
+                                    (*yyvsp.offset(-2)).Node,
                                     '|' as i32,
                                     (*yyvsp.offset(0)).Node,
                                 );
@@ -1977,28 +1840,22 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                             }
                         }
                         44 => {
-                            if (*((*lParse).Nodes).offset((*yyvsp.offset(-2_isize)).Node as isize))
-                                .ntype
+                            if (lParse.Nodes[(*yyvsp.offset(-2)).Node as usize]).ntype
                                 != fits_parser_yytokentype::LONG as c_int
-                                || (*((*lParse).Nodes).offset((*yyvsp.offset(0)).Node as isize))
-                                    .ntype
+                                || (lParse.Nodes[(*yyvsp.offset(0)).Node as usize]).ntype
                                     != fits_parser_yytokentype::LONG as c_int
                             {
                                 fits_parser_yyerror(
-                                scanner,
-                                lParse,
-                                b"Bitwise operations with incompatible types; only (bit OP bit) and (int OP int) are allowed\0"
-                                    as *const u8 as *const c_char
-                                    as *mut c_char,
-                            );
+                                    scanner,
+                                    lParse,
+                                    cs!(c"Bitwise operations with incompatible types; only (bit OP bit) and (int OP int) are allowed"),
+                                );
                                 current_block = 4830776507462815627;
                             } else {
                                 yyval.Node = New_BinOp(
                                     lParse,
-                                    (*((*lParse).Nodes)
-                                        .offset((*yyvsp.offset(-2_isize)).Node as isize))
-                                    .ntype,
-                                    (*yyvsp.offset(-2_isize)).Node,
+                                    ((lParse.Nodes)[(*yyvsp.offset(-2)).Node as usize]).ntype,
+                                    (*yyvsp.offset(-2)).Node,
                                     '^' as i32,
                                     (*yyvsp.offset(0)).Node,
                                 );
@@ -2006,39 +1863,29 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                             }
                         }
                         45 => {
-                            if (*((*lParse).Nodes).offset((*yyvsp.offset(-2_isize)).Node as isize))
-                                .ntype
-                                > (*((*lParse).Nodes).offset((*yyvsp.offset(0)).Node as isize))
-                                    .ntype
+                            if (lParse.Nodes[(*yyvsp.offset(-2)).Node as usize]).ntype
+                                > (lParse.Nodes[(*yyvsp.offset(0)).Node as usize]).ntype
                             {
                                 (*yyvsp.offset(0)).Node = New_Unary(
                                     lParse,
-                                    (*((*lParse).Nodes)
-                                        .offset((*yyvsp.offset(-2_isize)).Node as isize))
-                                    .ntype,
+                                    ((lParse.Nodes)[(*yyvsp.offset(-2)).Node as usize]).ntype,
                                     0,
                                     (*yyvsp.offset(0)).Node,
                                 );
-                            } else if (*((*lParse).Nodes)
-                                .offset((*yyvsp.offset(-2_isize)).Node as isize))
-                            .ntype
-                                < (*((*lParse).Nodes).offset((*yyvsp.offset(0)).Node as isize))
-                                    .ntype
+                            } else if ((lParse.Nodes)[(*yyvsp.offset(-2)).Node as usize]).ntype
+                                < (lParse.Nodes[(*yyvsp.offset(0)).Node as usize]).ntype
                             {
-                                (*yyvsp.offset(-2_isize)).Node = New_Unary(
+                                (*yyvsp.offset(-2)).Node = New_Unary(
                                     lParse,
-                                    (*((*lParse).Nodes).offset((*yyvsp.offset(0)).Node as isize))
-                                        .ntype,
+                                    (lParse.Nodes[(*yyvsp.offset(0)).Node as usize]).ntype,
                                     0,
-                                    (*yyvsp.offset(-2_isize)).Node,
+                                    (*yyvsp.offset(-2)).Node,
                                 );
                             }
                             yyval.Node = New_BinOp(
                                 lParse,
-                                (*((*lParse).Nodes)
-                                    .offset((*yyvsp.offset(-2_isize)).Node as isize))
-                                .ntype,
-                                (*yyvsp.offset(-2_isize)).Node,
+                                (lParse.Nodes[(*yyvsp.offset(-2)).Node as usize]).ntype,
+                                (*yyvsp.offset(-2)).Node,
                                 fits_parser_yytokentype::POWER as c_int,
                                 (*yyvsp.offset(0)).Node,
                             );
@@ -2055,7 +1902,7 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                         47 => {
                             yyval.Node = New_Unary(
                                 lParse,
-                                (*((*lParse).Nodes).offset((*yyvsp.offset(0)).Node as isize)).ntype,
+                                (lParse.Nodes[(*yyvsp.offset(0)).Node as usize]).ntype,
                                 fits_parser_yytokentype::UMINUS as c_int,
                                 (*yyvsp.offset(0)).Node,
                             );
@@ -2066,24 +1913,20 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                             }
                         }
                         48 => {
-                            yyval.Node = (*yyvsp.offset(-1_isize)).Node;
+                            yyval.Node = (*yyvsp.offset(-1)).Node;
                             current_block = 17353983478346836848;
                         }
                         49 => {
                             (*yyvsp.offset(0)).Node = New_Unary(
                                 lParse,
-                                (*((*lParse).Nodes)
-                                    .offset((*yyvsp.offset(-2_isize)).Node as isize))
-                                .ntype,
+                                (lParse.Nodes[(*yyvsp.offset(-2)).Node as usize]).ntype,
                                 0,
                                 (*yyvsp.offset(0)).Node,
                             );
                             yyval.Node = New_BinOp(
                                 lParse,
-                                (*((*lParse).Nodes)
-                                    .offset((*yyvsp.offset(-2_isize)).Node as isize))
-                                .ntype,
-                                (*yyvsp.offset(-2_isize)).Node,
+                                (lParse.Nodes[(*yyvsp.offset(-2)).Node as usize]).ntype,
+                                (*yyvsp.offset(-2)).Node,
                                 '*' as i32,
                                 (*yyvsp.offset(0)).Node,
                             );
@@ -2094,16 +1937,16 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                             }
                         }
                         50 => {
-                            (*yyvsp.offset(-2_isize)).Node = New_Unary(
+                            (*yyvsp.offset(-2)).Node = New_Unary(
                                 lParse,
-                                (*((*lParse).Nodes).offset((*yyvsp.offset(0)).Node as isize)).ntype,
+                                (lParse.Nodes[(*yyvsp.offset(0)).Node as usize]).ntype,
                                 0,
-                                (*yyvsp.offset(-2_isize)).Node,
+                                (*yyvsp.offset(-2)).Node,
                             );
                             yyval.Node = New_BinOp(
                                 lParse,
-                                (*((*lParse).Nodes).offset((*yyvsp.offset(0)).Node as isize)).ntype,
-                                (*yyvsp.offset(-2_isize)).Node,
+                                (lParse.Nodes[(*yyvsp.offset(0)).Node as usize]).ntype,
+                                (*yyvsp.offset(-2)).Node,
                                 '*' as i32,
                                 (*yyvsp.offset(0)).Node,
                             );
@@ -2114,45 +1957,32 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                             }
                         }
                         51 => {
-                            if (*((*lParse).Nodes).offset((*yyvsp.offset(-2_isize)).Node as isize))
-                                .ntype
-                                > (*((*lParse).Nodes).offset((*yyvsp.offset(0)).Node as isize))
-                                    .ntype
+                            if (lParse.Nodes[(*yyvsp.offset(-2)).Node as usize]).ntype
+                                > (lParse.Nodes[(*yyvsp.offset(0)).Node as usize]).ntype
                             {
                                 (*yyvsp.offset(0)).Node = New_Unary(
                                     lParse,
-                                    (*((*lParse).Nodes)
-                                        .offset((*yyvsp.offset(-2_isize)).Node as isize))
-                                    .ntype,
+                                    ((lParse.Nodes)[(*yyvsp.offset(-2)).Node as usize]).ntype,
                                     0,
                                     (*yyvsp.offset(0)).Node,
                                 );
-                            } else if (*((*lParse).Nodes)
-                                .offset((*yyvsp.offset(-2_isize)).Node as isize))
-                            .ntype
-                                < (*((*lParse).Nodes).offset((*yyvsp.offset(0)).Node as isize))
-                                    .ntype
+                            } else if ((lParse.Nodes)[(*yyvsp.offset(-2)).Node as usize]).ntype
+                                < (lParse.Nodes[(*yyvsp.offset(0)).Node as usize]).ntype
                             {
-                                (*yyvsp.offset(-2_isize)).Node = New_Unary(
+                                (*yyvsp.offset(-2)).Node = New_Unary(
                                     lParse,
-                                    (*((*lParse).Nodes).offset((*yyvsp.offset(0)).Node as isize))
-                                        .ntype,
+                                    (lParse.Nodes[(*yyvsp.offset(0)).Node as usize]).ntype,
                                     0,
-                                    (*yyvsp.offset(-2_isize)).Node,
+                                    (*yyvsp.offset(-2)).Node,
                                 );
                             }
-                            if Test_Dims(
-                                lParse,
-                                (*yyvsp.offset(-2_isize)).Node,
-                                (*yyvsp.offset(0)).Node,
-                            ) == 0
+                            if Test_Dims(lParse, (*yyvsp.offset(-2)).Node, (*yyvsp.offset(0)).Node)
+                                == 0
                             {
                                 fits_parser_yyerror(
                                     scanner,
                                     lParse,
-                                    b"Incompatible dimensions in '?:' arguments\0" as *const u8
-                                        as *const c_char
-                                        as *mut c_char,
+                                    cs!(c"Incompatible dimensions in '?:' arguments"),
                                 );
                                 current_block = 4830776507462815627;
                             } else {
@@ -2161,9 +1991,9 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                     0,
                                     ifthenelse_fct,
                                     3 as c_int,
-                                    (*yyvsp.offset(-2_isize)).Node,
+                                    (*yyvsp.offset(-2)).Node,
                                     (*yyvsp.offset(0)).Node,
-                                    (*yyvsp.offset(-4_isize)).Node,
+                                    (*yyvsp.offset(-4)).Node,
                                     0,
                                     0,
                                     0,
@@ -2172,50 +2002,34 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                 if yyval.Node < 0 {
                                     current_block = 4830776507462815627;
                                 } else {
-                                    if (*((*lParse).Nodes)
-                                        .offset((*yyvsp.offset(-2_isize)).Node as isize))
-                                    .value
-                                    .nelem
-                                        < (*((*lParse).Nodes)
-                                            .offset((*yyvsp.offset(0)).Node as isize))
+                                    if ((lParse.Nodes)[(*yyvsp.offset(-2)).Node as usize])
                                         .value
                                         .nelem
+                                        < (lParse.Nodes[(*yyvsp.offset(0)).Node as usize])
+                                            .value
+                                            .nelem
                                     {
                                         Copy_Dims(lParse, yyval.Node, (*yyvsp.offset(0)).Node);
                                     }
-                                    (*((*lParse).Nodes)
-                                        .offset((*yyvsp.offset(-4_isize)).Node as isize))
-                                    .ntype = (*((*lParse).Nodes)
-                                        .offset((*yyvsp.offset(-2_isize)).Node as isize))
-                                    .ntype;
-                                    if Test_Dims(lParse, (*yyvsp.offset(-4_isize)).Node, yyval.Node)
-                                        == 0
+                                    ((lParse.Nodes)[(*yyvsp.offset(-4)).Node as usize]).ntype =
+                                        ((lParse.Nodes)[(*yyvsp.offset(-2)).Node as usize]).ntype;
+                                    if Test_Dims(lParse, (*yyvsp.offset(-4)).Node, yyval.Node) == 0
                                     {
                                         fits_parser_yyerror(
                                             scanner,
                                             lParse,
-                                            b"Incompatible dimensions in '?:' condition\0"
-                                                as *const u8
-                                                as *const c_char
-                                                as *mut c_char,
+                                            cs!(c"Incompatible dimensions in '?:' condition"),
                                         );
                                         current_block = 4830776507462815627;
                                     } else {
-                                        (*((*lParse).Nodes)
-                                            .offset((*yyvsp.offset(-4_isize)).Node as isize))
-                                        .ntype = fits_parser_yytokentype::BOOLEAN as c_int;
-                                        if ((*((*lParse).Nodes).offset(yyval.Node as isize)).value)
-                                            .nelem
-                                            < (*((*lParse).Nodes)
-                                                .offset((*yyvsp.offset(-4_isize)).Node as isize))
-                                            .value
-                                            .nelem
+                                        ((lParse.Nodes)[(*yyvsp.offset(-4)).Node as usize]).ntype =
+                                            fits_parser_yytokentype::BOOLEAN as c_int;
+                                        if (((lParse.Nodes)[yyval.Node as usize]).value).nelem
+                                            < ((lParse.Nodes)[(*yyvsp.offset(-4)).Node as usize])
+                                                .value
+                                                .nelem
                                         {
-                                            Copy_Dims(
-                                                lParse,
-                                                yyval.Node,
-                                                (*yyvsp.offset(-4_isize)).Node,
-                                            );
+                                            Copy_Dims(lParse, yyval.Node, (*yyvsp.offset(-4)).Node);
                                         }
                                         current_block = 17353983478346836848;
                                     }
@@ -2223,45 +2037,32 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                             }
                         }
                         52 => {
-                            if (*((*lParse).Nodes).offset((*yyvsp.offset(-2_isize)).Node as isize))
-                                .ntype
-                                > (*((*lParse).Nodes).offset((*yyvsp.offset(0)).Node as isize))
-                                    .ntype
+                            if (lParse.Nodes[(*yyvsp.offset(-2)).Node as usize]).ntype
+                                > (lParse.Nodes[(*yyvsp.offset(0)).Node as usize]).ntype
                             {
                                 (*yyvsp.offset(0)).Node = New_Unary(
                                     lParse,
-                                    (*((*lParse).Nodes)
-                                        .offset((*yyvsp.offset(-2_isize)).Node as isize))
-                                    .ntype,
+                                    ((lParse.Nodes)[(*yyvsp.offset(-2)).Node as usize]).ntype,
                                     0,
                                     (*yyvsp.offset(0)).Node,
                                 );
-                            } else if (*((*lParse).Nodes)
-                                .offset((*yyvsp.offset(-2_isize)).Node as isize))
-                            .ntype
-                                < (*((*lParse).Nodes).offset((*yyvsp.offset(0)).Node as isize))
-                                    .ntype
+                            } else if ((lParse.Nodes)[(*yyvsp.offset(-2)).Node as usize]).ntype
+                                < (lParse.Nodes[(*yyvsp.offset(0)).Node as usize]).ntype
                             {
-                                (*yyvsp.offset(-2_isize)).Node = New_Unary(
+                                (*yyvsp.offset(-2)).Node = New_Unary(
                                     lParse,
-                                    (*((*lParse).Nodes).offset((*yyvsp.offset(0)).Node as isize))
-                                        .ntype,
+                                    (lParse.Nodes[(*yyvsp.offset(0)).Node as usize]).ntype,
                                     0,
-                                    (*yyvsp.offset(-2_isize)).Node,
+                                    (*yyvsp.offset(-2)).Node,
                                 );
                             }
-                            if Test_Dims(
-                                lParse,
-                                (*yyvsp.offset(-2_isize)).Node,
-                                (*yyvsp.offset(0)).Node,
-                            ) == 0
+                            if Test_Dims(lParse, (*yyvsp.offset(-2)).Node, (*yyvsp.offset(0)).Node)
+                                == 0
                             {
                                 fits_parser_yyerror(
                                     scanner,
                                     lParse,
-                                    b"Incompatible dimensions in '?:' arguments\0" as *const u8
-                                        as *const c_char
-                                        as *mut c_char,
+                                    cs!(c"Incompatible dimensions in '?:' arguments"),
                                 );
                                 current_block = 4830776507462815627;
                             } else {
@@ -2270,9 +2071,9 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                     0,
                                     ifthenelse_fct,
                                     3 as c_int,
-                                    (*yyvsp.offset(-2_isize)).Node,
+                                    (*yyvsp.offset(-2)).Node,
                                     (*yyvsp.offset(0)).Node,
-                                    (*yyvsp.offset(-4_isize)).Node,
+                                    (*yyvsp.offset(-4)).Node,
                                     0,
                                     0,
                                     0,
@@ -2281,50 +2082,34 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                 if yyval.Node < 0 {
                                     current_block = 4830776507462815627;
                                 } else {
-                                    if (*((*lParse).Nodes)
-                                        .offset((*yyvsp.offset(-2_isize)).Node as isize))
-                                    .value
-                                    .nelem
-                                        < (*((*lParse).Nodes)
-                                            .offset((*yyvsp.offset(0)).Node as isize))
+                                    if ((lParse.Nodes)[(*yyvsp.offset(-2)).Node as usize])
                                         .value
                                         .nelem
+                                        < (lParse.Nodes[(*yyvsp.offset(0)).Node as usize])
+                                            .value
+                                            .nelem
                                     {
                                         Copy_Dims(lParse, yyval.Node, (*yyvsp.offset(0)).Node);
                                     }
-                                    (*((*lParse).Nodes)
-                                        .offset((*yyvsp.offset(-4_isize)).Node as isize))
-                                    .ntype = (*((*lParse).Nodes)
-                                        .offset((*yyvsp.offset(-2_isize)).Node as isize))
-                                    .ntype;
-                                    if Test_Dims(lParse, (*yyvsp.offset(-4_isize)).Node, yyval.Node)
-                                        == 0
+                                    ((lParse.Nodes)[(*yyvsp.offset(-4)).Node as usize]).ntype =
+                                        ((lParse.Nodes)[(*yyvsp.offset(-2)).Node as usize]).ntype;
+                                    if Test_Dims(lParse, (*yyvsp.offset(-4)).Node, yyval.Node) == 0
                                     {
                                         fits_parser_yyerror(
                                             scanner,
                                             lParse,
-                                            b"Incompatible dimensions in '?:' condition\0"
-                                                as *const u8
-                                                as *const c_char
-                                                as *mut c_char,
+                                            cs!(c"Incompatible dimensions in '?:' condition"),
                                         );
                                         current_block = 4830776507462815627;
                                     } else {
-                                        (*((*lParse).Nodes)
-                                            .offset((*yyvsp.offset(-4_isize)).Node as isize))
-                                        .ntype = fits_parser_yytokentype::BOOLEAN as c_int;
-                                        if ((*((*lParse).Nodes).offset(yyval.Node as isize)).value)
-                                            .nelem
-                                            < (*((*lParse).Nodes)
-                                                .offset((*yyvsp.offset(-4_isize)).Node as isize))
-                                            .value
-                                            .nelem
+                                        ((lParse.Nodes)[(*yyvsp.offset(-4)).Node as usize]).ntype =
+                                            fits_parser_yytokentype::BOOLEAN as c_int;
+                                        if (((lParse.Nodes)[yyval.Node as usize]).value).nelem
+                                            < ((lParse.Nodes)[(*yyvsp.offset(-4)).Node as usize])
+                                                .value
+                                                .nelem
                                         {
-                                            Copy_Dims(
-                                                lParse,
-                                                yyval.Node,
-                                                (*yyvsp.offset(-4_isize)).Node,
-                                            );
+                                            Copy_Dims(lParse, yyval.Node, (*yyvsp.offset(-4)).Node);
                                         }
                                         current_block = 17353983478346836848;
                                     }
@@ -2332,45 +2117,32 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                             }
                         }
                         53 => {
-                            if (*((*lParse).Nodes).offset((*yyvsp.offset(-2_isize)).Node as isize))
-                                .ntype
-                                > (*((*lParse).Nodes).offset((*yyvsp.offset(0)).Node as isize))
-                                    .ntype
+                            if (lParse.Nodes[(*yyvsp.offset(-2)).Node as usize]).ntype
+                                > (lParse.Nodes[(*yyvsp.offset(0)).Node as usize]).ntype
                             {
                                 (*yyvsp.offset(0)).Node = New_Unary(
                                     lParse,
-                                    (*((*lParse).Nodes)
-                                        .offset((*yyvsp.offset(-2_isize)).Node as isize))
-                                    .ntype,
+                                    ((lParse.Nodes)[(*yyvsp.offset(-2)).Node as usize]).ntype,
                                     0,
                                     (*yyvsp.offset(0)).Node,
                                 );
-                            } else if (*((*lParse).Nodes)
-                                .offset((*yyvsp.offset(-2_isize)).Node as isize))
-                            .ntype
-                                < (*((*lParse).Nodes).offset((*yyvsp.offset(0)).Node as isize))
-                                    .ntype
+                            } else if ((lParse.Nodes)[(*yyvsp.offset(-2)).Node as usize]).ntype
+                                < (lParse.Nodes[(*yyvsp.offset(0)).Node as usize]).ntype
                             {
-                                (*yyvsp.offset(-2_isize)).Node = New_Unary(
+                                (*yyvsp.offset(-2)).Node = New_Unary(
                                     lParse,
-                                    (*((*lParse).Nodes).offset((*yyvsp.offset(0)).Node as isize))
-                                        .ntype,
+                                    (lParse.Nodes[(*yyvsp.offset(0)).Node as usize]).ntype,
                                     0,
-                                    (*yyvsp.offset(-2_isize)).Node,
+                                    (*yyvsp.offset(-2)).Node,
                                 );
                             }
-                            if Test_Dims(
-                                lParse,
-                                (*yyvsp.offset(-2_isize)).Node,
-                                (*yyvsp.offset(0)).Node,
-                            ) == 0
+                            if Test_Dims(lParse, (*yyvsp.offset(-2)).Node, (*yyvsp.offset(0)).Node)
+                                == 0
                             {
                                 fits_parser_yyerror(
                                     scanner,
                                     lParse,
-                                    b"Incompatible dimensions in '?:' arguments\0" as *const u8
-                                        as *const c_char
-                                        as *mut c_char,
+                                    cs!(c"Incompatible dimensions in '?:' arguments"),
                                 );
                                 current_block = 4830776507462815627;
                             } else {
@@ -2379,9 +2151,9 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                     0,
                                     ifthenelse_fct,
                                     3 as c_int,
-                                    (*yyvsp.offset(-2_isize)).Node,
+                                    (*yyvsp.offset(-2)).Node,
                                     (*yyvsp.offset(0)).Node,
-                                    (*yyvsp.offset(-4_isize)).Node,
+                                    (*yyvsp.offset(-4)).Node,
                                     0,
                                     0,
                                     0,
@@ -2390,50 +2162,34 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                 if yyval.Node < 0 {
                                     current_block = 4830776507462815627;
                                 } else {
-                                    if (*((*lParse).Nodes)
-                                        .offset((*yyvsp.offset(-2_isize)).Node as isize))
-                                    .value
-                                    .nelem
-                                        < (*((*lParse).Nodes)
-                                            .offset((*yyvsp.offset(0)).Node as isize))
+                                    if ((lParse.Nodes)[(*yyvsp.offset(-2)).Node as usize])
                                         .value
                                         .nelem
+                                        < (lParse.Nodes[(*yyvsp.offset(0)).Node as usize])
+                                            .value
+                                            .nelem
                                     {
                                         Copy_Dims(lParse, yyval.Node, (*yyvsp.offset(0)).Node);
                                     }
-                                    (*((*lParse).Nodes)
-                                        .offset((*yyvsp.offset(-4_isize)).Node as isize))
-                                    .ntype = (*((*lParse).Nodes)
-                                        .offset((*yyvsp.offset(-2_isize)).Node as isize))
-                                    .ntype;
-                                    if Test_Dims(lParse, (*yyvsp.offset(-4_isize)).Node, yyval.Node)
-                                        == 0
+                                    ((lParse.Nodes)[(*yyvsp.offset(-4)).Node as usize]).ntype =
+                                        ((lParse.Nodes)[(*yyvsp.offset(-2)).Node as usize]).ntype;
+                                    if Test_Dims(lParse, (*yyvsp.offset(-4)).Node, yyval.Node) == 0
                                     {
                                         fits_parser_yyerror(
                                             scanner,
                                             lParse,
-                                            b"Incompatible dimensions in '?:' condition\0"
-                                                as *const u8
-                                                as *const c_char
-                                                as *mut c_char,
+                                            cs!(c"Incompatible dimensions in '?:' condition"),
                                         );
                                         current_block = 4830776507462815627;
                                     } else {
-                                        (*((*lParse).Nodes)
-                                            .offset((*yyvsp.offset(-4_isize)).Node as isize))
-                                        .ntype = fits_parser_yytokentype::BOOLEAN as c_int;
-                                        if ((*((*lParse).Nodes).offset(yyval.Node as isize)).value)
-                                            .nelem
-                                            < (*((*lParse).Nodes)
-                                                .offset((*yyvsp.offset(-4_isize)).Node as isize))
-                                            .value
-                                            .nelem
+                                        ((lParse.Nodes)[(*yyvsp.offset(-4)).Node as usize]).ntype =
+                                            fits_parser_yytokentype::BOOLEAN as c_int;
+                                        if (((lParse.Nodes)[yyval.Node as usize]).value).nelem
+                                            < ((lParse.Nodes)[(*yyvsp.offset(-4)).Node as usize])
+                                                .value
+                                                .nelem
                                         {
-                                            Copy_Dims(
-                                                lParse,
-                                                yyval.Node,
-                                                (*yyvsp.offset(-4_isize)).Node,
-                                            );
+                                            Copy_Dims(lParse, yyval.Node, (*yyvsp.offset(-4)).Node);
                                         }
                                         current_block = 17353983478346836848;
                                     }
@@ -2441,19 +2197,19 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                             }
                         }
                         54 => {
-                            if (if ((*yyvsp.offset(-1_isize)).astr[0] as c_int)
+                            if (if ((*yyvsp.offset(-1)).astr[0] as c_int)
                                 < (*::core::mem::transmute::<&[u8; 8], &[c_char; 8]>(b"RANDOM(\0"))
                                     [0] as c_int
                             {
                                 -(1)
-                            } else if (*yyvsp.offset(-1_isize)).astr[0] as c_int
+                            } else if (*yyvsp.offset(-1)).astr[0] as c_int
                                 > (*::core::mem::transmute::<&[u8; 8], &[c_char; 8]>(b"RANDOM(\0"))
                                     [0] as c_int
                             {
                                 1
                             } else {
                                 strcmp(
-                                    ((*yyvsp.offset(-1_isize)).astr).as_mut_ptr(),
+                                    ((*yyvsp.offset(-1)).astr).as_mut_ptr(),
                                     b"RANDOM(\0" as *const u8 as *const c_char,
                                 )
                             }) == 0
@@ -2472,19 +2228,19 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                     0,
                                 );
                                 current_block = 1297461190301222800;
-                            } else if (if ((*yyvsp.offset(-1_isize)).astr[0] as c_int)
+                            } else if (if ((*yyvsp.offset(-1)).astr[0] as c_int)
                                 < (*::core::mem::transmute::<&[u8; 9], &[c_char; 9]>(b"RANDOMN(\0"))
                                     [0] as c_int
                             {
                                 -(1)
-                            } else if (*yyvsp.offset(-1_isize)).astr[0] as c_int
+                            } else if (*yyvsp.offset(-1)).astr[0] as c_int
                                 > (*::core::mem::transmute::<&[u8; 9], &[c_char; 9]>(b"RANDOMN(\0"))
                                     [0] as c_int
                             {
                                 1
                             } else {
                                 strcmp(
-                                    ((*yyvsp.offset(-1_isize)).astr).as_mut_ptr(),
+                                    ((*yyvsp.offset(-1)).astr).as_mut_ptr(),
                                     b"RANDOMN(\0" as *const u8 as *const c_char,
                                 )
                             }) == 0
@@ -2507,8 +2263,7 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                 fits_parser_yyerror(
                                     scanner,
                                     lParse,
-                                    b"Function() not supported\0" as *const u8 as *const c_char
-                                        as *mut c_char,
+                                    cs!(c"Function() not supported"),
                                 );
                                 current_block = 4830776507462815627;
                             }
@@ -2524,19 +2279,19 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                             }
                         }
                         55 => {
-                            if (if ((*yyvsp.offset(-2_isize)).astr[0] as c_int)
+                            if (if ((*yyvsp.offset(-2)).astr[0] as c_int)
                                 < (*::core::mem::transmute::<&[u8; 5], &[c_char; 5]>(b"SUM(\0"))[0]
                                     as c_int
                             {
                                 -(1)
-                            } else if (*yyvsp.offset(-2_isize)).astr[0] as c_int
+                            } else if (*yyvsp.offset(-2)).astr[0] as c_int
                                 > (*::core::mem::transmute::<&[u8; 5], &[c_char; 5]>(b"SUM(\0"))[0]
                                     as c_int
                             {
                                 1
                             } else {
                                 strcmp(
-                                    ((*yyvsp.offset(-2_isize)).astr).as_mut_ptr(),
+                                    ((*yyvsp.offset(-2)).astr).as_mut_ptr(),
                                     b"SUM(\0" as *const u8 as *const c_char,
                                 )
                             }) == 0
@@ -2546,7 +2301,7 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                     fits_parser_yytokentype::LONG as c_int,
                                     sum_fct,
                                     1,
-                                    (*yyvsp.offset(-1_isize)).Node,
+                                    (*yyvsp.offset(-1)).Node,
                                     0,
                                     0,
                                     0,
@@ -2555,19 +2310,19 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                     0,
                                 );
                                 current_block = 10848699504537784535;
-                            } else if (if ((*yyvsp.offset(-2_isize)).astr[0] as c_int)
+                            } else if (if ((*yyvsp.offset(-2)).astr[0] as c_int)
                                 < (*::core::mem::transmute::<&[u8; 7], &[c_char; 7]>(b"NELEM(\0"))
                                     [0] as c_int
                             {
                                 -(1)
-                            } else if (*yyvsp.offset(-2_isize)).astr[0] as c_int
+                            } else if (*yyvsp.offset(-2)).astr[0] as c_int
                                 > (*::core::mem::transmute::<&[u8; 7], &[c_char; 7]>(b"NELEM(\0"))
                                     [0] as c_int
                             {
                                 1
                             } else {
                                 strcmp(
-                                    ((*yyvsp.offset(-2_isize)).astr).as_mut_ptr(),
+                                    ((*yyvsp.offset(-2)).astr).as_mut_ptr(),
                                     b"NELEM(\0" as *const u8 as *const c_char,
                                 )
                             }) == 0
@@ -2575,51 +2330,51 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                 yyval.Node = New_Const(
                                     lParse,
                                     fits_parser_yytokentype::LONG as c_int,
-                                    &mut (*((*lParse).Nodes)
-                                        .offset((*yyvsp.offset(-1_isize)).Node as isize))
-                                    .value
-                                    .nelem as *mut c_long
-                                        as *mut c_void,
+                                    &((lParse.Nodes)[(*yyvsp.offset(-1)).Node as usize])
+                                        .value
+                                        .nelem as *const c_long
+                                        as *const c_void,
                                     ::core::mem::size_of::<c_long>() as c_ulong as c_long,
                                 );
                                 current_block = 10848699504537784535;
-                            } else if (if ((*yyvsp.offset(-2_isize)).astr[0] as c_int)
+                            } else if (if ((*yyvsp.offset(-2)).astr[0] as c_int)
                                 < (*::core::mem::transmute::<&[u8; 7], &[c_char; 7]>(b"ACCUM(\0"))
                                     [0] as c_int
                             {
                                 -(1)
-                            } else if (*yyvsp.offset(-2_isize)).astr[0] as c_int
+                            } else if (*yyvsp.offset(-2)).astr[0] as c_int
                                 > (*::core::mem::transmute::<&[u8; 7], &[c_char; 7]>(b"ACCUM(\0"))
                                     [0] as c_int
                             {
                                 1
                             } else {
                                 strcmp(
-                                    ((*yyvsp.offset(-2_isize)).astr).as_mut_ptr(),
+                                    ((*yyvsp.offset(-2)).astr).as_mut_ptr(),
                                     b"ACCUM(\0" as *const u8 as *const c_char,
                                 )
                             }) == 0
                             {
                                 let mut zero: c_long = 0;
+                                let mut new_node = New_Const(
+                                    lParse,
+                                    fits_parser_yytokentype::LONG as c_int,
+                                    &mut zero as *mut c_long as *mut c_void,
+                                    ::core::mem::size_of::<c_long>() as c_ulong as c_long,
+                                );
+
                                 yyval.Node = New_BinOp(
                                     lParse,
                                     fits_parser_yytokentype::LONG as c_int,
-                                    (*yyvsp.offset(-1_isize)).Node,
+                                    (*yyvsp.offset(-1)).Node,
                                     fits_parser_yytokentype::ACCUM as c_int,
-                                    New_Const(
-                                        lParse,
-                                        fits_parser_yytokentype::LONG as c_int,
-                                        &mut zero as *mut c_long as *mut c_void,
-                                        ::core::mem::size_of::<c_long>() as c_ulong as c_long,
-                                    ),
+                                    new_node,
                                 );
                                 current_block = 10848699504537784535;
                             } else {
                                 fits_parser_yyerror(
                                     scanner,
                                     lParse,
-                                    b"Function(bool) not supported\0" as *const u8 as *const c_char
-                                        as *mut c_char,
+                                    cs!(c"Function(bool) not supported"),
                                 );
                                 current_block = 4830776507462815627;
                             }
@@ -2635,13 +2390,13 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                             }
                         }
                         56 => {
-                            if (if ((*yyvsp.offset(-4_isize)).astr[0] as c_int)
+                            if (if ((*yyvsp.offset(-4)).astr[0] as c_int)
                                 < (*::core::mem::transmute::<&[u8; 10], &[c_char; 10]>(
                                     b"AXISELEM(\0",
                                 ))[0] as c_int
                             {
                                 -(1)
-                            } else if (*yyvsp.offset(-4_isize)).astr[0] as c_int
+                            } else if (*yyvsp.offset(-4)).astr[0] as c_int
                                 > (*::core::mem::transmute::<&[u8; 10], &[c_char; 10]>(
                                     b"AXISELEM(\0",
                                 ))[0] as c_int
@@ -2649,34 +2404,27 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                 1
                             } else {
                                 strcmp(
-                                    ((*yyvsp.offset(-4_isize)).astr).as_mut_ptr(),
+                                    ((*yyvsp.offset(-4)).astr).as_mut_ptr(),
                                     b"AXISELEM(\0" as *const u8 as *const c_char,
                                 )
                             }) == 0
                             {
-                                if (*((*lParse).Nodes)
-                                    .offset((*yyvsp.offset(-1_isize)).Node as isize))
-                                .operation
-                                    != -(1000 as c_int)
-                                    || (*((*lParse).Nodes)
-                                        .offset((*yyvsp.offset(-1_isize)).Node as isize))
-                                    .value
-                                    .nelem
+                                if ((lParse.Nodes)[(*yyvsp.offset(-1)).Node as usize]).operation
+                                    != -1000
+                                    || ((lParse.Nodes)[(*yyvsp.offset(-1)).Node as usize])
+                                        .value
+                                        .nelem
                                         != 1
                                 {
                                     fits_parser_yyerror(
                                         scanner,
                                         lParse,
-                                        b"AXISELEM second argument must be a scalar constant\0"
-                                            as *const u8
-                                            as *const c_char
-                                            as *mut c_char,
+                                        cs!(c"AXISELEM second argument must be a scalar constant"),
                                     );
                                     current_block = 4830776507462815627;
-                                } else if (*((*lParse).Nodes)
-                                    .offset((*yyvsp.offset(-3_isize)).Node as isize))
-                                .operation
-                                    == -(1000 as c_int)
+                                } else if ((lParse.Nodes)[(*yyvsp.offset(-3)).Node as usize])
+                                    .operation
+                                    == -1000
                                 {
                                     let mut one: c_long = 1;
                                     yyval.Node = New_Const(
@@ -2687,16 +2435,14 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                     );
                                     current_block = 13755523488868872559;
                                 } else {
-                                    if (*((*lParse).Nodes)
-                                        .offset((*yyvsp.offset(-1_isize)).Node as isize))
-                                    .ntype
+                                    if ((lParse.Nodes)[(*yyvsp.offset(-1)).Node as usize]).ntype
                                         != fits_parser_yytokentype::LONG as c_int
                                     {
-                                        (*yyvsp.offset(-1_isize)).Node = New_Unary(
+                                        (*yyvsp.offset(-1)).Node = New_Unary(
                                             lParse,
                                             fits_parser_yytokentype::LONG as c_int,
                                             0,
-                                            (*yyvsp.offset(-1_isize)).Node,
+                                            (*yyvsp.offset(-1)).Node,
                                         );
                                     }
                                     yyval.Node = New_Func(
@@ -2704,8 +2450,8 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                         0,
                                         axiselem_fct,
                                         2 as c_int,
-                                        (*yyvsp.offset(-3_isize)).Node,
-                                        (*yyvsp.offset(-1_isize)).Node,
+                                        (*yyvsp.offset(-3)).Node,
+                                        (*yyvsp.offset(-1)).Node,
                                         0,
                                         0,
                                         0,
@@ -2715,51 +2461,44 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                     if yyval.Node < 0 {
                                         current_block = 4830776507462815627;
                                     } else {
-                                        (*((*lParse).Nodes).offset(yyval.Node as isize)).ntype =
+                                        ((lParse.Nodes)[yyval.Node as usize]).ntype =
                                             fits_parser_yytokentype::LONG as c_int;
                                         current_block = 13755523488868872559;
                                     }
                                 }
-                            } else if (if ((*yyvsp.offset(-4_isize)).astr[0] as c_int)
+                            } else if (if ((*yyvsp.offset(-4)).astr[0] as c_int)
                                 < (*::core::mem::transmute::<&[u8; 7], &[c_char; 7]>(b"NAXES(\0"))
                                     [0] as c_int
                             {
                                 -(1)
-                            } else if (*yyvsp.offset(-4_isize)).astr[0] as c_int
+                            } else if (*yyvsp.offset(-4)).astr[0] as c_int
                                 > (*::core::mem::transmute::<&[u8; 7], &[c_char; 7]>(b"NAXES(\0"))
                                     [0] as c_int
                             {
                                 1
                             } else {
                                 strcmp(
-                                    ((*yyvsp.offset(-4_isize)).astr).as_mut_ptr(),
+                                    ((*yyvsp.offset(-4)).astr).as_mut_ptr(),
                                     b"NAXES(\0" as *const u8 as *const c_char,
                                 )
                             }) == 0
                             {
-                                if (*((*lParse).Nodes)
-                                    .offset((*yyvsp.offset(-1_isize)).Node as isize))
-                                .operation
-                                    != -(1000 as c_int)
-                                    || (*((*lParse).Nodes)
-                                        .offset((*yyvsp.offset(-1_isize)).Node as isize))
-                                    .value
-                                    .nelem
+                                if ((lParse.Nodes)[(*yyvsp.offset(-1)).Node as usize]).operation
+                                    != -1000
+                                    || ((lParse.Nodes)[(*yyvsp.offset(-1)).Node as usize])
+                                        .value
+                                        .nelem
                                         != 1
                                 {
                                     fits_parser_yyerror(
                                         scanner,
                                         lParse,
-                                        b"NAXES second argument must be a scalar constant\0"
-                                            as *const u8
-                                            as *const c_char
-                                            as *mut c_char,
+                                        cs!(c"NAXES second argument must be a scalar constant"),
                                     );
                                     current_block = 4830776507462815627;
-                                } else if (*((*lParse).Nodes)
-                                    .offset((*yyvsp.offset(-3_isize)).Node as isize))
-                                .operation
-                                    == -(1000 as c_int)
+                                } else if ((lParse.Nodes)[(*yyvsp.offset(-3)).Node as usize])
+                                    .operation
+                                    == -1000
                                 {
                                     let mut one_0: c_long = 1;
                                     yyval.Node = New_Const(
@@ -2772,34 +2511,30 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                 } else {
                                     let mut iaxis: c_long = 0;
                                     let mut naxis: c_int = 0;
-                                    if (*((*lParse).Nodes)
-                                        .offset((*yyvsp.offset(-1_isize)).Node as isize))
-                                    .ntype
+                                    if ((lParse.Nodes)[(*yyvsp.offset(-1)).Node as usize]).ntype
                                         != fits_parser_yytokentype::LONG as c_int
                                     {
-                                        (*yyvsp.offset(-1_isize)).Node = New_Unary(
+                                        (*yyvsp.offset(-1)).Node = New_Unary(
                                             lParse,
                                             fits_parser_yytokentype::LONG as c_int,
                                             0,
-                                            (*yyvsp.offset(-1_isize)).Node,
+                                            (*yyvsp.offset(-1)).Node,
                                         );
                                     }
-                                    iaxis = (*((*lParse).Nodes)
-                                        .offset((*yyvsp.offset(-1_isize)).Node as isize))
-                                    .value
-                                    .data
-                                    .lng;
-                                    naxis = (*((*lParse).Nodes)
-                                        .offset((*yyvsp.offset(-3_isize)).Node as isize))
-                                    .value
-                                    .naxis;
+                                    iaxis = ((lParse.Nodes)[(*yyvsp.offset(-1)).Node as usize])
+                                        .value
+                                        .data
+                                        .lng;
+                                    naxis = ((lParse.Nodes)[(*yyvsp.offset(-3)).Node as usize])
+                                        .value
+                                        .naxis;
                                     if iaxis == 0 {
                                         iaxis = naxis as c_long;
                                     } else if iaxis <= naxis as c_long {
-                                        iaxis = (*((*lParse).Nodes)
-                                            .offset((*yyvsp.offset(-3_isize)).Node as isize))
-                                        .value
-                                        .naxes[(iaxis - 1) as usize];
+                                        iaxis = ((lParse.Nodes)[(*yyvsp.offset(-3)).Node as usize])
+                                            .value
+                                            .naxes
+                                            [(iaxis - 1) as usize];
                                     } else {
                                         iaxis = 1;
                                     }
@@ -2815,27 +2550,27 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                         current_block = 13755523488868872559;
                                     }
                                 }
-                            } else if (if ((*yyvsp.offset(-4_isize)).astr[0] as c_int)
+                            } else if (if ((*yyvsp.offset(-4)).astr[0] as c_int)
                                 < (*::core::mem::transmute::<&[u8; 7], &[c_char; 7]>(b"ARRAY(\0"))
                                     [0] as c_int
                             {
                                 -(1)
-                            } else if (*yyvsp.offset(-4_isize)).astr[0] as c_int
+                            } else if (*yyvsp.offset(-4)).astr[0] as c_int
                                 > (*::core::mem::transmute::<&[u8; 7], &[c_char; 7]>(b"ARRAY(\0"))
                                     [0] as c_int
                             {
                                 1
                             } else {
                                 strcmp(
-                                    ((*yyvsp.offset(-4_isize)).astr).as_mut_ptr(),
+                                    ((*yyvsp.offset(-4)).astr).as_mut_ptr(),
                                     b"ARRAY(\0" as *const u8 as *const c_char,
                                 )
                             }) == 0
                             {
                                 yyval.Node = New_Array(
                                     lParse,
-                                    (*yyvsp.offset(-3_isize)).Node,
-                                    (*yyvsp.offset(-1_isize)).Node,
+                                    (*yyvsp.offset(-3)).Node,
+                                    (*yyvsp.offset(-1)).Node,
                                 );
                                 if yyval.Node < 0 {
                                     current_block = 4830776507462815627;
@@ -2846,9 +2581,7 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                 fits_parser_yyerror(
                                     scanner,
                                     lParse,
-                                    b"Function(bool,expr) not supported\0" as *const u8
-                                        as *const c_char
-                                        as *mut c_char,
+                                    cs!(c"Function(bool,expr) not supported"),
                                 );
                                 current_block = 4830776507462815627;
                             }
@@ -2864,19 +2597,19 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                             }
                         }
                         57 => {
-                            if (if ((*yyvsp.offset(-2_isize)).astr[0] as c_int)
+                            if (if ((*yyvsp.offset(-2)).astr[0] as c_int)
                                 < (*::core::mem::transmute::<&[u8; 7], &[c_char; 7]>(b"NELEM(\0"))
                                     [0] as c_int
                             {
                                 -(1)
-                            } else if (*yyvsp.offset(-2_isize)).astr[0] as c_int
+                            } else if (*yyvsp.offset(-2)).astr[0] as c_int
                                 > (*::core::mem::transmute::<&[u8; 7], &[c_char; 7]>(b"NELEM(\0"))
                                     [0] as c_int
                             {
                                 1
                             } else {
                                 strcmp(
-                                    ((*yyvsp.offset(-2_isize)).astr).as_mut_ptr(),
+                                    ((*yyvsp.offset(-2)).astr).as_mut_ptr(),
                                     b"NELEM(\0" as *const u8 as *const c_char,
                                 )
                             }) == 0
@@ -2884,27 +2617,26 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                 yyval.Node = New_Const(
                                     lParse,
                                     fits_parser_yytokentype::LONG as c_int,
-                                    &mut (*((*lParse).Nodes)
-                                        .offset((*yyvsp.offset(-1_isize)).Node as isize))
-                                    .value
-                                    .nelem as *mut c_long
-                                        as *mut c_void,
+                                    &((lParse.Nodes)[(*yyvsp.offset(-1)).Node as usize])
+                                        .value
+                                        .nelem as *const c_long
+                                        as *const c_void,
                                     ::core::mem::size_of::<c_long>() as c_ulong as c_long,
                                 );
                                 current_block = 15752106442776732052;
-                            } else if (if ((*yyvsp.offset(-2_isize)).astr[0] as c_int)
+                            } else if (if ((*yyvsp.offset(-2)).astr[0] as c_int)
                                 < (*::core::mem::transmute::<&[u8; 8], &[c_char; 8]>(b"NVALID(\0"))
                                     [0] as c_int
                             {
                                 -(1)
-                            } else if (*yyvsp.offset(-2_isize)).astr[0] as c_int
+                            } else if (*yyvsp.offset(-2)).astr[0] as c_int
                                 > (*::core::mem::transmute::<&[u8; 8], &[c_char; 8]>(b"NVALID(\0"))
                                     [0] as c_int
                             {
                                 1
                             } else {
                                 strcmp(
-                                    ((*yyvsp.offset(-2_isize)).astr).as_mut_ptr(),
+                                    ((*yyvsp.offset(-2)).astr).as_mut_ptr(),
                                     b"NVALID(\0" as *const u8 as *const c_char,
                                 )
                             }) == 0
@@ -2914,7 +2646,7 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                     fits_parser_yytokentype::LONG as c_int,
                                     nonnull_fct,
                                     1,
-                                    (*yyvsp.offset(-1_isize)).Node,
+                                    (*yyvsp.offset(-1)).Node,
                                     0,
                                     0,
                                     0,
@@ -2927,8 +2659,7 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                 fits_parser_yyerror(
                                     scanner,
                                     lParse,
-                                    b"Function(str) not supported\0" as *const u8 as *const c_char
-                                        as *mut c_char,
+                                    cs!(c"Function(str) not supported"),
                                 );
                                 current_block = 4830776507462815627;
                             }
@@ -2944,19 +2675,19 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                             }
                         }
                         58 => {
-                            if (if ((*yyvsp.offset(-2_isize)).astr[0] as c_int)
+                            if (if ((*yyvsp.offset(-2)).astr[0] as c_int)
                                 < (*::core::mem::transmute::<&[u8; 7], &[c_char; 7]>(b"NELEM(\0"))
                                     [0] as c_int
                             {
                                 -(1)
-                            } else if (*yyvsp.offset(-2_isize)).astr[0] as c_int
+                            } else if (*yyvsp.offset(-2)).astr[0] as c_int
                                 > (*::core::mem::transmute::<&[u8; 7], &[c_char; 7]>(b"NELEM(\0"))
                                     [0] as c_int
                             {
                                 1
                             } else {
                                 strcmp(
-                                    ((*yyvsp.offset(-2_isize)).astr).as_mut_ptr(),
+                                    ((*yyvsp.offset(-2)).astr).as_mut_ptr(),
                                     b"NELEM(\0" as *const u8 as *const c_char,
                                 )
                             }) == 0
@@ -2964,27 +2695,26 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                 yyval.Node = New_Const(
                                     lParse,
                                     fits_parser_yytokentype::LONG as c_int,
-                                    &mut (*((*lParse).Nodes)
-                                        .offset((*yyvsp.offset(-1_isize)).Node as isize))
-                                    .value
-                                    .nelem as *mut c_long
-                                        as *mut c_void,
+                                    &((lParse.Nodes)[(*yyvsp.offset(-1)).Node as usize])
+                                        .value
+                                        .nelem as *const c_long
+                                        as *const c_void,
                                     ::core::mem::size_of::<c_long>() as c_ulong as c_long,
                                 );
                                 current_block = 494012601817399562;
-                            } else if (if ((*yyvsp.offset(-2_isize)).astr[0] as c_int)
+                            } else if (if ((*yyvsp.offset(-2)).astr[0] as c_int)
                                 < (*::core::mem::transmute::<&[u8; 8], &[c_char; 8]>(b"NVALID(\0"))
                                     [0] as c_int
                             {
                                 -(1)
-                            } else if (*yyvsp.offset(-2_isize)).astr[0] as c_int
+                            } else if (*yyvsp.offset(-2)).astr[0] as c_int
                                 > (*::core::mem::transmute::<&[u8; 8], &[c_char; 8]>(b"NVALID(\0"))
                                     [0] as c_int
                             {
                                 1
                             } else {
                                 strcmp(
-                                    ((*yyvsp.offset(-2_isize)).astr).as_mut_ptr(),
+                                    ((*yyvsp.offset(-2)).astr).as_mut_ptr(),
                                     b"NVALID(\0" as *const u8 as *const c_char,
                                 )
                             }) == 0
@@ -2992,27 +2722,26 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                 yyval.Node = New_Const(
                                     lParse,
                                     fits_parser_yytokentype::LONG as c_int,
-                                    &mut (*((*lParse).Nodes)
-                                        .offset((*yyvsp.offset(-1_isize)).Node as isize))
-                                    .value
-                                    .nelem as *mut c_long
-                                        as *mut c_void,
+                                    &((lParse.Nodes)[(*yyvsp.offset(-1)).Node as usize])
+                                        .value
+                                        .nelem as *const c_long
+                                        as *const c_void,
                                     ::core::mem::size_of::<c_long>() as c_ulong as c_long,
                                 );
                                 current_block = 494012601817399562;
-                            } else if (if ((*yyvsp.offset(-2_isize)).astr[0] as c_int)
+                            } else if (if ((*yyvsp.offset(-2)).astr[0] as c_int)
                                 < (*::core::mem::transmute::<&[u8; 5], &[c_char; 5]>(b"SUM(\0"))[0]
                                     as c_int
                             {
                                 -(1)
-                            } else if (*yyvsp.offset(-2_isize)).astr[0] as c_int
+                            } else if (*yyvsp.offset(-2)).astr[0] as c_int
                                 > (*::core::mem::transmute::<&[u8; 5], &[c_char; 5]>(b"SUM(\0"))[0]
                                     as c_int
                             {
                                 1
                             } else {
                                 strcmp(
-                                    ((*yyvsp.offset(-2_isize)).astr).as_mut_ptr(),
+                                    ((*yyvsp.offset(-2)).astr).as_mut_ptr(),
                                     b"SUM(\0" as *const u8 as *const c_char,
                                 )
                             }) == 0
@@ -3022,7 +2751,7 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                     fits_parser_yytokentype::LONG as c_int,
                                     sum_fct,
                                     1,
-                                    (*yyvsp.offset(-1_isize)).Node,
+                                    (*yyvsp.offset(-1)).Node,
                                     0,
                                     0,
                                     0,
@@ -3031,31 +2760,29 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                     0,
                                 );
                                 current_block = 494012601817399562;
-                            } else if (if ((*yyvsp.offset(-2_isize)).astr[0] as c_int)
+                            } else if (if ((*yyvsp.offset(-2)).astr[0] as c_int)
                                 < (*::core::mem::transmute::<&[u8; 5], &[c_char; 5]>(b"MIN(\0"))[0]
                                     as c_int
                             {
                                 -(1)
-                            } else if (*yyvsp.offset(-2_isize)).astr[0] as c_int
+                            } else if (*yyvsp.offset(-2)).astr[0] as c_int
                                 > (*::core::mem::transmute::<&[u8; 5], &[c_char; 5]>(b"MIN(\0"))[0]
                                     as c_int
                             {
                                 1
                             } else {
                                 strcmp(
-                                    ((*yyvsp.offset(-2_isize)).astr).as_mut_ptr(),
+                                    ((*yyvsp.offset(-2)).astr).as_mut_ptr(),
                                     b"MIN(\0" as *const u8 as *const c_char,
                                 )
                             }) == 0
                             {
                                 yyval.Node = New_Func(
                                     lParse,
-                                    (*((*lParse).Nodes)
-                                        .offset((*yyvsp.offset(-1_isize)).Node as isize))
-                                    .ntype,
+                                    ((lParse.Nodes)[(*yyvsp.offset(-1)).Node as usize]).ntype,
                                     min1_fct,
                                     1,
-                                    (*yyvsp.offset(-1_isize)).Node,
+                                    (*yyvsp.offset(-1)).Node,
                                     0,
                                     0,
                                     0,
@@ -3063,64 +2790,64 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                     0,
                                     0,
                                 );
-                                ((*((*lParse).Nodes).offset(yyval.Node as isize)).value).nelem = 1;
+                                (((lParse.Nodes)[yyval.Node as usize]).value).nelem = 1;
                                 current_block = 494012601817399562;
-                            } else if (if ((*yyvsp.offset(-2_isize)).astr[0] as c_int)
+                            } else if (if ((*yyvsp.offset(-2)).astr[0] as c_int)
                                 < (*::core::mem::transmute::<&[u8; 7], &[c_char; 7]>(b"ACCUM(\0"))
                                     [0] as c_int
                             {
                                 -(1)
-                            } else if (*yyvsp.offset(-2_isize)).astr[0] as c_int
+                            } else if (*yyvsp.offset(-2)).astr[0] as c_int
                                 > (*::core::mem::transmute::<&[u8; 7], &[c_char; 7]>(b"ACCUM(\0"))
                                     [0] as c_int
                             {
                                 1
                             } else {
                                 strcmp(
-                                    ((*yyvsp.offset(-2_isize)).astr).as_mut_ptr(),
+                                    ((*yyvsp.offset(-2)).astr).as_mut_ptr(),
                                     b"ACCUM(\0" as *const u8 as *const c_char,
                                 )
                             }) == 0
                             {
                                 let mut zero_0: c_long = 0;
+                                let mut new_node = New_Const(
+                                    lParse,
+                                    fits_parser_yytokentype::LONG as c_int,
+                                    &mut zero_0 as *mut c_long as *mut c_void,
+                                    ::core::mem::size_of::<c_long>() as c_ulong as c_long,
+                                );
+
                                 yyval.Node = New_BinOp(
                                     lParse,
                                     fits_parser_yytokentype::LONG as c_int,
-                                    (*yyvsp.offset(-1_isize)).Node,
+                                    (*yyvsp.offset(-1)).Node,
                                     fits_parser_yytokentype::ACCUM as c_int,
-                                    New_Const(
-                                        lParse,
-                                        fits_parser_yytokentype::LONG as c_int,
-                                        &mut zero_0 as *mut c_long as *mut c_void,
-                                        ::core::mem::size_of::<c_long>() as c_ulong as c_long,
-                                    ),
+                                    new_node,
                                 );
                                 current_block = 494012601817399562;
-                            } else if (if ((*yyvsp.offset(-2_isize)).astr[0] as c_int)
+                            } else if (if ((*yyvsp.offset(-2)).astr[0] as c_int)
                                 < (*::core::mem::transmute::<&[u8; 5], &[c_char; 5]>(b"MAX(\0"))[0]
                                     as c_int
                             {
                                 -(1)
-                            } else if (*yyvsp.offset(-2_isize)).astr[0] as c_int
+                            } else if (*yyvsp.offset(-2)).astr[0] as c_int
                                 > (*::core::mem::transmute::<&[u8; 5], &[c_char; 5]>(b"MAX(\0"))[0]
                                     as c_int
                             {
                                 1
                             } else {
                                 strcmp(
-                                    ((*yyvsp.offset(-2_isize)).astr).as_mut_ptr(),
+                                    ((*yyvsp.offset(-2)).astr).as_mut_ptr(),
                                     b"MAX(\0" as *const u8 as *const c_char,
                                 )
                             }) == 0
                             {
                                 yyval.Node = New_Func(
                                     lParse,
-                                    (*((*lParse).Nodes)
-                                        .offset((*yyvsp.offset(-1_isize)).Node as isize))
-                                    .ntype,
+                                    ((lParse.Nodes)[(*yyvsp.offset(-1)).Node as usize]).ntype,
                                     max1_fct,
                                     1,
-                                    (*yyvsp.offset(-1_isize)).Node,
+                                    (*yyvsp.offset(-1)).Node,
                                     0,
                                     0,
                                     0,
@@ -3128,14 +2855,13 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                     0,
                                     0,
                                 );
-                                ((*((*lParse).Nodes).offset(yyval.Node as isize)).value).nelem = 1;
+                                (((lParse.Nodes)[yyval.Node as usize]).value).nelem = 1;
                                 current_block = 494012601817399562;
                             } else {
                                 fits_parser_yyerror(
                                     scanner,
                                     lParse,
-                                    b"Function(bits) not supported\0" as *const u8 as *const c_char
-                                        as *mut c_char,
+                                    cs!(c"Function(bits) not supported"),
                                 );
                                 current_block = 4830776507462815627;
                             }
@@ -3151,31 +2877,29 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                             }
                         }
                         59 => {
-                            if (if ((*yyvsp.offset(-2_isize)).astr[0] as c_int)
+                            if (if ((*yyvsp.offset(-2)).astr[0] as c_int)
                                 < (*::core::mem::transmute::<&[u8; 5], &[c_char; 5]>(b"SUM(\0"))[0]
                                     as c_int
                             {
                                 -(1)
-                            } else if (*yyvsp.offset(-2_isize)).astr[0] as c_int
+                            } else if (*yyvsp.offset(-2)).astr[0] as c_int
                                 > (*::core::mem::transmute::<&[u8; 5], &[c_char; 5]>(b"SUM(\0"))[0]
                                     as c_int
                             {
                                 1
                             } else {
                                 strcmp(
-                                    ((*yyvsp.offset(-2_isize)).astr).as_mut_ptr(),
+                                    ((*yyvsp.offset(-2)).astr).as_mut_ptr(),
                                     b"SUM(\0" as *const u8 as *const c_char,
                                 )
                             }) == 0
                             {
                                 yyval.Node = New_Func(
                                     lParse,
-                                    (*((*lParse).Nodes)
-                                        .offset((*yyvsp.offset(-1_isize)).Node as isize))
-                                    .ntype,
+                                    ((lParse.Nodes)[(*yyvsp.offset(-1)).Node as usize]).ntype,
                                     sum_fct,
                                     1,
-                                    (*yyvsp.offset(-1_isize)).Node,
+                                    (*yyvsp.offset(-1)).Node,
                                     0,
                                     0,
                                     0,
@@ -3184,19 +2908,19 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                     0,
                                 );
                                 current_block = 7600445499126923600;
-                            } else if (if ((*yyvsp.offset(-2_isize)).astr[0] as c_int)
+                            } else if (if ((*yyvsp.offset(-2)).astr[0] as c_int)
                                 < (*::core::mem::transmute::<&[u8; 9], &[c_char; 9]>(b"AVERAGE(\0"))
                                     [0] as c_int
                             {
                                 -(1)
-                            } else if (*yyvsp.offset(-2_isize)).astr[0] as c_int
+                            } else if (*yyvsp.offset(-2)).astr[0] as c_int
                                 > (*::core::mem::transmute::<&[u8; 9], &[c_char; 9]>(b"AVERAGE(\0"))
                                     [0] as c_int
                             {
                                 1
                             } else {
                                 strcmp(
-                                    ((*yyvsp.offset(-2_isize)).astr).as_mut_ptr(),
+                                    ((*yyvsp.offset(-2)).astr).as_mut_ptr(),
                                     b"AVERAGE(\0" as *const u8 as *const c_char,
                                 )
                             }) == 0
@@ -3206,7 +2930,7 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                     fits_parser_yytokentype::DOUBLE as c_int,
                                     average_fct,
                                     1,
-                                    (*yyvsp.offset(-1_isize)).Node,
+                                    (*yyvsp.offset(-1)).Node,
                                     0,
                                     0,
                                     0,
@@ -3215,19 +2939,19 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                     0,
                                 );
                                 current_block = 7600445499126923600;
-                            } else if (if ((*yyvsp.offset(-2_isize)).astr[0] as c_int)
+                            } else if (if ((*yyvsp.offset(-2)).astr[0] as c_int)
                                 < (*::core::mem::transmute::<&[u8; 8], &[c_char; 8]>(b"STDDEV(\0"))
                                     [0] as c_int
                             {
                                 -(1)
-                            } else if (*yyvsp.offset(-2_isize)).astr[0] as c_int
+                            } else if (*yyvsp.offset(-2)).astr[0] as c_int
                                 > (*::core::mem::transmute::<&[u8; 8], &[c_char; 8]>(b"STDDEV(\0"))
                                     [0] as c_int
                             {
                                 1
                             } else {
                                 strcmp(
-                                    ((*yyvsp.offset(-2_isize)).astr).as_mut_ptr(),
+                                    ((*yyvsp.offset(-2)).astr).as_mut_ptr(),
                                     b"STDDEV(\0" as *const u8 as *const c_char,
                                 )
                             }) == 0
@@ -3237,7 +2961,7 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                     fits_parser_yytokentype::DOUBLE as c_int,
                                     stddev_fct,
                                     1,
-                                    (*yyvsp.offset(-1_isize)).Node,
+                                    (*yyvsp.offset(-1)).Node,
                                     0,
                                     0,
                                     0,
@@ -3246,31 +2970,29 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                     0,
                                 );
                                 current_block = 7600445499126923600;
-                            } else if (if ((*yyvsp.offset(-2_isize)).astr[0] as c_int)
+                            } else if (if ((*yyvsp.offset(-2)).astr[0] as c_int)
                                 < (*::core::mem::transmute::<&[u8; 8], &[c_char; 8]>(b"MEDIAN(\0"))
                                     [0] as c_int
                             {
                                 -(1)
-                            } else if (*yyvsp.offset(-2_isize)).astr[0] as c_int
+                            } else if (*yyvsp.offset(-2)).astr[0] as c_int
                                 > (*::core::mem::transmute::<&[u8; 8], &[c_char; 8]>(b"MEDIAN(\0"))
                                     [0] as c_int
                             {
                                 1
                             } else {
                                 strcmp(
-                                    ((*yyvsp.offset(-2_isize)).astr).as_mut_ptr(),
+                                    ((*yyvsp.offset(-2)).astr).as_mut_ptr(),
                                     b"MEDIAN(\0" as *const u8 as *const c_char,
                                 )
                             }) == 0
                             {
                                 yyval.Node = New_Func(
                                     lParse,
-                                    (*((*lParse).Nodes)
-                                        .offset((*yyvsp.offset(-1_isize)).Node as isize))
-                                    .ntype,
+                                    ((lParse.Nodes)[(*yyvsp.offset(-1)).Node as usize]).ntype,
                                     median_fct,
                                     1,
-                                    (*yyvsp.offset(-1_isize)).Node,
+                                    (*yyvsp.offset(-1)).Node,
                                     0,
                                     0,
                                     0,
@@ -3279,19 +3001,19 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                     0,
                                 );
                                 current_block = 7600445499126923600;
-                            } else if (if ((*yyvsp.offset(-2_isize)).astr[0] as c_int)
+                            } else if (if ((*yyvsp.offset(-2)).astr[0] as c_int)
                                 < (*::core::mem::transmute::<&[u8; 7], &[c_char; 7]>(b"NELEM(\0"))
                                     [0] as c_int
                             {
                                 -(1)
-                            } else if (*yyvsp.offset(-2_isize)).astr[0] as c_int
+                            } else if (*yyvsp.offset(-2)).astr[0] as c_int
                                 > (*::core::mem::transmute::<&[u8; 7], &[c_char; 7]>(b"NELEM(\0"))
                                     [0] as c_int
                             {
                                 1
                             } else {
                                 strcmp(
-                                    ((*yyvsp.offset(-2_isize)).astr).as_mut_ptr(),
+                                    ((*yyvsp.offset(-2)).astr).as_mut_ptr(),
                                     b"NELEM(\0" as *const u8 as *const c_char,
                                 )
                             }) == 0
@@ -3299,27 +3021,26 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                 yyval.Node = New_Const(
                                     lParse,
                                     fits_parser_yytokentype::LONG as c_int,
-                                    &mut (*((*lParse).Nodes)
-                                        .offset((*yyvsp.offset(-1_isize)).Node as isize))
-                                    .value
-                                    .nelem as *mut c_long
-                                        as *mut c_void,
+                                    &((lParse.Nodes)[(*yyvsp.offset(-1)).Node as usize])
+                                        .value
+                                        .nelem as *const c_long
+                                        as *const c_void,
                                     ::core::mem::size_of::<c_long>() as c_ulong as c_long,
                                 );
                                 current_block = 7600445499126923600;
-                            } else if (if ((*yyvsp.offset(-2_isize)).astr[0] as c_int)
+                            } else if (if ((*yyvsp.offset(-2)).astr[0] as c_int)
                                 < (*::core::mem::transmute::<&[u8; 8], &[c_char; 8]>(b"NVALID(\0"))
                                     [0] as c_int
                             {
                                 -(1)
-                            } else if (*yyvsp.offset(-2_isize)).astr[0] as c_int
+                            } else if (*yyvsp.offset(-2)).astr[0] as c_int
                                 > (*::core::mem::transmute::<&[u8; 8], &[c_char; 8]>(b"NVALID(\0"))
                                     [0] as c_int
                             {
                                 1
                             } else {
                                 strcmp(
-                                    ((*yyvsp.offset(-2_isize)).astr).as_mut_ptr(),
+                                    ((*yyvsp.offset(-2)).astr).as_mut_ptr(),
                                     b"NVALID(\0" as *const u8 as *const c_char,
                                 )
                             }) == 0
@@ -3329,7 +3050,7 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                     fits_parser_yytokentype::LONG as c_int,
                                     nonnull_fct,
                                     1,
-                                    (*yyvsp.offset(-1_isize)).Node,
+                                    (*yyvsp.offset(-1)).Node,
                                     0,
                                     0,
                                     0,
@@ -3338,159 +3059,162 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                     0,
                                 );
                                 current_block = 7600445499126923600;
-                            } else if (if ((*yyvsp.offset(-2_isize)).astr[0] as c_int)
+                            } else if (if ((*yyvsp.offset(-2)).astr[0] as c_int)
                                 < (*::core::mem::transmute::<&[u8; 7], &[c_char; 7]>(b"ACCUM(\0"))
                                     [0] as c_int
                             {
                                 -(1)
-                            } else if (*yyvsp.offset(-2_isize)).astr[0] as c_int
+                            } else if (*yyvsp.offset(-2)).astr[0] as c_int
                                 > (*::core::mem::transmute::<&[u8; 7], &[c_char; 7]>(b"ACCUM(\0"))
                                     [0] as c_int
                             {
                                 1
                             } else {
                                 strcmp(
-                                    ((*yyvsp.offset(-2_isize)).astr).as_mut_ptr(),
+                                    ((*yyvsp.offset(-2)).astr).as_mut_ptr(),
                                     b"ACCUM(\0" as *const u8 as *const c_char,
                                 )
                             }) == 0
-                                && (*((*lParse).Nodes)
-                                    .offset((*yyvsp.offset(-1_isize)).Node as isize))
-                                .ntype
+                                && ((lParse.Nodes)[(*yyvsp.offset(-1)).Node as usize]).ntype
                                     == fits_parser_yytokentype::LONG as c_int
                             {
                                 let mut zero_1: c_long = 0;
+
+                                let mut rc_parse: Rc<ParseData> = Rc::from_raw(lParse);
+
+                                let mut new_node = New_Const(
+                                    lParse,
+                                    fits_parser_yytokentype::LONG as c_int,
+                                    &mut zero_1 as *mut c_long as *mut c_void,
+                                    ::core::mem::size_of::<c_long>() as c_ulong as c_long,
+                                );
+
                                 yyval.Node = New_BinOp(
                                     lParse,
                                     fits_parser_yytokentype::LONG as c_int,
-                                    (*yyvsp.offset(-1_isize)).Node,
+                                    (*yyvsp.offset(-1)).Node,
                                     fits_parser_yytokentype::ACCUM as c_int,
-                                    New_Const(
-                                        lParse,
-                                        fits_parser_yytokentype::LONG as c_int,
-                                        &mut zero_1 as *mut c_long as *mut c_void,
-                                        ::core::mem::size_of::<c_long>() as c_ulong as c_long,
-                                    ),
+                                    new_node,
                                 );
                                 current_block = 7600445499126923600;
-                            } else if (if ((*yyvsp.offset(-2_isize)).astr[0] as c_int)
+                            } else if (if ((*yyvsp.offset(-2)).astr[0] as c_int)
                                 < (*::core::mem::transmute::<&[u8; 7], &[c_char; 7]>(b"ACCUM(\0"))
                                     [0] as c_int
                             {
                                 -(1)
-                            } else if (*yyvsp.offset(-2_isize)).astr[0] as c_int
+                            } else if (*yyvsp.offset(-2)).astr[0] as c_int
                                 > (*::core::mem::transmute::<&[u8; 7], &[c_char; 7]>(b"ACCUM(\0"))
                                     [0] as c_int
                             {
                                 1
                             } else {
                                 strcmp(
-                                    ((*yyvsp.offset(-2_isize)).astr).as_mut_ptr(),
+                                    ((*yyvsp.offset(-2)).astr).as_mut_ptr(),
                                     b"ACCUM(\0" as *const u8 as *const c_char,
                                 )
                             }) == 0
-                                && (*((*lParse).Nodes)
-                                    .offset((*yyvsp.offset(-1_isize)).Node as isize))
-                                .ntype
+                                && ((lParse.Nodes)[(*yyvsp.offset(-1)).Node as usize]).ntype
                                     == fits_parser_yytokentype::DOUBLE as c_int
                             {
                                 let mut zero_2: c_double = 0.0;
+                                let mut new_node = New_Const(
+                                    lParse,
+                                    fits_parser_yytokentype::DOUBLE as c_int,
+                                    &mut zero_2 as *mut c_double as *mut c_void,
+                                    ::core::mem::size_of::<c_double>() as c_ulong as c_long,
+                                );
+
                                 yyval.Node = New_BinOp(
                                     lParse,
                                     fits_parser_yytokentype::DOUBLE as c_int,
-                                    (*yyvsp.offset(-1_isize)).Node,
+                                    (*yyvsp.offset(-1)).Node,
                                     fits_parser_yytokentype::ACCUM as c_int,
-                                    New_Const(
-                                        lParse,
-                                        fits_parser_yytokentype::DOUBLE as c_int,
-                                        &mut zero_2 as *mut c_double as *mut c_void,
-                                        ::core::mem::size_of::<c_double>() as c_ulong as c_long,
-                                    ),
+                                    new_node,
                                 );
                                 current_block = 7600445499126923600;
-                            } else if (if ((*yyvsp.offset(-2_isize)).astr[0] as c_int)
+                            } else if (if ((*yyvsp.offset(-2)).astr[0] as c_int)
                                 < (*::core::mem::transmute::<&[u8; 9], &[c_char; 9]>(b"SEQDIFF(\0"))
                                     [0] as c_int
                             {
                                 -(1)
-                            } else if (*yyvsp.offset(-2_isize)).astr[0] as c_int
+                            } else if (*yyvsp.offset(-2)).astr[0] as c_int
                                 > (*::core::mem::transmute::<&[u8; 9], &[c_char; 9]>(b"SEQDIFF(\0"))
                                     [0] as c_int
                             {
                                 1
                             } else {
                                 strcmp(
-                                    ((*yyvsp.offset(-2_isize)).astr).as_mut_ptr(),
+                                    ((*yyvsp.offset(-2)).astr).as_mut_ptr(),
                                     b"SEQDIFF(\0" as *const u8 as *const c_char,
                                 )
                             }) == 0
-                                && (*((*lParse).Nodes)
-                                    .offset((*yyvsp.offset(-1_isize)).Node as isize))
-                                .ntype
+                                && ((lParse.Nodes)[(*yyvsp.offset(-1)).Node as usize]).ntype
                                     == fits_parser_yytokentype::LONG as c_int
                             {
                                 let mut zero_3: c_long = 0;
+                                let mut new_node = New_Const(
+                                    lParse,
+                                    fits_parser_yytokentype::LONG as c_int,
+                                    &mut zero_3 as *mut c_long as *mut c_void,
+                                    ::core::mem::size_of::<c_long>() as c_ulong as c_long,
+                                );
+
                                 yyval.Node = New_BinOp(
                                     lParse,
                                     fits_parser_yytokentype::LONG as c_int,
-                                    (*yyvsp.offset(-1_isize)).Node,
+                                    (*yyvsp.offset(-1)).Node,
                                     fits_parser_yytokentype::DIFF as c_int,
-                                    New_Const(
-                                        lParse,
-                                        fits_parser_yytokentype::LONG as c_int,
-                                        &mut zero_3 as *mut c_long as *mut c_void,
-                                        ::core::mem::size_of::<c_long>() as c_ulong as c_long,
-                                    ),
+                                    new_node,
                                 );
                                 current_block = 7600445499126923600;
-                            } else if (if ((*yyvsp.offset(-2_isize)).astr[0] as c_int)
+                            } else if (if ((*yyvsp.offset(-2)).astr[0] as c_int)
                                 < (*::core::mem::transmute::<&[u8; 9], &[c_char; 9]>(b"SEQDIFF(\0"))
                                     [0] as c_int
                             {
                                 -(1)
-                            } else if (*yyvsp.offset(-2_isize)).astr[0] as c_int
+                            } else if (*yyvsp.offset(-2)).astr[0] as c_int
                                 > (*::core::mem::transmute::<&[u8; 9], &[c_char; 9]>(b"SEQDIFF(\0"))
                                     [0] as c_int
                             {
                                 1
                             } else {
                                 strcmp(
-                                    ((*yyvsp.offset(-2_isize)).astr).as_mut_ptr(),
+                                    ((*yyvsp.offset(-2)).astr).as_mut_ptr(),
                                     b"SEQDIFF(\0" as *const u8 as *const c_char,
                                 )
                             }) == 0
-                                && (*((*lParse).Nodes)
-                                    .offset((*yyvsp.offset(-1_isize)).Node as isize))
-                                .ntype
+                                && ((lParse.Nodes)[(*yyvsp.offset(-1)).Node as usize]).ntype
                                     == fits_parser_yytokentype::DOUBLE as c_int
                             {
                                 let mut zero_4: c_double = 0.0;
+                                let mut new_node = New_Const(
+                                    lParse,
+                                    fits_parser_yytokentype::DOUBLE as c_int,
+                                    &mut zero_4 as *mut c_double as *mut c_void,
+                                    ::core::mem::size_of::<c_double>() as c_ulong as c_long,
+                                );
+
                                 yyval.Node = New_BinOp(
                                     lParse,
                                     fits_parser_yytokentype::DOUBLE as c_int,
-                                    (*yyvsp.offset(-1_isize)).Node,
+                                    (*yyvsp.offset(-1)).Node,
                                     fits_parser_yytokentype::DIFF as c_int,
-                                    New_Const(
-                                        lParse,
-                                        fits_parser_yytokentype::DOUBLE as c_int,
-                                        &mut zero_4 as *mut c_double as *mut c_void,
-                                        ::core::mem::size_of::<c_double>() as c_ulong as c_long,
-                                    ),
+                                    new_node,
                                 );
                                 current_block = 7600445499126923600;
-                            } else if (if ((*yyvsp.offset(-2_isize)).astr[0] as c_int)
+                            } else if (if ((*yyvsp.offset(-2)).astr[0] as c_int)
                                 < (*::core::mem::transmute::<&[u8; 5], &[c_char; 5]>(b"ABS(\0"))[0]
                                     as c_int
                             {
                                 -(1)
-                            } else if (*yyvsp.offset(-2_isize)).astr[0] as c_int
+                            } else if (*yyvsp.offset(-2)).astr[0] as c_int
                                 > (*::core::mem::transmute::<&[u8; 5], &[c_char; 5]>(b"ABS(\0"))[0]
                                     as c_int
                             {
                                 1
                             } else {
                                 strcmp(
-                                    ((*yyvsp.offset(-2_isize)).astr).as_mut_ptr(),
+                                    ((*yyvsp.offset(-2)).astr).as_mut_ptr(),
                                     b"ABS(\0" as *const u8 as *const c_char,
                                 )
                             }) == 0
@@ -3500,7 +3224,7 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                     0,
                                     abs_fct,
                                     1,
-                                    (*yyvsp.offset(-1_isize)).Node,
+                                    (*yyvsp.offset(-1)).Node,
                                     0,
                                     0,
                                     0,
@@ -3509,31 +3233,29 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                     0,
                                 );
                                 current_block = 7600445499126923600;
-                            } else if (if ((*yyvsp.offset(-2_isize)).astr[0] as c_int)
+                            } else if (if ((*yyvsp.offset(-2)).astr[0] as c_int)
                                 < (*::core::mem::transmute::<&[u8; 5], &[c_char; 5]>(b"MIN(\0"))[0]
                                     as c_int
                             {
                                 -(1)
-                            } else if (*yyvsp.offset(-2_isize)).astr[0] as c_int
+                            } else if (*yyvsp.offset(-2)).astr[0] as c_int
                                 > (*::core::mem::transmute::<&[u8; 5], &[c_char; 5]>(b"MIN(\0"))[0]
                                     as c_int
                             {
                                 1
                             } else {
                                 strcmp(
-                                    ((*yyvsp.offset(-2_isize)).astr).as_mut_ptr(),
+                                    ((*yyvsp.offset(-2)).astr).as_mut_ptr(),
                                     b"MIN(\0" as *const u8 as *const c_char,
                                 )
                             }) == 0
                             {
                                 yyval.Node = New_Func(
                                     lParse,
-                                    (*((*lParse).Nodes)
-                                        .offset((*yyvsp.offset(-1_isize)).Node as isize))
-                                    .ntype,
+                                    ((lParse.Nodes)[(*yyvsp.offset(-1)).Node as usize]).ntype,
                                     min1_fct,
                                     1,
-                                    (*yyvsp.offset(-1_isize)).Node,
+                                    (*yyvsp.offset(-1)).Node,
                                     0,
                                     0,
                                     0,
@@ -3542,31 +3264,29 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                     0,
                                 );
                                 current_block = 7600445499126923600;
-                            } else if (if ((*yyvsp.offset(-2_isize)).astr[0] as c_int)
+                            } else if (if ((*yyvsp.offset(-2)).astr[0] as c_int)
                                 < (*::core::mem::transmute::<&[u8; 5], &[c_char; 5]>(b"MAX(\0"))[0]
                                     as c_int
                             {
                                 -(1)
-                            } else if (*yyvsp.offset(-2_isize)).astr[0] as c_int
+                            } else if (*yyvsp.offset(-2)).astr[0] as c_int
                                 > (*::core::mem::transmute::<&[u8; 5], &[c_char; 5]>(b"MAX(\0"))[0]
                                     as c_int
                             {
                                 1
                             } else {
                                 strcmp(
-                                    ((*yyvsp.offset(-2_isize)).astr).as_mut_ptr(),
+                                    ((*yyvsp.offset(-2)).astr).as_mut_ptr(),
                                     b"MAX(\0" as *const u8 as *const c_char,
                                 )
                             }) == 0
                             {
                                 yyval.Node = New_Func(
                                     lParse,
-                                    (*((*lParse).Nodes)
-                                        .offset((*yyvsp.offset(-1_isize)).Node as isize))
-                                    .ntype,
+                                    ((lParse.Nodes)[(*yyvsp.offset(-1)).Node as usize]).ntype,
                                     max1_fct,
                                     1,
-                                    (*yyvsp.offset(-1_isize)).Node,
+                                    (*yyvsp.offset(-1)).Node,
                                     0,
                                     0,
                                     0,
@@ -3575,19 +3295,19 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                     0,
                                 );
                                 current_block = 7600445499126923600;
-                            } else if (if ((*yyvsp.offset(-2_isize)).astr[0] as c_int)
+                            } else if (if ((*yyvsp.offset(-2)).astr[0] as c_int)
                                 < (*::core::mem::transmute::<&[u8; 8], &[c_char; 8]>(b"RANDOM(\0"))
                                     [0] as c_int
                             {
                                 -(1)
-                            } else if (*yyvsp.offset(-2_isize)).astr[0] as c_int
+                            } else if (*yyvsp.offset(-2)).astr[0] as c_int
                                 > (*::core::mem::transmute::<&[u8; 8], &[c_char; 8]>(b"RANDOM(\0"))
                                     [0] as c_int
                             {
                                 1
                             } else {
                                 strcmp(
-                                    ((*yyvsp.offset(-2_isize)).astr).as_mut_ptr(),
+                                    ((*yyvsp.offset(-2)).astr).as_mut_ptr(),
                                     b"RANDOM(\0" as *const u8 as *const c_char,
                                 )
                             }) == 0
@@ -3597,7 +3317,7 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                     0,
                                     rnd_fct,
                                     1,
-                                    (*yyvsp.offset(-1_isize)).Node,
+                                    (*yyvsp.offset(-1)).Node,
                                     0,
                                     0,
                                     0,
@@ -3608,23 +3328,23 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                 if yyval.Node < 0 {
                                     current_block = 4830776507462815627;
                                 } else {
-                                    (*((*lParse).Nodes).offset(yyval.Node as isize)).ntype =
+                                    ((lParse.Nodes)[yyval.Node as usize]).ntype =
                                         fits_parser_yytokentype::DOUBLE as c_int;
                                     current_block = 7600445499126923600;
                                 }
-                            } else if (if ((*yyvsp.offset(-2_isize)).astr[0] as c_int)
+                            } else if (if ((*yyvsp.offset(-2)).astr[0] as c_int)
                                 < (*::core::mem::transmute::<&[u8; 9], &[c_char; 9]>(b"RANDOMN(\0"))
                                     [0] as c_int
                             {
                                 -(1)
-                            } else if (*yyvsp.offset(-2_isize)).astr[0] as c_int
+                            } else if (*yyvsp.offset(-2)).astr[0] as c_int
                                 > (*::core::mem::transmute::<&[u8; 9], &[c_char; 9]>(b"RANDOMN(\0"))
                                     [0] as c_int
                             {
                                 1
                             } else {
                                 strcmp(
-                                    ((*yyvsp.offset(-2_isize)).astr).as_mut_ptr(),
+                                    ((*yyvsp.offset(-2)).astr).as_mut_ptr(),
                                     b"RANDOMN(\0" as *const u8 as *const c_char,
                                 )
                             }) == 0
@@ -3634,7 +3354,7 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                     0,
                                     gasrnd_fct,
                                     1,
-                                    (*yyvsp.offset(-1_isize)).Node,
+                                    (*yyvsp.offset(-1)).Node,
                                     0,
                                     0,
                                     0,
@@ -3645,17 +3365,17 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                 if yyval.Node < 0 {
                                     current_block = 4830776507462815627;
                                 } else {
-                                    (*((*lParse).Nodes).offset(yyval.Node as isize)).ntype =
+                                    ((lParse.Nodes)[yyval.Node as usize]).ntype =
                                         fits_parser_yytokentype::DOUBLE as c_int;
                                     current_block = 7600445499126923600;
                                 }
-                            } else if (if ((*yyvsp.offset(-2_isize)).astr[0] as c_int)
+                            } else if (if ((*yyvsp.offset(-2)).astr[0] as c_int)
                                 < (*::core::mem::transmute::<&[u8; 12], &[c_char; 12]>(
                                     b"ELEMENTNUM(\0",
                                 ))[0] as c_int
                             {
                                 -(1)
-                            } else if (*yyvsp.offset(-2_isize)).astr[0] as c_int
+                            } else if (*yyvsp.offset(-2)).astr[0] as c_int
                                 > (*::core::mem::transmute::<&[u8; 12], &[c_char; 12]>(
                                     b"ELEMENTNUM(\0",
                                 ))[0] as c_int
@@ -3663,15 +3383,13 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                 1
                             } else {
                                 strcmp(
-                                    ((*yyvsp.offset(-2_isize)).astr).as_mut_ptr(),
+                                    ((*yyvsp.offset(-2)).astr).as_mut_ptr(),
                                     b"ELEMENTNUM(\0" as *const u8 as *const c_char,
                                 )
                             }) == 0
                             {
-                                if (*((*lParse).Nodes)
-                                    .offset((*yyvsp.offset(-1_isize)).Node as isize))
-                                .operation
-                                    == -(1000 as c_int)
+                                if ((lParse.Nodes)[(*yyvsp.offset(-1)).Node as usize]).operation
+                                    == -1000
                                 {
                                     let mut one_1: c_long = 1;
                                     yyval.Node = New_Const(
@@ -3687,7 +3405,7 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                         0,
                                         elemnum_fct,
                                         1,
-                                        (*yyvsp.offset(-1_isize)).Node,
+                                        (*yyvsp.offset(-1)).Node,
                                         0,
                                         0,
                                         0,
@@ -3698,32 +3416,30 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                     if yyval.Node < 0 {
                                         current_block = 4830776507462815627;
                                     } else {
-                                        (*((*lParse).Nodes).offset(yyval.Node as isize)).ntype =
+                                        ((lParse.Nodes)[yyval.Node as usize]).ntype =
                                             fits_parser_yytokentype::LONG as c_int;
                                         current_block = 7600445499126923600;
                                     }
                                 }
-                            } else if (if ((*yyvsp.offset(-2_isize)).astr[0] as c_int)
+                            } else if (if ((*yyvsp.offset(-2)).astr[0] as c_int)
                                 < (*::core::mem::transmute::<&[u8; 7], &[c_char; 7]>(b"NAXIS(\0"))
                                     [0] as c_int
                             {
                                 -(1)
-                            } else if (*yyvsp.offset(-2_isize)).astr[0] as c_int
+                            } else if (*yyvsp.offset(-2)).astr[0] as c_int
                                 > (*::core::mem::transmute::<&[u8; 7], &[c_char; 7]>(b"NAXIS(\0"))
                                     [0] as c_int
                             {
                                 1
                             } else {
                                 strcmp(
-                                    ((*yyvsp.offset(-2_isize)).astr).as_mut_ptr(),
+                                    ((*yyvsp.offset(-2)).astr).as_mut_ptr(),
                                     b"NAXIS(\0" as *const u8 as *const c_char,
                                 )
                             }) == 0
                             {
-                                if (*((*lParse).Nodes)
-                                    .offset((*yyvsp.offset(-1_isize)).Node as isize))
-                                .operation
-                                    == -(1000 as c_int)
+                                if ((lParse.Nodes)[(*yyvsp.offset(-1)).Node as usize]).operation
+                                    == -1000
                                 {
                                     let mut one_2: c_long = 1;
                                     yyval.Node = New_Const(
@@ -3734,10 +3450,10 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                     );
                                     current_block = 7600445499126923600;
                                 } else {
-                                    let mut naxis_0: c_long = (*((*lParse).Nodes)
-                                        .offset((*yyvsp.offset(-1_isize)).Node as isize))
-                                    .value
-                                    .naxis
+                                    let mut naxis_0: c_long = ((lParse.Nodes)
+                                        [(*yyvsp.offset(-1)).Node as usize])
+                                        .value
+                                        .naxis
                                         as c_long;
                                     yyval.Node = New_Const(
                                         lParse,
@@ -3752,31 +3468,29 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                     }
                                 }
                             } else {
-                                if (*((*lParse).Nodes)
-                                    .offset((*yyvsp.offset(-1_isize)).Node as isize))
-                                .ntype
+                                if ((lParse.Nodes)[(*yyvsp.offset(-1)).Node as usize]).ntype
                                     != fits_parser_yytokentype::DOUBLE as c_int
                                 {
-                                    (*yyvsp.offset(-1_isize)).Node = New_Unary(
+                                    (*yyvsp.offset(-1)).Node = New_Unary(
                                         lParse,
                                         fits_parser_yytokentype::DOUBLE as c_int,
                                         0,
-                                        (*yyvsp.offset(-1_isize)).Node,
+                                        (*yyvsp.offset(-1)).Node,
                                     );
                                 }
-                                if (if ((*yyvsp.offset(-2_isize)).astr[0] as c_int)
+                                if (if ((*yyvsp.offset(-2)).astr[0] as c_int)
                                     < (*::core::mem::transmute::<&[u8; 5], &[c_char; 5]>(b"SIN(\0"))
                                         [0] as c_int
                                 {
                                     -(1)
-                                } else if (*yyvsp.offset(-2_isize)).astr[0] as c_int
+                                } else if (*yyvsp.offset(-2)).astr[0] as c_int
                                     > (*::core::mem::transmute::<&[u8; 5], &[c_char; 5]>(b"SIN(\0"))
                                         [0] as c_int
                                 {
                                     1
                                 } else {
                                     strcmp(
-                                        ((*yyvsp.offset(-2_isize)).astr).as_mut_ptr(),
+                                        ((*yyvsp.offset(-2)).astr).as_mut_ptr(),
                                         b"SIN(\0" as *const u8 as *const c_char,
                                     )
                                 }) == 0
@@ -3786,7 +3500,7 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                         0,
                                         sin_fct,
                                         1,
-                                        (*yyvsp.offset(-1_isize)).Node,
+                                        (*yyvsp.offset(-1)).Node,
                                         0,
                                         0,
                                         0,
@@ -3795,19 +3509,19 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                         0,
                                     );
                                     current_block = 7600445499126923600;
-                                } else if (if ((*yyvsp.offset(-2_isize)).astr[0] as c_int)
+                                } else if (if ((*yyvsp.offset(-2)).astr[0] as c_int)
                                     < (*::core::mem::transmute::<&[u8; 5], &[c_char; 5]>(b"COS(\0"))
                                         [0] as c_int
                                 {
                                     -(1)
-                                } else if (*yyvsp.offset(-2_isize)).astr[0] as c_int
+                                } else if (*yyvsp.offset(-2)).astr[0] as c_int
                                     > (*::core::mem::transmute::<&[u8; 5], &[c_char; 5]>(b"COS(\0"))
                                         [0] as c_int
                                 {
                                     1
                                 } else {
                                     strcmp(
-                                        ((*yyvsp.offset(-2_isize)).astr).as_mut_ptr(),
+                                        ((*yyvsp.offset(-2)).astr).as_mut_ptr(),
                                         b"COS(\0" as *const u8 as *const c_char,
                                     )
                                 }) == 0
@@ -3817,7 +3531,7 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                         0,
                                         cos_fct,
                                         1,
-                                        (*yyvsp.offset(-1_isize)).Node,
+                                        (*yyvsp.offset(-1)).Node,
                                         0,
                                         0,
                                         0,
@@ -3826,19 +3540,19 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                         0,
                                     );
                                     current_block = 7600445499126923600;
-                                } else if (if ((*yyvsp.offset(-2_isize)).astr[0] as c_int)
+                                } else if (if ((*yyvsp.offset(-2)).astr[0] as c_int)
                                     < (*::core::mem::transmute::<&[u8; 5], &[c_char; 5]>(b"TAN(\0"))
                                         [0] as c_int
                                 {
                                     -(1)
-                                } else if (*yyvsp.offset(-2_isize)).astr[0] as c_int
+                                } else if (*yyvsp.offset(-2)).astr[0] as c_int
                                     > (*::core::mem::transmute::<&[u8; 5], &[c_char; 5]>(b"TAN(\0"))
                                         [0] as c_int
                                 {
                                     1
                                 } else {
                                     strcmp(
-                                        ((*yyvsp.offset(-2_isize)).astr).as_mut_ptr(),
+                                        ((*yyvsp.offset(-2)).astr).as_mut_ptr(),
                                         b"TAN(\0" as *const u8 as *const c_char,
                                     )
                                 }) == 0
@@ -3848,7 +3562,7 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                         0,
                                         tan_fct,
                                         1,
-                                        (*yyvsp.offset(-1_isize)).Node,
+                                        (*yyvsp.offset(-1)).Node,
                                         0,
                                         0,
                                         0,
@@ -3857,13 +3571,13 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                         0,
                                     );
                                     current_block = 7600445499126923600;
-                                } else if (if ((*yyvsp.offset(-2_isize)).astr[0] as c_int)
+                                } else if (if ((*yyvsp.offset(-2)).astr[0] as c_int)
                                     < (*::core::mem::transmute::<&[u8; 8], &[c_char; 8]>(
                                         b"ARCSIN(\0",
                                     ))[0] as c_int
                                 {
                                     -(1)
-                                } else if (*yyvsp.offset(-2_isize)).astr[0] as c_int
+                                } else if (*yyvsp.offset(-2)).astr[0] as c_int
                                     > (*::core::mem::transmute::<&[u8; 8], &[c_char; 8]>(
                                         b"ARCSIN(\0",
                                     ))[0] as c_int
@@ -3871,17 +3585,17 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                     1
                                 } else {
                                     strcmp(
-                                        ((*yyvsp.offset(-2_isize)).astr).as_mut_ptr(),
+                                        ((*yyvsp.offset(-2)).astr).as_mut_ptr(),
                                         b"ARCSIN(\0" as *const u8 as *const c_char,
                                     )
                                 }) == 0
-                                    || (if ((*yyvsp.offset(-2_isize)).astr[0] as c_int)
+                                    || (if ((*yyvsp.offset(-2)).astr[0] as c_int)
                                         < (*::core::mem::transmute::<&[u8; 6], &[c_char; 6]>(
                                             b"ASIN(\0",
                                         ))[0] as c_int
                                     {
                                         -(1)
-                                    } else if (*yyvsp.offset(-2_isize)).astr[0] as c_int
+                                    } else if (*yyvsp.offset(-2)).astr[0] as c_int
                                         > (*::core::mem::transmute::<&[u8; 6], &[c_char; 6]>(
                                             b"ASIN(\0",
                                         ))[0] as c_int
@@ -3889,7 +3603,7 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                         1
                                     } else {
                                         strcmp(
-                                            ((*yyvsp.offset(-2_isize)).astr).as_mut_ptr(),
+                                            ((*yyvsp.offset(-2)).astr).as_mut_ptr(),
                                             b"ASIN(\0" as *const u8 as *const c_char,
                                         )
                                     }) == 0
@@ -3899,7 +3613,7 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                         0,
                                         asin_fct,
                                         1,
-                                        (*yyvsp.offset(-1_isize)).Node,
+                                        (*yyvsp.offset(-1)).Node,
                                         0,
                                         0,
                                         0,
@@ -3908,13 +3622,13 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                         0,
                                     );
                                     current_block = 7600445499126923600;
-                                } else if (if ((*yyvsp.offset(-2_isize)).astr[0] as c_int)
+                                } else if (if ((*yyvsp.offset(-2)).astr[0] as c_int)
                                     < (*::core::mem::transmute::<&[u8; 8], &[c_char; 8]>(
                                         b"ARCCOS(\0",
                                     ))[0] as c_int
                                 {
                                     -(1)
-                                } else if (*yyvsp.offset(-2_isize)).astr[0] as c_int
+                                } else if (*yyvsp.offset(-2)).astr[0] as c_int
                                     > (*::core::mem::transmute::<&[u8; 8], &[c_char; 8]>(
                                         b"ARCCOS(\0",
                                     ))[0] as c_int
@@ -3922,17 +3636,17 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                     1
                                 } else {
                                     strcmp(
-                                        ((*yyvsp.offset(-2_isize)).astr).as_mut_ptr(),
+                                        ((*yyvsp.offset(-2)).astr).as_mut_ptr(),
                                         b"ARCCOS(\0" as *const u8 as *const c_char,
                                     )
                                 }) == 0
-                                    || (if ((*yyvsp.offset(-2_isize)).astr[0] as c_int)
+                                    || (if ((*yyvsp.offset(-2)).astr[0] as c_int)
                                         < (*::core::mem::transmute::<&[u8; 6], &[c_char; 6]>(
                                             b"ACOS(\0",
                                         ))[0] as c_int
                                     {
                                         -(1)
-                                    } else if (*yyvsp.offset(-2_isize)).astr[0] as c_int
+                                    } else if (*yyvsp.offset(-2)).astr[0] as c_int
                                         > (*::core::mem::transmute::<&[u8; 6], &[c_char; 6]>(
                                             b"ACOS(\0",
                                         ))[0] as c_int
@@ -3940,7 +3654,7 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                         1
                                     } else {
                                         strcmp(
-                                            ((*yyvsp.offset(-2_isize)).astr).as_mut_ptr(),
+                                            ((*yyvsp.offset(-2)).astr).as_mut_ptr(),
                                             b"ACOS(\0" as *const u8 as *const c_char,
                                         )
                                     }) == 0
@@ -3950,7 +3664,7 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                         0,
                                         acos_fct,
                                         1,
-                                        (*yyvsp.offset(-1_isize)).Node,
+                                        (*yyvsp.offset(-1)).Node,
                                         0,
                                         0,
                                         0,
@@ -3959,13 +3673,13 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                         0,
                                     );
                                     current_block = 7600445499126923600;
-                                } else if (if ((*yyvsp.offset(-2_isize)).astr[0] as c_int)
+                                } else if (if ((*yyvsp.offset(-2)).astr[0] as c_int)
                                     < (*::core::mem::transmute::<&[u8; 8], &[c_char; 8]>(
                                         b"ARCTAN(\0",
                                     ))[0] as c_int
                                 {
                                     -(1)
-                                } else if (*yyvsp.offset(-2_isize)).astr[0] as c_int
+                                } else if (*yyvsp.offset(-2)).astr[0] as c_int
                                     > (*::core::mem::transmute::<&[u8; 8], &[c_char; 8]>(
                                         b"ARCTAN(\0",
                                     ))[0] as c_int
@@ -3973,17 +3687,17 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                     1
                                 } else {
                                     strcmp(
-                                        ((*yyvsp.offset(-2_isize)).astr).as_mut_ptr(),
+                                        ((*yyvsp.offset(-2)).astr).as_mut_ptr(),
                                         b"ARCTAN(\0" as *const u8 as *const c_char,
                                     )
                                 }) == 0
-                                    || (if ((*yyvsp.offset(-2_isize)).astr[0] as c_int)
+                                    || (if ((*yyvsp.offset(-2)).astr[0] as c_int)
                                         < (*::core::mem::transmute::<&[u8; 6], &[c_char; 6]>(
                                             b"ATAN(\0",
                                         ))[0] as c_int
                                     {
                                         -(1)
-                                    } else if (*yyvsp.offset(-2_isize)).astr[0] as c_int
+                                    } else if (*yyvsp.offset(-2)).astr[0] as c_int
                                         > (*::core::mem::transmute::<&[u8; 6], &[c_char; 6]>(
                                             b"ATAN(\0",
                                         ))[0] as c_int
@@ -3991,7 +3705,7 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                         1
                                     } else {
                                         strcmp(
-                                            ((*yyvsp.offset(-2_isize)).astr).as_mut_ptr(),
+                                            ((*yyvsp.offset(-2)).astr).as_mut_ptr(),
                                             b"ATAN(\0" as *const u8 as *const c_char,
                                         )
                                     }) == 0
@@ -4001,7 +3715,7 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                         0,
                                         atan_fct,
                                         1,
-                                        (*yyvsp.offset(-1_isize)).Node,
+                                        (*yyvsp.offset(-1)).Node,
                                         0,
                                         0,
                                         0,
@@ -4010,13 +3724,13 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                         0,
                                     );
                                     current_block = 7600445499126923600;
-                                } else if (if ((*yyvsp.offset(-2_isize)).astr[0] as c_int)
+                                } else if (if ((*yyvsp.offset(-2)).astr[0] as c_int)
                                     < (*::core::mem::transmute::<&[u8; 6], &[c_char; 6]>(
                                         b"SINH(\0",
                                     ))[0] as c_int
                                 {
                                     -(1)
-                                } else if (*yyvsp.offset(-2_isize)).astr[0] as c_int
+                                } else if (*yyvsp.offset(-2)).astr[0] as c_int
                                     > (*::core::mem::transmute::<&[u8; 6], &[c_char; 6]>(
                                         b"SINH(\0",
                                     ))[0] as c_int
@@ -4024,7 +3738,7 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                     1
                                 } else {
                                     strcmp(
-                                        ((*yyvsp.offset(-2_isize)).astr).as_mut_ptr(),
+                                        ((*yyvsp.offset(-2)).astr).as_mut_ptr(),
                                         b"SINH(\0" as *const u8 as *const c_char,
                                     )
                                 }) == 0
@@ -4034,7 +3748,7 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                         0,
                                         sinh_fct,
                                         1,
-                                        (*yyvsp.offset(-1_isize)).Node,
+                                        (*yyvsp.offset(-1)).Node,
                                         0,
                                         0,
                                         0,
@@ -4043,13 +3757,13 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                         0,
                                     );
                                     current_block = 7600445499126923600;
-                                } else if (if ((*yyvsp.offset(-2_isize)).astr[0] as c_int)
+                                } else if (if ((*yyvsp.offset(-2)).astr[0] as c_int)
                                     < (*::core::mem::transmute::<&[u8; 6], &[c_char; 6]>(
                                         b"COSH(\0",
                                     ))[0] as c_int
                                 {
                                     -(1)
-                                } else if (*yyvsp.offset(-2_isize)).astr[0] as c_int
+                                } else if (*yyvsp.offset(-2)).astr[0] as c_int
                                     > (*::core::mem::transmute::<&[u8; 6], &[c_char; 6]>(
                                         b"COSH(\0",
                                     ))[0] as c_int
@@ -4057,7 +3771,7 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                     1
                                 } else {
                                     strcmp(
-                                        ((*yyvsp.offset(-2_isize)).astr).as_mut_ptr(),
+                                        ((*yyvsp.offset(-2)).astr).as_mut_ptr(),
                                         b"COSH(\0" as *const u8 as *const c_char,
                                     )
                                 }) == 0
@@ -4067,7 +3781,7 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                         0,
                                         cosh_fct,
                                         1,
-                                        (*yyvsp.offset(-1_isize)).Node,
+                                        (*yyvsp.offset(-1)).Node,
                                         0,
                                         0,
                                         0,
@@ -4076,13 +3790,13 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                         0,
                                     );
                                     current_block = 7600445499126923600;
-                                } else if (if ((*yyvsp.offset(-2_isize)).astr[0] as c_int)
+                                } else if (if ((*yyvsp.offset(-2)).astr[0] as c_int)
                                     < (*::core::mem::transmute::<&[u8; 6], &[c_char; 6]>(
                                         b"TANH(\0",
                                     ))[0] as c_int
                                 {
                                     -(1)
-                                } else if (*yyvsp.offset(-2_isize)).astr[0] as c_int
+                                } else if (*yyvsp.offset(-2)).astr[0] as c_int
                                     > (*::core::mem::transmute::<&[u8; 6], &[c_char; 6]>(
                                         b"TANH(\0",
                                     ))[0] as c_int
@@ -4090,7 +3804,7 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                     1
                                 } else {
                                     strcmp(
-                                        ((*yyvsp.offset(-2_isize)).astr).as_mut_ptr(),
+                                        ((*yyvsp.offset(-2)).astr).as_mut_ptr(),
                                         b"TANH(\0" as *const u8 as *const c_char,
                                     )
                                 }) == 0
@@ -4100,7 +3814,7 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                         0,
                                         tanh_fct,
                                         1,
-                                        (*yyvsp.offset(-1_isize)).Node,
+                                        (*yyvsp.offset(-1)).Node,
                                         0,
                                         0,
                                         0,
@@ -4109,19 +3823,19 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                         0,
                                     );
                                     current_block = 7600445499126923600;
-                                } else if (if ((*yyvsp.offset(-2_isize)).astr[0] as c_int)
+                                } else if (if ((*yyvsp.offset(-2)).astr[0] as c_int)
                                     < (*::core::mem::transmute::<&[u8; 5], &[c_char; 5]>(b"EXP(\0"))
                                         [0] as c_int
                                 {
                                     -(1)
-                                } else if (*yyvsp.offset(-2_isize)).astr[0] as c_int
+                                } else if (*yyvsp.offset(-2)).astr[0] as c_int
                                     > (*::core::mem::transmute::<&[u8; 5], &[c_char; 5]>(b"EXP(\0"))
                                         [0] as c_int
                                 {
                                     1
                                 } else {
                                     strcmp(
-                                        ((*yyvsp.offset(-2_isize)).astr).as_mut_ptr(),
+                                        ((*yyvsp.offset(-2)).astr).as_mut_ptr(),
                                         b"EXP(\0" as *const u8 as *const c_char,
                                     )
                                 }) == 0
@@ -4131,7 +3845,7 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                         0,
                                         exp_fct,
                                         1,
-                                        (*yyvsp.offset(-1_isize)).Node,
+                                        (*yyvsp.offset(-1)).Node,
                                         0,
                                         0,
                                         0,
@@ -4140,19 +3854,19 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                         0,
                                     );
                                     current_block = 7600445499126923600;
-                                } else if (if ((*yyvsp.offset(-2_isize)).astr[0] as c_int)
+                                } else if (if ((*yyvsp.offset(-2)).astr[0] as c_int)
                                     < (*::core::mem::transmute::<&[u8; 5], &[c_char; 5]>(b"LOG(\0"))
                                         [0] as c_int
                                 {
                                     -(1)
-                                } else if (*yyvsp.offset(-2_isize)).astr[0] as c_int
+                                } else if (*yyvsp.offset(-2)).astr[0] as c_int
                                     > (*::core::mem::transmute::<&[u8; 5], &[c_char; 5]>(b"LOG(\0"))
                                         [0] as c_int
                                 {
                                     1
                                 } else {
                                     strcmp(
-                                        ((*yyvsp.offset(-2_isize)).astr).as_mut_ptr(),
+                                        ((*yyvsp.offset(-2)).astr).as_mut_ptr(),
                                         b"LOG(\0" as *const u8 as *const c_char,
                                     )
                                 }) == 0
@@ -4162,7 +3876,7 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                         0,
                                         log_fct,
                                         1,
-                                        (*yyvsp.offset(-1_isize)).Node,
+                                        (*yyvsp.offset(-1)).Node,
                                         0,
                                         0,
                                         0,
@@ -4171,13 +3885,13 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                         0,
                                     );
                                     current_block = 7600445499126923600;
-                                } else if (if ((*yyvsp.offset(-2_isize)).astr[0] as c_int)
+                                } else if (if ((*yyvsp.offset(-2)).astr[0] as c_int)
                                     < (*::core::mem::transmute::<&[u8; 7], &[c_char; 7]>(
                                         b"LOG10(\0",
                                     ))[0] as c_int
                                 {
                                     -(1)
-                                } else if (*yyvsp.offset(-2_isize)).astr[0] as c_int
+                                } else if (*yyvsp.offset(-2)).astr[0] as c_int
                                     > (*::core::mem::transmute::<&[u8; 7], &[c_char; 7]>(
                                         b"LOG10(\0",
                                     ))[0] as c_int
@@ -4185,7 +3899,7 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                     1
                                 } else {
                                     strcmp(
-                                        ((*yyvsp.offset(-2_isize)).astr).as_mut_ptr(),
+                                        ((*yyvsp.offset(-2)).astr).as_mut_ptr(),
                                         b"LOG10(\0" as *const u8 as *const c_char,
                                     )
                                 }) == 0
@@ -4195,7 +3909,7 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                         0,
                                         log10_fct,
                                         1,
-                                        (*yyvsp.offset(-1_isize)).Node,
+                                        (*yyvsp.offset(-1)).Node,
                                         0,
                                         0,
                                         0,
@@ -4204,13 +3918,13 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                         0,
                                     );
                                     current_block = 7600445499126923600;
-                                } else if (if ((*yyvsp.offset(-2_isize)).astr[0] as c_int)
+                                } else if (if ((*yyvsp.offset(-2)).astr[0] as c_int)
                                     < (*::core::mem::transmute::<&[u8; 6], &[c_char; 6]>(
                                         b"SQRT(\0",
                                     ))[0] as c_int
                                 {
                                     -(1)
-                                } else if (*yyvsp.offset(-2_isize)).astr[0] as c_int
+                                } else if (*yyvsp.offset(-2)).astr[0] as c_int
                                     > (*::core::mem::transmute::<&[u8; 6], &[c_char; 6]>(
                                         b"SQRT(\0",
                                     ))[0] as c_int
@@ -4218,7 +3932,7 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                     1
                                 } else {
                                     strcmp(
-                                        ((*yyvsp.offset(-2_isize)).astr).as_mut_ptr(),
+                                        ((*yyvsp.offset(-2)).astr).as_mut_ptr(),
                                         b"SQRT(\0" as *const u8 as *const c_char,
                                     )
                                 }) == 0
@@ -4228,7 +3942,7 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                         0,
                                         sqrt_fct,
                                         1,
-                                        (*yyvsp.offset(-1_isize)).Node,
+                                        (*yyvsp.offset(-1)).Node,
                                         0,
                                         0,
                                         0,
@@ -4237,13 +3951,13 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                         0,
                                     );
                                     current_block = 7600445499126923600;
-                                } else if (if ((*yyvsp.offset(-2_isize)).astr[0] as c_int)
+                                } else if (if ((*yyvsp.offset(-2)).astr[0] as c_int)
                                     < (*::core::mem::transmute::<&[u8; 7], &[c_char; 7]>(
                                         b"ROUND(\0",
                                     ))[0] as c_int
                                 {
                                     -(1)
-                                } else if (*yyvsp.offset(-2_isize)).astr[0] as c_int
+                                } else if (*yyvsp.offset(-2)).astr[0] as c_int
                                     > (*::core::mem::transmute::<&[u8; 7], &[c_char; 7]>(
                                         b"ROUND(\0",
                                     ))[0] as c_int
@@ -4251,7 +3965,7 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                     1
                                 } else {
                                     strcmp(
-                                        ((*yyvsp.offset(-2_isize)).astr).as_mut_ptr(),
+                                        ((*yyvsp.offset(-2)).astr).as_mut_ptr(),
                                         b"ROUND(\0" as *const u8 as *const c_char,
                                     )
                                 }) == 0
@@ -4261,7 +3975,7 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                         0,
                                         round_fct,
                                         1,
-                                        (*yyvsp.offset(-1_isize)).Node,
+                                        (*yyvsp.offset(-1)).Node,
                                         0,
                                         0,
                                         0,
@@ -4270,13 +3984,13 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                         0,
                                     );
                                     current_block = 7600445499126923600;
-                                } else if (if ((*yyvsp.offset(-2_isize)).astr[0] as c_int)
+                                } else if (if ((*yyvsp.offset(-2)).astr[0] as c_int)
                                     < (*::core::mem::transmute::<&[u8; 7], &[c_char; 7]>(
                                         b"FLOOR(\0",
                                     ))[0] as c_int
                                 {
                                     -(1)
-                                } else if (*yyvsp.offset(-2_isize)).astr[0] as c_int
+                                } else if (*yyvsp.offset(-2)).astr[0] as c_int
                                     > (*::core::mem::transmute::<&[u8; 7], &[c_char; 7]>(
                                         b"FLOOR(\0",
                                     ))[0] as c_int
@@ -4284,7 +3998,7 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                     1
                                 } else {
                                     strcmp(
-                                        ((*yyvsp.offset(-2_isize)).astr).as_mut_ptr(),
+                                        ((*yyvsp.offset(-2)).astr).as_mut_ptr(),
                                         b"FLOOR(\0" as *const u8 as *const c_char,
                                     )
                                 }) == 0
@@ -4294,7 +4008,7 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                         0,
                                         floor_fct,
                                         1,
-                                        (*yyvsp.offset(-1_isize)).Node,
+                                        (*yyvsp.offset(-1)).Node,
                                         0,
                                         0,
                                         0,
@@ -4303,13 +4017,13 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                         0,
                                     );
                                     current_block = 7600445499126923600;
-                                } else if (if ((*yyvsp.offset(-2_isize)).astr[0] as c_int)
+                                } else if (if ((*yyvsp.offset(-2)).astr[0] as c_int)
                                     < (*::core::mem::transmute::<&[u8; 6], &[c_char; 6]>(
                                         b"CEIL(\0",
                                     ))[0] as c_int
                                 {
                                     -(1)
-                                } else if (*yyvsp.offset(-2_isize)).astr[0] as c_int
+                                } else if (*yyvsp.offset(-2)).astr[0] as c_int
                                     > (*::core::mem::transmute::<&[u8; 6], &[c_char; 6]>(
                                         b"CEIL(\0",
                                     ))[0] as c_int
@@ -4317,7 +4031,7 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                     1
                                 } else {
                                     strcmp(
-                                        ((*yyvsp.offset(-2_isize)).astr).as_mut_ptr(),
+                                        ((*yyvsp.offset(-2)).astr).as_mut_ptr(),
                                         b"CEIL(\0" as *const u8 as *const c_char,
                                     )
                                 }) == 0
@@ -4327,7 +4041,7 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                         0,
                                         ceil_fct,
                                         1,
-                                        (*yyvsp.offset(-1_isize)).Node,
+                                        (*yyvsp.offset(-1)).Node,
                                         0,
                                         0,
                                         0,
@@ -4336,13 +4050,13 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                         0,
                                     );
                                     current_block = 7600445499126923600;
-                                } else if (if ((*yyvsp.offset(-2_isize)).astr[0] as c_int)
+                                } else if (if ((*yyvsp.offset(-2)).astr[0] as c_int)
                                     < (*::core::mem::transmute::<&[u8; 9], &[c_char; 9]>(
                                         b"RANDOMP(\0",
                                     ))[0] as c_int
                                 {
                                     -(1)
-                                } else if (*yyvsp.offset(-2_isize)).astr[0] as c_int
+                                } else if (*yyvsp.offset(-2)).astr[0] as c_int
                                     > (*::core::mem::transmute::<&[u8; 9], &[c_char; 9]>(
                                         b"RANDOMP(\0",
                                     ))[0] as c_int
@@ -4350,7 +4064,7 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                     1
                                 } else {
                                     strcmp(
-                                        ((*yyvsp.offset(-2_isize)).astr).as_mut_ptr(),
+                                        ((*yyvsp.offset(-2)).astr).as_mut_ptr(),
                                         b"RANDOMP(\0" as *const u8 as *const c_char,
                                     )
                                 }) == 0
@@ -4360,7 +4074,7 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                         0,
                                         poirnd_fct,
                                         1,
-                                        (*yyvsp.offset(-1_isize)).Node,
+                                        (*yyvsp.offset(-1)).Node,
                                         0,
                                         0,
                                         0,
@@ -4368,16 +4082,14 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                         0,
                                         0,
                                     );
-                                    (*((*lParse).Nodes).offset(yyval.Node as isize)).ntype =
+                                    ((lParse.Nodes)[yyval.Node as usize]).ntype =
                                         fits_parser_yytokentype::LONG as c_int;
                                     current_block = 7600445499126923600;
                                 } else {
                                     fits_parser_yyerror(
                                         scanner,
                                         lParse,
-                                        b"Function(expr) not supported\0" as *const u8
-                                            as *const c_char
-                                            as *mut c_char,
+                                        cs!(c"Function(expr) not supported"),
                                     );
                                     current_block = 4830776507462815627;
                                 }
@@ -4394,19 +4106,19 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                             }
                         }
                         60 => {
-                            if (if ((*yyvsp.offset(-4_isize)).astr[0] as c_int)
+                            if (if ((*yyvsp.offset(-4)).astr[0] as c_int)
                                 < (*::core::mem::transmute::<&[u8; 8], &[c_char; 8]>(b"STRSTR(\0"))
                                     [0] as c_int
                             {
                                 -(1)
-                            } else if (*yyvsp.offset(-4_isize)).astr[0] as c_int
+                            } else if (*yyvsp.offset(-4)).astr[0] as c_int
                                 > (*::core::mem::transmute::<&[u8; 8], &[c_char; 8]>(b"STRSTR(\0"))
                                     [0] as c_int
                             {
                                 1
                             } else {
                                 strcmp(
-                                    ((*yyvsp.offset(-4_isize)).astr).as_mut_ptr(),
+                                    ((*yyvsp.offset(-4)).astr).as_mut_ptr(),
                                     b"STRSTR(\0" as *const u8 as *const c_char,
                                 )
                             }) == 0
@@ -4416,8 +4128,8 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                     fits_parser_yytokentype::LONG as c_int,
                                     strpos_fct,
                                     2 as c_int,
-                                    (*yyvsp.offset(-3_isize)).Node,
-                                    (*yyvsp.offset(-1_isize)).Node,
+                                    (*yyvsp.offset(-3)).Node,
+                                    (*yyvsp.offset(-1)).Node,
                                     0,
                                     0,
                                     0,
@@ -4440,66 +4152,55 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                             }
                         }
                         61 => {
-                            if (if ((*yyvsp.offset(-4_isize)).astr[0] as c_int)
+                            if (if ((*yyvsp.offset(-4)).astr[0] as c_int)
                                 < (*::core::mem::transmute::<&[u8; 9], &[c_char; 9]>(b"DEFNULL(\0"))
                                     [0] as c_int
                             {
                                 -(1)
-                            } else if (*yyvsp.offset(-4_isize)).astr[0] as c_int
+                            } else if (*yyvsp.offset(-4)).astr[0] as c_int
                                 > (*::core::mem::transmute::<&[u8; 9], &[c_char; 9]>(b"DEFNULL(\0"))
                                     [0] as c_int
                             {
                                 1
                             } else {
                                 strcmp(
-                                    ((*yyvsp.offset(-4_isize)).astr).as_mut_ptr(),
+                                    ((*yyvsp.offset(-4)).astr).as_mut_ptr(),
                                     b"DEFNULL(\0" as *const u8 as *const c_char,
                                 )
                             }) == 0
                             {
-                                if (*((*lParse).Nodes)
-                                    .offset((*yyvsp.offset(-3_isize)).Node as isize))
-                                .value
-                                .nelem
-                                    >= (*((*lParse).Nodes)
-                                        .offset((*yyvsp.offset(-1_isize)).Node as isize))
+                                if ((lParse.Nodes)[(*yyvsp.offset(-3)).Node as usize])
                                     .value
                                     .nelem
+                                    >= ((lParse.Nodes)[(*yyvsp.offset(-1)).Node as usize])
+                                        .value
+                                        .nelem
                                     && Test_Dims(
                                         lParse,
-                                        (*yyvsp.offset(-3_isize)).Node,
-                                        (*yyvsp.offset(-1_isize)).Node,
+                                        (*yyvsp.offset(-3)).Node,
+                                        (*yyvsp.offset(-1)).Node,
                                     ) != 0
                                 {
-                                    if (*((*lParse).Nodes)
-                                        .offset((*yyvsp.offset(-3_isize)).Node as isize))
-                                    .ntype
-                                        > (*((*lParse).Nodes)
-                                            .offset((*yyvsp.offset(-1_isize)).Node as isize))
-                                        .ntype
+                                    if ((lParse.Nodes)[(*yyvsp.offset(-3)).Node as usize]).ntype
+                                        > ((lParse.Nodes)[(*yyvsp.offset(-1)).Node as usize]).ntype
                                     {
-                                        (*yyvsp.offset(-1_isize)).Node = New_Unary(
+                                        (*yyvsp.offset(-1)).Node = New_Unary(
                                             lParse,
-                                            (*((*lParse).Nodes)
-                                                .offset((*yyvsp.offset(-3_isize)).Node as isize))
-                                            .ntype,
+                                            ((lParse.Nodes)[(*yyvsp.offset(-3)).Node as usize])
+                                                .ntype,
                                             0,
-                                            (*yyvsp.offset(-1_isize)).Node,
+                                            (*yyvsp.offset(-1)).Node,
                                         );
-                                    } else if (*((*lParse).Nodes)
-                                        .offset((*yyvsp.offset(-3_isize)).Node as isize))
-                                    .ntype
-                                        < (*((*lParse).Nodes)
-                                            .offset((*yyvsp.offset(-1_isize)).Node as isize))
+                                    } else if ((lParse.Nodes)[(*yyvsp.offset(-3)).Node as usize])
                                         .ntype
+                                        < ((lParse.Nodes)[(*yyvsp.offset(-1)).Node as usize]).ntype
                                     {
-                                        (*yyvsp.offset(-3_isize)).Node = New_Unary(
+                                        (*yyvsp.offset(-3)).Node = New_Unary(
                                             lParse,
-                                            (*((*lParse).Nodes)
-                                                .offset((*yyvsp.offset(-1_isize)).Node as isize))
-                                            .ntype,
+                                            ((lParse.Nodes)[(*yyvsp.offset(-1)).Node as usize])
+                                                .ntype,
                                             0,
-                                            (*yyvsp.offset(-3_isize)).Node,
+                                            (*yyvsp.offset(-3)).Node,
                                         );
                                     }
                                     yyval.Node = New_Func(
@@ -4507,8 +4208,8 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                         0,
                                         defnull_fct,
                                         2 as c_int,
-                                        (*yyvsp.offset(-3_isize)).Node,
-                                        (*yyvsp.offset(-1_isize)).Node,
+                                        (*yyvsp.offset(-3)).Node,
+                                        (*yyvsp.offset(-1)).Node,
                                         0,
                                         0,
                                         0,
@@ -4524,58 +4225,51 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                     fits_parser_yyerror(
                                         scanner,
                                         lParse,
-                                        b"Dimensions of DEFNULL arguments are not compatible\0"
-                                            as *const u8
-                                            as *const c_char
-                                            as *mut c_char,
+                                        cs!(c"Dimensions of DEFNULL arguments are not compatible"),
                                     );
                                     current_block = 4830776507462815627;
                                 }
-                            } else if (if ((*yyvsp.offset(-4_isize)).astr[0] as c_int)
+                            } else if (if ((*yyvsp.offset(-4)).astr[0] as c_int)
                                 < (*::core::mem::transmute::<&[u8; 9], &[c_char; 9]>(b"ARCTAN2(\0"))
                                     [0] as c_int
                             {
                                 -(1)
-                            } else if (*yyvsp.offset(-4_isize)).astr[0] as c_int
+                            } else if (*yyvsp.offset(-4)).astr[0] as c_int
                                 > (*::core::mem::transmute::<&[u8; 9], &[c_char; 9]>(b"ARCTAN2(\0"))
                                     [0] as c_int
                             {
                                 1
                             } else {
                                 strcmp(
-                                    ((*yyvsp.offset(-4_isize)).astr).as_mut_ptr(),
+                                    ((*yyvsp.offset(-4)).astr).as_mut_ptr(),
                                     b"ARCTAN2(\0" as *const u8 as *const c_char,
                                 )
                             }) == 0
                             {
-                                if (*((*lParse).Nodes)
-                                    .offset((*yyvsp.offset(-3_isize)).Node as isize))
-                                .ntype
+                                if ((lParse.Nodes)[(*yyvsp.offset(-3)).Node as usize]).ntype
                                     != fits_parser_yytokentype::DOUBLE as c_int
                                 {
-                                    (*yyvsp.offset(-3_isize)).Node = New_Unary(
+                                    (*yyvsp.offset(-3)).Node = New_Unary(
                                         lParse,
                                         fits_parser_yytokentype::DOUBLE as c_int,
                                         0,
-                                        (*yyvsp.offset(-3_isize)).Node,
+                                        (*yyvsp.offset(-3)).Node,
                                     );
                                 }
-                                if (*((*lParse).Nodes)
-                                    .offset((*yyvsp.offset(-1_isize)).Node as isize))
-                                .ntype
+                                if ((lParse.Nodes)[(*yyvsp.offset(-1)).Node as usize]).ntype
                                     != fits_parser_yytokentype::DOUBLE as c_int
                                 {
-                                    (*yyvsp.offset(-1_isize)).Node = New_Unary(
+                                    (*yyvsp.offset(-1)).Node = New_Unary(
                                         lParse,
                                         fits_parser_yytokentype::DOUBLE as c_int,
                                         0,
-                                        (*yyvsp.offset(-1_isize)).Node,
+                                        (*yyvsp.offset(-1)).Node,
                                     );
                                 }
                                 if Test_Dims(
                                     lParse,
-                                    (*yyvsp.offset(-3_isize)).Node,
-                                    (*yyvsp.offset(-1_isize)).Node,
+                                    (*yyvsp.offset(-3)).Node,
+                                    (*yyvsp.offset(-1)).Node,
                                 ) != 0
                                 {
                                     yyval.Node = New_Func(
@@ -4583,8 +4277,8 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                         0,
                                         atan2_fct,
                                         2 as c_int,
-                                        (*yyvsp.offset(-3_isize)).Node,
-                                        (*yyvsp.offset(-1_isize)).Node,
+                                        (*yyvsp.offset(-3)).Node,
+                                        (*yyvsp.offset(-1)).Node,
                                         0,
                                         0,
                                         0,
@@ -4594,20 +4288,14 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                     if yyval.Node < 0 {
                                         current_block = 4830776507462815627;
                                     } else {
-                                        if (*((*lParse).Nodes)
-                                            .offset((*yyvsp.offset(-3_isize)).Node as isize))
-                                        .value
-                                        .nelem
-                                            < (*((*lParse).Nodes)
-                                                .offset((*yyvsp.offset(-1_isize)).Node as isize))
+                                        if ((lParse.Nodes)[(*yyvsp.offset(-3)).Node as usize])
                                             .value
                                             .nelem
+                                            < ((lParse.Nodes)[(*yyvsp.offset(-1)).Node as usize])
+                                                .value
+                                                .nelem
                                         {
-                                            Copy_Dims(
-                                                lParse,
-                                                yyval.Node,
-                                                (*yyvsp.offset(-1_isize)).Node,
-                                            );
+                                            Copy_Dims(lParse, yyval.Node, (*yyvsp.offset(-1)).Node);
                                         }
                                         current_block = 9966817879908499150;
                                     }
@@ -4615,65 +4303,50 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                     fits_parser_yyerror(
                                         scanner,
                                         lParse,
-                                        b"Dimensions of arctan2 arguments are not compatible\0"
-                                            as *const u8
-                                            as *const c_char
-                                            as *mut c_char,
+                                        cs!(c"Dimensions of arctan2 arguments are not compatible"),
                                     );
                                     current_block = 4830776507462815627;
                                 }
-                            } else if (if ((*yyvsp.offset(-4_isize)).astr[0] as c_int)
+                            } else if (if ((*yyvsp.offset(-4)).astr[0] as c_int)
                                 < (*::core::mem::transmute::<&[u8; 5], &[c_char; 5]>(b"MIN(\0"))[0]
                                     as c_int
                             {
                                 -(1)
-                            } else if (*yyvsp.offset(-4_isize)).astr[0] as c_int
+                            } else if (*yyvsp.offset(-4)).astr[0] as c_int
                                 > (*::core::mem::transmute::<&[u8; 5], &[c_char; 5]>(b"MIN(\0"))[0]
                                     as c_int
                             {
                                 1
                             } else {
                                 strcmp(
-                                    ((*yyvsp.offset(-4_isize)).astr).as_mut_ptr(),
+                                    ((*yyvsp.offset(-4)).astr).as_mut_ptr(),
                                     b"MIN(\0" as *const u8 as *const c_char,
                                 )
                             }) == 0
                             {
-                                if (*((*lParse).Nodes)
-                                    .offset((*yyvsp.offset(-3_isize)).Node as isize))
-                                .ntype
-                                    > (*((*lParse).Nodes)
-                                        .offset((*yyvsp.offset(-1_isize)).Node as isize))
-                                    .ntype
+                                if ((lParse.Nodes)[(*yyvsp.offset(-3)).Node as usize]).ntype
+                                    > ((lParse.Nodes)[(*yyvsp.offset(-1)).Node as usize]).ntype
                                 {
-                                    (*yyvsp.offset(-1_isize)).Node = New_Unary(
+                                    (*yyvsp.offset(-1)).Node = New_Unary(
                                         lParse,
-                                        (*((*lParse).Nodes)
-                                            .offset((*yyvsp.offset(-3_isize)).Node as isize))
-                                        .ntype,
+                                        ((lParse.Nodes)[(*yyvsp.offset(-3)).Node as usize]).ntype,
                                         0,
-                                        (*yyvsp.offset(-1_isize)).Node,
+                                        (*yyvsp.offset(-1)).Node,
                                     );
-                                } else if (*((*lParse).Nodes)
-                                    .offset((*yyvsp.offset(-3_isize)).Node as isize))
-                                .ntype
-                                    < (*((*lParse).Nodes)
-                                        .offset((*yyvsp.offset(-1_isize)).Node as isize))
-                                    .ntype
+                                } else if ((lParse.Nodes)[(*yyvsp.offset(-3)).Node as usize]).ntype
+                                    < ((lParse.Nodes)[(*yyvsp.offset(-1)).Node as usize]).ntype
                                 {
-                                    (*yyvsp.offset(-3_isize)).Node = New_Unary(
+                                    (*yyvsp.offset(-3)).Node = New_Unary(
                                         lParse,
-                                        (*((*lParse).Nodes)
-                                            .offset((*yyvsp.offset(-1_isize)).Node as isize))
-                                        .ntype,
+                                        ((lParse.Nodes)[(*yyvsp.offset(-1)).Node as usize]).ntype,
                                         0,
-                                        (*yyvsp.offset(-3_isize)).Node,
+                                        (*yyvsp.offset(-3)).Node,
                                     );
                                 }
                                 if Test_Dims(
                                     lParse,
-                                    (*yyvsp.offset(-3_isize)).Node,
-                                    (*yyvsp.offset(-1_isize)).Node,
+                                    (*yyvsp.offset(-3)).Node,
+                                    (*yyvsp.offset(-1)).Node,
                                 ) != 0
                                 {
                                     yyval.Node = New_Func(
@@ -4681,8 +4354,8 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                         0,
                                         min2_fct,
                                         2 as c_int,
-                                        (*yyvsp.offset(-3_isize)).Node,
-                                        (*yyvsp.offset(-1_isize)).Node,
+                                        (*yyvsp.offset(-3)).Node,
+                                        (*yyvsp.offset(-1)).Node,
                                         0,
                                         0,
                                         0,
@@ -4692,20 +4365,14 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                     if yyval.Node < 0 {
                                         current_block = 4830776507462815627;
                                     } else {
-                                        if (*((*lParse).Nodes)
-                                            .offset((*yyvsp.offset(-3_isize)).Node as isize))
-                                        .value
-                                        .nelem
-                                            < (*((*lParse).Nodes)
-                                                .offset((*yyvsp.offset(-1_isize)).Node as isize))
+                                        if ((lParse.Nodes)[(*yyvsp.offset(-3)).Node as usize])
                                             .value
                                             .nelem
+                                            < ((lParse.Nodes)[(*yyvsp.offset(-1)).Node as usize])
+                                                .value
+                                                .nelem
                                         {
-                                            Copy_Dims(
-                                                lParse,
-                                                yyval.Node,
-                                                (*yyvsp.offset(-1_isize)).Node,
-                                            );
+                                            Copy_Dims(lParse, yyval.Node, (*yyvsp.offset(-1)).Node);
                                         }
                                         current_block = 9966817879908499150;
                                     }
@@ -4713,65 +4380,50 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                     fits_parser_yyerror(
                                         scanner,
                                         lParse,
-                                        b"Dimensions of min(a,b) arguments are not compatible\0"
-                                            as *const u8
-                                            as *const c_char
-                                            as *mut c_char,
+                                        cs!(c"Dimensions of min(a,b) arguments are not compatible"),
                                     );
                                     current_block = 4830776507462815627;
                                 }
-                            } else if (if ((*yyvsp.offset(-4_isize)).astr[0] as c_int)
+                            } else if (if ((*yyvsp.offset(-4)).astr[0] as c_int)
                                 < (*::core::mem::transmute::<&[u8; 5], &[c_char; 5]>(b"MAX(\0"))[0]
                                     as c_int
                             {
                                 -(1)
-                            } else if (*yyvsp.offset(-4_isize)).astr[0] as c_int
+                            } else if (*yyvsp.offset(-4)).astr[0] as c_int
                                 > (*::core::mem::transmute::<&[u8; 5], &[c_char; 5]>(b"MAX(\0"))[0]
                                     as c_int
                             {
                                 1
                             } else {
                                 strcmp(
-                                    ((*yyvsp.offset(-4_isize)).astr).as_mut_ptr(),
+                                    ((*yyvsp.offset(-4)).astr).as_mut_ptr(),
                                     b"MAX(\0" as *const u8 as *const c_char,
                                 )
                             }) == 0
                             {
-                                if (*((*lParse).Nodes)
-                                    .offset((*yyvsp.offset(-3_isize)).Node as isize))
-                                .ntype
-                                    > (*((*lParse).Nodes)
-                                        .offset((*yyvsp.offset(-1_isize)).Node as isize))
-                                    .ntype
+                                if ((lParse.Nodes)[(*yyvsp.offset(-3)).Node as usize]).ntype
+                                    > ((lParse.Nodes)[(*yyvsp.offset(-1)).Node as usize]).ntype
                                 {
-                                    (*yyvsp.offset(-1_isize)).Node = New_Unary(
+                                    (*yyvsp.offset(-1)).Node = New_Unary(
                                         lParse,
-                                        (*((*lParse).Nodes)
-                                            .offset((*yyvsp.offset(-3_isize)).Node as isize))
-                                        .ntype,
+                                        ((lParse.Nodes)[(*yyvsp.offset(-3)).Node as usize]).ntype,
                                         0,
-                                        (*yyvsp.offset(-1_isize)).Node,
+                                        (*yyvsp.offset(-1)).Node,
                                     );
-                                } else if (*((*lParse).Nodes)
-                                    .offset((*yyvsp.offset(-3_isize)).Node as isize))
-                                .ntype
-                                    < (*((*lParse).Nodes)
-                                        .offset((*yyvsp.offset(-1_isize)).Node as isize))
-                                    .ntype
+                                } else if ((lParse.Nodes)[(*yyvsp.offset(-3)).Node as usize]).ntype
+                                    < ((lParse.Nodes)[(*yyvsp.offset(-1)).Node as usize]).ntype
                                 {
-                                    (*yyvsp.offset(-3_isize)).Node = New_Unary(
+                                    (*yyvsp.offset(-3)).Node = New_Unary(
                                         lParse,
-                                        (*((*lParse).Nodes)
-                                            .offset((*yyvsp.offset(-1_isize)).Node as isize))
-                                        .ntype,
+                                        ((lParse.Nodes)[(*yyvsp.offset(-1)).Node as usize]).ntype,
                                         0,
-                                        (*yyvsp.offset(-3_isize)).Node,
+                                        (*yyvsp.offset(-3)).Node,
                                     );
                                 }
                                 if Test_Dims(
                                     lParse,
-                                    (*yyvsp.offset(-3_isize)).Node,
-                                    (*yyvsp.offset(-1_isize)).Node,
+                                    (*yyvsp.offset(-3)).Node,
+                                    (*yyvsp.offset(-1)).Node,
                                 ) != 0
                                 {
                                     yyval.Node = New_Func(
@@ -4779,8 +4431,8 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                         0,
                                         max2_fct,
                                         2 as c_int,
-                                        (*yyvsp.offset(-3_isize)).Node,
-                                        (*yyvsp.offset(-1_isize)).Node,
+                                        (*yyvsp.offset(-3)).Node,
+                                        (*yyvsp.offset(-1)).Node,
                                         0,
                                         0,
                                         0,
@@ -4790,20 +4442,14 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                     if yyval.Node < 0 {
                                         current_block = 4830776507462815627;
                                     } else {
-                                        if (*((*lParse).Nodes)
-                                            .offset((*yyvsp.offset(-3_isize)).Node as isize))
-                                        .value
-                                        .nelem
-                                            < (*((*lParse).Nodes)
-                                                .offset((*yyvsp.offset(-1_isize)).Node as isize))
+                                        if ((lParse.Nodes)[(*yyvsp.offset(-3)).Node as usize])
                                             .value
                                             .nelem
+                                            < ((lParse.Nodes)[(*yyvsp.offset(-1)).Node as usize])
+                                                .value
+                                                .nelem
                                         {
-                                            Copy_Dims(
-                                                lParse,
-                                                yyval.Node,
-                                                (*yyvsp.offset(-1_isize)).Node,
-                                            );
+                                            Copy_Dims(lParse, yyval.Node, (*yyvsp.offset(-1)).Node);
                                         }
                                         current_block = 9966817879908499150;
                                     }
@@ -4811,64 +4457,50 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                     fits_parser_yyerror(
                                         scanner,
                                         lParse,
-                                        b"Dimensions of max(a,b) arguments are not compatible\0"
-                                            as *const u8
-                                            as *const c_char
-                                            as *mut c_char,
+                                        cs!(c"Dimensions of max(a,b) arguments are not compatible"),
                                     );
                                     current_block = 4830776507462815627;
                                 }
-                            } else if (if ((*yyvsp.offset(-4_isize)).astr[0] as c_int)
+                            } else if (if ((*yyvsp.offset(-4)).astr[0] as c_int)
                                 < (*::core::mem::transmute::<&[u8; 9], &[c_char; 9]>(b"SETNULL(\0"))
                                     [0] as c_int
                             {
                                 -(1)
-                            } else if (*yyvsp.offset(-4_isize)).astr[0] as c_int
+                            } else if (*yyvsp.offset(-4)).astr[0] as c_int
                                 > (*::core::mem::transmute::<&[u8; 9], &[c_char; 9]>(b"SETNULL(\0"))
                                     [0] as c_int
                             {
                                 1
                             } else {
                                 strcmp(
-                                    ((*yyvsp.offset(-4_isize)).astr).as_mut_ptr(),
+                                    ((*yyvsp.offset(-4)).astr).as_mut_ptr(),
                                     b"SETNULL(\0" as *const u8 as *const c_char,
                                 )
                             }) == 0
                             {
-                                if (*((*lParse).Nodes)
-                                    .offset((*yyvsp.offset(-3_isize)).Node as isize))
-                                .operation
-                                    != -(1000 as c_int)
-                                    || (*((*lParse).Nodes)
-                                        .offset((*yyvsp.offset(-3_isize)).Node as isize))
-                                    .value
-                                    .nelem
+                                if ((lParse.Nodes)[(*yyvsp.offset(-3)).Node as usize]).operation
+                                    != -1000
+                                    || ((lParse.Nodes)[(*yyvsp.offset(-3)).Node as usize])
+                                        .value
+                                        .nelem
                                         != 1
                                 {
                                     fits_parser_yyerror(
                                         scanner,
                                         lParse,
-                                        b"SETNULL first argument must be a scalar constant\0"
-                                            as *const u8
-                                            as *const c_char
-                                            as *mut c_char,
+                                        cs!(c"SETNULL first argument must be a scalar constant"),
                                     );
                                     current_block = 4830776507462815627;
                                 } else {
-                                    if (*((*lParse).Nodes)
-                                        .offset((*yyvsp.offset(-3_isize)).Node as isize))
-                                    .ntype
-                                        != (*((*lParse).Nodes)
-                                            .offset((*yyvsp.offset(-1_isize)).Node as isize))
-                                        .ntype
+                                    if ((lParse.Nodes)[(*yyvsp.offset(-3)).Node as usize]).ntype
+                                        != ((lParse.Nodes)[(*yyvsp.offset(-1)).Node as usize]).ntype
                                     {
-                                        (*yyvsp.offset(-3_isize)).Node = New_Unary(
+                                        (*yyvsp.offset(-3)).Node = New_Unary(
                                             lParse,
-                                            (*((*lParse).Nodes)
-                                                .offset((*yyvsp.offset(-1_isize)).Node as isize))
-                                            .ntype,
+                                            ((lParse.Nodes)[(*yyvsp.offset(-1)).Node as usize])
+                                                .ntype,
                                             0,
-                                            (*yyvsp.offset(-3_isize)).Node,
+                                            (*yyvsp.offset(-3)).Node,
                                         );
                                     }
                                     yyval.Node = New_Func(
@@ -4876,8 +4508,8 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                         0,
                                         setnull_fct,
                                         2 as c_int,
-                                        (*yyvsp.offset(-1_isize)).Node,
-                                        (*yyvsp.offset(-3_isize)).Node,
+                                        (*yyvsp.offset(-1)).Node,
+                                        (*yyvsp.offset(-3)).Node,
                                         0,
                                         0,
                                         0,
@@ -4886,13 +4518,13 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                     );
                                     current_block = 9966817879908499150;
                                 }
-                            } else if (if ((*yyvsp.offset(-4_isize)).astr[0] as c_int)
+                            } else if (if ((*yyvsp.offset(-4)).astr[0] as c_int)
                                 < (*::core::mem::transmute::<&[u8; 10], &[c_char; 10]>(
                                     b"AXISELEM(\0",
                                 ))[0] as c_int
                             {
                                 -(1)
-                            } else if (*yyvsp.offset(-4_isize)).astr[0] as c_int
+                            } else if (*yyvsp.offset(-4)).astr[0] as c_int
                                 > (*::core::mem::transmute::<&[u8; 10], &[c_char; 10]>(
                                     b"AXISELEM(\0",
                                 ))[0] as c_int
@@ -4900,34 +4532,27 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                 1
                             } else {
                                 strcmp(
-                                    ((*yyvsp.offset(-4_isize)).astr).as_mut_ptr(),
+                                    ((*yyvsp.offset(-4)).astr).as_mut_ptr(),
                                     b"AXISELEM(\0" as *const u8 as *const c_char,
                                 )
                             }) == 0
                             {
-                                if (*((*lParse).Nodes)
-                                    .offset((*yyvsp.offset(-1_isize)).Node as isize))
-                                .operation
-                                    != -(1000 as c_int)
-                                    || (*((*lParse).Nodes)
-                                        .offset((*yyvsp.offset(-1_isize)).Node as isize))
-                                    .value
-                                    .nelem
+                                if ((lParse.Nodes)[(*yyvsp.offset(-1)).Node as usize]).operation
+                                    != -1000
+                                    || ((lParse.Nodes)[(*yyvsp.offset(-1)).Node as usize])
+                                        .value
+                                        .nelem
                                         != 1
                                 {
                                     fits_parser_yyerror(
                                         scanner,
                                         lParse,
-                                        b"AXISELEM second argument must be a scalar constant\0"
-                                            as *const u8
-                                            as *const c_char
-                                            as *mut c_char,
+                                        cs!(c"AXISELEM second argument must be a scalar constant"),
                                     );
                                     current_block = 4830776507462815627;
-                                } else if (*((*lParse).Nodes)
-                                    .offset((*yyvsp.offset(-3_isize)).Node as isize))
-                                .operation
-                                    == -(1000 as c_int)
+                                } else if ((lParse.Nodes)[(*yyvsp.offset(-3)).Node as usize])
+                                    .operation
+                                    == -1000
                                 {
                                     let mut one_3: c_long = 1;
                                     yyval.Node = New_Const(
@@ -4938,16 +4563,14 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                     );
                                     current_block = 9966817879908499150;
                                 } else {
-                                    if (*((*lParse).Nodes)
-                                        .offset((*yyvsp.offset(-1_isize)).Node as isize))
-                                    .ntype
+                                    if ((lParse.Nodes)[(*yyvsp.offset(-1)).Node as usize]).ntype
                                         != fits_parser_yytokentype::LONG as c_int
                                     {
-                                        (*yyvsp.offset(-1_isize)).Node = New_Unary(
+                                        (*yyvsp.offset(-1)).Node = New_Unary(
                                             lParse,
                                             fits_parser_yytokentype::LONG as c_int,
                                             0,
-                                            (*yyvsp.offset(-1_isize)).Node,
+                                            (*yyvsp.offset(-1)).Node,
                                         );
                                     }
                                     yyval.Node = New_Func(
@@ -4955,8 +4578,8 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                         0,
                                         axiselem_fct,
                                         2 as c_int,
-                                        (*yyvsp.offset(-3_isize)).Node,
-                                        (*yyvsp.offset(-1_isize)).Node,
+                                        (*yyvsp.offset(-3)).Node,
+                                        (*yyvsp.offset(-1)).Node,
                                         0,
                                         0,
                                         0,
@@ -4966,51 +4589,44 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                     if yyval.Node < 0 {
                                         current_block = 4830776507462815627;
                                     } else {
-                                        (*((*lParse).Nodes).offset(yyval.Node as isize)).ntype =
+                                        ((lParse.Nodes)[yyval.Node as usize]).ntype =
                                             fits_parser_yytokentype::LONG as c_int;
                                         current_block = 9966817879908499150;
                                     }
                                 }
-                            } else if (if ((*yyvsp.offset(-4_isize)).astr[0] as c_int)
+                            } else if (if ((*yyvsp.offset(-4)).astr[0] as c_int)
                                 < (*::core::mem::transmute::<&[u8; 7], &[c_char; 7]>(b"NAXES(\0"))
                                     [0] as c_int
                             {
                                 -(1)
-                            } else if (*yyvsp.offset(-4_isize)).astr[0] as c_int
+                            } else if (*yyvsp.offset(-4)).astr[0] as c_int
                                 > (*::core::mem::transmute::<&[u8; 7], &[c_char; 7]>(b"NAXES(\0"))
                                     [0] as c_int
                             {
                                 1
                             } else {
                                 strcmp(
-                                    ((*yyvsp.offset(-4_isize)).astr).as_mut_ptr(),
+                                    ((*yyvsp.offset(-4)).astr).as_mut_ptr(),
                                     b"NAXES(\0" as *const u8 as *const c_char,
                                 )
                             }) == 0
                             {
-                                if (*((*lParse).Nodes)
-                                    .offset((*yyvsp.offset(-1_isize)).Node as isize))
-                                .operation
-                                    != -(1000 as c_int)
-                                    || (*((*lParse).Nodes)
-                                        .offset((*yyvsp.offset(-1_isize)).Node as isize))
-                                    .value
-                                    .nelem
+                                if ((lParse.Nodes)[(*yyvsp.offset(-1)).Node as usize]).operation
+                                    != -1000
+                                    || ((lParse.Nodes)[(*yyvsp.offset(-1)).Node as usize])
+                                        .value
+                                        .nelem
                                         != 1
                                 {
                                     fits_parser_yyerror(
                                         scanner,
                                         lParse,
-                                        b"NAXES second argument must be a scalar constant\0"
-                                            as *const u8
-                                            as *const c_char
-                                            as *mut c_char,
+                                        cs!(c"NAXES second argument must be a scalar constant"),
                                     );
                                     current_block = 4830776507462815627;
-                                } else if (*((*lParse).Nodes)
-                                    .offset((*yyvsp.offset(-3_isize)).Node as isize))
-                                .operation
-                                    == -(1000 as c_int)
+                                } else if ((lParse.Nodes)[(*yyvsp.offset(-3)).Node as usize])
+                                    .operation
+                                    == -1000
                                 {
                                     let mut one_4: c_long = 1;
                                     yyval.Node = New_Const(
@@ -5023,34 +4639,31 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                 } else {
                                     let mut iaxis_0: c_long = 0;
                                     let mut naxis_1: c_int = 0;
-                                    if (*((*lParse).Nodes)
-                                        .offset((*yyvsp.offset(-1_isize)).Node as isize))
-                                    .ntype
+                                    if ((lParse.Nodes)[(*yyvsp.offset(-1)).Node as usize]).ntype
                                         != fits_parser_yytokentype::LONG as c_int
                                     {
-                                        (*yyvsp.offset(-1_isize)).Node = New_Unary(
+                                        (*yyvsp.offset(-1)).Node = New_Unary(
                                             lParse,
                                             fits_parser_yytokentype::LONG as c_int,
                                             0,
-                                            (*yyvsp.offset(-1_isize)).Node,
+                                            (*yyvsp.offset(-1)).Node,
                                         );
                                     }
-                                    iaxis_0 = (*((*lParse).Nodes)
-                                        .offset((*yyvsp.offset(-1_isize)).Node as isize))
-                                    .value
-                                    .data
-                                    .lng;
-                                    naxis_1 = (*((*lParse).Nodes)
-                                        .offset((*yyvsp.offset(-3_isize)).Node as isize))
-                                    .value
-                                    .naxis;
+                                    iaxis_0 = ((lParse.Nodes)[(*yyvsp.offset(-1)).Node as usize])
+                                        .value
+                                        .data
+                                        .lng;
+                                    naxis_1 = ((lParse.Nodes)[(*yyvsp.offset(-3)).Node as usize])
+                                        .value
+                                        .naxis;
                                     if iaxis_0 == 0 {
                                         iaxis_0 = naxis_1 as c_long;
                                     } else if iaxis_0 <= naxis_1 as c_long {
-                                        iaxis_0 = (*((*lParse).Nodes)
-                                            .offset((*yyvsp.offset(-3_isize)).Node as isize))
-                                        .value
-                                        .naxes[(iaxis_0 - 1) as usize];
+                                        iaxis_0 = ((lParse.Nodes)
+                                            [(*yyvsp.offset(-3)).Node as usize])
+                                            .value
+                                            .naxes
+                                            [(iaxis_0 - 1) as usize];
                                     } else {
                                         iaxis_0 = 1;
                                     }
@@ -5066,27 +4679,27 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                         current_block = 9966817879908499150;
                                     }
                                 }
-                            } else if (if ((*yyvsp.offset(-4_isize)).astr[0] as c_int)
+                            } else if (if ((*yyvsp.offset(-4)).astr[0] as c_int)
                                 < (*::core::mem::transmute::<&[u8; 7], &[c_char; 7]>(b"ARRAY(\0"))
                                     [0] as c_int
                             {
                                 -(1)
-                            } else if (*yyvsp.offset(-4_isize)).astr[0] as c_int
+                            } else if (*yyvsp.offset(-4)).astr[0] as c_int
                                 > (*::core::mem::transmute::<&[u8; 7], &[c_char; 7]>(b"ARRAY(\0"))
                                     [0] as c_int
                             {
                                 1
                             } else {
                                 strcmp(
-                                    ((*yyvsp.offset(-4_isize)).astr).as_mut_ptr(),
+                                    ((*yyvsp.offset(-4)).astr).as_mut_ptr(),
                                     b"ARRAY(\0" as *const u8 as *const c_char,
                                 )
                             }) == 0
                             {
                                 yyval.Node = New_Array(
                                     lParse,
-                                    (*yyvsp.offset(-3_isize)).Node,
-                                    (*yyvsp.offset(-1_isize)).Node,
+                                    (*yyvsp.offset(-3)).Node,
+                                    (*yyvsp.offset(-1)).Node,
                                 );
                                 if yyval.Node < 0 {
                                     current_block = 4830776507462815627;
@@ -5097,9 +4710,7 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                 fits_parser_yyerror(
                                     scanner,
                                     lParse,
-                                    b"Function(expr,expr) not supported\0" as *const u8
-                                        as *const c_char
-                                        as *mut c_char,
+                                    cs!(c"Function(expr,expr) not supported"),
                                 );
                                 current_block = 4830776507462815627;
                             }
@@ -5111,37 +4722,34 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                             }
                         }
                         62 => {
-                            if (if ((*yyvsp.offset(-(8 as c_int) as isize)).astr[0] as c_int)
+                            if (if ((*yyvsp.offset(-8)).astr[0] as c_int)
                                 < (*::core::mem::transmute::<&[u8; 8], &[c_char; 8]>(b"ANGSEP(\0"))
                                     [0] as c_int
                             {
                                 -(1)
-                            } else if (*yyvsp.offset(-(8 as c_int) as isize)).astr[0] as c_int
+                            } else if (*yyvsp.offset(-8)).astr[0] as c_int
                                 > (*::core::mem::transmute::<&[u8; 8], &[c_char; 8]>(b"ANGSEP(\0"))
                                     [0] as c_int
                             {
                                 1
                             } else {
                                 strcmp(
-                                    ((*yyvsp.offset(-(8 as c_int) as isize)).astr).as_mut_ptr(),
+                                    ((*yyvsp.offset(-8)).astr).as_mut_ptr(),
                                     b"ANGSEP(\0" as *const u8 as *const c_char,
                                 )
                             }) == 0
                             {
-                                if (*((*lParse).Nodes)
-                                    .offset((*yyvsp.offset(-(7 as c_int) as isize)).Node as isize))
-                                .ntype
+                                if ((lParse.Nodes)[(*yyvsp.offset(-7)).Node as usize]).ntype
                                     != fits_parser_yytokentype::DOUBLE as c_int
                                 {
-                                    (*yyvsp.offset(-(7 as c_int) as isize)).Node = New_Unary(
+                                    (*yyvsp.offset(-7)).Node = New_Unary(
                                         lParse,
                                         fits_parser_yytokentype::DOUBLE as c_int,
                                         0,
-                                        (*yyvsp.offset(-(7 as c_int) as isize)).Node,
+                                        (*yyvsp.offset(-7)).Node,
                                     );
                                 }
-                                if (*((*lParse).Nodes).offset((*yyvsp.offset(-(5))).Node as isize))
-                                    .ntype
+                                if ((lParse.Nodes)[(*yyvsp.offset(-(5))).Node as usize]).ntype
                                     != fits_parser_yytokentype::DOUBLE as c_int
                                 {
                                     (*yyvsp.offset(-(5))).Node = New_Unary(
@@ -5151,44 +4759,40 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                         (*yyvsp.offset(-(5))).Node,
                                     );
                                 }
-                                if (*((*lParse).Nodes)
-                                    .offset((*yyvsp.offset(-3_isize)).Node as isize))
-                                .ntype
+                                if ((lParse.Nodes)[(*yyvsp.offset(-3)).Node as usize]).ntype
                                     != fits_parser_yytokentype::DOUBLE as c_int
                                 {
-                                    (*yyvsp.offset(-3_isize)).Node = New_Unary(
+                                    (*yyvsp.offset(-3)).Node = New_Unary(
                                         lParse,
                                         fits_parser_yytokentype::DOUBLE as c_int,
                                         0,
-                                        (*yyvsp.offset(-3_isize)).Node,
+                                        (*yyvsp.offset(-3)).Node,
                                     );
                                 }
-                                if (*((*lParse).Nodes)
-                                    .offset((*yyvsp.offset(-1_isize)).Node as isize))
-                                .ntype
+                                if ((lParse.Nodes)[(*yyvsp.offset(-1)).Node as usize]).ntype
                                     != fits_parser_yytokentype::DOUBLE as c_int
                                 {
-                                    (*yyvsp.offset(-1_isize)).Node = New_Unary(
+                                    (*yyvsp.offset(-1)).Node = New_Unary(
                                         lParse,
                                         fits_parser_yytokentype::DOUBLE as c_int,
                                         0,
-                                        (*yyvsp.offset(-1_isize)).Node,
+                                        (*yyvsp.offset(-1)).Node,
                                     );
                                 }
                                 if Test_Dims(
                                     lParse,
-                                    (*yyvsp.offset(-(7 as c_int) as isize)).Node,
+                                    (*yyvsp.offset(-7)).Node,
                                     (*yyvsp.offset(-(5))).Node,
                                 ) != 0
                                     && Test_Dims(
                                         lParse,
                                         (*yyvsp.offset(-(5))).Node,
-                                        (*yyvsp.offset(-3_isize)).Node,
+                                        (*yyvsp.offset(-3)).Node,
                                     ) != 0
                                     && Test_Dims(
                                         lParse,
-                                        (*yyvsp.offset(-3_isize)).Node,
-                                        (*yyvsp.offset(-1_isize)).Node,
+                                        (*yyvsp.offset(-3)).Node,
+                                        (*yyvsp.offset(-1)).Node,
                                     ) != 0
                                 {
                                     yyval.Node = New_Func(
@@ -5196,10 +4800,10 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                         0,
                                         angsep_fct,
                                         4 as c_int,
-                                        (*yyvsp.offset(-(7 as c_int) as isize)).Node,
+                                        (*yyvsp.offset(-7)).Node,
                                         (*yyvsp.offset(-(5))).Node,
-                                        (*yyvsp.offset(-3_isize)).Node,
-                                        (*yyvsp.offset(-1_isize)).Node,
+                                        (*yyvsp.offset(-3)).Node,
+                                        (*yyvsp.offset(-1)).Node,
                                         0,
                                         0,
                                         0,
@@ -5207,15 +4811,12 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                     if yyval.Node < 0 {
                                         current_block = 4830776507462815627;
                                     } else {
-                                        if (*((*lParse).Nodes).offset(
-                                            (*yyvsp.offset(-(7 as c_int) as isize)).Node as isize,
-                                        ))
-                                        .value
-                                        .nelem
-                                            < (*((*lParse).Nodes)
-                                                .offset((*yyvsp.offset(-(5))).Node as isize))
+                                        if ((lParse.Nodes)[(*yyvsp.offset(-7)).Node as usize])
                                             .value
                                             .nelem
+                                            < ((lParse.Nodes)[(*yyvsp.offset(-(5))).Node as usize])
+                                                .value
+                                                .nelem
                                         {
                                             Copy_Dims(
                                                 lParse,
@@ -5223,35 +4824,23 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                                 (*yyvsp.offset(-(5))).Node,
                                             );
                                         }
-                                        if (*((*lParse).Nodes)
-                                            .offset((*yyvsp.offset(-(5))).Node as isize))
-                                        .value
-                                        .nelem
-                                            < (*((*lParse).Nodes)
-                                                .offset((*yyvsp.offset(-3_isize)).Node as isize))
+                                        if ((lParse.Nodes)[(*yyvsp.offset(-(5))).Node as usize])
                                             .value
                                             .nelem
+                                            < ((lParse.Nodes)[(*yyvsp.offset(-3)).Node as usize])
+                                                .value
+                                                .nelem
                                         {
-                                            Copy_Dims(
-                                                lParse,
-                                                yyval.Node,
-                                                (*yyvsp.offset(-3_isize)).Node,
-                                            );
+                                            Copy_Dims(lParse, yyval.Node, (*yyvsp.offset(-3)).Node);
                                         }
-                                        if (*((*lParse).Nodes)
-                                            .offset((*yyvsp.offset(-3_isize)).Node as isize))
-                                        .value
-                                        .nelem
-                                            < (*((*lParse).Nodes)
-                                                .offset((*yyvsp.offset(-1_isize)).Node as isize))
+                                        if ((lParse.Nodes)[(*yyvsp.offset(-3)).Node as usize])
                                             .value
                                             .nelem
+                                            < ((lParse.Nodes)[(*yyvsp.offset(-1)).Node as usize])
+                                                .value
+                                                .nelem
                                         {
-                                            Copy_Dims(
-                                                lParse,
-                                                yyval.Node,
-                                                (*yyvsp.offset(-1_isize)).Node,
-                                            );
+                                            Copy_Dims(lParse, yyval.Node, (*yyvsp.offset(-1)).Node);
                                         }
                                         current_block = 17353983478346836848;
                                     }
@@ -5259,10 +4848,7 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                     fits_parser_yyerror(
                                         scanner,
                                         lParse,
-                                        b"Dimensions of ANGSEP arguments are not compatible\0"
-                                            as *const u8
-                                            as *const c_char
-                                            as *mut c_char,
+                                        cs!(c"Dimensions of ANGSEP arguments are not compatible"),
                                     );
                                     current_block = 4830776507462815627;
                                 }
@@ -5270,9 +4856,7 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                 fits_parser_yyerror(
                                     scanner,
                                     lParse,
-                                    b"Function(expr,expr,expr,expr) not supported\0" as *const u8
-                                        as *const c_char
-                                        as *mut c_char,
+                                    cs!(c"Function(expr,expr,expr,expr) not supported"),
                                 );
                                 current_block = 4830776507462815627;
                             }
@@ -5282,8 +4866,8 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                 lParse,
                                 gtiover_fct,
                                 ((*yyvsp.offset(-(5))).astr).as_mut_ptr(),
-                                (*yyvsp.offset(-3_isize)).Node,
-                                (*yyvsp.offset(-1_isize)).Node,
+                                (*yyvsp.offset(-3)).Node,
+                                (*yyvsp.offset(-1)).Node,
                                 b"*START*\0" as *const u8 as *const c_char as *mut c_char,
                                 b"*STOP*\0" as *const u8 as *const c_char as *mut c_char,
                             );
@@ -5297,11 +4881,11 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                             yyval.Node = New_GTI(
                                 lParse,
                                 gtiover_fct,
-                                ((*yyvsp.offset(-(9 as c_int) as isize)).astr).as_mut_ptr(),
-                                (*yyvsp.offset(-(7 as c_int) as isize)).Node,
+                                ((*yyvsp.offset(-9)).astr).as_mut_ptr(),
+                                (*yyvsp.offset(-7)).Node,
                                 (*yyvsp.offset(-(5))).Node,
-                                ((*yyvsp.offset(-3_isize)).astr).as_mut_ptr(),
-                                ((*yyvsp.offset(-1_isize)).astr).as_mut_ptr(),
+                                ((*yyvsp.offset(-3)).astr).as_mut_ptr(),
+                                ((*yyvsp.offset(-1)).astr).as_mut_ptr(),
                             );
                             if yyval.Node < 0 {
                                 current_block = 4830776507462815627;
@@ -5312,9 +4896,9 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                         65 => {
                             yyval.Node = New_Deref(
                                 lParse,
-                                (*yyvsp.offset(-3_isize)).Node,
+                                (*yyvsp.offset(-3)).Node,
                                 1,
-                                (*yyvsp.offset(-1_isize)).Node,
+                                (*yyvsp.offset(-1)).Node,
                                 0,
                                 0,
                                 0,
@@ -5331,8 +4915,8 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                 lParse,
                                 (*yyvsp.offset(-(5))).Node,
                                 2 as c_int,
-                                (*yyvsp.offset(-3_isize)).Node,
-                                (*yyvsp.offset(-1_isize)).Node,
+                                (*yyvsp.offset(-3)).Node,
+                                (*yyvsp.offset(-1)).Node,
                                 0,
                                 0,
                                 0,
@@ -5346,11 +4930,11 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                         67 => {
                             yyval.Node = New_Deref(
                                 lParse,
-                                (*yyvsp.offset(-(7 as c_int) as isize)).Node,
+                                (*yyvsp.offset(-7)).Node,
                                 3 as c_int,
                                 (*yyvsp.offset(-(5))).Node,
-                                (*yyvsp.offset(-3_isize)).Node,
-                                (*yyvsp.offset(-1_isize)).Node,
+                                (*yyvsp.offset(-3)).Node,
+                                (*yyvsp.offset(-1)).Node,
                                 0,
                                 0,
                             );
@@ -5363,12 +4947,12 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                         68 => {
                             yyval.Node = New_Deref(
                                 lParse,
-                                (*yyvsp.offset(-(9 as c_int) as isize)).Node,
+                                (*yyvsp.offset(-9)).Node,
                                 4 as c_int,
-                                (*yyvsp.offset(-(7 as c_int) as isize)).Node,
+                                (*yyvsp.offset(-7)).Node,
                                 (*yyvsp.offset(-(5))).Node,
-                                (*yyvsp.offset(-3_isize)).Node,
-                                (*yyvsp.offset(-1_isize)).Node,
+                                (*yyvsp.offset(-3)).Node,
+                                (*yyvsp.offset(-1)).Node,
                                 0,
                             );
                             if yyval.Node < 0 {
@@ -5380,13 +4964,13 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                         69 => {
                             yyval.Node = New_Deref(
                                 lParse,
-                                (*yyvsp.offset(-(11 as c_int) as isize)).Node,
+                                (*yyvsp.offset(-11)).Node,
                                 5 as c_int,
-                                (*yyvsp.offset(-(9 as c_int) as isize)).Node,
-                                (*yyvsp.offset(-(7 as c_int) as isize)).Node,
+                                (*yyvsp.offset(-9)).Node,
+                                (*yyvsp.offset(-7)).Node,
                                 (*yyvsp.offset(-(5))).Node,
-                                (*yyvsp.offset(-3_isize)).Node,
-                                (*yyvsp.offset(-1_isize)).Node,
+                                (*yyvsp.offset(-3)).Node,
+                                (*yyvsp.offset(-1)).Node,
                             );
                             if yyval.Node < 0 {
                                 current_block = 4830776507462815627;
@@ -5468,27 +5052,22 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                             }
                         }
                         76 => {
-                            if (*((*lParse).Nodes).offset((*yyvsp.offset(-1_isize)).Node as isize))
-                                .ntype
+                            if ((lParse.Nodes)[(*yyvsp.offset(-1)).Node as usize]).ntype
                                 != fits_parser_yytokentype::LONG as c_int
-                                || (*((*lParse).Nodes)
-                                    .offset((*yyvsp.offset(-1_isize)).Node as isize))
-                                .operation
-                                    != -(1000 as c_int)
+                                || ((lParse.Nodes)[(*yyvsp.offset(-1)).Node as usize]).operation
+                                    != -1000
                             {
                                 fits_parser_yyerror(
                                     scanner,
                                     lParse,
-                                    b"Offset argument must be a constant integer\0" as *const u8
-                                        as *const c_char
-                                        as *mut c_char,
+                                    cs!(c"Offset argument must be a constant integer"),
                                 );
                                 current_block = 4830776507462815627;
                             } else {
                                 yyval.Node = New_Offset(
                                     lParse,
-                                    (*yyvsp.offset(-3_isize)).lng as c_int,
-                                    (*yyvsp.offset(-1_isize)).Node,
+                                    (*yyvsp.offset(-3)).lng as c_int,
+                                    (*yyvsp.offset(-1)).Node,
                                 );
                                 if yyval.Node < 0 {
                                     current_block = 4830776507462815627;
@@ -5501,14 +5080,14 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                             yyval.Node = New_BinOp(
                                 lParse,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
-                                (*yyvsp.offset(-2_isize)).Node,
+                                (*yyvsp.offset(-2)).Node,
                                 fits_parser_yytokentype::EQ as c_int,
                                 (*yyvsp.offset(0)).Node,
                             );
                             if yyval.Node < 0 {
                                 current_block = 4830776507462815627;
                             } else {
-                                ((*((*lParse).Nodes).offset(yyval.Node as isize)).value).nelem = 1;
+                                (((lParse.Nodes)[yyval.Node as usize]).value).nelem = 1;
                                 current_block = 17353983478346836848;
                             }
                         }
@@ -5516,14 +5095,14 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                             yyval.Node = New_BinOp(
                                 lParse,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
-                                (*yyvsp.offset(-2_isize)).Node,
+                                (*yyvsp.offset(-2)).Node,
                                 fits_parser_yytokentype::NE as c_int,
                                 (*yyvsp.offset(0)).Node,
                             );
                             if yyval.Node < 0 {
                                 current_block = 4830776507462815627;
                             } else {
-                                ((*((*lParse).Nodes).offset(yyval.Node as isize)).value).nelem = 1;
+                                (((lParse.Nodes)[yyval.Node as usize]).value).nelem = 1;
                                 current_block = 17353983478346836848;
                             }
                         }
@@ -5531,14 +5110,14 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                             yyval.Node = New_BinOp(
                                 lParse,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
-                                (*yyvsp.offset(-2_isize)).Node,
+                                (*yyvsp.offset(-2)).Node,
                                 fits_parser_yytokentype::LT as c_int,
                                 (*yyvsp.offset(0)).Node,
                             );
                             if yyval.Node < 0 {
                                 current_block = 4830776507462815627;
                             } else {
-                                ((*((*lParse).Nodes).offset(yyval.Node as isize)).value).nelem = 1;
+                                (((lParse.Nodes)[yyval.Node as usize]).value).nelem = 1;
                                 current_block = 17353983478346836848;
                             }
                         }
@@ -5546,14 +5125,14 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                             yyval.Node = New_BinOp(
                                 lParse,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
-                                (*yyvsp.offset(-2_isize)).Node,
+                                (*yyvsp.offset(-2)).Node,
                                 fits_parser_yytokentype::LTE as c_int,
                                 (*yyvsp.offset(0)).Node,
                             );
                             if yyval.Node < 0 {
                                 current_block = 4830776507462815627;
                             } else {
-                                ((*((*lParse).Nodes).offset(yyval.Node as isize)).value).nelem = 1;
+                                (((lParse.Nodes)[yyval.Node as usize]).value).nelem = 1;
                                 current_block = 17353983478346836848;
                             }
                         }
@@ -5561,14 +5140,14 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                             yyval.Node = New_BinOp(
                                 lParse,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
-                                (*yyvsp.offset(-2_isize)).Node,
+                                (*yyvsp.offset(-2)).Node,
                                 fits_parser_yytokentype::GT as c_int,
                                 (*yyvsp.offset(0)).Node,
                             );
                             if yyval.Node < 0 {
                                 current_block = 4830776507462815627;
                             } else {
-                                ((*((*lParse).Nodes).offset(yyval.Node as isize)).value).nelem = 1;
+                                (((lParse.Nodes)[yyval.Node as usize]).value).nelem = 1;
                                 current_block = 17353983478346836848;
                             }
                         }
@@ -5576,49 +5155,41 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                             yyval.Node = New_BinOp(
                                 lParse,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
-                                (*yyvsp.offset(-2_isize)).Node,
+                                (*yyvsp.offset(-2)).Node,
                                 fits_parser_yytokentype::GTE as c_int,
                                 (*yyvsp.offset(0)).Node,
                             );
                             if yyval.Node < 0 {
                                 current_block = 4830776507462815627;
                             } else {
-                                ((*((*lParse).Nodes).offset(yyval.Node as isize)).value).nelem = 1;
+                                (((lParse.Nodes)[yyval.Node as usize]).value).nelem = 1;
                                 current_block = 17353983478346836848;
                             }
                         }
                         83 => {
-                            if (*((*lParse).Nodes).offset((*yyvsp.offset(-2_isize)).Node as isize))
-                                .ntype
-                                > (*((*lParse).Nodes).offset((*yyvsp.offset(0)).Node as isize))
-                                    .ntype
+                            if (lParse.Nodes[(*yyvsp.offset(-2)).Node as usize]).ntype
+                                > (lParse.Nodes[(*yyvsp.offset(0)).Node as usize]).ntype
                             {
                                 (*yyvsp.offset(0)).Node = New_Unary(
                                     lParse,
-                                    (*((*lParse).Nodes)
-                                        .offset((*yyvsp.offset(-2_isize)).Node as isize))
-                                    .ntype,
+                                    ((lParse.Nodes)[(*yyvsp.offset(-2)).Node as usize]).ntype,
                                     0,
                                     (*yyvsp.offset(0)).Node,
                                 );
-                            } else if (*((*lParse).Nodes)
-                                .offset((*yyvsp.offset(-2_isize)).Node as isize))
-                            .ntype
-                                < (*((*lParse).Nodes).offset((*yyvsp.offset(0)).Node as isize))
-                                    .ntype
+                            } else if ((lParse.Nodes)[(*yyvsp.offset(-2)).Node as usize]).ntype
+                                < (lParse.Nodes[(*yyvsp.offset(0)).Node as usize]).ntype
                             {
-                                (*yyvsp.offset(-2_isize)).Node = New_Unary(
+                                (*yyvsp.offset(-2)).Node = New_Unary(
                                     lParse,
-                                    (*((*lParse).Nodes).offset((*yyvsp.offset(0)).Node as isize))
-                                        .ntype,
+                                    (lParse.Nodes[(*yyvsp.offset(0)).Node as usize]).ntype,
                                     0,
-                                    (*yyvsp.offset(-2_isize)).Node,
+                                    (*yyvsp.offset(-2)).Node,
                                 );
                             }
                             yyval.Node = New_BinOp(
                                 lParse,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
-                                (*yyvsp.offset(-2_isize)).Node,
+                                (*yyvsp.offset(-2)).Node,
                                 fits_parser_yytokentype::GT as c_int,
                                 (*yyvsp.offset(0)).Node,
                             );
@@ -5629,37 +5200,29 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                             }
                         }
                         84 => {
-                            if (*((*lParse).Nodes).offset((*yyvsp.offset(-2_isize)).Node as isize))
-                                .ntype
-                                > (*((*lParse).Nodes).offset((*yyvsp.offset(0)).Node as isize))
-                                    .ntype
+                            if (lParse.Nodes[(*yyvsp.offset(-2)).Node as usize]).ntype
+                                > (lParse.Nodes[(*yyvsp.offset(0)).Node as usize]).ntype
                             {
                                 (*yyvsp.offset(0)).Node = New_Unary(
                                     lParse,
-                                    (*((*lParse).Nodes)
-                                        .offset((*yyvsp.offset(-2_isize)).Node as isize))
-                                    .ntype,
+                                    ((lParse.Nodes)[(*yyvsp.offset(-2)).Node as usize]).ntype,
                                     0,
                                     (*yyvsp.offset(0)).Node,
                                 );
-                            } else if (*((*lParse).Nodes)
-                                .offset((*yyvsp.offset(-2_isize)).Node as isize))
-                            .ntype
-                                < (*((*lParse).Nodes).offset((*yyvsp.offset(0)).Node as isize))
-                                    .ntype
+                            } else if ((lParse.Nodes)[(*yyvsp.offset(-2)).Node as usize]).ntype
+                                < (lParse.Nodes[(*yyvsp.offset(0)).Node as usize]).ntype
                             {
-                                (*yyvsp.offset(-2_isize)).Node = New_Unary(
+                                (*yyvsp.offset(-2)).Node = New_Unary(
                                     lParse,
-                                    (*((*lParse).Nodes).offset((*yyvsp.offset(0)).Node as isize))
-                                        .ntype,
+                                    (lParse.Nodes[(*yyvsp.offset(0)).Node as usize]).ntype,
                                     0,
-                                    (*yyvsp.offset(-2_isize)).Node,
+                                    (*yyvsp.offset(-2)).Node,
                                 );
                             }
                             yyval.Node = New_BinOp(
                                 lParse,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
-                                (*yyvsp.offset(-2_isize)).Node,
+                                (*yyvsp.offset(-2)).Node,
                                 fits_parser_yytokentype::LT as c_int,
                                 (*yyvsp.offset(0)).Node,
                             );
@@ -5670,37 +5233,29 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                             }
                         }
                         85 => {
-                            if (*((*lParse).Nodes).offset((*yyvsp.offset(-2_isize)).Node as isize))
-                                .ntype
-                                > (*((*lParse).Nodes).offset((*yyvsp.offset(0)).Node as isize))
-                                    .ntype
+                            if (lParse.Nodes[(*yyvsp.offset(-2)).Node as usize]).ntype
+                                > (lParse.Nodes[(*yyvsp.offset(0)).Node as usize]).ntype
                             {
                                 (*yyvsp.offset(0)).Node = New_Unary(
                                     lParse,
-                                    (*((*lParse).Nodes)
-                                        .offset((*yyvsp.offset(-2_isize)).Node as isize))
-                                    .ntype,
+                                    ((lParse.Nodes)[(*yyvsp.offset(-2)).Node as usize]).ntype,
                                     0,
                                     (*yyvsp.offset(0)).Node,
                                 );
-                            } else if (*((*lParse).Nodes)
-                                .offset((*yyvsp.offset(-2_isize)).Node as isize))
-                            .ntype
-                                < (*((*lParse).Nodes).offset((*yyvsp.offset(0)).Node as isize))
-                                    .ntype
+                            } else if ((lParse.Nodes)[(*yyvsp.offset(-2)).Node as usize]).ntype
+                                < (lParse.Nodes[(*yyvsp.offset(0)).Node as usize]).ntype
                             {
-                                (*yyvsp.offset(-2_isize)).Node = New_Unary(
+                                (*yyvsp.offset(-2)).Node = New_Unary(
                                     lParse,
-                                    (*((*lParse).Nodes).offset((*yyvsp.offset(0)).Node as isize))
-                                        .ntype,
+                                    (lParse.Nodes[(*yyvsp.offset(0)).Node as usize]).ntype,
                                     0,
-                                    (*yyvsp.offset(-2_isize)).Node,
+                                    (*yyvsp.offset(-2)).Node,
                                 );
                             }
                             yyval.Node = New_BinOp(
                                 lParse,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
-                                (*yyvsp.offset(-2_isize)).Node,
+                                (*yyvsp.offset(-2)).Node,
                                 fits_parser_yytokentype::GTE as c_int,
                                 (*yyvsp.offset(0)).Node,
                             );
@@ -5711,37 +5266,29 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                             }
                         }
                         86 => {
-                            if (*((*lParse).Nodes).offset((*yyvsp.offset(-2_isize)).Node as isize))
-                                .ntype
-                                > (*((*lParse).Nodes).offset((*yyvsp.offset(0)).Node as isize))
-                                    .ntype
+                            if (lParse.Nodes[(*yyvsp.offset(-2)).Node as usize]).ntype
+                                > (lParse.Nodes[(*yyvsp.offset(0)).Node as usize]).ntype
                             {
                                 (*yyvsp.offset(0)).Node = New_Unary(
                                     lParse,
-                                    (*((*lParse).Nodes)
-                                        .offset((*yyvsp.offset(-2_isize)).Node as isize))
-                                    .ntype,
+                                    ((lParse.Nodes)[(*yyvsp.offset(-2)).Node as usize]).ntype,
                                     0,
                                     (*yyvsp.offset(0)).Node,
                                 );
-                            } else if (*((*lParse).Nodes)
-                                .offset((*yyvsp.offset(-2_isize)).Node as isize))
-                            .ntype
-                                < (*((*lParse).Nodes).offset((*yyvsp.offset(0)).Node as isize))
-                                    .ntype
+                            } else if ((lParse.Nodes)[(*yyvsp.offset(-2)).Node as usize]).ntype
+                                < (lParse.Nodes[(*yyvsp.offset(0)).Node as usize]).ntype
                             {
-                                (*yyvsp.offset(-2_isize)).Node = New_Unary(
+                                (*yyvsp.offset(-2)).Node = New_Unary(
                                     lParse,
-                                    (*((*lParse).Nodes).offset((*yyvsp.offset(0)).Node as isize))
-                                        .ntype,
+                                    (lParse.Nodes[(*yyvsp.offset(0)).Node as usize]).ntype,
                                     0,
-                                    (*yyvsp.offset(-2_isize)).Node,
+                                    (*yyvsp.offset(-2)).Node,
                                 );
                             }
                             yyval.Node = New_BinOp(
                                 lParse,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
-                                (*yyvsp.offset(-2_isize)).Node,
+                                (*yyvsp.offset(-2)).Node,
                                 fits_parser_yytokentype::LTE as c_int,
                                 (*yyvsp.offset(0)).Node,
                             );
@@ -5752,37 +5299,29 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                             }
                         }
                         87 => {
-                            if (*((*lParse).Nodes).offset((*yyvsp.offset(-2_isize)).Node as isize))
-                                .ntype
-                                > (*((*lParse).Nodes).offset((*yyvsp.offset(0)).Node as isize))
-                                    .ntype
+                            if (lParse.Nodes[(*yyvsp.offset(-2)).Node as usize]).ntype
+                                > (lParse.Nodes[(*yyvsp.offset(0)).Node as usize]).ntype
                             {
                                 (*yyvsp.offset(0)).Node = New_Unary(
                                     lParse,
-                                    (*((*lParse).Nodes)
-                                        .offset((*yyvsp.offset(-2_isize)).Node as isize))
-                                    .ntype,
+                                    ((lParse.Nodes)[(*yyvsp.offset(-2)).Node as usize]).ntype,
                                     0,
                                     (*yyvsp.offset(0)).Node,
                                 );
-                            } else if (*((*lParse).Nodes)
-                                .offset((*yyvsp.offset(-2_isize)).Node as isize))
-                            .ntype
-                                < (*((*lParse).Nodes).offset((*yyvsp.offset(0)).Node as isize))
-                                    .ntype
+                            } else if ((lParse.Nodes)[(*yyvsp.offset(-2)).Node as usize]).ntype
+                                < (lParse.Nodes[(*yyvsp.offset(0)).Node as usize]).ntype
                             {
-                                (*yyvsp.offset(-2_isize)).Node = New_Unary(
+                                (*yyvsp.offset(-2)).Node = New_Unary(
                                     lParse,
-                                    (*((*lParse).Nodes).offset((*yyvsp.offset(0)).Node as isize))
-                                        .ntype,
+                                    (lParse.Nodes[(*yyvsp.offset(0)).Node as usize]).ntype,
                                     0,
-                                    (*yyvsp.offset(-2_isize)).Node,
+                                    (*yyvsp.offset(-2)).Node,
                                 );
                             }
                             yyval.Node = New_BinOp(
                                 lParse,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
-                                (*yyvsp.offset(-2_isize)).Node,
+                                (*yyvsp.offset(-2)).Node,
                                 '~' as i32,
                                 (*yyvsp.offset(0)).Node,
                             );
@@ -5793,37 +5332,29 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                             }
                         }
                         88 => {
-                            if (*((*lParse).Nodes).offset((*yyvsp.offset(-2_isize)).Node as isize))
-                                .ntype
-                                > (*((*lParse).Nodes).offset((*yyvsp.offset(0)).Node as isize))
-                                    .ntype
+                            if (lParse.Nodes[(*yyvsp.offset(-2)).Node as usize]).ntype
+                                > (lParse.Nodes[(*yyvsp.offset(0)).Node as usize]).ntype
                             {
                                 (*yyvsp.offset(0)).Node = New_Unary(
                                     lParse,
-                                    (*((*lParse).Nodes)
-                                        .offset((*yyvsp.offset(-2_isize)).Node as isize))
-                                    .ntype,
+                                    ((lParse.Nodes)[(*yyvsp.offset(-2)).Node as usize]).ntype,
                                     0,
                                     (*yyvsp.offset(0)).Node,
                                 );
-                            } else if (*((*lParse).Nodes)
-                                .offset((*yyvsp.offset(-2_isize)).Node as isize))
-                            .ntype
-                                < (*((*lParse).Nodes).offset((*yyvsp.offset(0)).Node as isize))
-                                    .ntype
+                            } else if ((lParse.Nodes)[(*yyvsp.offset(-2)).Node as usize]).ntype
+                                < (lParse.Nodes[(*yyvsp.offset(0)).Node as usize]).ntype
                             {
-                                (*yyvsp.offset(-2_isize)).Node = New_Unary(
+                                (*yyvsp.offset(-2)).Node = New_Unary(
                                     lParse,
-                                    (*((*lParse).Nodes).offset((*yyvsp.offset(0)).Node as isize))
-                                        .ntype,
+                                    (lParse.Nodes[(*yyvsp.offset(0)).Node as usize]).ntype,
                                     0,
-                                    (*yyvsp.offset(-2_isize)).Node,
+                                    (*yyvsp.offset(-2)).Node,
                                 );
                             }
                             yyval.Node = New_BinOp(
                                 lParse,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
-                                (*yyvsp.offset(-2_isize)).Node,
+                                (*yyvsp.offset(-2)).Node,
                                 fits_parser_yytokentype::EQ as c_int,
                                 (*yyvsp.offset(0)).Node,
                             );
@@ -5834,37 +5365,29 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                             }
                         }
                         89 => {
-                            if (*((*lParse).Nodes).offset((*yyvsp.offset(-2_isize)).Node as isize))
-                                .ntype
-                                > (*((*lParse).Nodes).offset((*yyvsp.offset(0)).Node as isize))
-                                    .ntype
+                            if (lParse.Nodes[(*yyvsp.offset(-2)).Node as usize]).ntype
+                                > (lParse.Nodes[(*yyvsp.offset(0)).Node as usize]).ntype
                             {
                                 (*yyvsp.offset(0)).Node = New_Unary(
                                     lParse,
-                                    (*((*lParse).Nodes)
-                                        .offset((*yyvsp.offset(-2_isize)).Node as isize))
-                                    .ntype,
+                                    ((lParse.Nodes)[(*yyvsp.offset(-2)).Node as usize]).ntype,
                                     0,
                                     (*yyvsp.offset(0)).Node,
                                 );
-                            } else if (*((*lParse).Nodes)
-                                .offset((*yyvsp.offset(-2_isize)).Node as isize))
-                            .ntype
-                                < (*((*lParse).Nodes).offset((*yyvsp.offset(0)).Node as isize))
-                                    .ntype
+                            } else if ((lParse.Nodes)[(*yyvsp.offset(-2)).Node as usize]).ntype
+                                < (lParse.Nodes[(*yyvsp.offset(0)).Node as usize]).ntype
                             {
-                                (*yyvsp.offset(-2_isize)).Node = New_Unary(
+                                (*yyvsp.offset(-2)).Node = New_Unary(
                                     lParse,
-                                    (*((*lParse).Nodes).offset((*yyvsp.offset(0)).Node as isize))
-                                        .ntype,
+                                    (lParse.Nodes[(*yyvsp.offset(0)).Node as usize]).ntype,
                                     0,
-                                    (*yyvsp.offset(-2_isize)).Node,
+                                    (*yyvsp.offset(-2)).Node,
                                 );
                             }
                             yyval.Node = New_BinOp(
                                 lParse,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
-                                (*yyvsp.offset(-2_isize)).Node,
+                                (*yyvsp.offset(-2)).Node,
                                 fits_parser_yytokentype::NE as c_int,
                                 (*yyvsp.offset(0)).Node,
                             );
@@ -5878,14 +5401,14 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                             yyval.Node = New_BinOp(
                                 lParse,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
-                                (*yyvsp.offset(-2_isize)).Node,
+                                (*yyvsp.offset(-2)).Node,
                                 fits_parser_yytokentype::EQ as c_int,
                                 (*yyvsp.offset(0)).Node,
                             );
                             if yyval.Node < 0 {
                                 current_block = 4830776507462815627;
                             } else {
-                                ((*((*lParse).Nodes).offset(yyval.Node as isize)).value).nelem = 1;
+                                (((lParse.Nodes)[yyval.Node as usize]).value).nelem = 1;
                                 current_block = 17353983478346836848;
                             }
                         }
@@ -5893,14 +5416,14 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                             yyval.Node = New_BinOp(
                                 lParse,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
-                                (*yyvsp.offset(-2_isize)).Node,
+                                (*yyvsp.offset(-2)).Node,
                                 fits_parser_yytokentype::NE as c_int,
                                 (*yyvsp.offset(0)).Node,
                             );
                             if yyval.Node < 0 {
                                 current_block = 4830776507462815627;
                             } else {
-                                ((*((*lParse).Nodes).offset(yyval.Node as isize)).value).nelem = 1;
+                                (((lParse.Nodes)[yyval.Node as usize]).value).nelem = 1;
                                 current_block = 17353983478346836848;
                             }
                         }
@@ -5908,14 +5431,14 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                             yyval.Node = New_BinOp(
                                 lParse,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
-                                (*yyvsp.offset(-2_isize)).Node,
+                                (*yyvsp.offset(-2)).Node,
                                 fits_parser_yytokentype::GT as c_int,
                                 (*yyvsp.offset(0)).Node,
                             );
                             if yyval.Node < 0 {
                                 current_block = 4830776507462815627;
                             } else {
-                                ((*((*lParse).Nodes).offset(yyval.Node as isize)).value).nelem = 1;
+                                (((lParse.Nodes)[yyval.Node as usize]).value).nelem = 1;
                                 current_block = 17353983478346836848;
                             }
                         }
@@ -5923,14 +5446,14 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                             yyval.Node = New_BinOp(
                                 lParse,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
-                                (*yyvsp.offset(-2_isize)).Node,
+                                (*yyvsp.offset(-2)).Node,
                                 fits_parser_yytokentype::GTE as c_int,
                                 (*yyvsp.offset(0)).Node,
                             );
                             if yyval.Node < 0 {
                                 current_block = 4830776507462815627;
                             } else {
-                                ((*((*lParse).Nodes).offset(yyval.Node as isize)).value).nelem = 1;
+                                (((lParse.Nodes)[yyval.Node as usize]).value).nelem = 1;
                                 current_block = 17353983478346836848;
                             }
                         }
@@ -5938,14 +5461,14 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                             yyval.Node = New_BinOp(
                                 lParse,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
-                                (*yyvsp.offset(-2_isize)).Node,
+                                (*yyvsp.offset(-2)).Node,
                                 fits_parser_yytokentype::LT as c_int,
                                 (*yyvsp.offset(0)).Node,
                             );
                             if yyval.Node < 0 {
                                 current_block = 4830776507462815627;
                             } else {
-                                ((*((*lParse).Nodes).offset(yyval.Node as isize)).value).nelem = 1;
+                                (((lParse.Nodes)[yyval.Node as usize]).value).nelem = 1;
                                 current_block = 17353983478346836848;
                             }
                         }
@@ -5953,14 +5476,14 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                             yyval.Node = New_BinOp(
                                 lParse,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
-                                (*yyvsp.offset(-2_isize)).Node,
+                                (*yyvsp.offset(-2)).Node,
                                 fits_parser_yytokentype::LTE as c_int,
                                 (*yyvsp.offset(0)).Node,
                             );
                             if yyval.Node < 0 {
                                 current_block = 4830776507462815627;
                             } else {
-                                ((*((*lParse).Nodes).offset(yyval.Node as isize)).value).nelem = 1;
+                                (((lParse.Nodes)[yyval.Node as usize]).value).nelem = 1;
                                 current_block = 17353983478346836848;
                             }
                         }
@@ -5968,7 +5491,7 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                             yyval.Node = New_BinOp(
                                 lParse,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
-                                (*yyvsp.offset(-2_isize)).Node,
+                                (*yyvsp.offset(-2)).Node,
                                 fits_parser_yytokentype::AND as c_int,
                                 (*yyvsp.offset(0)).Node,
                             );
@@ -5982,7 +5505,7 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                             yyval.Node = New_BinOp(
                                 lParse,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
-                                (*yyvsp.offset(-2_isize)).Node,
+                                (*yyvsp.offset(-2)).Node,
                                 fits_parser_yytokentype::OR as c_int,
                                 (*yyvsp.offset(0)).Node,
                             );
@@ -5996,7 +5519,7 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                             yyval.Node = New_BinOp(
                                 lParse,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
-                                (*yyvsp.offset(-2_isize)).Node,
+                                (*yyvsp.offset(-2)).Node,
                                 fits_parser_yytokentype::EQ as c_int,
                                 (*yyvsp.offset(0)).Node,
                             );
@@ -6010,7 +5533,7 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                             yyval.Node = New_BinOp(
                                 lParse,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
-                                (*yyvsp.offset(-2_isize)).Node,
+                                (*yyvsp.offset(-2)).Node,
                                 fits_parser_yytokentype::NE as c_int,
                                 (*yyvsp.offset(0)).Node,
                             );
@@ -6021,108 +5544,81 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                             }
                         }
                         100 => {
-                            if (*((*lParse).Nodes).offset((*yyvsp.offset(-4_isize)).Node as isize))
-                                .ntype
-                                > (*((*lParse).Nodes)
-                                    .offset((*yyvsp.offset(-2_isize)).Node as isize))
-                                .ntype
+                            if ((lParse.Nodes)[(*yyvsp.offset(-4)).Node as usize]).ntype
+                                > (lParse.Nodes[(*yyvsp.offset(-2)).Node as usize]).ntype
                             {
-                                (*yyvsp.offset(-2_isize)).Node = New_Unary(
+                                (*yyvsp.offset(-2)).Node = New_Unary(
                                     lParse,
-                                    (*((*lParse).Nodes)
-                                        .offset((*yyvsp.offset(-4_isize)).Node as isize))
-                                    .ntype,
+                                    ((lParse.Nodes)[(*yyvsp.offset(-4)).Node as usize]).ntype,
                                     0,
-                                    (*yyvsp.offset(-2_isize)).Node,
+                                    (*yyvsp.offset(-2)).Node,
                                 );
-                            } else if (*((*lParse).Nodes)
-                                .offset((*yyvsp.offset(-4_isize)).Node as isize))
-                            .ntype
-                                < (*((*lParse).Nodes)
-                                    .offset((*yyvsp.offset(-2_isize)).Node as isize))
-                                .ntype
+                            } else if ((lParse.Nodes)[(*yyvsp.offset(-4)).Node as usize]).ntype
+                                < (lParse.Nodes[(*yyvsp.offset(-2)).Node as usize]).ntype
                             {
-                                (*yyvsp.offset(-4_isize)).Node = New_Unary(
+                                (*yyvsp.offset(-4)).Node = New_Unary(
                                     lParse,
-                                    (*((*lParse).Nodes)
-                                        .offset((*yyvsp.offset(-2_isize)).Node as isize))
-                                    .ntype,
+                                    ((lParse.Nodes)[(*yyvsp.offset(-2)).Node as usize]).ntype,
                                     0,
-                                    (*yyvsp.offset(-4_isize)).Node,
+                                    (*yyvsp.offset(-4)).Node,
                                 );
                             }
-                            if (*((*lParse).Nodes).offset((*yyvsp.offset(-4_isize)).Node as isize))
-                                .ntype
-                                > (*((*lParse).Nodes).offset((*yyvsp.offset(0)).Node as isize))
-                                    .ntype
+                            if ((lParse.Nodes)[(*yyvsp.offset(-4)).Node as usize]).ntype
+                                > (lParse.Nodes[(*yyvsp.offset(0)).Node as usize]).ntype
                             {
                                 (*yyvsp.offset(0)).Node = New_Unary(
                                     lParse,
-                                    (*((*lParse).Nodes)
-                                        .offset((*yyvsp.offset(-4_isize)).Node as isize))
-                                    .ntype,
+                                    ((lParse.Nodes)[(*yyvsp.offset(-4)).Node as usize]).ntype,
                                     0,
                                     (*yyvsp.offset(0)).Node,
                                 );
-                            } else if (*((*lParse).Nodes)
-                                .offset((*yyvsp.offset(-4_isize)).Node as isize))
-                            .ntype
-                                < (*((*lParse).Nodes).offset((*yyvsp.offset(0)).Node as isize))
-                                    .ntype
+                            } else if ((lParse.Nodes)[(*yyvsp.offset(-4)).Node as usize]).ntype
+                                < (lParse.Nodes[(*yyvsp.offset(0)).Node as usize]).ntype
                             {
-                                (*yyvsp.offset(-4_isize)).Node = New_Unary(
+                                (*yyvsp.offset(-4)).Node = New_Unary(
                                     lParse,
-                                    (*((*lParse).Nodes).offset((*yyvsp.offset(0)).Node as isize))
-                                        .ntype,
+                                    (lParse.Nodes[(*yyvsp.offset(0)).Node as usize]).ntype,
                                     0,
-                                    (*yyvsp.offset(-4_isize)).Node,
+                                    (*yyvsp.offset(-4)).Node,
                                 );
                             }
-                            if (*((*lParse).Nodes).offset((*yyvsp.offset(-2_isize)).Node as isize))
-                                .ntype
-                                > (*((*lParse).Nodes).offset((*yyvsp.offset(0)).Node as isize))
-                                    .ntype
+                            if (lParse.Nodes[(*yyvsp.offset(-2)).Node as usize]).ntype
+                                > (lParse.Nodes[(*yyvsp.offset(0)).Node as usize]).ntype
                             {
                                 (*yyvsp.offset(0)).Node = New_Unary(
                                     lParse,
-                                    (*((*lParse).Nodes)
-                                        .offset((*yyvsp.offset(-2_isize)).Node as isize))
-                                    .ntype,
+                                    ((lParse.Nodes)[(*yyvsp.offset(-2)).Node as usize]).ntype,
                                     0,
                                     (*yyvsp.offset(0)).Node,
                                 );
-                            } else if (*((*lParse).Nodes)
-                                .offset((*yyvsp.offset(-2_isize)).Node as isize))
-                            .ntype
-                                < (*((*lParse).Nodes).offset((*yyvsp.offset(0)).Node as isize))
-                                    .ntype
+                            } else if ((lParse.Nodes)[(*yyvsp.offset(-2)).Node as usize]).ntype
+                                < (lParse.Nodes[(*yyvsp.offset(0)).Node as usize]).ntype
                             {
-                                (*yyvsp.offset(-2_isize)).Node = New_Unary(
+                                (*yyvsp.offset(-2)).Node = New_Unary(
                                     lParse,
-                                    (*((*lParse).Nodes).offset((*yyvsp.offset(0)).Node as isize))
-                                        .ntype,
+                                    (lParse.Nodes[(*yyvsp.offset(0)).Node as usize]).ntype,
                                     0,
-                                    (*yyvsp.offset(-2_isize)).Node,
+                                    (*yyvsp.offset(-2)).Node,
                                 );
                             }
-                            (*yyvsp.offset(-2_isize)).Node = New_BinOp(
+                            (*yyvsp.offset(-2)).Node = New_BinOp(
                                 lParse,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
-                                (*yyvsp.offset(-2_isize)).Node,
+                                (*yyvsp.offset(-2)).Node,
                                 fits_parser_yytokentype::LTE as c_int,
-                                (*yyvsp.offset(-4_isize)).Node,
+                                (*yyvsp.offset(-4)).Node,
                             );
                             (*yyvsp.offset(0)).Node = New_BinOp(
                                 lParse,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
-                                (*yyvsp.offset(-4_isize)).Node,
+                                (*yyvsp.offset(-4)).Node,
                                 fits_parser_yytokentype::LTE as c_int,
                                 (*yyvsp.offset(0)).Node,
                             );
                             yyval.Node = New_BinOp(
                                 lParse,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
-                                (*yyvsp.offset(-2_isize)).Node,
+                                (*yyvsp.offset(-2)).Node,
                                 fits_parser_yytokentype::AND as c_int,
                                 (*yyvsp.offset(0)).Node,
                             );
@@ -6133,18 +5629,13 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                             }
                         }
                         101 => {
-                            if Test_Dims(
-                                lParse,
-                                (*yyvsp.offset(-2_isize)).Node,
-                                (*yyvsp.offset(0)).Node,
-                            ) == 0
+                            if Test_Dims(lParse, (*yyvsp.offset(-2)).Node, (*yyvsp.offset(0)).Node)
+                                == 0
                             {
                                 fits_parser_yyerror(
                                     scanner,
                                     lParse,
-                                    b"Incompatible dimensions in '?:' arguments\0" as *const u8
-                                        as *const c_char
-                                        as *mut c_char,
+                                    cs!(c"Incompatible dimensions in '?:' arguments"),
                                 );
                                 current_block = 4830776507462815627;
                             } else {
@@ -6153,9 +5644,9 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                     0,
                                     ifthenelse_fct,
                                     3 as c_int,
-                                    (*yyvsp.offset(-2_isize)).Node,
+                                    (*yyvsp.offset(-2)).Node,
                                     (*yyvsp.offset(0)).Node,
-                                    (*yyvsp.offset(-4_isize)).Node,
+                                    (*yyvsp.offset(-4)).Node,
                                     0,
                                     0,
                                     0,
@@ -6164,42 +5655,30 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                 if yyval.Node < 0 {
                                     current_block = 4830776507462815627;
                                 } else {
-                                    if (*((*lParse).Nodes)
-                                        .offset((*yyvsp.offset(-2_isize)).Node as isize))
-                                    .value
-                                    .nelem
-                                        < (*((*lParse).Nodes)
-                                            .offset((*yyvsp.offset(0)).Node as isize))
+                                    if ((lParse.Nodes)[(*yyvsp.offset(-2)).Node as usize])
                                         .value
                                         .nelem
+                                        < (lParse.Nodes[(*yyvsp.offset(0)).Node as usize])
+                                            .value
+                                            .nelem
                                     {
                                         Copy_Dims(lParse, yyval.Node, (*yyvsp.offset(0)).Node);
                                     }
-                                    if Test_Dims(lParse, (*yyvsp.offset(-4_isize)).Node, yyval.Node)
-                                        == 0
+                                    if Test_Dims(lParse, (*yyvsp.offset(-4)).Node, yyval.Node) == 0
                                     {
                                         fits_parser_yyerror(
                                             scanner,
                                             lParse,
-                                            b"Incompatible dimensions in '?:' condition\0"
-                                                as *const u8
-                                                as *const c_char
-                                                as *mut c_char,
+                                            cs!(c"Incompatible dimensions in '?:' condition"),
                                         );
                                         current_block = 4830776507462815627;
                                     } else {
-                                        if ((*((*lParse).Nodes).offset(yyval.Node as isize)).value)
-                                            .nelem
-                                            < (*((*lParse).Nodes)
-                                                .offset((*yyvsp.offset(-4_isize)).Node as isize))
-                                            .value
-                                            .nelem
+                                        if (((lParse.Nodes)[yyval.Node as usize]).value).nelem
+                                            < ((lParse.Nodes)[(*yyvsp.offset(-4)).Node as usize])
+                                                .value
+                                                .nelem
                                         {
-                                            Copy_Dims(
-                                                lParse,
-                                                yyval.Node,
-                                                (*yyvsp.offset(-4_isize)).Node,
-                                            );
+                                            Copy_Dims(lParse, yyval.Node, (*yyvsp.offset(-4)).Node);
                                         }
                                         current_block = 17353983478346836848;
                                     }
@@ -6207,19 +5686,19 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                             }
                         }
                         102 => {
-                            if (if ((*yyvsp.offset(-2_isize)).astr[0] as c_int)
+                            if (if ((*yyvsp.offset(-2)).astr[0] as c_int)
                                 < (*::core::mem::transmute::<&[u8; 8], &[c_char; 8]>(b"ISNULL(\0"))
                                     [0] as c_int
                             {
                                 -(1)
-                            } else if (*yyvsp.offset(-2_isize)).astr[0] as c_int
+                            } else if (*yyvsp.offset(-2)).astr[0] as c_int
                                 > (*::core::mem::transmute::<&[u8; 8], &[c_char; 8]>(b"ISNULL(\0"))
                                     [0] as c_int
                             {
                                 1
                             } else {
                                 strcmp(
-                                    ((*yyvsp.offset(-2_isize)).astr).as_mut_ptr(),
+                                    ((*yyvsp.offset(-2)).astr).as_mut_ptr(),
                                     b"ISNULL(\0" as *const u8 as *const c_char,
                                 )
                             }) == 0
@@ -6229,7 +5708,7 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                     0,
                                     isnull_fct,
                                     1,
-                                    (*yyvsp.offset(-1_isize)).Node,
+                                    (*yyvsp.offset(-1)).Node,
                                     0,
                                     0,
                                     0,
@@ -6240,7 +5719,7 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                 if yyval.Node < 0 {
                                     current_block = 4830776507462815627;
                                 } else {
-                                    (*((*lParse).Nodes).offset(yyval.Node as isize)).ntype =
+                                    ((lParse.Nodes)[yyval.Node as usize]).ntype =
                                         fits_parser_yytokentype::BOOLEAN as c_int;
                                     current_block = 17353983478346836848;
                                 }
@@ -6248,27 +5727,25 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                 fits_parser_yyerror(
                                     scanner,
                                     lParse,
-                                    b"Boolean Function(expr) not supported\0" as *const u8
-                                        as *const c_char
-                                        as *mut c_char,
+                                    cs!(c"Boolean Function(expr) not supported"),
                                 );
                                 current_block = 4830776507462815627;
                             }
                         }
                         103 => {
-                            if (if ((*yyvsp.offset(-2_isize)).astr[0] as c_int)
+                            if (if ((*yyvsp.offset(-2)).astr[0] as c_int)
                                 < (*::core::mem::transmute::<&[u8; 8], &[c_char; 8]>(b"ISNULL(\0"))
                                     [0] as c_int
                             {
                                 -(1)
-                            } else if (*yyvsp.offset(-2_isize)).astr[0] as c_int
+                            } else if (*yyvsp.offset(-2)).astr[0] as c_int
                                 > (*::core::mem::transmute::<&[u8; 8], &[c_char; 8]>(b"ISNULL(\0"))
                                     [0] as c_int
                             {
                                 1
                             } else {
                                 strcmp(
-                                    ((*yyvsp.offset(-2_isize)).astr).as_mut_ptr(),
+                                    ((*yyvsp.offset(-2)).astr).as_mut_ptr(),
                                     b"ISNULL(\0" as *const u8 as *const c_char,
                                 )
                             }) == 0
@@ -6278,7 +5755,7 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                     0,
                                     isnull_fct,
                                     1,
-                                    (*yyvsp.offset(-1_isize)).Node,
+                                    (*yyvsp.offset(-1)).Node,
                                     0,
                                     0,
                                     0,
@@ -6289,7 +5766,7 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                 if yyval.Node < 0 {
                                     current_block = 4830776507462815627;
                                 } else {
-                                    (*((*lParse).Nodes).offset(yyval.Node as isize)).ntype =
+                                    ((lParse.Nodes)[yyval.Node as usize]).ntype =
                                         fits_parser_yytokentype::BOOLEAN as c_int;
                                     current_block = 17353983478346836848;
                                 }
@@ -6297,27 +5774,25 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                 fits_parser_yyerror(
                                     scanner,
                                     lParse,
-                                    b"Boolean Function(expr) not supported\0" as *const u8
-                                        as *const c_char
-                                        as *mut c_char,
+                                    cs!(c"Boolean Function(expr) not supported"),
                                 );
                                 current_block = 4830776507462815627;
                             }
                         }
                         104 => {
-                            if (if ((*yyvsp.offset(-2_isize)).astr[0] as c_int)
+                            if (if ((*yyvsp.offset(-2)).astr[0] as c_int)
                                 < (*::core::mem::transmute::<&[u8; 8], &[c_char; 8]>(b"ISNULL(\0"))
                                     [0] as c_int
                             {
                                 -(1)
-                            } else if (*yyvsp.offset(-2_isize)).astr[0] as c_int
+                            } else if (*yyvsp.offset(-2)).astr[0] as c_int
                                 > (*::core::mem::transmute::<&[u8; 8], &[c_char; 8]>(b"ISNULL(\0"))
                                     [0] as c_int
                             {
                                 1
                             } else {
                                 strcmp(
-                                    ((*yyvsp.offset(-2_isize)).astr).as_mut_ptr(),
+                                    ((*yyvsp.offset(-2)).astr).as_mut_ptr(),
                                     b"ISNULL(\0" as *const u8 as *const c_char,
                                 )
                             }) == 0
@@ -6327,7 +5802,7 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                     fits_parser_yytokentype::BOOLEAN as c_int,
                                     isnull_fct,
                                     1,
-                                    (*yyvsp.offset(-1_isize)).Node,
+                                    (*yyvsp.offset(-1)).Node,
                                     0,
                                     0,
                                     0,
@@ -6344,43 +5819,39 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                 fits_parser_yyerror(
                                     scanner,
                                     lParse,
-                                    b"Boolean Function(expr) not supported\0" as *const u8
-                                        as *const c_char
-                                        as *mut c_char,
+                                    cs!(c"Boolean Function(expr) not supported"),
                                 );
                                 current_block = 4830776507462815627;
                             }
                         }
                         105 => {
-                            if (if ((*yyvsp.offset(-4_isize)).astr[0] as c_int)
+                            if (if ((*yyvsp.offset(-4)).astr[0] as c_int)
                                 < (*::core::mem::transmute::<&[u8; 9], &[c_char; 9]>(b"DEFNULL(\0"))
                                     [0] as c_int
                             {
                                 -(1)
-                            } else if (*yyvsp.offset(-4_isize)).astr[0] as c_int
+                            } else if (*yyvsp.offset(-4)).astr[0] as c_int
                                 > (*::core::mem::transmute::<&[u8; 9], &[c_char; 9]>(b"DEFNULL(\0"))
                                     [0] as c_int
                             {
                                 1
                             } else {
                                 strcmp(
-                                    ((*yyvsp.offset(-4_isize)).astr).as_mut_ptr(),
+                                    ((*yyvsp.offset(-4)).astr).as_mut_ptr(),
                                     b"DEFNULL(\0" as *const u8 as *const c_char,
                                 )
                             }) == 0
                             {
-                                if (*((*lParse).Nodes)
-                                    .offset((*yyvsp.offset(-3_isize)).Node as isize))
-                                .value
-                                .nelem
-                                    >= (*((*lParse).Nodes)
-                                        .offset((*yyvsp.offset(-1_isize)).Node as isize))
+                                if ((lParse.Nodes)[(*yyvsp.offset(-3)).Node as usize])
                                     .value
                                     .nelem
+                                    >= ((lParse.Nodes)[(*yyvsp.offset(-1)).Node as usize])
+                                        .value
+                                        .nelem
                                     && Test_Dims(
                                         lParse,
-                                        (*yyvsp.offset(-3_isize)).Node,
-                                        (*yyvsp.offset(-1_isize)).Node,
+                                        (*yyvsp.offset(-3)).Node,
+                                        (*yyvsp.offset(-1)).Node,
                                     ) != 0
                                 {
                                     yyval.Node = New_Func(
@@ -6388,8 +5859,8 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                         0,
                                         defnull_fct,
                                         2 as c_int,
-                                        (*yyvsp.offset(-3_isize)).Node,
-                                        (*yyvsp.offset(-1_isize)).Node,
+                                        (*yyvsp.offset(-3)).Node,
+                                        (*yyvsp.offset(-1)).Node,
                                         0,
                                         0,
                                         0,
@@ -6405,10 +5876,7 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                     fits_parser_yyerror(
                                         scanner,
                                         lParse,
-                                        b"Dimensions of DEFNULL arguments are not compatible\0"
-                                            as *const u8
-                                            as *const c_char
-                                            as *mut c_char,
+                                        cs!(c"Dimensions of DEFNULL arguments are not compatible"),
                                     );
                                     current_block = 4830776507462815627;
                                 }
@@ -6416,16 +5884,13 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                 fits_parser_yyerror(
                                     scanner,
                                     lParse,
-                                    b"Boolean Function(expr,expr) not supported\0" as *const u8
-                                        as *const c_char
-                                        as *mut c_char,
+                                    cs!(c"Boolean Function(expr,expr) not supported"),
                                 );
                                 current_block = 4830776507462815627;
                             }
                         }
                         106 => {
-                            if (*((*lParse).Nodes).offset((*yyvsp.offset(-(5))).Node as isize))
-                                .ntype
+                            if ((lParse.Nodes)[(*yyvsp.offset(-(5))).Node as usize]).ntype
                                 != fits_parser_yytokentype::DOUBLE as c_int
                             {
                                 (*yyvsp.offset(-(5))).Node = New_Unary(
@@ -6435,61 +5900,56 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                     (*yyvsp.offset(-(5))).Node,
                                 );
                             }
-                            if (*((*lParse).Nodes).offset((*yyvsp.offset(-3_isize)).Node as isize))
-                                .ntype
+                            if ((lParse.Nodes)[(*yyvsp.offset(-3)).Node as usize]).ntype
                                 != fits_parser_yytokentype::DOUBLE as c_int
                             {
-                                (*yyvsp.offset(-3_isize)).Node = New_Unary(
+                                (*yyvsp.offset(-3)).Node = New_Unary(
                                     lParse,
                                     fits_parser_yytokentype::DOUBLE as c_int,
                                     0,
-                                    (*yyvsp.offset(-3_isize)).Node,
+                                    (*yyvsp.offset(-3)).Node,
                                 );
                             }
-                            if (*((*lParse).Nodes).offset((*yyvsp.offset(-1_isize)).Node as isize))
-                                .ntype
+                            if ((lParse.Nodes)[(*yyvsp.offset(-1)).Node as usize]).ntype
                                 != fits_parser_yytokentype::DOUBLE as c_int
                             {
-                                (*yyvsp.offset(-1_isize)).Node = New_Unary(
+                                (*yyvsp.offset(-1)).Node = New_Unary(
                                     lParse,
                                     fits_parser_yytokentype::DOUBLE as c_int,
                                     0,
-                                    (*yyvsp.offset(-1_isize)).Node,
+                                    (*yyvsp.offset(-1)).Node,
                                 );
                             }
                             if !(Test_Dims(
                                 lParse,
                                 (*yyvsp.offset(-(5))).Node,
-                                (*yyvsp.offset(-3_isize)).Node,
+                                (*yyvsp.offset(-3)).Node,
                             ) != 0
                                 && Test_Dims(
                                     lParse,
-                                    (*yyvsp.offset(-3_isize)).Node,
-                                    (*yyvsp.offset(-1_isize)).Node,
+                                    (*yyvsp.offset(-3)).Node,
+                                    (*yyvsp.offset(-1)).Node,
                                 ) != 0)
                             {
                                 fits_parser_yyerror(
                                     scanner,
                                     lParse,
-                                    b"Dimensions of NEAR arguments are not compatible\0"
-                                        as *const u8
-                                        as *const c_char
-                                        as *mut c_char,
+                                    cs!(c"Dimensions of NEAR arguments are not compatible"),
                                 );
                                 current_block = 4830776507462815627;
-                            } else if (if ((*yyvsp.offset(-(6 as c_int) as isize)).astr[0] as c_int)
+                            } else if (if ((*yyvsp.offset(-6)).astr[0] as c_int)
                                 < (*::core::mem::transmute::<&[u8; 6], &[c_char; 6]>(b"NEAR(\0"))[0]
                                     as c_int
                             {
                                 -(1)
-                            } else if (*yyvsp.offset(-(6 as c_int) as isize)).astr[0] as c_int
+                            } else if (*yyvsp.offset(-6)).astr[0] as c_int
                                 > (*::core::mem::transmute::<&[u8; 6], &[c_char; 6]>(b"NEAR(\0"))[0]
                                     as c_int
                             {
                                 1
                             } else {
                                 strcmp(
-                                    ((*yyvsp.offset(-(6 as c_int) as isize)).astr).as_mut_ptr(),
+                                    ((*yyvsp.offset(-6)).astr).as_mut_ptr(),
                                     b"NEAR(\0" as *const u8 as *const c_char,
                                 )
                             }) == 0
@@ -6500,8 +5960,8 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                     near_fct,
                                     3 as c_int,
                                     (*yyvsp.offset(-(5))).Node,
-                                    (*yyvsp.offset(-3_isize)).Node,
-                                    (*yyvsp.offset(-1_isize)).Node,
+                                    (*yyvsp.offset(-3)).Node,
+                                    (*yyvsp.offset(-1)).Node,
                                     0,
                                     0,
                                     0,
@@ -6510,44 +5970,30 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                 if yyval.Node < 0 {
                                     current_block = 4830776507462815627;
                                 } else {
-                                    if ((*((*lParse).Nodes).offset(yyval.Node as isize)).value)
-                                        .nelem
-                                        < (*((*lParse).Nodes)
-                                            .offset((*yyvsp.offset(-(5))).Node as isize))
-                                        .value
-                                        .nelem
+                                    if (((lParse.Nodes)[yyval.Node as usize]).value).nelem
+                                        < ((lParse.Nodes)[(*yyvsp.offset(-(5))).Node as usize])
+                                            .value
+                                            .nelem
                                     {
                                         Copy_Dims(lParse, yyval.Node, (*yyvsp.offset(-(5))).Node);
                                     }
-                                    if (*((*lParse).Nodes)
-                                        .offset((*yyvsp.offset(-(5))).Node as isize))
-                                    .value
-                                    .nelem
-                                        < (*((*lParse).Nodes)
-                                            .offset((*yyvsp.offset(-3_isize)).Node as isize))
+                                    if ((lParse.Nodes)[(*yyvsp.offset(-(5))).Node as usize])
                                         .value
                                         .nelem
+                                        < ((lParse.Nodes)[(*yyvsp.offset(-3)).Node as usize])
+                                            .value
+                                            .nelem
                                     {
-                                        Copy_Dims(
-                                            lParse,
-                                            yyval.Node,
-                                            (*yyvsp.offset(-3_isize)).Node,
-                                        );
+                                        Copy_Dims(lParse, yyval.Node, (*yyvsp.offset(-3)).Node);
                                     }
-                                    if (*((*lParse).Nodes)
-                                        .offset((*yyvsp.offset(-3_isize)).Node as isize))
-                                    .value
-                                    .nelem
-                                        < (*((*lParse).Nodes)
-                                            .offset((*yyvsp.offset(-1_isize)).Node as isize))
+                                    if ((lParse.Nodes)[(*yyvsp.offset(-3)).Node as usize])
                                         .value
                                         .nelem
+                                        < ((lParse.Nodes)[(*yyvsp.offset(-1)).Node as usize])
+                                            .value
+                                            .nelem
                                     {
-                                        Copy_Dims(
-                                            lParse,
-                                            yyval.Node,
-                                            (*yyvsp.offset(-1_isize)).Node,
-                                        );
+                                        Copy_Dims(lParse, yyval.Node, (*yyvsp.offset(-1)).Node);
                                     }
                                     current_block = 17353983478346836848;
                                 }
@@ -6555,40 +6001,33 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                 fits_parser_yyerror(
                                     scanner,
                                     lParse,
-                                    b"Boolean Function not supported\0" as *const u8
-                                        as *const c_char
-                                        as *mut c_char,
+                                    cs!(c"Boolean Function not supported"),
                                 );
                                 current_block = 4830776507462815627;
                             }
                         }
                         107 => {
-                            if (*((*lParse).Nodes)
-                                .offset((*yyvsp.offset(-(9 as c_int) as isize)).Node as isize))
-                            .ntype
+                            if ((lParse.Nodes)[(*yyvsp.offset(-9)).Node as usize]).ntype
                                 != fits_parser_yytokentype::DOUBLE as c_int
                             {
-                                (*yyvsp.offset(-(9 as c_int) as isize)).Node = New_Unary(
+                                (*yyvsp.offset(-9)).Node = New_Unary(
                                     lParse,
                                     fits_parser_yytokentype::DOUBLE as c_int,
                                     0,
-                                    (*yyvsp.offset(-(9 as c_int) as isize)).Node,
+                                    (*yyvsp.offset(-9)).Node,
                                 );
                             }
-                            if (*((*lParse).Nodes)
-                                .offset((*yyvsp.offset(-(7 as c_int) as isize)).Node as isize))
-                            .ntype
+                            if ((lParse.Nodes)[(*yyvsp.offset(-7)).Node as usize]).ntype
                                 != fits_parser_yytokentype::DOUBLE as c_int
                             {
-                                (*yyvsp.offset(-(7 as c_int) as isize)).Node = New_Unary(
+                                (*yyvsp.offset(-7)).Node = New_Unary(
                                     lParse,
                                     fits_parser_yytokentype::DOUBLE as c_int,
                                     0,
-                                    (*yyvsp.offset(-(7 as c_int) as isize)).Node,
+                                    (*yyvsp.offset(-7)).Node,
                                 );
                             }
-                            if (*((*lParse).Nodes).offset((*yyvsp.offset(-(5))).Node as isize))
-                                .ntype
+                            if ((lParse.Nodes)[(*yyvsp.offset(-(5))).Node as usize]).ntype
                                 != fits_parser_yytokentype::DOUBLE as c_int
                             {
                                 (*yyvsp.offset(-(5))).Node = New_Unary(
@@ -6598,72 +6037,66 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                     (*yyvsp.offset(-(5))).Node,
                                 );
                             }
-                            if (*((*lParse).Nodes).offset((*yyvsp.offset(-3_isize)).Node as isize))
-                                .ntype
+                            if ((lParse.Nodes)[(*yyvsp.offset(-3)).Node as usize]).ntype
                                 != fits_parser_yytokentype::DOUBLE as c_int
                             {
-                                (*yyvsp.offset(-3_isize)).Node = New_Unary(
+                                (*yyvsp.offset(-3)).Node = New_Unary(
                                     lParse,
                                     fits_parser_yytokentype::DOUBLE as c_int,
                                     0,
-                                    (*yyvsp.offset(-3_isize)).Node,
+                                    (*yyvsp.offset(-3)).Node,
                                 );
                             }
-                            if (*((*lParse).Nodes).offset((*yyvsp.offset(-1_isize)).Node as isize))
-                                .ntype
+                            if ((lParse.Nodes)[(*yyvsp.offset(-1)).Node as usize]).ntype
                                 != fits_parser_yytokentype::DOUBLE as c_int
                             {
-                                (*yyvsp.offset(-1_isize)).Node = New_Unary(
+                                (*yyvsp.offset(-1)).Node = New_Unary(
                                     lParse,
                                     fits_parser_yytokentype::DOUBLE as c_int,
                                     0,
-                                    (*yyvsp.offset(-1_isize)).Node,
+                                    (*yyvsp.offset(-1)).Node,
                                 );
                             }
                             if !(Test_Dims(
                                 lParse,
-                                (*yyvsp.offset(-(9 as c_int) as isize)).Node,
-                                (*yyvsp.offset(-(7 as c_int) as isize)).Node,
+                                (*yyvsp.offset(-9)).Node,
+                                (*yyvsp.offset(-7)).Node,
                             ) != 0
                                 && Test_Dims(
                                     lParse,
-                                    (*yyvsp.offset(-(7 as c_int) as isize)).Node,
+                                    (*yyvsp.offset(-7)).Node,
                                     (*yyvsp.offset(-(5))).Node,
                                 ) != 0
                                 && Test_Dims(
                                     lParse,
                                     (*yyvsp.offset(-(5))).Node,
-                                    (*yyvsp.offset(-3_isize)).Node,
+                                    (*yyvsp.offset(-3)).Node,
                                 ) != 0
                                 && Test_Dims(
                                     lParse,
-                                    (*yyvsp.offset(-3_isize)).Node,
-                                    (*yyvsp.offset(-1_isize)).Node,
+                                    (*yyvsp.offset(-3)).Node,
+                                    (*yyvsp.offset(-1)).Node,
                                 ) != 0)
                             {
                                 fits_parser_yyerror(
                                     scanner,
                                     lParse,
-                                    b"Dimensions of CIRCLE arguments are not compatible\0"
-                                        as *const u8
-                                        as *const c_char
-                                        as *mut c_char,
+                                    cs!(c"Dimensions of CIRCLE arguments are not compatible"),
                                 );
                                 current_block = 4830776507462815627;
-                            } else if (if ((*yyvsp.offset(-(10 as c_int) as isize)).astr[0]
-                                as c_int)
+                            } else if (if ((*yyvsp.offset(-10)).astr[0] as c_int)
                                 < (*::core::mem::transmute::<&[u8; 8], &[c_char; 8]>(b"CIRCLE(\0"))
                                     [0] as c_int
                             {
                                 -(1)
-                            } else if (*yyvsp.offset(-(10 as c_int) as isize)).astr[0] as c_int
+                            } else if (*yyvsp.offset(-10)).astr[0] as c_int
                                 > (*::core::mem::transmute::<&[u8; 8], &[c_char; 8]>(b"CIRCLE(\0"))
                                     [0] as c_int
                             {
                                 1
                             } else {
                                 strcmp(
-                                    ((*yyvsp.offset(-(10 as c_int) as isize)).astr).as_mut_ptr(),
+                                    ((*yyvsp.offset(-10)).astr).as_mut_ptr(),
                                     b"CIRCLE(\0" as *const u8 as *const c_char,
                                 )
                             }) == 0
@@ -6673,89 +6106,59 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                     fits_parser_yytokentype::BOOLEAN as c_int,
                                     circle_fct,
                                     5 as c_int,
-                                    (*yyvsp.offset(-(9 as c_int) as isize)).Node,
-                                    (*yyvsp.offset(-(7 as c_int) as isize)).Node,
+                                    (*yyvsp.offset(-9)).Node,
+                                    (*yyvsp.offset(-7)).Node,
                                     (*yyvsp.offset(-(5))).Node,
-                                    (*yyvsp.offset(-3_isize)).Node,
-                                    (*yyvsp.offset(-1_isize)).Node,
+                                    (*yyvsp.offset(-3)).Node,
+                                    (*yyvsp.offset(-1)).Node,
                                     0,
                                     0,
                                 );
                                 if yyval.Node < 0 {
                                     current_block = 4830776507462815627;
                                 } else {
-                                    if ((*((*lParse).Nodes).offset(yyval.Node as isize)).value)
-                                        .nelem
-                                        < (*((*lParse).Nodes).offset(
-                                            (*yyvsp.offset(-(9 as c_int) as isize)).Node as isize,
-                                        ))
-                                        .value
-                                        .nelem
+                                    if (((lParse.Nodes)[yyval.Node as usize]).value).nelem
+                                        < ((lParse.Nodes)[(*yyvsp.offset(-9)).Node as usize])
+                                            .value
+                                            .nelem
                                     {
-                                        Copy_Dims(
-                                            lParse,
-                                            yyval.Node,
-                                            (*yyvsp.offset(-(9 as c_int) as isize)).Node,
-                                        );
+                                        Copy_Dims(lParse, yyval.Node, (*yyvsp.offset(-9)).Node);
                                     }
-                                    if (*((*lParse).Nodes).offset(
-                                        (*yyvsp.offset(-(9 as c_int) as isize)).Node as isize,
-                                    ))
-                                    .value
-                                    .nelem
-                                        < (*((*lParse).Nodes).offset(
-                                            (*yyvsp.offset(-(7 as c_int) as isize)).Node as isize,
-                                        ))
+                                    if ((lParse.Nodes)[(*yyvsp.offset(-9)).Node as usize])
                                         .value
                                         .nelem
+                                        < ((lParse.Nodes)[(*yyvsp.offset(-7)).Node as usize])
+                                            .value
+                                            .nelem
                                     {
-                                        Copy_Dims(
-                                            lParse,
-                                            yyval.Node,
-                                            (*yyvsp.offset(-(7 as c_int) as isize)).Node,
-                                        );
+                                        Copy_Dims(lParse, yyval.Node, (*yyvsp.offset(-7)).Node);
                                     }
-                                    if (*((*lParse).Nodes).offset(
-                                        (*yyvsp.offset(-(7 as c_int) as isize)).Node as isize,
-                                    ))
-                                    .value
-                                    .nelem
-                                        < (*((*lParse).Nodes)
-                                            .offset((*yyvsp.offset(-(5))).Node as isize))
+                                    if ((lParse.Nodes)[(*yyvsp.offset(-7)).Node as usize])
                                         .value
                                         .nelem
+                                        < ((lParse.Nodes)[(*yyvsp.offset(-(5))).Node as usize])
+                                            .value
+                                            .nelem
                                     {
                                         Copy_Dims(lParse, yyval.Node, (*yyvsp.offset(-(5))).Node);
                                     }
-                                    if (*((*lParse).Nodes)
-                                        .offset((*yyvsp.offset(-(5))).Node as isize))
-                                    .value
-                                    .nelem
-                                        < (*((*lParse).Nodes)
-                                            .offset((*yyvsp.offset(-3_isize)).Node as isize))
+                                    if ((lParse.Nodes)[(*yyvsp.offset(-(5))).Node as usize])
                                         .value
                                         .nelem
+                                        < ((lParse.Nodes)[(*yyvsp.offset(-3)).Node as usize])
+                                            .value
+                                            .nelem
                                     {
-                                        Copy_Dims(
-                                            lParse,
-                                            yyval.Node,
-                                            (*yyvsp.offset(-3_isize)).Node,
-                                        );
+                                        Copy_Dims(lParse, yyval.Node, (*yyvsp.offset(-3)).Node);
                                     }
-                                    if (*((*lParse).Nodes)
-                                        .offset((*yyvsp.offset(-3_isize)).Node as isize))
-                                    .value
-                                    .nelem
-                                        < (*((*lParse).Nodes)
-                                            .offset((*yyvsp.offset(-1_isize)).Node as isize))
+                                    if ((lParse.Nodes)[(*yyvsp.offset(-3)).Node as usize])
                                         .value
                                         .nelem
+                                        < ((lParse.Nodes)[(*yyvsp.offset(-1)).Node as usize])
+                                            .value
+                                            .nelem
                                     {
-                                        Copy_Dims(
-                                            lParse,
-                                            yyval.Node,
-                                            (*yyvsp.offset(-1_isize)).Node,
-                                        );
+                                        Copy_Dims(lParse, yyval.Node, (*yyvsp.offset(-1)).Node);
                                     }
                                     current_block = 17353983478346836848;
                                 }
@@ -6763,64 +6166,53 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                 fits_parser_yyerror(
                                     scanner,
                                     lParse,
-                                    b"Boolean Function not supported\0" as *const u8
-                                        as *const c_char
-                                        as *mut c_char,
+                                    cs!(c"Boolean Function not supported"),
                                 );
                                 current_block = 4830776507462815627;
                             }
                         }
                         108 => {
-                            if (*((*lParse).Nodes)
-                                .offset((*yyvsp.offset(-(13 as c_int) as isize)).Node as isize))
-                            .ntype
+                            if ((lParse.Nodes)[(*yyvsp.offset(-13)).Node as usize]).ntype
                                 != fits_parser_yytokentype::DOUBLE as c_int
                             {
-                                (*yyvsp.offset(-(13 as c_int) as isize)).Node = New_Unary(
+                                (*yyvsp.offset(-13)).Node = New_Unary(
                                     lParse,
                                     fits_parser_yytokentype::DOUBLE as c_int,
                                     0,
-                                    (*yyvsp.offset(-(13 as c_int) as isize)).Node,
+                                    (*yyvsp.offset(-13)).Node,
                                 );
                             }
-                            if (*((*lParse).Nodes)
-                                .offset((*yyvsp.offset(-(11 as c_int) as isize)).Node as isize))
-                            .ntype
+                            if ((lParse.Nodes)[(*yyvsp.offset(-11)).Node as usize]).ntype
                                 != fits_parser_yytokentype::DOUBLE as c_int
                             {
-                                (*yyvsp.offset(-(11 as c_int) as isize)).Node = New_Unary(
+                                (*yyvsp.offset(-11)).Node = New_Unary(
                                     lParse,
                                     fits_parser_yytokentype::DOUBLE as c_int,
                                     0,
-                                    (*yyvsp.offset(-(11 as c_int) as isize)).Node,
+                                    (*yyvsp.offset(-11)).Node,
                                 );
                             }
-                            if (*((*lParse).Nodes)
-                                .offset((*yyvsp.offset(-(9 as c_int) as isize)).Node as isize))
-                            .ntype
+                            if ((lParse.Nodes)[(*yyvsp.offset(-9)).Node as usize]).ntype
                                 != fits_parser_yytokentype::DOUBLE as c_int
                             {
-                                (*yyvsp.offset(-(9 as c_int) as isize)).Node = New_Unary(
+                                (*yyvsp.offset(-9)).Node = New_Unary(
                                     lParse,
                                     fits_parser_yytokentype::DOUBLE as c_int,
                                     0,
-                                    (*yyvsp.offset(-(9 as c_int) as isize)).Node,
+                                    (*yyvsp.offset(-9)).Node,
                                 );
                             }
-                            if (*((*lParse).Nodes)
-                                .offset((*yyvsp.offset(-(7 as c_int) as isize)).Node as isize))
-                            .ntype
+                            if ((lParse.Nodes)[(*yyvsp.offset(-7)).Node as usize]).ntype
                                 != fits_parser_yytokentype::DOUBLE as c_int
                             {
-                                (*yyvsp.offset(-(7 as c_int) as isize)).Node = New_Unary(
+                                (*yyvsp.offset(-7)).Node = New_Unary(
                                     lParse,
                                     fits_parser_yytokentype::DOUBLE as c_int,
                                     0,
-                                    (*yyvsp.offset(-(7 as c_int) as isize)).Node,
+                                    (*yyvsp.offset(-7)).Node,
                                 );
                             }
-                            if (*((*lParse).Nodes).offset((*yyvsp.offset(-(5))).Node as isize))
-                                .ntype
+                            if ((lParse.Nodes)[(*yyvsp.offset(-(5))).Node as usize]).ntype
                                 != fits_parser_yytokentype::DOUBLE as c_int
                             {
                                 (*yyvsp.offset(-(5))).Node = New_Unary(
@@ -6830,83 +6222,77 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                     (*yyvsp.offset(-(5))).Node,
                                 );
                             }
-                            if (*((*lParse).Nodes).offset((*yyvsp.offset(-3_isize)).Node as isize))
-                                .ntype
+                            if ((lParse.Nodes)[(*yyvsp.offset(-3)).Node as usize]).ntype
                                 != fits_parser_yytokentype::DOUBLE as c_int
                             {
-                                (*yyvsp.offset(-3_isize)).Node = New_Unary(
+                                (*yyvsp.offset(-3)).Node = New_Unary(
                                     lParse,
                                     fits_parser_yytokentype::DOUBLE as c_int,
                                     0,
-                                    (*yyvsp.offset(-3_isize)).Node,
+                                    (*yyvsp.offset(-3)).Node,
                                 );
                             }
-                            if (*((*lParse).Nodes).offset((*yyvsp.offset(-1_isize)).Node as isize))
-                                .ntype
+                            if ((lParse.Nodes)[(*yyvsp.offset(-1)).Node as usize]).ntype
                                 != fits_parser_yytokentype::DOUBLE as c_int
                             {
-                                (*yyvsp.offset(-1_isize)).Node = New_Unary(
+                                (*yyvsp.offset(-1)).Node = New_Unary(
                                     lParse,
                                     fits_parser_yytokentype::DOUBLE as c_int,
                                     0,
-                                    (*yyvsp.offset(-1_isize)).Node,
+                                    (*yyvsp.offset(-1)).Node,
                                 );
                             }
                             if !(Test_Dims(
                                 lParse,
-                                (*yyvsp.offset(-(13 as c_int) as isize)).Node,
-                                (*yyvsp.offset(-(11 as c_int) as isize)).Node,
+                                (*yyvsp.offset(-13)).Node,
+                                (*yyvsp.offset(-11)).Node,
                             ) != 0
                                 && Test_Dims(
                                     lParse,
-                                    (*yyvsp.offset(-(11 as c_int) as isize)).Node,
-                                    (*yyvsp.offset(-(9 as c_int) as isize)).Node,
+                                    (*yyvsp.offset(-11)).Node,
+                                    (*yyvsp.offset(-9)).Node,
                                 ) != 0
                                 && Test_Dims(
                                     lParse,
-                                    (*yyvsp.offset(-(9 as c_int) as isize)).Node,
-                                    (*yyvsp.offset(-(7 as c_int) as isize)).Node,
+                                    (*yyvsp.offset(-9)).Node,
+                                    (*yyvsp.offset(-7)).Node,
                                 ) != 0
                                 && Test_Dims(
                                     lParse,
-                                    (*yyvsp.offset(-(7 as c_int) as isize)).Node,
+                                    (*yyvsp.offset(-7)).Node,
                                     (*yyvsp.offset(-(5))).Node,
                                 ) != 0
                                 && Test_Dims(
                                     lParse,
                                     (*yyvsp.offset(-(5))).Node,
-                                    (*yyvsp.offset(-3_isize)).Node,
+                                    (*yyvsp.offset(-3)).Node,
                                 ) != 0
                                 && Test_Dims(
                                     lParse,
-                                    (*yyvsp.offset(-3_isize)).Node,
-                                    (*yyvsp.offset(-1_isize)).Node,
+                                    (*yyvsp.offset(-3)).Node,
+                                    (*yyvsp.offset(-1)).Node,
                                 ) != 0)
                             {
                                 fits_parser_yyerror(
                                     scanner,
                                     lParse,
-                                    b"Dimensions of BOX or ELLIPSE arguments are not compatible\0"
-                                        as *const u8
-                                        as *const c_char
-                                        as *mut c_char,
+                                    cs!(c"Dimensions of BOX or ELLIPSE arguments are not compatible"),
                                 );
                                 current_block = 4830776507462815627;
                             } else {
-                                if (if ((*yyvsp.offset(-(14 as c_int) as isize)).astr[0] as c_int)
+                                if (if ((*yyvsp.offset(-14)).astr[0] as c_int)
                                     < (*::core::mem::transmute::<&[u8; 5], &[c_char; 5]>(b"BOX(\0"))
                                         [0] as c_int
                                 {
                                     -(1)
-                                } else if (*yyvsp.offset(-(14 as c_int) as isize)).astr[0] as c_int
+                                } else if (*yyvsp.offset(-14)).astr[0] as c_int
                                     > (*::core::mem::transmute::<&[u8; 5], &[c_char; 5]>(b"BOX(\0"))
                                         [0] as c_int
                                 {
                                     1
                                 } else {
                                     strcmp(
-                                        ((*yyvsp.offset(-(14 as c_int) as isize)).astr)
-                                            .as_mut_ptr(),
+                                        ((*yyvsp.offset(-14)).astr).as_mut_ptr(),
                                         b"BOX(\0" as *const u8 as *const c_char,
                                     )
                                 }) == 0
@@ -6916,23 +6302,22 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                         fits_parser_yytokentype::BOOLEAN as c_int,
                                         box_fct,
                                         7 as c_int,
-                                        (*yyvsp.offset(-(13 as c_int) as isize)).Node,
-                                        (*yyvsp.offset(-(11 as c_int) as isize)).Node,
-                                        (*yyvsp.offset(-(9 as c_int) as isize)).Node,
-                                        (*yyvsp.offset(-(7 as c_int) as isize)).Node,
+                                        (*yyvsp.offset(-13)).Node,
+                                        (*yyvsp.offset(-11)).Node,
+                                        (*yyvsp.offset(-9)).Node,
+                                        (*yyvsp.offset(-7)).Node,
                                         (*yyvsp.offset(-(5))).Node,
-                                        (*yyvsp.offset(-3_isize)).Node,
-                                        (*yyvsp.offset(-1_isize)).Node,
+                                        (*yyvsp.offset(-3)).Node,
+                                        (*yyvsp.offset(-1)).Node,
                                     );
                                     current_block = 3023179740610631044;
-                                } else if (if ((*yyvsp.offset(-(14 as c_int) as isize)).astr[0]
-                                    as c_int)
+                                } else if (if ((*yyvsp.offset(-14)).astr[0] as c_int)
                                     < (*::core::mem::transmute::<&[u8; 9], &[c_char; 9]>(
                                         b"ELLIPSE(\0",
                                     ))[0] as c_int
                                 {
                                     -(1)
-                                } else if (*yyvsp.offset(-(14 as c_int) as isize)).astr[0] as c_int
+                                } else if (*yyvsp.offset(-14)).astr[0] as c_int
                                     > (*::core::mem::transmute::<&[u8; 9], &[c_char; 9]>(
                                         b"ELLIPSE(\0",
                                     ))[0] as c_int
@@ -6940,8 +6325,7 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                     1
                                 } else {
                                     strcmp(
-                                        ((*yyvsp.offset(-(14 as c_int) as isize)).astr)
-                                            .as_mut_ptr(),
+                                        ((*yyvsp.offset(-14)).astr).as_mut_ptr(),
                                         b"ELLIPSE(\0" as *const u8 as *const c_char,
                                     )
                                 }) == 0
@@ -6951,22 +6335,20 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                         fits_parser_yytokentype::BOOLEAN as c_int,
                                         elps_fct,
                                         7 as c_int,
-                                        (*yyvsp.offset(-(13 as c_int) as isize)).Node,
-                                        (*yyvsp.offset(-(11 as c_int) as isize)).Node,
-                                        (*yyvsp.offset(-(9 as c_int) as isize)).Node,
-                                        (*yyvsp.offset(-(7 as c_int) as isize)).Node,
+                                        (*yyvsp.offset(-13)).Node,
+                                        (*yyvsp.offset(-11)).Node,
+                                        (*yyvsp.offset(-9)).Node,
+                                        (*yyvsp.offset(-7)).Node,
                                         (*yyvsp.offset(-(5))).Node,
-                                        (*yyvsp.offset(-3_isize)).Node,
-                                        (*yyvsp.offset(-1_isize)).Node,
+                                        (*yyvsp.offset(-3)).Node,
+                                        (*yyvsp.offset(-1)).Node,
                                     );
                                     current_block = 3023179740610631044;
                                 } else {
                                     fits_parser_yyerror(
                                         scanner,
                                         lParse,
-                                        b"SAO Image Function not supported\0" as *const u8
-                                            as *const c_char
-                                            as *mut c_char,
+                                        cs!(c"SAO Image Function not supported"),
                                     );
                                     current_block = 4830776507462815627;
                                 }
@@ -6976,89 +6358,67 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                         if yyval.Node < 0 {
                                             current_block = 4830776507462815627;
                                         } else {
-                                            if ((*((*lParse).Nodes).offset(yyval.Node as isize))
-                                                .value)
-                                                .nelem
-                                                < (*((*lParse).Nodes).offset(
-                                                    (*yyvsp.offset(-(13 as c_int) as isize)).Node
-                                                        as isize,
-                                                ))
-                                                .value
-                                                .nelem
+                                            if (((lParse.Nodes)[yyval.Node as usize]).value).nelem
+                                                < ((lParse.Nodes)
+                                                    [(*yyvsp.offset(-13)).Node as usize])
+                                                    .value
+                                                    .nelem
                                             {
                                                 Copy_Dims(
                                                     lParse,
                                                     yyval.Node,
-                                                    (*yyvsp.offset(-(13 as c_int) as isize)).Node,
+                                                    (*yyvsp.offset(-13)).Node,
                                                 );
                                             }
-                                            if (*((*lParse).Nodes).offset(
-                                                (*yyvsp.offset(-(13 as c_int) as isize)).Node
-                                                    as isize,
-                                            ))
-                                            .value
-                                            .nelem
-                                                < (*((*lParse).Nodes).offset(
-                                                    (*yyvsp.offset(-(11 as c_int) as isize)).Node
-                                                        as isize,
-                                                ))
+                                            if ((lParse.Nodes)[(*yyvsp.offset(-13)).Node as usize])
                                                 .value
                                                 .nelem
+                                                < ((lParse.Nodes)
+                                                    [(*yyvsp.offset(-11)).Node as usize])
+                                                    .value
+                                                    .nelem
                                             {
                                                 Copy_Dims(
                                                     lParse,
                                                     yyval.Node,
-                                                    (*yyvsp.offset(-(11 as c_int) as isize)).Node,
+                                                    (*yyvsp.offset(-11)).Node,
                                                 );
                                             }
-                                            if (*((*lParse).Nodes).offset(
-                                                (*yyvsp.offset(-(11 as c_int) as isize)).Node
-                                                    as isize,
-                                            ))
-                                            .value
-                                            .nelem
-                                                < (*((*lParse).Nodes).offset(
-                                                    (*yyvsp.offset(-(9 as c_int) as isize)).Node
-                                                        as isize,
-                                                ))
+                                            if ((lParse.Nodes)[(*yyvsp.offset(-11)).Node as usize])
                                                 .value
                                                 .nelem
+                                                < ((lParse.Nodes)
+                                                    [(*yyvsp.offset(-9)).Node as usize])
+                                                    .value
+                                                    .nelem
                                             {
                                                 Copy_Dims(
                                                     lParse,
                                                     yyval.Node,
-                                                    (*yyvsp.offset(-(9 as c_int) as isize)).Node,
+                                                    (*yyvsp.offset(-9)).Node,
                                                 );
                                             }
-                                            if (*((*lParse).Nodes).offset(
-                                                (*yyvsp.offset(-(9 as c_int) as isize)).Node
-                                                    as isize,
-                                            ))
-                                            .value
-                                            .nelem
-                                                < (*((*lParse).Nodes).offset(
-                                                    (*yyvsp.offset(-(7 as c_int) as isize)).Node
-                                                        as isize,
-                                                ))
+                                            if ((lParse.Nodes)[(*yyvsp.offset(-9)).Node as usize])
                                                 .value
                                                 .nelem
+                                                < ((lParse.Nodes)
+                                                    [(*yyvsp.offset(-7)).Node as usize])
+                                                    .value
+                                                    .nelem
                                             {
                                                 Copy_Dims(
                                                     lParse,
                                                     yyval.Node,
-                                                    (*yyvsp.offset(-(7 as c_int) as isize)).Node,
+                                                    (*yyvsp.offset(-7)).Node,
                                                 );
                                             }
-                                            if (*((*lParse).Nodes).offset(
-                                                (*yyvsp.offset(-(7 as c_int) as isize)).Node
-                                                    as isize,
-                                            ))
-                                            .value
-                                            .nelem
-                                                < (*((*lParse).Nodes)
-                                                    .offset((*yyvsp.offset(-(5))).Node as isize))
+                                            if ((lParse.Nodes)[(*yyvsp.offset(-7)).Node as usize])
                                                 .value
                                                 .nelem
+                                                < ((lParse.Nodes)
+                                                    [(*yyvsp.offset(-(5))).Node as usize])
+                                                    .value
+                                                    .nelem
                                             {
                                                 Copy_Dims(
                                                     lParse,
@@ -7066,36 +6426,32 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                                     (*yyvsp.offset(-(5))).Node,
                                                 );
                                             }
-                                            if (*((*lParse).Nodes)
-                                                .offset((*yyvsp.offset(-(5))).Node as isize))
-                                            .value
-                                            .nelem
-                                                < (*((*lParse).Nodes).offset(
-                                                    (*yyvsp.offset(-3_isize)).Node as isize,
-                                                ))
+                                            if ((lParse.Nodes)[(*yyvsp.offset(-(5))).Node as usize])
                                                 .value
                                                 .nelem
+                                                < ((lParse.Nodes)
+                                                    [(*yyvsp.offset(-3)).Node as usize])
+                                                    .value
+                                                    .nelem
                                             {
                                                 Copy_Dims(
                                                     lParse,
                                                     yyval.Node,
-                                                    (*yyvsp.offset(-3_isize)).Node,
+                                                    (*yyvsp.offset(-3)).Node,
                                                 );
                                             }
-                                            if (*((*lParse).Nodes)
-                                                .offset((*yyvsp.offset(-3_isize)).Node as isize))
-                                            .value
-                                            .nelem
-                                                < (*((*lParse).Nodes).offset(
-                                                    (*yyvsp.offset(-1_isize)).Node as isize,
-                                                ))
+                                            if ((lParse.Nodes)[(*yyvsp.offset(-3)).Node as usize])
                                                 .value
                                                 .nelem
+                                                < ((lParse.Nodes)
+                                                    [(*yyvsp.offset(-1)).Node as usize])
+                                                    .value
+                                                    .nelem
                                             {
                                                 Copy_Dims(
                                                     lParse,
                                                     yyval.Node,
-                                                    (*yyvsp.offset(-1_isize)).Node,
+                                                    (*yyvsp.offset(-1)).Node,
                                                 );
                                             }
                                             current_block = 17353983478346836848;
@@ -7109,8 +6465,8 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                 lParse,
                                 gtifilt_fct,
                                 b"\0" as *const u8 as *const c_char as *mut c_char,
-                                -(99 as c_int),
-                                -(99 as c_int),
+                                -99,
+                                -99,
                                 b"*START*\0" as *const u8 as *const c_char as *mut c_char,
                                 b"*STOP*\0" as *const u8 as *const c_char as *mut c_char,
                             );
@@ -7124,9 +6480,9 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                             yyval.Node = New_GTI(
                                 lParse,
                                 gtifilt_fct,
-                                ((*yyvsp.offset(-1_isize)).astr).as_mut_ptr(),
-                                -(99 as c_int),
-                                -(99 as c_int),
+                                ((*yyvsp.offset(-1)).astr).as_mut_ptr(),
+                                -99,
+                                -99,
                                 b"*START*\0" as *const u8 as *const c_char as *mut c_char,
                                 b"*STOP*\0" as *const u8 as *const c_char as *mut c_char,
                             );
@@ -7140,9 +6496,9 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                             yyval.Node = New_GTI(
                                 lParse,
                                 gtifilt_fct,
-                                ((*yyvsp.offset(-3_isize)).astr).as_mut_ptr(),
-                                (*yyvsp.offset(-1_isize)).Node,
-                                -(99 as c_int),
+                                ((*yyvsp.offset(-3)).astr).as_mut_ptr(),
+                                (*yyvsp.offset(-1)).Node,
+                                -99,
                                 b"*START*\0" as *const u8 as *const c_char as *mut c_char,
                                 b"*STOP*\0" as *const u8 as *const c_char as *mut c_char,
                             );
@@ -7156,11 +6512,11 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                             yyval.Node = New_GTI(
                                 lParse,
                                 gtifilt_fct,
-                                ((*yyvsp.offset(-(7 as c_int) as isize)).astr).as_mut_ptr(),
+                                ((*yyvsp.offset(-7)).astr).as_mut_ptr(),
                                 (*yyvsp.offset(-(5))).Node,
-                                -(99 as c_int),
-                                ((*yyvsp.offset(-3_isize)).astr).as_mut_ptr(),
-                                ((*yyvsp.offset(-1_isize)).astr).as_mut_ptr(),
+                                -99,
+                                ((*yyvsp.offset(-3)).astr).as_mut_ptr(),
+                                ((*yyvsp.offset(-1)).astr).as_mut_ptr(),
                             );
                             if yyval.Node < 0 {
                                 current_block = 4830776507462815627;
@@ -7173,8 +6529,8 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                 lParse,
                                 gtifind_fct,
                                 b"\0" as *const u8 as *const c_char as *mut c_char,
-                                -(99 as c_int),
-                                -(99 as c_int),
+                                -99,
+                                -99,
                                 b"*START*\0" as *const u8 as *const c_char as *mut c_char,
                                 b"*STOP*\0" as *const u8 as *const c_char as *mut c_char,
                             );
@@ -7188,9 +6544,9 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                             yyval.Node = New_GTI(
                                 lParse,
                                 gtifind_fct,
-                                ((*yyvsp.offset(-1_isize)).astr).as_mut_ptr(),
-                                -(99 as c_int),
-                                -(99 as c_int),
+                                ((*yyvsp.offset(-1)).astr).as_mut_ptr(),
+                                -99,
+                                -99,
                                 b"*START*\0" as *const u8 as *const c_char as *mut c_char,
                                 b"*STOP*\0" as *const u8 as *const c_char as *mut c_char,
                             );
@@ -7204,9 +6560,9 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                             yyval.Node = New_GTI(
                                 lParse,
                                 gtifind_fct,
-                                ((*yyvsp.offset(-3_isize)).astr).as_mut_ptr(),
-                                (*yyvsp.offset(-1_isize)).Node,
-                                -(99 as c_int),
+                                ((*yyvsp.offset(-3)).astr).as_mut_ptr(),
+                                (*yyvsp.offset(-1)).Node,
+                                -99,
                                 b"*START*\0" as *const u8 as *const c_char as *mut c_char,
                                 b"*STOP*\0" as *const u8 as *const c_char as *mut c_char,
                             );
@@ -7220,11 +6576,11 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                             yyval.Node = New_GTI(
                                 lParse,
                                 gtifind_fct,
-                                ((*yyvsp.offset(-(7 as c_int) as isize)).astr).as_mut_ptr(),
+                                ((*yyvsp.offset(-7)).astr).as_mut_ptr(),
                                 (*yyvsp.offset(-(5))).Node,
-                                -(99 as c_int),
-                                ((*yyvsp.offset(-3_isize)).astr).as_mut_ptr(),
-                                ((*yyvsp.offset(-1_isize)).astr).as_mut_ptr(),
+                                -99,
+                                ((*yyvsp.offset(-3)).astr).as_mut_ptr(),
+                                ((*yyvsp.offset(-1)).astr).as_mut_ptr(),
                             );
                             if yyval.Node < 0 {
                                 current_block = 4830776507462815627;
@@ -7233,12 +6589,13 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                             }
                         }
                         117 => {
+                            let mut dummy = [0];
                             yyval.Node = New_REG(
                                 lParse,
-                                ((*yyvsp.offset(-1_isize)).astr).as_mut_ptr(),
-                                -(99 as c_int),
-                                -(99 as c_int),
-                                b"\0" as *const u8 as *const c_char as *mut c_char,
+                                ((*yyvsp.offset(-1)).astr).as_mut_ptr(),
+                                -99,
+                                -99,
+                                dummy.as_mut_ptr(),
                             );
                             if yyval.Node < 0 {
                                 current_block = 4830776507462815627;
@@ -7247,12 +6604,13 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                             }
                         }
                         118 => {
+                            let mut dummy = [0];
                             yyval.Node = New_REG(
                                 lParse,
                                 ((*yyvsp.offset(-(5))).astr).as_mut_ptr(),
-                                (*yyvsp.offset(-3_isize)).Node,
-                                (*yyvsp.offset(-1_isize)).Node,
-                                b"\0" as *const u8 as *const c_char as *mut c_char,
+                                (*yyvsp.offset(-3)).Node,
+                                (*yyvsp.offset(-1)).Node,
+                                dummy.as_mut_ptr(),
                             );
                             if yyval.Node < 0 {
                                 current_block = 4830776507462815627;
@@ -7263,10 +6621,10 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                         119 => {
                             yyval.Node = New_REG(
                                 lParse,
-                                ((*yyvsp.offset(-(7 as c_int) as isize)).astr).as_mut_ptr(),
+                                ((*yyvsp.offset(-7)).astr).as_mut_ptr(),
                                 (*yyvsp.offset(-(5))).Node,
-                                (*yyvsp.offset(-3_isize)).Node,
-                                ((*yyvsp.offset(-1_isize)).astr).as_mut_ptr(),
+                                (*yyvsp.offset(-3)).Node,
+                                ((*yyvsp.offset(-1)).astr).as_mut_ptr(),
                             );
                             if yyval.Node < 0 {
                                 current_block = 4830776507462815627;
@@ -7277,9 +6635,9 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                         120 => {
                             yyval.Node = New_Deref(
                                 lParse,
-                                (*yyvsp.offset(-3_isize)).Node,
+                                (*yyvsp.offset(-3)).Node,
                                 1,
-                                (*yyvsp.offset(-1_isize)).Node,
+                                (*yyvsp.offset(-1)).Node,
                                 0,
                                 0,
                                 0,
@@ -7296,8 +6654,8 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                 lParse,
                                 (*yyvsp.offset(-(5))).Node,
                                 2 as c_int,
-                                (*yyvsp.offset(-3_isize)).Node,
-                                (*yyvsp.offset(-1_isize)).Node,
+                                (*yyvsp.offset(-3)).Node,
+                                (*yyvsp.offset(-1)).Node,
                                 0,
                                 0,
                                 0,
@@ -7311,11 +6669,11 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                         122 => {
                             yyval.Node = New_Deref(
                                 lParse,
-                                (*yyvsp.offset(-(7 as c_int) as isize)).Node,
+                                (*yyvsp.offset(-7)).Node,
                                 3 as c_int,
                                 (*yyvsp.offset(-(5))).Node,
-                                (*yyvsp.offset(-3_isize)).Node,
-                                (*yyvsp.offset(-1_isize)).Node,
+                                (*yyvsp.offset(-3)).Node,
+                                (*yyvsp.offset(-1)).Node,
                                 0,
                                 0,
                             );
@@ -7328,12 +6686,12 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                         123 => {
                             yyval.Node = New_Deref(
                                 lParse,
-                                (*yyvsp.offset(-(9 as c_int) as isize)).Node,
+                                (*yyvsp.offset(-9)).Node,
                                 4 as c_int,
-                                (*yyvsp.offset(-(7 as c_int) as isize)).Node,
+                                (*yyvsp.offset(-7)).Node,
                                 (*yyvsp.offset(-(5))).Node,
-                                (*yyvsp.offset(-3_isize)).Node,
-                                (*yyvsp.offset(-1_isize)).Node,
+                                (*yyvsp.offset(-3)).Node,
+                                (*yyvsp.offset(-1)).Node,
                                 0,
                             );
                             if yyval.Node < 0 {
@@ -7345,13 +6703,13 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                         124 => {
                             yyval.Node = New_Deref(
                                 lParse,
-                                (*yyvsp.offset(-(11 as c_int) as isize)).Node,
+                                (*yyvsp.offset(-11)).Node,
                                 5 as c_int,
-                                (*yyvsp.offset(-(9 as c_int) as isize)).Node,
-                                (*yyvsp.offset(-(7 as c_int) as isize)).Node,
+                                (*yyvsp.offset(-9)).Node,
+                                (*yyvsp.offset(-7)).Node,
                                 (*yyvsp.offset(-(5))).Node,
-                                (*yyvsp.offset(-3_isize)).Node,
-                                (*yyvsp.offset(-1_isize)).Node,
+                                (*yyvsp.offset(-3)).Node,
+                                (*yyvsp.offset(-1)).Node,
                             );
                             if yyval.Node < 0 {
                                 current_block = 4830776507462815627;
@@ -7373,7 +6731,7 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                             }
                         }
                         126 => {
-                            yyval.Node = (*yyvsp.offset(-1_isize)).Node;
+                            yyval.Node = (*yyvsp.offset(-1)).Node;
                             current_block = 17353983478346836848;
                         }
                         127 => {
@@ -7388,7 +6746,7 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                             if yyval.Node < 0 {
                                 current_block = 4830776507462815627;
                             } else {
-                                ((*((*lParse).Nodes).offset(yyval.Node as isize)).value).nelem =
+                                (((lParse.Nodes)[yyval.Node as usize]).value).nelem =
                                     strlen(((*yyvsp.offset(0)).astr).as_mut_ptr()) as c_long;
                                 current_block = 17353983478346836848;
                             }
@@ -7402,27 +6760,22 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                             }
                         }
                         129 => {
-                            if (*((*lParse).Nodes).offset((*yyvsp.offset(-1_isize)).Node as isize))
-                                .ntype
+                            if ((lParse.Nodes)[(*yyvsp.offset(-1)).Node as usize]).ntype
                                 != fits_parser_yytokentype::LONG as c_int
-                                || (*((*lParse).Nodes)
-                                    .offset((*yyvsp.offset(-1_isize)).Node as isize))
-                                .operation
-                                    != -(1000 as c_int)
+                                || ((lParse.Nodes)[(*yyvsp.offset(-1)).Node as usize]).operation
+                                    != -1000
                             {
                                 fits_parser_yyerror(
                                     scanner,
                                     lParse,
-                                    b"Offset argument must be a constant integer\0" as *const u8
-                                        as *const c_char
-                                        as *mut c_char,
+                                    cs!(c"Offset argument must be a constant integer"),
                                 );
                                 current_block = 4830776507462815627;
                             } else {
                                 yyval.Node = New_Offset(
                                     lParse,
-                                    (*yyvsp.offset(-3_isize)).lng as c_int,
-                                    (*yyvsp.offset(-1_isize)).Node,
+                                    (*yyvsp.offset(-3)).lng as c_int,
+                                    (*yyvsp.offset(-1)).Node,
                                 );
                                 if yyval.Node < 0 {
                                     current_block = 4830776507462815627;
@@ -7448,53 +6801,47 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                             current_block = 17353983478346836848;
                         }
                         131 => {
-                            yyval.Node = (*yyvsp.offset(-1_isize)).Node;
+                            yyval.Node = (*yyvsp.offset(-1)).Node;
                             current_block = 17353983478346836848;
                         }
                         132 => {
-                            if (*((*lParse).Nodes).offset((*yyvsp.offset(-2_isize)).Node as isize))
+                            if (lParse.Nodes[(*yyvsp.offset(-2)).Node as usize])
                                 .value
                                 .nelem
-                                + (*((*lParse).Nodes).offset((*yyvsp.offset(0)).Node as isize))
-                                    .value
-                                    .nelem
+                                + (lParse.Nodes[(*yyvsp.offset(0)).Node as usize]).value.nelem
                                 >= 256 as c_long
                             {
                                 fits_parser_yyerror(
                                     scanner,
                                     lParse,
-                                    b"Combined string size exceeds 255 characters\0" as *const u8
-                                        as *const c_char
-                                        as *mut c_char,
+                                    cs!(c"Combined string size exceeds 255 characters"),
                                 );
                                 current_block = 4830776507462815627;
                             } else {
                                 yyval.Node = New_BinOp(
                                     lParse,
                                     fits_parser_yytokentype::STRING as c_int,
-                                    (*yyvsp.offset(-2_isize)).Node,
+                                    (*yyvsp.offset(-2)).Node,
                                     '+' as i32,
                                     (*yyvsp.offset(0)).Node,
                                 );
                                 if yyval.Node < 0 {
                                     current_block = 4830776507462815627;
                                 } else {
-                                    ((*((*lParse).Nodes).offset(yyval.Node as isize)).value)
-                                        .nelem = (*((*lParse).Nodes)
-                                        .offset((*yyvsp.offset(-2_isize)).Node as isize))
-                                    .value
-                                    .nelem
-                                        + (*((*lParse).Nodes)
-                                            .offset((*yyvsp.offset(0)).Node as isize))
-                                        .value
-                                        .nelem;
+                                    (((lParse.Nodes)[yyval.Node as usize]).value).nelem =
+                                        ((lParse.Nodes)[(*yyvsp.offset(-2)).Node as usize])
+                                            .value
+                                            .nelem
+                                            + ((lParse.Nodes)[(*yyvsp.offset(0)).Node as usize])
+                                                .value
+                                                .nelem;
                                     current_block = 17353983478346836848;
                                 }
                             }
                         }
                         133 => {
                             let mut outSize: c_int = 0;
-                            if (*((*lParse).Nodes).offset((*yyvsp.offset(-4_isize)).Node as isize))
+                            if ((lParse.Nodes)[(*yyvsp.offset(-4)).Node as usize])
                                 .value
                                 .nelem
                                 != 1
@@ -7502,34 +6849,29 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                 fits_parser_yyerror(
                                     scanner,
                                     lParse,
-                                    b"Cannot have a vector string column\0" as *const u8
-                                        as *const c_char
-                                        as *mut c_char,
+                                    cs!(c"Cannot have a vector string column"),
                                 );
                                 current_block = 4830776507462815627;
                             } else {
-                                outSize = ((*((*lParse).Nodes)
-                                    .offset((*yyvsp.offset(-2_isize)).Node as isize))
-                                .value)
+                                outSize = (((lParse.Nodes)[(*yyvsp.offset(-2)).Node as usize])
+                                    .value)
                                     .nelem as c_int;
-                                if (*((*lParse).Nodes).offset((*yyvsp.offset(0)).Node as isize))
-                                    .value
-                                    .nelem
+                                if (lParse.Nodes[(*yyvsp.offset(0)).Node as usize]).value.nelem
                                     > outSize as c_long
                                 {
-                                    outSize = (*((*lParse).Nodes)
-                                        .offset((*yyvsp.offset(0)).Node as isize))
-                                    .value
-                                    .nelem as c_int;
+                                    outSize = ((lParse.Nodes)[(*yyvsp.offset(0)).Node as usize])
+                                        .value
+                                        .nelem
+                                        as c_int;
                                 }
                                 yyval.Node = New_FuncSize(
                                     lParse,
                                     0,
                                     ifthenelse_fct,
                                     3 as c_int,
-                                    (*yyvsp.offset(-2_isize)).Node,
+                                    (*yyvsp.offset(-2)).Node,
                                     (*yyvsp.offset(0)).Node,
-                                    (*yyvsp.offset(-4_isize)).Node,
+                                    (*yyvsp.offset(-4)).Node,
                                     0,
                                     0,
                                     0,
@@ -7539,14 +6881,12 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                 if yyval.Node < 0 {
                                     current_block = 4830776507462815627;
                                 } else {
-                                    if (*((*lParse).Nodes)
-                                        .offset((*yyvsp.offset(-2_isize)).Node as isize))
-                                    .value
-                                    .nelem
-                                        < (*((*lParse).Nodes)
-                                            .offset((*yyvsp.offset(0)).Node as isize))
+                                    if ((lParse.Nodes)[(*yyvsp.offset(-2)).Node as usize])
                                         .value
                                         .nelem
+                                        < (lParse.Nodes[(*yyvsp.offset(0)).Node as usize])
+                                            .value
+                                            .nelem
                                     {
                                         Copy_Dims(lParse, yyval.Node, (*yyvsp.offset(0)).Node);
                                     }
@@ -7555,46 +6895,44 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                             }
                         }
                         134 => {
-                            if (if ((*yyvsp.offset(-4_isize)).astr[0] as c_int)
+                            if (if ((*yyvsp.offset(-4)).astr[0] as c_int)
                                 < (*::core::mem::transmute::<&[u8; 9], &[c_char; 9]>(b"DEFNULL(\0"))
                                     [0] as c_int
                             {
                                 -(1)
-                            } else if (*yyvsp.offset(-4_isize)).astr[0] as c_int
+                            } else if (*yyvsp.offset(-4)).astr[0] as c_int
                                 > (*::core::mem::transmute::<&[u8; 9], &[c_char; 9]>(b"DEFNULL(\0"))
                                     [0] as c_int
                             {
                                 1
                             } else {
                                 strcmp(
-                                    ((*yyvsp.offset(-4_isize)).astr).as_mut_ptr(),
+                                    ((*yyvsp.offset(-4)).astr).as_mut_ptr(),
                                     b"DEFNULL(\0" as *const u8 as *const c_char,
                                 )
                             }) == 0
                             {
                                 let mut outSize_0: c_int = 0;
-                                outSize_0 = (*((*lParse).Nodes)
-                                    .offset((*yyvsp.offset(-3_isize)).Node as isize))
-                                .value
-                                .nelem as c_int;
-                                if (*((*lParse).Nodes)
-                                    .offset((*yyvsp.offset(-1_isize)).Node as isize))
-                                .value
-                                .nelem
-                                    > outSize_0 as c_long
-                                {
-                                    outSize_0 = (*((*lParse).Nodes)
-                                        .offset((*yyvsp.offset(-1_isize)).Node as isize))
+                                outSize_0 = ((lParse.Nodes)[(*yyvsp.offset(-3)).Node as usize])
                                     .value
                                     .nelem as c_int;
+                                if ((lParse.Nodes)[(*yyvsp.offset(-1)).Node as usize])
+                                    .value
+                                    .nelem
+                                    > outSize_0 as c_long
+                                {
+                                    outSize_0 = ((lParse.Nodes)[(*yyvsp.offset(-1)).Node as usize])
+                                        .value
+                                        .nelem
+                                        as c_int;
                                 }
                                 yyval.Node = New_FuncSize(
                                     lParse,
                                     0,
                                     defnull_fct,
                                     2 as c_int,
-                                    (*yyvsp.offset(-3_isize)).Node,
-                                    (*yyvsp.offset(-1_isize)).Node,
+                                    (*yyvsp.offset(-3)).Node,
+                                    (*yyvsp.offset(-1)).Node,
                                     0,
                                     0,
                                     0,
@@ -7605,20 +6943,17 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                 if yyval.Node < 0 {
                                     current_block = 4830776507462815627;
                                 } else {
-                                    if (*((*lParse).Nodes)
-                                        .offset((*yyvsp.offset(-1_isize)).Node as isize))
-                                    .value
-                                    .nelem
-                                        > (*((*lParse).Nodes)
-                                            .offset((*yyvsp.offset(-3_isize)).Node as isize))
+                                    if ((lParse.Nodes)[(*yyvsp.offset(-1)).Node as usize])
                                         .value
                                         .nelem
+                                        > ((lParse.Nodes)[(*yyvsp.offset(-3)).Node as usize])
+                                            .value
+                                            .nelem
                                     {
-                                        ((*((*lParse).Nodes).offset(yyval.Node as isize)).value)
-                                            .nelem = (*((*lParse).Nodes)
-                                            .offset((*yyvsp.offset(-1_isize)).Node as isize))
-                                        .value
-                                        .nelem;
+                                        (((lParse.Nodes)[yyval.Node as usize]).value).nelem =
+                                            ((lParse.Nodes)[(*yyvsp.offset(-1)).Node as usize])
+                                                .value
+                                                .nelem;
                                     }
                                     current_block = 17353983478346836848;
                                 }
@@ -7626,84 +6961,69 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                 fits_parser_yyerror(
                                     scanner,
                                     lParse,
-                                    b"Function(string,string) not supported\0" as *const u8
-                                        as *const c_char
-                                        as *mut c_char,
+                                    cs!(c"Function(string,string) not supported"),
                                 );
                                 current_block = 4830776507462815627;
                             }
                         }
                         135 => {
-                            if (if ((*yyvsp.offset(-(6 as c_int) as isize)).astr[0] as c_int)
+                            if (if ((*yyvsp.offset(-6)).astr[0] as c_int)
                                 < (*::core::mem::transmute::<&[u8; 8], &[c_char; 8]>(b"STRMID(\0"))
                                     [0] as c_int
                             {
                                 -(1)
-                            } else if (*yyvsp.offset(-(6 as c_int) as isize)).astr[0] as c_int
+                            } else if (*yyvsp.offset(-6)).astr[0] as c_int
                                 > (*::core::mem::transmute::<&[u8; 8], &[c_char; 8]>(b"STRMID(\0"))
                                     [0] as c_int
                             {
                                 1
                             } else {
                                 strcmp(
-                                    ((*yyvsp.offset(-(6 as c_int) as isize)).astr).as_mut_ptr(),
+                                    ((*yyvsp.offset(-6)).astr).as_mut_ptr(),
                                     b"STRMID(\0" as *const u8 as *const c_char,
                                 )
                             }) == 0
                             {
                                 let mut len: c_int = 0;
-                                if (*((*lParse).Nodes)
-                                    .offset((*yyvsp.offset(-3_isize)).Node as isize))
-                                .ntype
+                                if ((lParse.Nodes)[(*yyvsp.offset(-3)).Node as usize]).ntype
                                     != fits_parser_yytokentype::LONG as c_int
-                                    || (*((*lParse).Nodes)
-                                        .offset((*yyvsp.offset(-3_isize)).Node as isize))
-                                    .value
-                                    .nelem
+                                    || ((lParse.Nodes)[(*yyvsp.offset(-3)).Node as usize])
+                                        .value
+                                        .nelem
                                         != 1
-                                    || (*((*lParse).Nodes)
-                                        .offset((*yyvsp.offset(-1_isize)).Node as isize))
-                                    .ntype
+                                    || ((lParse.Nodes)[(*yyvsp.offset(-1)).Node as usize]).ntype
                                         != fits_parser_yytokentype::LONG as c_int
-                                    || (*((*lParse).Nodes)
-                                        .offset((*yyvsp.offset(-1_isize)).Node as isize))
-                                    .value
-                                    .nelem
+                                    || ((lParse.Nodes)[(*yyvsp.offset(-1)).Node as usize])
+                                        .value
+                                        .nelem
                                         != 1
                                 {
                                     fits_parser_yyerror(
-                                    scanner,
-                                    lParse,
-                                    b"When using STRMID(S,P,N), P and N must be integers (and not vector columns)\0"
-                                        as *const u8 as *const c_char
-                                        as *mut c_char,
-                                );
+                                        scanner,
+                                        lParse,
+                                        cs!(c"When using STRMID(S,P,N), P and N must be integers (and not vector columns)"),
+                                    );
                                     current_block = 4830776507462815627;
                                 } else {
-                                    if (*((*lParse).Nodes)
-                                        .offset((*yyvsp.offset(-1_isize)).Node as isize))
-                                    .operation
-                                        == -(1000 as c_int)
+                                    if ((lParse.Nodes)[(*yyvsp.offset(-1)).Node as usize]).operation
+                                        == -1000
                                     {
-                                        len = (*((*lParse).Nodes)
-                                            .offset((*yyvsp.offset(-1_isize)).Node as isize))
-                                        .value
-                                        .data
-                                        .lng as c_int;
+                                        len = ((lParse.Nodes)[(*yyvsp.offset(-1)).Node as usize])
+                                            .value
+                                            .data
+                                            .lng
+                                            as c_int;
                                     } else {
-                                        len = (*((*lParse).Nodes)
-                                            .offset((*yyvsp.offset(-(5))).Node as isize))
-                                        .value
-                                        .nelem
+                                        len = ((lParse.Nodes)[(*yyvsp.offset(-(5))).Node as usize])
+                                            .value
+                                            .nelem
                                             as c_int;
                                     }
                                     if len <= 0 || len >= 256 as c_int {
                                         fits_parser_yyerror(
                                             scanner,
                                             lParse,
-                                            b"STRMID(S,P,N), N must be 1-255\0" as *const u8
-                                                as *const c_char
-                                                as *mut c_char,
+                                            cs!(c"STRMID(S,P,N), N must be 1-255"),
                                         );
                                         current_block = 4830776507462815627;
                                     } else {
@@ -7713,8 +7033,8 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                             strmid_fct,
                                             3 as c_int,
                                             (*yyvsp.offset(-(5))).Node,
-                                            (*yyvsp.offset(-3_isize)).Node,
-                                            (*yyvsp.offset(-1_isize)).Node,
+                                            (*yyvsp.offset(-3)).Node,
+                                            (*yyvsp.offset(-1)).Node,
                                             0,
                                             0,
                                             0,
@@ -7732,9 +7052,7 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
                                 fits_parser_yyerror(
                                     scanner,
                                     lParse,
-                                    b"Function(string,expr,expr) not supported\0" as *const u8
-                                        as *const c_char
-                                        as *mut c_char,
+                                    cs!(c"Function(string,expr,expr) not supported"),
                                 );
                                 current_block = 4830776507462815627;
                             }
@@ -7814,11 +7132,7 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
         }
         match current_block {
             11794367917084412820 => {
-                fits_parser_yyerror(
-                    scanner,
-                    lParse,
-                    b"memory exhausted\0" as *const u8 as *const c_char as *mut c_char,
-                );
+                fits_parser_yyerror(scanner, lParse, cs!(c"memory exhausted"));
                 yyresult = 2 as c_int;
             }
             3964311021479492664 => {
@@ -7860,7 +7174,7 @@ pub unsafe fn fits_parser_yyparse(mut scanner: yyscan_t, mut lParse: *mut ParseD
     }
 }
 unsafe fn New_Deref(
-    mut lParse: *mut ParseData,
+    lParse: &mut ParseData,
     mut Var: c_int,
     mut nDim: c_int,
     mut Dim1: c_int,
@@ -7880,36 +7194,31 @@ unsafe fn New_Deref(
         if Var < 0 || Dim1 < 0 || Dim2 < 0 || Dim3 < 0 || Dim4 < 0 || Dim5 < 0 {
             return -(1);
         }
-        theVar = ((*lParse).Nodes).offset(Var as isize);
-        if (*theVar).operation == -(1000 as c_int) || (*theVar).value.nelem == 1 {
-            fits_parser_yyerror(
-                0 as yyscan_t,
-                lParse,
-                b"Cannot index a scalar value\0" as *const u8 as *const c_char as *mut c_char,
-            );
+        theVar = &mut (lParse.Nodes)[Var as usize];
+        if (*theVar).operation == -1000 || (*theVar).value.nelem == 1 {
+            fits_parser_yyerror(ptr::null_mut(), lParse, cs!(c"Cannot index a scalar value"));
             return -(1);
         }
         n = Alloc_Node(lParse);
         if n >= 0 {
-            this = ((*lParse).Nodes).offset(n as isize);
+            this = &mut (lParse.Nodes)[n as usize];
             (*this).nSubNodes = nDim + 1;
             (*this).SubNodes[0] = Var;
-            theVar = ((*lParse).Nodes).offset((*this).SubNodes[0] as isize);
+            theVar = &mut (lParse.Nodes)[(*this).SubNodes[0] as usize];
             (*this).SubNodes[1] = Dim1;
-            theDim[0] = ((*lParse).Nodes).offset((*this).SubNodes[1] as isize);
+            theDim[0] = &mut (lParse.Nodes)[(*this).SubNodes[1] as usize];
             (*this).SubNodes[2] = Dim2;
-            theDim[1] = ((*lParse).Nodes).offset((*this).SubNodes[2] as isize);
+            theDim[1] = &mut (lParse.Nodes)[(*this).SubNodes[2] as usize];
             (*this).SubNodes[3] = Dim3;
-            theDim[2] = ((*lParse).Nodes).offset((*this).SubNodes[3] as isize);
+            theDim[2] = &mut (lParse.Nodes)[(*this).SubNodes[3] as usize];
             (*this).SubNodes[4] = Dim4;
-            theDim[3] = ((*lParse).Nodes).offset((*this).SubNodes[4] as isize);
+            theDim[3] = &mut (lParse.Nodes)[(*this).SubNodes[4] as usize];
             (*this).SubNodes[5] = Dim5;
-            theDim[4] = ((*lParse).Nodes).offset((*this).SubNodes[5] as isize);
-            constant = ((*theVar).operation == -(1000 as c_int)) as c_int;
+            theDim[4] = &mut (lParse.Nodes)[(*this).SubNodes[5] as usize];
+            constant = ((*theVar).operation == -1000) as c_int;
             idx = 0;
             while idx < nDim {
-                constant = (constant != 0 && (*theDim[idx as usize]).operation == -(1000 as c_int))
-                    as c_int;
+                constant = (constant != 0 && (*theDim[idx as usize]).operation == -1000) as c_int;
                 idx += 1;
                 idx;
             }
@@ -7918,19 +7227,17 @@ unsafe fn New_Deref(
                 if (*theDim[idx as usize]).value.nelem > 1 {
                     Free_Last_Node(lParse);
                     fits_parser_yyerror(
-                        0 as yyscan_t,
+                        ptr::null_mut(),
                         lParse,
-                        b"Cannot use an array as an index value\0" as *const u8 as *const c_char
-                            as *mut c_char,
+                        cs!(c"Cannot use an array as an index value"),
                     );
                     return -(1);
                 } else if (*theDim[idx as usize]).ntype != fits_parser_yytokentype::LONG as c_int {
                     Free_Last_Node(lParse);
                     fits_parser_yyerror(
-                        0 as yyscan_t,
+                        ptr::null_mut(),
                         lParse,
-                        b"Index value must be an integer type\0" as *const u8 as *const c_char
-                            as *mut c_char,
+                        cs!(c"Index value must be an integer type"),
                     );
                     return -(1);
                 }
@@ -7958,10 +7265,9 @@ unsafe fn New_Deref(
             } else {
                 Free_Last_Node(lParse);
                 fits_parser_yyerror(
-                    0 as yyscan_t,
+                    ptr::null_mut(),
                     lParse,
-                    b"Must specify just one or all indices for vector\0" as *const u8
-                        as *const c_char as *mut c_char,
+                    cs!(c"Must specify just one or all indices for vector"),
                 );
                 return -(1);
             }
@@ -7972,14 +7278,15 @@ unsafe fn New_Deref(
         n
     }
 }
+
 unsafe fn New_GTI(
-    mut lParse: *mut ParseData,
+    lParse: &mut ParseData,
     mut Op: funcOp,
     mut fname: *mut c_char,
     mut Node1: c_int,
     mut Node2: c_int,
-    mut start: *mut c_char,
-    mut stop: *mut c_char,
+    start: *mut c_char,
+    stop: *mut c_char,
 ) -> c_int {
     unsafe {
         let mut fptr: *mut fitsfile = std::ptr::null_mut();
@@ -8004,39 +7311,33 @@ unsafe fn New_GTI(
         let mut nrows: c_long = 0;
         let mut timeZeroI: [c_double; 2] = [0.; 2];
         let mut timeZeroF: [c_double; 2] = [0.; 2];
-        let mut dt: c_double = 0.;
-        let mut timeSpan: c_double = 0.;
+        let mut dt: c_double = 0.0;
+        let mut timeSpan: c_double = 0.0;
         let mut xcol: [c_char; 20] = [0; 20];
         let mut xexpr: [c_char; 20] = [0; 20];
         let mut colVal: FITS_PARSER_YYSTYPE = FITS_PARSER_YYSTYPE { Node: 0 };
         if (Op as c_uint == gtifilt_fct as c_int as c_uint
             || Op as c_uint == gtifind_fct as c_int as c_uint)
-            && Node1 == -(99 as c_int)
+            && Node1 == -99
         {
-            type_0 = fits_parser_yyGetVariable(
-                lParse,
-                b"TIME\0" as *const u8 as *const c_char as *mut c_char,
-                &mut colVal,
-            );
+            type_0 = fits_parser_yyGetVariable(lParse, cs!(c"TIME"), &mut colVal);
             if type_0 == fits_parser_yytokentype::COLUMN as c_int {
                 Node1 = New_Column(lParse, colVal.lng as c_int);
             } else {
                 fits_parser_yyerror(
-                    0 as yyscan_t,
+                    ptr::null_mut(),
                     lParse,
-                    b"Could not build TIME column for GTIFILTER/GTIFIND\0" as *const u8
-                        as *const c_char as *mut c_char,
+                    cs!(c"Could not build TIME column for GTIFILTER/GTIFIND"),
                 );
                 return -(1);
             }
         }
         if Op as c_uint == gtiover_fct as c_int as c_uint {
-            if Node1 == -(99 as c_int) || Node2 == -(99 as c_int) {
+            if Node1 == -99 || Node2 == -99 {
                 fits_parser_yyerror(
-                    0 as yyscan_t,
+                    ptr::null_mut(),
                     lParse,
-                    b"startExpr and stopExpr values must be defined for GTIOVERLAP\0" as *const u8
-                        as *const c_char as *mut c_char,
+                    cs!(c"startExpr and stopExpr values must be defined for GTIOVERLAP"),
                 );
                 return -(1);
             }
@@ -8050,7 +7351,7 @@ unsafe fn New_GTI(
         if Node1 < 0 || Node0 < 0 {
             return -(1);
         }
-        fptr = (*lParse).def_fptr;
+        fptr = lParse.def_fptr;
         ffghdn(fptr, &mut evthdu);
         tstat = 0;
         if ffgkyd(
@@ -8111,7 +7412,7 @@ unsafe fn New_GTI(
                         &mut movetotype,
                         xcol.as_mut_ptr(),
                         xexpr.as_mut_ptr(),
-                        &mut (*lParse).status,
+                        &mut lParse.status,
                     );
                     if *extname.as_mut_ptr() != 0 {
                         ffmnhd(
@@ -8119,27 +7420,25 @@ unsafe fn New_GTI(
                             movetotype,
                             extname.as_mut_ptr(),
                             extvers,
-                            &mut (*lParse).status,
+                            &mut lParse.status,
                         );
                         ffghdn(fptr, &mut hdunum);
                     } else if hdunum != 0 {
                         hdunum += 1;
-                        ffmahd(fptr, hdunum, &mut hdutype, &mut (*lParse).status);
-                    } else if (*lParse).status == 0 {
+                        ffmahd(fptr, hdunum, &mut hdutype, &mut lParse.status);
+                    } else if lParse.status == 0 {
                         fits_parser_yyerror(
-                            0 as yyscan_t,
+                            ptr::null_mut(),
                             lParse,
-                            b"Cannot use primary array for GTI filter\0" as *const u8
-                                as *const c_char as *mut c_char,
+                            cs!(c"Cannot use primary array for GTI filter"),
                         );
                         return -(1);
                     }
                 } else {
                     fits_parser_yyerror(
-                        0 as yyscan_t,
+                        ptr::null_mut(),
                         lParse,
-                        b"File extension specifier lacks closing ']'\0" as *const u8
-                            as *const c_char as *mut c_char,
+                        cs!(c"File extension specifier lacks closing ']'"),
                     );
                     return -(1);
                 }
@@ -8149,13 +7448,12 @@ unsafe fn New_GTI(
                 hdunum =
                     atoi(std::ffi::CStr::from_ptr(fname).to_str().unwrap_or("0")).unwrap_or(0) + 1;
                 if hdunum > 1 {
-                    ffmahd(fptr, hdunum, &mut hdutype, &mut (*lParse).status);
+                    ffmahd(fptr, hdunum, &mut hdutype, &mut lParse.status);
                 } else {
                     fits_parser_yyerror(
-                        0 as yyscan_t,
+                        ptr::null_mut(),
                         lParse,
-                        b"Cannot use primary array for GTI filter / GTIFIND\0" as *const u8
-                            as *const c_char as *mut c_char,
+                        cs!(c"Cannot use primary array for GTI filter / GTIFIND"),
                     );
                     return -(1);
                 }
@@ -8164,19 +7462,19 @@ unsafe fn New_GTI(
                 samefile = 0;
                 let mut fptr_tmp: *mut Option<Box<fitsfile>> =
                     &mut None as *mut Option<Box<fitsfile>>;
-                if ffopen(fptr_tmp, fname, 0, &mut (*lParse).status) == 0 {
+                if ffopen(fptr_tmp, fname, 0, &mut lParse.status) == 0 {
                     ffghdn(fptr, &mut hdunum);
                 }
             }
         }
-        if (*lParse).status != 0 {
+        if lParse.status != 0 {
             return -(1);
         }
         if hdunum == 1 {
             loop {
                 hdunum += 1;
                 hdunum;
-                if ffmahd(fptr, hdunum, &mut hdutype, &mut (*lParse).status) != 0 {
+                if ffmahd(fptr, hdunum, &mut hdutype, &mut lParse.status) != 0 {
                     break;
                 }
                 if hdutype == 0 {
@@ -8199,21 +7497,20 @@ unsafe fn New_GTI(
                     break;
                 }
             }
-            if (*lParse).status != 0 {
-                if (*lParse).status == 107 as c_int {
+            if lParse.status != 0 {
+                if lParse.status == 107 as c_int {
                     fits_parser_yyerror(
-                        0 as yyscan_t,
+                        ptr::null_mut(),
                         lParse,
-                        b"GTI extension not found in this file\0" as *const u8 as *const c_char
-                            as *mut c_char,
+                        cs!(c"GTI extension not found in this file"),
                     );
                 }
                 return -(1);
             }
         }
-        ffgcno(fptr, 0, start, &mut startCol, &mut (*lParse).status);
-        ffgcno(fptr, 0, stop, &mut stopCol, &mut (*lParse).status);
-        if (*lParse).status != 0 {
+        ffgcno(fptr, 0, start, &mut startCol, &mut lParse.status);
+        ffgcno(fptr, 0, stop, &mut stopCol, &mut lParse.status);
+        if lParse.status != 0 {
             return -(1);
         }
         tstat = 0;
@@ -8251,7 +7548,7 @@ unsafe fn New_GTI(
         }
         n = Alloc_Node(lParse);
         if n >= 0 {
-            this = ((*lParse).Nodes).offset(n as isize);
+            this = &mut (lParse.Nodes)[n as usize];
             (*this).SubNodes[1] = Node1;
             (*this).operation = Op as c_int;
             if Op as c_uint == gtifilt_fct as c_int as c_uint {
@@ -8267,7 +7564,7 @@ unsafe fn New_GTI(
                 (*this).DoOp = Some(Do_GTI_Over);
                 (*this).ntype = fits_parser_yytokentype::DOUBLE as c_int;
             }
-            that1 = ((*lParse).Nodes).offset(Node1 as isize);
+            that1 = &mut (lParse.Nodes)[Node1 as usize];
             (*this).value.nelem = (*that1).value.nelem;
             (*this).value.naxis = (*that1).value.naxis;
             i = 0;
@@ -8278,20 +7575,19 @@ unsafe fn New_GTI(
             }
             if Op as c_uint == gtiover_fct as c_int as c_uint {
                 (*this).SubNodes[2] = Node2;
-                that2 = ((*lParse).Nodes).offset(Node2 as isize);
+                that2 = &mut (lParse.Nodes)[Node2 as usize];
                 if (*that1).value.nelem != (*that2).value.nelem {
                     fits_parser_yyerror(
-                        0 as yyscan_t,
+                        ptr::null_mut(),
                         lParse,
-                        b"Dimensions of TIME and TIME_STOP must match for GTIOVERLAP\0" as *const u8
-                            as *const c_char as *mut c_char,
+                        cs!(c"Dimensions of TIME and TIME_STOP must match for GTIOVERLAP"),
                     );
                     return -(1);
                 }
             }
             (*this).SubNodes[0] = Node0;
-            that0 = ((*lParse).Nodes).offset(Node0 as isize);
-            (*that0).operation = -(1000 as c_int);
+            that0 = &mut (lParse.Nodes)[Node0 as usize];
+            (*that0).operation = -1000;
             (*that0).DoOp = None;
             (*that0).value.data.ptr = std::ptr::null_mut::<c_void>();
             if ffgkyj(
@@ -8299,7 +7595,7 @@ unsafe fn New_GTI(
                 b"NAXIS2\0" as *const u8 as *const c_char,
                 &mut nrows,
                 std::ptr::null_mut::<c_char>(),
-                &mut (*lParse).status,
+                &mut lParse.status,
             ) != 0
             {
                 return -(1);
@@ -8315,7 +7611,7 @@ unsafe fn New_GTI(
                         .unwrap(),
                 ) as *mut c_double;
                 if ((*that0).value.data.dblptr).is_null() {
-                    (*lParse).status = 113 as c_int;
+                    lParse.status = 113 as c_int;
                     return -(1);
                 }
                 startptr = (*that0).value.data.dblptr;
@@ -8329,7 +7625,7 @@ unsafe fn New_GTI(
                     0.0f64,
                     startptr,
                     &mut i,
-                    &mut (*lParse).status,
+                    &mut lParse.status,
                 );
                 ffgcvd(
                     fptr,
@@ -8340,9 +7636,9 @@ unsafe fn New_GTI(
                     0.0f64,
                     stopptr,
                     &mut i,
-                    &mut (*lParse).status,
+                    &mut lParse.status,
                 );
-                if (*lParse).status != 0 {
+                if lParse.status != 0 {
                     free((*that0).value.data.dblptr as *mut c_void);
                     return -(1);
                 }
@@ -8369,7 +7665,7 @@ unsafe fn New_GTI(
                             as *const c_char,
                         i + 1,
                     );
-                    fits_parser_yyerror(0 as yyscan_t, lParse, errmsg.as_mut_ptr());
+                    fits_parser_yyerror(ptr::null_mut(), lParse, &errmsg);
                     return -(1);
                 }
                 dt = timeZeroI[1] - timeZeroI[0] + (timeZeroF[1] - timeZeroF[0]);
@@ -8387,25 +7683,25 @@ unsafe fn New_GTI(
                     }
                 }
             }
-            if (*((*lParse).Nodes).offset(Node1 as isize)).operation == -(1000 as c_int)
+            if ((lParse.Nodes)[Node1 as usize]).operation == -1000
                 && (Op as c_uint == gtifilt_fct as c_int as c_uint
-                    || (*((*lParse).Nodes).offset(Node2 as isize)).operation == -(1000 as c_int))
+                    || ((lParse.Nodes)[Node2 as usize]).operation == -1000)
             {
                 ((*this).DoOp).expect("non-null function pointer")(lParse, this);
             }
         }
         if samefile != 0 {
-            ffmahd(fptr, evthdu, &mut hdutype, &mut (*lParse).status);
+            ffmahd(fptr, evthdu, &mut hdutype, &mut lParse.status);
         } else {
-            ffclos(Some(Box::from_raw(fptr)), &mut (*lParse).status);
+            ffclos(Some(Box::from_raw(fptr)), &mut lParse.status);
         }
         n
     }
 }
 
 unsafe fn New_REG(
-    mut lParse: *mut ParseData,
-    mut fname: *mut c_char,
+    lParse: &mut ParseData,
+    fname: *mut c_char,
     mut NodeX: c_int,
     mut NodeY: c_int,
     mut colNames: *mut c_char,
@@ -8434,38 +7730,28 @@ unsafe fn New_REG(
         let mut cX: *mut c_char = ptr::null_mut();
         let mut cY: *mut c_char = ptr::null_mut();
         let mut colVal: FITS_PARSER_YYSTYPE = FITS_PARSER_YYSTYPE { Node: 0 };
-        if NodeX == -(99 as c_int) {
-            type_0 = fits_parser_yyGetVariable(
-                lParse,
-                b"X\0" as *const u8 as *const c_char as *mut c_char,
-                &mut colVal,
-            );
+        if NodeX == -99 {
+            type_0 = fits_parser_yyGetVariable(lParse, cs!(c"X"), &mut colVal);
             if type_0 == fits_parser_yytokentype::COLUMN as c_int {
                 NodeX = New_Column(lParse, colVal.lng as c_int);
             } else {
                 fits_parser_yyerror(
-                    0 as yyscan_t,
+                    ptr::null_mut(),
                     lParse,
-                    b"Could not build X column for REGFILTER\0" as *const u8 as *const c_char
-                        as *mut c_char,
+                    cs!(c"Could not build X column for REGFILTER"),
                 );
                 return -(1);
             }
         }
-        if NodeY == -(99 as c_int) {
-            type_0 = fits_parser_yyGetVariable(
-                lParse,
-                b"Y\0" as *const u8 as *const c_char as *mut c_char,
-                &mut colVal,
-            );
+        if NodeY == -99 {
+            type_0 = fits_parser_yyGetVariable(lParse, cs!(c"Y"), &mut colVal);
             if type_0 == fits_parser_yytokentype::COLUMN as c_int {
                 NodeY = New_Column(lParse, colVal.lng as c_int);
             } else {
                 fits_parser_yyerror(
-                    0 as yyscan_t,
+                    ptr::null_mut(),
                     lParse,
-                    b"Could not build Y column for REGFILTER\0" as *const u8 as *const c_char
-                        as *mut c_char,
+                    cs!(c"Could not build Y column for REGFILTER"),
                 );
                 return -(1);
             }
@@ -8478,16 +7764,15 @@ unsafe fn New_REG(
         }
         if Test_Dims(lParse, NodeX, NodeY) == 0 {
             fits_parser_yyerror(
-                0 as yyscan_t,
+                ptr::null_mut(),
                 lParse,
-                b"Dimensions of REGFILTER arguments are not compatible\0" as *const u8
-                    as *const c_char as *mut c_char,
+                cs!(c"Dimensions of REGFILTER arguments are not compatible"),
             );
             return -(1);
         }
         n = Alloc_Node(lParse);
         if n >= 0 {
-            this = ((*lParse).Nodes).offset(n as isize);
+            this = &mut (lParse.Nodes)[n as usize];
             (*this).nSubNodes = 3 as c_int;
             (*this).SubNodes[0] = Node0;
             (*this).SubNodes[1] = NodeX;
@@ -8499,13 +7784,13 @@ unsafe fn New_REG(
             (*this).value.naxis = 1;
             (*this).value.naxes[0] = 1;
             Copy_Dims(lParse, n, NodeX);
-            if ((*((*lParse).Nodes).offset(NodeX as isize)).value).nelem
-                < ((*((*lParse).Nodes).offset(NodeY as isize)).value).nelem
+            if (((lParse.Nodes)[NodeX as usize]).value).nelem
+                < (((lParse.Nodes)[NodeY as usize]).value).nelem
             {
                 Copy_Dims(lParse, n, NodeY);
             }
-            that0 = ((*lParse).Nodes).offset(Node0 as isize);
-            (*that0).operation = -(1000 as c_int);
+            that0 = &mut (lParse.Nodes)[Node0 as usize];
+            (*that0).operation = -1000;
             (*that0).DoOp = None;
             Ycol = 0;
             Xcol = Ycol;
@@ -8514,6 +7799,7 @@ unsafe fn New_REG(
                     colNames = colNames.offset(1);
                     colNames;
                 }
+
                 cY = colNames;
                 cX = cY;
                 while *cY as c_int != 0 && *cY as c_int != ' ' as i32 && *cY as c_int != ',' as i32
@@ -8532,35 +7818,32 @@ unsafe fn New_REG(
                 }
                 if *cY == 0 {
                     fits_parser_yyerror(
-                        0 as yyscan_t,
+                        ptr::null_mut(),
                         lParse,
-                        b"Could not extract valid pair of column names from REGFILTER\0"
-                            as *const u8 as *const c_char as *mut c_char,
+                        cs!(c"Could not extract valid pair of column names from REGFILTER"),
                     );
                     Free_Last_Node(lParse);
                     return -(1);
                 }
-                ffgcno((*lParse).def_fptr, 0, cX, &mut Xcol, &mut (*lParse).status);
-                ffgcno((*lParse).def_fptr, 0, cY, &mut Ycol, &mut (*lParse).status);
-                if (*lParse).status != 0 {
+                ffgcno(lParse.def_fptr, 0, cX, &mut Xcol, &mut lParse.status);
+                ffgcno(lParse.def_fptr, 0, cY, &mut Ycol, &mut lParse.status);
+                if lParse.status != 0 {
                     fits_parser_yyerror(
-                        0 as yyscan_t,
+                        ptr::null_mut(),
                         lParse,
-                        b"Could not locate columns indicated for WCS info\0" as *const u8
-                            as *const c_char as *mut c_char,
+                        cs!(c"Could not locate columns indicated for WCS info"),
                     );
                     Free_Last_Node(lParse);
                     return -(1);
                 }
             } else {
-                Xcol = Locate_Col(lParse, ((*lParse).Nodes).offset(NodeX as isize));
-                Ycol = Locate_Col(lParse, ((*lParse).Nodes).offset(NodeY as isize));
+                Xcol = Locate_Col(lParse, &(lParse.Nodes)[NodeX as usize]);
+                Ycol = Locate_Col(lParse, &(lParse.Nodes)[NodeY as usize]);
                 if Xcol < 0 || Ycol < 0 {
                     fits_parser_yyerror(
-                        0 as yyscan_t,
+                        ptr::null_mut(),
                         lParse,
-                        b"Found multiple X/Y column references in REGFILTER\0" as *const u8
-                            as *const c_char as *mut c_char,
+                        cs!(c"Found multiple X/Y column references in REGFILTER"),
                     );
                     Free_Last_Node(lParse);
                     return -(1);
@@ -8570,7 +7853,7 @@ unsafe fn New_REG(
             if Xcol > 0 && Ycol > 0 {
                 tstat = 0;
                 ffgtcs(
-                    (*lParse).def_fptr,
+                    lParse.def_fptr,
                     Xcol,
                     Ycol,
                     &mut wcs.xrefval,
@@ -8586,7 +7869,7 @@ unsafe fn New_REG(
                 if tstat == 505 as c_int {
                     wcs.exists = false;
                 } else if tstat != 0 {
-                    (*lParse).status = tstat;
+                    lParse.status = tstat;
                     Free_Last_Node(lParse);
                     return -(1);
                 } else {
@@ -8600,15 +7883,15 @@ unsafe fn New_REG(
                 cast_slice(fname_slice.to_bytes_with_nul()),
                 &mut wcs,
                 &mut Some(rgn_box),
-                &mut (*lParse).status,
+                &mut lParse.status,
             );
-            if (*lParse).status != 0 {
+            if lParse.status != 0 {
                 Free_Last_Node(lParse);
                 return -(1);
             }
             (*that0).value.data.ptr = Rgn as *mut c_void;
-            if (*((*lParse).Nodes).offset(NodeX as isize)).operation == -(1000 as c_int)
-                && (*((*lParse).Nodes).offset(NodeY as isize)).operation == -(1000 as c_int)
+            if ((lParse.Nodes)[NodeX as usize]).operation == -1000
+                && ((lParse.Nodes)[NodeY as usize]).operation == -1000
             {
                 ((*this).DoOp).expect("non-null function pointer")(lParse, this);
             }
@@ -8616,15 +7899,15 @@ unsafe fn New_REG(
         n
     }
 }
-unsafe fn New_Vector(mut lParse: *mut ParseData, mut subNode: c_int) -> c_int {
+unsafe fn New_Vector(lParse: &mut ParseData, mut subNode: c_int) -> c_int {
     unsafe {
         let mut this: *mut Node = std::ptr::null_mut::<Node>();
         let mut that: *mut Node = std::ptr::null_mut::<Node>();
         let mut n: c_int = 0;
         n = Alloc_Node(lParse);
         if n >= 0 {
-            this = ((*lParse).Nodes).offset(n as isize);
-            that = ((*lParse).Nodes).offset(subNode as isize);
+            this = &mut (lParse.Nodes)[n as usize];
+            that = &mut (lParse.Nodes)[subNode as usize];
             (*this).ntype = (*that).ntype;
             (*this).nSubNodes = 1;
             (*this).SubNodes[0] = subNode;
@@ -8634,17 +7917,15 @@ unsafe fn New_Vector(mut lParse: *mut ParseData, mut subNode: c_int) -> c_int {
         n
     }
 }
-unsafe fn Close_Vec(mut lParse: *mut ParseData, mut vecNode: c_int) -> c_int {
+unsafe fn Close_Vec(lParse: &mut ParseData, mut vecNode: c_int) -> c_int {
     unsafe {
         let mut this: *mut Node = std::ptr::null_mut::<Node>();
         let mut n: c_int = 0;
         let mut nelem: c_int = 0;
-        this = ((*lParse).Nodes).offset(vecNode as isize);
+        this = &mut (lParse.Nodes)[vecNode as usize];
         n = 0;
         while n < (*this).nSubNodes {
-            if (*((*lParse).Nodes).offset((*this).SubNodes[n as usize] as isize)).ntype
-                != (*this).ntype
-            {
+            if ((lParse.Nodes)[(*this).SubNodes[n as usize] as usize]).ntype != (*this).ntype {
                 (*this).SubNodes[n as usize] =
                     New_Unary(lParse, (*this).ntype, 0, (*this).SubNodes[n as usize]);
                 if (*this).SubNodes[n as usize] < 0 {
@@ -8652,7 +7933,7 @@ unsafe fn Close_Vec(mut lParse: *mut ParseData, mut vecNode: c_int) -> c_int {
                 }
             }
             nelem = (nelem as c_long
-                + (*((*lParse).Nodes).offset((*this).SubNodes[n as usize] as isize))
+                + ((lParse.Nodes)[(*this).SubNodes[n as usize] as usize])
                     .value
                     .nelem) as c_int;
             n += 1;
@@ -8664,7 +7945,7 @@ unsafe fn Close_Vec(mut lParse: *mut ParseData, mut vecNode: c_int) -> c_int {
         vecNode
     }
 }
-unsafe fn New_Array(mut lParse: *mut ParseData, mut valueNode: c_int, mut dimNode: c_int) -> c_int {
+unsafe fn New_Array(lParse: &mut ParseData, mut valueNode: c_int, mut dimNode: c_int) -> c_int {
     unsafe {
         let mut dims: *mut Node = std::ptr::null_mut::<Node>();
         let mut naxis: c_long = 0;
@@ -8676,40 +7957,35 @@ unsafe fn New_Array(mut lParse: *mut ParseData, mut valueNode: c_int, mut dimNod
         if valueNode < 0 || dimNode < 0 {
             return -(1);
         }
-        dims = &mut *((*lParse).Nodes).offset(dimNode as isize) as *mut Node;
+        dims = &mut (lParse.Nodes)[dimNode as usize];
         i = 0;
         while i < 5 as c_int {
             naxes[i as usize] = 1;
             i += 1;
             i;
         }
-        if (*((*lParse).Nodes).offset(dimNode as isize)).operation == -(1000 as c_int) {
-            if (*((*lParse).Nodes).offset(dimNode as isize)).ntype
-                != fits_parser_yytokentype::LONG as c_int
-            {
+        if ((lParse.Nodes)[dimNode as usize]).operation == -1000 {
+            if ((lParse.Nodes)[dimNode as usize]).ntype != fits_parser_yytokentype::LONG as c_int {
                 dimNode = New_Unary(lParse, fits_parser_yytokentype::LONG as c_int, 0, dimNode);
             }
             if dimNode < 0 {
                 return -(1);
             }
             naxis = 1;
-            naxes[0] = ((*((*lParse).Nodes).offset(dimNode as isize)).value)
-                .data
-                .lng;
-        } else if (*((*lParse).Nodes).offset(dimNode as isize)).operation == '{' as i32 {
+            naxes[0] = (((lParse.Nodes)[dimNode as usize]).value).data.lng;
+        } else if ((lParse.Nodes)[dimNode as usize]).operation == '{' as i32 {
             if (*dims).nSubNodes > 5 as c_int {
                 fits_parser_yyerror(
-                    0 as yyscan_t,
+                    ptr::null_mut(),
                     lParse,
-                    b"ARRAY(V,{...}) number of dimensions must not exceed 5\0" as *const u8
-                        as *const c_char as *mut c_char,
+                    cs!(c"ARRAY(V,{...}) number of dimensions must not exceed 5"),
                 );
                 return -(1);
             }
             naxis = (*dims).nSubNodes as c_long;
             i = 0;
             while i < (*dims).nSubNodes {
-                if (*((*lParse).Nodes).offset((*dims).SubNodes[i as usize] as isize)).ntype
+                if ((lParse.Nodes)[(*dims).SubNodes[i as usize] as usize]).ntype
                     != fits_parser_yytokentype::LONG as c_int
                 {
                     (*dims).SubNodes[i as usize] = New_Unary(
@@ -8722,20 +7998,18 @@ unsafe fn New_Array(mut lParse: *mut ParseData, mut valueNode: c_int, mut dimNod
                         return -(1);
                     }
                 }
-                naxes[i as usize] = (*((*lParse).Nodes)
-                    .offset((*dims).SubNodes[i as usize] as isize))
-                .value
-                .data
-                .lng;
+                naxes[i as usize] = ((lParse.Nodes)[(*dims).SubNodes[i as usize] as usize])
+                    .value
+                    .data
+                    .lng;
                 i += 1;
                 i;
             }
         } else {
             fits_parser_yyerror(
-                0 as yyscan_t,
+                ptr::null_mut(),
                 lParse,
-                b"ARRAY(V,dims) dims must be either integer or const vector\0" as *const u8
-                    as *const c_char as *mut c_char,
+                cs!(c"ARRAY(V,dims) dims must be either integer or const vector"),
             );
             return -(1);
         }
@@ -8744,10 +8018,9 @@ unsafe fn New_Array(mut lParse: *mut ParseData, mut valueNode: c_int, mut dimNod
         while (i as c_long) < naxis {
             if naxes[i as usize] <= 0 {
                 fits_parser_yyerror(
-                    0 as yyscan_t,
+                    ptr::null_mut(),
                     lParse,
-                    b"ARRAY(V,dims) must have positive dimensions\0" as *const u8 as *const c_char
-                        as *mut c_char,
+                    cs!(c"ARRAY(V,dims) must have positive dimensions"),
                 );
                 return -(1);
             }
@@ -8755,32 +8028,30 @@ unsafe fn New_Array(mut lParse: *mut ParseData, mut valueNode: c_int, mut dimNod
             i += 1;
             i;
         }
-        if !(((*((*lParse).Nodes).offset(valueNode as isize)).value).nelem == nelem && nelem > 1) {
-            if ((*((*lParse).Nodes).offset(valueNode as isize)).value).nelem > 1 && nelem > 1 {
+        if !((((lParse.Nodes)[valueNode as usize]).value).nelem == nelem && nelem > 1) {
+            if (((lParse.Nodes)[valueNode as usize]).value).nelem > 1 && nelem > 1 {
                 fits_parser_yyerror(
-                    0 as yyscan_t,
+                    ptr::null_mut(),
                     lParse,
-                    b"ARRAY(V,d) mismatch between number of elements in V and d\0" as *const u8
-                        as *const c_char as *mut c_char,
+                    cs!(c"ARRAY(V,d) mismatch between number of elements in V and d"),
                 );
                 return -(1);
-            } else if ((*((*lParse).Nodes).offset(valueNode as isize)).value).nelem > 1 {
+            } else if (((lParse.Nodes)[valueNode as usize]).value).nelem > 1 {
                 fits_parser_yyerror(
-                    0 as yyscan_t,
+                    ptr::null_mut(),
                     lParse,
-                    b"ARRAY(V,n) value V must have vector dimension of 1\0" as *const u8
-                        as *const c_char as *mut c_char,
+                    cs!(c"ARRAY(V,n) value V must have vector dimension of 1"),
                 );
                 return -(1);
             }
         }
         n = Alloc_Node(lParse);
         if n >= 0 {
-            this = ((*lParse).Nodes).offset(n as isize);
+            this = &mut (lParse.Nodes)[n as usize];
             (*this).operation = array_fct as c_int;
             (*this).nSubNodes = 1;
             (*this).SubNodes[0] = valueNode;
-            (*this).ntype = (*((*lParse).Nodes).offset(valueNode as isize)).ntype;
+            (*this).ntype = ((lParse.Nodes)[valueNode as usize]).ntype;
             (*this).value.nelem = nelem;
             (*this).value.naxis = naxis as c_int;
             i = 0;
@@ -8794,21 +8065,19 @@ unsafe fn New_Array(mut lParse: *mut ParseData, mut valueNode: c_int, mut dimNod
         n
     }
 }
-unsafe fn Locate_Col(mut lParse: *mut ParseData, mut this: *mut Node) -> c_int {
+unsafe fn Locate_Col(lParse: &ParseData, this: &Node) -> c_int {
     unsafe {
-        let mut that: *mut Node = std::ptr::null_mut::<Node>();
         let mut i: c_int = 0;
         let mut col: c_int = 0;
         let mut newCol: c_int = 0;
         let mut nfound: c_int = 0;
-        if (*this).nSubNodes == 0 && (*this).operation <= 0 && (*this).operation != -(1000 as c_int)
-        {
-            return (*((*lParse).colData).offset(-(*this).operation as isize)).colnum;
+        if this.nSubNodes == 0 && this.operation <= 0 && this.operation != -1000 {
+            return (*(lParse.colData).offset(-this.operation as isize)).colnum;
         }
         i = 0;
-        while i < (*this).nSubNodes {
-            that = ((*lParse).Nodes).offset((*this).SubNodes[i as usize] as isize);
-            if (*that).operation > 0 {
+        while i < this.nSubNodes {
+            let that = &(lParse.Nodes)[this.SubNodes[i as usize] as usize];
+            if that.operation > 0 {
                 newCol = Locate_Col(lParse, that);
                 if newCol <= 0 {
                     nfound += -newCol;
@@ -8820,8 +8089,8 @@ unsafe fn Locate_Col(mut lParse: *mut ParseData, mut this: *mut Node) -> c_int {
                     nfound += 1;
                     nfound;
                 }
-            } else if (*that).operation != -(1000 as c_int) {
-                newCol = (*((*lParse).colData).offset(-(*that).operation as isize)).colnum;
+            } else if that.operation != -1000 {
+                newCol = (*(lParse.colData).offset(-that.operation as isize)).colnum;
                 if nfound == 0 {
                     col = newCol;
                     nfound += 1;
@@ -8837,7 +8106,7 @@ unsafe fn Locate_Col(mut lParse: *mut ParseData, mut this: *mut Node) -> c_int {
         if nfound != 1 { -nfound } else { col }
     }
 }
-unsafe fn Test_Dims(mut lParse: *mut ParseData, mut Node1: c_int, mut Node2: c_int) -> c_int {
+unsafe fn Test_Dims(lParse: &mut ParseData, mut Node1: c_int, mut Node2: c_int) -> c_int {
     unsafe {
         let mut that1: *mut Node = std::ptr::null_mut::<Node>();
         let mut that2: *mut Node = std::ptr::null_mut::<Node>();
@@ -8846,8 +8115,8 @@ unsafe fn Test_Dims(mut lParse: *mut ParseData, mut Node1: c_int, mut Node2: c_i
         if Node1 < 0 || Node2 < 0 {
             return 0;
         }
-        that1 = ((*lParse).Nodes).offset(Node1 as isize);
-        that2 = ((*lParse).Nodes).offset(Node2 as isize);
+        that1 = &mut (lParse.Nodes)[Node1 as usize];
+        that2 = &mut (lParse.Nodes)[Node2 as usize];
         if (*that1).value.nelem == 1 || (*that2).value.nelem == 1 {
             valid = 1;
         } else if (*that1).ntype == (*that2).ntype
@@ -8869,7 +8138,7 @@ unsafe fn Test_Dims(mut lParse: *mut ParseData, mut Node1: c_int, mut Node2: c_i
         valid
     }
 }
-unsafe fn Copy_Dims(mut lParse: *mut ParseData, mut Node1: c_int, mut Node2: c_int) {
+unsafe fn Copy_Dims(lParse: &mut ParseData, mut Node1: c_int, mut Node2: c_int) {
     unsafe {
         let mut that1: *mut Node = std::ptr::null_mut::<Node>();
         let mut that2: *mut Node = std::ptr::null_mut::<Node>();
@@ -8877,8 +8146,8 @@ unsafe fn Copy_Dims(mut lParse: *mut ParseData, mut Node1: c_int, mut Node2: c_i
         if Node1 < 0 || Node2 < 0 {
             return;
         }
-        that1 = ((*lParse).Nodes).offset(Node1 as isize);
-        that2 = ((*lParse).Nodes).offset(Node2 as isize);
+        that1 = &mut (lParse.Nodes)[Node1 as usize];
+        that2 = &mut (lParse.Nodes)[Node2 as usize];
         (*that1).value.nelem = (*that2).value.nelem;
         (*that1).value.naxis = (*that2).value.naxis;
         i = 0;
@@ -8890,7 +8159,7 @@ unsafe fn Copy_Dims(mut lParse: *mut ParseData, mut Node1: c_int, mut Node2: c_i
     }
 }
 
-pub unsafe fn Evaluate_Parser(mut lParse: *mut ParseData, mut firstRow: c_long, mut nRows: c_long) {
+pub unsafe fn Evaluate_Parser(lParse: &mut ParseData, mut firstRow: c_long, mut nRows: c_long) {
     unsafe {
         let mut i: c_int = 0;
         let mut column: c_int = 0;
@@ -8901,57 +8170,52 @@ pub unsafe fn Evaluate_Parser(mut lParse: *mut ParseData, mut firstRow: c_long, 
             simplerng_srand(time(std::ptr::null_mut::<time_t>()) as c_uint);
             rand_initialized = 1;
         }
-        (*lParse).firstRow = firstRow;
-        (*lParse).nRows = nRows;
-        rowOffset = firstRow - (*lParse).firstDataRow;
+        lParse.firstRow = firstRow;
+        lParse.nRows = nRows;
+        rowOffset = firstRow - lParse.firstDataRow;
         i = 0;
-        while i < (*lParse).nNodes {
-            if !((*((*lParse).Nodes).offset(i as isize)).operation > 0
-                || (*((*lParse).Nodes).offset(i as isize)).operation == -(1000 as c_int))
+        while i < lParse.nNodes {
+            if !(((lParse.Nodes)[i as usize]).operation > 0
+                || ((lParse.Nodes)[i as usize]).operation == -1000)
             {
-                column = -(*((*lParse).Nodes).offset(i as isize)).operation;
-                offset = (*((*lParse).varData).offset(column as isize)).nelem * rowOffset;
-                let fresh11 = &mut ((*((*lParse).Nodes).offset(i as isize)).value).undef;
+                column = -((lParse.Nodes)[i as usize]).operation;
+                offset = (*(lParse.varData).offset(column as isize)).nelem * rowOffset;
+                let fresh11 = &mut (((lParse.Nodes)[i as usize]).value).undef;
                 *fresh11 =
-                    ((*((*lParse).varData).offset(column as isize)).undef).offset(offset as isize);
-                match (*((*lParse).Nodes).offset(i as isize)).ntype {
+                    ((*(lParse.varData).offset(column as isize)).undef).offset(offset as isize);
+                match ((lParse.Nodes)[i as usize]).ntype {
                     262 => {
-                        let fresh12 =
-                            &mut ((*((*lParse).Nodes).offset(i as isize)).value).data.strptr;
-                        *fresh12 = ((*((*lParse).varData).offset(column as isize)).data
+                        let fresh12 = &mut (((lParse.Nodes)[i as usize]).value).data.strptr;
+                        *fresh12 = ((*(lParse.varData).offset(column as isize)).data
                             as *mut *mut c_char)
                             .offset(rowOffset as isize);
-                        let fresh13 = &mut ((*((*lParse).Nodes).offset(i as isize)).value).undef;
+                        let fresh13 = &mut (((lParse.Nodes)[i as usize]).value).undef;
                         *fresh13 = ptr::null_mut();
                     }
                     261 => {
-                        let fresh14 =
-                            &mut ((*((*lParse).Nodes).offset(i as isize)).value).data.strptr;
-                        *fresh14 = ((*((*lParse).varData).offset(column as isize)).data
+                        let fresh14 = &mut (((lParse.Nodes)[i as usize]).value).data.strptr;
+                        *fresh14 = ((*(lParse.varData).offset(column as isize)).data
                             as *mut *mut c_char)
                             .offset(rowOffset as isize);
-                        let fresh15 = &mut ((*((*lParse).Nodes).offset(i as isize)).value).undef;
-                        *fresh15 = ((*((*lParse).varData).offset(column as isize)).undef)
+                        let fresh15 = &mut (((lParse.Nodes)[i as usize]).value).undef;
+                        *fresh15 = ((*(lParse.varData).offset(column as isize)).undef)
                             .offset(rowOffset as isize);
                     }
                     258 => {
-                        let fresh16 =
-                            &mut ((*((*lParse).Nodes).offset(i as isize)).value).data.logptr;
-                        *fresh16 = ((*((*lParse).varData).offset(column as isize)).data as *const _
+                        let fresh16 = &mut (((lParse.Nodes)[i as usize]).value).data.logptr;
+                        *fresh16 = ((*(lParse.varData).offset(column as isize)).data as *const _
                             as *mut c_char)
                             .offset(offset as isize);
                     }
                     259 => {
-                        let fresh17 =
-                            &mut ((*((*lParse).Nodes).offset(i as isize)).value).data.lngptr;
-                        *fresh17 = ((*((*lParse).varData).offset(column as isize)).data as *const _
+                        let fresh17 = &mut (((lParse.Nodes)[i as usize]).value).data.lngptr;
+                        *fresh17 = ((*(lParse.varData).offset(column as isize)).data as *const _
                             as *mut c_long)
                             .offset(offset as isize);
                     }
                     260 => {
-                        let fresh18 =
-                            &mut ((*((*lParse).Nodes).offset(i as isize)).value).data.dblptr;
-                        *fresh18 = ((*((*lParse).varData).offset(column as isize)).data as *const _
+                        let fresh18 = &mut (((lParse.Nodes)[i as usize]).value).data.dblptr;
+                        *fresh18 = ((*(lParse.varData).offset(column as isize)).data as *const _
                             as *mut c_double)
                             .offset(offset as isize);
                     }
@@ -8961,17 +8225,17 @@ pub unsafe fn Evaluate_Parser(mut lParse: *mut ParseData, mut firstRow: c_long, 
             i += 1;
             i;
         }
-        Evaluate_Node(lParse, (*lParse).resultNode);
+        Evaluate_Node(lParse, lParse.resultNode);
     }
 }
-unsafe fn Evaluate_Node(mut lParse: *mut ParseData, mut thisNode: c_int) {
+unsafe fn Evaluate_Node(lParse: &mut ParseData, mut thisNode: c_int) {
     unsafe {
         let mut this: *mut Node = std::ptr::null_mut::<Node>();
         let mut i: c_int = 0;
-        if (*lParse).status != 0 {
+        if lParse.status != 0 {
             return;
         }
-        this = ((*lParse).Nodes).offset(thisNode as isize);
+        this = &mut (lParse.Nodes)[thisNode as usize];
         if (*this).operation > 0 {
             i = (*this).nSubNodes;
             loop {
@@ -8981,7 +8245,7 @@ unsafe fn Evaluate_Node(mut lParse: *mut ParseData, mut thisNode: c_int) {
                     break;
                 }
                 Evaluate_Node(lParse, (*this).SubNodes[i as usize]);
-                if (*lParse).status != 0 {
+                if lParse.status != 0 {
                     return;
                 }
             }
@@ -8989,7 +8253,7 @@ unsafe fn Evaluate_Node(mut lParse: *mut ParseData, mut thisNode: c_int) {
         }
     }
 }
-unsafe fn Allocate_Ptrs(mut lParse: *mut ParseData, mut this: *mut Node) {
+unsafe fn Allocate_Ptrs(lParse: &mut ParseData, mut this: *mut Node) {
     unsafe {
         let mut elem: c_long = 0;
         let mut row: c_long = 0;
@@ -8998,7 +8262,7 @@ unsafe fn Allocate_Ptrs(mut lParse: *mut ParseData, mut this: *mut Node) {
             || (*this).ntype == fits_parser_yytokentype::STRING as c_int
         {
             (*this).value.data.strptr = malloc(
-                ((*lParse).nRows as c_ulong)
+                (lParse.nRows as c_ulong)
                     .wrapping_mul(::core::mem::size_of::<*mut c_char>() as c_ulong)
                     .try_into()
                     .unwrap(),
@@ -9006,7 +8270,7 @@ unsafe fn Allocate_Ptrs(mut lParse: *mut ParseData, mut this: *mut Node) {
             if !((*this).value.data.strptr).is_null() {
                 let fresh20 = &mut *((*this).value.data.strptr).offset(0);
                 *fresh20 = malloc(
-                    (((*lParse).nRows * ((*this).value.nelem + 2 as c_long)) as c_ulong)
+                    ((lParse.nRows * ((*this).value.nelem + 2 as c_long)) as c_ulong)
                         .wrapping_mul(::core::mem::size_of::<c_char>() as c_ulong)
                         .try_into()
                         .unwrap(),
@@ -9015,7 +8279,7 @@ unsafe fn Allocate_Ptrs(mut lParse: *mut ParseData, mut this: *mut Node) {
                     row = 0;
                     loop {
                         row += 1;
-                        if row >= (*lParse).nRows {
+                        if row >= lParse.nRows {
                             break;
                         }
                         let fresh21 = &mut *((*this).value.data.strptr).offset(row as isize);
@@ -9032,14 +8296,14 @@ unsafe fn Allocate_Ptrs(mut lParse: *mut ParseData, mut this: *mut Node) {
                         (*this).value.undef = ptr::null_mut();
                     }
                 } else {
-                    (*lParse).status = 113 as c_int;
+                    lParse.status = 113 as c_int;
                     free((*this).value.data.strptr as *mut c_void);
                 }
             } else {
-                (*lParse).status = 113 as c_int;
+                lParse.status = 113 as c_int;
             }
         } else {
-            elem = (*this).value.nelem * (*lParse).nRows;
+            elem = (*this).value.nelem * lParse.nRows;
             match (*this).ntype {
                 260 => {
                     size = ::core::mem::size_of::<c_double>() as c_ulong as c_long;
@@ -9059,7 +8323,7 @@ unsafe fn Allocate_Ptrs(mut lParse: *mut ParseData, mut this: *mut Node) {
                 (elem as c_ulong).try_into().unwrap(),
             );
             if ((*this).value.data.ptr).is_null() {
-                (*lParse).status = 113 as c_int;
+                lParse.status = 113 as c_int;
             } else {
                 (*this).value.undef =
                     ((*this).value.data.ptr as *mut c_char).offset((elem * size) as isize);
@@ -9067,12 +8331,12 @@ unsafe fn Allocate_Ptrs(mut lParse: *mut ParseData, mut this: *mut Node) {
         };
     }
 }
-unsafe fn Do_Unary(mut lParse: *mut ParseData, mut this: *mut Node) {
+unsafe fn Do_Unary(lParse: &mut ParseData, mut this: *mut Node) {
     unsafe {
         let mut that: *mut Node = std::ptr::null_mut::<Node>();
         let mut elem: c_long = 0;
-        that = ((*lParse).Nodes).offset((*this).SubNodes[0] as isize);
-        if (*that).operation == -(1000 as c_int) {
+        that = &mut (lParse.Nodes)[(*this).SubNodes[0] as usize];
+        if (*that).operation == -1000 {
             match (*this).operation {
                 x if x == fits_parser_yytokentype::DOUBLE as c_int
                     || x == fits_parser_yytokentype::FLTCAST as c_int =>
@@ -9130,12 +8394,12 @@ unsafe fn Do_Unary(mut lParse: *mut ParseData, mut this: *mut Node) {
                 }
                 _ => {}
             }
-            (*this).operation = -(1000 as c_int);
+            (*this).operation = -1000;
         } else {
             Allocate_Ptrs(lParse, this);
-            if (*lParse).status == 0 {
+            if lParse.status == 0 {
                 if (*this).ntype != fits_parser_yytokentype::BITSTR as c_int {
-                    elem = (*lParse).nRows;
+                    elem = lParse.nRows;
                     if (*this).ntype != fits_parser_yytokentype::STRING as c_int {
                         elem *= (*this).value.nelem;
                     }
@@ -9149,7 +8413,7 @@ unsafe fn Do_Unary(mut lParse: *mut ParseData, mut this: *mut Node) {
                             *((*that).value.undef).offset(elem as isize);
                     }
                 }
-                elem = (*lParse).nRows * (*this).value.nelem;
+                elem = lParse.nRows * (*this).value.nelem;
                 match (*this).operation {
                     258 => {
                         if (*that).ntype == fits_parser_yytokentype::DOUBLE as c_int {
@@ -9277,7 +8541,7 @@ unsafe fn Do_Unary(mut lParse: *mut ParseData, mut this: *mut Node) {
                                         as c_int as c_char;
                             }
                         } else if (*that).ntype == fits_parser_yytokentype::BITSTR as c_int {
-                            elem = (*lParse).nRows;
+                            elem = lParse.nRows;
                             loop {
                                 let fresh32 = elem;
                                 elem -= 1;
@@ -9300,7 +8564,7 @@ unsafe fn Do_Unary(mut lParse: *mut ParseData, mut this: *mut Node) {
         }
     }
 }
-unsafe fn Do_Offset(mut lParse: *mut ParseData, mut this: *mut Node) {
+unsafe fn Do_Offset(lParse: &mut ParseData, mut this: *mut Node) {
     unsafe {
         let mut col: *mut Node = std::ptr::null_mut::<Node>();
         let mut fRow: c_long = 0;
@@ -9312,13 +8576,13 @@ unsafe fn Do_Offset(mut lParse: *mut ParseData, mut this: *mut Node) {
         let mut offset: c_long = 0;
         let mut nRealElem: c_long = 0;
         let mut status: c_int = 0;
-        col = ((*lParse).Nodes).offset((*this).SubNodes[0] as isize);
-        rowOffset = (*((*lParse).Nodes).offset((*this).SubNodes[1] as isize))
+        col = &mut (lParse.Nodes)[(*this).SubNodes[0] as usize];
+        rowOffset = ((lParse.Nodes)[(*this).SubNodes[1] as usize])
             .value
             .data
             .lng;
         Allocate_Ptrs(lParse, this);
-        fRow = (*lParse).firstRow + rowOffset;
+        fRow = lParse.firstRow + rowOffset;
         if (*this).ntype == fits_parser_yytokentype::STRING as c_int
             || (*this).ntype == fits_parser_yytokentype::BITSTR as c_int
         {
@@ -9327,12 +8591,12 @@ unsafe fn Do_Offset(mut lParse: *mut ParseData, mut this: *mut Node) {
             nRealElem = (*this).value.nelem;
         }
         nelem = nRealElem;
-        if fRow < (*lParse).firstDataRow {
-            nRowReload = (*lParse).firstDataRow - fRow;
-            if nRowReload > (*lParse).nRows {
-                nRowReload = (*lParse).nRows;
+        if fRow < lParse.firstDataRow {
+            nRowReload = lParse.firstDataRow - fRow;
+            if nRowReload > lParse.nRows {
+                nRowReload = lParse.nRows;
             }
-            nRowOverlap = (*lParse).nRows - nRowReload;
+            nRowOverlap = lParse.nRows - nRowReload;
             offset = 0;
             while fRow < 1 && nRowReload > 0 {
                 if (*this).ntype == fits_parser_yytokentype::BITSTR as c_int {
@@ -9368,17 +8632,17 @@ unsafe fn Do_Offset(mut lParse: *mut ParseData, mut this: *mut Node) {
                 nRowReload -= 1;
                 nRowReload;
             }
-        } else if fRow + (*lParse).nRows > (*lParse).firstDataRow + (*lParse).nDataRows {
-            nRowReload = fRow + (*lParse).nRows - ((*lParse).firstDataRow + (*lParse).nDataRows);
-            if nRowReload > (*lParse).nRows {
-                nRowReload = (*lParse).nRows;
+        } else if fRow + lParse.nRows > lParse.firstDataRow + lParse.nDataRows {
+            nRowReload = fRow + lParse.nRows - (lParse.firstDataRow + lParse.nDataRows);
+            if nRowReload > lParse.nRows {
+                nRowReload = lParse.nRows;
             } else {
-                fRow = (*lParse).firstDataRow + (*lParse).nDataRows;
+                fRow = lParse.firstDataRow + lParse.nDataRows;
             }
-            nRowOverlap = (*lParse).nRows - nRowReload;
+            nRowOverlap = lParse.nRows - nRowReload;
             offset = nRowOverlap * nelem;
-            elem = (*lParse).nRows * nelem;
-            while fRow + nRowReload > (*lParse).totalRows && nRowReload > 0 {
+            elem = lParse.nRows * nelem;
+            while fRow + nRowReload > lParse.totalRows && nRowReload > 0 {
                 if (*this).ntype == fits_parser_yytokentype::BITSTR as c_int {
                     nelem = (*this).value.nelem;
                     elem -= 1;
@@ -9411,13 +8675,13 @@ unsafe fn Do_Offset(mut lParse: *mut ParseData, mut this: *mut Node) {
             }
         } else {
             nRowReload = 0;
-            nRowOverlap = (*lParse).nRows;
+            nRowOverlap = lParse.nRows;
             offset = 0;
         }
         if nRowReload > 0 {
             match (*this).ntype {
                 262 | 261 => {
-                    status = ((*lParse).loadData).expect("non-null function pointer")(
+                    status = (lParse.loadData).expect("non-null function pointer")(
                         lParse,
                         -(*col).operation,
                         fRow,
@@ -9427,7 +8691,7 @@ unsafe fn Do_Offset(mut lParse: *mut ParseData, mut this: *mut Node) {
                     );
                 }
                 258 => {
-                    status = ((*lParse).loadData).expect("non-null function pointer")(
+                    status = (lParse.loadData).expect("non-null function pointer")(
                         lParse,
                         -(*col).operation,
                         fRow,
@@ -9437,7 +8701,7 @@ unsafe fn Do_Offset(mut lParse: *mut ParseData, mut this: *mut Node) {
                     );
                 }
                 259 => {
-                    status = ((*lParse).loadData).expect("non-null function pointer")(
+                    status = (lParse.loadData).expect("non-null function pointer")(
                         lParse,
                         -(*col).operation,
                         fRow,
@@ -9447,7 +8711,7 @@ unsafe fn Do_Offset(mut lParse: *mut ParseData, mut this: *mut Node) {
                     );
                 }
                 260 => {
-                    status = ((*lParse).loadData).expect("non-null function pointer")(
+                    status = (lParse.loadData).expect("non-null function pointer")(
                         lParse,
                         -(*col).operation,
                         fRow,
@@ -9465,19 +8729,19 @@ unsafe fn Do_Offset(mut lParse: *mut ParseData, mut this: *mut Node) {
         if rowOffset > 0 {
             elem = nRowOverlap * nelem;
         } else {
-            elem = (*lParse).nRows * nelem;
+            elem = lParse.nRows * nelem;
         }
         offset = nelem * rowOffset;
         loop {
             let fresh38 = nRowOverlap;
             nRowOverlap -= 1;
-            if !(fresh38 != 0 && (*lParse).status == 0) {
+            if !(fresh38 != 0 && lParse.status == 0) {
                 break;
             }
             loop {
                 let fresh39 = nelem;
                 nelem -= 1;
-                if !(fresh39 != 0 && (*lParse).status == 0) {
+                if !(fresh39 != 0 && lParse.status == 0) {
                     break;
                 }
                 elem -= 1;
@@ -9518,7 +8782,7 @@ unsafe fn Do_Offset(mut lParse: *mut ParseData, mut this: *mut Node) {
         }
     }
 }
-unsafe fn Do_BinOp_bit(mut lParse: *mut ParseData, mut this: *mut Node) {
+unsafe fn Do_BinOp_bit(lParse: &mut ParseData, mut this: *mut Node) {
     unsafe {
         let mut that1: *mut Node = std::ptr::null_mut::<Node>();
         let mut that2: *mut Node = std::ptr::null_mut::<Node>();
@@ -9527,10 +8791,10 @@ unsafe fn Do_BinOp_bit(mut lParse: *mut ParseData, mut this: *mut Node) {
         let mut const1: c_int = 0;
         let mut const2: c_int = 0;
         let mut rows: c_long = 0;
-        that1 = ((*lParse).Nodes).offset((*this).SubNodes[0] as isize);
-        that2 = ((*lParse).Nodes).offset((*this).SubNodes[1] as isize);
-        const1 = ((*that1).operation == -(1000 as c_int)) as c_int;
-        const2 = ((*that2).operation == -(1000 as c_int)) as c_int;
+        that1 = &mut (lParse.Nodes)[(*this).SubNodes[0] as usize];
+        that2 = &mut (lParse.Nodes)[(*this).SubNodes[1] as usize];
+        const1 = ((*that1).operation == -1000) as c_int;
+        const2 = ((*that2).operation == -1000) as c_int;
         sptr1 = if const1 != 0 {
             ((*that1).value.data.astr).as_mut_ptr()
         } else {
@@ -9575,11 +8839,11 @@ unsafe fn Do_BinOp_bit(mut lParse: *mut ParseData, mut this: *mut Node) {
                 }
                 _ => {}
             }
-            (*this).operation = -(1000 as c_int);
+            (*this).operation = -1000;
         } else {
             Allocate_Ptrs(lParse, this);
-            if (*lParse).status == 0 {
-                rows = (*lParse).nRows;
+            if lParse.status == 0 {
+                rows = lParse.nRows;
                 match (*this).operation {
                     279..=284 => loop {
                         let fresh40 = rows;
@@ -9678,7 +8942,7 @@ unsafe fn Do_BinOp_bit(mut lParse: *mut ParseData, mut this: *mut Node) {
         }
     }
 }
-unsafe fn Do_BinOp_str(mut lParse: *mut ParseData, mut this: *mut Node) {
+unsafe fn Do_BinOp_str(lParse: &mut ParseData, mut this: *mut Node) {
     unsafe {
         let mut that1: *mut Node = std::ptr::null_mut::<Node>();
         let mut that2: *mut Node = std::ptr::null_mut::<Node>();
@@ -9690,10 +8954,10 @@ unsafe fn Do_BinOp_str(mut lParse: *mut ParseData, mut this: *mut Node) {
         let mut const2: c_int = 0;
         let mut val: c_int = 0;
         let mut rows: c_long = 0;
-        that1 = ((*lParse).Nodes).offset((*this).SubNodes[0] as isize);
-        that2 = ((*lParse).Nodes).offset((*this).SubNodes[1] as isize);
-        const1 = ((*that1).operation == -(1000 as c_int)) as c_int;
-        const2 = ((*that2).operation == -(1000 as c_int)) as c_int;
+        that1 = &mut (lParse.Nodes)[(*this).SubNodes[0] as usize];
+        that2 = &mut (lParse.Nodes)[(*this).SubNodes[1] as usize];
+        const1 = ((*that1).operation == -1000) as c_int;
+        const2 = ((*that2).operation == -1000) as c_int;
         sptr1 = if const1 != 0 {
             ((*that1).value.data.astr).as_mut_ptr()
         } else {
@@ -9787,11 +9051,11 @@ unsafe fn Do_BinOp_str(mut lParse: *mut ParseData, mut this: *mut Node) {
                 }
                 _ => {}
             }
-            (*this).operation = -(1000 as c_int);
+            (*this).operation = -1000;
         } else {
             Allocate_Ptrs(lParse, this);
-            if (*lParse).status == 0 {
-                rows = (*lParse).nRows;
+            if lParse.status == 0 {
+                rows = lParse.nRows;
                 match (*this).operation {
                     280 | 279 => loop {
                         let fresh42 = rows;
@@ -9956,7 +9220,7 @@ unsafe fn Do_BinOp_str(mut lParse: *mut ParseData, mut this: *mut Node) {
         }
     }
 }
-unsafe fn Do_BinOp_log(mut lParse: *mut ParseData, mut this: *mut Node) {
+unsafe fn Do_BinOp_log(lParse: &mut ParseData, mut this: *mut Node) {
     unsafe {
         let mut that1: *mut Node = std::ptr::null_mut::<Node>();
         let mut that2: *mut Node = std::ptr::null_mut::<Node>();
@@ -9969,15 +9233,15 @@ unsafe fn Do_BinOp_log(mut lParse: *mut ParseData, mut this: *mut Node) {
         let mut rows: c_long = 0;
         let mut nelem: c_long = 0;
         let mut elem: c_long = 0;
-        that1 = ((*lParse).Nodes).offset((*this).SubNodes[0] as isize);
-        that2 = ((*lParse).Nodes).offset((*this).SubNodes[1] as isize);
-        vector1 = ((*that1).operation != -(1000 as c_int)) as c_int;
+        that1 = &mut (lParse.Nodes)[(*this).SubNodes[0] as usize];
+        that2 = &mut (lParse.Nodes)[(*this).SubNodes[1] as usize];
+        vector1 = ((*that1).operation != -1000) as c_int;
         if vector1 != 0 {
             vector1 = (*that1).value.nelem as c_int;
         } else {
             val1 = (*that1).value.data.log;
         }
-        vector2 = ((*that2).operation != -(1000 as c_int)) as c_int;
+        vector2 = ((*that2).operation != -1000) as c_int;
         if vector2 != 0 {
             vector2 = (*that2).value.nelem as c_int;
         } else {
@@ -10017,16 +9281,16 @@ unsafe fn Do_BinOp_log(mut lParse: *mut ParseData, mut this: *mut Node) {
                 }
                 _ => {}
             }
-            (*this).operation = -(1000 as c_int);
+            (*this).operation = -1000;
         } else if (*this).operation == fits_parser_yytokentype::ACCUM as c_int {
             let mut i: c_long = 0;
             let mut previous: c_long = 0;
             let mut curr: c_long = 0;
-            rows = (*lParse).nRows;
+            rows = lParse.nRows;
             nelem = (*this).value.nelem;
             elem = (*this).value.nelem * rows;
             Allocate_Ptrs(lParse, this);
-            if (*lParse).status == 0 {
+            if lParse.status == 0 {
                 previous = (*that2).value.data.lng;
                 i = 0;
                 while i < elem {
@@ -10042,11 +9306,11 @@ unsafe fn Do_BinOp_log(mut lParse: *mut ParseData, mut this: *mut Node) {
                 (*that2).value.data.lng = previous;
             }
         } else {
-            rows = (*lParse).nRows;
+            rows = lParse.nRows;
             nelem = (*this).value.nelem;
             elem = (*this).value.nelem * rows;
             Allocate_Ptrs(lParse, this);
-            if (*lParse).status == 0 {
+            if lParse.status == 0 {
                 if (*this).operation == fits_parser_yytokentype::ACCUM as c_int {
                     let mut i_0: c_long = 0;
                     let mut previous_0: c_long = 0;
@@ -10157,7 +9421,7 @@ unsafe fn Do_BinOp_log(mut lParse: *mut ParseData, mut this: *mut Node) {
         }
     }
 }
-unsafe fn Do_BinOp_lng(mut lParse: *mut ParseData, mut this: *mut Node) {
+unsafe fn Do_BinOp_lng(lParse: &mut ParseData, mut this: *mut Node) {
     unsafe {
         let mut that1: *mut Node = std::ptr::null_mut::<Node>();
         let mut that2: *mut Node = std::ptr::null_mut::<Node>();
@@ -10170,15 +9434,15 @@ unsafe fn Do_BinOp_lng(mut lParse: *mut ParseData, mut this: *mut Node) {
         let mut rows: c_long = 0;
         let mut nelem: c_long = 0;
         let mut elem: c_long = 0;
-        that1 = ((*lParse).Nodes).offset((*this).SubNodes[0] as isize);
-        that2 = ((*lParse).Nodes).offset((*this).SubNodes[1] as isize);
-        vector1 = ((*that1).operation != -(1000 as c_int)) as c_int;
+        that1 = &mut (lParse.Nodes)[(*this).SubNodes[0] as usize];
+        that2 = &mut (lParse.Nodes)[(*this).SubNodes[1] as usize];
+        vector1 = ((*that1).operation != -1000) as c_int;
         if vector1 != 0 {
             vector1 = (*that1).value.nelem as c_int;
         } else {
             val1 = (*that1).value.data.lng;
         }
-        vector2 = ((*that2).operation != -(1000 as c_int)) as c_int;
+        vector2 = ((*that2).operation != -1000) as c_int;
         if vector2 != 0 {
             vector2 = (*that2).value.nelem as c_int;
         } else {
@@ -10226,22 +9490,14 @@ unsafe fn Do_BinOp_lng(mut lParse: *mut ParseData, mut this: *mut Node) {
                     if val2 != 0 {
                         (*this).value.data.lng = val1 % val2;
                     } else {
-                        fits_parser_yyerror(
-                            0 as yyscan_t,
-                            lParse,
-                            b"Divide by Zero\0" as *const u8 as *const c_char as *mut c_char,
-                        );
+                        fits_parser_yyerror(ptr::null_mut(), lParse, cs!(c"Divide by Zero"));
                     }
                 }
                 47 => {
                     if val2 != 0 {
                         (*this).value.data.lng = val1 / val2;
                     } else {
-                        fits_parser_yyerror(
-                            0 as yyscan_t,
-                            lParse,
-                            b"Divide by Zero\0" as *const u8 as *const c_char as *mut c_char,
-                        );
+                        fits_parser_yyerror(ptr::null_mut(), lParse, cs!(c"Divide by Zero"));
                     }
                 }
                 286 => {
@@ -10255,7 +9511,7 @@ unsafe fn Do_BinOp_lng(mut lParse: *mut ParseData, mut this: *mut Node) {
                 }
                 _ => {}
             }
-            (*this).operation = -(1000 as c_int);
+            (*this).operation = -1000;
         } else if (*this).operation == fits_parser_yytokentype::ACCUM as c_int
             || (*this).operation == fits_parser_yytokentype::DIFF as c_int
         {
@@ -10263,11 +9519,11 @@ unsafe fn Do_BinOp_lng(mut lParse: *mut ParseData, mut this: *mut Node) {
             let mut previous: c_long = 0;
             let mut curr: c_long = 0;
             let mut undef: c_long = 0;
-            rows = (*lParse).nRows;
+            rows = lParse.nRows;
             nelem = (*this).value.nelem;
             elem = (*this).value.nelem * rows;
             Allocate_Ptrs(lParse, this);
-            if (*lParse).status == 0 {
+            if lParse.status == 0 {
                 previous = (*that2).value.data.lng;
                 undef = *(*that2).value.undef as c_long;
                 if (*this).operation == fits_parser_yytokentype::ACCUM as c_int {
@@ -10303,20 +9559,20 @@ unsafe fn Do_BinOp_lng(mut lParse: *mut ParseData, mut this: *mut Node) {
                 (*that2).value.undef = undef as *mut c_char;
             }
         } else {
-            rows = (*lParse).nRows;
+            rows = lParse.nRows;
             nelem = (*this).value.nelem;
             elem = (*this).value.nelem * rows;
             Allocate_Ptrs(lParse, this);
             loop {
                 let fresh48 = rows;
                 rows -= 1;
-                if !(fresh48 != 0 && (*lParse).status == 0) {
+                if !(fresh48 != 0 && lParse.status == 0) {
                     break;
                 }
                 loop {
                     let fresh49 = nelem;
                     nelem -= 1;
-                    if !(fresh49 != 0 && (*lParse).status == 0) {
+                    if !(fresh49 != 0 && lParse.status == 0) {
                         break;
                     }
                     elem -= 1;
@@ -10418,7 +9674,7 @@ unsafe fn Do_BinOp_lng(mut lParse: *mut ParseData, mut this: *mut Node) {
         }
     }
 }
-unsafe fn Do_BinOp_dbl(mut lParse: *mut ParseData, mut this: *mut Node) {
+unsafe fn Do_BinOp_dbl(lParse: &mut ParseData, mut this: *mut Node) {
     unsafe {
         let mut that1: *mut Node = std::ptr::null_mut::<Node>();
         let mut that2: *mut Node = std::ptr::null_mut::<Node>();
@@ -10431,15 +9687,15 @@ unsafe fn Do_BinOp_dbl(mut lParse: *mut ParseData, mut this: *mut Node) {
         let mut rows: c_long = 0;
         let mut nelem: c_long = 0;
         let mut elem: c_long = 0;
-        that1 = ((*lParse).Nodes).offset((*this).SubNodes[0] as isize);
-        that2 = ((*lParse).Nodes).offset((*this).SubNodes[1] as isize);
-        vector1 = ((*that1).operation != -(1000 as c_int)) as c_int;
+        that1 = &mut (lParse.Nodes)[(*this).SubNodes[0] as usize];
+        that2 = &mut (lParse.Nodes)[(*this).SubNodes[1] as usize];
+        vector1 = ((*that1).operation != -1000) as c_int;
         if vector1 != 0 {
             vector1 = (*that1).value.nelem as c_int;
         } else {
             val1 = (*that1).value.data.dbl;
         }
-        vector2 = ((*that2).operation != -(1000 as c_int)) as c_int;
+        vector2 = ((*that2).operation != -1000) as c_int;
         if vector2 != 0 {
             vector2 = (*that2).value.nelem as c_int;
         } else {
@@ -10481,22 +9737,14 @@ unsafe fn Do_BinOp_dbl(mut lParse: *mut ParseData, mut this: *mut Node) {
                     if val2 != 0. {
                         (*this).value.data.dbl = val1 - val2 * (val1 / val2) as c_int as c_double;
                     } else {
-                        fits_parser_yyerror(
-                            0 as yyscan_t,
-                            lParse,
-                            b"Divide by Zero\0" as *const u8 as *const c_char as *mut c_char,
-                        );
+                        fits_parser_yyerror(ptr::null_mut(), lParse, cs!(c"Divide by Zero"));
                     }
                 }
                 47 => {
                     if val2 != 0. {
                         (*this).value.data.dbl = val1 / val2;
                     } else {
-                        fits_parser_yyerror(
-                            0 as yyscan_t,
-                            lParse,
-                            b"Divide by Zero\0" as *const u8 as *const c_char as *mut c_char,
-                        );
+                        fits_parser_yyerror(ptr::null_mut(), lParse, cs!(c"Divide by Zero"));
                     }
                 }
                 286 => {
@@ -10510,19 +9758,19 @@ unsafe fn Do_BinOp_dbl(mut lParse: *mut ParseData, mut this: *mut Node) {
                 }
                 _ => {}
             }
-            (*this).operation = -(1000 as c_int);
+            (*this).operation = -1000;
         } else if (*this).operation == fits_parser_yytokentype::ACCUM as c_int
             || (*this).operation == fits_parser_yytokentype::DIFF as c_int
         {
             let mut i: c_long = 0;
             let mut undef: c_long = 0;
-            let mut previous: c_double = 0.;
-            let mut curr: c_double = 0.;
-            rows = (*lParse).nRows;
+            let mut previous: c_double = 0.0;
+            let mut curr: c_double = 0.0;
+            rows = lParse.nRows;
             nelem = (*this).value.nelem;
             elem = (*this).value.nelem * rows;
             Allocate_Ptrs(lParse, this);
-            if (*lParse).status == 0 {
+            if lParse.status == 0 {
                 previous = (*that2).value.data.dbl;
                 undef = *(*that2).value.undef as c_long;
                 if (*this).operation == fits_parser_yytokentype::ACCUM as c_int {
@@ -10558,20 +9806,20 @@ unsafe fn Do_BinOp_dbl(mut lParse: *mut ParseData, mut this: *mut Node) {
                 (*that2).value.undef = undef as *mut c_char;
             }
         } else {
-            rows = (*lParse).nRows;
+            rows = lParse.nRows;
             nelem = (*this).value.nelem;
             elem = (*this).value.nelem * rows;
             Allocate_Ptrs(lParse, this);
             loop {
                 let fresh50 = rows;
                 rows -= 1;
-                if !(fresh50 != 0 && (*lParse).status == 0) {
+                if !(fresh50 != 0 && lParse.status == 0) {
                     break;
                 }
                 loop {
                     let fresh51 = nelem;
                     nelem -= 1;
-                    if !(fresh51 != 0 && (*lParse).status == 0) {
+                    if !(fresh51 != 0 && lParse.status == 0) {
                         break;
                     }
                     elem -= 1;
@@ -10835,9 +10083,9 @@ pub unsafe fn angsep_calc(
 ) -> c_double {
     unsafe {
         static mut deg: c_double = 0.0;
-        let mut a: c_double = 0.;
-        let mut sdec: c_double = 0.;
-        let mut sra: c_double = 0.;
+        let mut a: c_double = 0.0;
+        let mut sdec: c_double = 0.0;
+        let mut sra: c_double = 0.0;
         if deg == 0.0 {
             deg = 4.0 * atan(1.0) / 180.0;
         }
@@ -10853,7 +10101,7 @@ pub unsafe fn angsep_calc(
         2.0f64 * atan2((a).sqrt(), (1.0f64 - a).sqrt()) / deg
     }
 }
-unsafe fn Do_Func(mut lParse: *mut ParseData, mut this: *mut Node) {
+unsafe fn Do_Func(lParse: &mut ParseData, mut this: *mut Node) {
     unsafe {
         let mut theParams: [*mut Node; 10] = [std::ptr::null_mut::<Node>(); 10];
         let mut vector: [c_int; 10] = [0; 10];
@@ -10867,7 +10115,7 @@ unsafe fn Do_Func(mut lParse: *mut ParseData, mut this: *mut Node) {
         }; 10];
         let mut pNull: [c_char; 10] = [0; 10];
         let mut ival: c_long = 0;
-        let mut dval: c_double = 0.;
+        let mut dval: c_double = 0.0;
         let mut i: c_int = 0;
         let mut valInit: c_int = 0;
         let mut row: c_long = 0;
@@ -10881,8 +10129,8 @@ unsafe fn Do_Func(mut lParse: *mut ParseData, mut this: *mut Node) {
             if fresh52 == 0 {
                 break;
             }
-            theParams[i as usize] = ((*lParse).Nodes).offset((*this).SubNodes[i as usize] as isize);
-            vector[i as usize] = ((*theParams[i as usize]).operation != -(1000 as c_int)) as c_int;
+            theParams[i as usize] = &mut (lParse.Nodes)[(*this).SubNodes[i as usize] as usize];
+            vector[i as usize] = ((*theParams[i as usize]).operation != -1000) as c_int;
             if vector[i as usize] != 0 {
                 allConst = 0;
                 vector[i as usize] = (*theParams[i as usize]).value.nelem as c_int;
@@ -11030,10 +10278,9 @@ unsafe fn Do_Func(mut lParse: *mut ParseData, mut this: *mut Node) {
                     dval = pVals[0].data.dbl;
                     if dval < -1.0f64 || dval > 1.0f64 {
                         fits_parser_yyerror(
-                            0 as yyscan_t,
+                            ptr::null_mut(),
                             lParse,
-                            b"Out of range argument to arcsin\0" as *const u8 as *const c_char
-                                as *mut c_char,
+                            cs!(c"Out of range argument to arcsin"),
                         );
                     } else {
                         (*this).value.data.dbl = asin(dval);
@@ -11044,10 +10291,9 @@ unsafe fn Do_Func(mut lParse: *mut ParseData, mut this: *mut Node) {
                     dval = pVals[0].data.dbl;
                     if dval < -1.0f64 || dval > 1.0f64 {
                         fits_parser_yyerror(
-                            0 as yyscan_t,
+                            ptr::null_mut(),
                             lParse,
-                            b"Out of range argument to arccos\0" as *const u8 as *const c_char
-                                as *mut c_char,
+                            cs!(c"Out of range argument to arccos"),
                         );
                     } else {
                         (*this).value.data.dbl = acos(dval);
@@ -11078,10 +10324,9 @@ unsafe fn Do_Func(mut lParse: *mut ParseData, mut this: *mut Node) {
                     dval = pVals[0].data.dbl;
                     if dval <= 0.0f64 {
                         fits_parser_yyerror(
-                            0 as yyscan_t,
+                            ptr::null_mut(),
                             lParse,
-                            b"Out of range argument to log\0" as *const u8 as *const c_char
-                                as *mut c_char,
+                            cs!(c"Out of range argument to log"),
                         );
                     } else {
                         (*this).value.data.dbl = log(dval);
@@ -11092,10 +10337,9 @@ unsafe fn Do_Func(mut lParse: *mut ParseData, mut this: *mut Node) {
                     dval = pVals[0].data.dbl;
                     if dval <= 0.0f64 {
                         fits_parser_yyerror(
-                            0 as yyscan_t,
+                            ptr::null_mut(),
                             lParse,
-                            b"Out of range argument to log10\0" as *const u8 as *const c_char
-                                as *mut c_char,
+                            cs!(c"Out of range argument to log10"),
                         );
                     } else {
                         (*this).value.data.dbl = log10(dval);
@@ -11106,10 +10350,9 @@ unsafe fn Do_Func(mut lParse: *mut ParseData, mut this: *mut Node) {
                     dval = pVals[0].data.dbl;
                     if dval < 0.0f64 {
                         fits_parser_yyerror(
-                            0 as yyscan_t,
+                            ptr::null_mut(),
                             lParse,
-                            b"Out of range argument to sqrt\0" as *const u8 as *const c_char
-                                as *mut c_char,
+                            cs!(c"Out of range argument to sqrt"),
                         );
                     } else {
                         (*this).value.data.dbl = sqrt(dval);
@@ -11125,7 +10368,7 @@ unsafe fn Do_Func(mut lParse: *mut ParseData, mut this: *mut Node) {
                     current_block_139 = 7627602990488000394;
                 }
                 1021 => {
-                    (*this).value.data.dbl = floor(pVals[0].data.dbl + 0.5f64);
+                    (*this).value.data.dbl = floor(pVals[0].data.dbl + 0.5);
                     current_block_139 = 7627602990488000394;
                 }
                 1018 => {
@@ -11305,12 +10548,12 @@ unsafe fn Do_Func(mut lParse: *mut ParseData, mut this: *mut Node) {
                     );
                 }
             }
-            (*this).operation = -(1000 as c_int);
+            (*this).operation = -1000;
         } else {
             Allocate_Ptrs(lParse, this);
-            row = (*lParse).nRows;
+            row = lParse.nRows;
             elem = row * (*this).value.nelem;
-            if (*lParse).status == 0 {
+            if lParse.status == 0 {
                 match (*this).operation {
                     1035 => loop {
                         let fresh53 = row;
@@ -11318,8 +10561,7 @@ unsafe fn Do_Func(mut lParse: *mut ParseData, mut this: *mut Node) {
                         if fresh53 == 0 {
                             break;
                         }
-                        *((*this).value.data.lngptr).offset(row as isize) =
-                            (*lParse).firstRow + row;
+                        *((*this).value.data.lngptr).offset(row as isize) = lParse.firstRow + row;
                         *((*this).value.undef).offset(row as isize) = 0;
                     },
                     1036 => {
@@ -11353,10 +10595,9 @@ unsafe fn Do_Func(mut lParse: *mut ParseData, mut this: *mut Node) {
                         let mut j: c_int = 0;
                         if ipos < 0 || ipos >= 5 as c_long {
                             fits_parser_yyerror(
-                                0 as yyscan_t,
+                                ptr::null_mut(),
                                 lParse,
-                                b"AXISELEM(V,n) n value exceeded maximum dimension\0" as *const u8
-                                    as *const c_char as *mut c_char,
+                                cs!(c"AXISELEM(V,n) n value exceeded maximum dimension"),
                             );
                             free((*this).value.data.ptr);
                         } else {
@@ -11422,7 +10663,7 @@ unsafe fn Do_Func(mut lParse: *mut ParseData, mut this: *mut Node) {
                     },
                     1043 => {
                         if (*theParams[0]).ntype == fits_parser_yytokentype::DOUBLE as c_int {
-                            if (*theParams[0]).operation == -(1000 as c_int) {
+                            if (*theParams[0]).operation == -1000 {
                                 loop {
                                     let fresh58 = elem;
                                     elem -= 1;
@@ -11459,7 +10700,7 @@ unsafe fn Do_Func(mut lParse: *mut ParseData, mut this: *mut Node) {
                                     }
                                 }
                             }
-                        } else if (*theParams[0]).operation == -(1000 as c_int) {
+                        } else if (*theParams[0]).operation == -1000 {
                             loop {
                                 let fresh60 = elem;
                                 elem -= 1;
@@ -11831,12 +11072,9 @@ unsafe fn Do_Func(mut lParse: *mut ParseData, mut this: *mut Node) {
                             let mut irow: c_int = 0;
                             if mptr.is_null() {
                                 fits_parser_yyerror(
-                                    0 as yyscan_t,
+                                    ptr::null_mut(),
                                     lParse,
-                                    b"Could not allocate temporary memory in median function\0"
-                                        as *const u8
-                                        as *const c_char
-                                        as *mut c_char,
+                                    cs!(c"Could not allocate temporary memory in median function"),
                                 );
                                 free((*this).value.data.ptr);
                             } else {
@@ -11887,12 +11125,9 @@ unsafe fn Do_Func(mut lParse: *mut ParseData, mut this: *mut Node) {
                             let mut irow_0: c_int = 0;
                             if mptr_0.is_null() {
                                 fits_parser_yyerror(
-                                    0 as yyscan_t,
+                                    ptr::null_mut(),
                                     lParse,
-                                    b"Could not allocate temporary memory in median function\0"
-                                        as *const u8
-                                        as *const c_char
-                                        as *mut c_char,
+                                    cs!(c"Could not allocate temporary memory in median function"),
                                 );
                                 free((*this).value.data.ptr);
                             } else {
@@ -12460,7 +11695,7 @@ unsafe fn Do_Func(mut lParse: *mut ParseData, mut this: *mut Node) {
                         *fresh134 = *((*theParams[0]).value.undef).offset(elem as isize);
                         if *fresh134 == 0 {
                             *((*this).value.data.dblptr).offset(elem as isize) = floor(
-                                *((*theParams[0]).value.data.dblptr).offset(elem as isize) + 0.5f64,
+                                *((*theParams[0]).value.data.dblptr).offset(elem as isize) + 0.5,
                             );
                         }
                     },
@@ -13477,12 +12712,9 @@ unsafe fn Do_Func(mut lParse: *mut ParseData, mut this: *mut Node) {
                         _ => {}
                     },
                     1044 => {
-                        let mut strconst: c_int =
-                            ((*theParams[0]).operation == -(1000 as c_int)) as c_int;
-                        let mut posconst: c_int =
-                            ((*theParams[1]).operation == -(1000 as c_int)) as c_int;
-                        let mut lenconst: c_int =
-                            ((*theParams[2]).operation == -(1000 as c_int)) as c_int;
+                        let mut strconst: c_int = ((*theParams[0]).operation == -1000) as c_int;
+                        let mut posconst: c_int = ((*theParams[1]).operation == -1000) as c_int;
+                        let mut lenconst: c_int = ((*theParams[2]).operation == -1000) as c_int;
                         let mut dest_len: c_int = (*this).value.nelem as c_int;
                         let mut src_len: c_int = (*theParams[0]).value.nelem as c_int;
                         loop {
@@ -13544,10 +12776,8 @@ unsafe fn Do_Func(mut lParse: *mut ParseData, mut this: *mut Node) {
                         }
                     }
                     1045 => {
-                        let mut const1: c_int =
-                            ((*theParams[0]).operation == -(1000 as c_int)) as c_int;
-                        let mut const2: c_int =
-                            ((*theParams[1]).operation == -(1000 as c_int)) as c_int;
+                        let mut const1: c_int = ((*theParams[0]).operation == -1000) as c_int;
+                        let mut const2: c_int = ((*theParams[1]).operation == -1000) as c_int;
                         loop {
                             let fresh197 = row;
                             row -= 1;
@@ -13604,7 +12834,7 @@ unsafe fn Do_Func(mut lParse: *mut ParseData, mut this: *mut Node) {
         }
     }
 }
-unsafe fn Do_Deref(mut lParse: *mut ParseData, mut this: *mut Node) {
+unsafe fn Do_Deref(lParse: &mut ParseData, mut this: *mut Node) {
     unsafe {
         let mut theVar: *mut Node = std::ptr::null_mut::<Node>();
         let mut theDims: [*mut Node; 5] = [std::ptr::null_mut::<Node>(); 5];
@@ -13616,7 +12846,7 @@ unsafe fn Do_Deref(mut lParse: *mut ParseData, mut this: *mut Node) {
         let mut row: c_long = 0;
         let mut elem: c_long = 0;
         let mut dsize: c_long = 0;
-        theVar = ((*lParse).Nodes).offset((*this).SubNodes[0] as isize);
+        theVar = &mut (lParse.Nodes)[(*this).SubNodes[0] as usize];
         nDims = (*this).nSubNodes - 1;
         i = nDims;
         allConst = 1;
@@ -13626,9 +12856,8 @@ unsafe fn Do_Deref(mut lParse: *mut ParseData, mut this: *mut Node) {
             if fresh199 == 0 {
                 break;
             }
-            theDims[i as usize] =
-                ((*lParse).Nodes).offset((*this).SubNodes[(i + 1) as usize] as isize);
-            isConst[i as usize] = ((*theDims[i as usize]).operation == -(1000 as c_int)) as c_int;
+            theDims[i as usize] = &mut (lParse.Nodes)[(*this).SubNodes[(i + 1) as usize] as usize];
+            isConst[i as usize] = ((*theDims[i as usize]).operation == -1000) as c_int;
             if isConst[i as usize] != 0 {
                 dimVals[i as usize] = (*theDims[i as usize]).value.data.lng;
             } else {
@@ -13645,7 +12874,7 @@ unsafe fn Do_Deref(mut lParse: *mut ParseData, mut this: *mut Node) {
             dsize = 0;
         }
         Allocate_Ptrs(lParse, this);
-        if (*lParse).status == 0 {
+        if lParse.status == 0 {
             if allConst != 0 && (*theVar).value.naxis == nDims {
                 elem = 0;
                 i = nDims;
@@ -13664,7 +12893,7 @@ unsafe fn Do_Deref(mut lParse: *mut ParseData, mut this: *mut Node) {
                 }
                 if i < 0 {
                     row = 0;
-                    while row < (*lParse).nRows {
+                    while row < lParse.nRows {
                         if (*this).ntype == fits_parser_yytokentype::STRING as c_int {
                             *((*this).value.undef).offset(row as isize) =
                                 *((*theVar).value.undef).offset(row as isize);
@@ -13693,29 +12922,21 @@ unsafe fn Do_Deref(mut lParse: *mut ParseData, mut this: *mut Node) {
                         row;
                     }
                 } else {
-                    fits_parser_yyerror(
-                        0 as yyscan_t,
-                        lParse,
-                        b"Index out of range\0" as *const u8 as *const c_char as *mut c_char,
-                    );
+                    fits_parser_yyerror(ptr::null_mut(), lParse, cs!(c"Index out of range"));
                     free((*this).value.data.ptr);
                 }
             } else if allConst != 0 && nDims == 1 {
                 if dimVals[0] < 1
                     || dimVals[0] > (*theVar).value.naxes[((*theVar).value.naxis - 1) as usize]
                 {
-                    fits_parser_yyerror(
-                        0 as yyscan_t,
-                        lParse,
-                        b"Index out of range\0" as *const u8 as *const c_char as *mut c_char,
-                    );
+                    fits_parser_yyerror(ptr::null_mut(), lParse, cs!(c"Index out of range"));
                     free((*this).value.data.ptr);
                 } else if (*this).ntype == fits_parser_yytokentype::BITSTR as c_int
                     || (*this).ntype == fits_parser_yytokentype::STRING as c_int
                 {
                     elem = (*this).value.nelem * (dimVals[0] - 1);
                     row = 0;
-                    while row < (*lParse).nRows {
+                    while row < lParse.nRows {
                         if !((*this).value.undef).is_null() {
                             *((*this).value.undef).offset(row as isize) =
                                 *((*theVar).value.undef).offset(row as isize);
@@ -13746,7 +12967,7 @@ unsafe fn Do_Deref(mut lParse: *mut ParseData, mut this: *mut Node) {
                 } else {
                     elem = (*this).value.nelem * (dimVals[0] - 1);
                     row = 0;
-                    while row < (*lParse).nRows {
+                    while row < lParse.nRows {
                         memcpy(
                             ((*this).value.undef).offset((row * (*this).value.nelem) as isize)
                                 as *mut c_void,
@@ -13774,17 +12995,15 @@ unsafe fn Do_Deref(mut lParse: *mut ParseData, mut this: *mut Node) {
                 }
             } else if (*theVar).value.naxis == nDims {
                 row = 0;
-                while row < (*lParse).nRows {
+                while row < lParse.nRows {
                     i = 0;
                     while i < nDims {
                         if isConst[i as usize] == 0 {
                             if *((*theDims[i as usize]).value.undef).offset(row as isize) != 0 {
                                 fits_parser_yyerror(
-                                    0 as yyscan_t,
+                                    ptr::null_mut(),
                                     lParse,
-                                    b"Null encountered as vector index\0" as *const u8
-                                        as *const c_char
-                                        as *mut c_char,
+                                    cs!(c"Null encountered as vector index"),
                                 );
                                 free((*this).value.data.ptr);
                                 break;
@@ -13796,7 +13015,7 @@ unsafe fn Do_Deref(mut lParse: *mut ParseData, mut this: *mut Node) {
                         i += 1;
                         i;
                     }
-                    if (*lParse).status != 0 {
+                    if lParse.status != 0 {
                         break;
                     }
                     elem = 0;
@@ -13840,11 +13059,7 @@ unsafe fn Do_Deref(mut lParse: *mut ParseData, mut this: *mut Node) {
                                 .offset(1 as c_int as isize) = 0;
                         }
                     } else {
-                        fits_parser_yyerror(
-                            0 as yyscan_t,
-                            lParse,
-                            b"Index out of range\0" as *const u8 as *const c_char as *mut c_char,
-                        );
+                        fits_parser_yyerror(ptr::null_mut(), lParse, cs!(c"Index out of range"));
                         free((*this).value.data.ptr);
                     }
                     row += 1;
@@ -13852,13 +13067,12 @@ unsafe fn Do_Deref(mut lParse: *mut ParseData, mut this: *mut Node) {
                 }
             } else {
                 row = 0;
-                while row < (*lParse).nRows {
+                while row < lParse.nRows {
                     if *((*theDims[0]).value.undef).offset(row as isize) != 0 {
                         fits_parser_yyerror(
-                            0 as yyscan_t,
+                            ptr::null_mut(),
                             lParse,
-                            b"Null encountered as vector index\0" as *const u8 as *const c_char
-                                as *mut c_char,
+                            cs!(c"Null encountered as vector index"),
                         );
                         free((*this).value.data.ptr);
                         break;
@@ -13869,10 +13083,9 @@ unsafe fn Do_Deref(mut lParse: *mut ParseData, mut this: *mut Node) {
                                 > (*theVar).value.naxes[((*theVar).value.naxis - 1) as usize]
                         {
                             fits_parser_yyerror(
-                                0 as yyscan_t,
+                                ptr::null_mut(),
                                 lParse,
-                                b"Index out of range\0" as *const u8 as *const c_char
-                                    as *mut c_char,
+                                cs!(c"Index out of range"),
                             );
                             free((*this).value.data.ptr);
                         } else if (*this).ntype == fits_parser_yytokentype::BITSTR as c_int
@@ -13952,7 +13165,7 @@ unsafe fn Do_Deref(mut lParse: *mut ParseData, mut this: *mut Node) {
         }
     }
 }
-unsafe fn Do_GTI(mut lParse: *mut ParseData, mut this: *mut Node) {
+unsafe fn Do_GTI(lParse: &mut ParseData, mut this: *mut Node) {
     unsafe {
         let mut theExpr: *mut Node = std::ptr::null_mut::<Node>();
         let mut theTimes: *mut Node = std::ptr::null_mut::<Node>();
@@ -13964,13 +13177,13 @@ unsafe fn Do_GTI(mut lParse: *mut ParseData, mut this: *mut Node) {
         let mut gti: c_long = 0;
         let mut ordered: c_int = 0;
         let mut dorow: c_int = ((*this).operation == gtifind_fct as c_int) as c_int;
-        theTimes = ((*lParse).Nodes).offset((*this).SubNodes[0] as isize);
-        theExpr = ((*lParse).Nodes).offset((*this).SubNodes[1] as isize);
+        theTimes = &mut (lParse.Nodes)[(*this).SubNodes[0] as usize];
+        theExpr = &mut (lParse.Nodes)[(*this).SubNodes[1] as usize];
         nGTI = (*theTimes).value.nelem;
         start = (*theTimes).value.data.dblptr;
         stop = ((*theTimes).value.data.dblptr).offset(nGTI as isize);
         ordered = (*theTimes).ntype;
-        if (*theExpr).operation == -(1000 as c_int) {
+        if (*theExpr).operation == -1000 {
             gti = Search_GTI(
                 (*theExpr).value.data.dbl,
                 nGTI,
@@ -13984,12 +13197,12 @@ unsafe fn Do_GTI(mut lParse: *mut ParseData, mut this: *mut Node) {
             } else {
                 (*this).value.data.log = if gti >= 0 { 1 } else { 0 };
             }
-            (*this).operation = -(1000 as c_int);
+            (*this).operation = -1000;
         } else {
             Allocate_Ptrs(lParse, this);
             times = (*theExpr).value.data.dblptr;
-            if (*lParse).status == 0 {
-                elem = (*lParse).nRows * (*this).value.nelem;
+            if lParse.status == 0 {
+                elem = lParse.nRows * (*this).value.nelem;
                 if nGTI != 0 {
                     gti = -(1) as c_long;
                     loop {
@@ -14053,7 +13266,7 @@ unsafe fn Do_GTI(mut lParse: *mut ParseData, mut this: *mut Node) {
         }
     }
 }
-unsafe fn Do_GTI_Over(mut lParse: *mut ParseData, mut this: *mut Node) {
+unsafe fn Do_GTI_Over(lParse: &mut ParseData, mut this: *mut Node) {
     unsafe {
         let mut theTimes: *mut Node = std::ptr::null_mut::<Node>();
         let mut theStart: *mut Node = std::ptr::null_mut::<Node>();
@@ -14067,13 +13280,13 @@ unsafe fn Do_GTI_Over(mut lParse: *mut ParseData, mut this: *mut Node) {
         let mut gti: c_long = 0;
         let mut nextGTI: c_long = 0;
         let mut ordered: c_int = 0;
-        theTimes = ((*lParse).Nodes).offset((*this).SubNodes[0] as isize);
-        theStop = ((*lParse).Nodes).offset((*this).SubNodes[2] as isize);
-        theStart = ((*lParse).Nodes).offset((*this).SubNodes[1] as isize);
+        theTimes = &mut (lParse.Nodes)[(*this).SubNodes[0] as usize];
+        theStop = &mut (lParse.Nodes)[(*this).SubNodes[2] as usize];
+        theStart = &mut (lParse.Nodes)[(*this).SubNodes[1] as usize];
         nGTI = (*theTimes).value.nelem;
         gtiStart = (*theTimes).value.data.dblptr;
         gtiStop = ((*theTimes).value.data.dblptr).offset(nGTI as isize);
-        if (*theStart).operation == -(1000 as c_int) && (*theStop).operation == -(1000 as c_int) {
+        if (*theStart).operation == -1000 && (*theStop).operation == -1000 {
             (*this).value.data.dbl = GTI_Over(
                 (*theStart).value.data.dbl,
                 (*theStop).value.data.dbl,
@@ -14082,23 +13295,23 @@ unsafe fn Do_GTI_Over(mut lParse: *mut ParseData, mut this: *mut Node) {
                 gtiStop,
                 &mut gti,
             );
-            (*this).operation = -(1000 as c_int);
+            (*this).operation = -1000;
         } else {
             let mut undefStart: c_char = 0;
             let mut undefStop: c_char = 0;
-            let mut uStart: c_double = 0.;
-            let mut uStop: c_double = 0.;
-            if (*theStart).operation == -(1000 as c_int) {
+            let mut uStart: c_double = 0.0;
+            let mut uStop: c_double = 0.0;
+            if (*theStart).operation == -1000 {
                 uStart = (*theStart).value.data.dbl;
             }
-            if (*theStop).operation == -(1000 as c_int) {
+            if (*theStop).operation == -1000 {
                 uStop = (*theStop).value.data.dbl;
             }
             Allocate_Ptrs(lParse, this);
             evtStart = (*theStart).value.data.dblptr;
             evtStop = (*theStop).value.data.dblptr;
-            if (*lParse).status == 0 {
-                elem = (*lParse).nRows * (*this).value.nelem;
+            if lParse.status == 0 {
+                elem = lParse.nRows * (*this).value.nelem;
                 if nGTI != 0 {
                     let mut toverlap: c_double = 0.0f64;
                     gti = -(1) as c_long;
@@ -14108,11 +13321,11 @@ unsafe fn Do_GTI_Over(mut lParse: *mut ParseData, mut this: *mut Node) {
                         if fresh206 == 0 {
                             break;
                         }
-                        if (*theStart).operation != -(1000 as c_int) {
+                        if (*theStart).operation != -1000 {
                             undefStart = *((*theStart).value.undef).offset(elem as isize);
                             uStart = *evtStart.offset(elem as isize);
                         }
-                        if (*theStop).operation != -(1000 as c_int) {
+                        if (*theStop).operation != -1000 {
                             undefStop = *((*theStop).value.undef).offset(elem as isize);
                             uStop = *evtStop.offset(elem as isize);
                         }
@@ -14288,7 +13501,7 @@ unsafe fn Search_GTI(
         gti
     }
 }
-unsafe fn Do_REG(mut lParse: *mut ParseData, mut this: *mut Node) {
+unsafe fn Do_REG(lParse: &mut ParseData, mut this: *mut Node) {
     unsafe {
         let mut theRegion: *mut Node = std::ptr::null_mut::<Node>();
         let mut theX: *mut Node = std::ptr::null_mut::<Node>();
@@ -14302,16 +13515,16 @@ unsafe fn Do_REG(mut lParse: *mut ParseData, mut this: *mut Node) {
         let mut nelem: c_long = 0;
         let mut elem: c_long = 0;
         let mut rows: c_long = 0;
-        theRegion = ((*lParse).Nodes).offset((*this).SubNodes[0] as isize);
-        theX = ((*lParse).Nodes).offset((*this).SubNodes[1] as isize);
-        theY = ((*lParse).Nodes).offset((*this).SubNodes[2] as isize);
-        Xvector = ((*theX).operation != -(1000 as c_int)) as c_int;
+        theRegion = &mut (lParse.Nodes)[(*this).SubNodes[0] as usize];
+        theX = &mut (lParse.Nodes)[(*this).SubNodes[1] as usize];
+        theY = &mut (lParse.Nodes)[(*this).SubNodes[2] as usize];
+        Xvector = ((*theX).operation != -1000) as c_int;
         if Xvector != 0 {
             Xvector = (*theX).value.nelem as c_int;
         } else {
             Xval = (*theX).value.data.dbl;
         }
-        Yvector = ((*theY).operation != -(1000 as c_int)) as c_int;
+        Yvector = ((*theY).operation != -1000) as c_int;
         if Yvector != 0 {
             Yvector = (*theY).value.nelem as c_int;
         } else {
@@ -14328,11 +13541,11 @@ unsafe fn Do_REG(mut lParse: *mut ParseData, mut this: *mut Node) {
             } else {
                 0
             };
-            (*this).operation = -(1000 as c_int);
+            (*this).operation = -1000;
         } else {
             Allocate_Ptrs(lParse, this);
-            if (*lParse).status == 0 {
-                rows = (*lParse).nRows;
+            if lParse.status == 0 {
+                rows = lParse.nRows;
                 nelem = (*this).value.nelem;
                 elem = rows * nelem;
                 loop {
@@ -14395,7 +13608,7 @@ unsafe fn Do_REG(mut lParse: *mut ParseData, mut this: *mut Node) {
         }
     }
 }
-unsafe fn Do_Vector(mut lParse: *mut ParseData, mut this: *mut Node) {
+unsafe fn Do_Vector(lParse: &mut ParseData, mut this: *mut Node) {
     unsafe {
         let mut that: *mut Node = std::ptr::null_mut::<Node>();
         let mut row: c_long = 0;
@@ -14405,12 +13618,12 @@ unsafe fn Do_Vector(mut lParse: *mut ParseData, mut this: *mut Node) {
         let mut offset: c_long = 0;
         let mut node: c_int = 0;
         Allocate_Ptrs(lParse, this);
-        if (*lParse).status == 0 {
+        if lParse.status == 0 {
             node = 0;
             while node < (*this).nSubNodes {
-                that = ((*lParse).Nodes).offset((*this).SubNodes[node as usize] as isize);
-                if (*that).operation == -(1000 as c_int) {
-                    idx = (*lParse).nRows * (*this).value.nelem + offset;
+                that = &mut (lParse.Nodes)[(*this).SubNodes[node as usize] as usize];
+                if (*that).operation == -1000 {
+                    idx = lParse.nRows * (*this).value.nelem + offset;
                     loop {
                         idx -= (*this).value.nelem;
                         if idx < 0 {
@@ -14434,7 +13647,7 @@ unsafe fn Do_Vector(mut lParse: *mut ParseData, mut this: *mut Node) {
                         }
                     }
                 } else {
-                    row = (*lParse).nRows;
+                    row = lParse.nRows;
                     idx = row * (*that).value.nelem;
                     loop {
                         let fresh212 = row;
@@ -14478,9 +13691,9 @@ unsafe fn Do_Vector(mut lParse: *mut ParseData, mut this: *mut Node) {
         }
         node = 0;
         while node < (*this).nSubNodes {
-            if (*((*lParse).Nodes).offset((*this).SubNodes[node as usize] as isize)).operation > 0 {
+            if ((lParse.Nodes)[(*this).SubNodes[node as usize] as usize]).operation > 0 {
                 free(
-                    (*((*lParse).Nodes).offset((*this).SubNodes[node as usize] as isize))
+                    ((lParse.Nodes)[(*this).SubNodes[node as usize] as usize])
                         .value
                         .data
                         .ptr,
@@ -14492,7 +13705,7 @@ unsafe fn Do_Vector(mut lParse: *mut ParseData, mut this: *mut Node) {
     }
 }
 
-unsafe fn Do_Array(mut lParse: *mut ParseData, mut this: *mut Node) {
+unsafe fn Do_Array(lParse: &mut ParseData, mut this: *mut Node) {
     unsafe {
         let mut that: *mut Node = std::ptr::null_mut::<Node>();
         let mut row: c_long = 0;
@@ -14502,10 +13715,10 @@ unsafe fn Do_Array(mut lParse: *mut ParseData, mut this: *mut Node) {
         let mut offset: c_long = 0;
         let mut node: c_int = 0;
         Allocate_Ptrs(lParse, this);
-        if (*lParse).status == 0 {
-            that = ((*lParse).Nodes).offset((*this).SubNodes[0] as isize);
-            if (*that).operation == -(1000 as c_int) {
-                idx = (*lParse).nRows * (*this).value.nelem + offset;
+        if lParse.status == 0 {
+            that = &mut (lParse.Nodes)[(*this).SubNodes[0] as usize];
+            if (*that).operation == -1000 {
+                idx = lParse.nRows * (*this).value.nelem + offset;
                 loop {
                     let fresh214 = idx;
                     idx -= 1;
@@ -14530,7 +13743,7 @@ unsafe fn Do_Array(mut lParse: *mut ParseData, mut this: *mut Node) {
                     }
                 }
             } else if (*that).value.nelem > 1 {
-                idx = (*lParse).nRows * (*this).value.nelem;
+                idx = lParse.nRows * (*this).value.nelem;
                 loop {
                     let fresh215 = idx;
                     idx -= 1;
@@ -14556,7 +13769,7 @@ unsafe fn Do_Array(mut lParse: *mut ParseData, mut this: *mut Node) {
                     }
                 }
             } else {
-                row = (*lParse).nRows;
+                row = lParse.nRows;
                 idx = row * (*this).value.nelem - 1;
                 loop {
                     let fresh216 = row;
@@ -14593,9 +13806,9 @@ unsafe fn Do_Array(mut lParse: *mut ParseData, mut this: *mut Node) {
                     }
                 }
             }
-            if (*((*lParse).Nodes).offset((*this).SubNodes[0] as isize)).operation > 0 {
+            if ((lParse.Nodes)[(*this).SubNodes[0] as usize]).operation > 0 {
                 free(
-                    (*((*lParse).Nodes).offset((*this).SubNodes[0] as isize))
+                    ((lParse.Nodes)[(*this).SubNodes[0] as usize])
                         .value
                         .data
                         .ptr,
@@ -14959,148 +14172,130 @@ unsafe fn bitnot(mut result: *mut c_char, mut bits: *mut c_char) {
         *result = 0;
     }
 }
+
 unsafe fn bitcmp(mut bitstrm1: *mut c_char, mut bitstrm2: *mut c_char) -> c_char {
     unsafe {
         let mut i: c_int = 0;
-        let mut l1: c_int = 0;
-        let mut l2: c_int = 0;
         let mut ldiff: c_int = 0;
         let mut largestStream: c_int = 0;
-        let mut stream: *mut c_char = ptr::null_mut();
         let mut chr1: c_char = 0;
         let mut chr2: c_char = 0;
-        l1 = strlen(bitstrm1) as c_int;
-        l2 = strlen(bitstrm2) as c_int;
-        largestStream = if l1 > l2 { l1 } else { l2 };
-        stream = malloc(
-            (::core::mem::size_of::<c_char>() as c_ulong)
-                .wrapping_mul((largestStream + 1) as c_ulong)
-                .try_into()
-                .unwrap(),
-        ) as *mut c_char;
+
+        let mut l1 = strlen(bitstrm1) as c_int;
+        let mut l2 = strlen(bitstrm2) as c_int;
+
+        let mut bitstrm1 = std::slice::from_raw_parts_mut(bitstrm1, l1 as usize);
+        let mut bitstrm2 = std::slice::from_raw_parts_mut(bitstrm2, l2 as usize);
+
+        largestStream = cmp::max(l1, l2);
+
+        let mut stream_vec: Vec<c_char> = vec![0; (largestStream + 1) as usize];
+        let mut stream = &mut stream_vec[..];
+
         if l1 < l2 {
             ldiff = l2 - l1;
             i = 0;
-            loop {
-                let fresh256 = ldiff;
+
+            while ldiff >= 0 {
                 ldiff -= 1;
-                if fresh256 == 0 {
-                    break;
-                }
-                let fresh257 = i;
+                stream[i as usize] = b'0' as c_char;
                 i += 1;
-                *stream.offset(fresh257 as isize) = b'0' as c_char;
             }
-            loop {
-                let fresh258 = l1;
+
+            while l1 >= 0 {
                 l1 -= 1;
-                if fresh258 == 0 {
-                    break;
-                }
-                let fresh259 = bitstrm1;
-                bitstrm1 = bitstrm1.offset(1);
-                let fresh260 = i;
+                stream[i as usize] = bitstrm1[0];
+                bitstrm1 = &mut bitstrm1[1..];
                 i += 1;
-                *stream.offset(fresh260 as isize) = *fresh259;
             }
-            *stream.offset(i as isize) = 0;
+
+            stream[i as usize] = 0;
             bitstrm1 = stream;
         } else if l2 < l1 {
             ldiff = l1 - l2;
             i = 0;
-            loop {
-                let fresh261 = ldiff;
+
+            while ldiff >= 0 {
                 ldiff -= 1;
-                if fresh261 == 0 {
-                    break;
-                }
-                let fresh262 = i;
+                stream[i as usize] = b'0' as c_char;
                 i += 1;
-                *stream.offset(fresh262 as isize) = b'0' as c_char;
             }
-            loop {
-                let fresh263 = l2;
+
+            while l2 >= 0 {
                 l2 -= 1;
-                if fresh263 == 0 {
-                    break;
-                }
-                let fresh264 = bitstrm2;
-                bitstrm2 = bitstrm2.offset(1);
-                let fresh265 = i;
+                stream[i as usize] = bitstrm2[0];
+                bitstrm2 = &mut bitstrm2[1..];
                 i += 1;
-                *stream.offset(fresh265 as isize) = *fresh264;
             }
-            *stream.offset(i as isize) = 0;
+
+            stream[i as usize] = 0;
             bitstrm2 = stream;
         }
+
         loop {
-            let fresh266 = bitstrm1;
-            bitstrm1 = bitstrm1.offset(1);
-            chr1 = *fresh266;
+            chr1 = bitstrm1[0];
+            bitstrm1 = &mut bitstrm1[1..];
             if chr1 == 0 {
                 break;
             }
-            let fresh267 = bitstrm2;
-            bitstrm2 = bitstrm2.offset(1);
-            chr2 = *fresh267;
-            if chr1 as c_int == '0' as i32 && chr2 as c_int == '1' as i32
-                || chr1 as c_int == '1' as i32 && chr2 as c_int == '0' as i32
+
+            chr2 = bitstrm2[0];
+            bitstrm2 = &mut bitstrm2[1..];
+
+            if (chr1 == b'0' as c_char && chr2 == b'1' as c_char)
+                || (chr1 == b'1' as c_char && chr2 == b'0' as c_char)
             {
-                free(stream as *mut c_void);
                 return 0;
             }
         }
-        free(stream as *mut c_void);
         1
     }
 }
-unsafe fn bnear(mut x: c_double, mut y: c_double, mut tolerance: c_double) -> c_char {
-    if fabs(x - y) < tolerance { 1 } else { 0 }
+
+fn bnear(x: c_double, y: c_double, tolerance: c_double) -> c_char {
+    if (x - y).abs() < tolerance { 1 } else { 0 }
 }
-unsafe fn saobox(
-    mut xcen: c_double,
-    mut ycen: c_double,
-    mut xwid: c_double,
-    mut ywid: c_double,
-    mut rot: c_double,
-    mut xcol: c_double,
-    mut ycol: c_double,
+
+fn saobox(
+    xcen: c_double,
+    ycen: c_double,
+    xwid: c_double,
+    ywid: c_double,
+    rot: c_double,
+    xcol: c_double,
+    ycol: c_double,
 ) -> c_char {
-    let mut x: c_double = 0.;
-    let mut y: c_double = 0.;
-    let mut xprime: c_double = 0.;
-    let mut yprime: c_double = 0.;
-    let mut xmin: c_double = 0.;
-    let mut xmax: c_double = 0.;
-    let mut ymin: c_double = 0.;
-    let mut ymax: c_double = 0.;
-    let mut theta: c_double = 0.;
-    theta = rot / 180.0f64 * 3.141_592_653_589_793_f64;
+    let mut x: c_double = 0.0;
+    let mut y: c_double = 0.0;
+    let mut xprime: c_double = 0.0;
+    let mut yprime: c_double = 0.0;
+    let mut xmin: c_double = 0.0;
+    let mut xmax: c_double = 0.0;
+    let mut ymin: c_double = 0.0;
+    let mut ymax: c_double = 0.0;
+    let mut theta: c_double = 0.0;
+    theta = rot / 180.0 * MY_PI;
     xprime = xcol - xcen;
     yprime = ycol - ycen;
-    x = xprime * cos(theta) + yprime * sin(theta);
-    y = -xprime * sin(theta) + yprime * cos(theta);
-    xmin = -0.5f64 * xwid;
-    xmax = 0.5f64 * xwid;
-    ymin = -0.5f64 * ywid;
-    ymax = 0.5f64 * ywid;
+    x = xprime * (theta.cos()) + yprime * (theta.sin());
+    y = -xprime * (theta.sin()) + yprime * (theta.cos());
+    xmin = -0.5 * xwid;
+    xmax = 0.5 * xwid;
+    ymin = -0.5 * ywid;
+    ymax = 0.5 * ywid;
+
     if x >= xmin && x <= xmax && y >= ymin && y <= ymax {
         1
     } else {
         0
     }
 }
-unsafe fn circle(
-    mut xcen: c_double,
-    mut ycen: c_double,
-    mut rad: c_double,
-    mut xcol: c_double,
-    mut ycol: c_double,
-) -> c_char {
-    let mut r2: c_double = 0.;
-    let mut dx: c_double = 0.;
-    let mut dy: c_double = 0.;
-    let mut dlen: c_double = 0.;
+
+fn circle(xcen: c_double, ycen: c_double, rad: c_double, xcol: c_double, ycol: c_double) -> c_char {
+    let mut r2: c_double = 0.0;
+    let mut dx: c_double = 0.0;
+    let mut dy: c_double = 0.0;
+    let mut dlen: c_double = 0.0;
     dx = xcol - xcen;
     dy = ycol - ycen;
     dx *= dx;
@@ -15109,103 +14304,102 @@ unsafe fn circle(
     r2 = rad * rad;
     if dlen <= r2 { 1 } else { 0 }
 }
-unsafe fn ellipse(
-    mut xcen: c_double,
-    mut ycen: c_double,
-    mut xrad: c_double,
-    mut yrad: c_double,
-    mut rot: c_double,
-    mut xcol: c_double,
-    mut ycol: c_double,
+
+fn ellipse(
+    xcen: c_double,
+    ycen: c_double,
+    xrad: c_double,
+    yrad: c_double,
+    rot: c_double,
+    xcol: c_double,
+    ycol: c_double,
 ) -> c_char {
-    let mut x: c_double = 0.;
-    let mut y: c_double = 0.;
-    let mut xprime: c_double = 0.;
-    let mut yprime: c_double = 0.;
-    let mut dx: c_double = 0.;
-    let mut dy: c_double = 0.;
-    let mut dlen: c_double = 0.;
-    let mut theta: c_double = 0.;
-    theta = rot / 180.0f64 * 3.141_592_653_589_793_f64;
+    let mut x: c_double = 0.0;
+    let mut y: c_double = 0.0;
+    let mut xprime: c_double = 0.0;
+    let mut yprime: c_double = 0.0;
+    let mut dx: c_double = 0.0;
+    let mut dy: c_double = 0.0;
+    let mut dlen: c_double = 0.0;
+    let mut theta: c_double = 0.0;
+
+    theta = rot / 180.0 * MY_PI;
     xprime = xcol - xcen;
     yprime = ycol - ycen;
-    x = xprime * cos(theta) + yprime * sin(theta);
-    y = -xprime * sin(theta) + yprime * cos(theta);
+    x = xprime * (theta.cos()) + yprime * (theta.sin());
+    y = -xprime * (theta.sin()) + yprime * (theta.cos());
     dx = x / xrad;
     dy = y / yrad;
     dx *= dx;
     dy *= dy;
     dlen = dx + dy;
-    if dlen <= 1.0f64 { 1 } else { 0 }
+    if dlen <= 1.0 { 1 } else { 0 }
 }
-unsafe fn cstrmid(
-    mut lParse: *mut ParseData,
-    mut dest_str: *mut c_char,
-    mut dest_len: c_int,
-    mut src_str: *mut c_char,
-    mut src_len: c_int,
-    mut pos: c_int,
+
+/// Extract substring
+fn cstrmid(
+    lParse: &mut ParseData,
+    dest_str: *mut c_char,
+    dest_len: c_int,
+    src_str: *const c_char,
+    src_len: c_int,
+    pos: c_int,
 ) -> c_int {
-    unsafe {
-        let mut fill_char: c_char = 0;
-        if src_len == 0 {
-            src_len = strlen(src_str) as c_int;
-        }
-        if pos < 0 {
-            fits_parser_yyerror(
-                0 as yyscan_t,
-                lParse,
-                b"STRMID(S,P,N) P must be 0 or greater\0" as *const u8 as *const c_char
-                    as *mut c_char,
-            );
-            return -(1);
-        }
-        if pos > src_len || pos == 0 {
-            memset(
-                dest_str as *mut c_void,
-                fill_char as c_int,
-                (dest_len as c_ulong).try_into().unwrap(),
-            );
-        } else if pos + dest_len > src_len {
-            let mut nsub: c_int = src_len - pos + 1;
-            let mut npad: c_int = dest_len - nsub;
-            memcpy(
-                dest_str as *mut c_void,
-                src_str.offset(pos as isize).offset(-(1 as c_int as isize)) as *const c_void,
-                (nsub as c_ulong).try_into().unwrap(),
-            );
-            memset(
-                dest_str.offset(nsub as isize) as *mut c_void,
-                fill_char as c_int,
-                (npad as c_ulong).try_into().unwrap(),
-            );
-        } else {
-            memcpy(
-                dest_str as *mut c_void,
-                src_str.offset(pos as isize).offset(-(1 as c_int as isize)) as *const c_void,
-                (dest_len as c_ulong).try_into().unwrap(),
-            );
-        }
-        *dest_str.offset(dest_len as isize) = 0;
-        0
-    }
-}
-unsafe fn fits_parser_yyerror(
-    mut scanner: yyscan_t,
-    mut lParse: *mut ParseData,
-    mut s: *mut c_char,
-) {
-    unsafe {
-        let mut msg: [c_char; 80] = [0; 80];
-        if (*lParse).status == 0 {
-            (*lParse).status = 431 as c_int;
-        }
-        strncpy(
-            msg.as_mut_ptr(),
-            s,
-            (80 as c_int as c_ulong).try_into().unwrap(),
+    let dest_str = unsafe { std::slice::from_raw_parts_mut(dest_str, (dest_len) as usize) };
+    let dest_len = dest_len as usize;
+    let mut src_len = src_len as usize;
+
+    /* char fill_char = ' '; */
+    let mut fill_char: c_char = 0;
+
+    if src_len == 0 {
+        src_len = unsafe { strlen(src_str) };
+    } /* .. if constant */
+
+    let src_str = unsafe { std::slice::from_raw_parts(src_str, src_len) };
+
+    /* Fill destination with blanks */
+    if pos < 0 {
+        fits_parser_yyerror(
+            ptr::null_mut(),
+            lParse,
+            cs!(c"STRMID(S,P,N) P must be 0 or greater"),
         );
-        msg[79] = 0;
-        ffpmsg(msg.as_mut_ptr());
+        return -(1);
     }
+
+    let pos = pos as usize; // Already checked if < 0
+
+    if pos > src_len || pos == 0 {
+        /* pos==0: blank string requested */
+        dest_str[..dest_len].fill(fill_char);
+    } else if pos + dest_len > src_len {
+        /* Copy a subset */
+        let mut nsub = src_len - pos + 1;
+        let mut npad = dest_len - nsub;
+        dest_str[..nsub].copy_from_slice(&src_str[(pos - 1)..(pos - 1 + nsub)]);
+
+        /* Fill remaining string with blanks */
+        dest_str[nsub..(nsub + npad)].fill(fill_char);
+    } else {
+        /* Full string copy */
+        dest_str[..dest_len].copy_from_slice(&src_str[(pos - 1)..(pos - 1 + dest_len)]);
+    }
+
+    /* Null-terminate */
+    dest_str[dest_len] = 0;
+
+    0
+}
+
+fn fits_parser_yyerror(scanner: yyscan_t, lParse: &mut ParseData, s: &[c_char]) {
+    let mut msg: [c_char; 80] = [0; 80];
+    if lParse.status == 0 {
+        lParse.status = PARSE_SYNTAX_ERR;
+    }
+
+    strncpy_safe(&mut msg, s, 80);
+    msg[79] = 0;
+
+    ffpmsg_slice(&msg);
 }

--- a/src/eval_y.rs
+++ b/src/eval_y.rs
@@ -894,7 +894,7 @@ fn New_FuncSize(
     n
 }
 
-pub fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData) -> c_int {
+pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData) -> c_int {
     unsafe {
         let mut current_block: u64;
         let mut yychar: c_int = 0;
@@ -7339,7 +7339,7 @@ fn New_GTI(
 
         /*  Resolve filename parameter  */
 
-        match *fname.offset(0) {
+        match *fname.offset(0) as u8 {
             0 => {
                 samefile = 1;
                 hdunum = 1;
@@ -7909,9 +7909,12 @@ fn Close_Vec(lParse: &mut ParseData, vecNode: c_int) -> c_int {
             )
             .try_into()
             .unwrap();
+
+            /*
             if (lParse.Nodes[this_node_idx]).SubNodes[n as usize] < 0 {
                 return -(1);
             }
+            */
         }
         nelem = (nelem as c_long
             + ((lParse.Nodes)[(lParse.Nodes[this_node_idx]).SubNodes[n as usize] as usize])
@@ -7985,9 +7988,12 @@ fn New_Array(lParse: &mut ParseData, valueNode: c_int, mut dimNode: c_int) -> c_
                     )
                     .try_into()
                     .unwrap();
+
+                    /*
                     if (lParse.Nodes[dims]).SubNodes[i as usize] < 0 {
                         return -(1);
                     }
+                    */
                 }
                 naxes[i as usize] = ((lParse.Nodes)
                     [(lParse.Nodes[dims]).SubNodes[i as usize] as usize])
@@ -8142,7 +8148,7 @@ fn Copy_Dims(lParse: &mut ParseData, Node1: c_int, Node2: c_int) {
     }
 }
 
-pub fn Evaluate_Parser(lParse: &mut ParseData, firstRow: c_long, nRows: c_long) {
+pub(crate) fn Evaluate_Parser(lParse: &mut ParseData, firstRow: c_long, nRows: c_long) {
     unsafe {
         let mut i: c_int = 0;
         let mut column: c_int = 0;
@@ -10074,7 +10080,7 @@ fn Do_BinOp_dbl(lParse: &mut ParseData, this_node_idx: usize) {
     }
 }
 
-pub fn qselect_median_lng(arr: *mut c_long, n: c_int) -> c_long {
+pub(crate) fn qselect_median_lng(arr: *mut c_long, n: c_int) -> c_long {
     unsafe {
         let mut low: c_int = 0;
         let mut high: c_int = 0;
@@ -10151,7 +10157,7 @@ pub fn qselect_median_lng(arr: *mut c_long, n: c_int) -> c_long {
     }
 }
 
-pub fn qselect_median_dbl(arr: *mut c_double, n: c_int) -> c_double {
+pub(crate) fn qselect_median_dbl(arr: *mut c_double, n: c_int) -> c_double {
     unsafe {
         let mut low: c_int = 0;
         let mut high: c_int = 0;
@@ -13939,7 +13945,7 @@ fn Do_GTI(lParse: &mut ParseData, this_node_idx: usize) {
             if lParse.status == 0 {
                 elem = lParse.nRows * (lParse.Nodes[this_node_idx]).value.nelem;
                 if nGTI != 0 {
-                    gti = -(1) as c_long;
+                    gti = -1;
                     loop {
                         let fresh202 = elem;
                         elem -= 1;
@@ -14059,7 +14065,7 @@ fn Do_GTI_Over(lParse: &mut ParseData, this_node_idx: usize) {
                 elem = lParse.nRows * (lParse.Nodes[this_node_idx]).value.nelem;
                 if nGTI != 0 {
                     let mut toverlap: c_double = 0.0;
-                    gti = -(1) as c_long;
+                    gti = -1;
                     loop {
                         let fresh206 = elem;
                         elem -= 1;
@@ -14242,7 +14248,7 @@ fn Search_GTI(
             }
         }
         if nextGTI >= nGTI {
-            nextGTI = -(1) as c_long;
+            nextGTI = -1;
         }
         if !nextGTI0.is_null() {
             *nextGTI0 = nextGTI;

--- a/src/fitscore.rs
+++ b/src/fitscore.rs
@@ -52,6 +52,7 @@ use crate::cfileio::{STREAM_DRIVER, ffinit_safer, fftrun, urltype2driver};
 use crate::cfileio::{ffclos_safer, ffurlt_safe};
 use crate::editcol::ffirow_safe;
 use crate::edithdu::ffcopy_safer;
+use crate::fitsio::*;
 use crate::fitsio2::*;
 use crate::getkey::{
     ffghsp_safe, ffgky_safe, ffgkyj_safe, ffgkyjj_safe, ffgkyl_safe, ffgkyn_safe, ffgkys_safe,
@@ -61,7 +62,6 @@ use crate::imcompress::{TILE_STRUCTS, imcomp_get_compressed_image_par};
 use crate::modkey::{ffdkey_safe, ffmkyj_safe, ffmrec_safe};
 use crate::putkey::ffprec_safe;
 use crate::relibc::header::stdio::{sscanf_ld, sscanf_lf};
-use crate::fitsio::*;
 use crate::{atoi, bb, cs, int_snprintf};
 use crate::{buffers::*, raw_to_slice};
 use crate::{slice_to_str, wrappers::*};
@@ -539,11 +539,11 @@ pub unsafe extern "C" fn ffpmsg(err_message: *const c_char) {
 /// put message on to error stack
 pub unsafe fn ffpmsg_safer(err_message: &[c_char]) {
     // Convert c_char slice to string and use the new safe implementation
-    if let Ok(c_str) = CStr::from_bytes_until_nul(cast_slice(err_message)) {
-        if let Ok(message) = c_str.to_str() {
-            let mut stack = ERROR_STACK.lock().unwrap();
-            stack.push_message(message);
-        }
+    if let Ok(c_str) = CStr::from_bytes_until_nul(cast_slice(err_message))
+        && let Ok(message) = c_str.to_str()
+    {
+        let mut stack = ERROR_STACK.lock().unwrap();
+        stack.push_message(message);
     }
 }
 
@@ -556,11 +556,11 @@ pub fn ffpmsg_cstr(err_message: &CStr) {
 
 pub(crate) fn ffpmsg_slice(err_message: &[c_char]) {
     // Convert c_char slice to string
-    if let Ok(c_str) = CStr::from_bytes_until_nul(cast_slice(err_message)) {
-        if let Ok(message) = c_str.to_str() {
-            let mut stack = ERROR_STACK.lock().unwrap();
-            stack.push_message(message);
-        }
+    if let Ok(c_str) = CStr::from_bytes_until_nul(cast_slice(err_message))
+        && let Ok(message) = c_str.to_str()
+    {
+        let mut stack = ERROR_STACK.lock().unwrap();
+        stack.push_message(message);
     }
 }
 
@@ -747,11 +747,9 @@ pub(crate) unsafe fn ffxmsg(action: c_int, errmsg: *mut c_char) {
                         *errmsg.add(copy_len) = 0; // null terminate
                     }
                 }
-            } else {
-                if !errmsg.is_null() {
-                    unsafe {
-                        *errmsg = 0; // empty string
-                    }
+            } else if !errmsg.is_null() {
+                unsafe {
+                    *errmsg = 0; // empty string
                 }
             }
         }

--- a/src/fitsio.rs
+++ b/src/fitsio.rs
@@ -1092,6 +1092,24 @@ pub struct iteratorCol {
     pub tdisp: [c_char; 70],
 }
 
+impl Default for iteratorCol {
+    fn default() -> Self {
+        Self {
+            fptr: Default::default(),
+            colnum: Default::default(),
+            colname: [0; 70],
+            datatype: Default::default(),
+            iotype: Default::default(),
+            array: Default::default(),
+            repeat: Default::default(),
+            tlmin: Default::default(),
+            tlmax: Default::default(),
+            tunit: [0; 70],
+            tdisp: [0; 70],
+        }
+    }
+}
+
 pub const InputCol: c_int = 0; /* flag for input only iterator column       */
 pub const InputOutputCol: c_int = 1; /* flag for input and output iterator column */
 pub const OutputCol: c_int = 2; /* flag for output only iterator column      */

--- a/src/fitsio.rs
+++ b/src/fitsio.rs
@@ -1066,6 +1066,7 @@ pub struct fitsfile {
 
 /// structure for the iterator function column information
 /// elements required as input to fits_iterate_data:
+#[derive(Debug, Clone, Copy)]
 #[repr(C)]
 pub struct iteratorCol {
     /// pointer to the HDU containing the column

--- a/src/histo.rs
+++ b/src/histo.rs
@@ -56,7 +56,7 @@ pub(crate) struct HistType<'a> {
     numIterCols: c_int,
     iterCols: &'a mut iteratorCol,
     parsers: &'a mut ParseData,
-    infos: &'a mut parseInfo<'a>,
+    infos: &'a mut parseInfo,
 }
 
 /*

--- a/src/histo.rs
+++ b/src/histo.rs
@@ -55,7 +55,7 @@ pub(crate) struct HistType<'a> {
     startCols: [c_int; 5],
     numIterCols: c_int,
     iterCols: &'a mut iteratorCol,
-    parsers: &'a mut ParseData<'a>,
+    parsers: &'a mut ParseData,
     infos: &'a mut parseInfo<'a>,
 }
 

--- a/src/imcompress.rs
+++ b/src/imcompress.rs
@@ -4912,7 +4912,7 @@ pub(crate) fn fits_write_compressed_img(
 
     /* cast to double to force alignment on 8-byte addresses */
     let buffersize = ((fptr.Fptr).maxtilelen as usize) * buffpixsiz;
-    let buffersize_f64 = (buffersize + 7) / 8;
+    let buffersize_f64 = buffersize.div_ceil(8);
 
     let mut f64_buffer: Vec<f64> = Vec::new();
     if f64_buffer.try_reserve_exact(buffersize_f64).is_err() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,6 +39,7 @@ pub mod editcol;
 pub mod eval_defs;
 pub mod eval_f;
 pub mod eval_l;
+pub mod eval_tab;
 pub mod eval_y;
 pub mod fits_hcompress;
 pub mod fits_hdecompress;

--- a/src/modkey.rs
+++ b/src/modkey.rs
@@ -1313,7 +1313,7 @@ pub fn ffmkls_safe(
     }
 
     let incomm_empty_or_continue =
-        incomm.is_none() || incomm.as_ref().map_or(false, |c| c[0] == bb(b'&'));
+        incomm.is_none() || incomm.as_ref().is_some_and(|c| c[0] == bb(b'&'));
 
     /* preserve the old comment string */
     if incomm_empty_or_continue {
@@ -1347,7 +1347,7 @@ pub fn ffmkls_safe(
         ffgrec_safe(fptr, keypos - 1, Some(&mut card), status);
     } else {
         /* copy the input comment string */
-        let incomm_shadow = incomm.as_deref().unwrap();
+        let incomm_shadow = incomm.unwrap();
         commlen = strlen_safe(cast_slice(incomm_shadow)) as c_int;
         if commlen > 0 {
             let mut c = vec![0; commlen as usize + 1];
@@ -1365,7 +1365,7 @@ pub fn ffmkls_safe(
 
     fits_make_longstr_key_util(fptr, keyname, value, comm.as_deref(), keypos, status);
 
-    return *status;
+    *status
 }
 
 /*--------------------------------------------------------------------------*/

--- a/src/putcol.rs
+++ b/src/putcol.rs
@@ -1991,7 +1991,7 @@ pub unsafe extern "C" fn fits_iter_set_by_num(
 /// set all the parameters for an iterator column, by column number
 pub fn fits_iter_set_by_num_safe(
     col: &mut iteratorCol, /* I - iterator col structure */
-    fptr: &mut fitsfile,   /* I - FITS file pointer                      */
+    fptr: *mut fitsfile,   /* I - FITS file pointer                      */
     colnum: c_int,         /* I - column number                          */
     datatype: c_int,       /* I - column datatype                        */
     iotype: c_int,         /* I - InputCol, InputOutputCol, or OutputCol */

--- a/src/putkey.rs
+++ b/src/putkey.rs
@@ -3889,7 +3889,7 @@ pub fn ffptdm_safe(
 
         int_snprintf!(&mut value, 80, "{}", naxes[ii]);
         /* This will either be followed by a ',' or ')'. */
-        if strlen_safe(&mut tdimstr) + strlen_safe(&value) + 1 > FLEN_VALUE - 1 {
+        if strlen_safe(&tdimstr) + strlen_safe(&value) + 1 > FLEN_VALUE - 1 {
             ffpmsg_str("TDIM string too long (ffptdm)");
             *status = BAD_TDIM;
             return *status;

--- a/src/putkey.rs
+++ b/src/putkey.rs
@@ -2147,7 +2147,7 @@ pub unsafe extern "C" fn ffpkls(
             return *status;
         }
 
-        return ffpkls_safe(fptr, keyname, value, comm, status); // call the safe version
+        ffpkls_safe(fptr, keyname, value, comm, status) // call the safe version
     }
 }
 

--- a/src/region.rs
+++ b/src/region.rs
@@ -31,15 +31,15 @@ const RAD_TO_DEG: f64 = 180.0 / MY_PI;
 
 #[derive(Default, Debug, Copy, Clone)]
 pub(crate) struct WCSdata {
-    exists: bool,
-    xrefval: f64,
-    yrefval: f64,
-    xrefpix: f64,
-    yrefpix: f64,
-    xinc: f64,
-    yinc: f64,
-    rot: f64,
-    dtype: [c_char; 5],
+    pub(crate) exists: bool,
+    pub(crate) xrefval: f64,
+    pub(crate) yrefval: f64,
+    pub(crate) xrefpix: f64,
+    pub(crate) yrefpix: f64,
+    pub(crate) xinc: f64,
+    pub(crate) yinc: f64,
+    pub(crate) rot: f64,
+    pub(crate) dtype: [c_char; 5],
 }
 
 #[derive(Default, Debug, PartialEq, Clone)]
@@ -73,19 +73,19 @@ enum CoordFmt {
 
 #[derive(Default, Debug, Clone)]
 pub(crate) struct RgnShape {
-    sign: c_char,     /*  Include or exclude?        */
-    shape: ShapeType, /*  Shape of this region       */
-    comp: c_int,      /*  Component number for this region */
+    pub(crate) sign: c_char,     /*  Include or exclude?        */
+    pub(crate) shape: ShapeType, /*  Shape of this region       */
+    pub(crate) comp: c_int,      /*  Component number for this region */
 
     /*  bounding box    */
-    xmin: f64,
-    xmax: f64,
-    ymin: f64,
-    ymax: f64,
+    pub(crate) xmin: f64,
+    pub(crate) xmax: f64,
+    pub(crate) ymin: f64,
+    pub(crate) ymax: f64,
 
     /*  Parameters - In pixels     */
-    genericParams: RgnShapeGeneric,
-    polyParams: RgnShapePolygon,
+    pub(crate) genericParams: RgnShapeGeneric,
+    pub(crate) polyParams: RgnShapePolygon,
 }
 
 #[derive(Default, Debug, Clone, Copy)]

--- a/src/region.rs
+++ b/src/region.rs
@@ -26,7 +26,7 @@ use crate::{KeywordDatatypeMut, bb, cs};
 use crate::{int_snprintf, wrappers::*};
 
 #[allow(clippy::approx_constant)]
-const MY_PI: f64 = 3.141_592_653_589_793;
+pub(crate) const MY_PI: f64 = 3.141_592_653_589_793;
 const RAD_TO_DEG: f64 = 180.0 / MY_PI;
 
 #[derive(Default, Debug, Copy, Clone)]

--- a/src/relibc/header/stdio/scanf.rs
+++ b/src/relibc/header/stdio/scanf.rs
@@ -393,9 +393,11 @@ unsafe fn inner_scanf_custom(
                                         Ok(v) => v,
                                         Err(_) => {
                                             // Overflow case - mimic libc behavior
-                                            if $type::MIN == 0 { // unsigned type
+                                            if $type::MIN == 0 {
+                                                // unsigned type
                                                 $type::MAX // wrap around for unsigned
-                                            } else { // signed type
+                                            } else {
+                                                // signed type
                                                 (-1i32) as $type // -1 for signed overflow
                                             }
                                         }

--- a/src/relibc/header/stdio/sscanf_tests.rs
+++ b/src/relibc/header/stdio/sscanf_tests.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod tests {
-    
+
     use crate::{
         c_types::{c_char, c_double, c_int, c_long, c_uint},
         relibc::header::stdio::{
@@ -9,8 +9,7 @@ mod tests {
         },
     };
 
-    
-    use std::ffi::{CStr, c_void, CString};
+    use std::ffi::{CStr, CString, c_void};
 
     // Helper to create null-terminated string from &str
     fn to_c_string(s: &str) -> Vec<c_char> {

--- a/tests/test_binary_table.rs
+++ b/tests/test_binary_table.rs
@@ -1,0 +1,413 @@
+use std::ffi::{CStr, CString};
+
+use bytemuck::{cast_slice, cast_slice_mut};
+use libc::{c_char, c_float, c_int, c_long, c_ushort};
+
+use rsfitsio::aliases::rust_api::*;
+use rsfitsio::fitsio::{ASCII_TBL, LONGLONG, TUSHORT, USHORT_IMG};
+use rsfitsio::fitsio::{BINARY_TBL, FLEN_VALUE, READONLY, READWRITE, TFLOAT, TLONG, fitsfile};
+use rsfitsio::helpers::testhelpers::with_temp_file;
+use rsfitsio::{KeywordDatatype, NullValue};
+
+fn writeimage(filename: &str) {
+    let mut fptr: Option<Box<fitsfile>> = None;
+    let mut status: c_int = 0;
+    let fpixel: c_long = 1;
+
+    /* initialize FITS image parameters */
+    let bitpix: c_int = USHORT_IMG; /* 16-bit unsigned short pixel values       */
+    let naxis: c_long = 2; /* 2-dimensional image                            */
+    let naxes: [c_long; 2] = [300, 200]; /* image is 300 pixels wide by 200 rows */
+    let nelements: c_long = naxes[0] * naxes[1];
+
+    /* allocate memory for the whole image */
+    let array_size = (naxes[0] * naxes[1]) as usize;
+    let mut array: Vec<c_ushort> = vec![0; array_size];
+
+    let _ = std::fs::remove_file(filename); /* Delete old file if it already exists */
+
+    let filename_cstr = CString::new(filename).unwrap();
+
+    unsafe {
+        fits_create_file(
+            &mut fptr,
+            cast_slice(filename_cstr.to_bytes_with_nul()),
+            &mut status,
+        );
+    }
+    assert_eq!(status, 0);
+
+    /* write the required keywords for the primary array image.     */
+    /* Since bitpix = USHORT_IMG, this will cause cfitsio to create */
+    /* a FITS image with BITPIX = 16 (signed short integers) with   */
+    /* BSCALE = 1.0 and BZERO = 32768.  This is the convention that */
+    /* FITS uses to store unsigned integers.  Note that the BSCALE  */
+    /* and BZERO keywords will be automatically written by cfitsio  */
+    /* in this case.                                                */
+
+    if let Some(ref mut fptr_box) = fptr {
+        unsafe { fits_create_img(fptr_box, bitpix, naxis as c_int, &naxes, &mut status) };
+        assert_eq!(status, 0);
+    }
+
+    /* initialize the values in the image with a linear ramp function */
+    for jj in 0..naxes[1] {
+        for ii in 0..naxes[0] {
+            let index = (jj * naxes[0] + ii) as usize;
+            array[index] = (ii + jj) as c_ushort;
+        }
+    }
+
+    /* write the array of unsigned integers to the FITS file */
+    if let Some(ref mut fptr_box) = fptr {
+        fits_write_img(
+            fptr_box,
+            TUSHORT,
+            fpixel as LONGLONG,
+            nelements as LONGLONG,
+            cast_slice::<c_ushort, u8>(&array),
+            &mut status,
+        );
+        assert_eq!(status, 0);
+    }
+
+    /* write another optional keyword to the header */
+    /* Note that the ADDRESS of the value is passed in the routine */
+    let exposure: c_long = 1500;
+    if let Some(ref mut fptr_box) = fptr {
+        let exposure_key = CString::new("EXPOSURE").unwrap();
+        let exposure_comment = CString::new("Total Exposure Time").unwrap();
+
+        fits_update_key(
+            fptr_box,
+            KeywordDatatype::TLONG(&exposure),
+            cast_slice(exposure_key.to_bytes_with_nul()),
+            Some(cast_slice(exposure_comment.to_bytes_with_nul())),
+            &mut status,
+        );
+        assert_eq!(status, 0);
+    }
+
+    if let Some(fptr_box) = fptr {
+        unsafe { fits_close_file(fptr_box, &mut status) };
+        assert_eq!(status, 0);
+    }
+}
+
+fn write_binary_tbl(filename: &str) {
+    let mut fptr: Option<Box<fitsfile>> = None;
+    let mut status: c_int = 0;
+    let mut hdutype: c_int = 0;
+    let firstrow: c_long = 1;
+    let firstelem: c_long = 1;
+
+    let tfields: c_int = 3; /* table will have 3 columns */
+    let nrows: LONGLONG = 6; /* table will have 6 rows    */
+
+    let extname = "PLANETS_Binary"; /* extension name */
+
+    /* define the name, datatype, and physical units for the 3 columns */
+    let ttype_strs = [
+        CString::new("Planet").unwrap(),
+        CString::new("Diameter").unwrap(),
+        CString::new("Density").unwrap(),
+    ];
+    let tform_strs = [
+        CString::new("8a").unwrap(),
+        CString::new("1J").unwrap(),
+        CString::new("1E").unwrap(),
+    ];
+    let tunit_strs = [
+        CString::new("").unwrap(),
+        CString::new("km").unwrap(),
+        CString::new("g/cm").unwrap(),
+    ];
+
+    let ttype: Vec<&[c_char]> = ttype_strs
+        .iter()
+        .map(|s| cast_slice(s.to_bytes_with_nul()))
+        .collect();
+    let tform: Vec<&[c_char]> = tform_strs
+        .iter()
+        .map(|s| cast_slice(s.to_bytes_with_nul()))
+        .collect();
+    let tunit: Vec<&[c_char]> = tunit_strs
+        .iter()
+        .map(|s| cast_slice(s.to_bytes_with_nul()))
+        .collect();
+
+    /* define the name diameter, and density of each planet */
+    let planet_strs = [
+        CString::new("Mercury").unwrap(),
+        CString::new("Venus").unwrap(),
+        CString::new("Earth").unwrap(),
+        CString::new("Mars").unwrap(),
+        CString::new("Jupiter").unwrap(),
+        CString::new("Saturn").unwrap(),
+    ];
+    let planet: Vec<&[c_char]> = planet_strs
+        .iter()
+        .map(|s| cast_slice(s.to_bytes_with_nul()))
+        .collect();
+    let diameter: [c_long; 6] = [4880, 12112, 12742, 6800, 143000, 121000];
+    let density: [c_float; 6] = [5.1, 5.3, 5.52, 3.94, 1.33, 0.69];
+
+    let filename_cstr = CString::new(filename).unwrap();
+    let extname_cstr = CString::new(extname).unwrap();
+
+    /* open the FITS file containing a primary array and an ASCII table */
+    fits_open_file(
+        &mut fptr,
+        cast_slice(filename_cstr.to_bytes_with_nul()),
+        READWRITE,
+        &mut status,
+    );
+    assert_eq!(status, 0);
+
+    if let Some(ref mut fptr_box) = fptr {
+        fits_movabs_hdu(fptr_box, 1, Some(&mut hdutype), &mut status);
+        assert_eq!(status, 0);
+    }
+
+    /* append a new empty binary table onto the FITS file */
+    if let Some(ref mut fptr_box) = fptr {
+        let ttype_opts: Vec<Option<&[c_char]>> = ttype.iter().map(|s| Some(*s)).collect();
+        let tunit_opts: Vec<Option<&[c_char]>> = tunit.iter().map(|s| Some(*s)).collect();
+
+        unsafe {
+            fits_create_tbl(
+                fptr_box,
+                BINARY_TBL,
+                nrows,
+                tfields,
+                &ttype_opts,
+                &tform,
+                Some(&tunit_opts),
+                Some(cast_slice(extname_cstr.to_bytes_with_nul())),
+                &mut status,
+            );
+        }
+        assert_eq!(status, 0);
+    }
+
+    /* write names to the first column (character strings) */
+    /* write diameters to the second column (longs) */
+    /* write density to the third column (floats) */
+
+    if let Some(ref mut fptr_box) = fptr {
+        fits_write_col_str(
+            fptr_box,
+            1,
+            firstrow as LONGLONG,
+            firstelem as LONGLONG,
+            planet.len() as LONGLONG,
+            &planet,
+            &mut status,
+        );
+        assert_eq!(status, 0);
+
+        fits_write_col(
+            fptr_box,
+            TLONG,
+            2,
+            firstrow as LONGLONG,
+            firstelem as LONGLONG,
+            diameter.len() as LONGLONG,
+            cast_slice(&diameter),
+            &mut status,
+        );
+        assert_eq!(status, 0);
+
+        fits_write_col(
+            fptr_box,
+            TFLOAT,
+            3,
+            firstrow as LONGLONG,
+            firstelem as LONGLONG,
+            density.len() as LONGLONG,
+            cast_slice(&density),
+            &mut status,
+        );
+        assert_eq!(status, 0);
+    }
+
+    if let Some(fptr_box) = fptr {
+        unsafe { fits_close_file(fptr_box, &mut status) };
+        assert_eq!(status, 0);
+    }
+}
+
+fn readtable(filename: &str) {
+    let mut fptr: Option<Box<fitsfile>> = None;
+    let mut status: c_int = 0;
+    let mut hdutype: c_int = 0;
+    let mut nfound: c_int = 0;
+    let frow: c_long = 1;
+    let felem: c_long = 1;
+    let nelem: c_long = 6;
+    let longnull: c_long = 0;
+    let mut dia: [c_long; 6] = [0; 6];
+    let floatnull: c_float = 0.0;
+    let mut den: [c_float; 6] = [0.0; 6];
+
+    let filename_cstr = CString::new(filename).unwrap();
+
+    fits_open_file(
+        &mut fptr,
+        cast_slice(filename_cstr.to_bytes_with_nul()),
+        READONLY,
+        &mut status,
+    );
+    assert_eq!(status, 0);
+
+    /* allocate space for the column labels - use Vec instead of malloc */
+    let mut ttype_vecs: Vec<Vec<u8>> = Vec::new();
+    for _i in 0..3 {
+        ttype_vecs.push(vec![0; FLEN_VALUE]);
+    }
+
+    /* allocate space for string column values - use Vec instead of malloc */
+    let mut name_vecs: Vec<Vec<u8>> = Vec::new();
+    for _i in 0..6 {
+        name_vecs.push(vec![0; 10]);
+    }
+
+    for hdunum in 2..=2 {
+        /*read ASCII, then binary table */
+        /* move to the HDU */
+        if let Some(ref mut fptr_box) = fptr {
+            fits_movabs_hdu(fptr_box, hdunum, Some(&mut hdutype), &mut status);
+            assert_eq!(status, 0);
+        }
+
+        if hdutype == ASCII_TBL {
+            println!("\nReading ASCII table in HDU {hdunum}:");
+        } else if hdutype == BINARY_TBL {
+            println!("\nReading binary table in HDU {hdunum}:");
+        } else {
+            println!("Error: this HDU is not an ASCII or binary table");
+            assert_eq!(1, 0);
+        }
+
+        /* read the column names from the TTYPEn keywords */
+        if let Some(ref mut fptr_box) = fptr {
+            let ttype_key = CString::new("TTYPE").unwrap();
+            let mut ttype_refs: Vec<&mut [u8]> =
+                ttype_vecs.iter_mut().map(|v| v.as_mut_slice()).collect();
+            fits_read_keys_str(
+                fptr_box,
+                cast_slice(ttype_key.to_bytes_with_nul()),
+                1,
+                3,
+                &mut ttype_refs
+                    .iter_mut()
+                    .map(|r| cast_slice_mut(r))
+                    .collect::<Vec<_>>(),
+                &mut nfound,
+                &mut status,
+            );
+            assert_eq!(status, 0);
+        }
+
+        let ttype0 =
+            unsafe { CStr::from_ptr(ttype_vecs[0].as_ptr() as *const c_char) }.to_string_lossy();
+        let ttype1 =
+            unsafe { CStr::from_ptr(ttype_vecs[1].as_ptr() as *const c_char) }.to_string_lossy();
+        let ttype2 =
+            unsafe { CStr::from_ptr(ttype_vecs[2].as_ptr() as *const c_char) }.to_string_lossy();
+        println!(" Row  {ttype0:>10} {ttype1:>10} {ttype2:>10}");
+
+        /*  read the columns */
+        if let Some(ref mut fptr_box) = fptr {
+            let mut name_refs: Vec<&mut [u8]> =
+                name_vecs.iter_mut().map(|v| v.as_mut_slice()).collect();
+
+            fits_read_col_str(
+                fptr_box,
+                1,
+                frow as LONGLONG,
+                felem as LONGLONG,
+                nelem as LONGLONG,
+                None,
+                &mut name_refs
+                    .iter_mut()
+                    .map(|r| cast_slice_mut(r))
+                    .collect::<Vec<_>>(),
+                None,
+                &mut status,
+            );
+            assert_eq!(status, 0);
+
+            fits_read_col(
+                fptr_box,
+                TLONG,
+                2,
+                frow as LONGLONG,
+                felem as LONGLONG,
+                nelem as LONGLONG,
+                Some(NullValue::Long(longnull)),
+                cast_slice_mut(&mut dia),
+                None,
+                &mut status,
+            );
+            assert_eq!(status, 0);
+
+            fits_read_col(
+                fptr_box,
+                TFLOAT,
+                3,
+                frow as LONGLONG,
+                felem as LONGLONG,
+                nelem as LONGLONG,
+                Some(NullValue::Float(floatnull)),
+                cast_slice_mut(&mut den),
+                None,
+                &mut status,
+            );
+            assert_eq!(status, 0);
+
+            for ii in 0..6 {
+                let name_str = unsafe { CStr::from_ptr(name_vecs[ii].as_ptr() as *const c_char) }
+                    .to_string_lossy();
+                println!(
+                    "{:5} {:>10} {:>10} {:>10.2}",
+                    ii + 1,
+                    name_str,
+                    dia[ii],
+                    den[ii]
+                );
+            }
+
+            let where_clause = c"Density > 4.0".to_bytes_with_nul();
+            let mut n_matched_rows = -1;
+            let mut row_status = [0; 6];
+            fits_find_rows(
+                fptr_box,
+                where_clause,
+                1,
+                6,
+                &mut n_matched_rows,
+                &mut row_status,
+                &mut status,
+            );
+            assert_eq!(status, 0);
+            assert_eq!(n_matched_rows, 3);
+        }
+    }
+
+    if let Some(fptr_box) = fptr {
+        unsafe {
+            fits_close_file(fptr_box, &mut status);
+        }
+        assert_eq!(status, 0);
+    }
+}
+
+#[test]
+fn test_read_table_where() {
+    with_temp_file(|filename| {
+        writeimage(filename);
+        write_binary_tbl(filename);
+        readtable(filename);
+    });
+}

--- a/tests/test_binary_table.rs
+++ b/tests/test_binary_table.rs
@@ -378,7 +378,7 @@ fn readtable(filename: &str) {
                 );
             }
 
-            let where_clause = c"Density > 4.0".to_bytes_with_nul();
+            let where_clause = cast_slice(c"Density > 4.0".to_bytes_with_nul());
             let mut n_matched_rows = -1;
             let mut row_status = [0; 6];
             fits_find_rows(

--- a/tests/test_binary_table.rs
+++ b/tests/test_binary_table.rs
@@ -378,6 +378,7 @@ fn readtable(filename: &str) {
                 );
             }
 
+            
             let where_clause = cast_slice(c"D > 3".to_bytes_with_nul());
             let mut n_matched_rows = -1;
             let mut row_status = [0; 6];
@@ -409,9 +410,11 @@ fn readtable(filename: &str) {
             );
             assert_eq!(status, 0);
             assert_eq!(n_matched_rows, 1);
+            
 
-            let where_clause = cast_slice(c"Diameter > 0".to_bytes_with_nul());
+            let where_clause = cast_slice(c"(DENSITY > 3.0) && (DIAMETER > 10000)".to_bytes_with_nul());
             let mut n_matched_rows = -1;
+            let mut row_status = [0; 6];
             fits_find_rows(
                 fptr_box,
                 where_clause,
@@ -422,11 +425,38 @@ fn readtable(filename: &str) {
                 &mut status,
             );
             assert_eq!(status, 0);
-            assert_eq!(n_matched_rows, 6);
+            assert_eq!(n_matched_rows, 2);
 
+            let where_clause = cast_slice(c"(DENSITY > 3.0) && (DIAMETER > 10000) && (Planet == \"Earth\")".to_bytes_with_nul());
+            let mut n_matched_rows = -1;
+            let mut row_status = [0; 6];
+            fits_find_rows(
+                fptr_box,
+                where_clause,
+                1,
+                6,
+                &mut n_matched_rows,
+                &mut row_status,
+                &mut status,
+            );
+            assert_eq!(status, 0);
+            assert_eq!(n_matched_rows, 1);
 
-            // FAILURES:
-            // #ROW > 3
+        
+            let where_clause = cast_slice(c"#ROW > 2".to_bytes_with_nul());
+            let mut n_matched_rows = -1;
+            let mut row_status = [0; 6];
+            fits_find_rows(
+                fptr_box,
+                where_clause,
+                1,
+                6,
+                &mut n_matched_rows,
+                &mut row_status,
+                &mut status,
+            );
+            assert_eq!(status, 0);
+            assert_eq!(n_matched_rows, 4);
 
             
         }

--- a/tests/test_binary_table.rs
+++ b/tests/test_binary_table.rs
@@ -378,7 +378,6 @@ fn readtable(filename: &str) {
                 );
             }
 
-            
             let where_clause = cast_slice(c"D > 3".to_bytes_with_nul());
             let mut n_matched_rows = -1;
             let mut row_status = [0; 6];
@@ -410,9 +409,9 @@ fn readtable(filename: &str) {
             );
             assert_eq!(status, 0);
             assert_eq!(n_matched_rows, 1);
-            
 
-            let where_clause = cast_slice(c"(DENSITY > 3.0) && (DIAMETER > 10000)".to_bytes_with_nul());
+            let where_clause =
+                cast_slice(c"(DENSITY > 3.0) && (DIAMETER > 10000)".to_bytes_with_nul());
             let mut n_matched_rows = -1;
             let mut row_status = [0; 6];
             fits_find_rows(
@@ -427,7 +426,10 @@ fn readtable(filename: &str) {
             assert_eq!(status, 0);
             assert_eq!(n_matched_rows, 2);
 
-            let where_clause = cast_slice(c"(DENSITY > 3.0) && (DIAMETER > 10000) && (Planet == \"Earth\")".to_bytes_with_nul());
+            let where_clause = cast_slice(
+                c"(DENSITY > 3.0) && (DIAMETER > 10000) && (Planet == \"Earth\")"
+                    .to_bytes_with_nul(),
+            );
             let mut n_matched_rows = -1;
             let mut row_status = [0; 6];
             fits_find_rows(
@@ -442,7 +444,6 @@ fn readtable(filename: &str) {
             assert_eq!(status, 0);
             assert_eq!(n_matched_rows, 1);
 
-        
             let where_clause = cast_slice(c"#ROW > 2".to_bytes_with_nul());
             let mut n_matched_rows = -1;
             let mut row_status = [0; 6];
@@ -457,8 +458,6 @@ fn readtable(filename: &str) {
             );
             assert_eq!(status, 0);
             assert_eq!(n_matched_rows, 4);
-
-            
         }
     }
 

--- a/tests/test_binary_table.rs
+++ b/tests/test_binary_table.rs
@@ -4,7 +4,7 @@ use bytemuck::{cast_slice, cast_slice_mut};
 use libc::{c_char, c_float, c_int, c_long, c_ushort};
 
 use rsfitsio::aliases::rust_api::*;
-use rsfitsio::fitsio::{ASCII_TBL, LONGLONG, TUSHORT, USHORT_IMG};
+use rsfitsio::fitsio::{ASCII_TBL, KEY_NO_EXIST, LONGLONG, TUSHORT, USHORT_IMG};
 use rsfitsio::fitsio::{BINARY_TBL, FLEN_VALUE, READONLY, READWRITE, TFLOAT, TLONG, fitsfile};
 use rsfitsio::helpers::testhelpers::with_temp_file;
 use rsfitsio::{KeywordDatatype, NullValue};
@@ -378,9 +378,26 @@ fn readtable(filename: &str) {
                 );
             }
 
-            let where_clause = cast_slice(c"Density > 4.0".to_bytes_with_nul());
+            let where_clause = cast_slice(c"D > 3".to_bytes_with_nul());
             let mut n_matched_rows = -1;
             let mut row_status = [0; 6];
+
+            // Try to query an invalid row.
+            fits_find_rows(
+                fptr_box,
+                where_clause,
+                1,
+                6,
+                &mut n_matched_rows,
+                &mut row_status,
+                &mut status,
+            );
+            assert_eq!(status, KEY_NO_EXIST);
+            assert_eq!(n_matched_rows, -1);
+
+            // Try a valid query: Planet = Earth
+            status = 0;
+            let where_clause = cast_slice(c"Planet == \"Earth\"".to_bytes_with_nul());
             fits_find_rows(
                 fptr_box,
                 where_clause,
@@ -391,7 +408,27 @@ fn readtable(filename: &str) {
                 &mut status,
             );
             assert_eq!(status, 0);
-            assert_eq!(n_matched_rows, 3);
+            assert_eq!(n_matched_rows, 1);
+
+            let where_clause = cast_slice(c"Diameter > 0".to_bytes_with_nul());
+            let mut n_matched_rows = -1;
+            fits_find_rows(
+                fptr_box,
+                where_clause,
+                1,
+                6,
+                &mut n_matched_rows,
+                &mut row_status,
+                &mut status,
+            );
+            assert_eq!(status, 0);
+            assert_eq!(n_matched_rows, 6);
+
+
+            // FAILURES:
+            // #ROW > 3
+
+            
         }
     }
 


### PR DESCRIPTION
MVP implementation of eval_* files.

`eval_y.rs` and `eval_l.rs` were translated using C2Rust and then modified heavily.

`eval_f.rs` was hand translated.

There is still a **lot** of unsafe code.