### PR TITLE
Eval unsafe reduction

### DIFF
--- a/src/eval_defs.rs
+++ b/src/eval_defs.rs
@@ -41,48 +41,89 @@ impl Default for DataInfo {
     }
 }
 
-/// Owns a numeric node's result buffer as a raw heap allocation. The node's
-/// `value.data.ptr`/`value.undef` are raw *views* into this buffer; keeping the
-/// backing store as a raw allocation (rather than a `Box`/`Vec`, which are
-/// `noalias`) lets those views stay valid under Stacked Borrows. Freed on drop.
-pub struct NodeBuf {
+/// A single zeroed, 8-byte-aligned raw heap allocation. Node result buffers are
+/// kept as raw allocations (rather than `Box`/`Vec`, which are `noalias`) so the
+/// union's raw *views* into them stay valid under Stacked Borrows. Freed on drop.
+struct RawBuf {
     ptr: *mut u8,
     /// Number of `u64` words backing the allocation.
     words: usize,
 }
 
-impl NodeBuf {
-    /// Allocate a zeroed buffer of at least `len` bytes, 8-byte aligned (the
-    /// buffer stores f64/c_long values, so it needs the same alignment the
-    /// former `calloc` provided), or `None` on allocation failure.
-    pub fn new(len: usize) -> Option<Self> {
+impl RawBuf {
+    /// Allocate a zeroed buffer of at least `len` bytes, 8-byte aligned (buffers
+    /// store f64/c_long and arrays of pointers, needing the alignment the former
+    /// `calloc` provided), or `None` on allocation failure.
+    fn new(len: usize) -> Option<Self> {
         let words = len.div_ceil(8).max(1);
         let mut v: Vec<u64> = Vec::new();
         v.try_reserve_exact(words).ok()?;
         v.resize(words, 0);
         let raw = Box::into_raw(v.into_boxed_slice());
-        Some(NodeBuf {
+        Some(RawBuf {
             ptr: raw as *mut u8,
             words,
         })
     }
 
-    /// Raw pointer to the start of the buffer (valid for the buffer's lifetime).
-    pub fn as_ptr(&self) -> *mut u8 {
+    fn as_ptr(&self) -> *mut u8 {
         self.ptr
     }
 }
 
-impl Drop for NodeBuf {
+impl Drop for RawBuf {
     fn drop(&mut self) {
-        // Reconstitute the boxed [u64] slice from the raw parts and drop it,
-        // freeing via the same (Rust global) allocator it was created with.
+        // Reconstitute the boxed [u64] slice and drop it, freeing via the same
+        // (Rust global) allocator it was created with.
         unsafe {
             drop(Box::from_raw(core::ptr::slice_from_raw_parts_mut(
                 self.ptr.cast::<u64>(),
                 self.words,
             )));
         }
+    }
+}
+
+/// Owns the heap storage for one node's result buffer. Numeric nodes use only
+/// `primary` (the data-plus-undef buffer). STRING/BITSTR nodes use `primary` as
+/// the array of row pointers (`strptr`) and `secondary` as the single backing
+/// character buffer those pointers index into. Everything is freed on drop.
+pub struct NodeBuf {
+    primary: RawBuf,
+    secondary: Option<RawBuf>,
+}
+
+impl NodeBuf {
+    /// Numeric node buffer: `len` bytes of data followed by the undef flags.
+    pub fn new_numeric(len: usize) -> Option<Self> {
+        Some(NodeBuf {
+            primary: RawBuf::new(len)?,
+            secondary: None,
+        })
+    }
+
+    /// String node buffer: `ptrs_len` bytes for the row-pointer array plus a
+    /// `backing_len`-byte character buffer they point into.
+    pub fn new_string(ptrs_len: usize, backing_len: usize) -> Option<Self> {
+        let primary = RawBuf::new(ptrs_len)?;
+        let secondary = RawBuf::new(backing_len)?;
+        Some(NodeBuf {
+            primary,
+            secondary: Some(secondary),
+        })
+    }
+
+    /// Raw view of the primary buffer (numeric data, or the `strptr` array).
+    pub fn as_ptr(&self) -> *mut u8 {
+        self.primary.as_ptr()
+    }
+
+    /// Raw view of the string backing buffer (only for string nodes).
+    pub fn backing_ptr(&self) -> *mut u8 {
+        self.secondary
+            .as_ref()
+            .expect("backing_ptr on a numeric NodeBuf")
+            .as_ptr()
     }
 }
 

--- a/src/eval_defs.rs
+++ b/src/eval_defs.rs
@@ -41,6 +41,51 @@ impl Default for DataInfo {
     }
 }
 
+/// Owns a numeric node's result buffer as a raw heap allocation. The node's
+/// `value.data.ptr`/`value.undef` are raw *views* into this buffer; keeping the
+/// backing store as a raw allocation (rather than a `Box`/`Vec`, which are
+/// `noalias`) lets those views stay valid under Stacked Borrows. Freed on drop.
+pub struct NodeBuf {
+    ptr: *mut u8,
+    /// Number of `u64` words backing the allocation.
+    words: usize,
+}
+
+impl NodeBuf {
+    /// Allocate a zeroed buffer of at least `len` bytes, 8-byte aligned (the
+    /// buffer stores f64/c_long values, so it needs the same alignment the
+    /// former `calloc` provided), or `None` on allocation failure.
+    pub fn new(len: usize) -> Option<Self> {
+        let words = len.div_ceil(8).max(1);
+        let mut v: Vec<u64> = Vec::new();
+        v.try_reserve_exact(words).ok()?;
+        v.resize(words, 0);
+        let raw = Box::into_raw(v.into_boxed_slice());
+        Some(NodeBuf {
+            ptr: raw as *mut u8,
+            words,
+        })
+    }
+
+    /// Raw pointer to the start of the buffer (valid for the buffer's lifetime).
+    pub fn as_ptr(&self) -> *mut u8 {
+        self.ptr
+    }
+}
+
+impl Drop for NodeBuf {
+    fn drop(&mut self) {
+        // Reconstitute the boxed [u64] slice from the raw parts and drop it,
+        // freeing via the same (Rust global) allocator it was created with.
+        unsafe {
+            drop(Box::from_raw(core::ptr::slice_from_raw_parts_mut(
+                self.ptr.cast::<u64>(),
+                self.words,
+            )));
+        }
+    }
+}
+
 #[derive(Copy, Clone)]
 pub union data_union {
     pub dbl: f64,
@@ -122,6 +167,14 @@ pub struct ParseData {
     pub nAxes: [c_long; MAXDIMS as usize],
     pub colData: Vec<iteratorCol>, // This is a list
     pub varData: Vec<DataInfo>,
+    /// Rust-owned backing store for the per-node result buffers of numeric
+    /// (DOUBLE/LONG/BOOLEAN) nodes, indexed by node number. When a slot is
+    /// `Some`, the node's `value.data.ptr`/`value.undef` are raw *views* into
+    /// this box (data followed by the undef flags), and the memory is owned and
+    /// freed here rather than via malloc/free. A `None` slot means the node's
+    /// pointer (if any) is owned elsewhere (legacy malloc, e.g. GTI data).
+    /// See `Allocate_Ptrs` / `free_node_data` in eval_y.
+    pub node_buffers: Vec<Option<NodeBuf>>,
     pub pixFilter: *mut PixelFilter,
     pub firstDataRow: c_long,
     pub nDataRows: c_long,
@@ -157,6 +210,7 @@ impl ParseData {
         self.nAxes = Default::default();
         self.colData = Default::default();
         self.varData = Default::default();
+        self.node_buffers = Default::default();
         self.pixFilter = Default::default();
         self.firstDataRow = Default::default();
         self.nDataRows = Default::default();

--- a/src/eval_defs.rs
+++ b/src/eval_defs.rs
@@ -127,77 +127,127 @@ impl NodeBuf {
     }
 }
 
+/// A node's value payload. Formerly an untyped `union`; now a discriminated
+/// enum so a value can't be read as the wrong kind.
+///
+/// - `None` is the default (unset) value; pointer getters read it as null and
+///   scalar getters as zero, matching the old all-zero default union.
+/// - `Double`/`Long`/`Logical`/`Str` are scalar constant values (one per
+///   `Node.ntype`; no cross-type punning — verified before the migration).
+/// - `Buffer` is the per-node result-buffer pointer (numeric array, string
+///   `strptr` array, or GTI/region data). The typed pointer getters all view
+///   this one pointer, cast per the node's `ntype`.
+///
+/// Getters are lenient (zero/null on a `None`, `debug_assert!` on a genuine
+/// wrong-variant read) to preserve the old union's read-anything behaviour.
 #[derive(Copy, Clone)]
-pub union data_union {
-    pub dbl: f64,
-    pub lng: c_long,
-    pub log: c_char,
-    pub astr: [c_char; MAX_STRLEN as usize],
-    pub dblptr: *mut f64,
-    pub lngptr: *mut c_long,
-    pub logptr: *mut c_char,
-    pub strptr: *mut *mut c_char,
-    pub ptr: *mut c_void,
+pub enum DataVal {
+    None,
+    Double(f64),
+    Long(c_long),
+    Logical(c_char),
+    Str([c_char; MAX_STRLEN as usize]),
+    Buffer(*mut c_void),
 }
 
-impl core::fmt::Debug for data_union {
+impl core::fmt::Debug for DataVal {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        write!(f, "data_union {{ long: {:?} }}", unsafe { self.lng })
+        write!(f, "DataVal({:?})", self.lng())
     }
 }
 
-impl Default for data_union {
+impl Default for DataVal {
     fn default() -> Self {
-        data_union {
-            ptr: core::ptr::null_mut(),
-        }
+        DataVal::None
     }
 }
 
-/// Typed read accessors over `data_union`. Call sites use these instead of
-/// reading the union fields directly, so the backing storage can later be
-/// swapped for a typed enum by reimplementing only these methods (see
-/// PLAN_union_enum.md). Writes stay as place-assignments to the fields for now
-/// (borrow-friendly), and become enum constructions when the storage is swapped.
-/// The pointer getters all view the same underlying result-buffer pointer, typed
-/// per the node's `ntype`.
-impl data_union {
+impl DataVal {
     // --- scalar constant getters ---
     pub fn dbl(&self) -> f64 {
-        unsafe { self.dbl }
+        match self {
+            DataVal::Double(v) => *v,
+            DataVal::None => 0.0,
+            _ => {
+                debug_assert!(false, "dbl() on non-Double DataVal");
+                0.0
+            }
+        }
     }
     pub fn lng(&self) -> c_long {
-        unsafe { self.lng }
+        match self {
+            DataVal::Long(v) => *v,
+            DataVal::None => 0,
+            _ => {
+                debug_assert!(false, "lng() on non-Long DataVal");
+                0
+            }
+        }
     }
     pub fn log(&self) -> c_char {
-        unsafe { self.log }
+        match self {
+            DataVal::Logical(v) => *v,
+            DataVal::None => 0,
+            _ => {
+                debug_assert!(false, "log() on non-Logical DataVal");
+                0
+            }
+        }
     }
 
     // --- fixed-size string constant buffer (astr) ---
     pub fn astr(&self) -> &[c_char; MAX_STRLEN as usize] {
-        unsafe { &self.astr }
+        match self {
+            DataVal::Str(a) => a,
+            _ => {
+                debug_assert!(false, "astr() on non-Str DataVal");
+                const ZEROS: [c_char; MAX_STRLEN as usize] = [0; MAX_STRLEN as usize];
+                &ZEROS
+            }
+        }
     }
+    /// Mutable view of the string buffer, initialising the value to an empty
+    /// `Str` first if needed so callers can build a string in place.
     pub fn astr_mut(&mut self) -> &mut [c_char; MAX_STRLEN as usize] {
-        unsafe { &mut self.astr }
+        if !matches!(self, DataVal::Str(_)) {
+            *self = DataVal::Str([0; MAX_STRLEN as usize]);
+        }
+        match self {
+            DataVal::Str(a) => a,
+            _ => unreachable!(),
+        }
     }
 
-    // --- result-buffer views (the pointer variants all alias one buffer) ---
+    // --- result-buffer views (all pointer kinds view one Buffer pointer) ---
+    fn buffer_ptr(&self) -> *mut c_void {
+        match self {
+            DataVal::Buffer(p) => *p,
+            DataVal::None => core::ptr::null_mut(),
+            _ => {
+                debug_assert!(false, "buffer view on a scalar DataVal");
+                core::ptr::null_mut()
+            }
+        }
+    }
     pub fn dblptr(&self) -> *mut f64 {
-        unsafe { self.dblptr }
+        self.buffer_ptr().cast::<f64>()
     }
     pub fn lngptr(&self) -> *mut c_long {
-        unsafe { self.lngptr }
+        self.buffer_ptr().cast::<c_long>()
     }
     pub fn logptr(&self) -> *mut c_char {
-        unsafe { self.logptr }
+        self.buffer_ptr().cast::<c_char>()
     }
     pub fn strptr(&self) -> *mut *mut c_char {
-        unsafe { self.strptr }
+        self.buffer_ptr().cast::<*mut c_char>()
     }
     pub fn ptr(&self) -> *mut c_void {
-        unsafe { self.ptr }
+        self.buffer_ptr()
     }
 }
+
+/// Backwards-compatible alias for the former union type name.
+pub use DataVal as data_union;
 
 #[derive(Default, Debug, Copy, Clone)]
 pub struct lval {

--- a/src/eval_defs.rs
+++ b/src/eval_defs.rs
@@ -154,6 +154,51 @@ impl Default for data_union {
     }
 }
 
+/// Typed read accessors over `data_union`. Call sites use these instead of
+/// reading the union fields directly, so the backing storage can later be
+/// swapped for a typed enum by reimplementing only these methods (see
+/// PLAN_union_enum.md). Writes stay as place-assignments to the fields for now
+/// (borrow-friendly), and become enum constructions when the storage is swapped.
+/// The pointer getters all view the same underlying result-buffer pointer, typed
+/// per the node's `ntype`.
+impl data_union {
+    // --- scalar constant getters ---
+    pub fn dbl(&self) -> f64 {
+        unsafe { self.dbl }
+    }
+    pub fn lng(&self) -> c_long {
+        unsafe { self.lng }
+    }
+    pub fn log(&self) -> c_char {
+        unsafe { self.log }
+    }
+
+    // --- fixed-size string constant buffer (astr) ---
+    pub fn astr(&self) -> &[c_char; MAX_STRLEN as usize] {
+        unsafe { &self.astr }
+    }
+    pub fn astr_mut(&mut self) -> &mut [c_char; MAX_STRLEN as usize] {
+        unsafe { &mut self.astr }
+    }
+
+    // --- result-buffer views (the pointer variants all alias one buffer) ---
+    pub fn dblptr(&self) -> *mut f64 {
+        unsafe { self.dblptr }
+    }
+    pub fn lngptr(&self) -> *mut c_long {
+        unsafe { self.lngptr }
+    }
+    pub fn logptr(&self) -> *mut c_char {
+        unsafe { self.logptr }
+    }
+    pub fn strptr(&self) -> *mut *mut c_char {
+        unsafe { self.strptr }
+    }
+    pub fn ptr(&self) -> *mut c_void {
+        unsafe { self.ptr }
+    }
+}
+
 #[derive(Default, Debug, Copy, Clone)]
 pub struct lval {
     pub nelem: c_long,

--- a/src/eval_f.rs
+++ b/src/eval_f.rs
@@ -2150,8 +2150,18 @@ pub(crate) fn fits_parser_workfn_safe(
                         }
                     }
                     if result.operation > 0 {
-                        FREE!(*(result.value.data.strptr));
-                        FREE!(result.value.data.strptr);
+                        // Rust-owned string buffer (strptr array + backing):
+                        // release via the owning side-table when present, else
+                        // fall back to the legacy frees. Inlined because
+                        // `result` still borrows lParse.Nodes here.
+                        let ridx = lParse.resultNode as usize;
+                        if ridx < lParse.node_buffers.len() && lParse.node_buffers[ridx].is_some() {
+                            lParse.node_buffers[ridx] = None;
+                            result.value.data.strptr = core::ptr::null_mut();
+                        } else {
+                            FREE!(*(result.value.data.strptr));
+                            FREE!(result.value.data.strptr);
+                        }
                     }
                 }
                 fits_parser_yytokentype::STRING => {
@@ -2188,8 +2198,18 @@ pub(crate) fn fits_parser_workfn_safe(
                         lParse.status = PARSE_BAD_TYPE;
                     }
                     if result.operation > 0 {
-                        FREE!(*(result.value.data.strptr));
-                        FREE!(result.value.data.strptr);
+                        // Rust-owned string buffer (strptr array + backing):
+                        // release via the owning side-table when present, else
+                        // fall back to the legacy frees. Inlined because
+                        // `result` still borrows lParse.Nodes here.
+                        let ridx = lParse.resultNode as usize;
+                        if ridx < lParse.node_buffers.len() && lParse.node_buffers[ridx].is_some() {
+                            lParse.node_buffers[ridx] = None;
+                            result.value.data.strptr = core::ptr::null_mut();
+                        } else {
+                            FREE!(*(result.value.data.strptr));
+                            FREE!(result.value.data.strptr);
+                        }
                     }
                 }
                 _ => {}

--- a/src/eval_f.rs
+++ b/src/eval_f.rs
@@ -2553,60 +2553,47 @@ fn ffcvtn(
 
         match outputType {
             TLOGICAL => {
+                let n = ntodo as usize;
+                let output = core::slice::from_raw_parts_mut(output.cast::<c_uchar>(), n);
                 match inputType {
                     TLOGICAL | TBYTE => {
-                        for i in 0..ntodo {
-                            if (*(input.cast::<c_uchar>().add(i.try_into().unwrap()))) != 0 {
-                                *(output.cast::<c_uchar>().add(i.try_into().unwrap())) = 1;
-                            } else {
-                                *(output.cast::<c_uchar>().add(i.try_into().unwrap())) = 0;
-                            }
+                        let input = core::slice::from_raw_parts(input.cast::<c_uchar>(), n);
+                        for i in 0..n {
+                            output[i] = (input[i] != 0) as c_uchar;
                         }
                     }
                     TSHORT => {
-                        for i in 0..ntodo {
-                            if (*(input.cast::<c_short>().add(i.try_into().unwrap()))) != 0 {
-                                *(output.cast::<c_uchar>().add(i.try_into().unwrap())) = 1;
-                            } else {
-                                *(output.cast::<c_uchar>().add(i.try_into().unwrap())) = 0;
-                            }
+                        let input = core::slice::from_raw_parts(input.cast::<c_short>(), n);
+                        for i in 0..n {
+                            output[i] = (input[i] != 0) as c_uchar;
                         }
                     }
                     TLONG => {
-                        for i in 0..ntodo {
-                            if (*(input.cast::<c_long>().add(i.try_into().unwrap()))) != 0 {
-                                *(output.cast::<c_uchar>().add(i.try_into().unwrap())) = 1;
-                            } else {
-                                *(output.cast::<c_uchar>().add(i.try_into().unwrap())) = 0;
-                            }
+                        let input = core::slice::from_raw_parts(input.cast::<c_long>(), n);
+                        for i in 0..n {
+                            output[i] = (input[i] != 0) as c_uchar;
                         }
                     }
                     TFLOAT => {
-                        for i in 0..ntodo {
-                            if (*(input.cast::<c_float>().add(i.try_into().unwrap()))) != 0.0 {
-                                *(output.cast::<c_uchar>().add(i.try_into().unwrap())) = 1;
-                            } else {
-                                *(output.cast::<c_uchar>().add(i.try_into().unwrap())) = 0;
-                            }
+                        let input = core::slice::from_raw_parts(input.cast::<c_float>(), n);
+                        for i in 0..n {
+                            output[i] = (input[i] != 0.0) as c_uchar;
                         }
                     }
                     TDOUBLE => {
-                        for i in 0..ntodo {
-                            if (*(input.cast::<c_double>().add(i.try_into().unwrap()))) != 0.0 {
-                                *(output.cast::<c_uchar>().add(i.try_into().unwrap())) = 1;
-                            } else {
-                                *(output.cast::<c_uchar>().add(i.try_into().unwrap())) = 0;
-                            }
+                        let input = core::slice::from_raw_parts(input.cast::<c_double>(), n);
+                        for i in 0..n {
+                            output[i] = (input[i] != 0.0) as c_uchar;
                         }
                     }
                     _ => {
                         *status = BAD_DATATYPE;
                     }
                 }
-                for i in 0..ntodo {
-                    if *((undef).add(i.try_into().unwrap())) != 0 {
-                        *(output.cast::<c_uchar>().add(i.try_into().unwrap())) =
-                            *nulval.cast::<c_uchar>();
+                let undef = core::slice::from_raw_parts(undef, n);
+                for i in 0..n {
+                    if undef[i] != 0 {
+                        output[i] = *nulval.cast::<c_uchar>();
                         *anynull = 1;
                     }
                 }

--- a/src/eval_f.rs
+++ b/src/eval_f.rs
@@ -4713,96 +4713,94 @@ fn find_keywd(
     keyname: &[c_char],
     itslval: &mut FITS_PARSER_YYSTYPE,
 ) -> c_int {
-    unsafe {
-        let thelval = itslval;
+    let thelval = itslval;
 
-        let mut status: c_int = 0;
-        let mut ktype: c_int = 0;
+    let mut status: c_int = 0;
+    let mut ktype: c_int = 0;
 
-        let mut keyvalue: [c_char; FLEN_VALUE] = [0; FLEN_VALUE];
-        let mut dtype: c_char = 0;
+    let mut keyvalue: [c_char; FLEN_VALUE] = [0; FLEN_VALUE];
+    let mut dtype: c_char = 0;
 
-        let mut rval: c_double = 0.0;
-        let mut bval: c_int = 0;
-        let mut ival: c_long = 0;
+    let mut rval: c_double = 0.0;
+    let mut bval: c_int = 0;
+    let mut ival: c_long = 0;
 
-        status = 0;
+    status = 0;
 
-        if lParse.def_fptr.is_null() {
-            ffpmsg_str("find_keywd: no default fitsfile defined");
-            lParse.status = P_ERROR;
-            return P_ERROR;
-        }
-
-        let fptr: &mut fitsfile = lParse.def_fptr.as_mut().expect(NULL_MSG);
-
-        if fits_read_keyword(fptr, keyname, &mut keyvalue, None, &mut status) != 0 {
-            if status == KEY_NO_EXIST {
-                /*  Do this since ffgkey doesn't put an error message on stack  */
-                int_snprintf!(
-                    &mut keyvalue,
-                    FLEN_VALUE,
-                    "ffgkey could not find keyword: {}",
-                    CStr::from_bytes_until_nul(cast_slice(keyname))
-                        .unwrap()
-                        .to_str()
-                        .unwrap(),
-                );
-                ffpmsg_slice(&keyvalue);
-            }
-            lParse.status = status;
-            return P_ERROR;
-        }
-
-        if fits_get_keytype(&keyvalue, &mut dtype, &mut status) != 0 {
-            lParse.status = status;
-            return P_ERROR;
-        }
-
-        /* Read appropriate value type and set to CONST_OP */
-        match dtype as u8 {
-            b'C' => {
-                // 'C' as c_char
-                fits_read_key_str(fptr, keyname, &mut keyvalue, None, &mut status);
-                ktype = fits_parser_yytokentype::STRING as c_int;
-                strcpy_safe(unsafe { &mut thelval.astr }, &keyvalue);
-            }
-            b'L' => {
-                // 'L' as c_char
-                fits_read_key_log(fptr, keyname, &mut bval, None, &mut status);
-                ktype = fits_parser_yytokentype::BOOLEAN as c_int;
-                unsafe {
-                    thelval.log = bval as c_char;
-                }
-            }
-            b'I' => {
-                // 'I' as c_char
-                fits_read_key_lng(fptr, keyname, &mut ival, None, &mut status);
-                ktype = fits_parser_yytokentype::LONG as c_int;
-                unsafe {
-                    thelval.lng = ival;
-                }
-            }
-            b'F' => {
-                // 'F' as c_char
-                fits_read_key_dbl(fptr, keyname, &mut rval, None, &mut status);
-                ktype = fits_parser_yytokentype::DOUBLE as c_int;
-                unsafe {
-                    thelval.dbl = rval;
-                }
-            }
-            _ => {
-                ktype = P_ERROR;
-            }
-        }
-
-        if status != 0 {
-            lParse.status = status;
-            return P_ERROR;
-        }
-
-        ktype
+    if lParse.def_fptr.is_null() {
+        ffpmsg_str("find_keywd: no default fitsfile defined");
+        lParse.status = P_ERROR;
+        return P_ERROR;
     }
+
+    let fptr: &mut fitsfile = unsafe { lParse.def_fptr.as_mut() }.expect(NULL_MSG);
+
+    if fits_read_keyword(fptr, keyname, &mut keyvalue, None, &mut status) != 0 {
+        if status == KEY_NO_EXIST {
+            /*  Do this since ffgkey doesn't put an error message on stack  */
+            int_snprintf!(
+                &mut keyvalue,
+                FLEN_VALUE,
+                "ffgkey could not find keyword: {}",
+                CStr::from_bytes_until_nul(cast_slice(keyname))
+                    .unwrap()
+                    .to_str()
+                    .unwrap(),
+            );
+            ffpmsg_slice(&keyvalue);
+        }
+        lParse.status = status;
+        return P_ERROR;
+    }
+
+    if fits_get_keytype(&keyvalue, &mut dtype, &mut status) != 0 {
+        lParse.status = status;
+        return P_ERROR;
+    }
+
+    /* Read appropriate value type and set to CONST_OP */
+    match dtype as u8 {
+        b'C' => {
+            // 'C' as c_char
+            fits_read_key_str(fptr, keyname, &mut keyvalue, None, &mut status);
+            ktype = fits_parser_yytokentype::STRING as c_int;
+            strcpy_safe(unsafe { &mut thelval.astr }, &keyvalue);
+        }
+        b'L' => {
+            // 'L' as c_char
+            fits_read_key_log(fptr, keyname, &mut bval, None, &mut status);
+            ktype = fits_parser_yytokentype::BOOLEAN as c_int;
+            unsafe {
+                thelval.log = bval as c_char;
+            }
+        }
+        b'I' => {
+            // 'I' as c_char
+            fits_read_key_lng(fptr, keyname, &mut ival, None, &mut status);
+            ktype = fits_parser_yytokentype::LONG as c_int;
+            unsafe {
+                thelval.lng = ival;
+            }
+        }
+        b'F' => {
+            // 'F' as c_char
+            fits_read_key_dbl(fptr, keyname, &mut rval, None, &mut status);
+            ktype = fits_parser_yytokentype::DOUBLE as c_int;
+            unsafe {
+                thelval.dbl = rval;
+            }
+        }
+        _ => {
+            ktype = P_ERROR;
+        }
+    }
+
+    if status != 0 {
+        lParse.status = status;
+        return P_ERROR;
+    }
+
+    ktype
 }
 
 /// Allocates parser iterator column storage for 25 columns *more* than nCols

--- a/src/eval_f.rs
+++ b/src/eval_f.rs
@@ -1911,11 +1911,22 @@ pub(crate) fn fits_parser_workfn_safe(
                 | fits_parser_yytokentype::DOUBLE => {
                     if constant != 0 {
                         let undef: c_char = 0;
+                        // Materialize the constant scalar into a typed cell so
+                        // ffcvtn reads it without depending on the in-memory
+                        // layout of value.data.
+                        let mut const_cell = [0u8; 8];
+                        if lParse.datatype == fits_parser_yytokentype::DOUBLE as c_int {
+                            const_cell = result.value.data.dbl().to_ne_bytes();
+                        } else if lParse.datatype == fits_parser_yytokentype::LONG as c_int {
+                            const_cell = (result.value.data.lng() as i64).to_ne_bytes();
+                        } else if lParse.datatype == fits_parser_yytokentype::BOOLEAN as c_int {
+                            const_cell[0] = result.value.data.log() as u8;
+                        }
                         for kk in 0..ntodo {
                             for jj in 0..pv.repeat {
                                 ffcvtn(
                                     lParse.datatype,
-                                    (&(result.value.data) as *const data_union).cast::<c_void>(),
+                                    const_cell.as_ptr().cast::<c_void>(),
                                     &undef,
                                     result.value.nelem, /* 1 */
                                     (*(pv.userInfo)).datatype,

--- a/src/eval_f.rs
+++ b/src/eval_f.rs
@@ -2533,6 +2533,50 @@ fn Setup_DataArrays(
     }
 }
 
+/// Element-wise convert `n` values of type `S` at `input` into type `T` at
+/// `output`, applying `f` to each element. Unsafe is confined to building the
+/// two slices from the FFI raw pointers; the per-element work is safe indexing.
+///
+/// # Safety
+/// `input`/`output` must point to at least `n` valid, correctly-aligned `S`/`T`
+/// elements and must not overlap.
+unsafe fn cvt_map<S: Copy, T>(
+    input: *const c_void,
+    output: *mut c_void,
+    n: usize,
+    f: impl Fn(S) -> T,
+) {
+    let inp = unsafe { core::slice::from_raw_parts(input.cast::<S>(), n) };
+    let out = unsafe { core::slice::from_raw_parts_mut(output.cast::<T>(), n) };
+    for i in 0..n {
+        out[i] = f(inp[i]);
+    }
+}
+
+/// Apply UNDEF handling for `n` elements of type `T`: wherever `undef[i]` is
+/// nonzero, store `*nulval` into `output[i]` and flag `anynull`.
+///
+/// # Safety
+/// `output`/`undef` must cover `n` valid `T`/`c_char` elements and `nulval` a
+/// valid `T`.
+unsafe fn cvt_apply_undef<T: Copy>(
+    output: *mut c_void,
+    undef: *const c_char,
+    nulval: *const c_void,
+    n: usize,
+    anynull: &mut c_int,
+) {
+    let out = unsafe { core::slice::from_raw_parts_mut(output.cast::<T>(), n) };
+    let und = unsafe { core::slice::from_raw_parts(undef, n) };
+    let nul = unsafe { *nulval.cast::<T>() };
+    for i in 0..n {
+        if und[i] != 0 {
+            out[i] = nul;
+            *anynull = 1;
+        }
+    }
+}
+
 /*--------------------------------------------------------------------------*/
 /// Convert an array of any input data type to an array of any output
 /// data type, using an array of UNDEF flags to assign nulvals to
@@ -2601,10 +2645,7 @@ fn ffcvtn(
             TBYTE => {
                 match inputType {
                     TLOGICAL | TBYTE => {
-                        for i in 0..ntodo {
-                            *(output.cast::<c_uchar>().add(i.try_into().unwrap())) =
-                                *(input.cast::<c_uchar>().add(i.try_into().unwrap()));
-                        }
+                        cvt_map::<c_uchar, c_uchar>(input, output, ntodo as usize, |v| v);
                     }
                     TSHORT => {
                         let input_slice = unsafe {
@@ -2636,23 +2677,23 @@ fn ffcvtn(
                         );
                     }
                     TLONG => {
-                        for i in 0..ntodo {
-                            if *((undef).add(i.try_into().unwrap())) != 0 {
-                                *(output.cast::<c_uchar>().add(i.try_into().unwrap())) =
-                                    *nulval.cast::<c_uchar>();
+                        let n = ntodo as usize;
+                        let inp = core::slice::from_raw_parts(input.cast::<c_long>(), n);
+                        let out = core::slice::from_raw_parts_mut(output.cast::<c_uchar>(), n);
+                        let und = core::slice::from_raw_parts(undef, n);
+                        let nul = *nulval.cast::<c_uchar>();
+                        for i in 0..n {
+                            if und[i] != 0 {
+                                out[i] = nul;
                                 *anynull = 1;
-                            } else if *(input.cast::<c_long>().add(i.try_into().unwrap())) < 0 {
+                            } else if inp[i] < 0 {
                                 *status = OVERFLOW_ERR;
-                                *(output.cast::<c_uchar>().add(i.try_into().unwrap())) = 0;
-                            } else if *(input.cast::<c_long>().add(i.try_into().unwrap()))
-                                > UCHAR_MAX as c_long
-                            {
+                                out[i] = 0;
+                            } else if inp[i] > UCHAR_MAX as c_long {
                                 *status = OVERFLOW_ERR;
-                                *(output.cast::<c_uchar>().add(i.try_into().unwrap())) =
-                                    UCHAR_MAX as c_uchar;
+                                out[i] = UCHAR_MAX as c_uchar;
                             } else {
-                                *(output.cast::<c_uchar>().add(i.try_into().unwrap())) =
-                                    *(input.cast::<c_long>().add(i.try_into().unwrap())) as c_uchar;
+                                out[i] = inp[i] as c_uchar;
                             }
                         }
                         return *status;
@@ -2718,50 +2759,36 @@ fn ffcvtn(
                     }
                 }
 
-                for i in 0..ntodo {
-                    if *((undef).add(i.try_into().unwrap())) != 0 {
-                        *(output.cast::<c_uchar>().add(i.try_into().unwrap())) =
-                            *nulval.cast::<c_uchar>();
-                        *anynull = 1;
-                    }
-                }
+                cvt_apply_undef::<c_uchar>(output, undef, nulval, ntodo as usize, anynull);
             }
             TSHORT => {
                 match inputType {
                     TLOGICAL | TBYTE => {
-                        for i in 0..ntodo {
-                            *(output.cast::<c_short>().add(i.try_into().unwrap())) = c_short::from(
-                                *(input.cast::<c_uchar>().add(i.try_into().unwrap())),
-                            );
-                        }
+                        cvt_map::<c_uchar, c_short>(input, output, ntodo as usize, |v| {
+                            c_short::from(v)
+                        });
                     }
                     TSHORT => {
-                        for i in 0..ntodo {
-                            *(output.cast::<c_short>().add(i.try_into().unwrap())) =
-                                *(input.cast::<c_short>().add(i.try_into().unwrap()));
-                        }
+                        cvt_map::<c_short, c_short>(input, output, ntodo as usize, |v| v);
                     }
                     TLONG => {
-                        for i in 0..ntodo {
-                            if *((undef).add(i.try_into().unwrap())) != 0 {
-                                *(output.cast::<c_short>().add(i.try_into().unwrap())) =
-                                    *nulval.cast::<c_short>();
+                        let n = ntodo as usize;
+                        let inp = core::slice::from_raw_parts(input.cast::<c_long>(), n);
+                        let out = core::slice::from_raw_parts_mut(output.cast::<c_short>(), n);
+                        let und = core::slice::from_raw_parts(undef, n);
+                        let nul = *nulval.cast::<c_short>();
+                        for i in 0..n {
+                            if und[i] != 0 {
+                                out[i] = nul;
                                 *anynull = 1;
-                            } else if *(input.cast::<c_long>().add(i.try_into().unwrap()))
-                                < SHRT_MIN as c_long
-                            {
+                            } else if inp[i] < SHRT_MIN as c_long {
                                 *status = OVERFLOW_ERR;
-                                *(output.cast::<c_short>().add(i.try_into().unwrap())) =
-                                    SHRT_MIN as c_short;
-                            } else if *(input.cast::<c_long>().add(i.try_into().unwrap()))
-                                > SHRT_MAX as c_long
-                            {
+                                out[i] = SHRT_MIN as c_short;
+                            } else if inp[i] > SHRT_MAX as c_long {
                                 *status = OVERFLOW_ERR;
-                                *(output.cast::<c_short>().add(i.try_into().unwrap())) =
-                                    SHRT_MAX as c_short;
+                                out[i] = SHRT_MAX as c_short;
                             } else {
-                                *(output.cast::<c_short>().add(i.try_into().unwrap())) =
-                                    *(input.cast::<c_long>().add(i.try_into().unwrap())) as c_short;
+                                out[i] = inp[i] as c_short;
                             }
                         }
                         return *status;
@@ -2826,33 +2853,22 @@ fn ffcvtn(
                         *status = BAD_DATATYPE;
                     }
                 }
-                for i in 0..ntodo {
-                    if *((undef).add(i.try_into().unwrap())) != 0 {
-                        *(output.cast::<c_short>().add(i.try_into().unwrap())) =
-                            *nulval.cast::<c_short>();
-                        *anynull = 1;
-                    }
-                }
+                cvt_apply_undef::<c_short>(output, undef, nulval, ntodo as usize, anynull);
             }
             TINT => {
                 match inputType {
                     TLOGICAL | TBYTE => {
-                        for i in 0..ntodo {
-                            *(output.cast::<c_int>().add(i.try_into().unwrap())) =
-                                c_int::from(*(input.cast::<c_uchar>().add(i.try_into().unwrap())));
-                        }
+                        cvt_map::<c_uchar, c_int>(input, output, ntodo as usize, |v| {
+                            c_int::from(v)
+                        });
                     }
                     TSHORT => {
-                        for i in 0..ntodo {
-                            *(output.cast::<c_int>().add(i.try_into().unwrap())) =
-                                c_int::from(*(input.cast::<c_short>().add(i.try_into().unwrap())));
-                        }
+                        cvt_map::<c_short, c_int>(input, output, ntodo as usize, |v| {
+                            c_int::from(v)
+                        });
                     }
                     TLONG => {
-                        for i in 0..ntodo {
-                            *(output.cast::<c_int>().add(i.try_into().unwrap())) =
-                                *(input.cast::<c_long>().add(i.try_into().unwrap())) as c_int;
-                        }
+                        cvt_map::<c_long, c_int>(input, output, ntodo as usize, |v| v as c_int);
                     }
                     TFLOAT => {
                         let input_slice = unsafe {
@@ -2914,33 +2930,22 @@ fn ffcvtn(
                         *status = BAD_DATATYPE;
                     }
                 }
-                for i in 0..ntodo {
-                    if *((undef).add(i.try_into().unwrap())) != 0 {
-                        *(output.cast::<c_int>().add(i.try_into().unwrap())) =
-                            *nulval.cast::<c_int>();
-                        *anynull = 1;
-                    }
-                }
+                cvt_apply_undef::<c_int>(output, undef, nulval, ntodo as usize, anynull);
             }
             TLONG => {
                 match inputType {
                     TLOGICAL | TBYTE => {
-                        for i in 0..ntodo {
-                            *(output.cast::<c_long>().add(i.try_into().unwrap())) =
-                                c_long::from(*(input.cast::<c_uchar>().add(i.try_into().unwrap())));
-                        }
+                        cvt_map::<c_uchar, c_long>(input, output, ntodo as usize, |v| {
+                            c_long::from(v)
+                        });
                     }
                     TSHORT => {
-                        for i in 0..ntodo {
-                            *(output.cast::<c_long>().add(i.try_into().unwrap())) =
-                                c_long::from(*(input.cast::<c_short>().add(i.try_into().unwrap())));
-                        }
+                        cvt_map::<c_short, c_long>(input, output, ntodo as usize, |v| {
+                            c_long::from(v)
+                        });
                     }
                     TLONG => {
-                        for i in 0..ntodo {
-                            *(output.cast::<c_long>().add(i.try_into().unwrap())) =
-                                *(input.cast::<c_long>().add(i.try_into().unwrap()));
-                        }
+                        cvt_map::<c_long, c_long>(input, output, ntodo as usize, |v| v);
                     }
                     TFLOAT => {
                         let input_slice = unsafe {
@@ -3002,37 +3007,24 @@ fn ffcvtn(
                         *status = BAD_DATATYPE;
                     }
                 }
-                for i in 0..ntodo {
-                    if *((undef).add(i.try_into().unwrap())) != 0 {
-                        *(output.cast::<c_long>().add(i.try_into().unwrap())) =
-                            *nulval.cast::<c_long>();
-                        *anynull = 1;
-                    }
-                }
+                cvt_apply_undef::<c_long>(output, undef, nulval, ntodo as usize, anynull);
             }
             TLONGLONG => {
                 match inputType {
                     TLOGICAL | TBYTE => {
-                        for i in 0..ntodo {
-                            *(output.cast::<LONGLONG>().add(i.try_into().unwrap())) =
-                                LONGLONG::from(
-                                    *(input.cast::<c_uchar>().add(i.try_into().unwrap())),
-                                );
-                        }
+                        cvt_map::<c_uchar, LONGLONG>(input, output, ntodo as usize, |v| {
+                            LONGLONG::from(v)
+                        });
                     }
                     TSHORT => {
-                        for i in 0..ntodo {
-                            *(output.cast::<LONGLONG>().add(i.try_into().unwrap())) =
-                                LONGLONG::from(
-                                    *(input.cast::<c_short>().add(i.try_into().unwrap())),
-                                );
-                        }
+                        cvt_map::<c_short, LONGLONG>(input, output, ntodo as usize, |v| {
+                            LONGLONG::from(v)
+                        });
                     }
                     TLONG => {
-                        for i in 0..ntodo {
-                            *(output.cast::<LONGLONG>().add(i.try_into().unwrap())) =
-                                *(input.cast::<c_long>().add(i.try_into().unwrap())) as LONGLONG;
-                        }
+                        cvt_map::<c_long, LONGLONG>(input, output, ntodo as usize, |v| {
+                            v as LONGLONG
+                        });
                     }
                     TFLOAT => {
                         let input_slice = unsafe {
@@ -3094,41 +3086,25 @@ fn ffcvtn(
                         *status = BAD_DATATYPE;
                     }
                 }
-                for i in 0..ntodo {
-                    if *((undef).add(i.try_into().unwrap())) != 0 {
-                        *(output.cast::<LONGLONG>().add(i.try_into().unwrap())) =
-                            *nulval.cast::<LONGLONG>();
-                        *anynull = 1;
-                    }
-                }
+                cvt_apply_undef::<LONGLONG>(output, undef, nulval, ntodo as usize, anynull);
             }
             TFLOAT => {
                 match inputType {
                     TLOGICAL | TBYTE => {
-                        for i in 0..ntodo {
-                            *(output.cast::<c_float>().add(i.try_into().unwrap())) = c_float::from(
-                                *(input.cast::<c_uchar>().add(i.try_into().unwrap())),
-                            );
-                        }
+                        cvt_map::<c_uchar, c_float>(input, output, ntodo as usize, |v| {
+                            c_float::from(v)
+                        });
                     }
                     TSHORT => {
-                        for i in 0..ntodo {
-                            *(output.cast::<c_float>().add(i.try_into().unwrap())) = c_float::from(
-                                *(input.cast::<c_short>().add(i.try_into().unwrap())),
-                            );
-                        }
+                        cvt_map::<c_short, c_float>(input, output, ntodo as usize, |v| {
+                            c_float::from(v)
+                        });
                     }
                     TLONG => {
-                        for i in 0..ntodo {
-                            *(output.cast::<c_float>().add(i.try_into().unwrap())) =
-                                *(input.cast::<c_long>().add(i.try_into().unwrap())) as c_float;
-                        }
+                        cvt_map::<c_long, c_float>(input, output, ntodo as usize, |v| v as c_float);
                     }
                     TFLOAT => {
-                        for i in 0..ntodo {
-                            *(output.cast::<c_float>().add(i.try_into().unwrap())) =
-                                *(input.cast::<c_float>().add(i.try_into().unwrap()));
-                        }
+                        cvt_map::<c_float, c_float>(input, output, ntodo as usize, |v| v);
                     }
                     TDOUBLE => {
                         let input_slice = unsafe {
@@ -3162,63 +3138,40 @@ fn ffcvtn(
                         *status = BAD_DATATYPE;
                     }
                 }
-                for i in 0..ntodo {
-                    if *((undef).add(i.try_into().unwrap())) != 0 {
-                        *(output.cast::<c_float>().add(i.try_into().unwrap())) =
-                            *nulval.cast::<c_float>();
-                        *anynull = 1;
-                    }
-                }
+                cvt_apply_undef::<c_float>(output, undef, nulval, ntodo as usize, anynull);
             }
             TDOUBLE => {
                 match inputType {
                     TLOGICAL | TBYTE => {
-                        for i in 0..ntodo {
-                            *(output.cast::<c_double>().add(i.try_into().unwrap())) =
-                                c_double::from(
-                                    *(input.cast::<c_uchar>().add(i.try_into().unwrap())),
-                                );
-                        }
+                        cvt_map::<c_uchar, c_double>(input, output, ntodo as usize, |v| {
+                            c_double::from(v)
+                        });
                     }
                     TSHORT => {
-                        for i in 0..ntodo {
-                            *(output.cast::<c_double>().add(i.try_into().unwrap())) =
-                                c_double::from(
-                                    *(input.cast::<c_short>().add(i.try_into().unwrap())),
-                                );
-                        }
+                        cvt_map::<c_short, c_double>(input, output, ntodo as usize, |v| {
+                            c_double::from(v)
+                        });
                     }
                     TLONG => {
-                        for i in 0..ntodo {
-                            *(output.cast::<c_double>().add(i.try_into().unwrap())) =
-                                *(input.cast::<c_long>().add(i.try_into().unwrap())) as c_double;
-                        }
+                        cvt_map::<c_long, c_double>(input, output, ntodo as usize, |v| {
+                            v as c_double
+                        });
                     }
                     TFLOAT => {
-                        for i in 0..ntodo {
-                            *(output.cast::<c_double>().add(i.try_into().unwrap())) =
-                                c_double::from(
-                                    *(input.cast::<c_float>().add(i.try_into().unwrap())),
-                                );
-                        }
+                        cvt_map::<c_float, c_double>(input, output, ntodo as usize, |v| {
+                            c_double::from(v)
+                        });
                     }
                     TDOUBLE => {
-                        for i in 0..ntodo {
-                            *(output.cast::<c_double>().add(i.try_into().unwrap())) =
-                                *(input.cast::<c_double>().add(i.try_into().unwrap())) as c_double;
-                        }
+                        cvt_map::<c_double, c_double>(input, output, ntodo as usize, |v| {
+                            v as c_double
+                        });
                     }
                     _ => {
                         *status = BAD_DATATYPE;
                     }
                 }
-                for i in 0..ntodo {
-                    if *((undef).add(i.try_into().unwrap())) != 0 {
-                        *(output.cast::<c_double>().add(i.try_into().unwrap())) =
-                            *nulval.cast::<c_double>();
-                        *anynull = 1;
-                    }
-                }
+                cvt_apply_undef::<c_double>(output, undef, nulval, ntodo as usize, anynull);
             }
             _ => {
                 *status = BAD_DATATYPE;

--- a/src/eval_f.rs
+++ b/src/eval_f.rs
@@ -4702,7 +4702,7 @@ fn find_column(
             }
         }
         lParse.nCols += 1;
-        thelval.lng = c_long::from(col_cnt);
+        *thelval = FITS_PARSER_YYSTYPE::Lng(c_long::from(col_cnt));
 
         ktype
     }
@@ -4764,14 +4764,14 @@ fn find_keywd(
             // 'C' as c_char
             fits_read_key_str(fptr, keyname, &mut keyvalue, None, &mut status);
             ktype = fits_parser_yytokentype::STRING as c_int;
-            strcpy_safe(unsafe { &mut thelval.astr }, &keyvalue);
+            strcpy_safe(thelval.astr_mut(), &keyvalue);
         }
         b'L' => {
             // 'L' as c_char
             fits_read_key_log(fptr, keyname, &mut bval, None, &mut status);
             ktype = fits_parser_yytokentype::BOOLEAN as c_int;
             unsafe {
-                thelval.log = bval as c_char;
+                *thelval = FITS_PARSER_YYSTYPE::Log(bval as c_char);
             }
         }
         b'I' => {
@@ -4779,7 +4779,7 @@ fn find_keywd(
             fits_read_key_lng(fptr, keyname, &mut ival, None, &mut status);
             ktype = fits_parser_yytokentype::LONG as c_int;
             unsafe {
-                thelval.lng = ival;
+                *thelval = FITS_PARSER_YYSTYPE::Lng(ival);
             }
         }
         b'F' => {
@@ -4787,7 +4787,7 @@ fn find_keywd(
             fits_read_key_dbl(fptr, keyname, &mut rval, None, &mut status);
             ktype = fits_parser_yytokentype::DOUBLE as c_int;
             unsafe {
-                thelval.dbl = rval;
+                *thelval = FITS_PARSER_YYSTYPE::Dbl(rval);
             }
         }
         _ => {

--- a/src/eval_f.rs
+++ b/src/eval_f.rs
@@ -1914,12 +1914,16 @@ pub(crate) fn fits_parser_workfn_safe(
                         // Materialize the constant scalar into a typed cell so
                         // ffcvtn reads it without depending on the in-memory
                         // layout of value.data.
+                        // Fill the cell according to the constant's own type
+                        // (result.ntype, a parser token), which is what
+                        // value.data actually holds; ffcvtn's inputType
+                        // (lParse.datatype) is the matching cfitsio type code.
                         let mut const_cell = [0u8; 8];
-                        if lParse.datatype == fits_parser_yytokentype::DOUBLE as c_int {
+                        if result.ntype == fits_parser_yytokentype::DOUBLE as c_int {
                             const_cell = result.value.data.dbl().to_ne_bytes();
-                        } else if lParse.datatype == fits_parser_yytokentype::LONG as c_int {
+                        } else if result.ntype == fits_parser_yytokentype::LONG as c_int {
                             const_cell = (result.value.data.lng() as i64).to_ne_bytes();
-                        } else if lParse.datatype == fits_parser_yytokentype::BOOLEAN as c_int {
+                        } else if result.ntype == fits_parser_yytokentype::BOOLEAN as c_int {
                             const_cell[0] = result.value.data.log() as u8;
                         }
                         for kk in 0..ntodo {
@@ -1965,7 +1969,7 @@ pub(crate) fn fits_parser_workfn_safe(
                                         result
                                             .value
                                             .data
-                                            .ptr
+                                            .ptr()
                                             .cast::<c_char>()
                                             .add((kk * (pv.resDataSize)).try_into().unwrap())
                                             as *const c_void,
@@ -2048,14 +2052,10 @@ pub(crate) fn fits_parser_workfn_safe(
                             // free_node_data) because `result` still borrows
                             // lParse.Nodes here; node_buffers is a disjoint field.
                             let ridx = lParse.resultNode as usize;
-                            if ridx < lParse.node_buffers.len()
-                                && lParse.node_buffers[ridx].is_some()
-                            {
-                                lParse.node_buffers[ridx] = None;
-                                result.value.data.ptr = core::ptr::null_mut();
-                            } else {
-                                FREE!(result.value.data.ptr);
+                            if ridx < lParse.node_buffers.len() {
+                                lParse.node_buffers[ridx] = None; // drop the owned result buffer
                             }
+                            result.value.data = data_union::None;
                         }
                     }
                     if lParse.status == OVERFLOW_ERR {
@@ -2086,7 +2086,7 @@ pub(crate) fn fits_parser_workfn_safe(
                                     } else if *(*(result
                                         .value
                                         .data
-                                        .strptr
+                                        .strptr()
                                         .add(kk.try_into().unwrap())))
                                     .add(jj.try_into().unwrap())
                                         == b'1' as c_char
@@ -2120,7 +2120,7 @@ pub(crate) fn fits_parser_workfn_safe(
                                         let r = if (*(*(result
                                             .value
                                             .data
-                                            .strptr
+                                            .strptr()
                                             .add(kk.try_into().unwrap())))
                                         .add(jj.try_into().unwrap()))
                                             == b'1' as c_char
@@ -2168,13 +2168,10 @@ pub(crate) fn fits_parser_workfn_safe(
                         // fall back to the legacy frees. Inlined because
                         // `result` still borrows lParse.Nodes here.
                         let ridx = lParse.resultNode as usize;
-                        if ridx < lParse.node_buffers.len() && lParse.node_buffers[ridx].is_some() {
-                            lParse.node_buffers[ridx] = None;
-                            result.value.data.strptr = core::ptr::null_mut();
-                        } else {
-                            FREE!(*(result.value.data.strptr));
-                            FREE!(result.value.data.strptr);
+                        if ridx < lParse.node_buffers.len() {
+                            lParse.node_buffers[ridx] = None; // drop the owned result buffer
                         }
+                        result.value.data = data_union::None;
                     }
                 }
                 fits_parser_yytokentype::STRING => {
@@ -2216,13 +2213,10 @@ pub(crate) fn fits_parser_workfn_safe(
                         // fall back to the legacy frees. Inlined because
                         // `result` still borrows lParse.Nodes here.
                         let ridx = lParse.resultNode as usize;
-                        if ridx < lParse.node_buffers.len() && lParse.node_buffers[ridx].is_some() {
-                            lParse.node_buffers[ridx] = None;
-                            result.value.data.strptr = core::ptr::null_mut();
-                        } else {
-                            FREE!(*(result.value.data.strptr));
-                            FREE!(result.value.data.strptr);
+                        if ridx < lParse.node_buffers.len() {
+                            lParse.node_buffers[ridx] = None; // drop the owned result buffer
                         }
+                        result.value.data = data_union::None;
                     }
                 }
                 _ => {}

--- a/src/eval_f.rs
+++ b/src/eval_f.rs
@@ -1541,66 +1541,66 @@ pub(crate) fn ffiprs(
 /*---------------------------------------------------------------------------*/
 /// Clear the parser, making it ready to accept a new expression.
 pub(crate) fn ffcprs(lParse: &mut ParseData) {
-    unsafe {
-        let col: c_int = 0;
-        let mut node: c_int = 0;
-        let mut i: usize = 0;
+    let mut node: c_int;
+    let mut i: usize;
 
-        if lParse.expr.is_some() {
-            lParse.expr = None; // Clear the Option<Box<[u8]>> instead of using FREE!
-        }
+    if lParse.expr.is_some() {
+        lParse.expr = None; // Clear the Option<Box<[u8]>> instead of using FREE!
+    }
 
-        if lParse.nCols > 0 {
-            lParse.colData.clear();
+    if lParse.nCols > 0 {
+        lParse.colData.clear();
 
-            for col in 0..lParse.nCols {
-                if lParse.varData[col as usize].undef.is_none() {
-                    continue;
-                }
+        for col in 0..lParse.nCols {
+            if lParse.varData[col as usize].undef.is_none() {
+                continue;
+            }
 
-                if lParse.varData[col as usize].dtype == fits_parser_yytokentype::BITSTR as c_int {
-                    let data_ptr = lParse.varData[col as usize].data.cast::<*mut c_char>();
+            if lParse.varData[col as usize].dtype == fits_parser_yytokentype::BITSTR as c_int {
+                // The BITSTR column data is a libc-malloc'd 2-D buffer.
+                let data_ptr = lParse.varData[col as usize].data.cast::<*mut c_char>();
+                unsafe {
                     let mut first_ptr = *data_ptr;
                     FREE!(first_ptr);
                 }
-
-                lParse.varData[col as usize].undef = None;
             }
-            lParse.varData.clear();
-            lParse.nCols = 0;
-        } else if !lParse.colData.is_empty() {
-            /* Special case if colData needed to be created with no columns */
-            lParse.colData.clear();
+
+            lParse.varData[col as usize].undef = None;
         }
-
-        if lParse.nNodes > 0 {
-            node = lParse.nNodes;
-            while node != 0 {
-                node -= 1;
-                if (lParse.Nodes[node as usize]).operation == GTIFILT_FCT as c_int {
-                    // The GTI START/STOP buffer is now Rust-owned; drop it via
-                    // the side-table rather than FREE! (which would be an
-                    // allocator mismatch).
-                    i = lParse.Nodes[node as usize].SubNodes[0];
-                    free_node_data(lParse, i);
-                } else if (lParse.Nodes[node as usize]).operation == REGFILT_FCT as c_int {
-                    i = (lParse.Nodes[node as usize]).SubNodes[0];
-                    fits_free_region(Box::from_raw(
-                        (lParse.Nodes[i]).value.data.ptr().cast::<SAORegion>(),
-                    ));
-                }
-            }
-            lParse.nNodes = 0;
-        }
-
-        lParse.Nodes = Vec::new(); // Frees
-        lParse.node_buffers = Vec::new(); // Frees Rust-owned numeric node buffers
-
-        lParse.hdutype = ANY_HDU;
-        lParse.pixFilter = core::ptr::null_mut();
-        lParse.nDataRows = 0;
-        lParse.nPrevDataRows = 0;
+        lParse.varData.clear();
+        lParse.nCols = 0;
+    } else if !lParse.colData.is_empty() {
+        /* Special case if colData needed to be created with no columns */
+        lParse.colData.clear();
     }
+
+    if lParse.nNodes > 0 {
+        node = lParse.nNodes;
+        while node != 0 {
+            node -= 1;
+            if (lParse.Nodes[node as usize]).operation == GTIFILT_FCT as c_int {
+                // The GTI START/STOP buffer is now Rust-owned; drop it via the
+                // side-table rather than FREE! (which would be an allocator
+                // mismatch).
+                i = lParse.Nodes[node as usize].SubNodes[0];
+                free_node_data(lParse, i);
+            } else if (lParse.Nodes[node as usize]).operation == REGFILT_FCT as c_int {
+                i = (lParse.Nodes[node as usize]).SubNodes[0];
+                let rgn = (lParse.Nodes[i]).value.data.ptr().cast::<SAORegion>();
+                // Reclaim the region Box::into_raw'd in New_REG.
+                fits_free_region(unsafe { Box::from_raw(rgn) });
+            }
+        }
+        lParse.nNodes = 0;
+    }
+
+    lParse.Nodes = Vec::new(); // Frees
+    lParse.node_buffers = Vec::new(); // Frees Rust-owned numeric node buffers
+
+    lParse.hdutype = ANY_HDU;
+    lParse.pixFilter = core::ptr::null_mut();
+    lParse.nDataRows = 0;
+    lParse.nPrevDataRows = 0;
 }
 
 /*---------------------------------------------------------------------------*/

--- a/src/eval_f.rs
+++ b/src/eval_f.rs
@@ -1592,6 +1592,7 @@ pub(crate) fn ffcprs(lParse: &mut ParseData) {
         }
 
         lParse.Nodes = Vec::new(); // Frees
+        lParse.node_buffers = Vec::new(); // Frees Rust-owned numeric node buffers
 
         lParse.hdutype = ANY_HDU;
         lParse.pixFilter = core::ptr::null_mut();
@@ -2028,7 +2029,20 @@ pub(crate) fn fits_parser_workfn_safe(
                             }
                         }
                         if result.operation > 0 {
-                            FREE!(result.value.data.ptr);
+                            // Release the numeric result buffer. If it is
+                            // Rust-owned (side-table), drop the box; otherwise
+                            // fall back to the legacy free. Inlined (rather than
+                            // free_node_data) because `result` still borrows
+                            // lParse.Nodes here; node_buffers is a disjoint field.
+                            let ridx = lParse.resultNode as usize;
+                            if ridx < lParse.node_buffers.len()
+                                && lParse.node_buffers[ridx].is_some()
+                            {
+                                lParse.node_buffers[ridx] = None;
+                                result.value.data.ptr = core::ptr::null_mut();
+                            } else {
+                                FREE!(result.value.data.ptr);
+                            }
                         }
                     }
                     if lParse.status == OVERFLOW_ERR {

--- a/src/eval_f.rs
+++ b/src/eval_f.rs
@@ -217,7 +217,7 @@ pub fn fffrow_safe(
 
     if constant {
         /* No need to call parser... have result from ffiprs */
-        result = unsafe { (lParse.Nodes[lParse.resultNode as usize]).value.data.log };
+        result = unsafe { (lParse.Nodes[lParse.resultNode as usize]).value.data.log() };
         *n_good_rows = nrows;
 
         for elem in 0..nrows {
@@ -444,7 +444,7 @@ pub fn ffsrow_safe(
         if constant != 0 {
             /*  Set all rows to the same value from constant result  */
 
-            result = (lParse.Nodes[lParse.resultNode as usize]).value.data.log;
+            result = (lParse.Nodes[lParse.resultNode as usize]).value.data.log();
 
             for ntodo in 0..inExt.numRows {
                 *Info.dataPtr.cast::<c_char>().add(ntodo as usize) = result;
@@ -1227,7 +1227,7 @@ pub fn ffcalc_rng_safe(
                 ffukyd_safe(
                     outfptr,
                     parName,
-                    unsafe { result.value.data.dbl },
+                    unsafe { result.value.data.dbl() },
                     15,
                     Some(parInfo),
                     status,
@@ -1237,7 +1237,7 @@ pub fn ffcalc_rng_safe(
                 ffukyj_safe(
                     outfptr,
                     parName,
-                    unsafe { result.value.data.lng } as LONGLONG,
+                    unsafe { result.value.data.lng() } as LONGLONG,
                     Some(parInfo),
                     status,
                 );
@@ -1246,21 +1246,21 @@ pub fn ffcalc_rng_safe(
                 ffukyl_safe(
                     outfptr,
                     parName,
-                    i32::from(unsafe { result.value.data.log }),
+                    i32::from(unsafe { result.value.data.log() }),
                     Some(parInfo),
                     status,
                 );
             }
             TBIT | TSTRING => {
                 if fits_strcasecmp(parName, cs!(c"HISTORY")) == 0 {
-                    ffphis_safe(outfptr, unsafe { &result.value.data.astr }, status);
+                    ffphis_safe(outfptr, result.value.data.astr(), status);
                 } else if fits_strcasecmp(parName, cs!(c"COMMENT")) == 0 {
-                    ffpcom_safe(outfptr, unsafe { &result.value.data.astr }, status);
+                    ffpcom_safe(outfptr, result.value.data.astr(), status);
                 } else {
                     ffukys_safe(
                         outfptr,
                         parName,
-                        unsafe { &result.value.data.astr },
+                        result.value.data.astr(),
                         Some(parInfo),
                         status,
                     );
@@ -1586,7 +1586,7 @@ pub(crate) fn ffcprs(lParse: &mut ParseData) {
                 } else if (lParse.Nodes[node as usize]).operation == REGFILT_FCT as c_int {
                     i = (lParse.Nodes[node as usize]).SubNodes[0];
                     fits_free_region(Box::from_raw(
-                        (lParse.Nodes[i]).value.data.ptr.cast::<SAORegion>(),
+                        (lParse.Nodes[i]).value.data.ptr().cast::<SAORegion>(),
                     ));
                 }
             }
@@ -1937,7 +1937,7 @@ pub(crate) fn fits_parser_workfn_safe(
                         if (pv.repeat) == result.value.nelem {
                             ffcvtn(
                                 lParse.datatype,
-                                result.value.data.ptr,
+                                result.value.data.ptr(),
                                 result.value.undef,
                                 result.value.nelem * ntodo,
                                 (*(pv.userInfo)).datatype,
@@ -1985,7 +1985,7 @@ pub(crate) fn fits_parser_workfn_safe(
                             for kk in 0..ntodo {
                                 ffcvtn(
                                     lParse.datatype,
-                                    (result.value.data.ptr as *const c_char)
+                                    (result.value.data.ptr() as *const c_char)
                                         .add(
                                             (kk * result.value.nelem * (pv.resDataSize))
                                                 .try_into()
@@ -2067,7 +2067,7 @@ pub(crate) fn fits_parser_workfn_safe(
                                             0;
                                     }
                                     if constant != 0 {
-                                        if result.value.data.astr[jj as usize] == b'1' as c_char {
+                                        if result.value.data.astr()[jj as usize] == b'1' as c_char {
                                             *(pv.Data
                                                 .cast::<c_uchar>()
                                                 .add(idx.try_into().unwrap())) |= 128 >> (jj % 8);
@@ -2091,7 +2091,7 @@ pub(crate) fn fits_parser_workfn_safe(
                             if constant != 0 {
                                 for kk in 0..ntodo {
                                     for jj in 0..result.value.nelem {
-                                        let r = if (result.value.data.astr[jj as usize])
+                                        let r = if (result.value.data.astr()[jj as usize])
                                             == b'1' as c_char
                                         {
                                             1
@@ -2132,7 +2132,7 @@ pub(crate) fn fits_parser_workfn_safe(
                                         *(pv.Data
                                             .cast::<*mut c_char>()
                                             .add(jj.try_into().unwrap())),
-                                        result.value.data.astr.as_ptr(),
+                                        result.value.data.astr().as_ptr(),
                                     );
                                 }
                             } else {
@@ -2141,7 +2141,7 @@ pub(crate) fn fits_parser_workfn_safe(
                                         *(pv.Data
                                             .cast::<*mut c_char>()
                                             .add(jj.try_into().unwrap())),
-                                        *(result.value.data.strptr.add(jj.try_into().unwrap())),
+                                        *(result.value.data.strptr().add(jj.try_into().unwrap())),
                                     );
                                 }
                             }
@@ -2172,7 +2172,7 @@ pub(crate) fn fits_parser_workfn_safe(
                             for jj in 0..ntodo {
                                 strcpy(
                                     *(pv.Data.cast::<*mut c_char>().add(jj.try_into().unwrap())),
-                                    result.value.data.astr.as_ptr(),
+                                    result.value.data.astr().as_ptr(),
                                 );
                             }
                         } else {
@@ -2190,7 +2190,7 @@ pub(crate) fn fits_parser_workfn_safe(
                                         *(pv.Data
                                             .cast::<*mut c_char>()
                                             .add(jj.try_into().unwrap())),
-                                        *(result.value.data.strptr.add(jj.try_into().unwrap())),
+                                        *(result.value.data.strptr().add(jj.try_into().unwrap())),
                                     );
                                 }
                             }
@@ -3436,7 +3436,7 @@ pub fn fffrwc_safe(
         if fits_uncompress_hkdata(&mut lParse, fptr, ntimes, times, status) == 0 {
             if constant != 0 {
                 let result_node = lParse.Nodes[lParse.resultNode as usize];
-                result = (result_node).value.data.log;
+                result = (result_node).value.data.log();
                 let mut elem = ntimes;
                 while elem > 0 {
                     elem -= 1;
@@ -3562,7 +3562,7 @@ pub fn ffffrw_safer(
     *rownum = 0;
     {
         if constant != 0 {
-            result = unsafe { (lParse.Nodes[lParse.resultNode as usize]).value.data.log };
+            result = unsafe { (lParse.Nodes[lParse.resultNode as usize]).value.data.log() };
             if result != 0 {
                 ffgnrw_safe(fptr, &mut nelem, status);
                 if nelem != 0 {
@@ -3885,13 +3885,13 @@ pub(crate) fn ffffrw_work_safe(
         if (lParse.status) == 0 {
             result = &mut lParse.Nodes[lParse.resultNode as usize];
             if result.operation == CONST_OP {
-                if result.value.data.log != 0 {
+                if result.value.data.log() != 0 {
                     *(workData.prownum) = firstrow;
                     return -1;
                 }
             } else {
                 for idx in 0..(nrows as usize) {
-                    if *(result.value.data.logptr.add(idx)) != 0
+                    if *(result.value.data.logptr().add(idx)) != 0
                         && *(result.value.undef.add(idx)) == 0
                     {
                         *(workData.prownum) = firstrow + idx as c_long;
@@ -4296,7 +4296,7 @@ pub fn fits_pixel_filter_safer(
                     ffukyd_safe(
                         outfptr.as_mut().unwrap(),
                         par_name,
-                        result.value.data.dbl,
+                        result.value.data.dbl(),
                         15,
                         par_info,
                         status,
@@ -4306,7 +4306,7 @@ pub fn fits_pixel_filter_safer(
                     ffukyj_safe(
                         outfptr.as_mut().unwrap(),
                         par_name,
-                        result.value.data.lng as LONGLONG,
+                        result.value.data.lng() as LONGLONG,
                         par_info,
                         status,
                     );
@@ -4315,7 +4315,7 @@ pub fn fits_pixel_filter_safer(
                     ffukyl_safe(
                         outfptr.as_mut().unwrap(),
                         par_name,
-                        result.value.data.log.into(),
+                        result.value.data.log().into(),
                         par_info,
                         status,
                     );
@@ -4323,8 +4323,8 @@ pub fn fits_pixel_filter_safer(
                 TBIT | TSTRING => {
                     let str_val = unsafe {
                         core::slice::from_raw_parts(
-                            result.value.data.astr.as_ptr(),
-                            strlen_safe(&result.value.data.astr),
+                            result.value.data.astr().as_ptr(),
+                            strlen_safe(result.value.data.astr()),
                         )
                     };
                     ffukys_safe(

--- a/src/eval_f.rs
+++ b/src/eval_f.rs
@@ -4771,7 +4771,7 @@ fn find_keywd(
                 // 'C' as c_char
                 fits_read_key_str(fptr, keyname, &mut keyvalue, None, &mut status);
                 ktype = fits_parser_yytokentype::STRING as c_int;
-                strcpy(unsafe { thelval.astr.as_mut_ptr() }, keyvalue.as_ptr());
+                strcpy_safe(unsafe { &mut thelval.astr }, &keyvalue);
             }
             b'L' => {
                 // 'L' as c_char

--- a/src/eval_f.rs
+++ b/src/eval_f.rs
@@ -74,7 +74,9 @@ use crate::eval_l::{
     fits_parser_yylex_destroy, fits_parser_yylex_init_extra, fits_parser_yyrestart, yyguts_t,
 };
 use crate::eval_tab::{FITS_PARSER_YYSTYPE, fits_parser_yytokentype};
-use crate::eval_y::{Evaluate_Parser, GTIFILT_FCT, REGFILT_FCT, fits_parser_yyparse};
+use crate::eval_y::{
+    Evaluate_Parser, GTIFILT_FCT, REGFILT_FCT, fits_parser_yyparse, free_node_data,
+};
 use crate::fitscore::{
     ffcmph_safe, ffcmsg_safe, ffgcno_safe, ffgdesll_safe, ffgncl_safe, ffgnrw_safe, ffiblk,
     ffkeyn_safe, ffmahd_safe, ffpdes_safe, ffpmrk_safe, fits_strcasecmp,
@@ -1576,11 +1578,11 @@ pub(crate) fn ffcprs(lParse: &mut ParseData) {
             while node != 0 {
                 node -= 1;
                 if (lParse.Nodes[node as usize]).operation == GTIFILT_FCT as c_int {
+                    // The GTI START/STOP buffer is now Rust-owned; drop it via
+                    // the side-table rather than FREE! (which would be an
+                    // allocator mismatch).
                     i = lParse.Nodes[node as usize].SubNodes[0];
-                    if !(lParse.Nodes[i]).value.data.ptr.is_null() {
-                        let mut data_ptr = (lParse.Nodes[i]).value.data.ptr;
-                        FREE!(data_ptr);
-                    }
+                    free_node_data(lParse, i);
                 } else if (lParse.Nodes[node as usize]).operation == REGFILT_FCT as c_int {
                     i = (lParse.Nodes[node as usize]).SubNodes[0];
                     fits_free_region(Box::from_raw(

--- a/src/eval_l.rs
+++ b/src/eval_l.rs
@@ -440,14 +440,14 @@ pub(crate) fn fits_parser_yylex(
                                     );
                                     strcat_safe(&mut errMsg, cs!(c"...'"));
                                     ffpmsg_slice(&errMsg);
-                                    (*yyscanner.yylval_r).astr[0] = 0;
+                                    (*yyscanner.yylval_r).astr_mut()[0] = 0;
                                 } else {
                                     strncpy(
-                                        ((*yyscanner.yylval_r).astr).as_mut_ptr(),
+                                        ((*yyscanner.yylval_r).astr_mut()).as_mut_ptr(),
                                         &*(yyscanner.yytext_r).offset(1),
                                         len as usize,
                                     );
-                                    (*yyscanner.yylval_r).astr[len as usize] = 0;
+                                    (*yyscanner.yylval_r).astr_mut()[len as usize] = 0;
                                 }
                                 return fits_parser_yytokentype::BITSTR as c_int;
                             }
@@ -562,10 +562,10 @@ pub(crate) fn fits_parser_yylex(
                                     len_0 += 1;
                                 }
                                 if overflow != 0 {
-                                    (*yyscanner.yylval_r).astr[0] = 0;
+                                    (*yyscanner.yylval_r).astr_mut()[0] = 0;
                                 } else {
                                     strcpy(
-                                        ((*yyscanner.yylval_r).astr).as_mut_ptr(),
+                                        ((*yyscanner.yylval_r).astr_mut()).as_mut_ptr(),
                                         bitstring.as_mut_ptr(),
                                     );
                                 }
@@ -713,14 +713,14 @@ pub(crate) fn fits_parser_yylex(
                                     len_1 += 1;
                                 }
                                 if overflow != 0 {
-                                    (*yyscanner.yylval_r).astr[0] = 0;
+                                    (*yyscanner.yylval_r).astr_mut()[0] = 0;
                                 } else {
                                     strcpy(
-                                        ((*yyscanner.yylval_r).astr).as_mut_ptr(),
+                                        ((*yyscanner.yylval_r).astr_mut()).as_mut_ptr(),
                                         bitstring_0.as_mut_ptr(),
                                     );
                                 }
-                                strcpy_safe(&mut ((*yyscanner.yylval_r).astr), &bitstring_0);
+                                strcpy_safe((*yyscanner.yylval_r).astr_mut(), &bitstring_0);
                                 return fits_parser_yytokentype::BITSTR as c_int;
                             }
                             5 => {
@@ -862,18 +862,22 @@ pub(crate) fn fits_parser_yylex(
                                             );
                                             strcat_safe(&mut errMsg, cs!(c"...'"));
                                             ffpmsg_slice(&errMsg);
-                                            (*yyscanner.yylval_r).astr[0] = 0;
+                                            (*yyscanner.yylval_r).astr_mut()[0] = 0;
                                         } else {
-                                            (*yyscanner.yylval_r).astr[0] = '#' as i32 as c_char;
+                                            (*yyscanner.yylval_r).astr_mut()[0] =
+                                                '#' as i32 as c_char;
                                             strncpy(
-                                                ((*yyscanner.yylval_r).astr).as_mut_ptr().offset(1),
+                                                ((*yyscanner.yylval_r).astr_mut())
+                                                    .as_mut_ptr()
+                                                    .offset(1),
                                                 &*(yyscanner.yytext_r).offset(2 as c_int as isize),
                                                 len_2 as usize,
                                             );
-                                            (*yyscanner.yylval_r).astr[(len_2 + 1) as usize] = 0;
+                                            (*yyscanner.yylval_r).astr_mut()
+                                                [(len_2 + 1) as usize] = 0;
                                         }
                                         yyscanner.yytext_r =
-                                            ((*yyscanner.yylval_r).astr).as_mut_ptr();
+                                            ((*yyscanner.yylval_r).astr_mut()).as_mut_ptr();
                                     }
 
                                     let yytext_r_slice = cast_slice(
@@ -913,12 +917,12 @@ pub(crate) fn fits_parser_yylex(
                                     len_3 = 0;
                                 } else {
                                     strncpy(
-                                        ((*yyscanner.yylval_r).astr).as_mut_ptr(),
+                                        ((*yyscanner.yylval_r).astr_mut()).as_mut_ptr(),
                                         &*(yyscanner.yytext_r).offset(1),
                                         len_3 as usize,
                                     );
                                 }
-                                (*yyscanner.yylval_r).astr[len_3 as usize] = 0;
+                                (*yyscanner.yylval_r).astr_mut()[len_3 as usize] = 0;
                                 return fits_parser_yytokentype::STRING as c_int;
                             }
                             13 => {
@@ -939,18 +943,20 @@ pub(crate) fn fits_parser_yylex(
                                     );
                                     strcat_safe(&mut errMsg, cs!(c"...'"));
                                     ffpmsg_slice(&errMsg);
-                                    (*yyscanner.yylval_r).astr[0] = 0;
-                                    yyscanner.yytext_r = ((*yyscanner.yylval_r).astr).as_mut_ptr();
+                                    (*yyscanner.yylval_r).astr_mut()[0] = 0;
+                                    yyscanner.yytext_r =
+                                        ((*yyscanner.yylval_r).astr_mut()).as_mut_ptr();
                                 } else if c_int::from(*(yyscanner.yytext_r).offset(0)) == '$' as i32
                                 {
                                     len_4 = (strlen(yyscanner.yytext_r)).wrapping_sub(2) as c_int;
                                     strncpy(
-                                        ((*yyscanner.yylval_r).astr).as_mut_ptr(),
+                                        ((*yyscanner.yylval_r).astr_mut()).as_mut_ptr(),
                                         &*(yyscanner.yytext_r).offset(1),
                                         len_4 as usize,
                                     );
-                                    (*yyscanner.yylval_r).astr[len_4 as usize] = 0;
-                                    yyscanner.yytext_r = ((*yyscanner.yylval_r).astr).as_mut_ptr();
+                                    (*yyscanner.yylval_r).astr_mut()[len_4 as usize] = 0;
+                                    yyscanner.yytext_r =
+                                        ((*yyscanner.yylval_r).astr_mut()).as_mut_ptr();
                                 }
 
                                 let yytext_r_slice = cast_slice(
@@ -966,7 +972,7 @@ pub(crate) fn fits_parser_yylex(
                             }
                             14 => {
                                 let mut len: usize = strlen(yyscanner.yytext_r);
-                                let fname = &mut ((*yyscanner.yylval_r).astr);
+                                let fname = (*yyscanner.yylval_r).astr_mut();
 
                                 if len >= MAX_STRLEN as usize {
                                     let mut errMsg: [c_char; 100] = [0; 100];

--- a/src/eval_l.rs
+++ b/src/eval_l.rs
@@ -209,7 +209,7 @@ pub(crate) fn fits_parser_yyGetVariable(
             }
         }
 
-        thelval.lng = c_long::from(varNum);
+        *thelval = FITS_PARSER_YYSTYPE::Lng(c_long::from(varNum));
     }
     dtype
 }
@@ -733,7 +733,7 @@ pub(crate) fn fits_parser_yylex(
                                         | c_int::from(c_int::from(*p) == '1' as i32) as c_long;
                                     p = p.offset(1);
                                 }
-                                (*yyscanner.yylval_r).lng = constval;
+                                (*yyscanner.yylval_r) = FITS_PARSER_YYSTYPE::Lng(constval);
                                 return fits_parser_yytokentype::LONG as c_int;
                             }
                             6 => {
@@ -746,7 +746,7 @@ pub(crate) fn fits_parser_yylex(
                                         | c_long::from(c_int::from(*p_0) - '0' as i32);
                                     p_0 = p_0.offset(1);
                                 }
-                                (*yyscanner.yylval_r).lng = constval_0;
+                                (*yyscanner.yylval_r) = FITS_PARSER_YYSTYPE::Lng(constval_0);
                                 return fits_parser_yytokentype::LONG as c_int;
                             }
                             7 => {
@@ -763,25 +763,27 @@ pub(crate) fn fits_parser_yylex(
                                     constval_1 = constval_1 << 4 as c_int | c_long::from(v);
                                     p_1 = p_1.offset(1);
                                 }
-                                (*yyscanner.yylval_r).lng = constval_1;
+                                (*yyscanner.yylval_r) = FITS_PARSER_YYSTYPE::Lng(constval_1);
                                 return fits_parser_yytokentype::LONG as c_int;
                             }
                             8 => {
-                                (*yyscanner.yylval_r).lng = atol(yyscanner.yytext_r);
+                                (*yyscanner.yylval_r) =
+                                    FITS_PARSER_YYSTYPE::Lng(atol(yyscanner.yytext_r));
                                 return fits_parser_yytokentype::LONG as c_int;
                             }
                             9 => {
                                 if c_int::from(*(yyscanner.yytext_r).offset(0)) == 't' as i32
                                     || c_int::from(*(yyscanner.yytext_r).offset(0)) == 'T' as i32
                                 {
-                                    (*yyscanner.yylval_r).log = 1;
+                                    (*yyscanner.yylval_r) = FITS_PARSER_YYSTYPE::Log(1);
                                 } else {
-                                    (*yyscanner.yylval_r).log = 0;
+                                    (*yyscanner.yylval_r) = FITS_PARSER_YYSTYPE::Log(0);
                                 }
                                 return fits_parser_yytokentype::BOOLEAN as c_int;
                             }
                             10 => {
-                                (*yyscanner.yylval_r).dbl = atof(yyscanner.yytext_r);
+                                (*yyscanner.yylval_r) =
+                                    FITS_PARSER_YYSTYPE::Dbl(atof(yyscanner.yytext_r));
                                 return fits_parser_yytokentype::DOUBLE as c_int;
                             }
                             11 => {
@@ -793,7 +795,8 @@ pub(crate) fn fits_parser_yylex(
                                     fits_strcasecmp(s1, cs!(c"#PI"))
                                 } == 0
                                 {
-                                    (*yyscanner.yylval_r).dbl = 4.0 * (1.0_f64).atan();
+                                    (*yyscanner.yylval_r) =
+                                        FITS_PARSER_YYSTYPE::Dbl(4.0 * (1.0_f64).atan());
                                     return fits_parser_yytokentype::DOUBLE as c_int;
                                 } else if {
                                     let s1 = core::slice::from_raw_parts(
@@ -803,7 +806,8 @@ pub(crate) fn fits_parser_yylex(
                                     fits_strcasecmp(s1, cs!(c"#E"))
                                 } == 0
                                 {
-                                    (*yyscanner.yylval_r).dbl = (1.0_f64).exp();
+                                    (*yyscanner.yylval_r) =
+                                        FITS_PARSER_YYSTYPE::Dbl((1.0_f64).exp());
                                     return fits_parser_yytokentype::DOUBLE as c_int;
                                 } else if {
                                     let s1 = core::slice::from_raw_parts(
@@ -813,7 +817,8 @@ pub(crate) fn fits_parser_yylex(
                                     fits_strcasecmp(s1, cs!(c"#DEG"))
                                 } == 0
                                 {
-                                    (*yyscanner.yylval_r).dbl = 4.0 * (1.0_f64).atan() / 180.0;
+                                    (*yyscanner.yylval_r) =
+                                        FITS_PARSER_YYSTYPE::Dbl(4.0 * (1.0_f64).atan() / 180.0);
                                     return fits_parser_yytokentype::DOUBLE as c_int;
                                 } else if {
                                     let s1 = core::slice::from_raw_parts(

--- a/src/eval_l.rs
+++ b/src/eval_l.rs
@@ -7,7 +7,7 @@ use core::ptr;
 use std::process::exit;
 
 use bytemuck::cast_slice;
-use libc::{ENOMEM, FILE, atof, atol, fileno, free, fwrite, isatty, size_t};
+use libc::{ENOMEM, FILE, atof, atol, fileno, fwrite, isatty, size_t};
 
 use crate::c_types::{c_char, c_int, c_long, c_short, c_uchar, c_uint, c_void};
 use crate::eval_defs::{MAX_STRLEN, MAXVARNAME, P_ERROR, ParseData};
@@ -1679,10 +1679,53 @@ pub(crate) fn fits_parser_yylex_destroy(mut yyscanner: Box<yyguts_t>) -> c_int {
             (*(yyscanner.yy_buffer_stack).add(yyscanner.yy_buffer_stack_top)) = None;
             fits_parser_yypop_buffer_state(&mut yyscanner);
         }
-        free(yyscanner.yy_buffer_stack.cast::<c_void>());
+        // `yy_buffer_stack` is allocated with the Rust global allocator (a `Vec`
+        // via `vec_into_raw_parts` in `yyensure_buffer_stack`), so it must be
+        // reclaimed the same way. Freeing it with `libc::free` is an allocator
+        // mismatch and undefined behaviour. All elements were set to `None`
+        // above, so dropping the reconstituted `Vec` just frees the backing
+        // store. `yy_buffer_stack_max` is the exact capacity (see the grow path,
+        // which reconstitutes it identically).
+        if !yyscanner.yy_buffer_stack.is_null() {
+            drop(Vec::from_raw_parts(
+                yyscanner.yy_buffer_stack,
+                yyscanner.yy_buffer_stack_max,
+                yyscanner.yy_buffer_stack_max,
+            ));
+        }
         yyscanner.yy_buffer_stack = core::ptr::null_mut();
         yy_init_globals(&mut yyscanner);
 
         0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The scanner buffer stack is allocated with the Rust global allocator
+    /// (`Vec`), so `fits_parser_yylex_destroy` must reclaim it the same way.
+    /// This exercises the full init -> allocate -> destroy cycle with no file
+    /// I/O so it runs under Miri, which flags allocator mismatches (e.g. the
+    /// previous `libc::free` of `Vec`-allocated memory) and leaks.
+    #[test]
+    fn buffer_stack_alloc_destroy_uses_matching_allocator() {
+        let mut lparse = ParseData::default();
+        let mut globals: Option<Box<yyguts_t>> = None;
+        assert_eq!(fits_parser_yylex_init_extra(&mut lparse, &mut globals), 0);
+
+        {
+            let g = globals.as_deref_mut().unwrap();
+            assert!(g.yy_buffer_stack.is_null());
+            fits_parser_yyensure_buffer_stack(g);
+            assert!(!g.yy_buffer_stack.is_null());
+            assert_eq!(g.yy_buffer_stack_max, 1);
+            // The freshly allocated slot must be initialised to None.
+            assert!(unsafe { (*g.yy_buffer_stack.add(g.yy_buffer_stack_top)).is_none() });
+        }
+
+        let b = globals.take().unwrap();
+        assert_eq!(fits_parser_yylex_destroy(b), 0);
     }
 }

--- a/src/eval_tab.rs
+++ b/src/eval_tab.rs
@@ -93,37 +93,78 @@ impl From<c_int> for fits_parser_yytokentype {
     }
 }
 
+/// The bison parser-stack value. Formerly an untyped `union`; now a
+/// discriminated enum so a stack slot can't be read as the wrong kind. The
+/// default/unset slot is `Node(0)` (matching the old `{ Node: 0 }` init).
+///
+/// Getters match on the variant (lenient with a `debug_assert!` on a genuine
+/// wrong-variant read, preserving the union's read-anything behaviour).
 #[derive(Copy, Clone)]
-pub(crate) union FITS_PARSER_YYSTYPE {
-    pub(crate) Node: c_int,                         /* Index of Node */
-    pub(crate) dbl: c_double,                       /* real value    */
-    pub(crate) lng: c_long,                         /* integer value */
-    pub(crate) log: c_char,                         /* logical value */
-    pub(crate) astr: [c_char; MAX_STRLEN as usize], /* string value  */
+pub(crate) enum FITS_PARSER_YYSTYPE {
+    Node(c_int),
+    Dbl(c_double),
+    Lng(c_long),
+    Log(c_char),
+    Astr([c_char; MAX_STRLEN as usize]),
 }
 
-/// Typed read accessors over the parser-stack value union. Call sites use these
-/// instead of reading the union fields directly, so the backing storage can
-/// later be swapped for a typed enum by reimplementing only these methods
-/// (mirrors the `DataVal` migration). Writes stay as field assignments for now.
 impl FITS_PARSER_YYSTYPE {
     /// Node index (the dominant variant on the parser stack).
     pub(crate) fn node(&self) -> c_int {
-        unsafe { self.Node }
+        match self {
+            Self::Node(v) => *v,
+            _ => {
+                debug_assert!(false, "node() on non-Node YYSTYPE");
+                0
+            }
+        }
     }
     pub(crate) fn dbl(&self) -> c_double {
-        unsafe { self.dbl }
+        match self {
+            Self::Dbl(v) => *v,
+            _ => {
+                debug_assert!(false, "dbl() on non-Dbl YYSTYPE");
+                0.0
+            }
+        }
     }
     pub(crate) fn lng(&self) -> c_long {
-        unsafe { self.lng }
+        match self {
+            Self::Lng(v) => *v,
+            _ => {
+                debug_assert!(false, "lng() on non-Lng YYSTYPE");
+                0
+            }
+        }
     }
     pub(crate) fn log(&self) -> c_char {
-        unsafe { self.log }
+        match self {
+            Self::Log(v) => *v,
+            _ => {
+                debug_assert!(false, "log() on non-Log YYSTYPE");
+                0
+            }
+        }
     }
     pub(crate) fn astr(&self) -> &[c_char; MAX_STRLEN as usize] {
-        unsafe { &self.astr }
+        match self {
+            Self::Astr(a) => a,
+            _ => {
+                debug_assert!(false, "astr() on non-Astr YYSTYPE");
+                const ZEROS: [c_char; MAX_STRLEN as usize] = [0; MAX_STRLEN as usize];
+                &ZEROS
+            }
+        }
     }
+    /// Mutable view of the string buffer, initialising to an empty `Astr` first
+    /// if needed so callers (the lexer) can build a string token in place.
     pub(crate) fn astr_mut(&mut self) -> &mut [c_char; MAX_STRLEN as usize] {
-        unsafe { &mut self.astr }
+        if !matches!(self, Self::Astr(_)) {
+            *self = Self::Astr([0; MAX_STRLEN as usize]);
+        }
+        match self {
+            Self::Astr(a) => a,
+            _ => unreachable!(),
+        }
     }
 }

--- a/src/eval_tab.rs
+++ b/src/eval_tab.rs
@@ -101,3 +101,29 @@ pub(crate) union FITS_PARSER_YYSTYPE {
     pub(crate) log: c_char,                         /* logical value */
     pub(crate) astr: [c_char; MAX_STRLEN as usize], /* string value  */
 }
+
+/// Typed read accessors over the parser-stack value union. Call sites use these
+/// instead of reading the union fields directly, so the backing storage can
+/// later be swapped for a typed enum by reimplementing only these methods
+/// (mirrors the `DataVal` migration). Writes stay as field assignments for now.
+impl FITS_PARSER_YYSTYPE {
+    /// Node index (the dominant variant on the parser stack).
+    pub(crate) fn node(&self) -> c_int {
+        unsafe { self.Node }
+    }
+    pub(crate) fn dbl(&self) -> c_double {
+        unsafe { self.dbl }
+    }
+    pub(crate) fn lng(&self) -> c_long {
+        unsafe { self.lng }
+    }
+    pub(crate) fn log(&self) -> c_char {
+        unsafe { self.log }
+    }
+    pub(crate) fn astr(&self) -> &[c_char; MAX_STRLEN as usize] {
+        unsafe { &self.astr }
+    }
+    pub(crate) fn astr_mut(&mut self) -> &mut [c_char; MAX_STRLEN as usize] {
+        unsafe { &mut self.astr }
+    }
+}

--- a/src/eval_y.rs
+++ b/src/eval_y.rs
@@ -103,6 +103,42 @@ fn astr_len(buf: &[c_char]) -> usize {
     buf.iter().position(|&b| b == 0).unwrap_or(buf.len())
 }
 
+/// Symbolic names for the `current_block` control-flow targets in the generated
+/// `fits_parser_yyparse` driver. These replace the opaque 19-digit block IDs
+/// emitted by the C-to-Rust goto translation; each constant keeps its original
+/// numeric value so the control flow is byte-for-byte unchanged, only readable.
+///
+/// The first group mirrors the standard bison skeleton labels (see the
+/// `yydefault`/`yyreduce`/`yynewstate` comments in the driver). The
+/// `REDUCE_JOIN_*` group are intra-reduction join points within grouped grammar
+/// rules; they have no bison name, so they are numbered by frequency.
+mod block {
+    pub const YYERRLAB: u64 = 4830776507462815627; // semantic error -> error recovery
+    pub const YYERRLAB1: u64 = 1774893048582444437; // error recovery loop
+    pub const YYNEWSTATE: u64 = 7872030484262409139; // push new state
+    pub const YYBACKUP: u64 = 1924505913685386279; // lookahead token handling
+    pub const YYDEFAULT: u64 = 5937473999264333383; // default action for state
+    pub const YYREDUCE: u64 = 670225253387957849; // do a reduction
+    pub const YYABORTLAB: u64 = 3964311021479492664; // parse failed (yyresult = 1)
+    pub const YYEXHAUSTEDLAB: u64 = 11794367917084412820; // memory exhausted (yyresult = 2)
+    pub const REDUCE_DONE: u64 = 17353983478346836848; // reduction action completed
+
+    pub const REDUCE_JOIN_1: u64 = 7600445499126923600;
+    pub const REDUCE_JOIN_2: u64 = 9966817879908499150;
+    pub const REDUCE_JOIN_3: u64 = 494012601817399562;
+    pub const REDUCE_JOIN_4: u64 = 13755523488868872559;
+    pub const REDUCE_JOIN_5: u64 = 10848699504537784535;
+    pub const REDUCE_JOIN_6: u64 = 12473999534294722905;
+    pub const REDUCE_JOIN_7: u64 = 1297461190301222800;
+    pub const REDUCE_JOIN_8: u64 = 15752106442776732052;
+    pub const REDUCE_JOIN_9: u64 = 17702298541784679949;
+    pub const REDUCE_JOIN_10: u64 = 2616667235040759262;
+    pub const REDUCE_JOIN_11: u64 = 2904036176499606090;
+    pub const REDUCE_JOIN_12: u64 = 3023179740610631044;
+    pub const REDUCE_JOIN_13: u64 = 1069630499025798221;
+    pub const REDUCE_JOIN_14: u64 = 15864720325503947191;
+}
+
 pub type yy_state_t = yytype_int16;
 pub type yytype_int16 = c_short;
 pub type yysymbol_kind_t = c_int;
@@ -1172,7 +1208,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                 /* Get the current used size of the three stacks, in elements.  */
                 let yysize: c_long = (yyssp + 1) as c_long;
                 if YYMAXDEPTH as c_long <= yystacksize {
-                    current_block = 11794367917084412820; // goto yyexhaustedlab;
+                    current_block = block::YYEXHAUSTEDLAB; // goto yyexhaustedlab;
                     break;
                 }
                 yystacksize *= 2 as c_long;
@@ -1192,7 +1228,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                 )
                 .cast::<yyalloc>();
                 if yyptr.is_null() {
-                    current_block = 11794367917084412820; // goto yyexhaustedlab;
+                    current_block = block::YYEXHAUSTEDLAB; // goto yyexhaustedlab;
                     break;
                 }
                 let mut yynewbytes: c_long = 0;
@@ -1232,13 +1268,13 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                 yyssp = yysize as usize - 1;
                 yyvsp = yysize as usize - 1;
                 if (yystacksize - 1) as usize <= yyssp {
-                    current_block = 3964311021479492664; // goto yyabortlab;
+                    current_block = block::YYABORTLAB; // goto yyabortlab;
                     break;
                 }
             }
             if yystate == YYFINAL as c_int {
                 yyresult = 0;
-                current_block = 15864720325503947191; // goto yyacceptlab;
+                current_block = block::REDUCE_JOIN_14; // goto yyacceptlab;
                 break;
             } else {
                 /*-----------.
@@ -1250,7 +1286,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                 /* First try to decide what to do without reference to lookahead token.  */
                 yyn = c_int::from(YYPACT[yystate as usize]);
                 if yyn == -41 {
-                    current_block = 5937473999264333383; // goto yydefault;
+                    current_block = block::YYDEFAULT; // goto yydefault;
                 } else {
                     /* Not known => get a lookahead token if don't already have one.  */
 
@@ -1269,7 +1305,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         if YYDEBUG {
                             eprintln!("Now at end of input.");
                         }
-                        current_block = 1924505913685386279;
+                        current_block = block::YYBACKUP;
                     } else if yychar == fits_parser_yytokentype::FITS_PARSER_YYerror as c_int {
                         /* The scanner already issued an error message, process directly
                         to error recovery.  But do not keep the error token as
@@ -1277,7 +1313,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         loop in error recovery. */
                         yychar = fits_parser_yytokentype::FITS_PARSER_YYUNDEF as c_int;
                         yytoken = YYSYMBOL_YYERROR;
-                        current_block = 1774893048582444437; // goto yyerrlab1;
+                        current_block = block::YYERRLAB1; // goto yyerrlab1;
                     } else {
                         yytoken = (if 0 <= yychar && yychar <= 292 as c_int {
                             yysymbol_kind_t::from(YYTRANSLATE[yychar as usize]) as c_int
@@ -1285,22 +1321,22 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             YYSYMBOL_YYUNDEF as c_int
                         }) as yysymbol_kind_t;
                         YY_SYMBOL_PRINT!("Next token is", yytoken, &yylval, scanner, lParse);
-                        current_block = 1924505913685386279;
+                        current_block = block::YYBACKUP;
                     }
                     match current_block {
-                        1774893048582444437 => {}
+                        block::YYERRLAB1 => {}
                         _ => {
                             yyn += yytoken as c_int;
                             if yyn < 0
                                 || (YYLAST as c_int) < yyn
                                 || c_int::from(YYCHECK[yyn as usize]) != yytoken as c_int
                             {
-                                current_block = 5937473999264333383;
+                                current_block = block::YYDEFAULT;
                             } else {
                                 yyn = c_int::from(YYTABLE[yyn as usize]);
                                 if yyn <= 0 {
                                     yyn = -yyn;
-                                    current_block = 670225253387957849;
+                                    current_block = block::YYREDUCE;
                                 } else {
                                     /* Count tokens shifted since error; after three, turn off error status.  */
                                     if yyerrstatus != 0 {
@@ -1311,14 +1347,14 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     yyvsp += 1;
                                     yyvs[yyvsp] = yylval;
                                     yychar = fits_parser_yytokentype::FITS_PARSER_YYEMPTY as c_int; /* Discard the shifted token.  */
-                                    current_block = 7872030484262409139;
+                                    current_block = block::YYNEWSTATE;
                                 }
                             }
                         }
                     }
                 }
 
-                if current_block == 5937473999264333383 {
+                if current_block == block::YYDEFAULT {
                     /*-----------------------------------------------------------.
                     | yydefault -- do the default action for the current state.  |
                     `-----------------------------------------------------------*/
@@ -1341,7 +1377,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         if yyerrstatus == 3 as c_int {
                             if yychar <= fits_parser_yytokentype::FITS_PARSER_YYEOF as c_int {
                                 if yychar == fits_parser_yytokentype::FITS_PARSER_YYEOF as c_int {
-                                    current_block = 3964311021479492664;
+                                    current_block = block::YYABORTLAB;
                                     break;
                                 }
                             } else {
@@ -1355,12 +1391,12 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 yychar = fits_parser_yytokentype::FITS_PARSER_YYEMPTY as c_int;
                             }
                         }
-                        current_block = 1774893048582444437;
+                        current_block = block::YYERRLAB1;
                     } else {
-                        current_block = 670225253387957849; // goto yyreduce;
+                        current_block = block::YYREDUCE; // goto yyreduce;
                     }
                 }
-                if current_block == 670225253387957849 {
+                if current_block == block::YYREDUCE {
                     /*-----------------------------.
                     | yyreduce -- do a reduction.  |
                     `-----------------------------*/
@@ -1385,7 +1421,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                     match yyn {
                         4 => {
                             /* line: '\n'  */
-                            current_block = 17353983478346836848;
+                            current_block = block::REDUCE_DONE;
                         }
                         5 => {
                             /* line: expr '\n'  */
@@ -1394,10 +1430,10 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     lParse,
                                     cs!(c"Couldn't build node structure: out of memory?"),
                                 );
-                                current_block = 4830776507462815627;
+                                current_block = block::YYERRLAB;
                             } else {
                                 lParse.resultNode = yyvs[yyvsp - 1].Node;
-                                current_block = 17353983478346836848;
+                                current_block = block::REDUCE_DONE;
                             }
                         }
                         6 => {
@@ -1407,10 +1443,10 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     lParse,
                                     cs!(c"Couldn't build node structure: out of memory?"),
                                 );
-                                current_block = 4830776507462815627;
+                                current_block = block::YYERRLAB;
                             } else {
                                 lParse.resultNode = yyvs[yyvsp - 1].Node;
-                                current_block = 17353983478346836848;
+                                current_block = block::REDUCE_DONE;
                             }
                         }
                         7 => {
@@ -1420,10 +1456,10 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     lParse,
                                     cs!(c"Couldn't build node structure: out of memory?"),
                                 );
-                                current_block = 4830776507462815627;
+                                current_block = block::YYERRLAB;
                             } else {
                                 lParse.resultNode = yyvs[yyvsp - 1].Node;
-                                current_block = 17353983478346836848;
+                                current_block = block::REDUCE_DONE;
                             }
                         }
                         8 => {
@@ -1433,24 +1469,24 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     lParse,
                                     cs!(c"Couldn't build node structure: out of memory?"),
                                 );
-                                current_block = 4830776507462815627;
+                                current_block = block::YYERRLAB;
                             } else {
                                 lParse.resultNode = yyvs[yyvsp - 1].Node;
-                                current_block = 17353983478346836848;
+                                current_block = block::REDUCE_DONE;
                             }
                         }
                         9 => {
                             /* line: error '\n'  */
                             yyerrstatus = 0;
-                            current_block = 17353983478346836848;
+                            current_block = block::REDUCE_DONE;
                         }
                         10 => {
                             /* bvector: '{' bexpr  */
                             yyval.Node = New_Vector(lParse, yyvs[yyvsp].Node);
                             if yyval.Node < 0 {
-                                current_block = 4830776507462815627;
+                                current_block = block::YYERRLAB;
                             } else {
-                                current_block = 17353983478346836848;
+                                current_block = block::REDUCE_DONE;
                             }
                         }
                         11 => {
@@ -1460,21 +1496,21 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             {
                                 yyvs[yyvsp - 2].Node = Close_Vec(lParse, yyvs[yyvsp - 2].Node);
                                 if yyvs[yyvsp - 2].Node < 0 {
-                                    current_block = 4830776507462815627;
+                                    current_block = block::YYERRLAB;
                                 } else {
                                     yyval.Node = New_Vector(lParse, yyvs[yyvsp - 2].Node);
                                     if yyval.Node < 0 {
-                                        current_block = 4830776507462815627;
+                                        current_block = block::YYERRLAB;
                                     } else {
-                                        current_block = 2616667235040759262;
+                                        current_block = block::REDUCE_JOIN_10;
                                     }
                                 }
                             } else {
                                 yyval.Node = yyvs[yyvsp - 2].Node;
-                                current_block = 2616667235040759262;
+                                current_block = block::REDUCE_JOIN_10;
                             }
                             match current_block {
-                                4830776507462815627 => {}
+                                block::YYERRLAB => {}
                                 _ => {
                                     let fresh2 =
                                         &mut ((lParse.Nodes)[yyval.Node as usize]).nSubNodes;
@@ -1482,7 +1518,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     *fresh2 += 1;
                                     ((lParse.Nodes)[yyval.Node as usize]).SubNodes
                                         [fresh3 as usize] = yyvs[yyvsp].Node.try_into().unwrap();
-                                    current_block = 17353983478346836848;
+                                    current_block = block::REDUCE_DONE;
                                 }
                             }
                         }
@@ -1490,9 +1526,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             /* vector: '{' expr  */
                             yyval.Node = New_Vector(lParse, yyvs[yyvsp].Node);
                             if yyval.Node < 0 {
-                                current_block = 4830776507462815627;
+                                current_block = block::YYERRLAB;
                             } else {
-                                current_block = 17353983478346836848;
+                                current_block = block::REDUCE_DONE;
                             }
                         }
                         13 => {
@@ -1508,21 +1544,21 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             {
                                 yyvs[yyvsp - 2].Node = Close_Vec(lParse, yyvs[yyvsp - 2].Node);
                                 if yyvs[yyvsp - 2].Node < 0 {
-                                    current_block = 4830776507462815627;
+                                    current_block = block::YYERRLAB;
                                 } else {
                                     yyval.Node = New_Vector(lParse, yyvs[yyvsp - 2].Node);
                                     if yyval.Node < 0 {
-                                        current_block = 4830776507462815627;
+                                        current_block = block::YYERRLAB;
                                     } else {
-                                        current_block = 2904036176499606090;
+                                        current_block = block::REDUCE_JOIN_11;
                                     }
                                 }
                             } else {
                                 yyval.Node = yyvs[yyvsp - 2].Node;
-                                current_block = 2904036176499606090;
+                                current_block = block::REDUCE_JOIN_11;
                             }
                             match current_block {
-                                4830776507462815627 => {}
+                                block::YYERRLAB => {}
                                 _ => {
                                     let fresh4 =
                                         &mut ((lParse.Nodes)[yyval.Node as usize]).nSubNodes;
@@ -1530,7 +1566,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     *fresh4 += 1;
                                     ((lParse.Nodes)[yyval.Node as usize]).SubNodes
                                         [fresh5 as usize] = yyvs[yyvsp].Node.try_into().unwrap();
-                                    current_block = 17353983478346836848;
+                                    current_block = block::REDUCE_DONE;
                                 }
                             }
                         }
@@ -1541,21 +1577,21 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             {
                                 yyvs[yyvsp - 2].Node = Close_Vec(lParse, yyvs[yyvsp - 2].Node);
                                 if yyvs[yyvsp - 2].Node < 0 {
-                                    current_block = 4830776507462815627;
+                                    current_block = block::YYERRLAB;
                                 } else {
                                     yyval.Node = New_Vector(lParse, yyvs[yyvsp - 2].Node);
                                     if yyval.Node < 0 {
-                                        current_block = 4830776507462815627;
+                                        current_block = block::YYERRLAB;
                                     } else {
-                                        current_block = 17702298541784679949;
+                                        current_block = block::REDUCE_JOIN_9;
                                     }
                                 }
                             } else {
                                 yyval.Node = yyvs[yyvsp - 2].Node;
-                                current_block = 17702298541784679949;
+                                current_block = block::REDUCE_JOIN_9;
                             }
                             match current_block {
-                                4830776507462815627 => {}
+                                block::YYERRLAB => {}
                                 _ => {
                                     let fresh6 =
                                         &mut ((lParse.Nodes)[yyval.Node as usize]).nSubNodes;
@@ -1563,7 +1599,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     *fresh6 += 1;
                                     ((lParse.Nodes)[yyval.Node as usize]).SubNodes
                                         [fresh7 as usize] = yyvs[yyvsp].Node.try_into().unwrap();
-                                    current_block = 17353983478346836848;
+                                    current_block = block::REDUCE_DONE;
                                 }
                             }
                         }
@@ -1576,21 +1612,21 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             {
                                 yyvs[yyvsp - 2].Node = Close_Vec(lParse, yyvs[yyvsp - 2].Node);
                                 if yyvs[yyvsp - 2].Node < 0 {
-                                    current_block = 4830776507462815627;
+                                    current_block = block::YYERRLAB;
                                 } else {
                                     yyval.Node = New_Vector(lParse, yyvs[yyvsp - 2].Node);
                                     if yyval.Node < 0 {
-                                        current_block = 4830776507462815627;
+                                        current_block = block::YYERRLAB;
                                     } else {
-                                        current_block = 1069630499025798221;
+                                        current_block = block::REDUCE_JOIN_13;
                                     }
                                 }
                             } else {
                                 yyval.Node = yyvs[yyvsp - 2].Node;
-                                current_block = 1069630499025798221;
+                                current_block = block::REDUCE_JOIN_13;
                             }
                             match current_block {
-                                4830776507462815627 => {}
+                                block::YYERRLAB => {}
                                 _ => {
                                     let fresh8 =
                                         &mut ((lParse.Nodes)[yyval.Node as usize]).nSubNodes;
@@ -1598,7 +1634,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     *fresh8 += 1;
                                     ((lParse.Nodes)[yyval.Node as usize]).SubNodes
                                         [fresh9 as usize] = yyvs[yyvsp].Node.try_into().unwrap();
-                                    current_block = 17353983478346836848;
+                                    current_block = block::REDUCE_DONE;
                                 }
                             }
                         }
@@ -1606,18 +1642,18 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             /* expr: vector '}'  */
                             yyval.Node = Close_Vec(lParse, yyvs[yyvsp - 1].Node);
                             if yyval.Node < 0 {
-                                current_block = 4830776507462815627;
+                                current_block = block::YYERRLAB;
                             } else {
-                                current_block = 17353983478346836848;
+                                current_block = block::REDUCE_DONE;
                             }
                         }
                         17 => {
                             /* bexpr: bvector '}'  */
                             yyval.Node = Close_Vec(lParse, yyvs[yyvsp - 1].Node);
                             if yyval.Node < 0 {
-                                current_block = 4830776507462815627;
+                                current_block = block::YYERRLAB;
                             } else {
-                                current_block = 17353983478346836848;
+                                current_block = block::REDUCE_DONE;
                             }
                         }
                         18 => {
@@ -1630,20 +1666,20 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     as c_long,
                             );
                             if yyval.Node < 0 {
-                                current_block = 4830776507462815627;
+                                current_block = block::YYERRLAB;
                             } else {
                                 (((lParse.Nodes)[yyval.Node as usize]).value).nelem =
                                     astr_len(&yyvs[yyvsp].astr) as c_long;
-                                current_block = 17353983478346836848;
+                                current_block = block::REDUCE_DONE;
                             }
                         }
                         19 => {
                             /* bits: BITCOL  */
                             yyval.Node = New_Column(lParse, yyvs[yyvsp].lng as c_int);
                             if yyval.Node < 0 {
-                                current_block = 4830776507462815627;
+                                current_block = block::YYERRLAB;
                             } else {
-                                current_block = 17353983478346836848;
+                                current_block = block::REDUCE_DONE;
                             }
                         }
                         20 => {
@@ -1657,7 +1693,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     lParse,
                                     cs!(c"Offset argument must be a constant integer"),
                                 );
-                                current_block = 4830776507462815627;
+                                current_block = block::YYERRLAB;
                             } else {
                                 yyval.Node = New_Offset(
                                     lParse,
@@ -1665,9 +1701,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     yyvs[yyvsp - 1].Node,
                                 );
                                 if yyval.Node < 0 {
-                                    current_block = 4830776507462815627;
+                                    current_block = block::YYERRLAB;
                                 } else {
-                                    current_block = 17353983478346836848;
+                                    current_block = block::REDUCE_DONE;
                                 }
                             }
                         }
@@ -1681,7 +1717,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 yyvs[yyvsp].Node,
                             );
                             if yyval.Node < 0 {
-                                current_block = 4830776507462815627;
+                                current_block = block::YYERRLAB;
                             } else {
                                 (((lParse.Nodes)[yyval.Node as usize]).value).nelem =
                                     if (((lParse.Nodes)[yyvs[yyvsp - 2].Node as usize]).value).nelem
@@ -1691,7 +1727,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     } else {
                                         (lParse.Nodes[yyvs[yyvsp].Node as usize]).value.nelem
                                     };
-                                current_block = 17353983478346836848;
+                                current_block = block::REDUCE_DONE;
                             }
                         }
                         22 => {
@@ -1704,7 +1740,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 yyvs[yyvsp].Node,
                             );
                             if yyval.Node < 0 {
-                                current_block = 4830776507462815627;
+                                current_block = block::YYERRLAB;
                             } else {
                                 (((lParse.Nodes)[yyval.Node as usize]).value).nelem =
                                     if (((lParse.Nodes)[yyvs[yyvsp - 2].Node as usize]).value).nelem
@@ -1714,7 +1750,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     } else {
                                         (lParse.Nodes[yyvs[yyvsp].Node as usize]).value.nelem
                                     };
-                                current_block = 17353983478346836848;
+                                current_block = block::REDUCE_DONE;
                             }
                         }
                         23 => {
@@ -1727,7 +1763,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     lParse,
                                     cs!(c"Combined bit string size exceeds 255 bits"),
                                 );
-                                current_block = 4830776507462815627;
+                                current_block = block::YYERRLAB;
                             } else {
                                 yyval.Node = New_BinOp(
                                     lParse,
@@ -1737,14 +1773,14 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     yyvs[yyvsp].Node,
                                 );
                                 if yyval.Node < 0 {
-                                    current_block = 4830776507462815627;
+                                    current_block = block::YYERRLAB;
                                 } else {
                                     (((lParse.Nodes)[yyval.Node as usize]).value).nelem =
                                         ((lParse.Nodes)[yyvs[yyvsp - 2].Node as usize]).value.nelem
                                             + ((lParse.Nodes)[yyvs[yyvsp].Node as usize])
                                                 .value
                                                 .nelem;
-                                    current_block = 17353983478346836848;
+                                    current_block = block::REDUCE_DONE;
                                 }
                             }
                         }
@@ -1761,9 +1797,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 0,
                             );
                             if yyval.Node < 0 {
-                                current_block = 4830776507462815627;
+                                current_block = block::YYERRLAB;
                             } else {
-                                current_block = 17353983478346836848;
+                                current_block = block::REDUCE_DONE;
                             }
                         }
                         25 => {
@@ -1779,9 +1815,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 0,
                             );
                             if yyval.Node < 0 {
-                                current_block = 4830776507462815627;
+                                current_block = block::YYERRLAB;
                             } else {
-                                current_block = 17353983478346836848;
+                                current_block = block::REDUCE_DONE;
                             }
                         }
                         26 => {
@@ -1797,9 +1833,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 0,
                             );
                             if yyval.Node < 0 {
-                                current_block = 4830776507462815627;
+                                current_block = block::YYERRLAB;
                             } else {
-                                current_block = 17353983478346836848;
+                                current_block = block::REDUCE_DONE;
                             }
                         }
                         27 => {
@@ -1815,9 +1851,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 0,
                             );
                             if yyval.Node < 0 {
-                                current_block = 4830776507462815627;
+                                current_block = block::YYERRLAB;
                             } else {
-                                current_block = 17353983478346836848;
+                                current_block = block::REDUCE_DONE;
                             }
                         }
                         28 => {
@@ -1833,9 +1869,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 yyvs[yyvsp - 1].Node,
                             );
                             if yyval.Node < 0 {
-                                current_block = 4830776507462815627;
+                                current_block = block::YYERRLAB;
                             } else {
-                                current_block = 17353983478346836848;
+                                current_block = block::REDUCE_DONE;
                             }
                         }
                         29 => {
@@ -1847,15 +1883,15 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 yyvs[yyvsp].Node,
                             );
                             if yyval.Node < 0 {
-                                current_block = 4830776507462815627;
+                                current_block = block::YYERRLAB;
                             } else {
-                                current_block = 17353983478346836848;
+                                current_block = block::REDUCE_DONE;
                             }
                         }
                         30 => {
                             /* bits: '(' bits ')'  */
                             yyval.Node = yyvs[yyvsp - 1].Node;
-                            current_block = 17353983478346836848;
+                            current_block = block::REDUCE_DONE;
                         }
                         31 => {
                             /* expr: LONG  */
@@ -1866,9 +1902,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 ::core::mem::size_of::<c_long>() as c_ulong as c_long,
                             );
                             if yyval.Node < 0 {
-                                current_block = 4830776507462815627;
+                                current_block = block::YYERRLAB;
                             } else {
-                                current_block = 17353983478346836848;
+                                current_block = block::REDUCE_DONE;
                             }
                         }
                         32 => {
@@ -1880,18 +1916,18 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 ::core::mem::size_of::<c_double>() as c_ulong as c_long,
                             );
                             if yyval.Node < 0 {
-                                current_block = 4830776507462815627;
+                                current_block = block::YYERRLAB;
                             } else {
-                                current_block = 17353983478346836848;
+                                current_block = block::REDUCE_DONE;
                             }
                         }
                         33 => {
                             /* expr: COLUMN  */
                             yyval.Node = New_Column(lParse, yyvs[yyvsp].lng as c_int);
                             if yyval.Node < 0 {
-                                current_block = 4830776507462815627;
+                                current_block = block::YYERRLAB;
                             } else {
-                                current_block = 17353983478346836848;
+                                current_block = block::REDUCE_DONE;
                             }
                         }
                         34 => {
@@ -1905,7 +1941,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     lParse,
                                     cs!(c"Offset argument must be a constant integer"),
                                 );
-                                current_block = 4830776507462815627;
+                                current_block = block::YYERRLAB;
                             } else {
                                 yyval.Node = New_Offset(
                                     lParse,
@@ -1913,9 +1949,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     yyvs[yyvsp - 1].Node,
                                 );
                                 if yyval.Node < 0 {
-                                    current_block = 4830776507462815627;
+                                    current_block = block::YYERRLAB;
                                 } else {
-                                    current_block = 17353983478346836848;
+                                    current_block = block::REDUCE_DONE;
                                 }
                             }
                         }
@@ -1934,7 +1970,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 0,
                                 0,
                             );
-                            current_block = 17353983478346836848;
+                            current_block = block::REDUCE_DONE;
                         }
                         36 => {
                             /* expr: NULLREF  */
@@ -1951,7 +1987,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 0,
                                 0,
                             );
-                            current_block = 17353983478346836848;
+                            current_block = block::REDUCE_DONE;
                         }
                         37 => {
                             /* expr: expr '%' expr  */
@@ -1982,9 +2018,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 yyvs[yyvsp].Node,
                             );
                             if yyval.Node < 0 {
-                                current_block = 4830776507462815627;
+                                current_block = block::YYERRLAB;
                             } else {
-                                current_block = 17353983478346836848;
+                                current_block = block::REDUCE_DONE;
                             }
                         }
                         38 => {
@@ -2016,9 +2052,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 yyvs[yyvsp].Node,
                             );
                             if yyval.Node < 0 {
-                                current_block = 4830776507462815627;
+                                current_block = block::YYERRLAB;
                             } else {
-                                current_block = 17353983478346836848;
+                                current_block = block::REDUCE_DONE;
                             }
                         }
                         39 => {
@@ -2050,9 +2086,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 yyvs[yyvsp].Node,
                             );
                             if yyval.Node < 0 {
-                                current_block = 4830776507462815627;
+                                current_block = block::YYERRLAB;
                             } else {
-                                current_block = 17353983478346836848;
+                                current_block = block::REDUCE_DONE;
                             }
                         }
                         40 => {
@@ -2084,9 +2120,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 yyvs[yyvsp].Node,
                             );
                             if yyval.Node < 0 {
-                                current_block = 4830776507462815627;
+                                current_block = block::YYERRLAB;
                             } else {
-                                current_block = 17353983478346836848;
+                                current_block = block::REDUCE_DONE;
                             }
                         }
                         41 => {
@@ -2118,9 +2154,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 yyvs[yyvsp].Node,
                             );
                             if yyval.Node < 0 {
-                                current_block = 4830776507462815627;
+                                current_block = block::YYERRLAB;
                             } else {
-                                current_block = 17353983478346836848;
+                                current_block = block::REDUCE_DONE;
                             }
                         }
                         42 => {
@@ -2131,7 +2167,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     != fits_parser_yytokentype::LONG as c_int
                             {
                                 fits_parser_yyerror(lParse, cs!(c"Bitwise operations with incompatible types; only (bit OP bit) and (int OP int) are allowed"));
-                                current_block = 4830776507462815627;
+                                current_block = block::YYERRLAB;
                             } else {
                                 yyval.Node = New_BinOp(
                                     lParse,
@@ -2140,7 +2176,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     '&' as i32,
                                     yyvs[yyvsp].Node,
                                 );
-                                current_block = 17353983478346836848;
+                                current_block = block::REDUCE_DONE;
                             }
                         }
                         43 => {
@@ -2151,7 +2187,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     != fits_parser_yytokentype::LONG as c_int
                             {
                                 fits_parser_yyerror(lParse, cs!(c"Bitwise operations with incompatible types; only (bit OP bit) and (int OP int) are allowed"));
-                                current_block = 4830776507462815627;
+                                current_block = block::YYERRLAB;
                             } else {
                                 yyval.Node = New_BinOp(
                                     lParse,
@@ -2160,7 +2196,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     '|' as i32,
                                     yyvs[yyvsp].Node,
                                 );
-                                current_block = 17353983478346836848;
+                                current_block = block::REDUCE_DONE;
                             }
                         }
                         44 => {
@@ -2171,7 +2207,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     != fits_parser_yytokentype::LONG as c_int
                             {
                                 fits_parser_yyerror(lParse, cs!(c"Bitwise operations with incompatible types; only (bit OP bit) and (int OP int) are allowed"));
-                                current_block = 4830776507462815627;
+                                current_block = block::YYERRLAB;
                             } else {
                                 yyval.Node = New_BinOp(
                                     lParse,
@@ -2180,7 +2216,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     '^' as i32,
                                     yyvs[yyvsp].Node,
                                 );
-                                current_block = 17353983478346836848;
+                                current_block = block::REDUCE_DONE;
                             }
                         }
                         45 => {
@@ -2212,15 +2248,15 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 yyvs[yyvsp].Node,
                             );
                             if yyval.Node < 0 {
-                                current_block = 4830776507462815627;
+                                current_block = block::YYERRLAB;
                             } else {
-                                current_block = 17353983478346836848;
+                                current_block = block::REDUCE_DONE;
                             }
                         }
                         46 => {
                             /* expr: '+' expr  */
                             yyval.Node = yyvs[yyvsp].Node;
-                            current_block = 17353983478346836848;
+                            current_block = block::REDUCE_DONE;
                         }
                         47 => {
                             /* expr: '-' expr  */
@@ -2231,15 +2267,15 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 yyvs[yyvsp].Node,
                             );
                             if yyval.Node < 0 {
-                                current_block = 4830776507462815627;
+                                current_block = block::YYERRLAB;
                             } else {
-                                current_block = 17353983478346836848;
+                                current_block = block::REDUCE_DONE;
                             }
                         }
                         48 => {
                             /* expr: '(' expr ')'  */
                             yyval.Node = yyvs[yyvsp - 1].Node;
-                            current_block = 17353983478346836848;
+                            current_block = block::REDUCE_DONE;
                         }
                         49 => {
                             /* expr: expr '*' bexpr  */
@@ -2257,9 +2293,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 yyvs[yyvsp].Node,
                             );
                             if yyval.Node < 0 {
-                                current_block = 4830776507462815627;
+                                current_block = block::YYERRLAB;
                             } else {
-                                current_block = 17353983478346836848;
+                                current_block = block::REDUCE_DONE;
                             }
                         }
                         50 => {
@@ -2278,9 +2314,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 yyvs[yyvsp].Node,
                             );
                             if yyval.Node < 0 {
-                                current_block = 4830776507462815627;
+                                current_block = block::YYERRLAB;
                             } else {
-                                current_block = 17353983478346836848;
+                                current_block = block::REDUCE_DONE;
                             }
                         }
                         51 => {
@@ -2309,7 +2345,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     lParse,
                                     cs!(c"Incompatible dimensions in '?:' arguments"),
                                 );
-                                current_block = 4830776507462815627;
+                                current_block = block::YYERRLAB;
                             } else {
                                 yyval.Node = New_Func(
                                     lParse,
@@ -2325,7 +2361,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     0,
                                 );
                                 if yyval.Node < 0 {
-                                    current_block = 4830776507462815627;
+                                    current_block = block::YYERRLAB;
                                 } else {
                                     if ((lParse.Nodes)[yyvs[yyvsp - 2].Node as usize]).value.nelem
                                         < (lParse.Nodes[yyvs[yyvsp].Node as usize]).value.nelem
@@ -2339,7 +2375,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                             lParse,
                                             cs!(c"Incompatible dimensions in '?:' condition"),
                                         );
-                                        current_block = 4830776507462815627;
+                                        current_block = block::YYERRLAB;
                                     } else {
                                         ((lParse.Nodes)[yyvs[yyvsp - 4].Node as usize]).ntype =
                                             fits_parser_yytokentype::BOOLEAN as c_int;
@@ -2350,7 +2386,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         {
                                             Copy_Dims(lParse, yyval.Node, yyvs[yyvsp - 4].Node);
                                         }
-                                        current_block = 17353983478346836848;
+                                        current_block = block::REDUCE_DONE;
                                     }
                                 }
                             }
@@ -2381,7 +2417,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     lParse,
                                     cs!(c"Incompatible dimensions in '?:' arguments"),
                                 );
-                                current_block = 4830776507462815627;
+                                current_block = block::YYERRLAB;
                             } else {
                                 yyval.Node = New_Func(
                                     lParse,
@@ -2397,7 +2433,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     0,
                                 );
                                 if yyval.Node < 0 {
-                                    current_block = 4830776507462815627;
+                                    current_block = block::YYERRLAB;
                                 } else {
                                     if ((lParse.Nodes)[yyvs[yyvsp - 2].Node as usize]).value.nelem
                                         < (lParse.Nodes[yyvs[yyvsp].Node as usize]).value.nelem
@@ -2411,7 +2447,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                             lParse,
                                             cs!(c"Incompatible dimensions in '?:' condition"),
                                         );
-                                        current_block = 4830776507462815627;
+                                        current_block = block::YYERRLAB;
                                     } else {
                                         ((lParse.Nodes)[yyvs[yyvsp - 4].Node as usize]).ntype =
                                             fits_parser_yytokentype::BOOLEAN as c_int;
@@ -2422,7 +2458,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         {
                                             Copy_Dims(lParse, yyval.Node, yyvs[yyvsp - 4].Node);
                                         }
-                                        current_block = 17353983478346836848;
+                                        current_block = block::REDUCE_DONE;
                                     }
                                 }
                             }
@@ -2453,7 +2489,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     lParse,
                                     cs!(c"Incompatible dimensions in '?:' arguments"),
                                 );
-                                current_block = 4830776507462815627;
+                                current_block = block::YYERRLAB;
                             } else {
                                 yyval.Node = New_Func(
                                     lParse,
@@ -2469,7 +2505,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     0,
                                 );
                                 if yyval.Node < 0 {
-                                    current_block = 4830776507462815627;
+                                    current_block = block::YYERRLAB;
                                 } else {
                                     if ((lParse.Nodes)[yyvs[yyvsp - 2].Node as usize]).value.nelem
                                         < (lParse.Nodes[yyvs[yyvsp].Node as usize]).value.nelem
@@ -2483,7 +2519,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                             lParse,
                                             cs!(c"Incompatible dimensions in '?:' condition"),
                                         );
-                                        current_block = 4830776507462815627;
+                                        current_block = block::YYERRLAB;
                                     } else {
                                         ((lParse.Nodes)[yyvs[yyvsp - 4].Node as usize]).ntype =
                                             fits_parser_yytokentype::BOOLEAN as c_int;
@@ -2494,7 +2530,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         {
                                             Copy_Dims(lParse, yyval.Node, yyvs[yyvsp - 4].Node);
                                         }
-                                        current_block = 17353983478346836848;
+                                        current_block = block::REDUCE_DONE;
                                     }
                                 }
                             }
@@ -2515,7 +2551,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     0,
                                     0,
                                 );
-                                current_block = 1297461190301222800;
+                                current_block = block::REDUCE_JOIN_7;
                             } else if astr_eq(&yyvs[yyvsp - 1].astr, c"RANDOMN(") {
                                 yyval.Node = New_Func(
                                     lParse,
@@ -2530,18 +2566,18 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     0,
                                     0,
                                 );
-                                current_block = 1297461190301222800;
+                                current_block = block::REDUCE_JOIN_7;
                             } else {
                                 fits_parser_yyerror(lParse, cs!(c"Function() not supported"));
-                                current_block = 4830776507462815627;
+                                current_block = block::YYERRLAB;
                             }
                             match current_block {
-                                4830776507462815627 => {}
+                                block::YYERRLAB => {}
                                 _ => {
                                     if yyval.Node < 0 {
-                                        current_block = 4830776507462815627;
+                                        current_block = block::YYERRLAB;
                                     } else {
-                                        current_block = 17353983478346836848;
+                                        current_block = block::REDUCE_DONE;
                                     }
                                 }
                             }
@@ -2562,7 +2598,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     0,
                                     0,
                                 );
-                                current_block = 10848699504537784535;
+                                current_block = block::REDUCE_JOIN_5;
                             } else if astr_eq(&yyvs[yyvsp - 2].astr, c"NELEM(") {
                                 yyval.Node = New_Const(
                                     lParse,
@@ -2572,7 +2608,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         .cast::<c_void>(),
                                     ::core::mem::size_of::<c_long>() as c_ulong as c_long,
                                 );
-                                current_block = 10848699504537784535;
+                                current_block = block::REDUCE_JOIN_5;
                             } else if astr_eq(&yyvs[yyvsp - 2].astr, c"ACCUM(") {
                                 let mut zero: c_long = 0;
                                 let new_node = New_Const(
@@ -2589,18 +2625,18 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     fits_parser_yytokentype::ACCUM as c_int,
                                     new_node,
                                 );
-                                current_block = 10848699504537784535;
+                                current_block = block::REDUCE_JOIN_5;
                             } else {
                                 fits_parser_yyerror(lParse, cs!(c"Function(bool) not supported"));
-                                current_block = 4830776507462815627;
+                                current_block = block::YYERRLAB;
                             }
                             match current_block {
-                                4830776507462815627 => {}
+                                block::YYERRLAB => {}
                                 _ => {
                                     if yyval.Node < 0 {
-                                        current_block = 4830776507462815627;
+                                        current_block = block::YYERRLAB;
                                     } else {
-                                        current_block = 17353983478346836848;
+                                        current_block = block::REDUCE_DONE;
                                     }
                                 }
                             }
@@ -2617,7 +2653,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         lParse,
                                         cs!(c"AXISELEM second argument must be a scalar constant"),
                                     );
-                                    current_block = 4830776507462815627;
+                                    current_block = block::YYERRLAB;
                                 } else if ((lParse.Nodes)[yyvs[yyvsp - 3].Node as usize]).operation
                                     == CONST_OP
                                 {
@@ -2628,7 +2664,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         (&mut one as *mut c_long).cast::<c_void>(),
                                         ::core::mem::size_of::<c_long>() as c_ulong as c_long,
                                     );
-                                    current_block = 13755523488868872559;
+                                    current_block = block::REDUCE_JOIN_4;
                                 } else {
                                     if ((lParse.Nodes)[yyvs[yyvsp - 1].Node as usize]).ntype
                                         != fits_parser_yytokentype::LONG as c_int
@@ -2654,11 +2690,11 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         0,
                                     );
                                     if yyval.Node < 0 {
-                                        current_block = 4830776507462815627;
+                                        current_block = block::YYERRLAB;
                                     } else {
                                         ((lParse.Nodes)[yyval.Node as usize]).ntype =
                                             fits_parser_yytokentype::LONG as c_int;
-                                        current_block = 13755523488868872559;
+                                        current_block = block::REDUCE_JOIN_4;
                                     }
                                 }
                             } else if astr_eq(&yyvs[yyvsp - 4].astr, c"NAXES(") {
@@ -2671,7 +2707,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         lParse,
                                         cs!(c"NAXES second argument must be a scalar constant"),
                                     );
-                                    current_block = 4830776507462815627;
+                                    current_block = block::YYERRLAB;
                                 } else if ((lParse.Nodes)[yyvs[yyvsp - 3].Node as usize]).operation
                                     == CONST_OP
                                 {
@@ -2682,7 +2718,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         (&mut one_0 as *mut c_long).cast::<c_void>(),
                                         ::core::mem::size_of::<c_long>() as c_ulong as c_long,
                                     );
-                                    current_block = 13755523488868872559;
+                                    current_block = block::REDUCE_JOIN_4;
                                 } else {
                                     let mut iaxis: c_long = 0;
                                     let mut naxis: c_int = 0;
@@ -2719,33 +2755,33 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         ::core::mem::size_of::<c_long>() as c_ulong as c_long,
                                     );
                                     if yyval.Node < 0 {
-                                        current_block = 4830776507462815627;
+                                        current_block = block::YYERRLAB;
                                     } else {
-                                        current_block = 13755523488868872559;
+                                        current_block = block::REDUCE_JOIN_4;
                                     }
                                 }
                             } else if astr_eq(&yyvs[yyvsp - 4].astr, c"ARRAY(") {
                                 yyval.Node =
                                     New_Array(lParse, yyvs[yyvsp - 3].Node, yyvs[yyvsp - 1].Node);
                                 if yyval.Node < 0 {
-                                    current_block = 4830776507462815627;
+                                    current_block = block::YYERRLAB;
                                 } else {
-                                    current_block = 13755523488868872559;
+                                    current_block = block::REDUCE_JOIN_4;
                                 }
                             } else {
                                 fits_parser_yyerror(
                                     lParse,
                                     cs!(c"Function(bool,expr) not supported"),
                                 );
-                                current_block = 4830776507462815627;
+                                current_block = block::YYERRLAB;
                             }
                             match current_block {
-                                4830776507462815627 => {}
+                                block::YYERRLAB => {}
                                 _ => {
                                     if yyval.Node < 0 {
-                                        current_block = 4830776507462815627;
+                                        current_block = block::YYERRLAB;
                                     } else {
-                                        current_block = 17353983478346836848;
+                                        current_block = block::REDUCE_DONE;
                                     }
                                 }
                             }
@@ -2761,7 +2797,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         .cast::<c_void>(),
                                     ::core::mem::size_of::<c_long>() as c_ulong as c_long,
                                 );
-                                current_block = 15752106442776732052;
+                                current_block = block::REDUCE_JOIN_8;
                             } else if astr_eq(&yyvs[yyvsp - 2].astr, c"NVALID(") {
                                 yyval.Node = New_Func(
                                     lParse,
@@ -2776,18 +2812,18 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     0,
                                     0,
                                 );
-                                current_block = 15752106442776732052;
+                                current_block = block::REDUCE_JOIN_8;
                             } else {
                                 fits_parser_yyerror(lParse, cs!(c"Function(str) not supported"));
-                                current_block = 4830776507462815627;
+                                current_block = block::YYERRLAB;
                             }
                             match current_block {
-                                4830776507462815627 => {}
+                                block::YYERRLAB => {}
                                 _ => {
                                     if yyval.Node < 0 {
-                                        current_block = 4830776507462815627;
+                                        current_block = block::YYERRLAB;
                                     } else {
-                                        current_block = 17353983478346836848;
+                                        current_block = block::REDUCE_DONE;
                                     }
                                 }
                             }
@@ -2803,7 +2839,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         .cast::<c_void>(),
                                     ::core::mem::size_of::<c_long>() as c_ulong as c_long,
                                 );
-                                current_block = 494012601817399562;
+                                current_block = block::REDUCE_JOIN_3;
                             } else if astr_eq(&yyvs[yyvsp - 2].astr, c"NVALID(") {
                                 yyval.Node = New_Const(
                                     lParse,
@@ -2813,7 +2849,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         .cast::<c_void>(),
                                     ::core::mem::size_of::<c_long>() as c_ulong as c_long,
                                 );
-                                current_block = 494012601817399562;
+                                current_block = block::REDUCE_JOIN_3;
                             } else if astr_eq(&yyvs[yyvsp - 2].astr, c"SUM(") {
                                 yyval.Node = New_Func(
                                     lParse,
@@ -2828,7 +2864,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     0,
                                     0,
                                 );
-                                current_block = 494012601817399562;
+                                current_block = block::REDUCE_JOIN_3;
                             } else if astr_eq(&yyvs[yyvsp - 2].astr, c"MIN(") {
                                 yyval.Node = New_Func(
                                     lParse,
@@ -2844,7 +2880,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     0,
                                 );
                                 (((lParse.Nodes)[yyval.Node as usize]).value).nelem = 1;
-                                current_block = 494012601817399562;
+                                current_block = block::REDUCE_JOIN_3;
                             } else if astr_eq(&yyvs[yyvsp - 2].astr, c"ACCUM(") {
                                 let mut zero_0: c_long = 0;
                                 let new_node = New_Const(
@@ -2861,7 +2897,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     fits_parser_yytokentype::ACCUM as c_int,
                                     new_node,
                                 );
-                                current_block = 494012601817399562;
+                                current_block = block::REDUCE_JOIN_3;
                             } else if astr_eq(&yyvs[yyvsp - 2].astr, c"MAX(") {
                                 yyval.Node = New_Func(
                                     lParse,
@@ -2877,18 +2913,18 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     0,
                                 );
                                 (((lParse.Nodes)[yyval.Node as usize]).value).nelem = 1;
-                                current_block = 494012601817399562;
+                                current_block = block::REDUCE_JOIN_3;
                             } else {
                                 fits_parser_yyerror(lParse, cs!(c"Function(bits) not supported"));
-                                current_block = 4830776507462815627;
+                                current_block = block::YYERRLAB;
                             }
                             match current_block {
-                                4830776507462815627 => {}
+                                block::YYERRLAB => {}
                                 _ => {
                                     if yyval.Node < 0 {
-                                        current_block = 4830776507462815627;
+                                        current_block = block::YYERRLAB;
                                     } else {
-                                        current_block = 17353983478346836848;
+                                        current_block = block::REDUCE_DONE;
                                     }
                                 }
                             }
@@ -2909,7 +2945,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     0,
                                     0,
                                 );
-                                current_block = 7600445499126923600;
+                                current_block = block::REDUCE_JOIN_1;
                             } else if astr_eq(&yyvs[yyvsp - 2].astr, c"AVERAGE(") {
                                 yyval.Node = New_Func(
                                     lParse,
@@ -2924,7 +2960,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     0,
                                     0,
                                 );
-                                current_block = 7600445499126923600;
+                                current_block = block::REDUCE_JOIN_1;
                             } else if astr_eq(&yyvs[yyvsp - 2].astr, c"STDDEV(") {
                                 yyval.Node = New_Func(
                                     lParse,
@@ -2939,7 +2975,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     0,
                                     0,
                                 );
-                                current_block = 7600445499126923600;
+                                current_block = block::REDUCE_JOIN_1;
                             } else if astr_eq(&yyvs[yyvsp - 2].astr, c"MEDIAN(") {
                                 yyval.Node = New_Func(
                                     lParse,
@@ -2954,7 +2990,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     0,
                                     0,
                                 );
-                                current_block = 7600445499126923600;
+                                current_block = block::REDUCE_JOIN_1;
                             } else if astr_eq(&yyvs[yyvsp - 2].astr, c"NELEM(") {
                                 yyval.Node = New_Const(
                                     lParse,
@@ -2964,7 +3000,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         .cast::<c_void>(),
                                     ::core::mem::size_of::<c_long>() as c_ulong as c_long,
                                 );
-                                current_block = 7600445499126923600;
+                                current_block = block::REDUCE_JOIN_1;
                             } else if astr_eq(&yyvs[yyvsp - 2].astr, c"NVALID(") {
                                 yyval.Node = New_Func(
                                     lParse,
@@ -2979,7 +3015,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     0,
                                     0,
                                 );
-                                current_block = 7600445499126923600;
+                                current_block = block::REDUCE_JOIN_1;
                             } else if astr_eq(&yyvs[yyvsp - 2].astr, c"ACCUM(")
                                 && ((lParse.Nodes)[yyvs[yyvsp - 1].Node as usize]).ntype
                                     == fits_parser_yytokentype::LONG as c_int
@@ -3002,7 +3038,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     fits_parser_yytokentype::ACCUM as c_int,
                                     new_node,
                                 );
-                                current_block = 7600445499126923600;
+                                current_block = block::REDUCE_JOIN_1;
                             } else if astr_eq(&yyvs[yyvsp - 2].astr, c"ACCUM(")
                                 && ((lParse.Nodes)[yyvs[yyvsp - 1].Node as usize]).ntype
                                     == fits_parser_yytokentype::DOUBLE as c_int
@@ -3022,7 +3058,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     fits_parser_yytokentype::ACCUM as c_int,
                                     new_node,
                                 );
-                                current_block = 7600445499126923600;
+                                current_block = block::REDUCE_JOIN_1;
                             } else if astr_eq(&yyvs[yyvsp - 2].astr, c"SEQDIFF(")
                                 && ((lParse.Nodes)[yyvs[yyvsp - 1].Node as usize]).ntype
                                     == fits_parser_yytokentype::LONG as c_int
@@ -3042,7 +3078,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     fits_parser_yytokentype::DIFF as c_int,
                                     new_node,
                                 );
-                                current_block = 7600445499126923600;
+                                current_block = block::REDUCE_JOIN_1;
                             } else if astr_eq(&yyvs[yyvsp - 2].astr, c"SEQDIFF(")
                                 && ((lParse.Nodes)[yyvs[yyvsp - 1].Node as usize]).ntype
                                     == fits_parser_yytokentype::DOUBLE as c_int
@@ -3062,7 +3098,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     fits_parser_yytokentype::DIFF as c_int,
                                     new_node,
                                 );
-                                current_block = 7600445499126923600;
+                                current_block = block::REDUCE_JOIN_1;
                             } else if astr_eq(&yyvs[yyvsp - 2].astr, c"ABS(") {
                                 yyval.Node = New_Func(
                                     lParse,
@@ -3077,7 +3113,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     0,
                                     0,
                                 );
-                                current_block = 7600445499126923600;
+                                current_block = block::REDUCE_JOIN_1;
                             } else if astr_eq(&yyvs[yyvsp - 2].astr, c"MIN(") {
                                 yyval.Node = New_Func(
                                     lParse,
@@ -3092,7 +3128,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     0,
                                     0,
                                 );
-                                current_block = 7600445499126923600;
+                                current_block = block::REDUCE_JOIN_1;
                             } else if astr_eq(&yyvs[yyvsp - 2].astr, c"MAX(") {
                                 yyval.Node = New_Func(
                                     lParse,
@@ -3107,7 +3143,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     0,
                                     0,
                                 );
-                                current_block = 7600445499126923600;
+                                current_block = block::REDUCE_JOIN_1;
                             } else if astr_eq(&yyvs[yyvsp - 2].astr, c"RANDOM(") {
                                 yyval.Node = New_Func(
                                     lParse,
@@ -3123,11 +3159,11 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     0,
                                 );
                                 if yyval.Node < 0 {
-                                    current_block = 4830776507462815627;
+                                    current_block = block::YYERRLAB;
                                 } else {
                                     ((lParse.Nodes)[yyval.Node as usize]).ntype =
                                         fits_parser_yytokentype::DOUBLE as c_int;
-                                    current_block = 7600445499126923600;
+                                    current_block = block::REDUCE_JOIN_1;
                                 }
                             } else if astr_eq(&yyvs[yyvsp - 2].astr, c"RANDOMN(") {
                                 yyval.Node = New_Func(
@@ -3144,11 +3180,11 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     0,
                                 );
                                 if yyval.Node < 0 {
-                                    current_block = 4830776507462815627;
+                                    current_block = block::YYERRLAB;
                                 } else {
                                     ((lParse.Nodes)[yyval.Node as usize]).ntype =
                                         fits_parser_yytokentype::DOUBLE as c_int;
-                                    current_block = 7600445499126923600;
+                                    current_block = block::REDUCE_JOIN_1;
                                 }
                             } else if astr_eq(&yyvs[yyvsp - 2].astr, c"ELEMENTNUM(") {
                                 if ((lParse.Nodes)[yyvs[yyvsp - 1].Node as usize]).operation
@@ -3161,7 +3197,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         (&mut one_1 as *mut c_long).cast::<c_void>(),
                                         ::core::mem::size_of::<c_long>() as c_ulong as c_long,
                                     );
-                                    current_block = 7600445499126923600;
+                                    current_block = block::REDUCE_JOIN_1;
                                 } else {
                                     yyval.Node = New_Func(
                                         lParse,
@@ -3177,11 +3213,11 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         0,
                                     );
                                     if yyval.Node < 0 {
-                                        current_block = 4830776507462815627;
+                                        current_block = block::YYERRLAB;
                                     } else {
                                         ((lParse.Nodes)[yyval.Node as usize]).ntype =
                                             fits_parser_yytokentype::LONG as c_int;
-                                        current_block = 7600445499126923600;
+                                        current_block = block::REDUCE_JOIN_1;
                                     }
                                 }
                             } else if astr_eq(&yyvs[yyvsp - 2].astr, c"NAXIS(") {
@@ -3195,7 +3231,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         (&mut one_2 as *mut c_long).cast::<c_void>(),
                                         ::core::mem::size_of::<c_long>() as c_ulong as c_long,
                                     );
-                                    current_block = 7600445499126923600;
+                                    current_block = block::REDUCE_JOIN_1;
                                 } else {
                                     let mut naxis_0: c_long = c_long::from(
                                         ((lParse.Nodes)[yyvs[yyvsp - 1].Node as usize]).value.naxis,
@@ -3207,9 +3243,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         ::core::mem::size_of::<c_long>() as c_ulong as c_long,
                                     );
                                     if yyval.Node < 0 {
-                                        current_block = 4830776507462815627;
+                                        current_block = block::YYERRLAB;
                                     } else {
-                                        current_block = 7600445499126923600;
+                                        current_block = block::REDUCE_JOIN_1;
                                     }
                                 }
                             } else {
@@ -3237,7 +3273,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         0,
                                         0,
                                     );
-                                    current_block = 7600445499126923600;
+                                    current_block = block::REDUCE_JOIN_1;
                                 } else if astr_eq(&yyvs[yyvsp - 2].astr, c"COS(") {
                                     yyval.Node = New_Func(
                                         lParse,
@@ -3252,7 +3288,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         0,
                                         0,
                                     );
-                                    current_block = 7600445499126923600;
+                                    current_block = block::REDUCE_JOIN_1;
                                 } else if astr_eq(&yyvs[yyvsp - 2].astr, c"TAN(") {
                                     yyval.Node = New_Func(
                                         lParse,
@@ -3267,7 +3303,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         0,
                                         0,
                                     );
-                                    current_block = 7600445499126923600;
+                                    current_block = block::REDUCE_JOIN_1;
                                 } else if astr_eq(&yyvs[yyvsp - 2].astr, c"ARCSIN(")
                                     || astr_eq(&yyvs[yyvsp - 2].astr, c"ASIN(")
                                 {
@@ -3284,7 +3320,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         0,
                                         0,
                                     );
-                                    current_block = 7600445499126923600;
+                                    current_block = block::REDUCE_JOIN_1;
                                 } else if astr_eq(&yyvs[yyvsp - 2].astr, c"ARCCOS(")
                                     || astr_eq(&yyvs[yyvsp - 2].astr, c"ACOS(")
                                 {
@@ -3301,7 +3337,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         0,
                                         0,
                                     );
-                                    current_block = 7600445499126923600;
+                                    current_block = block::REDUCE_JOIN_1;
                                 } else if astr_eq(&yyvs[yyvsp - 2].astr, c"ARCTAN(")
                                     || astr_eq(&yyvs[yyvsp - 2].astr, c"ATAN(")
                                 {
@@ -3318,7 +3354,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         0,
                                         0,
                                     );
-                                    current_block = 7600445499126923600;
+                                    current_block = block::REDUCE_JOIN_1;
                                 } else if astr_eq(&yyvs[yyvsp - 2].astr, c"SINH(") {
                                     yyval.Node = New_Func(
                                         lParse,
@@ -3333,7 +3369,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         0,
                                         0,
                                     );
-                                    current_block = 7600445499126923600;
+                                    current_block = block::REDUCE_JOIN_1;
                                 } else if astr_eq(&yyvs[yyvsp - 2].astr, c"COSH(") {
                                     yyval.Node = New_Func(
                                         lParse,
@@ -3348,7 +3384,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         0,
                                         0,
                                     );
-                                    current_block = 7600445499126923600;
+                                    current_block = block::REDUCE_JOIN_1;
                                 } else if astr_eq(&yyvs[yyvsp - 2].astr, c"TANH(") {
                                     yyval.Node = New_Func(
                                         lParse,
@@ -3363,7 +3399,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         0,
                                         0,
                                     );
-                                    current_block = 7600445499126923600;
+                                    current_block = block::REDUCE_JOIN_1;
                                 } else if astr_eq(&yyvs[yyvsp - 2].astr, c"EXP(") {
                                     yyval.Node = New_Func(
                                         lParse,
@@ -3378,7 +3414,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         0,
                                         0,
                                     );
-                                    current_block = 7600445499126923600;
+                                    current_block = block::REDUCE_JOIN_1;
                                 } else if astr_eq(&yyvs[yyvsp - 2].astr, c"LOG(") {
                                     yyval.Node = New_Func(
                                         lParse,
@@ -3393,7 +3429,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         0,
                                         0,
                                     );
-                                    current_block = 7600445499126923600;
+                                    current_block = block::REDUCE_JOIN_1;
                                 } else if astr_eq(&yyvs[yyvsp - 2].astr, c"LOG10(") {
                                     yyval.Node = New_Func(
                                         lParse,
@@ -3408,7 +3444,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         0,
                                         0,
                                     );
-                                    current_block = 7600445499126923600;
+                                    current_block = block::REDUCE_JOIN_1;
                                 } else if astr_eq(&yyvs[yyvsp - 2].astr, c"SQRT(") {
                                     yyval.Node = New_Func(
                                         lParse,
@@ -3423,7 +3459,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         0,
                                         0,
                                     );
-                                    current_block = 7600445499126923600;
+                                    current_block = block::REDUCE_JOIN_1;
                                 } else if astr_eq(&yyvs[yyvsp - 2].astr, c"ROUND(") {
                                     yyval.Node = New_Func(
                                         lParse,
@@ -3438,7 +3474,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         0,
                                         0,
                                     );
-                                    current_block = 7600445499126923600;
+                                    current_block = block::REDUCE_JOIN_1;
                                 } else if astr_eq(&yyvs[yyvsp - 2].astr, c"FLOOR(") {
                                     yyval.Node = New_Func(
                                         lParse,
@@ -3453,7 +3489,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         0,
                                         0,
                                     );
-                                    current_block = 7600445499126923600;
+                                    current_block = block::REDUCE_JOIN_1;
                                 } else if astr_eq(&yyvs[yyvsp - 2].astr, c"CEIL(") {
                                     yyval.Node = New_Func(
                                         lParse,
@@ -3468,7 +3504,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         0,
                                         0,
                                     );
-                                    current_block = 7600445499126923600;
+                                    current_block = block::REDUCE_JOIN_1;
                                 } else if astr_eq(&yyvs[yyvsp - 2].astr, c"RANDOMP(") {
                                     yyval.Node = New_Func(
                                         lParse,
@@ -3485,22 +3521,22 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     );
                                     ((lParse.Nodes)[yyval.Node as usize]).ntype =
                                         fits_parser_yytokentype::LONG as c_int;
-                                    current_block = 7600445499126923600;
+                                    current_block = block::REDUCE_JOIN_1;
                                 } else {
                                     fits_parser_yyerror(
                                         lParse,
                                         cs!(c"Function(expr) not supported"),
                                     );
-                                    current_block = 4830776507462815627;
+                                    current_block = block::YYERRLAB;
                                 }
                             }
                             match current_block {
-                                4830776507462815627 => {}
+                                block::YYERRLAB => {}
                                 _ => {
                                     if yyval.Node < 0 {
-                                        current_block = 4830776507462815627;
+                                        current_block = block::YYERRLAB;
                                     } else {
-                                        current_block = 17353983478346836848;
+                                        current_block = block::REDUCE_DONE;
                                     }
                                 }
                             }
@@ -3522,17 +3558,17 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     0,
                                 );
                                 if yyval.Node < 0 {
-                                    current_block = 4830776507462815627;
+                                    current_block = block::YYERRLAB;
                                 } else {
-                                    current_block = 12473999534294722905;
+                                    current_block = block::REDUCE_JOIN_6;
                                 }
                             } else {
-                                current_block = 12473999534294722905;
+                                current_block = block::REDUCE_JOIN_6;
                             }
                             match current_block {
-                                4830776507462815627 => {}
+                                block::YYERRLAB => {}
                                 _ => {
-                                    current_block = 17353983478346836848;
+                                    current_block = block::REDUCE_DONE;
                                 }
                             }
                         }
@@ -3577,16 +3613,16 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         0,
                                     );
                                     if yyval.Node < 0 {
-                                        current_block = 4830776507462815627;
+                                        current_block = block::YYERRLAB;
                                     } else {
-                                        current_block = 9966817879908499150;
+                                        current_block = block::REDUCE_JOIN_2;
                                     }
                                 } else {
                                     fits_parser_yyerror(
                                         lParse,
                                         cs!(c"Dimensions of DEFNULL arguments are not compatible"),
                                     );
-                                    current_block = 4830776507462815627;
+                                    current_block = block::YYERRLAB;
                                 }
                             } else if astr_eq(&yyvs[yyvsp - 4].astr, c"ARCTAN2(") {
                                 if ((lParse.Nodes)[yyvs[yyvsp - 3].Node as usize]).ntype
@@ -3626,7 +3662,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         0,
                                     );
                                     if yyval.Node < 0 {
-                                        current_block = 4830776507462815627;
+                                        current_block = block::YYERRLAB;
                                     } else {
                                         if ((lParse.Nodes)[yyvs[yyvsp - 3].Node as usize])
                                             .value
@@ -3637,14 +3673,14 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         {
                                             Copy_Dims(lParse, yyval.Node, yyvs[yyvsp - 1].Node);
                                         }
-                                        current_block = 9966817879908499150;
+                                        current_block = block::REDUCE_JOIN_2;
                                     }
                                 } else {
                                     fits_parser_yyerror(
                                         lParse,
                                         cs!(c"Dimensions of arctan2 arguments are not compatible"),
                                     );
-                                    current_block = 4830776507462815627;
+                                    current_block = block::YYERRLAB;
                                 }
                             } else if astr_eq(&yyvs[yyvsp - 4].astr, c"MIN(") {
                                 if ((lParse.Nodes)[yyvs[yyvsp - 3].Node as usize]).ntype
@@ -3683,7 +3719,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         0,
                                     );
                                     if yyval.Node < 0 {
-                                        current_block = 4830776507462815627;
+                                        current_block = block::YYERRLAB;
                                     } else {
                                         if ((lParse.Nodes)[yyvs[yyvsp - 3].Node as usize])
                                             .value
@@ -3694,14 +3730,14 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         {
                                             Copy_Dims(lParse, yyval.Node, yyvs[yyvsp - 1].Node);
                                         }
-                                        current_block = 9966817879908499150;
+                                        current_block = block::REDUCE_JOIN_2;
                                     }
                                 } else {
                                     fits_parser_yyerror(
                                         lParse,
                                         cs!(c"Dimensions of min(a,b) arguments are not compatible"),
                                     );
-                                    current_block = 4830776507462815627;
+                                    current_block = block::YYERRLAB;
                                 }
                             } else if astr_eq(&yyvs[yyvsp - 4].astr, c"MAX(") {
                                 if ((lParse.Nodes)[yyvs[yyvsp - 3].Node as usize]).ntype
@@ -3740,7 +3776,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         0,
                                     );
                                     if yyval.Node < 0 {
-                                        current_block = 4830776507462815627;
+                                        current_block = block::YYERRLAB;
                                     } else {
                                         if ((lParse.Nodes)[yyvs[yyvsp - 3].Node as usize])
                                             .value
@@ -3751,14 +3787,14 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         {
                                             Copy_Dims(lParse, yyval.Node, yyvs[yyvsp - 1].Node);
                                         }
-                                        current_block = 9966817879908499150;
+                                        current_block = block::REDUCE_JOIN_2;
                                     }
                                 } else {
                                     fits_parser_yyerror(
                                         lParse,
                                         cs!(c"Dimensions of max(a,b) arguments are not compatible"),
                                     );
-                                    current_block = 4830776507462815627;
+                                    current_block = block::YYERRLAB;
                                 }
                             } else if astr_eq(&yyvs[yyvsp - 4].astr, c"SETNULL(") {
                                 if ((lParse.Nodes)[yyvs[yyvsp - 3].Node as usize]).operation
@@ -3770,7 +3806,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         lParse,
                                         cs!(c"SETNULL first argument must be a scalar constant"),
                                     );
-                                    current_block = 4830776507462815627;
+                                    current_block = block::YYERRLAB;
                                 } else {
                                     if ((lParse.Nodes)[yyvs[yyvsp - 3].Node as usize]).ntype
                                         != ((lParse.Nodes)[yyvs[yyvsp - 1].Node as usize]).ntype
@@ -3795,7 +3831,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         0,
                                         0,
                                     );
-                                    current_block = 9966817879908499150;
+                                    current_block = block::REDUCE_JOIN_2;
                                 }
                             } else if astr_eq(&yyvs[yyvsp - 4].astr, c"AXISELEM(") {
                                 if ((lParse.Nodes)[yyvs[yyvsp - 1].Node as usize]).operation
@@ -3807,7 +3843,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         lParse,
                                         cs!(c"AXISELEM second argument must be a scalar constant"),
                                     );
-                                    current_block = 4830776507462815627;
+                                    current_block = block::YYERRLAB;
                                 } else if ((lParse.Nodes)[yyvs[yyvsp - 3].Node as usize]).operation
                                     == CONST_OP
                                 {
@@ -3818,7 +3854,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         (&mut one_3 as *mut c_long).cast::<c_void>(),
                                         ::core::mem::size_of::<c_long>() as c_ulong as c_long,
                                     );
-                                    current_block = 9966817879908499150;
+                                    current_block = block::REDUCE_JOIN_2;
                                 } else {
                                     if ((lParse.Nodes)[yyvs[yyvsp - 1].Node as usize]).ntype
                                         != fits_parser_yytokentype::LONG as c_int
@@ -3844,11 +3880,11 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         0,
                                     );
                                     if yyval.Node < 0 {
-                                        current_block = 4830776507462815627;
+                                        current_block = block::YYERRLAB;
                                     } else {
                                         ((lParse.Nodes)[yyval.Node as usize]).ntype =
                                             fits_parser_yytokentype::LONG as c_int;
-                                        current_block = 9966817879908499150;
+                                        current_block = block::REDUCE_JOIN_2;
                                     }
                                 }
                             } else if astr_eq(&yyvs[yyvsp - 4].astr, c"NAXES(") {
@@ -3861,7 +3897,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         lParse,
                                         cs!(c"NAXES second argument must be a scalar constant"),
                                     );
-                                    current_block = 4830776507462815627;
+                                    current_block = block::YYERRLAB;
                                 } else if ((lParse.Nodes)[yyvs[yyvsp - 3].Node as usize]).operation
                                     == CONST_OP
                                 {
@@ -3872,7 +3908,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         (&mut one_4 as *mut c_long).cast::<c_void>(),
                                         ::core::mem::size_of::<c_long>() as c_ulong as c_long,
                                     );
-                                    current_block = 9966817879908499150;
+                                    current_block = block::REDUCE_JOIN_2;
                                 } else {
                                     let mut iaxis_0: c_long = 0;
                                     let mut naxis_1: c_int = 0;
@@ -3909,30 +3945,30 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         ::core::mem::size_of::<c_long>() as c_ulong as c_long,
                                     );
                                     if yyval.Node < 0 {
-                                        current_block = 4830776507462815627;
+                                        current_block = block::YYERRLAB;
                                     } else {
-                                        current_block = 9966817879908499150;
+                                        current_block = block::REDUCE_JOIN_2;
                                     }
                                 }
                             } else if astr_eq(&yyvs[yyvsp - 4].astr, c"ARRAY(") {
                                 yyval.Node =
                                     New_Array(lParse, yyvs[yyvsp - 3].Node, yyvs[yyvsp - 1].Node);
                                 if yyval.Node < 0 {
-                                    current_block = 4830776507462815627;
+                                    current_block = block::YYERRLAB;
                                 } else {
-                                    current_block = 9966817879908499150;
+                                    current_block = block::REDUCE_JOIN_2;
                                 }
                             } else {
                                 fits_parser_yyerror(
                                     lParse,
                                     cs!(c"Function(expr,expr) not supported"),
                                 );
-                                current_block = 4830776507462815627;
+                                current_block = block::YYERRLAB;
                             }
                             match current_block {
-                                4830776507462815627 => {}
+                                block::YYERRLAB => {}
                                 _ => {
-                                    current_block = 17353983478346836848;
+                                    current_block = block::REDUCE_DONE;
                                 }
                             }
                         }
@@ -4000,7 +4036,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         0,
                                     );
                                     if yyval.Node < 0 {
-                                        current_block = 4830776507462815627;
+                                        current_block = block::YYERRLAB;
                                     } else {
                                         if ((lParse.Nodes)[yyvs[yyvsp - 7].Node as usize])
                                             .value
@@ -4029,21 +4065,21 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         {
                                             Copy_Dims(lParse, yyval.Node, yyvs[yyvsp - 1].Node);
                                         }
-                                        current_block = 17353983478346836848;
+                                        current_block = block::REDUCE_DONE;
                                     }
                                 } else {
                                     fits_parser_yyerror(
                                         lParse,
                                         cs!(c"Dimensions of ANGSEP arguments are not compatible"),
                                     );
-                                    current_block = 4830776507462815627;
+                                    current_block = block::YYERRLAB;
                                 }
                             } else {
                                 fits_parser_yyerror(
                                     lParse,
                                     cs!(c"Function(expr,expr,expr,expr) not supported"),
                                 );
-                                current_block = 4830776507462815627;
+                                current_block = block::YYERRLAB;
                             }
                         }
                         63 => {
@@ -4058,9 +4094,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 c"*STOP*".as_ptr() as *mut c_char,
                             );
                             if yyval.Node < 0 {
-                                current_block = 4830776507462815627;
+                                current_block = block::YYERRLAB;
                             } else {
-                                current_block = 17353983478346836848;
+                                current_block = block::REDUCE_DONE;
                             }
                         }
                         64 => {
@@ -4075,9 +4111,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 (yyvs[yyvsp - 1].astr).as_mut_ptr(),
                             );
                             if yyval.Node < 0 {
-                                current_block = 4830776507462815627;
+                                current_block = block::YYERRLAB;
                             } else {
-                                current_block = 17353983478346836848;
+                                current_block = block::REDUCE_DONE;
                             }
                         }
                         65 => {
@@ -4093,9 +4129,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 0,
                             );
                             if yyval.Node < 0 {
-                                current_block = 4830776507462815627;
+                                current_block = block::YYERRLAB;
                             } else {
-                                current_block = 17353983478346836848;
+                                current_block = block::REDUCE_DONE;
                             }
                         }
                         66 => {
@@ -4111,9 +4147,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 0,
                             );
                             if yyval.Node < 0 {
-                                current_block = 4830776507462815627;
+                                current_block = block::YYERRLAB;
                             } else {
-                                current_block = 17353983478346836848;
+                                current_block = block::REDUCE_DONE;
                             }
                         }
                         67 => {
@@ -4129,9 +4165,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 0,
                             );
                             if yyval.Node < 0 {
-                                current_block = 4830776507462815627;
+                                current_block = block::YYERRLAB;
                             } else {
-                                current_block = 17353983478346836848;
+                                current_block = block::REDUCE_DONE;
                             }
                         }
                         68 => {
@@ -4147,9 +4183,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 0,
                             );
                             if yyval.Node < 0 {
-                                current_block = 4830776507462815627;
+                                current_block = block::YYERRLAB;
                             } else {
-                                current_block = 17353983478346836848;
+                                current_block = block::REDUCE_DONE;
                             }
                         }
                         69 => {
@@ -4165,9 +4201,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 yyvs[yyvsp - 1].Node,
                             );
                             if yyval.Node < 0 {
-                                current_block = 4830776507462815627;
+                                current_block = block::YYERRLAB;
                             } else {
-                                current_block = 17353983478346836848;
+                                current_block = block::REDUCE_DONE;
                             }
                         }
                         70 => {
@@ -4179,9 +4215,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 yyvs[yyvsp].Node,
                             );
                             if yyval.Node < 0 {
-                                current_block = 4830776507462815627;
+                                current_block = block::YYERRLAB;
                             } else {
-                                current_block = 17353983478346836848;
+                                current_block = block::REDUCE_DONE;
                             }
                         }
                         71 => {
@@ -4193,9 +4229,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 yyvs[yyvsp].Node,
                             );
                             if yyval.Node < 0 {
-                                current_block = 4830776507462815627;
+                                current_block = block::YYERRLAB;
                             } else {
-                                current_block = 17353983478346836848;
+                                current_block = block::REDUCE_DONE;
                             }
                         }
                         72 => {
@@ -4207,9 +4243,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 yyvs[yyvsp].Node,
                             );
                             if yyval.Node < 0 {
-                                current_block = 4830776507462815627;
+                                current_block = block::YYERRLAB;
                             } else {
-                                current_block = 17353983478346836848;
+                                current_block = block::REDUCE_DONE;
                             }
                         }
                         73 => {
@@ -4221,9 +4257,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 yyvs[yyvsp].Node,
                             );
                             if yyval.Node < 0 {
-                                current_block = 4830776507462815627;
+                                current_block = block::YYERRLAB;
                             } else {
-                                current_block = 17353983478346836848;
+                                current_block = block::REDUCE_DONE;
                             }
                         }
                         74 => {
@@ -4235,18 +4271,18 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 ::core::mem::size_of::<c_char>() as c_ulong as c_long,
                             );
                             if yyval.Node < 0 {
-                                current_block = 4830776507462815627;
+                                current_block = block::YYERRLAB;
                             } else {
-                                current_block = 17353983478346836848;
+                                current_block = block::REDUCE_DONE;
                             }
                         }
                         75 => {
                             /* bexpr: BCOLUMN  */
                             yyval.Node = New_Column(lParse, yyvs[yyvsp].lng as c_int);
                             if yyval.Node < 0 {
-                                current_block = 4830776507462815627;
+                                current_block = block::YYERRLAB;
                             } else {
-                                current_block = 17353983478346836848;
+                                current_block = block::REDUCE_DONE;
                             }
                         }
                         76 => {
@@ -4260,7 +4296,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     lParse,
                                     cs!(c"Offset argument must be a constant integer"),
                                 );
-                                current_block = 4830776507462815627;
+                                current_block = block::YYERRLAB;
                             } else {
                                 yyval.Node = New_Offset(
                                     lParse,
@@ -4268,9 +4304,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     yyvs[yyvsp - 1].Node,
                                 );
                                 if yyval.Node < 0 {
-                                    current_block = 4830776507462815627;
+                                    current_block = block::YYERRLAB;
                                 } else {
-                                    current_block = 17353983478346836848;
+                                    current_block = block::REDUCE_DONE;
                                 }
                             }
                         }
@@ -4284,10 +4320,10 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 yyvs[yyvsp].Node,
                             );
                             if yyval.Node < 0 {
-                                current_block = 4830776507462815627;
+                                current_block = block::YYERRLAB;
                             } else {
                                 (((lParse.Nodes)[yyval.Node as usize]).value).nelem = 1;
-                                current_block = 17353983478346836848;
+                                current_block = block::REDUCE_DONE;
                             }
                         }
                         78 => {
@@ -4300,10 +4336,10 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 yyvs[yyvsp].Node,
                             );
                             if yyval.Node < 0 {
-                                current_block = 4830776507462815627;
+                                current_block = block::YYERRLAB;
                             } else {
                                 (((lParse.Nodes)[yyval.Node as usize]).value).nelem = 1;
-                                current_block = 17353983478346836848;
+                                current_block = block::REDUCE_DONE;
                             }
                         }
                         79 => {
@@ -4316,10 +4352,10 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 yyvs[yyvsp].Node,
                             );
                             if yyval.Node < 0 {
-                                current_block = 4830776507462815627;
+                                current_block = block::YYERRLAB;
                             } else {
                                 (((lParse.Nodes)[yyval.Node as usize]).value).nelem = 1;
-                                current_block = 17353983478346836848;
+                                current_block = block::REDUCE_DONE;
                             }
                         }
                         80 => {
@@ -4332,10 +4368,10 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 yyvs[yyvsp].Node,
                             );
                             if yyval.Node < 0 {
-                                current_block = 4830776507462815627;
+                                current_block = block::YYERRLAB;
                             } else {
                                 (((lParse.Nodes)[yyval.Node as usize]).value).nelem = 1;
-                                current_block = 17353983478346836848;
+                                current_block = block::REDUCE_DONE;
                             }
                         }
                         81 => {
@@ -4348,10 +4384,10 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 yyvs[yyvsp].Node,
                             );
                             if yyval.Node < 0 {
-                                current_block = 4830776507462815627;
+                                current_block = block::YYERRLAB;
                             } else {
                                 (((lParse.Nodes)[yyval.Node as usize]).value).nelem = 1;
-                                current_block = 17353983478346836848;
+                                current_block = block::REDUCE_DONE;
                             }
                         }
                         82 => {
@@ -4364,10 +4400,10 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 yyvs[yyvsp].Node,
                             );
                             if yyval.Node < 0 {
-                                current_block = 4830776507462815627;
+                                current_block = block::YYERRLAB;
                             } else {
                                 (((lParse.Nodes)[yyval.Node as usize]).value).nelem = 1;
-                                current_block = 17353983478346836848;
+                                current_block = block::REDUCE_DONE;
                             }
                         }
                         83 => {
@@ -4399,9 +4435,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 yyvs[yyvsp].Node,
                             );
                             if yyval.Node < 0 {
-                                current_block = 4830776507462815627;
+                                current_block = block::YYERRLAB;
                             } else {
-                                current_block = 17353983478346836848;
+                                current_block = block::REDUCE_DONE;
                             }
                         }
                         84 => {
@@ -4433,9 +4469,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 yyvs[yyvsp].Node,
                             );
                             if yyval.Node < 0 {
-                                current_block = 4830776507462815627;
+                                current_block = block::YYERRLAB;
                             } else {
-                                current_block = 17353983478346836848;
+                                current_block = block::REDUCE_DONE;
                             }
                         }
                         85 => {
@@ -4467,9 +4503,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 yyvs[yyvsp].Node,
                             );
                             if yyval.Node < 0 {
-                                current_block = 4830776507462815627;
+                                current_block = block::YYERRLAB;
                             } else {
-                                current_block = 17353983478346836848;
+                                current_block = block::REDUCE_DONE;
                             }
                         }
                         86 => {
@@ -4501,9 +4537,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 yyvs[yyvsp].Node,
                             );
                             if yyval.Node < 0 {
-                                current_block = 4830776507462815627;
+                                current_block = block::YYERRLAB;
                             } else {
-                                current_block = 17353983478346836848;
+                                current_block = block::REDUCE_DONE;
                             }
                         }
                         87 => {
@@ -4535,9 +4571,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 yyvs[yyvsp].Node,
                             );
                             if yyval.Node < 0 {
-                                current_block = 4830776507462815627;
+                                current_block = block::YYERRLAB;
                             } else {
-                                current_block = 17353983478346836848;
+                                current_block = block::REDUCE_DONE;
                             }
                         }
                         88 => {
@@ -4569,9 +4605,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 yyvs[yyvsp].Node,
                             );
                             if yyval.Node < 0 {
-                                current_block = 4830776507462815627;
+                                current_block = block::YYERRLAB;
                             } else {
-                                current_block = 17353983478346836848;
+                                current_block = block::REDUCE_DONE;
                             }
                         }
                         89 => {
@@ -4603,9 +4639,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 yyvs[yyvsp].Node,
                             );
                             if yyval.Node < 0 {
-                                current_block = 4830776507462815627;
+                                current_block = block::YYERRLAB;
                             } else {
-                                current_block = 17353983478346836848;
+                                current_block = block::REDUCE_DONE;
                             }
                         }
                         90 => {
@@ -4618,10 +4654,10 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 yyvs[yyvsp].Node,
                             );
                             if yyval.Node < 0 {
-                                current_block = 4830776507462815627;
+                                current_block = block::YYERRLAB;
                             } else {
                                 (((lParse.Nodes)[yyval.Node as usize]).value).nelem = 1;
-                                current_block = 17353983478346836848;
+                                current_block = block::REDUCE_DONE;
                             }
                         }
                         91 => {
@@ -4634,10 +4670,10 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 yyvs[yyvsp].Node,
                             );
                             if yyval.Node < 0 {
-                                current_block = 4830776507462815627;
+                                current_block = block::YYERRLAB;
                             } else {
                                 (((lParse.Nodes)[yyval.Node as usize]).value).nelem = 1;
-                                current_block = 17353983478346836848;
+                                current_block = block::REDUCE_DONE;
                             }
                         }
                         92 => {
@@ -4650,10 +4686,10 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 yyvs[yyvsp].Node,
                             );
                             if yyval.Node < 0 {
-                                current_block = 4830776507462815627;
+                                current_block = block::YYERRLAB;
                             } else {
                                 (((lParse.Nodes)[yyval.Node as usize]).value).nelem = 1;
-                                current_block = 17353983478346836848;
+                                current_block = block::REDUCE_DONE;
                             }
                         }
                         93 => {
@@ -4666,10 +4702,10 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 yyvs[yyvsp].Node,
                             );
                             if yyval.Node < 0 {
-                                current_block = 4830776507462815627;
+                                current_block = block::YYERRLAB;
                             } else {
                                 (((lParse.Nodes)[yyval.Node as usize]).value).nelem = 1;
-                                current_block = 17353983478346836848;
+                                current_block = block::REDUCE_DONE;
                             }
                         }
                         94 => {
@@ -4682,10 +4718,10 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 yyvs[yyvsp].Node,
                             );
                             if yyval.Node < 0 {
-                                current_block = 4830776507462815627;
+                                current_block = block::YYERRLAB;
                             } else {
                                 (((lParse.Nodes)[yyval.Node as usize]).value).nelem = 1;
-                                current_block = 17353983478346836848;
+                                current_block = block::REDUCE_DONE;
                             }
                         }
                         95 => {
@@ -4698,10 +4734,10 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 yyvs[yyvsp].Node,
                             );
                             if yyval.Node < 0 {
-                                current_block = 4830776507462815627;
+                                current_block = block::YYERRLAB;
                             } else {
                                 (((lParse.Nodes)[yyval.Node as usize]).value).nelem = 1;
-                                current_block = 17353983478346836848;
+                                current_block = block::REDUCE_DONE;
                             }
                         }
                         96 => {
@@ -4714,9 +4750,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 yyvs[yyvsp].Node,
                             );
                             if yyval.Node < 0 {
-                                current_block = 4830776507462815627;
+                                current_block = block::YYERRLAB;
                             } else {
-                                current_block = 17353983478346836848;
+                                current_block = block::REDUCE_DONE;
                             }
                         }
                         97 => {
@@ -4729,9 +4765,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 yyvs[yyvsp].Node,
                             );
                             if yyval.Node < 0 {
-                                current_block = 4830776507462815627;
+                                current_block = block::YYERRLAB;
                             } else {
-                                current_block = 17353983478346836848;
+                                current_block = block::REDUCE_DONE;
                             }
                         }
                         98 => {
@@ -4744,9 +4780,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 yyvs[yyvsp].Node,
                             );
                             if yyval.Node < 0 {
-                                current_block = 4830776507462815627;
+                                current_block = block::YYERRLAB;
                             } else {
-                                current_block = 17353983478346836848;
+                                current_block = block::REDUCE_DONE;
                             }
                         }
                         99 => {
@@ -4759,9 +4795,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 yyvs[yyvsp].Node,
                             );
                             if yyval.Node < 0 {
-                                current_block = 4830776507462815627;
+                                current_block = block::YYERRLAB;
                             } else {
-                                current_block = 17353983478346836848;
+                                current_block = block::REDUCE_DONE;
                             }
                         }
                         100 => {
@@ -4845,9 +4881,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 yyvs[yyvsp].Node,
                             );
                             if yyval.Node < 0 {
-                                current_block = 4830776507462815627;
+                                current_block = block::YYERRLAB;
                             } else {
-                                current_block = 17353983478346836848;
+                                current_block = block::REDUCE_DONE;
                             }
                         }
                         101 => {
@@ -4857,7 +4893,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     lParse,
                                     cs!(c"Incompatible dimensions in '?:' arguments"),
                                 );
-                                current_block = 4830776507462815627;
+                                current_block = block::YYERRLAB;
                             } else {
                                 yyval.Node = New_Func(
                                     lParse,
@@ -4873,7 +4909,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     0,
                                 );
                                 if yyval.Node < 0 {
-                                    current_block = 4830776507462815627;
+                                    current_block = block::YYERRLAB;
                                 } else {
                                     if ((lParse.Nodes)[yyvs[yyvsp - 2].Node as usize]).value.nelem
                                         < (lParse.Nodes[yyvs[yyvsp].Node as usize]).value.nelem
@@ -4885,7 +4921,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                             lParse,
                                             cs!(c"Incompatible dimensions in '?:' condition"),
                                         );
-                                        current_block = 4830776507462815627;
+                                        current_block = block::YYERRLAB;
                                     } else {
                                         if (((lParse.Nodes)[yyval.Node as usize]).value).nelem
                                             < ((lParse.Nodes)[yyvs[yyvsp - 4].Node as usize])
@@ -4894,7 +4930,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         {
                                             Copy_Dims(lParse, yyval.Node, yyvs[yyvsp - 4].Node);
                                         }
-                                        current_block = 17353983478346836848;
+                                        current_block = block::REDUCE_DONE;
                                     }
                                 }
                             }
@@ -4916,18 +4952,18 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     0,
                                 );
                                 if yyval.Node < 0 {
-                                    current_block = 4830776507462815627;
+                                    current_block = block::YYERRLAB;
                                 } else {
                                     ((lParse.Nodes)[yyval.Node as usize]).ntype =
                                         fits_parser_yytokentype::BOOLEAN as c_int;
-                                    current_block = 17353983478346836848;
+                                    current_block = block::REDUCE_DONE;
                                 }
                             } else {
                                 fits_parser_yyerror(
                                     lParse,
                                     cs!(c"Boolean Function(expr) not supported"),
                                 );
-                                current_block = 4830776507462815627;
+                                current_block = block::YYERRLAB;
                             }
                         }
                         103 => {
@@ -4947,18 +4983,18 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     0,
                                 );
                                 if yyval.Node < 0 {
-                                    current_block = 4830776507462815627;
+                                    current_block = block::YYERRLAB;
                                 } else {
                                     ((lParse.Nodes)[yyval.Node as usize]).ntype =
                                         fits_parser_yytokentype::BOOLEAN as c_int;
-                                    current_block = 17353983478346836848;
+                                    current_block = block::REDUCE_DONE;
                                 }
                             } else {
                                 fits_parser_yyerror(
                                     lParse,
                                     cs!(c"Boolean Function(expr) not supported"),
                                 );
-                                current_block = 4830776507462815627;
+                                current_block = block::YYERRLAB;
                             }
                         }
                         104 => {
@@ -4978,16 +5014,16 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     0,
                                 );
                                 if yyval.Node < 0 {
-                                    current_block = 4830776507462815627;
+                                    current_block = block::YYERRLAB;
                                 } else {
-                                    current_block = 17353983478346836848;
+                                    current_block = block::REDUCE_DONE;
                                 }
                             } else {
                                 fits_parser_yyerror(
                                     lParse,
                                     cs!(c"Boolean Function(expr) not supported"),
                                 );
-                                current_block = 4830776507462815627;
+                                current_block = block::YYERRLAB;
                             }
                         }
                         105 => {
@@ -5012,23 +5048,23 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         0,
                                     );
                                     if yyval.Node < 0 {
-                                        current_block = 4830776507462815627;
+                                        current_block = block::YYERRLAB;
                                     } else {
-                                        current_block = 17353983478346836848;
+                                        current_block = block::REDUCE_DONE;
                                     }
                                 } else {
                                     fits_parser_yyerror(
                                         lParse,
                                         cs!(c"Dimensions of DEFNULL arguments are not compatible"),
                                     );
-                                    current_block = 4830776507462815627;
+                                    current_block = block::YYERRLAB;
                                 }
                             } else {
                                 fits_parser_yyerror(
                                     lParse,
                                     cs!(c"Boolean Function(expr,expr) not supported"),
                                 );
-                                current_block = 4830776507462815627;
+                                current_block = block::YYERRLAB;
                             }
                         }
                         106 => {
@@ -5071,7 +5107,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     lParse,
                                     cs!(c"Dimensions of NEAR arguments are not compatible"),
                                 );
-                                current_block = 4830776507462815627;
+                                current_block = block::YYERRLAB;
                             } else if astr_eq(&yyvs[yyvsp - 6].astr, c"NEAR(") {
                                 yyval.Node = New_Func(
                                     lParse,
@@ -5087,7 +5123,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     0,
                                 );
                                 if yyval.Node < 0 {
-                                    current_block = 4830776507462815627;
+                                    current_block = block::YYERRLAB;
                                 } else {
                                     if (((lParse.Nodes)[yyval.Node as usize]).value).nelem
                                         < ((lParse.Nodes)[yyvs[yyvsp - 5].Node as usize])
@@ -5110,11 +5146,11 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     {
                                         Copy_Dims(lParse, yyval.Node, yyvs[yyvsp - 1].Node);
                                     }
-                                    current_block = 17353983478346836848;
+                                    current_block = block::REDUCE_DONE;
                                 }
                             } else {
                                 fits_parser_yyerror(lParse, cs!(c"Boolean Function not supported"));
-                                current_block = 4830776507462815627;
+                                current_block = block::YYERRLAB;
                             }
                         }
                         107 => {
@@ -5181,7 +5217,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     lParse,
                                     cs!(c"Dimensions of CIRCLE arguments are not compatible"),
                                 );
-                                current_block = 4830776507462815627;
+                                current_block = block::YYERRLAB;
                             } else if astr_eq(&yyvs[yyvsp - 10].astr, c"CIRCLE(") {
                                 yyval.Node = New_Func(
                                     lParse,
@@ -5197,7 +5233,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     0,
                                 );
                                 if yyval.Node < 0 {
-                                    current_block = 4830776507462815627;
+                                    current_block = block::YYERRLAB;
                                 } else {
                                     if (((lParse.Nodes)[yyval.Node as usize]).value).nelem
                                         < ((lParse.Nodes)[yyvs[yyvsp - 9].Node as usize])
@@ -5234,11 +5270,11 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     {
                                         Copy_Dims(lParse, yyval.Node, yyvs[yyvsp - 1].Node);
                                     }
-                                    current_block = 17353983478346836848;
+                                    current_block = block::REDUCE_DONE;
                                 }
                             } else {
                                 fits_parser_yyerror(lParse, cs!(c"Boolean Function not supported"));
-                                current_block = 4830776507462815627;
+                                current_block = block::YYERRLAB;
                             }
                         }
                         108 => {
@@ -5327,7 +5363,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     != 0)
                             {
                                 fits_parser_yyerror(lParse, cs!(c"Dimensions of BOX or ELLIPSE arguments are not compatible"));
-                                current_block = 4830776507462815627;
+                                current_block = block::YYERRLAB;
                             } else {
                                 if astr_eq(&yyvs[yyvsp - 14].astr, c"BOX(") {
                                     yyval.Node = New_Func(
@@ -5343,7 +5379,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         yyvs[yyvsp - 3].Node,
                                         yyvs[yyvsp - 1].Node,
                                     );
-                                    current_block = 3023179740610631044;
+                                    current_block = block::REDUCE_JOIN_12;
                                 } else if astr_eq(&yyvs[yyvsp - 14].astr, c"ELLIPSE(") {
                                     yyval.Node = New_Func(
                                         lParse,
@@ -5358,19 +5394,19 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         yyvs[yyvsp - 3].Node,
                                         yyvs[yyvsp - 1].Node,
                                     );
-                                    current_block = 3023179740610631044;
+                                    current_block = block::REDUCE_JOIN_12;
                                 } else {
                                     fits_parser_yyerror(
                                         lParse,
                                         cs!(c"SAO Image Function not supported"),
                                     );
-                                    current_block = 4830776507462815627;
+                                    current_block = block::YYERRLAB;
                                 }
                                 match current_block {
-                                    4830776507462815627 => {}
+                                    block::YYERRLAB => {}
                                     _ => {
                                         if yyval.Node < 0 {
-                                            current_block = 4830776507462815627;
+                                            current_block = block::YYERRLAB;
                                         } else {
                                             if (((lParse.Nodes)[yyval.Node as usize]).value).nelem
                                                 < ((lParse.Nodes)[yyvs[yyvsp - 13].Node as usize])
@@ -5441,7 +5477,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                             {
                                                 Copy_Dims(lParse, yyval.Node, yyvs[yyvsp - 1].Node);
                                             }
-                                            current_block = 17353983478346836848;
+                                            current_block = block::REDUCE_DONE;
                                         }
                                     }
                                 }
@@ -5460,9 +5496,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 c"*STOP*".as_ptr() as *mut c_char,
                             );
                             if yyval.Node < 0 {
-                                current_block = 4830776507462815627;
+                                current_block = block::YYERRLAB;
                             } else {
-                                current_block = 17353983478346836848;
+                                current_block = block::REDUCE_DONE;
                             }
                         }
                         110 => {
@@ -5478,9 +5514,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 c"*STOP*".as_ptr() as *mut c_char,
                             );
                             if yyval.Node < 0 {
-                                current_block = 4830776507462815627;
+                                current_block = block::YYERRLAB;
                             } else {
-                                current_block = 17353983478346836848;
+                                current_block = block::REDUCE_DONE;
                             }
                         }
                         111 => {
@@ -5495,9 +5531,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 c"*STOP*".as_ptr() as *mut c_char,
                             );
                             if yyval.Node < 0 {
-                                current_block = 4830776507462815627;
+                                current_block = block::YYERRLAB;
                             } else {
-                                current_block = 17353983478346836848;
+                                current_block = block::REDUCE_DONE;
                             }
                         }
                         112 => {
@@ -5512,9 +5548,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 (yyvs[yyvsp - 1].astr).as_mut_ptr(),
                             );
                             if yyval.Node < 0 {
-                                current_block = 4830776507462815627;
+                                current_block = block::YYERRLAB;
                             } else {
-                                current_block = 17353983478346836848;
+                                current_block = block::REDUCE_DONE;
                             }
                         }
                         113 => {
@@ -5530,9 +5566,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 c"*STOP*".as_ptr() as *mut c_char,
                             );
                             if yyval.Node < 0 {
-                                current_block = 4830776507462815627;
+                                current_block = block::YYERRLAB;
                             } else {
-                                current_block = 17353983478346836848;
+                                current_block = block::REDUCE_DONE;
                             }
                         }
                         114 => {
@@ -5547,9 +5583,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 c"*STOP*".as_ptr() as *mut c_char,
                             );
                             if yyval.Node < 0 {
-                                current_block = 4830776507462815627;
+                                current_block = block::YYERRLAB;
                             } else {
-                                current_block = 17353983478346836848;
+                                current_block = block::REDUCE_DONE;
                             }
                         }
                         115 => {
@@ -5564,9 +5600,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 c"*STOP*".as_ptr() as *mut c_char,
                             );
                             if yyval.Node < 0 {
-                                current_block = 4830776507462815627;
+                                current_block = block::YYERRLAB;
                             } else {
-                                current_block = 17353983478346836848;
+                                current_block = block::REDUCE_DONE;
                             }
                         }
                         116 => {
@@ -5581,9 +5617,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 (yyvs[yyvsp - 1].astr).as_mut_ptr(),
                             );
                             if yyval.Node < 0 {
-                                current_block = 4830776507462815627;
+                                current_block = block::YYERRLAB;
                             } else {
-                                current_block = 17353983478346836848;
+                                current_block = block::REDUCE_DONE;
                             }
                         }
                         117 => {
@@ -5597,9 +5633,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 dummy.as_mut_ptr(),
                             );
                             if yyval.Node < 0 {
-                                current_block = 4830776507462815627;
+                                current_block = block::YYERRLAB;
                             } else {
-                                current_block = 17353983478346836848;
+                                current_block = block::REDUCE_DONE;
                             }
                         }
                         118 => {
@@ -5613,9 +5649,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 dummy.as_mut_ptr(),
                             );
                             if yyval.Node < 0 {
-                                current_block = 4830776507462815627;
+                                current_block = block::YYERRLAB;
                             } else {
-                                current_block = 17353983478346836848;
+                                current_block = block::REDUCE_DONE;
                             }
                         }
                         119 => {
@@ -5628,9 +5664,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 (yyvs[yyvsp - 1].astr).as_mut_ptr(),
                             );
                             if yyval.Node < 0 {
-                                current_block = 4830776507462815627;
+                                current_block = block::YYERRLAB;
                             } else {
-                                current_block = 17353983478346836848;
+                                current_block = block::REDUCE_DONE;
                             }
                         }
                         120 => {
@@ -5646,9 +5682,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 0,
                             );
                             if yyval.Node < 0 {
-                                current_block = 4830776507462815627;
+                                current_block = block::YYERRLAB;
                             } else {
-                                current_block = 17353983478346836848;
+                                current_block = block::REDUCE_DONE;
                             }
                         }
                         121 => {
@@ -5664,9 +5700,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 0,
                             );
                             if yyval.Node < 0 {
-                                current_block = 4830776507462815627;
+                                current_block = block::YYERRLAB;
                             } else {
-                                current_block = 17353983478346836848;
+                                current_block = block::REDUCE_DONE;
                             }
                         }
                         122 => {
@@ -5682,9 +5718,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 0,
                             );
                             if yyval.Node < 0 {
-                                current_block = 4830776507462815627;
+                                current_block = block::YYERRLAB;
                             } else {
-                                current_block = 17353983478346836848;
+                                current_block = block::REDUCE_DONE;
                             }
                         }
                         123 => {
@@ -5700,9 +5736,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 0,
                             );
                             if yyval.Node < 0 {
-                                current_block = 4830776507462815627;
+                                current_block = block::YYERRLAB;
                             } else {
-                                current_block = 17353983478346836848;
+                                current_block = block::REDUCE_DONE;
                             }
                         }
                         124 => {
@@ -5718,9 +5754,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 yyvs[yyvsp - 1].Node,
                             );
                             if yyval.Node < 0 {
-                                current_block = 4830776507462815627;
+                                current_block = block::YYERRLAB;
                             } else {
-                                current_block = 17353983478346836848;
+                                current_block = block::REDUCE_DONE;
                             }
                         }
                         125 => {
@@ -5732,15 +5768,15 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 yyvs[yyvsp].Node,
                             );
                             if yyval.Node < 0 {
-                                current_block = 4830776507462815627;
+                                current_block = block::YYERRLAB;
                             } else {
-                                current_block = 17353983478346836848;
+                                current_block = block::REDUCE_DONE;
                             }
                         }
                         126 => {
                             /* bexpr: '(' bexpr ')'  */
                             yyval.Node = yyvs[yyvsp - 1].Node;
-                            current_block = 17353983478346836848;
+                            current_block = block::REDUCE_DONE;
                         }
                         127 => {
                             /* sexpr: STRING  */
@@ -5752,20 +5788,20 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     as c_long,
                             );
                             if yyval.Node < 0 {
-                                current_block = 4830776507462815627;
+                                current_block = block::YYERRLAB;
                             } else {
                                 (((lParse.Nodes)[yyval.Node as usize]).value).nelem =
                                     astr_len(&yyvs[yyvsp].astr) as c_long;
-                                current_block = 17353983478346836848;
+                                current_block = block::REDUCE_DONE;
                             }
                         }
                         128 => {
                             /* sexpr: SCOLUMN  */
                             yyval.Node = New_Column(lParse, yyvs[yyvsp].lng as c_int);
                             if yyval.Node < 0 {
-                                current_block = 4830776507462815627;
+                                current_block = block::YYERRLAB;
                             } else {
-                                current_block = 17353983478346836848;
+                                current_block = block::REDUCE_DONE;
                             }
                         }
                         129 => {
@@ -5779,7 +5815,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     lParse,
                                     cs!(c"Offset argument must be a constant integer"),
                                 );
-                                current_block = 4830776507462815627;
+                                current_block = block::YYERRLAB;
                             } else {
                                 yyval.Node = New_Offset(
                                     lParse,
@@ -5787,9 +5823,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     yyvs[yyvsp - 1].Node,
                                 );
                                 if yyval.Node < 0 {
-                                    current_block = 4830776507462815627;
+                                    current_block = block::YYERRLAB;
                                 } else {
-                                    current_block = 17353983478346836848;
+                                    current_block = block::REDUCE_DONE;
                                 }
                             }
                         }
@@ -5808,12 +5844,12 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 0,
                                 0,
                             );
-                            current_block = 17353983478346836848;
+                            current_block = block::REDUCE_DONE;
                         }
                         131 => {
                             /* sexpr: '(' sexpr ')'  */
                             yyval.Node = yyvs[yyvsp - 1].Node;
-                            current_block = 17353983478346836848;
+                            current_block = block::REDUCE_DONE;
                         }
                         132 => {
                             /* sexpr: sexpr '+' sexpr  */
@@ -5825,7 +5861,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     lParse,
                                     cs!(c"Combined string size exceeds 255 characters"),
                                 );
-                                current_block = 4830776507462815627;
+                                current_block = block::YYERRLAB;
                             } else {
                                 yyval.Node = New_BinOp(
                                     lParse,
@@ -5835,14 +5871,14 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     yyvs[yyvsp].Node,
                                 );
                                 if yyval.Node < 0 {
-                                    current_block = 4830776507462815627;
+                                    current_block = block::YYERRLAB;
                                 } else {
                                     (((lParse.Nodes)[yyval.Node as usize]).value).nelem =
                                         ((lParse.Nodes)[yyvs[yyvsp - 2].Node as usize]).value.nelem
                                             + ((lParse.Nodes)[yyvs[yyvsp].Node as usize])
                                                 .value
                                                 .nelem;
-                                    current_block = 17353983478346836848;
+                                    current_block = block::REDUCE_DONE;
                                 }
                             }
                         }
@@ -5854,7 +5890,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     lParse,
                                     cs!(c"Cannot have a vector string column"),
                                 );
-                                current_block = 4830776507462815627; // goto yyerrorlab
+                                current_block = block::YYERRLAB; // goto yyerrorlab
                             } else {
                                 /* Since the output can be calculated now, as a constant
                                 scalar, we must precalculate the output size, in
@@ -5884,14 +5920,14 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     outSize,
                                 );
                                 if yyval.Node < 0 {
-                                    current_block = 4830776507462815627;
+                                    current_block = block::YYERRLAB;
                                 } else {
                                     if ((lParse.Nodes)[yyvs[yyvsp - 2].Node as usize]).value.nelem
                                         < (lParse.Nodes[yyvs[yyvsp].Node as usize]).value.nelem
                                     {
                                         Copy_Dims(lParse, yyval.Node, yyvs[yyvsp].Node);
                                     }
-                                    current_block = 17353983478346836848;
+                                    current_block = block::REDUCE_DONE;
                                 }
                             }
                         }
@@ -5928,7 +5964,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     outSize_0,
                                 );
                                 if yyval.Node < 0 {
-                                    current_block = 4830776507462815627;
+                                    current_block = block::YYERRLAB;
                                 } else {
                                     if ((lParse.Nodes)[yyvs[yyvsp - 1].Node as usize]).value.nelem
                                         > ((lParse.Nodes)[yyvs[yyvsp - 3].Node as usize])
@@ -5940,14 +5976,14 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                                 .value
                                                 .nelem;
                                     }
-                                    current_block = 17353983478346836848;
+                                    current_block = block::REDUCE_DONE;
                                 }
                             } else {
                                 fits_parser_yyerror(
                                     lParse,
                                     cs!(c"Function(string,string) not supported"),
                                 );
-                                current_block = 4830776507462815627;
+                                current_block = block::YYERRLAB;
                             }
                         }
                         135 => {
@@ -5964,7 +6000,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         != 1
                                 {
                                     fits_parser_yyerror(lParse, cs!(c"When using STRMID(S,P,N), P and N must be integers (and not vector columns)"));
-                                    current_block = 4830776507462815627;
+                                    current_block = block::YYERRLAB;
                                 } else {
                                     if ((lParse.Nodes)[yyvs[yyvsp - 1].Node as usize]).operation
                                         == CONST_OP
@@ -5987,7 +6023,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                             lParse,
                                             cs!(c"STRMID(S,P,N), N must be 1-255"),
                                         );
-                                        current_block = 4830776507462815627;
+                                        current_block = block::YYERRLAB;
                                     } else {
                                         yyval.Node = New_FuncSize(
                                             lParse,
@@ -6004,9 +6040,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                             len,
                                         );
                                         if yyval.Node < 0 {
-                                            current_block = 4830776507462815627;
+                                            current_block = block::YYERRLAB;
                                         } else {
-                                            current_block = 17353983478346836848;
+                                            current_block = block::REDUCE_DONE;
                                         }
                                     }
                                 }
@@ -6015,11 +6051,11 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     lParse,
                                     cs!(c"Function(string,expr,expr) not supported"),
                                 );
-                                current_block = 4830776507462815627;
+                                current_block = block::YYERRLAB;
                             }
                         }
                         _ => {
-                            current_block = 17353983478346836848;
+                            current_block = block::REDUCE_DONE;
                         }
                     }
 
@@ -6044,13 +6080,13 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                     );
 
                     match current_block {
-                        4830776507462815627 => {
+                        block::YYERRLAB => {
                             fits_parser_yynerrs += 1;
                             yyvsp -= yylen as usize;
                             yyssp -= yylen as usize;
                             yylen = 0;
                             yystate = yy_state_fast_t::from(yyss[yyssp]);
-                            current_block = 1774893048582444437;
+                            current_block = block::YYERRLAB1;
                         }
                         _ => {
                             yyvsp -= yylen as usize;
@@ -6074,12 +6110,12 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             } else {
                                 c_int::from(YYDEFGOTO[yylhs as usize])
                             };
-                            current_block = 7872030484262409139; // goto yynewstate;
+                            current_block = block::YYNEWSTATE; // goto yynewstate;
                         }
                     }
                 }
 
-                if current_block == 1774893048582444437 {
+                if current_block == block::YYERRLAB1 {
                     yyerrstatus = 3 as c_int;
                     loop {
                         yyn = c_int::from(YYPACT[yystate as usize]);
@@ -6096,7 +6132,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             }
                         }
                         if yyssp == 0 {
-                            current_block = 3964311021479492664;
+                            current_block = block::YYABORTLAB;
                             break 's_54;
                         }
                         yydestruct(
@@ -6124,11 +6160,11 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
             }
         }
         match current_block {
-            11794367917084412820 => {
+            block::YYEXHAUSTEDLAB => {
                 fits_parser_yyerror(lParse, cs!(c"memory exhausted"));
                 yyresult = 2;
             }
-            3964311021479492664 => {
+            block::YYABORTLAB => {
                 yyresult = 1;
             }
             _ => {}

--- a/src/eval_y.rs
+++ b/src/eval_y.rs
@@ -13955,332 +13955,112 @@ fn Do_Array(lParse: &mut ParseData, this_node_idx: usize) {
     }
 }
 
-fn bitlgte(mut bits1: *mut c_char, oper: c_int, mut bits2: *mut c_char) -> c_char {
+/// Fetch bit `j` of a bit string that has been left-padded with '0' to `width`.
+/// Positions left of the original string (`j < width - len`) read as '0'.
+#[inline]
+fn padded_bit(s: &[c_char], width: usize, j: usize) -> c_char {
+    let len = s.len();
+    if j + len >= width {
+        s[j + len - width]
+    } else {
+        b'0' as c_char
+    }
+}
+
+fn bitlgte(bits1: *mut c_char, oper: c_int, bits2: *mut c_char) -> c_char {
     unsafe {
+        // Confine unsafe to reading the two NUL-terminated bit strings.
+        let l1 = strlen(bits1) as usize;
+        let l2 = strlen(bits2) as usize;
+        let s1 = core::slice::from_raw_parts(bits1, l1);
+        let s2 = core::slice::from_raw_parts(bits2, l2);
+        let length = l1.max(l2);
+
+        // Interpret both strings as unsigned integers (rightmost char = LSB),
+        // skipping don't-care ('x'/'X') positions, then compare magnitudes.
         let mut val1: c_int = 0;
         let mut val2: c_int = 0;
-        let mut nextbit: c_int = 0;
-        let mut result: c_char = 0;
-        let mut i: c_int = 0;
-        let mut l1: c_int = 0;
-        let mut l2: c_int = 0;
-        let mut length: c_int = 0;
-        let mut ldiff: c_int = 0;
-        let mut stream: *mut c_char = ptr::null_mut();
-        let mut chr1: c_char = 0;
-        let mut chr2: c_char = 0;
-        l1 = strlen(bits1) as c_int;
-        l2 = strlen(bits2) as c_int;
-        length = if l1 > l2 { l1 } else { l2 };
-        stream = malloc(
-            (::core::mem::size_of::<c_char>() as c_ulong)
-                .wrapping_mul((length + 1) as c_ulong)
-                .try_into()
-                .unwrap(),
-        )
-        .cast::<c_char>();
-        if l1 < l2 {
-            ldiff = l2 - l1;
-            i = 0;
-            loop {
-                let fresh218 = ldiff;
-                ldiff -= 1;
-                if fresh218 == 0 {
-                    break;
-                }
-                let fresh219 = i;
-                i += 1;
-                *stream.offset(fresh219 as isize) = b'0' as c_char;
-            }
-            loop {
-                let fresh220 = l1;
-                l1 -= 1;
-                if fresh220 == 0 {
-                    break;
-                }
-                let fresh221 = bits1;
-                bits1 = bits1.offset(1);
-                let fresh222 = i;
-                i += 1;
-                *stream.offset(fresh222 as isize) = *fresh221;
-            }
-            *stream.offset(i as isize) = 0;
-            bits1 = stream;
-        } else if l2 < l1 {
-            ldiff = l1 - l2;
-            i = 0;
-            loop {
-                let fresh223 = ldiff;
-                ldiff -= 1;
-                if fresh223 == 0 {
-                    break;
-                }
-                let fresh224 = i;
-                i += 1;
-                *stream.offset(fresh224 as isize) = b'0' as c_char;
-            }
-            loop {
-                let fresh225 = l2;
-                l2 -= 1;
-                if fresh225 == 0 {
-                    break;
-                }
-                let fresh226 = bits2;
-                bits2 = bits2.offset(1);
-                let fresh227 = i;
-                i += 1;
-                *stream.offset(fresh227 as isize) = *fresh226;
-            }
-            *stream.offset(i as isize) = 0;
-            bits2 = stream;
-        }
-        val2 = 0;
-        val1 = val2;
-        nextbit = 1;
-        loop {
-            let fresh228 = length;
-            length -= 1;
-            if fresh228 == 0 {
-                break;
-            }
-            chr1 = *bits1.offset(length as isize);
-            chr2 = *bits2.offset(length as isize);
-            if c_int::from(chr1) != 'x' as i32
-                && c_int::from(chr1) != 'X' as i32
-                && c_int::from(chr2) != 'x' as i32
-                && c_int::from(chr2) != 'X' as i32
+        let mut nextbit: c_int = 1;
+        for j in (0..length).rev() {
+            let chr1 = padded_bit(s1, length, j);
+            let chr2 = padded_bit(s2, length, j);
+            if chr1 != b'x' as c_char
+                && chr1 != b'X' as c_char
+                && chr2 != b'x' as c_char
+                && chr2 != b'X' as c_char
             {
-                if c_int::from(chr1) == '1' as i32 {
+                if chr1 == b'1' as c_char {
                     val1 += nextbit;
                 }
-                if c_int::from(chr2) == '1' as i32 {
+                if chr2 == b'1' as c_char {
                     val2 += nextbit;
                 }
                 nextbit *= 2;
             }
         }
-        result = 0;
-        match oper {
-            282 => {
-                if val1 < val2 {
-                    result = 1;
-                }
-            }
-            283 => {
-                if val1 <= val2 {
-                    result = 1;
-                }
-            }
-            281 => {
-                if val1 > val2 {
-                    result = 1;
-                }
-            }
-            284 => {
-                if val1 >= val2 {
-                    result = 1;
-                }
-            }
-            _ => {}
-        }
-        free(stream.cast::<c_void>());
-        result
+
+        (match oper {
+            282 => val1 < val2,
+            283 => val1 <= val2,
+            281 => val1 > val2,
+            284 => val1 >= val2,
+            _ => false,
+        }) as c_char
     }
 }
-fn bitand(mut result: *mut c_char, mut bitstrm1: *mut c_char, mut bitstrm2: *mut c_char) {
+/// Combine two NUL-terminated bit strings bit-by-bit with `op`, left-padding the
+/// shorter operand with '0', and write the NUL-terminated result to `result`
+/// (which must hold at least `max(len1, len2) + 1` bytes). Replaces the C
+/// malloc-a-scratch-stream-and-pointer-walk idiom with bounded slice access.
+///
+/// # Safety
+/// `bitstrm1`/`bitstrm2` must be valid NUL-terminated strings and `result` must
+/// point to a buffer large enough for the longer operand plus a NUL; `result`
+/// must not overlap either operand.
+unsafe fn bit_binop(
+    result: *mut c_char,
+    bitstrm1: *mut c_char,
+    bitstrm2: *mut c_char,
+    op: impl Fn(c_char, c_char) -> c_char,
+) {
     unsafe {
-        let mut i: c_int = 0;
-        let mut l1: c_int = 0;
-        let mut l2: c_int = 0;
-        let mut ldiff: c_int = 0;
-        let mut largestStream: c_int = 0;
-        let mut stream: *mut c_char = ptr::null_mut();
-        let mut chr1: c_char = 0;
-        let mut chr2: c_char = 0;
-        l1 = strlen(bitstrm1) as c_int;
-        l2 = strlen(bitstrm2) as c_int;
-        largestStream = if l1 > l2 { l1 } else { l2 };
-        stream = malloc(
-            (::core::mem::size_of::<c_char>() as c_ulong)
-                .wrapping_mul((largestStream + 1) as c_ulong)
-                .try_into()
-                .unwrap(),
-        )
-        .cast::<c_char>();
-        if l1 < l2 {
-            ldiff = l2 - l1;
-            i = 0;
-            loop {
-                let fresh229 = ldiff;
-                ldiff -= 1;
-                if fresh229 == 0 {
-                    break;
-                }
-                let fresh230 = i;
-                i += 1;
-                *stream.offset(fresh230 as isize) = b'0' as c_char;
-            }
-            loop {
-                let fresh231 = l1;
-                l1 -= 1;
-                if fresh231 == 0 {
-                    break;
-                }
-                let fresh232 = bitstrm1;
-                bitstrm1 = bitstrm1.offset(1);
-                let fresh233 = i;
-                i += 1;
-                *stream.offset(fresh233 as isize) = *fresh232;
-            }
-            *stream.offset(i as isize) = 0;
-            bitstrm1 = stream;
-        } else if l2 < l1 {
-            ldiff = l1 - l2;
-            i = 0;
-            loop {
-                let fresh234 = ldiff;
-                ldiff -= 1;
-                if fresh234 == 0 {
-                    break;
-                }
-                let fresh235 = i;
-                i += 1;
-                *stream.offset(fresh235 as isize) = b'0' as c_char;
-            }
-            loop {
-                let fresh236 = l2;
-                l2 -= 1;
-                if fresh236 == 0 {
-                    break;
-                }
-                let fresh237 = bitstrm2;
-                bitstrm2 = bitstrm2.offset(1);
-                let fresh238 = i;
-                i += 1;
-                *stream.offset(fresh238 as isize) = *fresh237;
-            }
-            *stream.offset(i as isize) = 0;
-            bitstrm2 = stream;
+        let l1 = strlen(bitstrm1) as usize;
+        let l2 = strlen(bitstrm2) as usize;
+        let s1 = core::slice::from_raw_parts(bitstrm1, l1);
+        let s2 = core::slice::from_raw_parts(bitstrm2, l2);
+        let n = l1.max(l2);
+        let out = core::slice::from_raw_parts_mut(result, n + 1);
+        for i in 0..n {
+            out[i] = op(padded_bit(s1, n, i), padded_bit(s2, n, i));
         }
-        loop {
-            let fresh239 = bitstrm1;
-            bitstrm1 = bitstrm1.offset(1);
-            chr1 = *fresh239;
-            if chr1 == 0 {
-                break;
-            }
-            let fresh240 = bitstrm2;
-            bitstrm2 = bitstrm2.offset(1);
-            chr2 = *fresh240;
-            if c_int::from(chr1) == 'x' as i32 || c_int::from(chr2) == 'x' as i32 {
-                *result = b'x' as c_char;
-            } else if c_int::from(chr1) == '1' as i32 && c_int::from(chr2) == '1' as i32 {
-                *result = b'1' as c_char;
-            } else {
-                *result = b'0' as c_char;
-            }
-            result = result.offset(1);
-        }
-        free(stream.cast::<c_void>());
-        *result = 0;
+        out[n] = 0;
     }
 }
-fn bitor(mut result: *mut c_char, mut bitstrm1: *mut c_char, mut bitstrm2: *mut c_char) {
+
+fn bitand(result: *mut c_char, bitstrm1: *mut c_char, bitstrm2: *mut c_char) {
     unsafe {
-        let mut i: c_int = 0;
-        let mut l1: c_int = 0;
-        let mut l2: c_int = 0;
-        let mut ldiff: c_int = 0;
-        let mut largestStream: c_int = 0;
-        let mut stream: *mut c_char = ptr::null_mut();
-        let mut chr1: c_char = 0;
-        let mut chr2: c_char = 0;
-        l1 = strlen(bitstrm1) as c_int;
-        l2 = strlen(bitstrm2) as c_int;
-        largestStream = if l1 > l2 { l1 } else { l2 };
-        stream = malloc(
-            (::core::mem::size_of::<c_char>() as c_ulong)
-                .wrapping_mul((largestStream + 1) as c_ulong)
-                .try_into()
-                .unwrap(),
-        )
-        .cast::<c_char>();
-        if l1 < l2 {
-            ldiff = l2 - l1;
-            i = 0;
-            loop {
-                let fresh241 = ldiff;
-                ldiff -= 1;
-                if fresh241 == 0 {
-                    break;
-                }
-                let fresh242 = i;
-                i += 1;
-                *stream.offset(fresh242 as isize) = b'0' as c_char;
-            }
-            loop {
-                let fresh243 = l1;
-                l1 -= 1;
-                if fresh243 == 0 {
-                    break;
-                }
-                let fresh244 = bitstrm1;
-                bitstrm1 = bitstrm1.offset(1);
-                let fresh245 = i;
-                i += 1;
-                *stream.offset(fresh245 as isize) = *fresh244;
-            }
-            *stream.offset(i as isize) = 0;
-            bitstrm1 = stream;
-        } else if l2 < l1 {
-            ldiff = l1 - l2;
-            i = 0;
-            loop {
-                let fresh246 = ldiff;
-                ldiff -= 1;
-                if fresh246 == 0 {
-                    break;
-                }
-                let fresh247 = i;
-                i += 1;
-                *stream.offset(fresh247 as isize) = b'0' as c_char;
-            }
-            loop {
-                let fresh248 = l2;
-                l2 -= 1;
-                if fresh248 == 0 {
-                    break;
-                }
-                let fresh249 = bitstrm2;
-                bitstrm2 = bitstrm2.offset(1);
-                let fresh250 = i;
-                i += 1;
-                *stream.offset(fresh250 as isize) = *fresh249;
-            }
-            *stream.offset(i as isize) = 0;
-            bitstrm2 = stream;
-        }
-        loop {
-            let fresh251 = bitstrm1;
-            bitstrm1 = bitstrm1.offset(1);
-            chr1 = *fresh251;
-            if chr1 == 0 {
-                break;
-            }
-            let fresh252 = bitstrm2;
-            bitstrm2 = bitstrm2.offset(1);
-            chr2 = *fresh252;
-            if c_int::from(chr1) == '1' as i32 || c_int::from(chr2) == '1' as i32 {
-                *result = b'1' as c_char;
-            } else if c_int::from(chr1) == '0' as i32 || c_int::from(chr2) == '0' as i32 {
-                *result = b'0' as c_char;
+        bit_binop(result, bitstrm1, bitstrm2, |chr1, chr2| {
+            if chr1 == b'x' as c_char || chr2 == b'x' as c_char {
+                b'x' as c_char
+            } else if chr1 == b'1' as c_char && chr2 == b'1' as c_char {
+                b'1' as c_char
             } else {
-                *result = b'x' as c_char;
+                b'0' as c_char
             }
-            result = result.offset(1);
-        }
-        free(stream.cast::<c_void>());
-        *result = 0;
+        });
+    }
+}
+fn bitor(result: *mut c_char, bitstrm1: *mut c_char, bitstrm2: *mut c_char) {
+    unsafe {
+        bit_binop(result, bitstrm1, bitstrm2, |chr1, chr2| {
+            if chr1 == b'1' as c_char || chr2 == b'1' as c_char {
+                b'1' as c_char
+            } else if chr1 == b'0' as c_char || chr2 == b'0' as c_char {
+                b'0' as c_char
+            } else {
+                b'x' as c_char
+            }
+        });
     }
 }
 fn bitnot(result: *mut c_char, bits: *mut c_char) {

--- a/src/eval_y.rs
+++ b/src/eval_y.rs
@@ -9438,156 +9438,114 @@ fn Do_BinOp_dbl(lParse: &mut ParseData, this_node_idx: usize) {
     }
 }
 
-pub(crate) fn qselect_median_lng(arr: *mut c_long, n: c_int) -> c_long {
-    unsafe {
-        let mut low: c_int = 0;
-        let mut high: c_int = 0;
-        let mut median: c_int = 0;
-        let mut middle: c_int = 0;
-        let mut ll: c_int = 0;
-        let mut hh: c_int = 0;
-        low = 0;
-        high = n - 1;
-        median = (low + high) / 2;
+/// Quickselect median of `arr[0..n]` (rearranges `arr`). Fully bounds-checked.
+pub(crate) fn qselect_median_lng(arr: &mut [c_long], n: c_int) -> c_long {
+    let mut low: c_int = 0;
+    let mut high: c_int = n - 1;
+    let median: c_int = (low + high) / 2;
+    loop {
+        if high <= low {
+            return arr[median as usize];
+        }
+        if high == low + 1 {
+            if arr[low as usize] > arr[high as usize] {
+                arr.swap(low as usize, high as usize);
+            }
+            return arr[median as usize];
+        }
+        let middle: c_int = (low + high) / 2;
+        if arr[middle as usize] > arr[high as usize] {
+            arr.swap(middle as usize, high as usize);
+        }
+        if arr[low as usize] > arr[high as usize] {
+            arr.swap(low as usize, high as usize);
+        }
+        if arr[middle as usize] > arr[low as usize] {
+            arr.swap(middle as usize, low as usize);
+        }
+        arr.swap(middle as usize, (low + 1) as usize);
+        let mut ll: c_int = low + 1;
+        let mut hh: c_int = high;
         loop {
-            if high <= low {
-                return *arr.offset(median as isize);
-            }
-            if high == low + 1 {
-                if *arr.offset(low as isize) > *arr.offset(high as isize) {
-                    let t: c_long = *arr.offset(low as isize);
-                    *arr.offset(low as isize) = *arr.offset(high as isize);
-                    *arr.offset(high as isize) = t;
-                }
-                return *arr.offset(median as isize);
-            }
-            middle = (low + high) / 2;
-            if *arr.offset(middle as isize) > *arr.offset(high as isize) {
-                let t_0: c_long = *arr.offset(middle as isize);
-                *arr.offset(middle as isize) = *arr.offset(high as isize);
-                *arr.offset(high as isize) = t_0;
-            }
-            if *arr.offset(low as isize) > *arr.offset(high as isize) {
-                let t_1: c_long = *arr.offset(low as isize);
-                *arr.offset(low as isize) = *arr.offset(high as isize);
-                *arr.offset(high as isize) = t_1;
-            }
-            if *arr.offset(middle as isize) > *arr.offset(low as isize) {
-                let t_2: c_long = *arr.offset(middle as isize);
-                *arr.offset(middle as isize) = *arr.offset(low as isize);
-                *arr.offset(low as isize) = t_2;
-            }
-            let t_3: c_long = *arr.offset(middle as isize);
-            *arr.offset(middle as isize) = *arr.offset((low + 1) as isize);
-            *arr.offset((low + 1) as isize) = t_3;
-            ll = low + 1;
-            hh = high;
             loop {
-                loop {
-                    ll += 1;
-                    if *arr.offset(low as isize) <= *arr.offset(ll as isize) {
-                        break;
-                    }
-                }
-                loop {
-                    hh -= 1;
-                    if *arr.offset(hh as isize) <= *arr.offset(low as isize) {
-                        break;
-                    }
-                }
-                if hh < ll {
+                ll += 1;
+                if arr[low as usize] <= arr[ll as usize] {
                     break;
                 }
-                let t_4: c_long = *arr.offset(ll as isize);
-                *arr.offset(ll as isize) = *arr.offset(hh as isize);
-                *arr.offset(hh as isize) = t_4;
             }
-            let t_5: c_long = *arr.offset(low as isize);
-            *arr.offset(low as isize) = *arr.offset(hh as isize);
-            *arr.offset(hh as isize) = t_5;
-            if hh <= median {
-                low = ll;
+            loop {
+                hh -= 1;
+                if arr[hh as usize] <= arr[low as usize] {
+                    break;
+                }
             }
-            if hh >= median {
-                high = hh - 1;
+            if hh < ll {
+                break;
             }
+            arr.swap(ll as usize, hh as usize);
+        }
+        arr.swap(low as usize, hh as usize);
+        if hh <= median {
+            low = ll;
+        }
+        if hh >= median {
+            high = hh - 1;
         }
     }
 }
 
-pub(crate) fn qselect_median_dbl(arr: *mut c_double, n: c_int) -> c_double {
-    unsafe {
-        let mut low: c_int = 0;
-        let mut high: c_int = 0;
-        let mut median: c_int = 0;
-        let mut middle: c_int = 0;
-        let mut ll: c_int = 0;
-        let mut hh: c_int = 0;
-        low = 0;
-        high = n - 1;
-        median = (low + high) / 2;
+/// Quickselect median of `arr[0..n]` (rearranges `arr`). Fully bounds-checked.
+pub(crate) fn qselect_median_dbl(arr: &mut [c_double], n: c_int) -> c_double {
+    let mut low: c_int = 0;
+    let mut high: c_int = n - 1;
+    let median: c_int = (low + high) / 2;
+    loop {
+        if high <= low {
+            return arr[median as usize];
+        }
+        if high == low + 1 {
+            if arr[low as usize] > arr[high as usize] {
+                arr.swap(low as usize, high as usize);
+            }
+            return arr[median as usize];
+        }
+        let middle: c_int = (low + high) / 2;
+        if arr[middle as usize] > arr[high as usize] {
+            arr.swap(middle as usize, high as usize);
+        }
+        if arr[low as usize] > arr[high as usize] {
+            arr.swap(low as usize, high as usize);
+        }
+        if arr[middle as usize] > arr[low as usize] {
+            arr.swap(middle as usize, low as usize);
+        }
+        arr.swap(middle as usize, (low + 1) as usize);
+        let mut ll: c_int = low + 1;
+        let mut hh: c_int = high;
         loop {
-            if high <= low {
-                return *arr.offset(median as isize);
-            }
-            if high == low + 1 {
-                if *arr.offset(low as isize) > *arr.offset(high as isize) {
-                    let t: c_double = *arr.offset(low as isize);
-                    *arr.offset(low as isize) = *arr.offset(high as isize);
-                    *arr.offset(high as isize) = t;
-                }
-                return *arr.offset(median as isize);
-            }
-            middle = (low + high) / 2;
-            if *arr.offset(middle as isize) > *arr.offset(high as isize) {
-                let t_0: c_double = *arr.offset(middle as isize);
-                *arr.offset(middle as isize) = *arr.offset(high as isize);
-                *arr.offset(high as isize) = t_0;
-            }
-            if *arr.offset(low as isize) > *arr.offset(high as isize) {
-                let t_1: c_double = *arr.offset(low as isize);
-                *arr.offset(low as isize) = *arr.offset(high as isize);
-                *arr.offset(high as isize) = t_1;
-            }
-            if *arr.offset(middle as isize) > *arr.offset(low as isize) {
-                let t_2: c_double = *arr.offset(middle as isize);
-                *arr.offset(middle as isize) = *arr.offset(low as isize);
-                *arr.offset(low as isize) = t_2;
-            }
-            let t_3: c_double = *arr.offset(middle as isize);
-            *arr.offset(middle as isize) = *arr.offset((low + 1) as isize);
-            *arr.offset((low + 1) as isize) = t_3;
-            ll = low + 1;
-            hh = high;
             loop {
-                loop {
-                    ll += 1;
-                    if !(*arr.offset(low as isize) > *arr.offset(ll as isize)) {
-                        break;
-                    }
-                }
-                loop {
-                    hh -= 1;
-                    if !(*arr.offset(hh as isize) > *arr.offset(low as isize)) {
-                        break;
-                    }
-                }
-                if hh < ll {
+                ll += 1;
+                if !(arr[low as usize] > arr[ll as usize]) {
                     break;
                 }
-                let t_4: c_double = *arr.offset(ll as isize);
-                *arr.offset(ll as isize) = *arr.offset(hh as isize);
-                *arr.offset(hh as isize) = t_4;
             }
-            let t_5: c_double = *arr.offset(low as isize);
-            *arr.offset(low as isize) = *arr.offset(hh as isize);
-            *arr.offset(hh as isize) = t_5;
-            if hh <= median {
-                low = ll;
+            loop {
+                hh -= 1;
+                if !(arr[hh as usize] > arr[low as usize]) {
+                    break;
+                }
             }
-            if hh >= median {
-                high = hh - 1;
+            if hh < ll {
+                break;
             }
+            arr.swap(ll as usize, hh as usize);
+        }
+        arr.swap(low as usize, hh as usize);
+        if hh <= median {
+            low = ll;
+        }
+        if hh >= median {
+            high = hh - 1;
         }
     }
 }
@@ -10774,46 +10732,35 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                                 (lParse.Nodes[theParams[0]]).value.data.lngptr();
                             let mut uptr: *mut c_char = (lParse.Nodes[theParams[0]]).value.undef;
                             let mut mptr_buf: Vec<c_long> = Vec::new();
-                            let mptr: *mut c_long =
-                                if mptr_buf.try_reserve_exact(nelem as usize).is_ok() {
-                                    mptr_buf.resize(nelem as usize, 0);
-                                    mptr_buf.as_mut_ptr()
-                                } else {
-                                    core::ptr::null_mut()
-                                };
-                            let mut irow: c_int = 0;
-                            if mptr.is_null() {
+                            if mptr_buf.try_reserve_exact(nelem as usize).is_err() {
                                 fits_parser_yyerror(
                                     lParse,
                                     cs!(c"Could not allocate temporary memory in median function"),
                                 );
                                 free_node_data(lParse, this_node_idx);
                             } else {
-                                irow = 0;
+                                mptr_buf.resize(nelem as usize, 0);
+                                let mut irow: c_int = 0;
                                 while c_long::from(irow) < row {
-                                    let mut p: *mut c_long = mptr;
-                                    let mut nelem1: c_int = nelem as c_int;
-                                    loop {
-                                        let fresh80 = nelem1;
-                                        nelem1 -= 1;
-                                        if fresh80 == 0 {
-                                            break;
-                                        }
+                                    // Gather this row's defined elements into the
+                                    // scratch buffer (bounds-checked).
+                                    let mut count: usize = 0;
+                                    for _ in 0..nelem {
                                         if c_int::from(*uptr) == 0 {
-                                            let fresh81 = p;
-                                            p = p.offset(1);
-                                            *fresh81 = *dptr;
+                                            mptr_buf[count] = *dptr;
+                                            count += 1;
                                         }
                                         dptr = dptr.offset(1);
                                         uptr = uptr.offset(1);
                                     }
-                                    nelem1 = p.offset_from(mptr) as c_long as c_int;
-                                    if nelem1 > 0 {
+                                    if count > 0 {
                                         *((lParse.Nodes[this_node_idx]).value.undef)
                                             .offset(irow as isize) = 0;
                                         *((lParse.Nodes[this_node_idx]).value.data.lngptr())
-                                            .offset(irow as isize) =
-                                            qselect_median_lng(mptr, nelem1);
+                                            .offset(irow as isize) = qselect_median_lng(
+                                            &mut mptr_buf[..count],
+                                            count as c_int,
+                                        );
                                     } else {
                                         *((lParse.Nodes[this_node_idx]).value.undef)
                                             .offset(irow as isize) = 1;
@@ -10828,46 +10775,35 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                                 (lParse.Nodes[theParams[0]]).value.data.dblptr();
                             let mut uptr_0: *mut c_char = (lParse.Nodes[theParams[0]]).value.undef;
                             let mut mptr_0_buf: Vec<c_double> = Vec::new();
-                            let mptr_0: *mut c_double =
-                                if mptr_0_buf.try_reserve_exact(nelem as usize).is_ok() {
-                                    mptr_0_buf.resize(nelem as usize, 0.0);
-                                    mptr_0_buf.as_mut_ptr()
-                                } else {
-                                    core::ptr::null_mut()
-                                };
-                            let mut irow_0: c_int = 0;
-                            if mptr_0.is_null() {
+                            if mptr_0_buf.try_reserve_exact(nelem as usize).is_err() {
                                 fits_parser_yyerror(
                                     lParse,
                                     cs!(c"Could not allocate temporary memory in median function"),
                                 );
                                 free_node_data(lParse, this_node_idx);
                             } else {
-                                irow_0 = 0;
+                                mptr_0_buf.resize(nelem as usize, 0.0);
+                                let mut irow_0: c_int = 0;
                                 while c_long::from(irow_0) < row {
-                                    let mut p_0: *mut c_double = mptr_0;
-                                    let mut nelem1_0: c_int = nelem as c_int;
-                                    loop {
-                                        let fresh82 = nelem1_0;
-                                        nelem1_0 -= 1;
-                                        if fresh82 == 0 {
-                                            break;
-                                        }
+                                    // Gather this row's defined elements into the
+                                    // scratch buffer (bounds-checked).
+                                    let mut count: usize = 0;
+                                    for _ in 0..nelem {
                                         if c_int::from(*uptr_0) == 0 {
-                                            let fresh83 = p_0;
-                                            p_0 = p_0.offset(1);
-                                            *fresh83 = *dptr_0;
+                                            mptr_0_buf[count] = *dptr_0;
+                                            count += 1;
                                         }
                                         dptr_0 = dptr_0.offset(1);
                                         uptr_0 = uptr_0.offset(1);
                                     }
-                                    nelem1_0 = p_0.offset_from(mptr_0) as c_long as c_int;
-                                    if nelem1_0 > 0 {
+                                    if count > 0 {
                                         *((lParse.Nodes[this_node_idx]).value.undef)
                                             .offset(irow_0 as isize) = 0;
                                         *((lParse.Nodes[this_node_idx]).value.data.dblptr())
-                                            .offset(irow_0 as isize) =
-                                            qselect_median_dbl(mptr_0, nelem1_0);
+                                            .offset(irow_0 as isize) = qselect_median_dbl(
+                                            &mut mptr_0_buf[..count],
+                                            count as c_int,
+                                        );
                                     } else {
                                         *((lParse.Nodes[this_node_idx]).value.undef)
                                             .offset(irow_0 as isize) = 1;

--- a/src/eval_y.rs
+++ b/src/eval_y.rs
@@ -6634,14 +6634,12 @@ fn New_GTI(
                 /* We are allocating storage for both START and STOP with one pointer
                 and stop is stored at dblptr+nrows, we will use aliases below to
                 make this easier to read */
-                (lParse.Nodes[that0_idx]).value.data.dblptr = malloc(
-                    ((2 as c_long * nrows) as c_ulong)
-                        .wrapping_mul(::core::mem::size_of::<c_double>() as c_ulong)
-                        .try_into()
-                        .unwrap(),
-                )
-                .cast::<c_double>();
-                if ((lParse.Nodes[that0_idx]).value.data.dblptr).is_null() {
+                // Rust-owned buffer for both START and STOP (STOP stored at
+                // dblptr + nrows); owned by lParse.node_buffers.
+                let n_bytes = (2 * nrows) as usize * size_of::<c_double>();
+                let p = alloc_node_data(lParse, that0_idx, n_bytes);
+                (lParse.Nodes[that0_idx]).value.data.ptr = p;
+                if p.is_null() {
                     lParse.status = 113 as c_int;
                     return -(1);
                 }
@@ -14522,5 +14520,39 @@ mod node_buffer_tests {
         assert!(lparse.node_buffers[1].is_none());
         // The remaining three are freed when node_buffers is cleared (ffcprs).
         lparse.node_buffers = Vec::new();
+    }
+
+    /// Mirrors New_GTI's buffer: one owned allocation holding START at [0, nrows)
+    /// and STOP at [nrows, 2*nrows) via aliased pointers. Confirms both halves
+    /// are writable/readable in bounds and freed cleanly (Miri-checked).
+    #[test]
+    fn gti_style_split_buffer_roundtrip() {
+        let mut lparse = ParseData::default();
+        let nrows = 3usize;
+        let mut node = Node::default();
+        node.operation = CONST_OP;
+        lparse.Nodes.push(node);
+        let idx = 0usize;
+
+        let n_bytes = 2 * nrows * core::mem::size_of::<f64>();
+        let p = alloc_node_data(&mut lparse, idx, n_bytes);
+        lparse.Nodes[idx].value.data.ptr = p;
+        assert!(!p.is_null());
+
+        unsafe {
+            let startptr = p.cast::<f64>();
+            let stopptr = startptr.add(nrows);
+            for r in 0..nrows {
+                *startptr.add(r) = r as f64;
+                *stopptr.add(r) = r as f64 + 0.5;
+            }
+            for r in 0..nrows {
+                assert_eq!(*startptr.add(r), r as f64);
+                assert_eq!(*stopptr.add(r), r as f64 + 0.5);
+            }
+        }
+
+        free_node_data(&mut lparse, idx);
+        assert!(lparse.node_buffers[idx].is_none());
     }
 }

--- a/src/eval_y.rs
+++ b/src/eval_y.rs
@@ -7257,88 +7257,90 @@ fn Copy_Dims(lParse: &mut ParseData, Node1: c_int, Node2: c_int) {
 }
 
 pub(crate) fn Evaluate_Parser(lParse: &mut ParseData, firstRow: c_long, nRows: c_long) {
+    let mut i: c_int = 0;
+    let mut column: c_int = 0;
+    let mut offset: c_long = 0;
+    let mut rowOffset: c_long = 0;
+    static mut RAND_INITIALIZED: c_int = 0;
+    // Access to the `static mut` RNG-init flag and the libc time() call are the
+    // only unsafe here.
     unsafe {
-        let mut i: c_int = 0;
-        let mut column: c_int = 0;
-        let mut offset: c_long = 0;
-        let mut rowOffset: c_long = 0;
-        static mut RAND_INITIALIZED: c_int = 0;
         if RAND_INITIALIZED == 0 {
             simplerng_srand(time(core::ptr::null_mut::<time_t>()) as c_uint);
             RAND_INITIALIZED = 1;
         }
-        lParse.firstRow = firstRow;
-        lParse.nRows = nRows;
-        rowOffset = firstRow - lParse.firstDataRow;
-        i = 0;
-        while i < lParse.nNodes {
-            if !(((lParse.Nodes)[i as usize]).operation > 0
-                || ((lParse.Nodes)[i as usize]).operation == CONST_OP)
-            {
-                column = -((lParse.Nodes)[i as usize]).operation;
-                offset = ((lParse.varData)[column as usize]).nelem * rowOffset;
-
-                (((lParse.Nodes)[i as usize]).value).undef =
-                    match (((lParse.varData)[column as usize]).undef).as_deref_mut() {
-                        Some(ud) => ud[(offset as usize)..].as_mut_ptr(),
-                        None => ptr::null_mut(),
-                    };
-
-                // Point the column node at its slice of the loaded column
-                // buffer. All the typed pointer views share one Buffer value.
-                match ((lParse.Nodes)[i as usize]).ntype.into() {
-                    fits_parser_yytokentype::BITSTR => {
-                        (lParse.Nodes[i as usize]).value.data = data_union::Buffer(
-                            ((lParse.varData)[column as usize])
-                                .data
-                                .cast::<*mut c_char>()
-                                .offset(rowOffset as isize)
-                                .cast::<c_void>(),
-                        );
-                        (lParse.Nodes[i as usize]).value.undef = ptr::null_mut();
-                    }
-                    fits_parser_yytokentype::STRING => {
-                        (lParse.Nodes[i as usize]).value.data = data_union::Buffer(
-                            ((lParse.varData)[column as usize])
-                                .data
-                                .cast::<*mut c_char>()
-                                .offset(rowOffset as isize)
-                                .cast::<c_void>(),
-                        );
-                        (lParse.Nodes[i as usize]).value.undef =
-                            (((lParse.varData)[column as usize]).undef)
-                                .as_deref_mut()
-                                .unwrap()[(rowOffset as usize)..]
-                                .as_mut_ptr();
-                    }
-                    fits_parser_yytokentype::BOOLEAN => {
-                        (lParse.Nodes[i as usize]).value.data = data_union::Buffer(
-                            (((lParse.varData)[column as usize]).data as *const _ as *mut c_char)
-                                .offset(offset as isize)
-                                .cast::<c_void>(),
-                        );
-                    }
-                    fits_parser_yytokentype::LONG => {
-                        (lParse.Nodes[i as usize]).value.data = data_union::Buffer(
-                            (((lParse.varData)[column as usize]).data as *const _ as *mut c_long)
-                                .offset(offset as isize)
-                                .cast::<c_void>(),
-                        );
-                    }
-                    fits_parser_yytokentype::DOUBLE => {
-                        (lParse.Nodes[i as usize]).value.data = data_union::Buffer(
-                            (((lParse.varData)[column as usize]).data as *const _ as *mut c_double)
-                                .offset(offset as isize)
-                                .cast::<c_void>(),
-                        );
-                    }
-                    _ => {}
-                }
-            }
-            i += 1;
-        }
-        Evaluate_Node(lParse, lParse.resultNode);
     }
+    lParse.firstRow = firstRow;
+    lParse.nRows = nRows;
+    rowOffset = firstRow - lParse.firstDataRow;
+    i = 0;
+    while i < lParse.nNodes {
+        if !(((lParse.Nodes)[i as usize]).operation > 0
+            || ((lParse.Nodes)[i as usize]).operation == CONST_OP)
+        {
+            column = -((lParse.Nodes)[i as usize]).operation;
+            offset = ((lParse.varData)[column as usize]).nelem * rowOffset;
+
+            (((lParse.Nodes)[i as usize]).value).undef =
+                match (((lParse.varData)[column as usize]).undef).as_deref_mut() {
+                    Some(ud) => ud[(offset as usize)..].as_mut_ptr(),
+                    None => ptr::null_mut(),
+                };
+
+            // Point the column node at its slice of the loaded column buffer.
+            // All the typed pointer views share one Buffer value; the raw
+            // `.offset()` into varData.data is the only unsafe part.
+            let col_data = (lParse.varData)[column as usize].data;
+            match ((lParse.Nodes)[i as usize]).ntype.into() {
+                fits_parser_yytokentype::BITSTR => {
+                    (lParse.Nodes[i as usize]).value.data = data_union::Buffer(unsafe {
+                        col_data
+                            .cast::<*mut c_char>()
+                            .offset(rowOffset as isize)
+                            .cast::<c_void>()
+                    });
+                    (lParse.Nodes[i as usize]).value.undef = ptr::null_mut();
+                }
+                fits_parser_yytokentype::STRING => {
+                    (lParse.Nodes[i as usize]).value.data = data_union::Buffer(unsafe {
+                        col_data
+                            .cast::<*mut c_char>()
+                            .offset(rowOffset as isize)
+                            .cast::<c_void>()
+                    });
+                    (lParse.Nodes[i as usize]).value.undef = (((lParse.varData)[column as usize])
+                        .undef)
+                        .as_deref_mut()
+                        .unwrap()[(rowOffset as usize)..]
+                        .as_mut_ptr();
+                }
+                fits_parser_yytokentype::BOOLEAN => {
+                    (lParse.Nodes[i as usize]).value.data = data_union::Buffer(unsafe {
+                        (col_data as *mut c_char)
+                            .offset(offset as isize)
+                            .cast::<c_void>()
+                    });
+                }
+                fits_parser_yytokentype::LONG => {
+                    (lParse.Nodes[i as usize]).value.data = data_union::Buffer(unsafe {
+                        (col_data as *mut c_long)
+                            .offset(offset as isize)
+                            .cast::<c_void>()
+                    });
+                }
+                fits_parser_yytokentype::DOUBLE => {
+                    (lParse.Nodes[i as usize]).value.data = data_union::Buffer(unsafe {
+                        (col_data as *mut c_double)
+                            .offset(offset as isize)
+                            .cast::<c_void>()
+                    });
+                }
+                _ => {}
+            }
+        }
+        i += 1;
+    }
+    Evaluate_Node(lParse, lParse.resultNode);
 }
 
 /**********************************************************************/
@@ -7445,28 +7447,27 @@ pub(crate) fn free_node_data(lParse: &mut ParseData, idx: usize) {
 }
 
 fn Allocate_Ptrs(lParse: &mut ParseData, this_node_idx: usize) {
-    unsafe {
-        let mut elem: c_long = 0;
-        let mut row: c_long = 0;
-        let mut size: c_long = 0;
-        if (lParse.Nodes[this_node_idx]).ntype == fits_parser_yytokentype::BITSTR as c_int
-            || (lParse.Nodes[this_node_idx]).ntype == fits_parser_yytokentype::STRING as c_int
-        {
-            // Rust-owned string storage: a row-pointer array (strptr) plus one
-            // backing char buffer of nRows * (nelem + 2) bytes. strptr[row]
-            // indexes into the backing buffer at stride (nelem + 1). Owned by
-            // lParse.node_buffers; strptr/undef are views.
-            let nelem = (lParse.Nodes[this_node_idx]).value.nelem;
-            let nrows = lParse.nRows as usize;
-            let backing_len = (lParse.nRows * (nelem + 2)) as usize;
-            let (strptr, backing) = alloc_str_node_data(lParse, this_node_idx, nrows, backing_len);
-            (lParse.Nodes[this_node_idx]).value.data =
-                data_union::Buffer((strptr).cast::<c_void>());
-            if strptr.is_null() {
-                lParse.status = MEMORY_ALLOCATION;
-            } else {
+    if (lParse.Nodes[this_node_idx]).ntype == fits_parser_yytokentype::BITSTR as c_int
+        || (lParse.Nodes[this_node_idx]).ntype == fits_parser_yytokentype::STRING as c_int
+    {
+        // Rust-owned string storage: a row-pointer array (strptr) plus one
+        // backing char buffer of nRows * (nelem + 2) bytes. strptr[row]
+        // indexes into the backing buffer at stride (nelem + 1). Owned by
+        // lParse.node_buffers; strptr/undef are views.
+        let nelem = (lParse.Nodes[this_node_idx]).value.nelem;
+        let nrows = lParse.nRows as usize;
+        let backing_len = (lParse.nRows * (nelem + 2)) as usize;
+        let (strptr, backing) = alloc_str_node_data(lParse, this_node_idx, nrows, backing_len);
+        (lParse.Nodes[this_node_idx]).value.data = data_union::Buffer((strptr).cast::<c_void>());
+        if strptr.is_null() {
+            lParse.status = MEMORY_ALLOCATION;
+        } else {
+            let is_string =
+                (lParse.Nodes[this_node_idx]).ntype == fits_parser_yytokentype::STRING as c_int;
+            // Wire up the row pointers into the backing buffer (raw walk).
+            let undef = unsafe {
                 *strptr.offset(0) = backing;
-                row = 0;
+                let mut row: c_long = 0;
                 loop {
                     row += 1;
                     if row >= lParse.nRows {
@@ -7477,44 +7478,35 @@ fn Allocate_Ptrs(lParse: &mut ParseData, this_node_idx: usize) {
                         .offset(nelem as isize)
                         .offset(1);
                 }
-                if (lParse.Nodes[this_node_idx]).ntype == fits_parser_yytokentype::STRING as c_int {
-                    (lParse.Nodes[this_node_idx]).value.undef = (*strptr
-                        .offset((row - 1) as isize))
-                    .offset(nelem as isize)
-                    .offset(1);
+                if is_string {
+                    (*strptr.offset((row - 1) as isize))
+                        .offset(nelem as isize)
+                        .offset(1)
                 } else {
-                    (lParse.Nodes[this_node_idx]).value.undef = ptr::null_mut(); /* BITSTRs don't use undef array */
+                    ptr::null_mut() /* BITSTRs don't use undef array */
                 }
-            }
-        } else {
-            elem = (lParse.Nodes[this_node_idx]).value.nelem * lParse.nRows;
-            match (lParse.Nodes[this_node_idx]).ntype.into() {
-                fits_parser_yytokentype::DOUBLE => {
-                    size = ::core::mem::size_of::<c_double>() as c_ulong as c_long;
-                }
-                fits_parser_yytokentype::LONG => {
-                    size = ::core::mem::size_of::<c_long>() as c_ulong as c_long;
-                }
-                fits_parser_yytokentype::BOOLEAN => {
-                    size = ::core::mem::size_of::<c_char>() as c_ulong as c_long;
-                }
-                _ => {
-                    size = 1;
-                }
-            }
-            // Rust-owned buffer of (size + 1) * elem bytes (matching the former
-            // calloc): `elem * size` bytes of data followed by `elem` undef
-            // flags. Owned by lParse.node_buffers; data.ptr/undef are views.
-            let n_bytes = ((size + 1) * elem) as usize;
-            let p = alloc_node_data(lParse, this_node_idx, n_bytes);
-            (lParse.Nodes[this_node_idx]).value.data = data_union::Buffer(p);
-            if p.is_null() {
-                lParse.status = MEMORY_ALLOCATION;
-            } else {
-                (lParse.Nodes[this_node_idx]).value.undef =
-                    p.cast::<c_char>().offset((elem * size) as isize);
-            }
+            };
+            (lParse.Nodes[this_node_idx]).value.undef = undef;
+        }
+    } else {
+        let elem = (lParse.Nodes[this_node_idx]).value.nelem * lParse.nRows;
+        let size: c_long = match (lParse.Nodes[this_node_idx]).ntype.into() {
+            fits_parser_yytokentype::DOUBLE => size_of::<c_double>() as c_long,
+            fits_parser_yytokentype::LONG => size_of::<c_long>() as c_long,
+            fits_parser_yytokentype::BOOLEAN => size_of::<c_char>() as c_long,
+            _ => 1,
         };
+        // Rust-owned buffer of (size + 1) * elem bytes (matching the former
+        // calloc): `elem * size` bytes of data followed by `elem` undef flags.
+        let n_bytes = ((size + 1) * elem) as usize;
+        let p = alloc_node_data(lParse, this_node_idx, n_bytes);
+        (lParse.Nodes[this_node_idx]).value.data = data_union::Buffer(p);
+        if p.is_null() {
+            lParse.status = MEMORY_ALLOCATION;
+        } else {
+            (lParse.Nodes[this_node_idx]).value.undef =
+                unsafe { p.cast::<c_char>().offset((elem * size) as isize) };
+        }
     }
 }
 

--- a/src/eval_y.rs
+++ b/src/eval_y.rs
@@ -14530,6 +14530,20 @@ fn fits_parser_yyerror(lParse: &mut ParseData, s: &[c_char]) {
 mod node_buffer_tests {
     use super::*;
 
+    /// qselect_median_* now operate on slices; check they pick the correct
+    /// median and are Miri-clean (no out-of-bounds / aliasing).
+    #[test]
+    fn qselect_median_slices() {
+        let mut a = [5_i64, 1, 4, 2, 3];
+        assert_eq!(qselect_median_lng(&mut a, 5), 3);
+        let mut b = [2_i64, 1, 3];
+        assert_eq!(qselect_median_lng(&mut b, 3), 2);
+        let mut c = [5.0_f64, 1.0, 4.0, 2.0, 3.0];
+        assert_eq!(qselect_median_dbl(&mut c, 5), 3.0);
+        let mut d = [42_i64];
+        assert_eq!(qselect_median_lng(&mut d, 1), 42);
+    }
+
     /// Exercises the Rust-owned numeric node buffer end to end: Allocate_Ptrs
     /// builds the backing store, data/undef are written and read back through
     /// the raw union views, and free_node_data releases it. Runs with no file

--- a/src/eval_y.rs
+++ b/src/eval_y.rs
@@ -6412,7 +6412,7 @@ fn New_GTI(
                         &mut xexpr,
                         &mut lParse.status,
                     );
-                    if *extname.as_mut_ptr() != 0 {
+                    if extname[0] != 0 {
                         ffmnhd_safe(fptr, movetotype, &extname, extvers, &mut lParse.status);
                         ffghdn_safe(fptr, &mut hdunum);
                     } else if hdunum != 0 {

--- a/src/eval_y.rs
+++ b/src/eval_y.rs
@@ -13463,10 +13463,9 @@ fn Do_GTI(lParse: &mut ParseData, this_node_idx: usize) {
             gti = Search_GTI(
                 (lParse.Nodes[theExpr]).value.data.dbl(),
                 nGTI,
-                start,
-                stop,
+                core::slice::from_raw_parts(start, (2 * nGTI) as usize),
                 ordered,
-                core::ptr::null_mut::<c_long>(),
+                None,
             );
             if dorow != 0 {
                 (lParse.Nodes[this_node_idx]).value.data =
@@ -13502,10 +13501,9 @@ fn Do_GTI(lParse: &mut ParseData, this_node_idx: usize) {
                             gti = Search_GTI(
                                 *times.offset(elem as isize),
                                 nGTI,
-                                start,
-                                stop,
+                                core::slice::from_raw_parts(start, (2 * nGTI) as usize),
                                 ordered,
-                                core::ptr::null_mut::<c_long>(),
+                                None,
                             );
                         }
                         if dorow != 0 {
@@ -13684,8 +13682,20 @@ fn GTI_Over(
         if evtStop <= evtStart {
             return 0.0;
         }
-        gti1 = Search_GTI(evtStart, nGTI, start, stop, 1, &mut nextGTI1);
-        gti2 = Search_GTI(evtStop, nGTI, start, stop, 1, &mut nextGTI2);
+        gti1 = Search_GTI(
+            evtStart,
+            nGTI,
+            core::slice::from_raw_parts(start, (2 * nGTI) as usize),
+            1,
+            Some(&mut nextGTI1),
+        );
+        gti2 = Search_GTI(
+            evtStop,
+            nGTI,
+            core::slice::from_raw_parts(start, (2 * nGTI) as usize),
+            1,
+            Some(&mut nextGTI2),
+        );
         if gti1 >= 0 {
             *gtiout = gti1;
         }
@@ -13721,77 +13731,79 @@ fn GTI_Over(
         overlap
     }
 }
+/// `gti_times` is one buffer of `2 * nGTI` doubles: START[0..nGTI] followed by
+/// STOP[0..nGTI] (as allocated by New_GTI). Fully bounds-checked — no unsafe.
 fn Search_GTI(
     evtTime: c_double,
     nGTI: c_long,
-    start: *mut c_double,
-    stop: *mut c_double,
+    gti_times: &[c_double],
     ordered: c_int,
-    nextGTI0: *mut c_long,
+    nextGTI0: Option<&mut c_long>,
 ) -> c_long {
-    unsafe {
-        let mut gti: c_long = 0;
-        let mut nextGTI: c_long = -(1 as c_long);
-        let mut step: c_long = 0;
-        if ordered != 0 && nGTI > 15 as c_long {
-            if evtTime >= *start.offset(0) && evtTime <= *stop.offset((nGTI - 1) as isize) {
-                step = nGTI >> 1;
-                gti = step;
-                loop {
-                    if step > 1 {
-                        step >>= 1;
-                    }
-                    if evtTime > *stop.offset(gti as isize) {
-                        if evtTime >= *start.offset((gti + 1) as isize) {
-                            gti += step;
-                        } else {
-                            nextGTI = gti + 1;
-                            gti = -(1 as c_long);
-                            break;
-                        }
-                    } else if evtTime < *start.offset(gti as isize) {
-                        if evtTime <= *stop.offset((gti - 1) as isize) {
-                            gti -= step;
-                        } else {
-                            nextGTI = gti;
-                            gti = -(1 as c_long);
-                            break;
-                        }
+    let start = |i: c_long| gti_times[i as usize];
+    let stop = |i: c_long| gti_times[(nGTI + i) as usize];
+
+    let mut gti: c_long = 0;
+    let mut nextGTI: c_long = -(1 as c_long);
+    let mut step: c_long = 0;
+    if ordered != 0 && nGTI > 15 as c_long {
+        if evtTime >= start(0) && evtTime <= stop(nGTI - 1) {
+            step = nGTI >> 1;
+            gti = step;
+            loop {
+                if step > 1 {
+                    step >>= 1;
+                }
+                if evtTime > stop(gti) {
+                    if evtTime >= start(gti + 1) {
+                        gti += step;
                     } else {
-                        nextGTI = gti;
+                        nextGTI = gti + 1;
+                        gti = -(1 as c_long);
                         break;
                     }
+                } else if evtTime < start(gti) {
+                    if evtTime <= stop(gti - 1) {
+                        gti -= step;
+                    } else {
+                        nextGTI = gti;
+                        gti = -(1 as c_long);
+                        break;
+                    }
+                } else {
+                    nextGTI = gti;
+                    break;
                 }
-            } else {
-                if *start.offset(0) > evtTime {
-                    nextGTI = 0;
-                }
-                gti = -(1 as c_long);
             }
         } else {
-            gti = nGTI;
-            loop {
-                let fresh209 = gti;
-                gti -= 1;
-                if fresh209 == 0 {
-                    break;
-                }
-                if *stop.offset(gti as isize) >= evtTime {
-                    nextGTI = gti;
-                }
-                if evtTime >= *start.offset(gti as isize) && evtTime <= *stop.offset(gti as isize) {
-                    break;
-                }
+            if start(0) > evtTime {
+                nextGTI = 0;
+            }
+            gti = -(1 as c_long);
+        }
+    } else {
+        gti = nGTI;
+        loop {
+            let fresh209 = gti;
+            gti -= 1;
+            if fresh209 == 0 {
+                break;
+            }
+            if stop(gti) >= evtTime {
+                nextGTI = gti;
+            }
+            if evtTime >= start(gti) && evtTime <= stop(gti) {
+                break;
             }
         }
-        if nextGTI >= nGTI {
-            nextGTI = -1;
-        }
-        if !nextGTI0.is_null() {
-            *nextGTI0 = nextGTI;
-        }
-        gti
     }
+    if nextGTI >= nGTI {
+        nextGTI = -1;
+    }
+    if let Some(n) = nextGTI0 {
+        *n = nextGTI;
+    }
+    gti
 }
 fn Do_REG(lParse: &mut ParseData, this_node_idx: usize) {
     unsafe {

--- a/src/eval_y.rs
+++ b/src/eval_y.rs
@@ -7353,7 +7353,7 @@ fn alloc_node_data(lParse: &mut ParseData, idx: usize, n_bytes: usize) -> *mut c
     if lParse.node_buffers.len() <= idx {
         lParse.node_buffers.resize_with(idx + 1, || None);
     }
-    match NodeBuf::new(n_bytes) {
+    match NodeBuf::new_numeric(n_bytes) {
         Some(buf) => {
             let ptr = buf.as_ptr().cast::<c_void>();
             lParse.node_buffers[idx] = Some(buf);
@@ -7362,6 +7362,34 @@ fn alloc_node_data(lParse: &mut ParseData, idx: usize, n_bytes: usize) -> *mut c
         None => {
             lParse.node_buffers[idx] = None;
             core::ptr::null_mut()
+        }
+    }
+}
+
+/// Allocate the Rust-owned backing store for a STRING/BITSTR node: the row
+/// pointer array (`nrows` pointers) plus a single character buffer of
+/// `backing_len` bytes. Returns `(strptr_array, backing_buffer)` raw views, or
+/// `(null, null)` on allocation failure.
+fn alloc_str_node_data(
+    lParse: &mut ParseData,
+    idx: usize,
+    nrows: usize,
+    backing_len: usize,
+) -> (*mut *mut c_char, *mut c_char) {
+    if lParse.node_buffers.len() <= idx {
+        lParse.node_buffers.resize_with(idx + 1, || None);
+    }
+    let ptrs_len = nrows * size_of::<*mut c_char>();
+    match NodeBuf::new_string(ptrs_len, backing_len) {
+        Some(buf) => {
+            let ptrs = buf.as_ptr().cast::<*mut c_char>();
+            let backing = buf.backing_ptr().cast::<c_char>();
+            lParse.node_buffers[idx] = Some(buf);
+            (ptrs, backing)
+        }
+        None => {
+            lParse.node_buffers[idx] = None;
+            (core::ptr::null_mut(), core::ptr::null_mut())
         }
     }
 }
@@ -7390,60 +7418,38 @@ fn Allocate_Ptrs(lParse: &mut ParseData, this_node_idx: usize) {
         if (lParse.Nodes[this_node_idx]).ntype == fits_parser_yytokentype::BITSTR as c_int
             || (lParse.Nodes[this_node_idx]).ntype == fits_parser_yytokentype::STRING as c_int
         {
-            (lParse.Nodes[this_node_idx]).value.data.strptr = malloc(
-                (lParse.nRows as c_ulong)
-                    .wrapping_mul(::core::mem::size_of::<*mut c_char>() as c_ulong)
-                    .try_into()
-                    .unwrap(),
-            )
-            .cast::<*mut c_char>();
-            if !((lParse.Nodes[this_node_idx]).value.data.strptr).is_null() {
-                let fresh20 = &mut *((lParse.Nodes[this_node_idx]).value.data.strptr).offset(0);
-                *fresh20 = malloc(
-                    ((lParse.nRows * ((lParse.Nodes[this_node_idx]).value.nelem + 2 as c_long))
-                        as c_ulong)
-                        .wrapping_mul(::core::mem::size_of::<c_char>() as c_ulong)
-                        .try_into()
-                        .unwrap(),
-                )
-                .cast::<c_char>();
-                if !(*((lParse.Nodes[this_node_idx]).value.data.strptr).offset(0)).is_null() {
-                    row = 0;
-                    loop {
-                        row += 1;
-                        if row >= lParse.nRows {
-                            break;
-                        }
-                        let fresh21 = &mut *((lParse.Nodes[this_node_idx]).value.data.strptr)
-                            .offset(row as isize);
-                        *fresh21 = (*((lParse.Nodes[this_node_idx]).value.data.strptr)
-                            .offset((row - 1) as isize))
-                        .offset((lParse.Nodes[this_node_idx]).value.nelem as isize)
-                        .offset(1);
-                    }
-                    if (lParse.Nodes[this_node_idx]).ntype
-                        == fits_parser_yytokentype::STRING as c_int
-                    {
-                        (lParse.Nodes[this_node_idx]).value.undef =
-                            (*((lParse.Nodes[this_node_idx]).value.data.strptr)
-                                .offset((row - 1) as isize))
-                            .offset((lParse.Nodes[this_node_idx]).value.nelem as isize)
-                            .offset(1);
-                    } else {
-                        (lParse.Nodes[this_node_idx]).value.undef = ptr::null_mut(); /* BITSTRs don't use undef array */
-                    }
-                } else {
-                    lParse.status = MEMORY_ALLOCATION;
-                    free(
-                        (lParse.Nodes[this_node_idx])
-                            .value
-                            .data
-                            .strptr
-                            .cast::<c_void>(),
-                    );
-                }
-            } else {
+            // Rust-owned string storage: a row-pointer array (strptr) plus one
+            // backing char buffer of nRows * (nelem + 2) bytes. strptr[row]
+            // indexes into the backing buffer at stride (nelem + 1). Owned by
+            // lParse.node_buffers; strptr/undef are views.
+            let nelem = (lParse.Nodes[this_node_idx]).value.nelem;
+            let nrows = lParse.nRows as usize;
+            let backing_len = (lParse.nRows * (nelem + 2)) as usize;
+            let (strptr, backing) = alloc_str_node_data(lParse, this_node_idx, nrows, backing_len);
+            (lParse.Nodes[this_node_idx]).value.data.strptr = strptr;
+            if strptr.is_null() {
                 lParse.status = MEMORY_ALLOCATION;
+            } else {
+                *strptr.offset(0) = backing;
+                row = 0;
+                loop {
+                    row += 1;
+                    if row >= lParse.nRows {
+                        break;
+                    }
+                    let fresh21 = &mut *strptr.offset(row as isize);
+                    *fresh21 = (*strptr.offset((row - 1) as isize))
+                        .offset(nelem as isize)
+                        .offset(1);
+                }
+                if (lParse.Nodes[this_node_idx]).ntype == fits_parser_yytokentype::STRING as c_int {
+                    (lParse.Nodes[this_node_idx]).value.undef = (*strptr
+                        .offset((row - 1) as isize))
+                    .offset(nelem as isize)
+                    .offset(1);
+                } else {
+                    (lParse.Nodes[this_node_idx]).value.undef = ptr::null_mut(); /* BITSTRs don't use undef array */
+                }
             }
         } else {
             elem = (lParse.Nodes[this_node_idx]).value.nelem * lParse.nRows;
@@ -7478,24 +7484,10 @@ fn Allocate_Ptrs(lParse: &mut ParseData, this_node_idx: usize) {
 }
 
 unsafe fn free_node_buffer(lParse: &mut ParseData, idx: usize) {
-    let ntype = lParse.Nodes[idx].ntype;
-    if ntype == fits_parser_yytokentype::BITSTR as c_int
-        || ntype == fits_parser_yytokentype::STRING as c_int
-    {
-        // STRING/BITSTR nodes still use the legacy malloc'd 2-D strptr buffer.
-        let strptr = lParse.Nodes[idx].value.data.strptr;
-        if !strptr.is_null() {
-            if !(*strptr).is_null() {
-                free((*strptr) as *mut c_void);
-            }
-            free(strptr as *mut c_void);
-            lParse.Nodes[idx].value.data.strptr = ptr::null_mut();
-        }
-    } else {
-        // Numeric nodes: Rust-owned buffer (or legacy malloc for GTI etc.).
-        free_node_data(lParse, idx);
-    }
-
+    // Both numeric and STRING/BITSTR result buffers are now Rust-owned in
+    // node_buffers; free_node_data drops the whole NodeBuf (string nodes' row
+    // pointer array and backing buffer together) and nulls the data pointer.
+    free_node_data(lParse, idx);
     lParse.Nodes[idx].value.undef = ptr::null_mut();
 }
 
@@ -8207,12 +8199,10 @@ fn Do_BinOp_bit(lParse: &mut ParseData, this_node_idx: usize) {
             }
         }
         if (lParse.Nodes[that1_idx]).operation > 0 {
-            free((*((lParse.Nodes[that1_idx]).value.data.strptr).offset(0)).cast::<c_void>());
-            free((lParse.Nodes[that1_idx]).value.data.strptr.cast::<c_void>());
+            free_node_data(lParse, that1_idx);
         }
         if (lParse.Nodes[that2_idx]).operation > 0 {
-            free((*((lParse.Nodes[that2_idx]).value.data.strptr).offset(0)).cast::<c_void>());
-            free((lParse.Nodes[that2_idx]).value.data.strptr.cast::<c_void>());
+            free_node_data(lParse, that2_idx);
         }
     }
 }
@@ -8526,12 +8516,10 @@ fn Do_BinOp_str(lParse: &mut ParseData, this_node_idx: usize) {
             }
         }
         if (lParse.Nodes[that1_idx]).operation > 0 {
-            free((*((lParse.Nodes[that1_idx]).value.data.strptr).offset(0)).cast::<c_void>());
-            free((lParse.Nodes[that1_idx]).value.data.strptr.cast::<c_void>());
+            free_node_data(lParse, that1_idx);
         }
         if (lParse.Nodes[that2_idx]).operation > 0 {
-            free((*((lParse.Nodes[that2_idx]).value.data.strptr).offset(0)).cast::<c_void>());
-            free((lParse.Nodes[that2_idx]).value.data.strptr.cast::<c_void>());
+            free_node_data(lParse, that2_idx);
         }
     }
 }
@@ -13208,13 +13196,8 @@ fn Do_Deref(lParse: &mut ParseData, this_node_idx: usize) {
             }
         }
         if (lParse.Nodes[theVar]).operation > 0 {
-            if (lParse.Nodes[theVar]).ntype == fits_parser_yytokentype::STRING as c_int
-                || (lParse.Nodes[theVar]).ntype == fits_parser_yytokentype::BITSTR as c_int
-            {
-                free((*((lParse.Nodes[theVar]).value.data.strptr).offset(0)).cast::<c_void>());
-            } else {
-                free_node_data(lParse, theVar);
-            }
+            // Rust-owned buffer (numeric data, or string strptr+backing).
+            free_node_data(lParse, theVar);
         }
         i = 0;
         while i < nDims {
@@ -14392,5 +14375,150 @@ mod node_buffer_tests {
         free_node_data(&mut lparse, idx);
         assert!(lparse.node_buffers[idx].is_none());
         assert!(unsafe { lparse.Nodes[idx].value.data.ptr }.is_null());
+    }
+
+    /// Exercises the Rust-owned STRING node buffer: Allocate_Ptrs builds the row
+    /// pointer array (strptr) plus backing buffer, each row string is written
+    /// and read back through the two-level raw views, and free_node_data
+    /// releases both. Runs under Miri to validate the aliased two-level access
+    /// and that no allocation is leaked or mismatched.
+    #[test]
+    fn string_node_buffer_alloc_access_free_roundtrip() {
+        let mut lparse = ParseData::default();
+        lparse.nRows = 3;
+
+        let mut node = Node::default();
+        node.ntype = fits_parser_yytokentype::STRING as c_int;
+        node.value.nelem = 5; // max string length
+        node.operation = 1;
+        lparse.Nodes.push(node);
+        let idx = 0usize;
+
+        Allocate_Ptrs(&mut lparse, idx);
+        assert_eq!(lparse.status, 0);
+        assert!(lparse.node_buffers[idx].is_some());
+
+        let strptr = unsafe { lparse.Nodes[idx].value.data.strptr };
+        let undef = lparse.Nodes[idx].value.undef;
+        assert!(!strptr.is_null());
+        assert!(!undef.is_null());
+
+        let nrows = lparse.nRows as usize;
+        unsafe {
+            // Distinct row pointers into the shared backing buffer.
+            for r in 0..nrows {
+                let rowp = *strptr.add(r);
+                assert!(!rowp.is_null());
+                // Write "ab" + NUL into each row string.
+                *rowp.add(0) = b'a' as c_char;
+                *rowp.add(1) = b'0' as c_char + r as c_char;
+                *rowp.add(2) = 0;
+                *undef.add(r) = 0;
+            }
+            for r in 0..nrows {
+                let rowp = *strptr.add(r);
+                assert_eq!(*rowp.add(0), b'a' as c_char);
+                assert_eq!(*rowp.add(1), b'0' as c_char + r as c_char);
+                assert_eq!(*rowp.add(2), 0);
+            }
+        }
+
+        free_node_data(&mut lparse, idx);
+        assert!(lparse.node_buffers[idx].is_none());
+        assert!(unsafe { lparse.Nodes[idx].value.data.strptr }.is_null());
+    }
+
+    /// BITSTR nodes allocate a strptr buffer but no undef array. Confirms the
+    /// buffer is owned and undef stays null.
+    #[test]
+    fn bitstr_node_buffer_has_no_undef() {
+        let mut lparse = ParseData::default();
+        lparse.nRows = 2;
+        let mut node = Node::default();
+        node.ntype = fits_parser_yytokentype::BITSTR as c_int;
+        node.value.nelem = 4;
+        node.operation = 1;
+        lparse.Nodes.push(node);
+
+        Allocate_Ptrs(&mut lparse, 0);
+        assert_eq!(lparse.status, 0);
+        assert!(lparse.node_buffers[0].is_some());
+        assert!(!unsafe { lparse.Nodes[0].value.data.strptr }.is_null());
+        assert!(lparse.Nodes[0].value.undef.is_null()); // BITSTRs don't use undef
+        free_node_data(&mut lparse, 0);
+        assert!(lparse.node_buffers[0].is_none());
+    }
+
+    /// Re-allocating a node's buffer (as happens when the tree is re-evaluated
+    /// for each row batch) must drop the previous buffer, not leak it. Under
+    /// Miri a leaked allocation fails the test.
+    #[test]
+    fn reallocating_a_node_buffer_drops_the_old_one() {
+        let mut lparse = ParseData::default();
+        lparse.nRows = 4;
+        let mut node = Node::default();
+        node.ntype = fits_parser_yytokentype::DOUBLE as c_int;
+        node.value.nelem = 2;
+        node.operation = 1;
+        lparse.Nodes.push(node);
+
+        Allocate_Ptrs(&mut lparse, 0);
+        let p1 = unsafe { lparse.Nodes[0].value.data.ptr };
+        Allocate_Ptrs(&mut lparse, 0); // old buffer must be dropped here
+        let p2 = unsafe { lparse.Nodes[0].value.data.ptr };
+        assert!(!p1.is_null() && !p2.is_null());
+        // New buffer is usable.
+        unsafe {
+            let d = p2.cast::<f64>();
+            *d.add(0) = 2.5;
+            assert_eq!(*d.add(0), 2.5);
+        }
+        free_node_data(&mut lparse, 0);
+        assert!(lparse.node_buffers[0].is_none());
+    }
+
+    /// free_node_data's legacy branch: a node whose pointer is NOT in the
+    /// side-table (e.g. GTI data malloc'd elsewhere) must be freed with
+    /// libc::free, not treated as a NodeBuf. This path is not covered by the
+    /// integration tests, so verify it (and its allocator match) directly.
+    #[test]
+    fn free_node_data_legacy_pointer_uses_libc_free() {
+        let mut lparse = ParseData::default();
+        let mut node = Node::default();
+        node.operation = 1;
+        // Simulate a legacy malloc'd buffer (as gtifilt would produce).
+        let raw = unsafe { libc::malloc(64) };
+        assert!(!raw.is_null());
+        node.value.data.ptr = raw;
+        lparse.Nodes.push(node);
+        // No side-table entry for this node -> legacy path.
+        assert!(lparse.node_buffers.is_empty());
+
+        free_node_data(&mut lparse, 0);
+        assert!(unsafe { lparse.Nodes[0].value.data.ptr }.is_null());
+    }
+
+    /// Dropping ParseData (as ffcprs does via `node_buffers = Vec::new()`) must
+    /// free every owned node buffer. Allocate several, free one explicitly, and
+    /// let the rest be reclaimed on drop; Miri flags any leak.
+    #[test]
+    fn dropping_parsedata_frees_all_owned_buffers() {
+        let mut lparse = ParseData::default();
+        lparse.nRows = 3;
+        for _ in 0..4 {
+            let mut node = Node::default();
+            node.ntype = fits_parser_yytokentype::LONG as c_int;
+            node.value.nelem = 2;
+            node.operation = 1;
+            lparse.Nodes.push(node);
+        }
+        for i in 0..4 {
+            Allocate_Ptrs(&mut lparse, i);
+            assert!(lparse.node_buffers[i].is_some());
+        }
+        free_node_data(&mut lparse, 1); // free one explicitly
+        assert!(lparse.node_buffers[1].is_none());
+        // The remaining three are freed when node_buffers is cleared (ffcprs).
+        lparse.node_buffers = Vec::new();
     }
 }

--- a/src/eval_y.rs
+++ b/src/eval_y.rs
@@ -103,40 +103,41 @@ fn astr_len(buf: &[c_char]) -> usize {
     buf.iter().position(|&b| b == 0).unwrap_or(buf.len())
 }
 
-/// Symbolic names for the `current_block` control-flow targets in the generated
+/// Control-flow targets for the `current_block` dispatch in the generated
 /// `fits_parser_yyparse` driver. These replace the opaque 19-digit block IDs
-/// emitted by the C-to-Rust goto translation; each constant keeps its original
-/// numeric value so the control flow is byte-for-byte unchanged, only readable.
+/// emitted by the C-to-Rust goto translation; converting them to an enum keeps
+/// the control flow byte-for-byte identical while making the state explicit and
+/// preventing the token from being treated as a number.
 ///
 /// The first group mirrors the standard bison skeleton labels (see the
 /// `yydefault`/`yyreduce`/`yynewstate` comments in the driver). The
-/// `REDUCE_JOIN_*` group are intra-reduction join points within grouped grammar
+/// `ReduceJoin*` variants are intra-reduction join points within grouped grammar
 /// rules; they have no bison name, so they are numbered by frequency.
-mod block {
-    pub const YYERRLAB: u64 = 4830776507462815627; // semantic error -> error recovery
-    pub const YYERRLAB1: u64 = 1774893048582444437; // error recovery loop
-    pub const YYNEWSTATE: u64 = 7872030484262409139; // push new state
-    pub const YYBACKUP: u64 = 1924505913685386279; // lookahead token handling
-    pub const YYDEFAULT: u64 = 5937473999264333383; // default action for state
-    pub const YYREDUCE: u64 = 670225253387957849; // do a reduction
-    pub const YYABORTLAB: u64 = 3964311021479492664; // parse failed (yyresult = 1)
-    pub const YYEXHAUSTEDLAB: u64 = 11794367917084412820; // memory exhausted (yyresult = 2)
-    pub const REDUCE_DONE: u64 = 17353983478346836848; // reduction action completed
-
-    pub const REDUCE_JOIN_1: u64 = 7600445499126923600;
-    pub const REDUCE_JOIN_2: u64 = 9966817879908499150;
-    pub const REDUCE_JOIN_3: u64 = 494012601817399562;
-    pub const REDUCE_JOIN_4: u64 = 13755523488868872559;
-    pub const REDUCE_JOIN_5: u64 = 10848699504537784535;
-    pub const REDUCE_JOIN_6: u64 = 12473999534294722905;
-    pub const REDUCE_JOIN_7: u64 = 1297461190301222800;
-    pub const REDUCE_JOIN_8: u64 = 15752106442776732052;
-    pub const REDUCE_JOIN_9: u64 = 17702298541784679949;
-    pub const REDUCE_JOIN_10: u64 = 2616667235040759262;
-    pub const REDUCE_JOIN_11: u64 = 2904036176499606090;
-    pub const REDUCE_JOIN_12: u64 = 3023179740610631044;
-    pub const REDUCE_JOIN_13: u64 = 1069630499025798221;
-    pub const REDUCE_JOIN_14: u64 = 15864720325503947191;
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Block {
+    YyErrLab,       // semantic error -> error recovery
+    YyErrLab1,      // error recovery loop
+    YyNewState,     // push new state
+    YyBackup,       // lookahead token handling
+    YyDefault,      // default action for state
+    YyReduce,       // do a reduction
+    YyAbortLab,     // parse failed (yyresult = 1)
+    YyExhaustedLab, // memory exhausted (yyresult = 2)
+    ReduceDone,     // reduction action completed
+    ReduceJoin1,
+    ReduceJoin2,
+    ReduceJoin3,
+    ReduceJoin4,
+    ReduceJoin5,
+    ReduceJoin6,
+    ReduceJoin7,
+    ReduceJoin8,
+    ReduceJoin9,
+    ReduceJoin10,
+    ReduceJoin11,
+    ReduceJoin12,
+    ReduceJoin13,
+    ReduceJoin14,
 }
 
 pub type yy_state_t = yytype_int16;
@@ -1173,7 +1174,7 @@ fn New_FuncSize(
 
 pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData) -> c_int {
     unsafe {
-        let mut current_block: u64;
+        let mut current_block: Block;
         let mut yychar: c_int = 0;
         static mut YYVAL_DEFAULT: FITS_PARSER_YYSTYPE = FITS_PARSER_YYSTYPE { Node: 0 };
         let mut yylval: FITS_PARSER_YYSTYPE = YYVAL_DEFAULT;
@@ -1208,7 +1209,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                 /* Get the current used size of the three stacks, in elements.  */
                 let yysize: c_long = (yyssp + 1) as c_long;
                 if YYMAXDEPTH as c_long <= yystacksize {
-                    current_block = block::YYEXHAUSTEDLAB; // goto yyexhaustedlab;
+                    current_block = Block::YyExhaustedLab; // goto yyexhaustedlab;
                     break;
                 }
                 yystacksize *= 2 as c_long;
@@ -1228,7 +1229,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                 )
                 .cast::<yyalloc>();
                 if yyptr.is_null() {
-                    current_block = block::YYEXHAUSTEDLAB; // goto yyexhaustedlab;
+                    current_block = Block::YyExhaustedLab; // goto yyexhaustedlab;
                     break;
                 }
                 let mut yynewbytes: c_long = 0;
@@ -1268,13 +1269,13 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                 yyssp = yysize as usize - 1;
                 yyvsp = yysize as usize - 1;
                 if (yystacksize - 1) as usize <= yyssp {
-                    current_block = block::YYABORTLAB; // goto yyabortlab;
+                    current_block = Block::YyAbortLab; // goto yyabortlab;
                     break;
                 }
             }
             if yystate == YYFINAL as c_int {
                 yyresult = 0;
-                current_block = block::REDUCE_JOIN_14; // goto yyacceptlab;
+                current_block = Block::ReduceJoin14; // goto yyacceptlab;
                 break;
             } else {
                 /*-----------.
@@ -1286,7 +1287,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                 /* First try to decide what to do without reference to lookahead token.  */
                 yyn = c_int::from(YYPACT[yystate as usize]);
                 if yyn == -41 {
-                    current_block = block::YYDEFAULT; // goto yydefault;
+                    current_block = Block::YyDefault; // goto yydefault;
                 } else {
                     /* Not known => get a lookahead token if don't already have one.  */
 
@@ -1305,7 +1306,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         if YYDEBUG {
                             eprintln!("Now at end of input.");
                         }
-                        current_block = block::YYBACKUP;
+                        current_block = Block::YyBackup;
                     } else if yychar == fits_parser_yytokentype::FITS_PARSER_YYerror as c_int {
                         /* The scanner already issued an error message, process directly
                         to error recovery.  But do not keep the error token as
@@ -1313,7 +1314,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         loop in error recovery. */
                         yychar = fits_parser_yytokentype::FITS_PARSER_YYUNDEF as c_int;
                         yytoken = YYSYMBOL_YYERROR;
-                        current_block = block::YYERRLAB1; // goto yyerrlab1;
+                        current_block = Block::YyErrLab1; // goto yyerrlab1;
                     } else {
                         yytoken = (if 0 <= yychar && yychar <= 292 as c_int {
                             yysymbol_kind_t::from(YYTRANSLATE[yychar as usize]) as c_int
@@ -1321,22 +1322,22 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             YYSYMBOL_YYUNDEF as c_int
                         }) as yysymbol_kind_t;
                         YY_SYMBOL_PRINT!("Next token is", yytoken, &yylval, scanner, lParse);
-                        current_block = block::YYBACKUP;
+                        current_block = Block::YyBackup;
                     }
                     match current_block {
-                        block::YYERRLAB1 => {}
+                        Block::YyErrLab1 => {}
                         _ => {
                             yyn += yytoken as c_int;
                             if yyn < 0
                                 || (YYLAST as c_int) < yyn
                                 || c_int::from(YYCHECK[yyn as usize]) != yytoken as c_int
                             {
-                                current_block = block::YYDEFAULT;
+                                current_block = Block::YyDefault;
                             } else {
                                 yyn = c_int::from(YYTABLE[yyn as usize]);
                                 if yyn <= 0 {
                                     yyn = -yyn;
-                                    current_block = block::YYREDUCE;
+                                    current_block = Block::YyReduce;
                                 } else {
                                     /* Count tokens shifted since error; after three, turn off error status.  */
                                     if yyerrstatus != 0 {
@@ -1347,14 +1348,14 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     yyvsp += 1;
                                     yyvs[yyvsp] = yylval;
                                     yychar = fits_parser_yytokentype::FITS_PARSER_YYEMPTY as c_int; /* Discard the shifted token.  */
-                                    current_block = block::YYNEWSTATE;
+                                    current_block = Block::YyNewState;
                                 }
                             }
                         }
                     }
                 }
 
-                if current_block == block::YYDEFAULT {
+                if current_block == Block::YyDefault {
                     /*-----------------------------------------------------------.
                     | yydefault -- do the default action for the current state.  |
                     `-----------------------------------------------------------*/
@@ -1377,7 +1378,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         if yyerrstatus == 3 as c_int {
                             if yychar <= fits_parser_yytokentype::FITS_PARSER_YYEOF as c_int {
                                 if yychar == fits_parser_yytokentype::FITS_PARSER_YYEOF as c_int {
-                                    current_block = block::YYABORTLAB;
+                                    current_block = Block::YyAbortLab;
                                     break;
                                 }
                             } else {
@@ -1391,12 +1392,12 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 yychar = fits_parser_yytokentype::FITS_PARSER_YYEMPTY as c_int;
                             }
                         }
-                        current_block = block::YYERRLAB1;
+                        current_block = Block::YyErrLab1;
                     } else {
-                        current_block = block::YYREDUCE; // goto yyreduce;
+                        current_block = Block::YyReduce; // goto yyreduce;
                     }
                 }
-                if current_block == block::YYREDUCE {
+                if current_block == Block::YyReduce {
                     /*-----------------------------.
                     | yyreduce -- do a reduction.  |
                     `-----------------------------*/
@@ -1421,7 +1422,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                     match yyn {
                         4 => {
                             /* line: '\n'  */
-                            current_block = block::REDUCE_DONE;
+                            current_block = Block::ReduceDone;
                         }
                         5 => {
                             /* line: expr '\n'  */
@@ -1430,10 +1431,10 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     lParse,
                                     cs!(c"Couldn't build node structure: out of memory?"),
                                 );
-                                current_block = block::YYERRLAB;
+                                current_block = Block::YyErrLab;
                             } else {
                                 lParse.resultNode = yyvs[yyvsp - 1].Node;
-                                current_block = block::REDUCE_DONE;
+                                current_block = Block::ReduceDone;
                             }
                         }
                         6 => {
@@ -1443,10 +1444,10 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     lParse,
                                     cs!(c"Couldn't build node structure: out of memory?"),
                                 );
-                                current_block = block::YYERRLAB;
+                                current_block = Block::YyErrLab;
                             } else {
                                 lParse.resultNode = yyvs[yyvsp - 1].Node;
-                                current_block = block::REDUCE_DONE;
+                                current_block = Block::ReduceDone;
                             }
                         }
                         7 => {
@@ -1456,10 +1457,10 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     lParse,
                                     cs!(c"Couldn't build node structure: out of memory?"),
                                 );
-                                current_block = block::YYERRLAB;
+                                current_block = Block::YyErrLab;
                             } else {
                                 lParse.resultNode = yyvs[yyvsp - 1].Node;
-                                current_block = block::REDUCE_DONE;
+                                current_block = Block::ReduceDone;
                             }
                         }
                         8 => {
@@ -1469,24 +1470,24 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     lParse,
                                     cs!(c"Couldn't build node structure: out of memory?"),
                                 );
-                                current_block = block::YYERRLAB;
+                                current_block = Block::YyErrLab;
                             } else {
                                 lParse.resultNode = yyvs[yyvsp - 1].Node;
-                                current_block = block::REDUCE_DONE;
+                                current_block = Block::ReduceDone;
                             }
                         }
                         9 => {
                             /* line: error '\n'  */
                             yyerrstatus = 0;
-                            current_block = block::REDUCE_DONE;
+                            current_block = Block::ReduceDone;
                         }
                         10 => {
                             /* bvector: '{' bexpr  */
                             yyval.Node = New_Vector(lParse, yyvs[yyvsp].Node);
                             if yyval.Node < 0 {
-                                current_block = block::YYERRLAB;
+                                current_block = Block::YyErrLab;
                             } else {
-                                current_block = block::REDUCE_DONE;
+                                current_block = Block::ReduceDone;
                             }
                         }
                         11 => {
@@ -1496,21 +1497,21 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             {
                                 yyvs[yyvsp - 2].Node = Close_Vec(lParse, yyvs[yyvsp - 2].Node);
                                 if yyvs[yyvsp - 2].Node < 0 {
-                                    current_block = block::YYERRLAB;
+                                    current_block = Block::YyErrLab;
                                 } else {
                                     yyval.Node = New_Vector(lParse, yyvs[yyvsp - 2].Node);
                                     if yyval.Node < 0 {
-                                        current_block = block::YYERRLAB;
+                                        current_block = Block::YyErrLab;
                                     } else {
-                                        current_block = block::REDUCE_JOIN_10;
+                                        current_block = Block::ReduceJoin10;
                                     }
                                 }
                             } else {
                                 yyval.Node = yyvs[yyvsp - 2].Node;
-                                current_block = block::REDUCE_JOIN_10;
+                                current_block = Block::ReduceJoin10;
                             }
                             match current_block {
-                                block::YYERRLAB => {}
+                                Block::YyErrLab => {}
                                 _ => {
                                     let fresh2 =
                                         &mut ((lParse.Nodes)[yyval.Node as usize]).nSubNodes;
@@ -1518,7 +1519,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     *fresh2 += 1;
                                     ((lParse.Nodes)[yyval.Node as usize]).SubNodes
                                         [fresh3 as usize] = yyvs[yyvsp].Node.try_into().unwrap();
-                                    current_block = block::REDUCE_DONE;
+                                    current_block = Block::ReduceDone;
                                 }
                             }
                         }
@@ -1526,9 +1527,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             /* vector: '{' expr  */
                             yyval.Node = New_Vector(lParse, yyvs[yyvsp].Node);
                             if yyval.Node < 0 {
-                                current_block = block::YYERRLAB;
+                                current_block = Block::YyErrLab;
                             } else {
-                                current_block = block::REDUCE_DONE;
+                                current_block = Block::ReduceDone;
                             }
                         }
                         13 => {
@@ -1544,21 +1545,21 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             {
                                 yyvs[yyvsp - 2].Node = Close_Vec(lParse, yyvs[yyvsp - 2].Node);
                                 if yyvs[yyvsp - 2].Node < 0 {
-                                    current_block = block::YYERRLAB;
+                                    current_block = Block::YyErrLab;
                                 } else {
                                     yyval.Node = New_Vector(lParse, yyvs[yyvsp - 2].Node);
                                     if yyval.Node < 0 {
-                                        current_block = block::YYERRLAB;
+                                        current_block = Block::YyErrLab;
                                     } else {
-                                        current_block = block::REDUCE_JOIN_11;
+                                        current_block = Block::ReduceJoin11;
                                     }
                                 }
                             } else {
                                 yyval.Node = yyvs[yyvsp - 2].Node;
-                                current_block = block::REDUCE_JOIN_11;
+                                current_block = Block::ReduceJoin11;
                             }
                             match current_block {
-                                block::YYERRLAB => {}
+                                Block::YyErrLab => {}
                                 _ => {
                                     let fresh4 =
                                         &mut ((lParse.Nodes)[yyval.Node as usize]).nSubNodes;
@@ -1566,7 +1567,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     *fresh4 += 1;
                                     ((lParse.Nodes)[yyval.Node as usize]).SubNodes
                                         [fresh5 as usize] = yyvs[yyvsp].Node.try_into().unwrap();
-                                    current_block = block::REDUCE_DONE;
+                                    current_block = Block::ReduceDone;
                                 }
                             }
                         }
@@ -1577,21 +1578,21 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             {
                                 yyvs[yyvsp - 2].Node = Close_Vec(lParse, yyvs[yyvsp - 2].Node);
                                 if yyvs[yyvsp - 2].Node < 0 {
-                                    current_block = block::YYERRLAB;
+                                    current_block = Block::YyErrLab;
                                 } else {
                                     yyval.Node = New_Vector(lParse, yyvs[yyvsp - 2].Node);
                                     if yyval.Node < 0 {
-                                        current_block = block::YYERRLAB;
+                                        current_block = Block::YyErrLab;
                                     } else {
-                                        current_block = block::REDUCE_JOIN_9;
+                                        current_block = Block::ReduceJoin9;
                                     }
                                 }
                             } else {
                                 yyval.Node = yyvs[yyvsp - 2].Node;
-                                current_block = block::REDUCE_JOIN_9;
+                                current_block = Block::ReduceJoin9;
                             }
                             match current_block {
-                                block::YYERRLAB => {}
+                                Block::YyErrLab => {}
                                 _ => {
                                     let fresh6 =
                                         &mut ((lParse.Nodes)[yyval.Node as usize]).nSubNodes;
@@ -1599,7 +1600,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     *fresh6 += 1;
                                     ((lParse.Nodes)[yyval.Node as usize]).SubNodes
                                         [fresh7 as usize] = yyvs[yyvsp].Node.try_into().unwrap();
-                                    current_block = block::REDUCE_DONE;
+                                    current_block = Block::ReduceDone;
                                 }
                             }
                         }
@@ -1612,21 +1613,21 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             {
                                 yyvs[yyvsp - 2].Node = Close_Vec(lParse, yyvs[yyvsp - 2].Node);
                                 if yyvs[yyvsp - 2].Node < 0 {
-                                    current_block = block::YYERRLAB;
+                                    current_block = Block::YyErrLab;
                                 } else {
                                     yyval.Node = New_Vector(lParse, yyvs[yyvsp - 2].Node);
                                     if yyval.Node < 0 {
-                                        current_block = block::YYERRLAB;
+                                        current_block = Block::YyErrLab;
                                     } else {
-                                        current_block = block::REDUCE_JOIN_13;
+                                        current_block = Block::ReduceJoin13;
                                     }
                                 }
                             } else {
                                 yyval.Node = yyvs[yyvsp - 2].Node;
-                                current_block = block::REDUCE_JOIN_13;
+                                current_block = Block::ReduceJoin13;
                             }
                             match current_block {
-                                block::YYERRLAB => {}
+                                Block::YyErrLab => {}
                                 _ => {
                                     let fresh8 =
                                         &mut ((lParse.Nodes)[yyval.Node as usize]).nSubNodes;
@@ -1634,7 +1635,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     *fresh8 += 1;
                                     ((lParse.Nodes)[yyval.Node as usize]).SubNodes
                                         [fresh9 as usize] = yyvs[yyvsp].Node.try_into().unwrap();
-                                    current_block = block::REDUCE_DONE;
+                                    current_block = Block::ReduceDone;
                                 }
                             }
                         }
@@ -1642,18 +1643,18 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             /* expr: vector '}'  */
                             yyval.Node = Close_Vec(lParse, yyvs[yyvsp - 1].Node);
                             if yyval.Node < 0 {
-                                current_block = block::YYERRLAB;
+                                current_block = Block::YyErrLab;
                             } else {
-                                current_block = block::REDUCE_DONE;
+                                current_block = Block::ReduceDone;
                             }
                         }
                         17 => {
                             /* bexpr: bvector '}'  */
                             yyval.Node = Close_Vec(lParse, yyvs[yyvsp - 1].Node);
                             if yyval.Node < 0 {
-                                current_block = block::YYERRLAB;
+                                current_block = Block::YyErrLab;
                             } else {
-                                current_block = block::REDUCE_DONE;
+                                current_block = Block::ReduceDone;
                             }
                         }
                         18 => {
@@ -1666,20 +1667,20 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     as c_long,
                             );
                             if yyval.Node < 0 {
-                                current_block = block::YYERRLAB;
+                                current_block = Block::YyErrLab;
                             } else {
                                 (((lParse.Nodes)[yyval.Node as usize]).value).nelem =
                                     astr_len(&yyvs[yyvsp].astr) as c_long;
-                                current_block = block::REDUCE_DONE;
+                                current_block = Block::ReduceDone;
                             }
                         }
                         19 => {
                             /* bits: BITCOL  */
                             yyval.Node = New_Column(lParse, yyvs[yyvsp].lng as c_int);
                             if yyval.Node < 0 {
-                                current_block = block::YYERRLAB;
+                                current_block = Block::YyErrLab;
                             } else {
-                                current_block = block::REDUCE_DONE;
+                                current_block = Block::ReduceDone;
                             }
                         }
                         20 => {
@@ -1693,7 +1694,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     lParse,
                                     cs!(c"Offset argument must be a constant integer"),
                                 );
-                                current_block = block::YYERRLAB;
+                                current_block = Block::YyErrLab;
                             } else {
                                 yyval.Node = New_Offset(
                                     lParse,
@@ -1701,9 +1702,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     yyvs[yyvsp - 1].Node,
                                 );
                                 if yyval.Node < 0 {
-                                    current_block = block::YYERRLAB;
+                                    current_block = Block::YyErrLab;
                                 } else {
-                                    current_block = block::REDUCE_DONE;
+                                    current_block = Block::ReduceDone;
                                 }
                             }
                         }
@@ -1717,7 +1718,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 yyvs[yyvsp].Node,
                             );
                             if yyval.Node < 0 {
-                                current_block = block::YYERRLAB;
+                                current_block = Block::YyErrLab;
                             } else {
                                 (((lParse.Nodes)[yyval.Node as usize]).value).nelem =
                                     if (((lParse.Nodes)[yyvs[yyvsp - 2].Node as usize]).value).nelem
@@ -1727,7 +1728,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     } else {
                                         (lParse.Nodes[yyvs[yyvsp].Node as usize]).value.nelem
                                     };
-                                current_block = block::REDUCE_DONE;
+                                current_block = Block::ReduceDone;
                             }
                         }
                         22 => {
@@ -1740,7 +1741,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 yyvs[yyvsp].Node,
                             );
                             if yyval.Node < 0 {
-                                current_block = block::YYERRLAB;
+                                current_block = Block::YyErrLab;
                             } else {
                                 (((lParse.Nodes)[yyval.Node as usize]).value).nelem =
                                     if (((lParse.Nodes)[yyvs[yyvsp - 2].Node as usize]).value).nelem
@@ -1750,7 +1751,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     } else {
                                         (lParse.Nodes[yyvs[yyvsp].Node as usize]).value.nelem
                                     };
-                                current_block = block::REDUCE_DONE;
+                                current_block = Block::ReduceDone;
                             }
                         }
                         23 => {
@@ -1763,7 +1764,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     lParse,
                                     cs!(c"Combined bit string size exceeds 255 bits"),
                                 );
-                                current_block = block::YYERRLAB;
+                                current_block = Block::YyErrLab;
                             } else {
                                 yyval.Node = New_BinOp(
                                     lParse,
@@ -1773,14 +1774,14 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     yyvs[yyvsp].Node,
                                 );
                                 if yyval.Node < 0 {
-                                    current_block = block::YYERRLAB;
+                                    current_block = Block::YyErrLab;
                                 } else {
                                     (((lParse.Nodes)[yyval.Node as usize]).value).nelem =
                                         ((lParse.Nodes)[yyvs[yyvsp - 2].Node as usize]).value.nelem
                                             + ((lParse.Nodes)[yyvs[yyvsp].Node as usize])
                                                 .value
                                                 .nelem;
-                                    current_block = block::REDUCE_DONE;
+                                    current_block = Block::ReduceDone;
                                 }
                             }
                         }
@@ -1797,9 +1798,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 0,
                             );
                             if yyval.Node < 0 {
-                                current_block = block::YYERRLAB;
+                                current_block = Block::YyErrLab;
                             } else {
-                                current_block = block::REDUCE_DONE;
+                                current_block = Block::ReduceDone;
                             }
                         }
                         25 => {
@@ -1815,9 +1816,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 0,
                             );
                             if yyval.Node < 0 {
-                                current_block = block::YYERRLAB;
+                                current_block = Block::YyErrLab;
                             } else {
-                                current_block = block::REDUCE_DONE;
+                                current_block = Block::ReduceDone;
                             }
                         }
                         26 => {
@@ -1833,9 +1834,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 0,
                             );
                             if yyval.Node < 0 {
-                                current_block = block::YYERRLAB;
+                                current_block = Block::YyErrLab;
                             } else {
-                                current_block = block::REDUCE_DONE;
+                                current_block = Block::ReduceDone;
                             }
                         }
                         27 => {
@@ -1851,9 +1852,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 0,
                             );
                             if yyval.Node < 0 {
-                                current_block = block::YYERRLAB;
+                                current_block = Block::YyErrLab;
                             } else {
-                                current_block = block::REDUCE_DONE;
+                                current_block = Block::ReduceDone;
                             }
                         }
                         28 => {
@@ -1869,9 +1870,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 yyvs[yyvsp - 1].Node,
                             );
                             if yyval.Node < 0 {
-                                current_block = block::YYERRLAB;
+                                current_block = Block::YyErrLab;
                             } else {
-                                current_block = block::REDUCE_DONE;
+                                current_block = Block::ReduceDone;
                             }
                         }
                         29 => {
@@ -1883,15 +1884,15 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 yyvs[yyvsp].Node,
                             );
                             if yyval.Node < 0 {
-                                current_block = block::YYERRLAB;
+                                current_block = Block::YyErrLab;
                             } else {
-                                current_block = block::REDUCE_DONE;
+                                current_block = Block::ReduceDone;
                             }
                         }
                         30 => {
                             /* bits: '(' bits ')'  */
                             yyval.Node = yyvs[yyvsp - 1].Node;
-                            current_block = block::REDUCE_DONE;
+                            current_block = Block::ReduceDone;
                         }
                         31 => {
                             /* expr: LONG  */
@@ -1902,9 +1903,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 ::core::mem::size_of::<c_long>() as c_ulong as c_long,
                             );
                             if yyval.Node < 0 {
-                                current_block = block::YYERRLAB;
+                                current_block = Block::YyErrLab;
                             } else {
-                                current_block = block::REDUCE_DONE;
+                                current_block = Block::ReduceDone;
                             }
                         }
                         32 => {
@@ -1916,18 +1917,18 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 ::core::mem::size_of::<c_double>() as c_ulong as c_long,
                             );
                             if yyval.Node < 0 {
-                                current_block = block::YYERRLAB;
+                                current_block = Block::YyErrLab;
                             } else {
-                                current_block = block::REDUCE_DONE;
+                                current_block = Block::ReduceDone;
                             }
                         }
                         33 => {
                             /* expr: COLUMN  */
                             yyval.Node = New_Column(lParse, yyvs[yyvsp].lng as c_int);
                             if yyval.Node < 0 {
-                                current_block = block::YYERRLAB;
+                                current_block = Block::YyErrLab;
                             } else {
-                                current_block = block::REDUCE_DONE;
+                                current_block = Block::ReduceDone;
                             }
                         }
                         34 => {
@@ -1941,7 +1942,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     lParse,
                                     cs!(c"Offset argument must be a constant integer"),
                                 );
-                                current_block = block::YYERRLAB;
+                                current_block = Block::YyErrLab;
                             } else {
                                 yyval.Node = New_Offset(
                                     lParse,
@@ -1949,9 +1950,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     yyvs[yyvsp - 1].Node,
                                 );
                                 if yyval.Node < 0 {
-                                    current_block = block::YYERRLAB;
+                                    current_block = Block::YyErrLab;
                                 } else {
-                                    current_block = block::REDUCE_DONE;
+                                    current_block = Block::ReduceDone;
                                 }
                             }
                         }
@@ -1970,7 +1971,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 0,
                                 0,
                             );
-                            current_block = block::REDUCE_DONE;
+                            current_block = Block::ReduceDone;
                         }
                         36 => {
                             /* expr: NULLREF  */
@@ -1987,7 +1988,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 0,
                                 0,
                             );
-                            current_block = block::REDUCE_DONE;
+                            current_block = Block::ReduceDone;
                         }
                         37 => {
                             /* expr: expr '%' expr  */
@@ -2018,9 +2019,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 yyvs[yyvsp].Node,
                             );
                             if yyval.Node < 0 {
-                                current_block = block::YYERRLAB;
+                                current_block = Block::YyErrLab;
                             } else {
-                                current_block = block::REDUCE_DONE;
+                                current_block = Block::ReduceDone;
                             }
                         }
                         38 => {
@@ -2052,9 +2053,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 yyvs[yyvsp].Node,
                             );
                             if yyval.Node < 0 {
-                                current_block = block::YYERRLAB;
+                                current_block = Block::YyErrLab;
                             } else {
-                                current_block = block::REDUCE_DONE;
+                                current_block = Block::ReduceDone;
                             }
                         }
                         39 => {
@@ -2086,9 +2087,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 yyvs[yyvsp].Node,
                             );
                             if yyval.Node < 0 {
-                                current_block = block::YYERRLAB;
+                                current_block = Block::YyErrLab;
                             } else {
-                                current_block = block::REDUCE_DONE;
+                                current_block = Block::ReduceDone;
                             }
                         }
                         40 => {
@@ -2120,9 +2121,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 yyvs[yyvsp].Node,
                             );
                             if yyval.Node < 0 {
-                                current_block = block::YYERRLAB;
+                                current_block = Block::YyErrLab;
                             } else {
-                                current_block = block::REDUCE_DONE;
+                                current_block = Block::ReduceDone;
                             }
                         }
                         41 => {
@@ -2154,9 +2155,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 yyvs[yyvsp].Node,
                             );
                             if yyval.Node < 0 {
-                                current_block = block::YYERRLAB;
+                                current_block = Block::YyErrLab;
                             } else {
-                                current_block = block::REDUCE_DONE;
+                                current_block = Block::ReduceDone;
                             }
                         }
                         42 => {
@@ -2167,7 +2168,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     != fits_parser_yytokentype::LONG as c_int
                             {
                                 fits_parser_yyerror(lParse, cs!(c"Bitwise operations with incompatible types; only (bit OP bit) and (int OP int) are allowed"));
-                                current_block = block::YYERRLAB;
+                                current_block = Block::YyErrLab;
                             } else {
                                 yyval.Node = New_BinOp(
                                     lParse,
@@ -2176,7 +2177,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     '&' as i32,
                                     yyvs[yyvsp].Node,
                                 );
-                                current_block = block::REDUCE_DONE;
+                                current_block = Block::ReduceDone;
                             }
                         }
                         43 => {
@@ -2187,7 +2188,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     != fits_parser_yytokentype::LONG as c_int
                             {
                                 fits_parser_yyerror(lParse, cs!(c"Bitwise operations with incompatible types; only (bit OP bit) and (int OP int) are allowed"));
-                                current_block = block::YYERRLAB;
+                                current_block = Block::YyErrLab;
                             } else {
                                 yyval.Node = New_BinOp(
                                     lParse,
@@ -2196,7 +2197,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     '|' as i32,
                                     yyvs[yyvsp].Node,
                                 );
-                                current_block = block::REDUCE_DONE;
+                                current_block = Block::ReduceDone;
                             }
                         }
                         44 => {
@@ -2207,7 +2208,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     != fits_parser_yytokentype::LONG as c_int
                             {
                                 fits_parser_yyerror(lParse, cs!(c"Bitwise operations with incompatible types; only (bit OP bit) and (int OP int) are allowed"));
-                                current_block = block::YYERRLAB;
+                                current_block = Block::YyErrLab;
                             } else {
                                 yyval.Node = New_BinOp(
                                     lParse,
@@ -2216,7 +2217,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     '^' as i32,
                                     yyvs[yyvsp].Node,
                                 );
-                                current_block = block::REDUCE_DONE;
+                                current_block = Block::ReduceDone;
                             }
                         }
                         45 => {
@@ -2248,15 +2249,15 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 yyvs[yyvsp].Node,
                             );
                             if yyval.Node < 0 {
-                                current_block = block::YYERRLAB;
+                                current_block = Block::YyErrLab;
                             } else {
-                                current_block = block::REDUCE_DONE;
+                                current_block = Block::ReduceDone;
                             }
                         }
                         46 => {
                             /* expr: '+' expr  */
                             yyval.Node = yyvs[yyvsp].Node;
-                            current_block = block::REDUCE_DONE;
+                            current_block = Block::ReduceDone;
                         }
                         47 => {
                             /* expr: '-' expr  */
@@ -2267,15 +2268,15 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 yyvs[yyvsp].Node,
                             );
                             if yyval.Node < 0 {
-                                current_block = block::YYERRLAB;
+                                current_block = Block::YyErrLab;
                             } else {
-                                current_block = block::REDUCE_DONE;
+                                current_block = Block::ReduceDone;
                             }
                         }
                         48 => {
                             /* expr: '(' expr ')'  */
                             yyval.Node = yyvs[yyvsp - 1].Node;
-                            current_block = block::REDUCE_DONE;
+                            current_block = Block::ReduceDone;
                         }
                         49 => {
                             /* expr: expr '*' bexpr  */
@@ -2293,9 +2294,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 yyvs[yyvsp].Node,
                             );
                             if yyval.Node < 0 {
-                                current_block = block::YYERRLAB;
+                                current_block = Block::YyErrLab;
                             } else {
-                                current_block = block::REDUCE_DONE;
+                                current_block = Block::ReduceDone;
                             }
                         }
                         50 => {
@@ -2314,9 +2315,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 yyvs[yyvsp].Node,
                             );
                             if yyval.Node < 0 {
-                                current_block = block::YYERRLAB;
+                                current_block = Block::YyErrLab;
                             } else {
-                                current_block = block::REDUCE_DONE;
+                                current_block = Block::ReduceDone;
                             }
                         }
                         51 => {
@@ -2345,7 +2346,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     lParse,
                                     cs!(c"Incompatible dimensions in '?:' arguments"),
                                 );
-                                current_block = block::YYERRLAB;
+                                current_block = Block::YyErrLab;
                             } else {
                                 yyval.Node = New_Func(
                                     lParse,
@@ -2361,7 +2362,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     0,
                                 );
                                 if yyval.Node < 0 {
-                                    current_block = block::YYERRLAB;
+                                    current_block = Block::YyErrLab;
                                 } else {
                                     if ((lParse.Nodes)[yyvs[yyvsp - 2].Node as usize]).value.nelem
                                         < (lParse.Nodes[yyvs[yyvsp].Node as usize]).value.nelem
@@ -2375,7 +2376,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                             lParse,
                                             cs!(c"Incompatible dimensions in '?:' condition"),
                                         );
-                                        current_block = block::YYERRLAB;
+                                        current_block = Block::YyErrLab;
                                     } else {
                                         ((lParse.Nodes)[yyvs[yyvsp - 4].Node as usize]).ntype =
                                             fits_parser_yytokentype::BOOLEAN as c_int;
@@ -2386,7 +2387,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         {
                                             Copy_Dims(lParse, yyval.Node, yyvs[yyvsp - 4].Node);
                                         }
-                                        current_block = block::REDUCE_DONE;
+                                        current_block = Block::ReduceDone;
                                     }
                                 }
                             }
@@ -2417,7 +2418,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     lParse,
                                     cs!(c"Incompatible dimensions in '?:' arguments"),
                                 );
-                                current_block = block::YYERRLAB;
+                                current_block = Block::YyErrLab;
                             } else {
                                 yyval.Node = New_Func(
                                     lParse,
@@ -2433,7 +2434,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     0,
                                 );
                                 if yyval.Node < 0 {
-                                    current_block = block::YYERRLAB;
+                                    current_block = Block::YyErrLab;
                                 } else {
                                     if ((lParse.Nodes)[yyvs[yyvsp - 2].Node as usize]).value.nelem
                                         < (lParse.Nodes[yyvs[yyvsp].Node as usize]).value.nelem
@@ -2447,7 +2448,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                             lParse,
                                             cs!(c"Incompatible dimensions in '?:' condition"),
                                         );
-                                        current_block = block::YYERRLAB;
+                                        current_block = Block::YyErrLab;
                                     } else {
                                         ((lParse.Nodes)[yyvs[yyvsp - 4].Node as usize]).ntype =
                                             fits_parser_yytokentype::BOOLEAN as c_int;
@@ -2458,7 +2459,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         {
                                             Copy_Dims(lParse, yyval.Node, yyvs[yyvsp - 4].Node);
                                         }
-                                        current_block = block::REDUCE_DONE;
+                                        current_block = Block::ReduceDone;
                                     }
                                 }
                             }
@@ -2489,7 +2490,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     lParse,
                                     cs!(c"Incompatible dimensions in '?:' arguments"),
                                 );
-                                current_block = block::YYERRLAB;
+                                current_block = Block::YyErrLab;
                             } else {
                                 yyval.Node = New_Func(
                                     lParse,
@@ -2505,7 +2506,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     0,
                                 );
                                 if yyval.Node < 0 {
-                                    current_block = block::YYERRLAB;
+                                    current_block = Block::YyErrLab;
                                 } else {
                                     if ((lParse.Nodes)[yyvs[yyvsp - 2].Node as usize]).value.nelem
                                         < (lParse.Nodes[yyvs[yyvsp].Node as usize]).value.nelem
@@ -2519,7 +2520,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                             lParse,
                                             cs!(c"Incompatible dimensions in '?:' condition"),
                                         );
-                                        current_block = block::YYERRLAB;
+                                        current_block = Block::YyErrLab;
                                     } else {
                                         ((lParse.Nodes)[yyvs[yyvsp - 4].Node as usize]).ntype =
                                             fits_parser_yytokentype::BOOLEAN as c_int;
@@ -2530,7 +2531,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         {
                                             Copy_Dims(lParse, yyval.Node, yyvs[yyvsp - 4].Node);
                                         }
-                                        current_block = block::REDUCE_DONE;
+                                        current_block = Block::ReduceDone;
                                     }
                                 }
                             }
@@ -2551,7 +2552,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     0,
                                     0,
                                 );
-                                current_block = block::REDUCE_JOIN_7;
+                                current_block = Block::ReduceJoin7;
                             } else if astr_eq(&yyvs[yyvsp - 1].astr, c"RANDOMN(") {
                                 yyval.Node = New_Func(
                                     lParse,
@@ -2566,18 +2567,18 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     0,
                                     0,
                                 );
-                                current_block = block::REDUCE_JOIN_7;
+                                current_block = Block::ReduceJoin7;
                             } else {
                                 fits_parser_yyerror(lParse, cs!(c"Function() not supported"));
-                                current_block = block::YYERRLAB;
+                                current_block = Block::YyErrLab;
                             }
                             match current_block {
-                                block::YYERRLAB => {}
+                                Block::YyErrLab => {}
                                 _ => {
                                     if yyval.Node < 0 {
-                                        current_block = block::YYERRLAB;
+                                        current_block = Block::YyErrLab;
                                     } else {
-                                        current_block = block::REDUCE_DONE;
+                                        current_block = Block::ReduceDone;
                                     }
                                 }
                             }
@@ -2598,7 +2599,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     0,
                                     0,
                                 );
-                                current_block = block::REDUCE_JOIN_5;
+                                current_block = Block::ReduceJoin5;
                             } else if astr_eq(&yyvs[yyvsp - 2].astr, c"NELEM(") {
                                 yyval.Node = New_Const(
                                     lParse,
@@ -2608,7 +2609,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         .cast::<c_void>(),
                                     ::core::mem::size_of::<c_long>() as c_ulong as c_long,
                                 );
-                                current_block = block::REDUCE_JOIN_5;
+                                current_block = Block::ReduceJoin5;
                             } else if astr_eq(&yyvs[yyvsp - 2].astr, c"ACCUM(") {
                                 let mut zero: c_long = 0;
                                 let new_node = New_Const(
@@ -2625,18 +2626,18 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     fits_parser_yytokentype::ACCUM as c_int,
                                     new_node,
                                 );
-                                current_block = block::REDUCE_JOIN_5;
+                                current_block = Block::ReduceJoin5;
                             } else {
                                 fits_parser_yyerror(lParse, cs!(c"Function(bool) not supported"));
-                                current_block = block::YYERRLAB;
+                                current_block = Block::YyErrLab;
                             }
                             match current_block {
-                                block::YYERRLAB => {}
+                                Block::YyErrLab => {}
                                 _ => {
                                     if yyval.Node < 0 {
-                                        current_block = block::YYERRLAB;
+                                        current_block = Block::YyErrLab;
                                     } else {
-                                        current_block = block::REDUCE_DONE;
+                                        current_block = Block::ReduceDone;
                                     }
                                 }
                             }
@@ -2653,7 +2654,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         lParse,
                                         cs!(c"AXISELEM second argument must be a scalar constant"),
                                     );
-                                    current_block = block::YYERRLAB;
+                                    current_block = Block::YyErrLab;
                                 } else if ((lParse.Nodes)[yyvs[yyvsp - 3].Node as usize]).operation
                                     == CONST_OP
                                 {
@@ -2664,7 +2665,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         (&mut one as *mut c_long).cast::<c_void>(),
                                         ::core::mem::size_of::<c_long>() as c_ulong as c_long,
                                     );
-                                    current_block = block::REDUCE_JOIN_4;
+                                    current_block = Block::ReduceJoin4;
                                 } else {
                                     if ((lParse.Nodes)[yyvs[yyvsp - 1].Node as usize]).ntype
                                         != fits_parser_yytokentype::LONG as c_int
@@ -2690,11 +2691,11 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         0,
                                     );
                                     if yyval.Node < 0 {
-                                        current_block = block::YYERRLAB;
+                                        current_block = Block::YyErrLab;
                                     } else {
                                         ((lParse.Nodes)[yyval.Node as usize]).ntype =
                                             fits_parser_yytokentype::LONG as c_int;
-                                        current_block = block::REDUCE_JOIN_4;
+                                        current_block = Block::ReduceJoin4;
                                     }
                                 }
                             } else if astr_eq(&yyvs[yyvsp - 4].astr, c"NAXES(") {
@@ -2707,7 +2708,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         lParse,
                                         cs!(c"NAXES second argument must be a scalar constant"),
                                     );
-                                    current_block = block::YYERRLAB;
+                                    current_block = Block::YyErrLab;
                                 } else if ((lParse.Nodes)[yyvs[yyvsp - 3].Node as usize]).operation
                                     == CONST_OP
                                 {
@@ -2718,7 +2719,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         (&mut one_0 as *mut c_long).cast::<c_void>(),
                                         ::core::mem::size_of::<c_long>() as c_ulong as c_long,
                                     );
-                                    current_block = block::REDUCE_JOIN_4;
+                                    current_block = Block::ReduceJoin4;
                                 } else {
                                     let mut iaxis: c_long = 0;
                                     let mut naxis: c_int = 0;
@@ -2755,33 +2756,33 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         ::core::mem::size_of::<c_long>() as c_ulong as c_long,
                                     );
                                     if yyval.Node < 0 {
-                                        current_block = block::YYERRLAB;
+                                        current_block = Block::YyErrLab;
                                     } else {
-                                        current_block = block::REDUCE_JOIN_4;
+                                        current_block = Block::ReduceJoin4;
                                     }
                                 }
                             } else if astr_eq(&yyvs[yyvsp - 4].astr, c"ARRAY(") {
                                 yyval.Node =
                                     New_Array(lParse, yyvs[yyvsp - 3].Node, yyvs[yyvsp - 1].Node);
                                 if yyval.Node < 0 {
-                                    current_block = block::YYERRLAB;
+                                    current_block = Block::YyErrLab;
                                 } else {
-                                    current_block = block::REDUCE_JOIN_4;
+                                    current_block = Block::ReduceJoin4;
                                 }
                             } else {
                                 fits_parser_yyerror(
                                     lParse,
                                     cs!(c"Function(bool,expr) not supported"),
                                 );
-                                current_block = block::YYERRLAB;
+                                current_block = Block::YyErrLab;
                             }
                             match current_block {
-                                block::YYERRLAB => {}
+                                Block::YyErrLab => {}
                                 _ => {
                                     if yyval.Node < 0 {
-                                        current_block = block::YYERRLAB;
+                                        current_block = Block::YyErrLab;
                                     } else {
-                                        current_block = block::REDUCE_DONE;
+                                        current_block = Block::ReduceDone;
                                     }
                                 }
                             }
@@ -2797,7 +2798,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         .cast::<c_void>(),
                                     ::core::mem::size_of::<c_long>() as c_ulong as c_long,
                                 );
-                                current_block = block::REDUCE_JOIN_8;
+                                current_block = Block::ReduceJoin8;
                             } else if astr_eq(&yyvs[yyvsp - 2].astr, c"NVALID(") {
                                 yyval.Node = New_Func(
                                     lParse,
@@ -2812,18 +2813,18 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     0,
                                     0,
                                 );
-                                current_block = block::REDUCE_JOIN_8;
+                                current_block = Block::ReduceJoin8;
                             } else {
                                 fits_parser_yyerror(lParse, cs!(c"Function(str) not supported"));
-                                current_block = block::YYERRLAB;
+                                current_block = Block::YyErrLab;
                             }
                             match current_block {
-                                block::YYERRLAB => {}
+                                Block::YyErrLab => {}
                                 _ => {
                                     if yyval.Node < 0 {
-                                        current_block = block::YYERRLAB;
+                                        current_block = Block::YyErrLab;
                                     } else {
-                                        current_block = block::REDUCE_DONE;
+                                        current_block = Block::ReduceDone;
                                     }
                                 }
                             }
@@ -2839,7 +2840,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         .cast::<c_void>(),
                                     ::core::mem::size_of::<c_long>() as c_ulong as c_long,
                                 );
-                                current_block = block::REDUCE_JOIN_3;
+                                current_block = Block::ReduceJoin3;
                             } else if astr_eq(&yyvs[yyvsp - 2].astr, c"NVALID(") {
                                 yyval.Node = New_Const(
                                     lParse,
@@ -2849,7 +2850,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         .cast::<c_void>(),
                                     ::core::mem::size_of::<c_long>() as c_ulong as c_long,
                                 );
-                                current_block = block::REDUCE_JOIN_3;
+                                current_block = Block::ReduceJoin3;
                             } else if astr_eq(&yyvs[yyvsp - 2].astr, c"SUM(") {
                                 yyval.Node = New_Func(
                                     lParse,
@@ -2864,7 +2865,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     0,
                                     0,
                                 );
-                                current_block = block::REDUCE_JOIN_3;
+                                current_block = Block::ReduceJoin3;
                             } else if astr_eq(&yyvs[yyvsp - 2].astr, c"MIN(") {
                                 yyval.Node = New_Func(
                                     lParse,
@@ -2880,7 +2881,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     0,
                                 );
                                 (((lParse.Nodes)[yyval.Node as usize]).value).nelem = 1;
-                                current_block = block::REDUCE_JOIN_3;
+                                current_block = Block::ReduceJoin3;
                             } else if astr_eq(&yyvs[yyvsp - 2].astr, c"ACCUM(") {
                                 let mut zero_0: c_long = 0;
                                 let new_node = New_Const(
@@ -2897,7 +2898,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     fits_parser_yytokentype::ACCUM as c_int,
                                     new_node,
                                 );
-                                current_block = block::REDUCE_JOIN_3;
+                                current_block = Block::ReduceJoin3;
                             } else if astr_eq(&yyvs[yyvsp - 2].astr, c"MAX(") {
                                 yyval.Node = New_Func(
                                     lParse,
@@ -2913,18 +2914,18 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     0,
                                 );
                                 (((lParse.Nodes)[yyval.Node as usize]).value).nelem = 1;
-                                current_block = block::REDUCE_JOIN_3;
+                                current_block = Block::ReduceJoin3;
                             } else {
                                 fits_parser_yyerror(lParse, cs!(c"Function(bits) not supported"));
-                                current_block = block::YYERRLAB;
+                                current_block = Block::YyErrLab;
                             }
                             match current_block {
-                                block::YYERRLAB => {}
+                                Block::YyErrLab => {}
                                 _ => {
                                     if yyval.Node < 0 {
-                                        current_block = block::YYERRLAB;
+                                        current_block = Block::YyErrLab;
                                     } else {
-                                        current_block = block::REDUCE_DONE;
+                                        current_block = Block::ReduceDone;
                                     }
                                 }
                             }
@@ -2945,7 +2946,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     0,
                                     0,
                                 );
-                                current_block = block::REDUCE_JOIN_1;
+                                current_block = Block::ReduceJoin1;
                             } else if astr_eq(&yyvs[yyvsp - 2].astr, c"AVERAGE(") {
                                 yyval.Node = New_Func(
                                     lParse,
@@ -2960,7 +2961,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     0,
                                     0,
                                 );
-                                current_block = block::REDUCE_JOIN_1;
+                                current_block = Block::ReduceJoin1;
                             } else if astr_eq(&yyvs[yyvsp - 2].astr, c"STDDEV(") {
                                 yyval.Node = New_Func(
                                     lParse,
@@ -2975,7 +2976,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     0,
                                     0,
                                 );
-                                current_block = block::REDUCE_JOIN_1;
+                                current_block = Block::ReduceJoin1;
                             } else if astr_eq(&yyvs[yyvsp - 2].astr, c"MEDIAN(") {
                                 yyval.Node = New_Func(
                                     lParse,
@@ -2990,7 +2991,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     0,
                                     0,
                                 );
-                                current_block = block::REDUCE_JOIN_1;
+                                current_block = Block::ReduceJoin1;
                             } else if astr_eq(&yyvs[yyvsp - 2].astr, c"NELEM(") {
                                 yyval.Node = New_Const(
                                     lParse,
@@ -3000,7 +3001,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         .cast::<c_void>(),
                                     ::core::mem::size_of::<c_long>() as c_ulong as c_long,
                                 );
-                                current_block = block::REDUCE_JOIN_1;
+                                current_block = Block::ReduceJoin1;
                             } else if astr_eq(&yyvs[yyvsp - 2].astr, c"NVALID(") {
                                 yyval.Node = New_Func(
                                     lParse,
@@ -3015,7 +3016,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     0,
                                     0,
                                 );
-                                current_block = block::REDUCE_JOIN_1;
+                                current_block = Block::ReduceJoin1;
                             } else if astr_eq(&yyvs[yyvsp - 2].astr, c"ACCUM(")
                                 && ((lParse.Nodes)[yyvs[yyvsp - 1].Node as usize]).ntype
                                     == fits_parser_yytokentype::LONG as c_int
@@ -3038,7 +3039,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     fits_parser_yytokentype::ACCUM as c_int,
                                     new_node,
                                 );
-                                current_block = block::REDUCE_JOIN_1;
+                                current_block = Block::ReduceJoin1;
                             } else if astr_eq(&yyvs[yyvsp - 2].astr, c"ACCUM(")
                                 && ((lParse.Nodes)[yyvs[yyvsp - 1].Node as usize]).ntype
                                     == fits_parser_yytokentype::DOUBLE as c_int
@@ -3058,7 +3059,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     fits_parser_yytokentype::ACCUM as c_int,
                                     new_node,
                                 );
-                                current_block = block::REDUCE_JOIN_1;
+                                current_block = Block::ReduceJoin1;
                             } else if astr_eq(&yyvs[yyvsp - 2].astr, c"SEQDIFF(")
                                 && ((lParse.Nodes)[yyvs[yyvsp - 1].Node as usize]).ntype
                                     == fits_parser_yytokentype::LONG as c_int
@@ -3078,7 +3079,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     fits_parser_yytokentype::DIFF as c_int,
                                     new_node,
                                 );
-                                current_block = block::REDUCE_JOIN_1;
+                                current_block = Block::ReduceJoin1;
                             } else if astr_eq(&yyvs[yyvsp - 2].astr, c"SEQDIFF(")
                                 && ((lParse.Nodes)[yyvs[yyvsp - 1].Node as usize]).ntype
                                     == fits_parser_yytokentype::DOUBLE as c_int
@@ -3098,7 +3099,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     fits_parser_yytokentype::DIFF as c_int,
                                     new_node,
                                 );
-                                current_block = block::REDUCE_JOIN_1;
+                                current_block = Block::ReduceJoin1;
                             } else if astr_eq(&yyvs[yyvsp - 2].astr, c"ABS(") {
                                 yyval.Node = New_Func(
                                     lParse,
@@ -3113,7 +3114,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     0,
                                     0,
                                 );
-                                current_block = block::REDUCE_JOIN_1;
+                                current_block = Block::ReduceJoin1;
                             } else if astr_eq(&yyvs[yyvsp - 2].astr, c"MIN(") {
                                 yyval.Node = New_Func(
                                     lParse,
@@ -3128,7 +3129,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     0,
                                     0,
                                 );
-                                current_block = block::REDUCE_JOIN_1;
+                                current_block = Block::ReduceJoin1;
                             } else if astr_eq(&yyvs[yyvsp - 2].astr, c"MAX(") {
                                 yyval.Node = New_Func(
                                     lParse,
@@ -3143,7 +3144,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     0,
                                     0,
                                 );
-                                current_block = block::REDUCE_JOIN_1;
+                                current_block = Block::ReduceJoin1;
                             } else if astr_eq(&yyvs[yyvsp - 2].astr, c"RANDOM(") {
                                 yyval.Node = New_Func(
                                     lParse,
@@ -3159,11 +3160,11 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     0,
                                 );
                                 if yyval.Node < 0 {
-                                    current_block = block::YYERRLAB;
+                                    current_block = Block::YyErrLab;
                                 } else {
                                     ((lParse.Nodes)[yyval.Node as usize]).ntype =
                                         fits_parser_yytokentype::DOUBLE as c_int;
-                                    current_block = block::REDUCE_JOIN_1;
+                                    current_block = Block::ReduceJoin1;
                                 }
                             } else if astr_eq(&yyvs[yyvsp - 2].astr, c"RANDOMN(") {
                                 yyval.Node = New_Func(
@@ -3180,11 +3181,11 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     0,
                                 );
                                 if yyval.Node < 0 {
-                                    current_block = block::YYERRLAB;
+                                    current_block = Block::YyErrLab;
                                 } else {
                                     ((lParse.Nodes)[yyval.Node as usize]).ntype =
                                         fits_parser_yytokentype::DOUBLE as c_int;
-                                    current_block = block::REDUCE_JOIN_1;
+                                    current_block = Block::ReduceJoin1;
                                 }
                             } else if astr_eq(&yyvs[yyvsp - 2].astr, c"ELEMENTNUM(") {
                                 if ((lParse.Nodes)[yyvs[yyvsp - 1].Node as usize]).operation
@@ -3197,7 +3198,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         (&mut one_1 as *mut c_long).cast::<c_void>(),
                                         ::core::mem::size_of::<c_long>() as c_ulong as c_long,
                                     );
-                                    current_block = block::REDUCE_JOIN_1;
+                                    current_block = Block::ReduceJoin1;
                                 } else {
                                     yyval.Node = New_Func(
                                         lParse,
@@ -3213,11 +3214,11 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         0,
                                     );
                                     if yyval.Node < 0 {
-                                        current_block = block::YYERRLAB;
+                                        current_block = Block::YyErrLab;
                                     } else {
                                         ((lParse.Nodes)[yyval.Node as usize]).ntype =
                                             fits_parser_yytokentype::LONG as c_int;
-                                        current_block = block::REDUCE_JOIN_1;
+                                        current_block = Block::ReduceJoin1;
                                     }
                                 }
                             } else if astr_eq(&yyvs[yyvsp - 2].astr, c"NAXIS(") {
@@ -3231,7 +3232,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         (&mut one_2 as *mut c_long).cast::<c_void>(),
                                         ::core::mem::size_of::<c_long>() as c_ulong as c_long,
                                     );
-                                    current_block = block::REDUCE_JOIN_1;
+                                    current_block = Block::ReduceJoin1;
                                 } else {
                                     let mut naxis_0: c_long = c_long::from(
                                         ((lParse.Nodes)[yyvs[yyvsp - 1].Node as usize]).value.naxis,
@@ -3243,9 +3244,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         ::core::mem::size_of::<c_long>() as c_ulong as c_long,
                                     );
                                     if yyval.Node < 0 {
-                                        current_block = block::YYERRLAB;
+                                        current_block = Block::YyErrLab;
                                     } else {
-                                        current_block = block::REDUCE_JOIN_1;
+                                        current_block = Block::ReduceJoin1;
                                     }
                                 }
                             } else {
@@ -3273,7 +3274,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         0,
                                         0,
                                     );
-                                    current_block = block::REDUCE_JOIN_1;
+                                    current_block = Block::ReduceJoin1;
                                 } else if astr_eq(&yyvs[yyvsp - 2].astr, c"COS(") {
                                     yyval.Node = New_Func(
                                         lParse,
@@ -3288,7 +3289,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         0,
                                         0,
                                     );
-                                    current_block = block::REDUCE_JOIN_1;
+                                    current_block = Block::ReduceJoin1;
                                 } else if astr_eq(&yyvs[yyvsp - 2].astr, c"TAN(") {
                                     yyval.Node = New_Func(
                                         lParse,
@@ -3303,7 +3304,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         0,
                                         0,
                                     );
-                                    current_block = block::REDUCE_JOIN_1;
+                                    current_block = Block::ReduceJoin1;
                                 } else if astr_eq(&yyvs[yyvsp - 2].astr, c"ARCSIN(")
                                     || astr_eq(&yyvs[yyvsp - 2].astr, c"ASIN(")
                                 {
@@ -3320,7 +3321,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         0,
                                         0,
                                     );
-                                    current_block = block::REDUCE_JOIN_1;
+                                    current_block = Block::ReduceJoin1;
                                 } else if astr_eq(&yyvs[yyvsp - 2].astr, c"ARCCOS(")
                                     || astr_eq(&yyvs[yyvsp - 2].astr, c"ACOS(")
                                 {
@@ -3337,7 +3338,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         0,
                                         0,
                                     );
-                                    current_block = block::REDUCE_JOIN_1;
+                                    current_block = Block::ReduceJoin1;
                                 } else if astr_eq(&yyvs[yyvsp - 2].astr, c"ARCTAN(")
                                     || astr_eq(&yyvs[yyvsp - 2].astr, c"ATAN(")
                                 {
@@ -3354,7 +3355,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         0,
                                         0,
                                     );
-                                    current_block = block::REDUCE_JOIN_1;
+                                    current_block = Block::ReduceJoin1;
                                 } else if astr_eq(&yyvs[yyvsp - 2].astr, c"SINH(") {
                                     yyval.Node = New_Func(
                                         lParse,
@@ -3369,7 +3370,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         0,
                                         0,
                                     );
-                                    current_block = block::REDUCE_JOIN_1;
+                                    current_block = Block::ReduceJoin1;
                                 } else if astr_eq(&yyvs[yyvsp - 2].astr, c"COSH(") {
                                     yyval.Node = New_Func(
                                         lParse,
@@ -3384,7 +3385,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         0,
                                         0,
                                     );
-                                    current_block = block::REDUCE_JOIN_1;
+                                    current_block = Block::ReduceJoin1;
                                 } else if astr_eq(&yyvs[yyvsp - 2].astr, c"TANH(") {
                                     yyval.Node = New_Func(
                                         lParse,
@@ -3399,7 +3400,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         0,
                                         0,
                                     );
-                                    current_block = block::REDUCE_JOIN_1;
+                                    current_block = Block::ReduceJoin1;
                                 } else if astr_eq(&yyvs[yyvsp - 2].astr, c"EXP(") {
                                     yyval.Node = New_Func(
                                         lParse,
@@ -3414,7 +3415,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         0,
                                         0,
                                     );
-                                    current_block = block::REDUCE_JOIN_1;
+                                    current_block = Block::ReduceJoin1;
                                 } else if astr_eq(&yyvs[yyvsp - 2].astr, c"LOG(") {
                                     yyval.Node = New_Func(
                                         lParse,
@@ -3429,7 +3430,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         0,
                                         0,
                                     );
-                                    current_block = block::REDUCE_JOIN_1;
+                                    current_block = Block::ReduceJoin1;
                                 } else if astr_eq(&yyvs[yyvsp - 2].astr, c"LOG10(") {
                                     yyval.Node = New_Func(
                                         lParse,
@@ -3444,7 +3445,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         0,
                                         0,
                                     );
-                                    current_block = block::REDUCE_JOIN_1;
+                                    current_block = Block::ReduceJoin1;
                                 } else if astr_eq(&yyvs[yyvsp - 2].astr, c"SQRT(") {
                                     yyval.Node = New_Func(
                                         lParse,
@@ -3459,7 +3460,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         0,
                                         0,
                                     );
-                                    current_block = block::REDUCE_JOIN_1;
+                                    current_block = Block::ReduceJoin1;
                                 } else if astr_eq(&yyvs[yyvsp - 2].astr, c"ROUND(") {
                                     yyval.Node = New_Func(
                                         lParse,
@@ -3474,7 +3475,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         0,
                                         0,
                                     );
-                                    current_block = block::REDUCE_JOIN_1;
+                                    current_block = Block::ReduceJoin1;
                                 } else if astr_eq(&yyvs[yyvsp - 2].astr, c"FLOOR(") {
                                     yyval.Node = New_Func(
                                         lParse,
@@ -3489,7 +3490,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         0,
                                         0,
                                     );
-                                    current_block = block::REDUCE_JOIN_1;
+                                    current_block = Block::ReduceJoin1;
                                 } else if astr_eq(&yyvs[yyvsp - 2].astr, c"CEIL(") {
                                     yyval.Node = New_Func(
                                         lParse,
@@ -3504,7 +3505,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         0,
                                         0,
                                     );
-                                    current_block = block::REDUCE_JOIN_1;
+                                    current_block = Block::ReduceJoin1;
                                 } else if astr_eq(&yyvs[yyvsp - 2].astr, c"RANDOMP(") {
                                     yyval.Node = New_Func(
                                         lParse,
@@ -3521,22 +3522,22 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     );
                                     ((lParse.Nodes)[yyval.Node as usize]).ntype =
                                         fits_parser_yytokentype::LONG as c_int;
-                                    current_block = block::REDUCE_JOIN_1;
+                                    current_block = Block::ReduceJoin1;
                                 } else {
                                     fits_parser_yyerror(
                                         lParse,
                                         cs!(c"Function(expr) not supported"),
                                     );
-                                    current_block = block::YYERRLAB;
+                                    current_block = Block::YyErrLab;
                                 }
                             }
                             match current_block {
-                                block::YYERRLAB => {}
+                                Block::YyErrLab => {}
                                 _ => {
                                     if yyval.Node < 0 {
-                                        current_block = block::YYERRLAB;
+                                        current_block = Block::YyErrLab;
                                     } else {
-                                        current_block = block::REDUCE_DONE;
+                                        current_block = Block::ReduceDone;
                                     }
                                 }
                             }
@@ -3558,17 +3559,17 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     0,
                                 );
                                 if yyval.Node < 0 {
-                                    current_block = block::YYERRLAB;
+                                    current_block = Block::YyErrLab;
                                 } else {
-                                    current_block = block::REDUCE_JOIN_6;
+                                    current_block = Block::ReduceJoin6;
                                 }
                             } else {
-                                current_block = block::REDUCE_JOIN_6;
+                                current_block = Block::ReduceJoin6;
                             }
                             match current_block {
-                                block::YYERRLAB => {}
+                                Block::YyErrLab => {}
                                 _ => {
-                                    current_block = block::REDUCE_DONE;
+                                    current_block = Block::ReduceDone;
                                 }
                             }
                         }
@@ -3613,16 +3614,16 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         0,
                                     );
                                     if yyval.Node < 0 {
-                                        current_block = block::YYERRLAB;
+                                        current_block = Block::YyErrLab;
                                     } else {
-                                        current_block = block::REDUCE_JOIN_2;
+                                        current_block = Block::ReduceJoin2;
                                     }
                                 } else {
                                     fits_parser_yyerror(
                                         lParse,
                                         cs!(c"Dimensions of DEFNULL arguments are not compatible"),
                                     );
-                                    current_block = block::YYERRLAB;
+                                    current_block = Block::YyErrLab;
                                 }
                             } else if astr_eq(&yyvs[yyvsp - 4].astr, c"ARCTAN2(") {
                                 if ((lParse.Nodes)[yyvs[yyvsp - 3].Node as usize]).ntype
@@ -3662,7 +3663,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         0,
                                     );
                                     if yyval.Node < 0 {
-                                        current_block = block::YYERRLAB;
+                                        current_block = Block::YyErrLab;
                                     } else {
                                         if ((lParse.Nodes)[yyvs[yyvsp - 3].Node as usize])
                                             .value
@@ -3673,14 +3674,14 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         {
                                             Copy_Dims(lParse, yyval.Node, yyvs[yyvsp - 1].Node);
                                         }
-                                        current_block = block::REDUCE_JOIN_2;
+                                        current_block = Block::ReduceJoin2;
                                     }
                                 } else {
                                     fits_parser_yyerror(
                                         lParse,
                                         cs!(c"Dimensions of arctan2 arguments are not compatible"),
                                     );
-                                    current_block = block::YYERRLAB;
+                                    current_block = Block::YyErrLab;
                                 }
                             } else if astr_eq(&yyvs[yyvsp - 4].astr, c"MIN(") {
                                 if ((lParse.Nodes)[yyvs[yyvsp - 3].Node as usize]).ntype
@@ -3719,7 +3720,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         0,
                                     );
                                     if yyval.Node < 0 {
-                                        current_block = block::YYERRLAB;
+                                        current_block = Block::YyErrLab;
                                     } else {
                                         if ((lParse.Nodes)[yyvs[yyvsp - 3].Node as usize])
                                             .value
@@ -3730,14 +3731,14 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         {
                                             Copy_Dims(lParse, yyval.Node, yyvs[yyvsp - 1].Node);
                                         }
-                                        current_block = block::REDUCE_JOIN_2;
+                                        current_block = Block::ReduceJoin2;
                                     }
                                 } else {
                                     fits_parser_yyerror(
                                         lParse,
                                         cs!(c"Dimensions of min(a,b) arguments are not compatible"),
                                     );
-                                    current_block = block::YYERRLAB;
+                                    current_block = Block::YyErrLab;
                                 }
                             } else if astr_eq(&yyvs[yyvsp - 4].astr, c"MAX(") {
                                 if ((lParse.Nodes)[yyvs[yyvsp - 3].Node as usize]).ntype
@@ -3776,7 +3777,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         0,
                                     );
                                     if yyval.Node < 0 {
-                                        current_block = block::YYERRLAB;
+                                        current_block = Block::YyErrLab;
                                     } else {
                                         if ((lParse.Nodes)[yyvs[yyvsp - 3].Node as usize])
                                             .value
@@ -3787,14 +3788,14 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         {
                                             Copy_Dims(lParse, yyval.Node, yyvs[yyvsp - 1].Node);
                                         }
-                                        current_block = block::REDUCE_JOIN_2;
+                                        current_block = Block::ReduceJoin2;
                                     }
                                 } else {
                                     fits_parser_yyerror(
                                         lParse,
                                         cs!(c"Dimensions of max(a,b) arguments are not compatible"),
                                     );
-                                    current_block = block::YYERRLAB;
+                                    current_block = Block::YyErrLab;
                                 }
                             } else if astr_eq(&yyvs[yyvsp - 4].astr, c"SETNULL(") {
                                 if ((lParse.Nodes)[yyvs[yyvsp - 3].Node as usize]).operation
@@ -3806,7 +3807,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         lParse,
                                         cs!(c"SETNULL first argument must be a scalar constant"),
                                     );
-                                    current_block = block::YYERRLAB;
+                                    current_block = Block::YyErrLab;
                                 } else {
                                     if ((lParse.Nodes)[yyvs[yyvsp - 3].Node as usize]).ntype
                                         != ((lParse.Nodes)[yyvs[yyvsp - 1].Node as usize]).ntype
@@ -3831,7 +3832,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         0,
                                         0,
                                     );
-                                    current_block = block::REDUCE_JOIN_2;
+                                    current_block = Block::ReduceJoin2;
                                 }
                             } else if astr_eq(&yyvs[yyvsp - 4].astr, c"AXISELEM(") {
                                 if ((lParse.Nodes)[yyvs[yyvsp - 1].Node as usize]).operation
@@ -3843,7 +3844,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         lParse,
                                         cs!(c"AXISELEM second argument must be a scalar constant"),
                                     );
-                                    current_block = block::YYERRLAB;
+                                    current_block = Block::YyErrLab;
                                 } else if ((lParse.Nodes)[yyvs[yyvsp - 3].Node as usize]).operation
                                     == CONST_OP
                                 {
@@ -3854,7 +3855,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         (&mut one_3 as *mut c_long).cast::<c_void>(),
                                         ::core::mem::size_of::<c_long>() as c_ulong as c_long,
                                     );
-                                    current_block = block::REDUCE_JOIN_2;
+                                    current_block = Block::ReduceJoin2;
                                 } else {
                                     if ((lParse.Nodes)[yyvs[yyvsp - 1].Node as usize]).ntype
                                         != fits_parser_yytokentype::LONG as c_int
@@ -3880,11 +3881,11 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         0,
                                     );
                                     if yyval.Node < 0 {
-                                        current_block = block::YYERRLAB;
+                                        current_block = Block::YyErrLab;
                                     } else {
                                         ((lParse.Nodes)[yyval.Node as usize]).ntype =
                                             fits_parser_yytokentype::LONG as c_int;
-                                        current_block = block::REDUCE_JOIN_2;
+                                        current_block = Block::ReduceJoin2;
                                     }
                                 }
                             } else if astr_eq(&yyvs[yyvsp - 4].astr, c"NAXES(") {
@@ -3897,7 +3898,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         lParse,
                                         cs!(c"NAXES second argument must be a scalar constant"),
                                     );
-                                    current_block = block::YYERRLAB;
+                                    current_block = Block::YyErrLab;
                                 } else if ((lParse.Nodes)[yyvs[yyvsp - 3].Node as usize]).operation
                                     == CONST_OP
                                 {
@@ -3908,7 +3909,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         (&mut one_4 as *mut c_long).cast::<c_void>(),
                                         ::core::mem::size_of::<c_long>() as c_ulong as c_long,
                                     );
-                                    current_block = block::REDUCE_JOIN_2;
+                                    current_block = Block::ReduceJoin2;
                                 } else {
                                     let mut iaxis_0: c_long = 0;
                                     let mut naxis_1: c_int = 0;
@@ -3945,30 +3946,30 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         ::core::mem::size_of::<c_long>() as c_ulong as c_long,
                                     );
                                     if yyval.Node < 0 {
-                                        current_block = block::YYERRLAB;
+                                        current_block = Block::YyErrLab;
                                     } else {
-                                        current_block = block::REDUCE_JOIN_2;
+                                        current_block = Block::ReduceJoin2;
                                     }
                                 }
                             } else if astr_eq(&yyvs[yyvsp - 4].astr, c"ARRAY(") {
                                 yyval.Node =
                                     New_Array(lParse, yyvs[yyvsp - 3].Node, yyvs[yyvsp - 1].Node);
                                 if yyval.Node < 0 {
-                                    current_block = block::YYERRLAB;
+                                    current_block = Block::YyErrLab;
                                 } else {
-                                    current_block = block::REDUCE_JOIN_2;
+                                    current_block = Block::ReduceJoin2;
                                 }
                             } else {
                                 fits_parser_yyerror(
                                     lParse,
                                     cs!(c"Function(expr,expr) not supported"),
                                 );
-                                current_block = block::YYERRLAB;
+                                current_block = Block::YyErrLab;
                             }
                             match current_block {
-                                block::YYERRLAB => {}
+                                Block::YyErrLab => {}
                                 _ => {
-                                    current_block = block::REDUCE_DONE;
+                                    current_block = Block::ReduceDone;
                                 }
                             }
                         }
@@ -4036,7 +4037,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         0,
                                     );
                                     if yyval.Node < 0 {
-                                        current_block = block::YYERRLAB;
+                                        current_block = Block::YyErrLab;
                                     } else {
                                         if ((lParse.Nodes)[yyvs[yyvsp - 7].Node as usize])
                                             .value
@@ -4065,21 +4066,21 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         {
                                             Copy_Dims(lParse, yyval.Node, yyvs[yyvsp - 1].Node);
                                         }
-                                        current_block = block::REDUCE_DONE;
+                                        current_block = Block::ReduceDone;
                                     }
                                 } else {
                                     fits_parser_yyerror(
                                         lParse,
                                         cs!(c"Dimensions of ANGSEP arguments are not compatible"),
                                     );
-                                    current_block = block::YYERRLAB;
+                                    current_block = Block::YyErrLab;
                                 }
                             } else {
                                 fits_parser_yyerror(
                                     lParse,
                                     cs!(c"Function(expr,expr,expr,expr) not supported"),
                                 );
-                                current_block = block::YYERRLAB;
+                                current_block = Block::YyErrLab;
                             }
                         }
                         63 => {
@@ -4094,9 +4095,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 c"*STOP*".as_ptr() as *mut c_char,
                             );
                             if yyval.Node < 0 {
-                                current_block = block::YYERRLAB;
+                                current_block = Block::YyErrLab;
                             } else {
-                                current_block = block::REDUCE_DONE;
+                                current_block = Block::ReduceDone;
                             }
                         }
                         64 => {
@@ -4111,9 +4112,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 (yyvs[yyvsp - 1].astr).as_mut_ptr(),
                             );
                             if yyval.Node < 0 {
-                                current_block = block::YYERRLAB;
+                                current_block = Block::YyErrLab;
                             } else {
-                                current_block = block::REDUCE_DONE;
+                                current_block = Block::ReduceDone;
                             }
                         }
                         65 => {
@@ -4129,9 +4130,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 0,
                             );
                             if yyval.Node < 0 {
-                                current_block = block::YYERRLAB;
+                                current_block = Block::YyErrLab;
                             } else {
-                                current_block = block::REDUCE_DONE;
+                                current_block = Block::ReduceDone;
                             }
                         }
                         66 => {
@@ -4147,9 +4148,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 0,
                             );
                             if yyval.Node < 0 {
-                                current_block = block::YYERRLAB;
+                                current_block = Block::YyErrLab;
                             } else {
-                                current_block = block::REDUCE_DONE;
+                                current_block = Block::ReduceDone;
                             }
                         }
                         67 => {
@@ -4165,9 +4166,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 0,
                             );
                             if yyval.Node < 0 {
-                                current_block = block::YYERRLAB;
+                                current_block = Block::YyErrLab;
                             } else {
-                                current_block = block::REDUCE_DONE;
+                                current_block = Block::ReduceDone;
                             }
                         }
                         68 => {
@@ -4183,9 +4184,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 0,
                             );
                             if yyval.Node < 0 {
-                                current_block = block::YYERRLAB;
+                                current_block = Block::YyErrLab;
                             } else {
-                                current_block = block::REDUCE_DONE;
+                                current_block = Block::ReduceDone;
                             }
                         }
                         69 => {
@@ -4201,9 +4202,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 yyvs[yyvsp - 1].Node,
                             );
                             if yyval.Node < 0 {
-                                current_block = block::YYERRLAB;
+                                current_block = Block::YyErrLab;
                             } else {
-                                current_block = block::REDUCE_DONE;
+                                current_block = Block::ReduceDone;
                             }
                         }
                         70 => {
@@ -4215,9 +4216,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 yyvs[yyvsp].Node,
                             );
                             if yyval.Node < 0 {
-                                current_block = block::YYERRLAB;
+                                current_block = Block::YyErrLab;
                             } else {
-                                current_block = block::REDUCE_DONE;
+                                current_block = Block::ReduceDone;
                             }
                         }
                         71 => {
@@ -4229,9 +4230,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 yyvs[yyvsp].Node,
                             );
                             if yyval.Node < 0 {
-                                current_block = block::YYERRLAB;
+                                current_block = Block::YyErrLab;
                             } else {
-                                current_block = block::REDUCE_DONE;
+                                current_block = Block::ReduceDone;
                             }
                         }
                         72 => {
@@ -4243,9 +4244,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 yyvs[yyvsp].Node,
                             );
                             if yyval.Node < 0 {
-                                current_block = block::YYERRLAB;
+                                current_block = Block::YyErrLab;
                             } else {
-                                current_block = block::REDUCE_DONE;
+                                current_block = Block::ReduceDone;
                             }
                         }
                         73 => {
@@ -4257,9 +4258,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 yyvs[yyvsp].Node,
                             );
                             if yyval.Node < 0 {
-                                current_block = block::YYERRLAB;
+                                current_block = Block::YyErrLab;
                             } else {
-                                current_block = block::REDUCE_DONE;
+                                current_block = Block::ReduceDone;
                             }
                         }
                         74 => {
@@ -4271,18 +4272,18 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 ::core::mem::size_of::<c_char>() as c_ulong as c_long,
                             );
                             if yyval.Node < 0 {
-                                current_block = block::YYERRLAB;
+                                current_block = Block::YyErrLab;
                             } else {
-                                current_block = block::REDUCE_DONE;
+                                current_block = Block::ReduceDone;
                             }
                         }
                         75 => {
                             /* bexpr: BCOLUMN  */
                             yyval.Node = New_Column(lParse, yyvs[yyvsp].lng as c_int);
                             if yyval.Node < 0 {
-                                current_block = block::YYERRLAB;
+                                current_block = Block::YyErrLab;
                             } else {
-                                current_block = block::REDUCE_DONE;
+                                current_block = Block::ReduceDone;
                             }
                         }
                         76 => {
@@ -4296,7 +4297,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     lParse,
                                     cs!(c"Offset argument must be a constant integer"),
                                 );
-                                current_block = block::YYERRLAB;
+                                current_block = Block::YyErrLab;
                             } else {
                                 yyval.Node = New_Offset(
                                     lParse,
@@ -4304,9 +4305,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     yyvs[yyvsp - 1].Node,
                                 );
                                 if yyval.Node < 0 {
-                                    current_block = block::YYERRLAB;
+                                    current_block = Block::YyErrLab;
                                 } else {
-                                    current_block = block::REDUCE_DONE;
+                                    current_block = Block::ReduceDone;
                                 }
                             }
                         }
@@ -4320,10 +4321,10 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 yyvs[yyvsp].Node,
                             );
                             if yyval.Node < 0 {
-                                current_block = block::YYERRLAB;
+                                current_block = Block::YyErrLab;
                             } else {
                                 (((lParse.Nodes)[yyval.Node as usize]).value).nelem = 1;
-                                current_block = block::REDUCE_DONE;
+                                current_block = Block::ReduceDone;
                             }
                         }
                         78 => {
@@ -4336,10 +4337,10 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 yyvs[yyvsp].Node,
                             );
                             if yyval.Node < 0 {
-                                current_block = block::YYERRLAB;
+                                current_block = Block::YyErrLab;
                             } else {
                                 (((lParse.Nodes)[yyval.Node as usize]).value).nelem = 1;
-                                current_block = block::REDUCE_DONE;
+                                current_block = Block::ReduceDone;
                             }
                         }
                         79 => {
@@ -4352,10 +4353,10 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 yyvs[yyvsp].Node,
                             );
                             if yyval.Node < 0 {
-                                current_block = block::YYERRLAB;
+                                current_block = Block::YyErrLab;
                             } else {
                                 (((lParse.Nodes)[yyval.Node as usize]).value).nelem = 1;
-                                current_block = block::REDUCE_DONE;
+                                current_block = Block::ReduceDone;
                             }
                         }
                         80 => {
@@ -4368,10 +4369,10 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 yyvs[yyvsp].Node,
                             );
                             if yyval.Node < 0 {
-                                current_block = block::YYERRLAB;
+                                current_block = Block::YyErrLab;
                             } else {
                                 (((lParse.Nodes)[yyval.Node as usize]).value).nelem = 1;
-                                current_block = block::REDUCE_DONE;
+                                current_block = Block::ReduceDone;
                             }
                         }
                         81 => {
@@ -4384,10 +4385,10 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 yyvs[yyvsp].Node,
                             );
                             if yyval.Node < 0 {
-                                current_block = block::YYERRLAB;
+                                current_block = Block::YyErrLab;
                             } else {
                                 (((lParse.Nodes)[yyval.Node as usize]).value).nelem = 1;
-                                current_block = block::REDUCE_DONE;
+                                current_block = Block::ReduceDone;
                             }
                         }
                         82 => {
@@ -4400,10 +4401,10 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 yyvs[yyvsp].Node,
                             );
                             if yyval.Node < 0 {
-                                current_block = block::YYERRLAB;
+                                current_block = Block::YyErrLab;
                             } else {
                                 (((lParse.Nodes)[yyval.Node as usize]).value).nelem = 1;
-                                current_block = block::REDUCE_DONE;
+                                current_block = Block::ReduceDone;
                             }
                         }
                         83 => {
@@ -4435,9 +4436,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 yyvs[yyvsp].Node,
                             );
                             if yyval.Node < 0 {
-                                current_block = block::YYERRLAB;
+                                current_block = Block::YyErrLab;
                             } else {
-                                current_block = block::REDUCE_DONE;
+                                current_block = Block::ReduceDone;
                             }
                         }
                         84 => {
@@ -4469,9 +4470,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 yyvs[yyvsp].Node,
                             );
                             if yyval.Node < 0 {
-                                current_block = block::YYERRLAB;
+                                current_block = Block::YyErrLab;
                             } else {
-                                current_block = block::REDUCE_DONE;
+                                current_block = Block::ReduceDone;
                             }
                         }
                         85 => {
@@ -4503,9 +4504,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 yyvs[yyvsp].Node,
                             );
                             if yyval.Node < 0 {
-                                current_block = block::YYERRLAB;
+                                current_block = Block::YyErrLab;
                             } else {
-                                current_block = block::REDUCE_DONE;
+                                current_block = Block::ReduceDone;
                             }
                         }
                         86 => {
@@ -4537,9 +4538,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 yyvs[yyvsp].Node,
                             );
                             if yyval.Node < 0 {
-                                current_block = block::YYERRLAB;
+                                current_block = Block::YyErrLab;
                             } else {
-                                current_block = block::REDUCE_DONE;
+                                current_block = Block::ReduceDone;
                             }
                         }
                         87 => {
@@ -4571,9 +4572,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 yyvs[yyvsp].Node,
                             );
                             if yyval.Node < 0 {
-                                current_block = block::YYERRLAB;
+                                current_block = Block::YyErrLab;
                             } else {
-                                current_block = block::REDUCE_DONE;
+                                current_block = Block::ReduceDone;
                             }
                         }
                         88 => {
@@ -4605,9 +4606,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 yyvs[yyvsp].Node,
                             );
                             if yyval.Node < 0 {
-                                current_block = block::YYERRLAB;
+                                current_block = Block::YyErrLab;
                             } else {
-                                current_block = block::REDUCE_DONE;
+                                current_block = Block::ReduceDone;
                             }
                         }
                         89 => {
@@ -4639,9 +4640,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 yyvs[yyvsp].Node,
                             );
                             if yyval.Node < 0 {
-                                current_block = block::YYERRLAB;
+                                current_block = Block::YyErrLab;
                             } else {
-                                current_block = block::REDUCE_DONE;
+                                current_block = Block::ReduceDone;
                             }
                         }
                         90 => {
@@ -4654,10 +4655,10 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 yyvs[yyvsp].Node,
                             );
                             if yyval.Node < 0 {
-                                current_block = block::YYERRLAB;
+                                current_block = Block::YyErrLab;
                             } else {
                                 (((lParse.Nodes)[yyval.Node as usize]).value).nelem = 1;
-                                current_block = block::REDUCE_DONE;
+                                current_block = Block::ReduceDone;
                             }
                         }
                         91 => {
@@ -4670,10 +4671,10 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 yyvs[yyvsp].Node,
                             );
                             if yyval.Node < 0 {
-                                current_block = block::YYERRLAB;
+                                current_block = Block::YyErrLab;
                             } else {
                                 (((lParse.Nodes)[yyval.Node as usize]).value).nelem = 1;
-                                current_block = block::REDUCE_DONE;
+                                current_block = Block::ReduceDone;
                             }
                         }
                         92 => {
@@ -4686,10 +4687,10 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 yyvs[yyvsp].Node,
                             );
                             if yyval.Node < 0 {
-                                current_block = block::YYERRLAB;
+                                current_block = Block::YyErrLab;
                             } else {
                                 (((lParse.Nodes)[yyval.Node as usize]).value).nelem = 1;
-                                current_block = block::REDUCE_DONE;
+                                current_block = Block::ReduceDone;
                             }
                         }
                         93 => {
@@ -4702,10 +4703,10 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 yyvs[yyvsp].Node,
                             );
                             if yyval.Node < 0 {
-                                current_block = block::YYERRLAB;
+                                current_block = Block::YyErrLab;
                             } else {
                                 (((lParse.Nodes)[yyval.Node as usize]).value).nelem = 1;
-                                current_block = block::REDUCE_DONE;
+                                current_block = Block::ReduceDone;
                             }
                         }
                         94 => {
@@ -4718,10 +4719,10 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 yyvs[yyvsp].Node,
                             );
                             if yyval.Node < 0 {
-                                current_block = block::YYERRLAB;
+                                current_block = Block::YyErrLab;
                             } else {
                                 (((lParse.Nodes)[yyval.Node as usize]).value).nelem = 1;
-                                current_block = block::REDUCE_DONE;
+                                current_block = Block::ReduceDone;
                             }
                         }
                         95 => {
@@ -4734,10 +4735,10 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 yyvs[yyvsp].Node,
                             );
                             if yyval.Node < 0 {
-                                current_block = block::YYERRLAB;
+                                current_block = Block::YyErrLab;
                             } else {
                                 (((lParse.Nodes)[yyval.Node as usize]).value).nelem = 1;
-                                current_block = block::REDUCE_DONE;
+                                current_block = Block::ReduceDone;
                             }
                         }
                         96 => {
@@ -4750,9 +4751,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 yyvs[yyvsp].Node,
                             );
                             if yyval.Node < 0 {
-                                current_block = block::YYERRLAB;
+                                current_block = Block::YyErrLab;
                             } else {
-                                current_block = block::REDUCE_DONE;
+                                current_block = Block::ReduceDone;
                             }
                         }
                         97 => {
@@ -4765,9 +4766,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 yyvs[yyvsp].Node,
                             );
                             if yyval.Node < 0 {
-                                current_block = block::YYERRLAB;
+                                current_block = Block::YyErrLab;
                             } else {
-                                current_block = block::REDUCE_DONE;
+                                current_block = Block::ReduceDone;
                             }
                         }
                         98 => {
@@ -4780,9 +4781,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 yyvs[yyvsp].Node,
                             );
                             if yyval.Node < 0 {
-                                current_block = block::YYERRLAB;
+                                current_block = Block::YyErrLab;
                             } else {
-                                current_block = block::REDUCE_DONE;
+                                current_block = Block::ReduceDone;
                             }
                         }
                         99 => {
@@ -4795,9 +4796,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 yyvs[yyvsp].Node,
                             );
                             if yyval.Node < 0 {
-                                current_block = block::YYERRLAB;
+                                current_block = Block::YyErrLab;
                             } else {
-                                current_block = block::REDUCE_DONE;
+                                current_block = Block::ReduceDone;
                             }
                         }
                         100 => {
@@ -4881,9 +4882,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 yyvs[yyvsp].Node,
                             );
                             if yyval.Node < 0 {
-                                current_block = block::YYERRLAB;
+                                current_block = Block::YyErrLab;
                             } else {
-                                current_block = block::REDUCE_DONE;
+                                current_block = Block::ReduceDone;
                             }
                         }
                         101 => {
@@ -4893,7 +4894,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     lParse,
                                     cs!(c"Incompatible dimensions in '?:' arguments"),
                                 );
-                                current_block = block::YYERRLAB;
+                                current_block = Block::YyErrLab;
                             } else {
                                 yyval.Node = New_Func(
                                     lParse,
@@ -4909,7 +4910,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     0,
                                 );
                                 if yyval.Node < 0 {
-                                    current_block = block::YYERRLAB;
+                                    current_block = Block::YyErrLab;
                                 } else {
                                     if ((lParse.Nodes)[yyvs[yyvsp - 2].Node as usize]).value.nelem
                                         < (lParse.Nodes[yyvs[yyvsp].Node as usize]).value.nelem
@@ -4921,7 +4922,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                             lParse,
                                             cs!(c"Incompatible dimensions in '?:' condition"),
                                         );
-                                        current_block = block::YYERRLAB;
+                                        current_block = Block::YyErrLab;
                                     } else {
                                         if (((lParse.Nodes)[yyval.Node as usize]).value).nelem
                                             < ((lParse.Nodes)[yyvs[yyvsp - 4].Node as usize])
@@ -4930,7 +4931,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         {
                                             Copy_Dims(lParse, yyval.Node, yyvs[yyvsp - 4].Node);
                                         }
-                                        current_block = block::REDUCE_DONE;
+                                        current_block = Block::ReduceDone;
                                     }
                                 }
                             }
@@ -4952,18 +4953,18 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     0,
                                 );
                                 if yyval.Node < 0 {
-                                    current_block = block::YYERRLAB;
+                                    current_block = Block::YyErrLab;
                                 } else {
                                     ((lParse.Nodes)[yyval.Node as usize]).ntype =
                                         fits_parser_yytokentype::BOOLEAN as c_int;
-                                    current_block = block::REDUCE_DONE;
+                                    current_block = Block::ReduceDone;
                                 }
                             } else {
                                 fits_parser_yyerror(
                                     lParse,
                                     cs!(c"Boolean Function(expr) not supported"),
                                 );
-                                current_block = block::YYERRLAB;
+                                current_block = Block::YyErrLab;
                             }
                         }
                         103 => {
@@ -4983,18 +4984,18 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     0,
                                 );
                                 if yyval.Node < 0 {
-                                    current_block = block::YYERRLAB;
+                                    current_block = Block::YyErrLab;
                                 } else {
                                     ((lParse.Nodes)[yyval.Node as usize]).ntype =
                                         fits_parser_yytokentype::BOOLEAN as c_int;
-                                    current_block = block::REDUCE_DONE;
+                                    current_block = Block::ReduceDone;
                                 }
                             } else {
                                 fits_parser_yyerror(
                                     lParse,
                                     cs!(c"Boolean Function(expr) not supported"),
                                 );
-                                current_block = block::YYERRLAB;
+                                current_block = Block::YyErrLab;
                             }
                         }
                         104 => {
@@ -5014,16 +5015,16 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     0,
                                 );
                                 if yyval.Node < 0 {
-                                    current_block = block::YYERRLAB;
+                                    current_block = Block::YyErrLab;
                                 } else {
-                                    current_block = block::REDUCE_DONE;
+                                    current_block = Block::ReduceDone;
                                 }
                             } else {
                                 fits_parser_yyerror(
                                     lParse,
                                     cs!(c"Boolean Function(expr) not supported"),
                                 );
-                                current_block = block::YYERRLAB;
+                                current_block = Block::YyErrLab;
                             }
                         }
                         105 => {
@@ -5048,23 +5049,23 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         0,
                                     );
                                     if yyval.Node < 0 {
-                                        current_block = block::YYERRLAB;
+                                        current_block = Block::YyErrLab;
                                     } else {
-                                        current_block = block::REDUCE_DONE;
+                                        current_block = Block::ReduceDone;
                                     }
                                 } else {
                                     fits_parser_yyerror(
                                         lParse,
                                         cs!(c"Dimensions of DEFNULL arguments are not compatible"),
                                     );
-                                    current_block = block::YYERRLAB;
+                                    current_block = Block::YyErrLab;
                                 }
                             } else {
                                 fits_parser_yyerror(
                                     lParse,
                                     cs!(c"Boolean Function(expr,expr) not supported"),
                                 );
-                                current_block = block::YYERRLAB;
+                                current_block = Block::YyErrLab;
                             }
                         }
                         106 => {
@@ -5107,7 +5108,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     lParse,
                                     cs!(c"Dimensions of NEAR arguments are not compatible"),
                                 );
-                                current_block = block::YYERRLAB;
+                                current_block = Block::YyErrLab;
                             } else if astr_eq(&yyvs[yyvsp - 6].astr, c"NEAR(") {
                                 yyval.Node = New_Func(
                                     lParse,
@@ -5123,7 +5124,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     0,
                                 );
                                 if yyval.Node < 0 {
-                                    current_block = block::YYERRLAB;
+                                    current_block = Block::YyErrLab;
                                 } else {
                                     if (((lParse.Nodes)[yyval.Node as usize]).value).nelem
                                         < ((lParse.Nodes)[yyvs[yyvsp - 5].Node as usize])
@@ -5146,11 +5147,11 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     {
                                         Copy_Dims(lParse, yyval.Node, yyvs[yyvsp - 1].Node);
                                     }
-                                    current_block = block::REDUCE_DONE;
+                                    current_block = Block::ReduceDone;
                                 }
                             } else {
                                 fits_parser_yyerror(lParse, cs!(c"Boolean Function not supported"));
-                                current_block = block::YYERRLAB;
+                                current_block = Block::YyErrLab;
                             }
                         }
                         107 => {
@@ -5217,7 +5218,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     lParse,
                                     cs!(c"Dimensions of CIRCLE arguments are not compatible"),
                                 );
-                                current_block = block::YYERRLAB;
+                                current_block = Block::YyErrLab;
                             } else if astr_eq(&yyvs[yyvsp - 10].astr, c"CIRCLE(") {
                                 yyval.Node = New_Func(
                                     lParse,
@@ -5233,7 +5234,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     0,
                                 );
                                 if yyval.Node < 0 {
-                                    current_block = block::YYERRLAB;
+                                    current_block = Block::YyErrLab;
                                 } else {
                                     if (((lParse.Nodes)[yyval.Node as usize]).value).nelem
                                         < ((lParse.Nodes)[yyvs[yyvsp - 9].Node as usize])
@@ -5270,11 +5271,11 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     {
                                         Copy_Dims(lParse, yyval.Node, yyvs[yyvsp - 1].Node);
                                     }
-                                    current_block = block::REDUCE_DONE;
+                                    current_block = Block::ReduceDone;
                                 }
                             } else {
                                 fits_parser_yyerror(lParse, cs!(c"Boolean Function not supported"));
-                                current_block = block::YYERRLAB;
+                                current_block = Block::YyErrLab;
                             }
                         }
                         108 => {
@@ -5363,7 +5364,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     != 0)
                             {
                                 fits_parser_yyerror(lParse, cs!(c"Dimensions of BOX or ELLIPSE arguments are not compatible"));
-                                current_block = block::YYERRLAB;
+                                current_block = Block::YyErrLab;
                             } else {
                                 if astr_eq(&yyvs[yyvsp - 14].astr, c"BOX(") {
                                     yyval.Node = New_Func(
@@ -5379,7 +5380,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         yyvs[yyvsp - 3].Node,
                                         yyvs[yyvsp - 1].Node,
                                     );
-                                    current_block = block::REDUCE_JOIN_12;
+                                    current_block = Block::ReduceJoin12;
                                 } else if astr_eq(&yyvs[yyvsp - 14].astr, c"ELLIPSE(") {
                                     yyval.Node = New_Func(
                                         lParse,
@@ -5394,19 +5395,19 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         yyvs[yyvsp - 3].Node,
                                         yyvs[yyvsp - 1].Node,
                                     );
-                                    current_block = block::REDUCE_JOIN_12;
+                                    current_block = Block::ReduceJoin12;
                                 } else {
                                     fits_parser_yyerror(
                                         lParse,
                                         cs!(c"SAO Image Function not supported"),
                                     );
-                                    current_block = block::YYERRLAB;
+                                    current_block = Block::YyErrLab;
                                 }
                                 match current_block {
-                                    block::YYERRLAB => {}
+                                    Block::YyErrLab => {}
                                     _ => {
                                         if yyval.Node < 0 {
-                                            current_block = block::YYERRLAB;
+                                            current_block = Block::YyErrLab;
                                         } else {
                                             if (((lParse.Nodes)[yyval.Node as usize]).value).nelem
                                                 < ((lParse.Nodes)[yyvs[yyvsp - 13].Node as usize])
@@ -5477,7 +5478,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                             {
                                                 Copy_Dims(lParse, yyval.Node, yyvs[yyvsp - 1].Node);
                                             }
-                                            current_block = block::REDUCE_DONE;
+                                            current_block = Block::ReduceDone;
                                         }
                                     }
                                 }
@@ -5496,9 +5497,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 c"*STOP*".as_ptr() as *mut c_char,
                             );
                             if yyval.Node < 0 {
-                                current_block = block::YYERRLAB;
+                                current_block = Block::YyErrLab;
                             } else {
-                                current_block = block::REDUCE_DONE;
+                                current_block = Block::ReduceDone;
                             }
                         }
                         110 => {
@@ -5514,9 +5515,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 c"*STOP*".as_ptr() as *mut c_char,
                             );
                             if yyval.Node < 0 {
-                                current_block = block::YYERRLAB;
+                                current_block = Block::YyErrLab;
                             } else {
-                                current_block = block::REDUCE_DONE;
+                                current_block = Block::ReduceDone;
                             }
                         }
                         111 => {
@@ -5531,9 +5532,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 c"*STOP*".as_ptr() as *mut c_char,
                             );
                             if yyval.Node < 0 {
-                                current_block = block::YYERRLAB;
+                                current_block = Block::YyErrLab;
                             } else {
-                                current_block = block::REDUCE_DONE;
+                                current_block = Block::ReduceDone;
                             }
                         }
                         112 => {
@@ -5548,9 +5549,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 (yyvs[yyvsp - 1].astr).as_mut_ptr(),
                             );
                             if yyval.Node < 0 {
-                                current_block = block::YYERRLAB;
+                                current_block = Block::YyErrLab;
                             } else {
-                                current_block = block::REDUCE_DONE;
+                                current_block = Block::ReduceDone;
                             }
                         }
                         113 => {
@@ -5566,9 +5567,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 c"*STOP*".as_ptr() as *mut c_char,
                             );
                             if yyval.Node < 0 {
-                                current_block = block::YYERRLAB;
+                                current_block = Block::YyErrLab;
                             } else {
-                                current_block = block::REDUCE_DONE;
+                                current_block = Block::ReduceDone;
                             }
                         }
                         114 => {
@@ -5583,9 +5584,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 c"*STOP*".as_ptr() as *mut c_char,
                             );
                             if yyval.Node < 0 {
-                                current_block = block::YYERRLAB;
+                                current_block = Block::YyErrLab;
                             } else {
-                                current_block = block::REDUCE_DONE;
+                                current_block = Block::ReduceDone;
                             }
                         }
                         115 => {
@@ -5600,9 +5601,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 c"*STOP*".as_ptr() as *mut c_char,
                             );
                             if yyval.Node < 0 {
-                                current_block = block::YYERRLAB;
+                                current_block = Block::YyErrLab;
                             } else {
-                                current_block = block::REDUCE_DONE;
+                                current_block = Block::ReduceDone;
                             }
                         }
                         116 => {
@@ -5617,9 +5618,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 (yyvs[yyvsp - 1].astr).as_mut_ptr(),
                             );
                             if yyval.Node < 0 {
-                                current_block = block::YYERRLAB;
+                                current_block = Block::YyErrLab;
                             } else {
-                                current_block = block::REDUCE_DONE;
+                                current_block = Block::ReduceDone;
                             }
                         }
                         117 => {
@@ -5633,9 +5634,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 dummy.as_mut_ptr(),
                             );
                             if yyval.Node < 0 {
-                                current_block = block::YYERRLAB;
+                                current_block = Block::YyErrLab;
                             } else {
-                                current_block = block::REDUCE_DONE;
+                                current_block = Block::ReduceDone;
                             }
                         }
                         118 => {
@@ -5649,9 +5650,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 dummy.as_mut_ptr(),
                             );
                             if yyval.Node < 0 {
-                                current_block = block::YYERRLAB;
+                                current_block = Block::YyErrLab;
                             } else {
-                                current_block = block::REDUCE_DONE;
+                                current_block = Block::ReduceDone;
                             }
                         }
                         119 => {
@@ -5664,9 +5665,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 (yyvs[yyvsp - 1].astr).as_mut_ptr(),
                             );
                             if yyval.Node < 0 {
-                                current_block = block::YYERRLAB;
+                                current_block = Block::YyErrLab;
                             } else {
-                                current_block = block::REDUCE_DONE;
+                                current_block = Block::ReduceDone;
                             }
                         }
                         120 => {
@@ -5682,9 +5683,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 0,
                             );
                             if yyval.Node < 0 {
-                                current_block = block::YYERRLAB;
+                                current_block = Block::YyErrLab;
                             } else {
-                                current_block = block::REDUCE_DONE;
+                                current_block = Block::ReduceDone;
                             }
                         }
                         121 => {
@@ -5700,9 +5701,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 0,
                             );
                             if yyval.Node < 0 {
-                                current_block = block::YYERRLAB;
+                                current_block = Block::YyErrLab;
                             } else {
-                                current_block = block::REDUCE_DONE;
+                                current_block = Block::ReduceDone;
                             }
                         }
                         122 => {
@@ -5718,9 +5719,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 0,
                             );
                             if yyval.Node < 0 {
-                                current_block = block::YYERRLAB;
+                                current_block = Block::YyErrLab;
                             } else {
-                                current_block = block::REDUCE_DONE;
+                                current_block = Block::ReduceDone;
                             }
                         }
                         123 => {
@@ -5736,9 +5737,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 0,
                             );
                             if yyval.Node < 0 {
-                                current_block = block::YYERRLAB;
+                                current_block = Block::YyErrLab;
                             } else {
-                                current_block = block::REDUCE_DONE;
+                                current_block = Block::ReduceDone;
                             }
                         }
                         124 => {
@@ -5754,9 +5755,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 yyvs[yyvsp - 1].Node,
                             );
                             if yyval.Node < 0 {
-                                current_block = block::YYERRLAB;
+                                current_block = Block::YyErrLab;
                             } else {
-                                current_block = block::REDUCE_DONE;
+                                current_block = Block::ReduceDone;
                             }
                         }
                         125 => {
@@ -5768,15 +5769,15 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 yyvs[yyvsp].Node,
                             );
                             if yyval.Node < 0 {
-                                current_block = block::YYERRLAB;
+                                current_block = Block::YyErrLab;
                             } else {
-                                current_block = block::REDUCE_DONE;
+                                current_block = Block::ReduceDone;
                             }
                         }
                         126 => {
                             /* bexpr: '(' bexpr ')'  */
                             yyval.Node = yyvs[yyvsp - 1].Node;
-                            current_block = block::REDUCE_DONE;
+                            current_block = Block::ReduceDone;
                         }
                         127 => {
                             /* sexpr: STRING  */
@@ -5788,20 +5789,20 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     as c_long,
                             );
                             if yyval.Node < 0 {
-                                current_block = block::YYERRLAB;
+                                current_block = Block::YyErrLab;
                             } else {
                                 (((lParse.Nodes)[yyval.Node as usize]).value).nelem =
                                     astr_len(&yyvs[yyvsp].astr) as c_long;
-                                current_block = block::REDUCE_DONE;
+                                current_block = Block::ReduceDone;
                             }
                         }
                         128 => {
                             /* sexpr: SCOLUMN  */
                             yyval.Node = New_Column(lParse, yyvs[yyvsp].lng as c_int);
                             if yyval.Node < 0 {
-                                current_block = block::YYERRLAB;
+                                current_block = Block::YyErrLab;
                             } else {
-                                current_block = block::REDUCE_DONE;
+                                current_block = Block::ReduceDone;
                             }
                         }
                         129 => {
@@ -5815,7 +5816,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     lParse,
                                     cs!(c"Offset argument must be a constant integer"),
                                 );
-                                current_block = block::YYERRLAB;
+                                current_block = Block::YyErrLab;
                             } else {
                                 yyval.Node = New_Offset(
                                     lParse,
@@ -5823,9 +5824,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     yyvs[yyvsp - 1].Node,
                                 );
                                 if yyval.Node < 0 {
-                                    current_block = block::YYERRLAB;
+                                    current_block = Block::YyErrLab;
                                 } else {
-                                    current_block = block::REDUCE_DONE;
+                                    current_block = Block::ReduceDone;
                                 }
                             }
                         }
@@ -5844,12 +5845,12 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 0,
                                 0,
                             );
-                            current_block = block::REDUCE_DONE;
+                            current_block = Block::ReduceDone;
                         }
                         131 => {
                             /* sexpr: '(' sexpr ')'  */
                             yyval.Node = yyvs[yyvsp - 1].Node;
-                            current_block = block::REDUCE_DONE;
+                            current_block = Block::ReduceDone;
                         }
                         132 => {
                             /* sexpr: sexpr '+' sexpr  */
@@ -5861,7 +5862,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     lParse,
                                     cs!(c"Combined string size exceeds 255 characters"),
                                 );
-                                current_block = block::YYERRLAB;
+                                current_block = Block::YyErrLab;
                             } else {
                                 yyval.Node = New_BinOp(
                                     lParse,
@@ -5871,14 +5872,14 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     yyvs[yyvsp].Node,
                                 );
                                 if yyval.Node < 0 {
-                                    current_block = block::YYERRLAB;
+                                    current_block = Block::YyErrLab;
                                 } else {
                                     (((lParse.Nodes)[yyval.Node as usize]).value).nelem =
                                         ((lParse.Nodes)[yyvs[yyvsp - 2].Node as usize]).value.nelem
                                             + ((lParse.Nodes)[yyvs[yyvsp].Node as usize])
                                                 .value
                                                 .nelem;
-                                    current_block = block::REDUCE_DONE;
+                                    current_block = Block::ReduceDone;
                                 }
                             }
                         }
@@ -5890,7 +5891,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     lParse,
                                     cs!(c"Cannot have a vector string column"),
                                 );
-                                current_block = block::YYERRLAB; // goto yyerrorlab
+                                current_block = Block::YyErrLab; // goto yyerrorlab
                             } else {
                                 /* Since the output can be calculated now, as a constant
                                 scalar, we must precalculate the output size, in
@@ -5920,14 +5921,14 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     outSize,
                                 );
                                 if yyval.Node < 0 {
-                                    current_block = block::YYERRLAB;
+                                    current_block = Block::YyErrLab;
                                 } else {
                                     if ((lParse.Nodes)[yyvs[yyvsp - 2].Node as usize]).value.nelem
                                         < (lParse.Nodes[yyvs[yyvsp].Node as usize]).value.nelem
                                     {
                                         Copy_Dims(lParse, yyval.Node, yyvs[yyvsp].Node);
                                     }
-                                    current_block = block::REDUCE_DONE;
+                                    current_block = Block::ReduceDone;
                                 }
                             }
                         }
@@ -5964,7 +5965,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     outSize_0,
                                 );
                                 if yyval.Node < 0 {
-                                    current_block = block::YYERRLAB;
+                                    current_block = Block::YyErrLab;
                                 } else {
                                     if ((lParse.Nodes)[yyvs[yyvsp - 1].Node as usize]).value.nelem
                                         > ((lParse.Nodes)[yyvs[yyvsp - 3].Node as usize])
@@ -5976,14 +5977,14 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                                 .value
                                                 .nelem;
                                     }
-                                    current_block = block::REDUCE_DONE;
+                                    current_block = Block::ReduceDone;
                                 }
                             } else {
                                 fits_parser_yyerror(
                                     lParse,
                                     cs!(c"Function(string,string) not supported"),
                                 );
-                                current_block = block::YYERRLAB;
+                                current_block = Block::YyErrLab;
                             }
                         }
                         135 => {
@@ -6000,7 +6001,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         != 1
                                 {
                                     fits_parser_yyerror(lParse, cs!(c"When using STRMID(S,P,N), P and N must be integers (and not vector columns)"));
-                                    current_block = block::YYERRLAB;
+                                    current_block = Block::YyErrLab;
                                 } else {
                                     if ((lParse.Nodes)[yyvs[yyvsp - 1].Node as usize]).operation
                                         == CONST_OP
@@ -6023,7 +6024,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                             lParse,
                                             cs!(c"STRMID(S,P,N), N must be 1-255"),
                                         );
-                                        current_block = block::YYERRLAB;
+                                        current_block = Block::YyErrLab;
                                     } else {
                                         yyval.Node = New_FuncSize(
                                             lParse,
@@ -6040,9 +6041,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                             len,
                                         );
                                         if yyval.Node < 0 {
-                                            current_block = block::YYERRLAB;
+                                            current_block = Block::YyErrLab;
                                         } else {
-                                            current_block = block::REDUCE_DONE;
+                                            current_block = Block::ReduceDone;
                                         }
                                     }
                                 }
@@ -6051,11 +6052,11 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     lParse,
                                     cs!(c"Function(string,expr,expr) not supported"),
                                 );
-                                current_block = block::YYERRLAB;
+                                current_block = Block::YyErrLab;
                             }
                         }
                         _ => {
-                            current_block = block::REDUCE_DONE;
+                            current_block = Block::ReduceDone;
                         }
                     }
 
@@ -6080,13 +6081,13 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                     );
 
                     match current_block {
-                        block::YYERRLAB => {
+                        Block::YyErrLab => {
                             fits_parser_yynerrs += 1;
                             yyvsp -= yylen as usize;
                             yyssp -= yylen as usize;
                             yylen = 0;
                             yystate = yy_state_fast_t::from(yyss[yyssp]);
-                            current_block = block::YYERRLAB1;
+                            current_block = Block::YyErrLab1;
                         }
                         _ => {
                             yyvsp -= yylen as usize;
@@ -6110,12 +6111,12 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             } else {
                                 c_int::from(YYDEFGOTO[yylhs as usize])
                             };
-                            current_block = block::YYNEWSTATE; // goto yynewstate;
+                            current_block = Block::YyNewState; // goto yynewstate;
                         }
                     }
                 }
 
-                if current_block == block::YYERRLAB1 {
+                if current_block == Block::YyErrLab1 {
                     yyerrstatus = 3 as c_int;
                     loop {
                         yyn = c_int::from(YYPACT[yystate as usize]);
@@ -6132,7 +6133,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             }
                         }
                         if yyssp == 0 {
-                            current_block = block::YYABORTLAB;
+                            current_block = Block::YyAbortLab;
                             break 's_54;
                         }
                         yydestruct(
@@ -6160,11 +6161,11 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
             }
         }
         match current_block {
-            block::YYEXHAUSTEDLAB => {
+            Block::YyExhaustedLab => {
                 fits_parser_yyerror(lParse, cs!(c"memory exhausted"));
                 yyresult = 2;
             }
-            block::YYABORTLAB => {
+            Block::YyAbortLab => {
                 yyresult = 1;
             }
             _ => {}

--- a/src/eval_y.rs
+++ b/src/eval_y.rs
@@ -634,17 +634,17 @@ fn New_Const(
             // bytes into the storage (which would depend on its in-memory
             // layout).
             if returnType == fits_parser_yytokentype::DOUBLE as c_int {
-                this_node.value.data.dbl = *value.cast::<f64>();
+                this_node.value.data = data_union::Double(*value.cast::<f64>());
             } else if returnType == fits_parser_yytokentype::LONG as c_int {
-                this_node.value.data.lng = *value.cast::<c_long>();
+                this_node.value.data = data_union::Long(*value.cast::<c_long>());
             } else if returnType == fits_parser_yytokentype::BOOLEAN as c_int {
-                this_node.value.data.log = *value.cast::<c_char>();
+                this_node.value.data = data_union::Logical(*value.cast::<c_char>());
             } else {
                 // STRING / BITSTR: copy the bytes into the fixed astr buffer.
                 let n = (len as usize).min(MAX_STRLEN as usize);
                 core::ptr::copy_nonoverlapping(
                     value.cast::<c_char>(),
-                    this_node.value.data.astr.as_mut_ptr(),
+                    this_node.value.data.astr_mut().as_mut_ptr(),
                     n,
                 );
             }
@@ -2751,7 +2751,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     iaxis = ((lParse.Nodes)[yyvs[yyvsp - 1].Node as usize])
                                         .value
                                         .data
-                                        .lng;
+                                        .lng();
                                     naxis =
                                         ((lParse.Nodes)[yyvs[yyvsp - 3].Node as usize]).value.naxis;
                                     if iaxis == 0 {
@@ -3941,7 +3941,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     iaxis_0 = ((lParse.Nodes)[yyvs[yyvsp - 1].Node as usize])
                                         .value
                                         .data
-                                        .lng;
+                                        .lng();
                                     naxis_1 =
                                         ((lParse.Nodes)[yyvs[yyvsp - 3].Node as usize]).value.naxis;
                                     if iaxis_0 == 0 {
@@ -6025,7 +6025,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         len = ((lParse.Nodes)[yyvs[yyvsp - 1].Node as usize])
                                             .value
                                             .data
-                                            .lng
+                                            .lng()
                                             as c_int;
                                     } else {
                                         /* Variable value: use the maximum possible (from $2) */
@@ -6631,7 +6631,8 @@ fn New_GTI(
             let that0_idx = Node0 as usize;
             (lParse.Nodes[that0_idx]).operation = CONST_OP;
             (lParse.Nodes[that0_idx]).DoOp = None;
-            (lParse.Nodes[that0_idx]).value.data.ptr = core::ptr::null_mut::<c_void>();
+            (lParse.Nodes[that0_idx]).value.data =
+                data_union::Buffer(core::ptr::null_mut::<c_void>());
 
             /*  Read in START/STOP times  */
 
@@ -6651,7 +6652,7 @@ fn New_GTI(
                 // dblptr + nrows); owned by lParse.node_buffers.
                 let n_bytes = (2 * nrows) as usize * size_of::<c_double>();
                 let p = alloc_node_data(lParse, that0_idx, n_bytes);
-                (lParse.Nodes[that0_idx]).value.data.ptr = p;
+                (lParse.Nodes[that0_idx]).value.data = data_union::Buffer(p);
                 if p.is_null() {
                     lParse.status = 113 as c_int;
                     return -(1);
@@ -6967,7 +6968,8 @@ fn New_REG(
                     return -(1);
                 }
             };
-            (lParse.Nodes[that0_idx]).value.data.ptr = Box::into_raw(rgn_box).cast::<c_void>();
+            (lParse.Nodes[that0_idx]).value.data =
+                data_union::Buffer(Box::into_raw(rgn_box).cast::<c_void>());
             if ((lParse.Nodes)[NodeX as usize]).operation == CONST_OP
                 && ((lParse.Nodes)[NodeY as usize]).operation == CONST_OP
             {
@@ -7071,7 +7073,7 @@ fn New_Array(lParse: &mut ParseData, valueNode: c_int, mut dimNode: c_int) -> c_
                 return -(1);
             }
             naxis = 1;
-            naxes[0] = (((lParse.Nodes)[dimNode as usize]).value).data.lng;
+            naxes[0] = (((lParse.Nodes)[dimNode as usize]).value).data.lng();
         } else if ((lParse.Nodes)[dimNode as usize]).operation == '{' as i32 {
             /* ARRAY(V,{a,b,c,d,e}) up to 5 dimensions */
 
@@ -7107,7 +7109,7 @@ fn New_Array(lParse: &mut ParseData, valueNode: c_int, mut dimNode: c_int) -> c_
                     [(lParse.Nodes[dims]).SubNodes[i as usize] as usize])
                     .value
                     .data
-                    .lng;
+                    .lng();
                 i += 1;
             }
         } else {
@@ -7284,45 +7286,53 @@ pub(crate) fn Evaluate_Parser(lParse: &mut ParseData, firstRow: c_long, nRows: c
                         None => ptr::null_mut(),
                     };
 
+                // Point the column node at its slice of the loaded column
+                // buffer. All the typed pointer views share one Buffer value.
                 match ((lParse.Nodes)[i as usize]).ntype.into() {
                     fits_parser_yytokentype::BITSTR => {
-                        let fresh12 = &mut (((lParse.Nodes)[i as usize]).value).data.strptr;
-                        *fresh12 = ((lParse.varData)[column as usize])
-                            .data
-                            .cast::<*mut c_char>()
-                            .offset(rowOffset as isize);
-                        let fresh13 = &mut (((lParse.Nodes)[i as usize]).value).undef;
-                        *fresh13 = ptr::null_mut();
+                        (lParse.Nodes[i as usize]).value.data = data_union::Buffer(
+                            ((lParse.varData)[column as usize])
+                                .data
+                                .cast::<*mut c_char>()
+                                .offset(rowOffset as isize)
+                                .cast::<c_void>(),
+                        );
+                        (lParse.Nodes[i as usize]).value.undef = ptr::null_mut();
                     }
                     fits_parser_yytokentype::STRING => {
-                        let fresh14 = &mut (((lParse.Nodes)[i as usize]).value).data.strptr;
-                        *fresh14 = ((lParse.varData)[column as usize])
-                            .data
-                            .cast::<*mut c_char>()
-                            .offset(rowOffset as isize);
-                        let fresh15 = &mut (((lParse.Nodes)[i as usize]).value).undef;
-                        *fresh15 = (((lParse.varData)[column as usize]).undef)
-                            .as_deref_mut()
-                            .unwrap()[(rowOffset as usize)..]
-                            .as_mut_ptr();
+                        (lParse.Nodes[i as usize]).value.data = data_union::Buffer(
+                            ((lParse.varData)[column as usize])
+                                .data
+                                .cast::<*mut c_char>()
+                                .offset(rowOffset as isize)
+                                .cast::<c_void>(),
+                        );
+                        (lParse.Nodes[i as usize]).value.undef =
+                            (((lParse.varData)[column as usize]).undef)
+                                .as_deref_mut()
+                                .unwrap()[(rowOffset as usize)..]
+                                .as_mut_ptr();
                     }
                     fits_parser_yytokentype::BOOLEAN => {
-                        let fresh16 = &mut (((lParse.Nodes)[i as usize]).value).data.logptr;
-                        *fresh16 = (((lParse.varData)[column as usize]).data as *const _
-                            as *mut c_char)
-                            .offset(offset as isize);
+                        (lParse.Nodes[i as usize]).value.data = data_union::Buffer(
+                            (((lParse.varData)[column as usize]).data as *const _ as *mut c_char)
+                                .offset(offset as isize)
+                                .cast::<c_void>(),
+                        );
                     }
                     fits_parser_yytokentype::LONG => {
-                        let fresh17 = &mut (((lParse.Nodes)[i as usize]).value).data.lngptr;
-                        *fresh17 = (((lParse.varData)[column as usize]).data as *const _
-                            as *mut c_long)
-                            .offset(offset as isize);
+                        (lParse.Nodes[i as usize]).value.data = data_union::Buffer(
+                            (((lParse.varData)[column as usize]).data as *const _ as *mut c_long)
+                                .offset(offset as isize)
+                                .cast::<c_void>(),
+                        );
                     }
                     fits_parser_yytokentype::DOUBLE => {
-                        let fresh18 = &mut (((lParse.Nodes)[i as usize]).value).data.dblptr;
-                        *fresh18 = (((lParse.varData)[column as usize]).data as *const _
-                            as *mut c_double)
-                            .offset(offset as isize);
+                        (lParse.Nodes[i as usize]).value.data = data_union::Buffer(
+                            (((lParse.varData)[column as usize]).data as *const _ as *mut c_double)
+                                .offset(offset as isize)
+                                .cast::<c_void>(),
+                        );
                     }
                     _ => {}
                 }
@@ -7433,7 +7443,7 @@ pub(crate) fn free_node_data(lParse: &mut ParseData, idx: usize) {
         // Legacy malloc'd pointer (e.g. GTI data); free with libc.
         unsafe { free((lParse.Nodes[idx]).value.data.ptr()) };
     }
-    (lParse.Nodes[idx]).value.data.ptr = core::ptr::null_mut();
+    (lParse.Nodes[idx]).value.data = data_union::Buffer(core::ptr::null_mut());
 }
 
 fn Allocate_Ptrs(lParse: &mut ParseData, this_node_idx: usize) {
@@ -7452,7 +7462,8 @@ fn Allocate_Ptrs(lParse: &mut ParseData, this_node_idx: usize) {
             let nrows = lParse.nRows as usize;
             let backing_len = (lParse.nRows * (nelem + 2)) as usize;
             let (strptr, backing) = alloc_str_node_data(lParse, this_node_idx, nrows, backing_len);
-            (lParse.Nodes[this_node_idx]).value.data.strptr = strptr;
+            (lParse.Nodes[this_node_idx]).value.data =
+                data_union::Buffer((strptr).cast::<c_void>());
             if strptr.is_null() {
                 lParse.status = MEMORY_ALLOCATION;
             } else {
@@ -7498,7 +7509,7 @@ fn Allocate_Ptrs(lParse: &mut ParseData, this_node_idx: usize) {
             // flags. Owned by lParse.node_buffers; data.ptr/undef are views.
             let n_bytes = ((size + 1) * elem) as usize;
             let p = alloc_node_data(lParse, this_node_idx, n_bytes);
-            (lParse.Nodes[this_node_idx]).value.data.ptr = p;
+            (lParse.Nodes[this_node_idx]).value.data = data_union::Buffer(p);
             if p.is_null() {
                 lParse.status = MEMORY_ALLOCATION;
             } else {
@@ -7533,59 +7544,64 @@ fn Do_Unary(lParse: &mut ParseData, this_node_idx: usize) {
                     || x == fits_parser_yytokentype::FLTCAST as c_int =>
                 {
                     if that_node.ntype == fits_parser_yytokentype::LONG as c_int {
-                        (this_node).value.data.dbl = that_node.value.data.lng() as c_double;
+                        (this_node).value.data =
+                            data_union::Double(that_node.value.data.lng() as c_double);
                     } else if that_node.ntype == fits_parser_yytokentype::BOOLEAN as c_int {
-                        (this_node).value.data.dbl = if c_int::from(that_node.value.data.log()) != 0
-                        {
-                            1.0
-                        } else {
-                            0.0
-                        };
+                        (this_node).value.data =
+                            data_union::Double(if c_int::from(that_node.value.data.log()) != 0 {
+                                1.0
+                            } else {
+                                0.0
+                            });
                     }
                 }
                 x if x == fits_parser_yytokentype::LONG as c_int
                     || x == fits_parser_yytokentype::INTCAST as c_int =>
                 {
                     if that_node.ntype == fits_parser_yytokentype::DOUBLE as c_int {
-                        (this_node).value.data.lng = that_node.value.data.dbl() as c_long;
+                        (this_node).value.data =
+                            data_union::Long(that_node.value.data.dbl() as c_long);
                     } else if that_node.ntype == fits_parser_yytokentype::BOOLEAN as c_int {
-                        (this_node).value.data.lng = if c_int::from(that_node.value.data.log()) != 0
-                        {
-                            1
-                        } else {
-                            0
-                        };
+                        (this_node).value.data =
+                            data_union::Long(if c_int::from(that_node.value.data.log()) != 0 {
+                                1
+                            } else {
+                                0
+                            });
                     }
                 }
                 x if x == fits_parser_yytokentype::BOOLEAN as c_int => {
                     if that_node.ntype == fits_parser_yytokentype::DOUBLE as c_int {
-                        (this_node).value.data.log = if that_node.value.data.dbl() != 0.0 {
-                            1
-                        } else {
-                            0
-                        };
+                        (this_node).value.data =
+                            data_union::Logical(if that_node.value.data.dbl() != 0.0 {
+                                1
+                            } else {
+                                0
+                            });
                     } else if that_node.ntype == fits_parser_yytokentype::LONG as c_int {
-                        (this_node).value.data.log = if that_node.value.data.lng() != 0 {
-                            1
-                        } else {
-                            0
-                        };
+                        (this_node).value.data =
+                            data_union::Logical(if that_node.value.data.lng() != 0 {
+                                1
+                            } else {
+                                0
+                            });
                     }
                 }
                 x if x == fits_parser_yytokentype::UMINUS as c_int => {
                     if that_node.ntype == fits_parser_yytokentype::DOUBLE as c_int {
-                        (this_node).value.data.dbl = -that_node.value.data.dbl();
+                        (this_node).value.data = data_union::Double(-that_node.value.data.dbl());
                     } else if that_node.ntype == fits_parser_yytokentype::LONG as c_int {
-                        (this_node).value.data.lng = -that_node.value.data.lng();
+                        (this_node).value.data = data_union::Long(-that_node.value.data.lng());
                     }
                 }
                 x if x == fits_parser_yytokentype::NOT as c_int => {
                     if that_node.ntype == fits_parser_yytokentype::BOOLEAN as c_int {
-                        (this_node).value.data.log = if that_node.value.data.log() == 0 {
-                            1
-                        } else {
-                            0
-                        };
+                        (this_node).value.data =
+                            data_union::Logical(if that_node.value.data.log() == 0 {
+                                1
+                            } else {
+                                0
+                            });
                     } else if that_node.ntype == fits_parser_yytokentype::BITSTR as c_int {
                         bitnot(
                             ((this_node).value.data.astr_mut()).as_mut_ptr(),
@@ -7793,7 +7809,7 @@ fn Do_Offset(lParse: &mut ParseData, this_node_idx: usize) {
         let rowOffset = ((lParse.Nodes)[(lParse.Nodes[this_node_idx]).SubNodes[1]])
             .value
             .data
-            .lng;
+            .lng();
 
         Allocate_Ptrs(lParse, this_node_idx);
 
@@ -8081,15 +8097,19 @@ fn Do_BinOp_bit(lParse: &mut ParseData, this_node_idx: usize) {
         if const1 != 0 && const2 != 0 {
             match (lParse.Nodes[this_node_idx]).operation {
                 280 => {
-                    (lParse.Nodes[this_node_idx]).value.data.log =
-                        if bitcmp(sptr1, sptr2) == 0 { 1 } else { 0 };
+                    (lParse.Nodes[this_node_idx]).value.data =
+                        data_union::Logical(if bitcmp(sptr1, sptr2) == 0 { 1 } else { 0 });
                 }
                 279 => {
-                    (lParse.Nodes[this_node_idx]).value.data.log = bitcmp(sptr1, sptr2);
+                    (lParse.Nodes[this_node_idx]).value.data =
+                        data_union::Logical(bitcmp(sptr1, sptr2));
                 }
                 281..=284 => {
-                    (lParse.Nodes[this_node_idx]).value.data.log =
-                        bitlgte(sptr1, (lParse.Nodes[this_node_idx]).operation, sptr2);
+                    (lParse.Nodes[this_node_idx]).value.data = data_union::Logical(bitlgte(
+                        sptr1,
+                        (lParse.Nodes[this_node_idx]).operation,
+                        sptr2,
+                    ));
                 }
                 124 => {
                     bitor(
@@ -8116,10 +8136,12 @@ fn Do_BinOp_bit(lParse: &mut ParseData, this_node_idx: usize) {
                     );
                 }
                 291 => {
-                    (lParse.Nodes[this_node_idx]).value.data.lng = 0;
+                    (lParse.Nodes[this_node_idx]).value.data = data_union::Long(0);
                     while *sptr1 != 0 {
                         if c_int::from(*sptr1) == '1' as i32 {
-                            (lParse.Nodes[this_node_idx]).value.data.lng += 1;
+                            (lParse.Nodes[this_node_idx]).value.data = data_union::Long(
+                                (lParse.Nodes[this_node_idx]).value.data.lng() + 1,
+                            );
                             (lParse.Nodes[this_node_idx]).value.data.lng();
                         }
                         sptr1 = sptr1.offset(1);
@@ -8229,7 +8251,7 @@ fn Do_BinOp_bit(lParse: &mut ParseData, this_node_idx: usize) {
                             *((lParse.Nodes[this_node_idx]).value.undef).offset(i as isize) = 0;
                             i += 1;
                         }
-                        (lParse.Nodes[that2_idx]).value.data.lng = previous;
+                        (lParse.Nodes[that2_idx]).value.data = data_union::Long(previous);
                     }
                     _ => {}
                 }
@@ -8284,17 +8306,18 @@ fn Do_BinOp_str(lParse: &mut ParseData, this_node_idx: usize) {
                             strcmp(sptr1, sptr2)
                         }) == 0,
                     );
-                    (lParse.Nodes[this_node_idx]).value.data.log = (if (lParse.Nodes[this_node_idx])
-                        .operation
-                        == fits_parser_yytokentype::EQ as c_int
-                    {
-                        val
-                    } else {
-                        c_int::from(val == 0)
-                    }) as c_char;
+                    (lParse.Nodes[this_node_idx]).value.data = data_union::Logical(
+                        (if (lParse.Nodes[this_node_idx]).operation
+                            == fits_parser_yytokentype::EQ as c_int
+                        {
+                            val
+                        } else {
+                            c_int::from(val == 0)
+                        }) as c_char,
+                    );
                 }
                 281 => {
-                    (lParse.Nodes[this_node_idx]).value.data.log =
+                    (lParse.Nodes[this_node_idx]).value.data = data_union::Logical(
                         if (if c_int::from(*sptr1.offset(0)) < c_int::from(*sptr2.offset(0)) {
                             -(1)
                         } else if c_int::from(*sptr1.offset(0)) > c_int::from(*sptr2.offset(0)) {
@@ -8306,10 +8329,11 @@ fn Do_BinOp_str(lParse: &mut ParseData, this_node_idx: usize) {
                             1
                         } else {
                             0
-                        };
+                        },
+                    );
                 }
                 282 => {
-                    (lParse.Nodes[this_node_idx]).value.data.log =
+                    (lParse.Nodes[this_node_idx]).value.data = data_union::Logical(
                         if (if c_int::from(*sptr1.offset(0)) < c_int::from(*sptr2.offset(0)) {
                             -(1)
                         } else if c_int::from(*sptr1.offset(0)) > c_int::from(*sptr2.offset(0)) {
@@ -8321,10 +8345,11 @@ fn Do_BinOp_str(lParse: &mut ParseData, this_node_idx: usize) {
                             1
                         } else {
                             0
-                        };
+                        },
+                    );
                 }
                 284 => {
-                    (lParse.Nodes[this_node_idx]).value.data.log =
+                    (lParse.Nodes[this_node_idx]).value.data = data_union::Logical(
                         if (if c_int::from(*sptr1.offset(0)) < c_int::from(*sptr2.offset(0)) {
                             -(1)
                         } else if c_int::from(*sptr1.offset(0)) > c_int::from(*sptr2.offset(0)) {
@@ -8336,10 +8361,11 @@ fn Do_BinOp_str(lParse: &mut ParseData, this_node_idx: usize) {
                             1
                         } else {
                             0
-                        };
+                        },
+                    );
                 }
                 283 => {
-                    (lParse.Nodes[this_node_idx]).value.data.log =
+                    (lParse.Nodes[this_node_idx]).value.data = data_union::Logical(
                         if (if c_int::from(*sptr1.offset(0)) < c_int::from(*sptr2.offset(0)) {
                             -(1)
                         } else if c_int::from(*sptr1.offset(0)) > c_int::from(*sptr2.offset(0)) {
@@ -8351,7 +8377,8 @@ fn Do_BinOp_str(lParse: &mut ParseData, this_node_idx: usize) {
                             1
                         } else {
                             0
-                        };
+                        },
+                    );
                 }
                 43 => {
                     strcpy(
@@ -8591,38 +8618,40 @@ fn Do_BinOp_log(lParse: &mut ParseData, this_node_idx: usize) {
         if vector1 == 0 && vector2 == 0 {
             match (lParse.Nodes[this_node_idx]).operation {
                 277 => {
-                    (lParse.Nodes[this_node_idx]).value.data.log =
-                        if c_int::from(val1) != 0 || c_int::from(val2) != 0 {
+                    (lParse.Nodes[this_node_idx]).value.data =
+                        data_union::Logical(if c_int::from(val1) != 0 || c_int::from(val2) != 0 {
                             1
                         } else {
                             0
-                        };
+                        });
                 }
                 278 => {
-                    (lParse.Nodes[this_node_idx]).value.data.log =
-                        if c_int::from(val1) != 0 && c_int::from(val2) != 0 {
+                    (lParse.Nodes[this_node_idx]).value.data =
+                        data_union::Logical(if c_int::from(val1) != 0 && c_int::from(val2) != 0 {
                             1
                         } else {
                             0
-                        };
+                        });
                 }
                 279 => {
-                    (lParse.Nodes[this_node_idx]).value.data.log = c_int::from(
+                    (lParse.Nodes[this_node_idx]).value.data = data_union::Logical(c_int::from(
                         c_int::from(val1) != 0 && c_int::from(val2) != 0 || val1 == 0 && val2 == 0,
-                    ) as c_char;
+                    )
+                        as c_char);
                 }
                 280 => {
-                    (lParse.Nodes[this_node_idx]).value.data.log = if c_int::from(val1) != 0
-                        && val2 == 0
-                        || val1 == 0 && c_int::from(val2) != 0
-                    {
-                        1
-                    } else {
-                        0
-                    };
+                    (lParse.Nodes[this_node_idx]).value.data = data_union::Logical(
+                        if c_int::from(val1) != 0 && val2 == 0
+                            || val1 == 0 && c_int::from(val2) != 0
+                        {
+                            1
+                        } else {
+                            0
+                        },
+                    );
                 }
                 291 => {
-                    (lParse.Nodes[this_node_idx]).value.data.lng = c_long::from(val1);
+                    (lParse.Nodes[this_node_idx]).value.data = data_union::Long(c_long::from(val1));
                 }
                 _ => {}
             }
@@ -8651,7 +8680,7 @@ fn Do_BinOp_log(lParse: &mut ParseData, this_node_idx: usize) {
                     *((lParse.Nodes[this_node_idx]).value.undef).offset(i as isize) = 0;
                     i += 1;
                 }
-                (lParse.Nodes[that2_idx]).value.data.lng = previous;
+                (lParse.Nodes[that2_idx]).value.data = data_union::Long(previous);
             }
         } else {
             rows = lParse.nRows;
@@ -8680,7 +8709,7 @@ fn Do_BinOp_log(lParse: &mut ParseData, this_node_idx: usize) {
                         *((lParse.Nodes[this_node_idx]).value.undef).offset(i_0 as isize) = 0;
                         i_0 += 1;
                     }
-                    (lParse.Nodes[that2_idx]).value.data.lng = previous_0;
+                    (lParse.Nodes[that2_idx]).value.data = data_union::Long(previous_0);
                 }
                 loop {
                     let fresh46 = rows;
@@ -8826,40 +8855,46 @@ fn Do_BinOp_lng(lParse: &mut ParseData, this_node_idx: usize) {
 
             match (lParse.Nodes[this_node_idx]).operation {
                 126 | 279 => {
-                    (lParse.Nodes[this_node_idx]).value.data.log = if val1 == val2 { 1 } else { 0 };
+                    (lParse.Nodes[this_node_idx]).value.data =
+                        data_union::Logical(if val1 == val2 { 1 } else { 0 });
                 }
                 280 => {
-                    (lParse.Nodes[this_node_idx]).value.data.log = if val1 != val2 { 1 } else { 0 };
+                    (lParse.Nodes[this_node_idx]).value.data =
+                        data_union::Logical(if val1 != val2 { 1 } else { 0 });
                 }
                 281 => {
-                    (lParse.Nodes[this_node_idx]).value.data.log = if val1 > val2 { 1 } else { 0 };
+                    (lParse.Nodes[this_node_idx]).value.data =
+                        data_union::Logical(if val1 > val2 { 1 } else { 0 });
                 }
                 282 => {
-                    (lParse.Nodes[this_node_idx]).value.data.log = if val1 < val2 { 1 } else { 0 };
+                    (lParse.Nodes[this_node_idx]).value.data =
+                        data_union::Logical(if val1 < val2 { 1 } else { 0 });
                 }
                 283 => {
-                    (lParse.Nodes[this_node_idx]).value.data.log = if val1 <= val2 { 1 } else { 0 };
+                    (lParse.Nodes[this_node_idx]).value.data =
+                        data_union::Logical(if val1 <= val2 { 1 } else { 0 });
                 }
                 284 => {
-                    (lParse.Nodes[this_node_idx]).value.data.log = if val1 >= val2 { 1 } else { 0 };
+                    (lParse.Nodes[this_node_idx]).value.data =
+                        data_union::Logical(if val1 >= val2 { 1 } else { 0 });
                 }
                 43 => {
-                    (lParse.Nodes[this_node_idx]).value.data.lng = val1 + val2;
+                    (lParse.Nodes[this_node_idx]).value.data = data_union::Long(val1 + val2);
                 }
                 45 => {
-                    (lParse.Nodes[this_node_idx]).value.data.lng = val1 - val2;
+                    (lParse.Nodes[this_node_idx]).value.data = data_union::Long(val1 - val2);
                 }
                 42 => {
-                    (lParse.Nodes[this_node_idx]).value.data.lng = val1 * val2;
+                    (lParse.Nodes[this_node_idx]).value.data = data_union::Long(val1 * val2);
                 }
                 38 => {
-                    (lParse.Nodes[this_node_idx]).value.data.lng = val1 & val2;
+                    (lParse.Nodes[this_node_idx]).value.data = data_union::Long(val1 & val2);
                 }
                 124 => {
-                    (lParse.Nodes[this_node_idx]).value.data.lng = val1 | val2;
+                    (lParse.Nodes[this_node_idx]).value.data = data_union::Long(val1 | val2);
                 }
                 94 => {
-                    (lParse.Nodes[this_node_idx]).value.data.lng = val1 ^ val2;
+                    (lParse.Nodes[this_node_idx]).value.data = data_union::Long(val1 ^ val2);
                 }
                 37 => {
                     if val2 != 0 {
@@ -8867,10 +8902,11 @@ fn Do_BinOp_lng(lParse: &mut ParseData, this_node_idx: usize) {
                             *(lParse.Nodes[this_node_idx])
                                 .value
                                 .data
-                                .lngptr
+                                .lngptr()
                                 .offset(elem as isize) = 0;
                         } else {
-                            (lParse.Nodes[this_node_idx]).value.data.lng = val1 % val2;
+                            (lParse.Nodes[this_node_idx]).value.data =
+                                data_union::Long(val1 % val2);
                         }
                     } else {
                         fits_parser_yyerror(lParse, cs!(c"Divide by Zero"));
@@ -8882,24 +8918,25 @@ fn Do_BinOp_lng(lParse: &mut ParseData, this_node_idx: usize) {
                             *(lParse.Nodes[this_node_idx])
                                 .value
                                 .data
-                                .lngptr
+                                .lngptr()
                                 .offset(elem as isize) = LONG_MAX;
                         } else {
-                            (lParse.Nodes[this_node_idx]).value.data.lng = val1 / val2;
+                            (lParse.Nodes[this_node_idx]).value.data =
+                                data_union::Long(val1 / val2);
                         }
                     } else {
                         fits_parser_yyerror(lParse, cs!(c"Divide by Zero"));
                     }
                 }
                 286 => {
-                    (lParse.Nodes[this_node_idx]).value.data.lng =
-                        pow(val1 as c_double, val2 as c_double) as c_long;
+                    (lParse.Nodes[this_node_idx]).value.data =
+                        data_union::Long(pow(val1 as c_double, val2 as c_double) as c_long);
                 }
                 291 => {
-                    (lParse.Nodes[this_node_idx]).value.data.lng = val1;
+                    (lParse.Nodes[this_node_idx]).value.data = data_union::Long(val1);
                 }
                 292 => {
-                    (lParse.Nodes[this_node_idx]).value.data.lng = 0;
+                    (lParse.Nodes[this_node_idx]).value.data = data_union::Long(0);
                 }
                 _ => {}
             }
@@ -8956,7 +8993,7 @@ fn Do_BinOp_lng(lParse: &mut ParseData, this_node_idx: usize) {
                         i += 1;
                     }
                 }
-                (lParse.Nodes[that2_idx]).value.data.lng = previous;
+                (lParse.Nodes[that2_idx]).value.data = data_union::Long(previous);
                 (lParse.Nodes[that2_idx]).value.undef = undef as *mut c_char;
             }
         } else {
@@ -9155,59 +9192,66 @@ fn Do_BinOp_dbl(lParse: &mut ParseData, this_node_idx: usize) {
             /*  Result is a constant  */
             match (lParse.Nodes[this_node_idx]).operation {
                 126 => {
-                    (lParse.Nodes[this_node_idx]).value.data.log =
-                        if fabs(val1 - val2) < APPROX { 1 } else { 0 };
+                    (lParse.Nodes[this_node_idx]).value.data =
+                        data_union::Logical(if fabs(val1 - val2) < APPROX { 1 } else { 0 });
                 }
                 279 => {
-                    (lParse.Nodes[this_node_idx]).value.data.log = if val1 == val2 { 1 } else { 0 };
+                    (lParse.Nodes[this_node_idx]).value.data =
+                        data_union::Logical(if val1 == val2 { 1 } else { 0 });
                 }
                 280 => {
-                    (lParse.Nodes[this_node_idx]).value.data.log = if val1 != val2 { 1 } else { 0 };
+                    (lParse.Nodes[this_node_idx]).value.data =
+                        data_union::Logical(if val1 != val2 { 1 } else { 0 });
                 }
                 281 => {
-                    (lParse.Nodes[this_node_idx]).value.data.log = if val1 > val2 { 1 } else { 0 };
+                    (lParse.Nodes[this_node_idx]).value.data =
+                        data_union::Logical(if val1 > val2 { 1 } else { 0 });
                 }
                 282 => {
-                    (lParse.Nodes[this_node_idx]).value.data.log = if val1 < val2 { 1 } else { 0 };
+                    (lParse.Nodes[this_node_idx]).value.data =
+                        data_union::Logical(if val1 < val2 { 1 } else { 0 });
                 }
                 283 => {
-                    (lParse.Nodes[this_node_idx]).value.data.log = if val1 <= val2 { 1 } else { 0 };
+                    (lParse.Nodes[this_node_idx]).value.data =
+                        data_union::Logical(if val1 <= val2 { 1 } else { 0 });
                 }
                 284 => {
-                    (lParse.Nodes[this_node_idx]).value.data.log = if val1 >= val2 { 1 } else { 0 };
+                    (lParse.Nodes[this_node_idx]).value.data =
+                        data_union::Logical(if val1 >= val2 { 1 } else { 0 });
                 }
                 43 => {
-                    (lParse.Nodes[this_node_idx]).value.data.dbl = val1 + val2;
+                    (lParse.Nodes[this_node_idx]).value.data = data_union::Double(val1 + val2);
                 }
                 45 => {
-                    (lParse.Nodes[this_node_idx]).value.data.dbl = val1 - val2;
+                    (lParse.Nodes[this_node_idx]).value.data = data_union::Double(val1 - val2);
                 }
                 42 => {
-                    (lParse.Nodes[this_node_idx]).value.data.dbl = val1 * val2;
+                    (lParse.Nodes[this_node_idx]).value.data = data_union::Double(val1 * val2);
                 }
                 37 => {
                     if val2 != 0. {
-                        (lParse.Nodes[this_node_idx]).value.data.dbl =
-                            val1 - val2 * c_double::from((val1 / val2) as c_int);
+                        (lParse.Nodes[this_node_idx]).value.data = data_union::Double(
+                            val1 - val2 * c_double::from((val1 / val2) as c_int),
+                        );
                     } else {
                         fits_parser_yyerror(lParse, cs!(c"Divide by Zero"));
                     }
                 }
                 47 => {
                     if val2 != 0. {
-                        (lParse.Nodes[this_node_idx]).value.data.dbl = val1 / val2;
+                        (lParse.Nodes[this_node_idx]).value.data = data_union::Double(val1 / val2);
                     } else {
                         fits_parser_yyerror(lParse, cs!(c"Divide by Zero"));
                     }
                 }
                 286 => {
-                    (lParse.Nodes[this_node_idx]).value.data.dbl = pow(val1, val2);
+                    (lParse.Nodes[this_node_idx]).value.data = data_union::Double(pow(val1, val2));
                 }
                 291 => {
-                    (lParse.Nodes[this_node_idx]).value.data.dbl = val1;
+                    (lParse.Nodes[this_node_idx]).value.data = data_union::Double(val1);
                 }
                 292 => {
-                    (lParse.Nodes[this_node_idx]).value.data.dbl = 0.0;
+                    (lParse.Nodes[this_node_idx]).value.data = data_union::Double(0.0);
                 }
                 _ => {}
             }
@@ -9266,7 +9310,7 @@ fn Do_BinOp_dbl(lParse: &mut ParseData, this_node_idx: usize) {
                         i += 1;
                     }
                 }
-                (lParse.Nodes[that2_idx]).value.data.dbl = previous;
+                (lParse.Nodes[that2_idx]).value.data = data_union::Double(previous);
                 (lParse.Nodes[that2_idx]).value.undef = undef as *mut c_char;
             }
         } else {
@@ -9590,7 +9634,7 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
             naxis: 0,
             naxes: [0; 5],
             undef: core::ptr::null_mut::<c_char>(),
-            data: data_union { dbl: 0. },
+            data: data_union::Double(0.),
         }; 10];
         let mut pNull: [c_char; 10] = [0; 10];
         let mut ival: c_long = 0;
@@ -9618,21 +9662,21 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                 if (lParse.Nodes[theParams[i as usize]]).ntype
                     == fits_parser_yytokentype::DOUBLE as c_int
                 {
-                    pVals[i as usize].data.dbl =
-                        (lParse.Nodes[theParams[i as usize]]).value.data.dbl();
+                    pVals[i as usize].data =
+                        data_union::Double((lParse.Nodes[theParams[i as usize]]).value.data.dbl());
                 } else if (lParse.Nodes[theParams[i as usize]]).ntype
                     == fits_parser_yytokentype::LONG as c_int
                 {
-                    pVals[i as usize].data.lng =
-                        (lParse.Nodes[theParams[i as usize]]).value.data.lng();
+                    pVals[i as usize].data =
+                        data_union::Long((lParse.Nodes[theParams[i as usize]]).value.data.lng());
                 } else if (lParse.Nodes[theParams[i as usize]]).ntype
                     == fits_parser_yytokentype::BOOLEAN as c_int
                 {
-                    pVals[i as usize].data.log =
-                        (lParse.Nodes[theParams[i as usize]]).value.data.log();
+                    pVals[i as usize].data =
+                        data_union::Logical((lParse.Nodes[theParams[i as usize]]).value.data.log());
                 } else {
                     strcpy(
-                        (pVals[i as usize].data.astr).as_mut_ptr(),
+                        (pVals[i as usize].data.astr_mut()).as_mut_ptr(),
                         ((lParse.Nodes[theParams[i as usize]]).value.data.astr_mut()).as_mut_ptr(),
                     );
                 }
@@ -9658,26 +9702,29 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                     if (lParse.Nodes[theParams[0]]).ntype
                         == fits_parser_yytokentype::BOOLEAN as c_int
                     {
-                        (lParse.Nodes[this_node_idx]).value.data.lng =
-                            c_long::from(if c_int::from(pVals[0].data.log) != 0 {
+                        (lParse.Nodes[this_node_idx]).value.data = data_union::Long(c_long::from(
+                            if c_int::from(pVals[0].data.log()) != 0 {
                                 1
                             } else {
                                 0
-                            });
+                            },
+                        ));
                     } else if (lParse.Nodes[theParams[0]]).ntype
                         == fits_parser_yytokentype::LONG as c_int
                     {
-                        (lParse.Nodes[this_node_idx]).value.data.lng = pVals[0].data.lng;
+                        (lParse.Nodes[this_node_idx]).value.data =
+                            data_union::Long(pVals[0].data.lng());
                     } else if (lParse.Nodes[theParams[0]]).ntype
                         == fits_parser_yytokentype::DOUBLE as c_int
                     {
-                        (lParse.Nodes[this_node_idx]).value.data.dbl = pVals[0].data.dbl;
+                        (lParse.Nodes[this_node_idx]).value.data =
+                            data_union::Double(pVals[0].data.dbl());
                     } else if (lParse.Nodes[theParams[0]]).ntype
                         == fits_parser_yytokentype::BITSTR as c_int
                     {
                         strcpy(
                             ((lParse.Nodes[this_node_idx]).value.data.astr_mut()).as_mut_ptr(),
-                            (pVals[0].data.astr).as_mut_ptr(),
+                            (pVals[0].data.astr_mut()).as_mut_ptr(),
                         );
                     }
                     current_block_139 = 7627602990488000394;
@@ -9685,35 +9732,39 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                 1038 => {
                     if (lParse.Nodes[theParams[0]]).ntype == fits_parser_yytokentype::LONG as c_int
                     {
-                        (lParse.Nodes[this_node_idx]).value.data.dbl =
-                            pVals[0].data.lng as c_double;
+                        (lParse.Nodes[this_node_idx]).value.data =
+                            data_union::Double(pVals[0].data.lng() as c_double);
                     } else if (lParse.Nodes[theParams[0]]).ntype
                         == fits_parser_yytokentype::DOUBLE as c_int
                     {
-                        (lParse.Nodes[this_node_idx]).value.data.dbl = pVals[0].data.dbl;
+                        (lParse.Nodes[this_node_idx]).value.data =
+                            data_union::Double(pVals[0].data.dbl());
                     }
                     current_block_139 = 7627602990488000394;
                 }
                 1039 => {
-                    (lParse.Nodes[this_node_idx]).value.data.dbl = 0.0;
+                    (lParse.Nodes[this_node_idx]).value.data = data_union::Double(0.0);
                     current_block_139 = 7627602990488000394;
                 }
                 1037 => {
                     if (lParse.Nodes[theParams[0]]).ntype
                         == fits_parser_yytokentype::BOOLEAN as c_int
                     {
-                        (lParse.Nodes[this_node_idx]).value.data.lng =
-                            c_long::from(if c_int::from(pVals[0].data.log) != 0 {
+                        (lParse.Nodes[this_node_idx]).value.data = data_union::Long(c_long::from(
+                            if c_int::from(pVals[0].data.log()) != 0 {
                                 1
                             } else {
                                 0
-                            });
+                            },
+                        ));
                     } else if (lParse.Nodes[theParams[0]]).ntype
                         == fits_parser_yytokentype::LONG as c_int
                     {
-                        (lParse.Nodes[this_node_idx]).value.data.lng = pVals[0].data.lng;
+                        (lParse.Nodes[this_node_idx]).value.data =
+                            data_union::Long(pVals[0].data.lng());
                     } else {
-                        (lParse.Nodes[this_node_idx]).value.data.dbl = pVals[0].data.dbl;
+                        (lParse.Nodes[this_node_idx]).value.data =
+                            data_union::Double(pVals[0].data.dbl());
                     }
                     current_block_139 = 7627602990488000394;
                 }
@@ -9721,11 +9772,13 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                     if (lParse.Nodes[theParams[0]]).ntype
                         == fits_parser_yytokentype::DOUBLE as c_int
                     {
-                        (lParse.Nodes[this_node_idx]).value.data.lng =
-                            c_long::from(simplerng_getpoisson(pVals[0].data.dbl));
+                        (lParse.Nodes[this_node_idx]).value.data = data_union::Long(c_long::from(
+                            simplerng_getpoisson(pVals[0].data.dbl()),
+                        ));
                     } else {
-                        (lParse.Nodes[this_node_idx]).value.data.lng =
-                            c_long::from(simplerng_getpoisson(pVals[0].data.lng as c_double));
+                        (lParse.Nodes[this_node_idx]).value.data = data_union::Long(c_long::from(
+                            simplerng_getpoisson(pVals[0].data.lng() as c_double),
+                        ));
                     }
                     current_block_139 = 7627602990488000394;
                 }
@@ -9733,43 +9786,46 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                     if (lParse.Nodes[theParams[0]]).ntype
                         == fits_parser_yytokentype::DOUBLE as c_int
                     {
-                        dval = pVals[0].data.dbl;
-                        (lParse.Nodes[this_node_idx]).value.data.dbl =
-                            if dval > 0.0 { dval } else { -dval };
+                        dval = pVals[0].data.dbl();
+                        (lParse.Nodes[this_node_idx]).value.data =
+                            data_union::Double(if dval > 0.0 { dval } else { -dval });
                     } else {
-                        ival = pVals[0].data.lng;
-                        (lParse.Nodes[this_node_idx]).value.data.lng =
-                            if ival > 0 { ival } else { -ival };
+                        ival = pVals[0].data.lng();
+                        (lParse.Nodes[this_node_idx]).value.data =
+                            data_union::Long(if ival > 0 { ival } else { -ival });
                     }
                     current_block_139 = 7627602990488000394;
                 }
                 1040 => {
-                    (lParse.Nodes[this_node_idx]).value.data.lng = 1;
+                    (lParse.Nodes[this_node_idx]).value.data = data_union::Long(1);
                     current_block_139 = 7627602990488000394;
                 }
                 1030 => {
-                    (lParse.Nodes[this_node_idx]).value.data.log = 0;
+                    (lParse.Nodes[this_node_idx]).value.data = data_union::Logical(0);
                     current_block_139 = 7627602990488000394;
                 }
                 1031 => {
                     if (lParse.Nodes[this_node_idx]).ntype
                         == fits_parser_yytokentype::BOOLEAN as c_int
                     {
-                        (lParse.Nodes[this_node_idx]).value.data.log = pVals[0].data.log;
+                        (lParse.Nodes[this_node_idx]).value.data =
+                            data_union::Logical(pVals[0].data.log());
                     } else if (lParse.Nodes[this_node_idx]).ntype
                         == fits_parser_yytokentype::LONG as c_int
                     {
-                        (lParse.Nodes[this_node_idx]).value.data.lng = pVals[0].data.lng;
+                        (lParse.Nodes[this_node_idx]).value.data =
+                            data_union::Long(pVals[0].data.lng());
                     } else if (lParse.Nodes[this_node_idx]).ntype
                         == fits_parser_yytokentype::DOUBLE as c_int
                     {
-                        (lParse.Nodes[this_node_idx]).value.data.dbl = pVals[0].data.dbl;
+                        (lParse.Nodes[this_node_idx]).value.data =
+                            data_union::Double(pVals[0].data.dbl());
                     } else if (lParse.Nodes[this_node_idx]).ntype
                         == fits_parser_yytokentype::STRING as c_int
                     {
                         strcpy(
                             ((lParse.Nodes[this_node_idx]).value.data.astr_mut()).as_mut_ptr(),
-                            (pVals[0].data.astr).as_mut_ptr(),
+                            (pVals[0].data.astr_mut()).as_mut_ptr(),
                         );
                     }
                     current_block_139 = 7627602990488000394;
@@ -9777,115 +9833,128 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                 1046 => {
                     if (lParse.Nodes[this_node_idx]).ntype == fits_parser_yytokentype::LONG as c_int
                     {
-                        (lParse.Nodes[this_node_idx]).value.data.lng = pVals[0].data.lng;
+                        (lParse.Nodes[this_node_idx]).value.data =
+                            data_union::Long(pVals[0].data.lng());
                     } else if (lParse.Nodes[this_node_idx]).ntype
                         == fits_parser_yytokentype::DOUBLE as c_int
                     {
-                        (lParse.Nodes[this_node_idx]).value.data.dbl = pVals[0].data.dbl;
+                        (lParse.Nodes[this_node_idx]).value.data =
+                            data_union::Double(pVals[0].data.dbl());
                     }
                     current_block_139 = 7627602990488000394;
                 }
                 1004 => {
-                    (lParse.Nodes[this_node_idx]).value.data.dbl = sin(pVals[0].data.dbl);
+                    (lParse.Nodes[this_node_idx]).value.data =
+                        data_union::Double(sin(pVals[0].data.dbl()));
                     current_block_139 = 7627602990488000394;
                 }
                 1005 => {
-                    (lParse.Nodes[this_node_idx]).value.data.dbl = cos(pVals[0].data.dbl);
+                    (lParse.Nodes[this_node_idx]).value.data =
+                        data_union::Double(cos(pVals[0].data.dbl()));
                     current_block_139 = 7627602990488000394;
                 }
                 1006 => {
-                    (lParse.Nodes[this_node_idx]).value.data.dbl = tan(pVals[0].data.dbl);
+                    (lParse.Nodes[this_node_idx]).value.data =
+                        data_union::Double(tan(pVals[0].data.dbl()));
                     current_block_139 = 7627602990488000394;
                 }
                 1007 => {
-                    dval = pVals[0].data.dbl;
+                    dval = pVals[0].data.dbl();
                     if dval < -1.0 || dval > 1.0 {
                         fits_parser_yyerror(lParse, cs!(c"Out of range argument to arcsin"));
                     } else {
-                        (lParse.Nodes[this_node_idx]).value.data.dbl = asin(dval);
+                        (lParse.Nodes[this_node_idx]).value.data = data_union::Double(asin(dval));
                     }
                     current_block_139 = 7627602990488000394;
                 }
                 1008 => {
-                    dval = pVals[0].data.dbl;
+                    dval = pVals[0].data.dbl();
                     if dval < -1.0 || dval > 1.0 {
                         fits_parser_yyerror(lParse, cs!(c"Out of range argument to arccos"));
                     } else {
-                        (lParse.Nodes[this_node_idx]).value.data.dbl = acos(dval);
+                        (lParse.Nodes[this_node_idx]).value.data = data_union::Double(acos(dval));
                     }
                     current_block_139 = 7627602990488000394;
                 }
                 1009 => {
-                    (lParse.Nodes[this_node_idx]).value.data.dbl = atan(pVals[0].data.dbl);
+                    (lParse.Nodes[this_node_idx]).value.data =
+                        data_union::Double(atan(pVals[0].data.dbl()));
                     current_block_139 = 7627602990488000394;
                 }
                 1010 => {
-                    (lParse.Nodes[this_node_idx]).value.data.dbl = sinh(pVals[0].data.dbl);
+                    (lParse.Nodes[this_node_idx]).value.data =
+                        data_union::Double(sinh(pVals[0].data.dbl()));
                     current_block_139 = 7627602990488000394;
                 }
                 1011 => {
-                    (lParse.Nodes[this_node_idx]).value.data.dbl = cosh(pVals[0].data.dbl);
+                    (lParse.Nodes[this_node_idx]).value.data =
+                        data_union::Double(cosh(pVals[0].data.dbl()));
                     current_block_139 = 7627602990488000394;
                 }
                 1012 => {
-                    (lParse.Nodes[this_node_idx]).value.data.dbl = tanh(pVals[0].data.dbl);
+                    (lParse.Nodes[this_node_idx]).value.data =
+                        data_union::Double(tanh(pVals[0].data.dbl()));
                     current_block_139 = 7627602990488000394;
                 }
                 1013 => {
-                    (lParse.Nodes[this_node_idx]).value.data.dbl = exp(pVals[0].data.dbl);
+                    (lParse.Nodes[this_node_idx]).value.data =
+                        data_union::Double(exp(pVals[0].data.dbl()));
                     current_block_139 = 7627602990488000394;
                 }
                 1014 => {
-                    dval = pVals[0].data.dbl;
+                    dval = pVals[0].data.dbl();
                     if dval <= 0.0 {
                         fits_parser_yyerror(lParse, cs!(c"Out of range argument to log"));
                     } else {
-                        (lParse.Nodes[this_node_idx]).value.data.dbl = log(dval);
+                        (lParse.Nodes[this_node_idx]).value.data = data_union::Double(log(dval));
                     }
                     current_block_139 = 7627602990488000394;
                 }
                 1015 => {
-                    dval = pVals[0].data.dbl;
+                    dval = pVals[0].data.dbl();
                     if dval <= 0.0 {
                         fits_parser_yyerror(lParse, cs!(c"Out of range argument to log10"));
                     } else {
-                        (lParse.Nodes[this_node_idx]).value.data.dbl = log10(dval);
+                        (lParse.Nodes[this_node_idx]).value.data = data_union::Double(log10(dval));
                     }
                     current_block_139 = 7627602990488000394;
                 }
                 1016 => {
-                    dval = pVals[0].data.dbl;
+                    dval = pVals[0].data.dbl();
                     if dval < 0.0 {
                         fits_parser_yyerror(lParse, cs!(c"Out of range argument to sqrt"));
                     } else {
-                        (lParse.Nodes[this_node_idx]).value.data.dbl = sqrt(dval);
+                        (lParse.Nodes[this_node_idx]).value.data = data_union::Double(sqrt(dval));
                     }
                     current_block_139 = 7627602990488000394;
                 }
                 1019 => {
-                    (lParse.Nodes[this_node_idx]).value.data.dbl = ceil(pVals[0].data.dbl);
+                    (lParse.Nodes[this_node_idx]).value.data =
+                        data_union::Double(ceil(pVals[0].data.dbl()));
                     current_block_139 = 7627602990488000394;
                 }
                 1020 => {
-                    (lParse.Nodes[this_node_idx]).value.data.dbl = floor(pVals[0].data.dbl);
+                    (lParse.Nodes[this_node_idx]).value.data =
+                        data_union::Double(floor(pVals[0].data.dbl()));
                     current_block_139 = 7627602990488000394;
                 }
                 1021 => {
-                    (lParse.Nodes[this_node_idx]).value.data.dbl = floor(pVals[0].data.dbl + 0.5);
+                    (lParse.Nodes[this_node_idx]).value.data =
+                        data_union::Double(floor(pVals[0].data.dbl() + 0.5));
                     current_block_139 = 7627602990488000394;
                 }
                 1018 => {
-                    (lParse.Nodes[this_node_idx]).value.data.dbl =
-                        atan2(pVals[0].data.dbl, pVals[1].data.dbl);
+                    (lParse.Nodes[this_node_idx]).value.data =
+                        data_union::Double(atan2(pVals[0].data.dbl(), pVals[1].data.dbl()));
                     current_block_139 = 7627602990488000394;
                 }
                 1041 => {
-                    (lParse.Nodes[this_node_idx]).value.data.dbl = angsep_calc(
-                        pVals[0].data.dbl,
-                        pVals[1].data.dbl,
-                        pVals[2].data.dbl,
-                        pVals[3].data.dbl,
-                    );
+                    (lParse.Nodes[this_node_idx]).value.data = data_union::Double(angsep_calc(
+                        pVals[0].data.dbl(),
+                        pVals[1].data.dbl(),
+                        pVals[2].data.dbl(),
+                        pVals[3].data.dbl(),
+                    ));
                     current_block_139 = 15934000668868306918;
                 }
                 1022 => {
@@ -9895,21 +9964,21 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                     if (lParse.Nodes[this_node_idx]).ntype
                         == fits_parser_yytokentype::DOUBLE as c_int
                     {
-                        (lParse.Nodes[this_node_idx]).value.data.dbl =
-                            if pVals[0].data.dbl < pVals[1].data.dbl {
-                                pVals[0].data.dbl
+                        (lParse.Nodes[this_node_idx]).value.data =
+                            data_union::Double(if pVals[0].data.dbl() < pVals[1].data.dbl() {
+                                pVals[0].data.dbl()
                             } else {
-                                pVals[1].data.dbl
-                            };
+                                pVals[1].data.dbl()
+                            });
                     } else if (lParse.Nodes[this_node_idx]).ntype
                         == fits_parser_yytokentype::LONG as c_int
                     {
-                        (lParse.Nodes[this_node_idx]).value.data.lng =
-                            if pVals[0].data.lng < pVals[1].data.lng {
-                                pVals[0].data.lng
+                        (lParse.Nodes[this_node_idx]).value.data =
+                            data_union::Long(if pVals[0].data.lng() < pVals[1].data.lng() {
+                                pVals[0].data.lng()
                             } else {
-                                pVals[1].data.lng
-                            };
+                                pVals[1].data.lng()
+                            });
                     }
                     current_block_139 = 7627602990488000394;
                 }
@@ -9917,17 +9986,19 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                     if (lParse.Nodes[this_node_idx]).ntype
                         == fits_parser_yytokentype::DOUBLE as c_int
                     {
-                        (lParse.Nodes[this_node_idx]).value.data.dbl = pVals[0].data.dbl;
+                        (lParse.Nodes[this_node_idx]).value.data =
+                            data_union::Double(pVals[0].data.dbl());
                     } else if (lParse.Nodes[this_node_idx]).ntype
                         == fits_parser_yytokentype::LONG as c_int
                     {
-                        (lParse.Nodes[this_node_idx]).value.data.lng = pVals[0].data.lng;
+                        (lParse.Nodes[this_node_idx]).value.data =
+                            data_union::Long(pVals[0].data.lng());
                     } else if (lParse.Nodes[this_node_idx]).ntype
                         == fits_parser_yytokentype::BITSTR as c_int
                     {
                         strcpy(
                             ((lParse.Nodes[this_node_idx]).value.data.astr_mut()).as_mut_ptr(),
-                            (pVals[0].data.astr).as_mut_ptr(),
+                            (pVals[0].data.astr_mut()).as_mut_ptr(),
                         );
                     }
                     current_block_139 = 7627602990488000394;
@@ -9936,96 +10007,100 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                     if (lParse.Nodes[this_node_idx]).ntype
                         == fits_parser_yytokentype::DOUBLE as c_int
                     {
-                        (lParse.Nodes[this_node_idx]).value.data.dbl =
-                            if pVals[0].data.dbl > pVals[1].data.dbl {
-                                pVals[0].data.dbl
+                        (lParse.Nodes[this_node_idx]).value.data =
+                            data_union::Double(if pVals[0].data.dbl() > pVals[1].data.dbl() {
+                                pVals[0].data.dbl()
                             } else {
-                                pVals[1].data.dbl
-                            };
+                                pVals[1].data.dbl()
+                            });
                     } else if (lParse.Nodes[this_node_idx]).ntype
                         == fits_parser_yytokentype::LONG as c_int
                     {
-                        (lParse.Nodes[this_node_idx]).value.data.lng =
-                            if pVals[0].data.lng > pVals[1].data.lng {
-                                pVals[0].data.lng
+                        (lParse.Nodes[this_node_idx]).value.data =
+                            data_union::Long(if pVals[0].data.lng() > pVals[1].data.lng() {
+                                pVals[0].data.lng()
                             } else {
-                                pVals[1].data.lng
-                            };
+                                pVals[1].data.lng()
+                            });
                     }
                     current_block_139 = 7627602990488000394;
                 }
                 1026 => {
-                    (lParse.Nodes[this_node_idx]).value.data.log =
-                        bnear(pVals[0].data.dbl, pVals[1].data.dbl, pVals[2].data.dbl);
+                    (lParse.Nodes[this_node_idx]).value.data = data_union::Logical(bnear(
+                        pVals[0].data.dbl(),
+                        pVals[1].data.dbl(),
+                        pVals[2].data.dbl(),
+                    ));
                     current_block_139 = 7627602990488000394;
                 }
                 1027 => {
-                    (lParse.Nodes[this_node_idx]).value.data.log = circle(
-                        pVals[0].data.dbl,
-                        pVals[1].data.dbl,
-                        pVals[2].data.dbl,
-                        pVals[3].data.dbl,
-                        pVals[4].data.dbl,
-                    );
+                    (lParse.Nodes[this_node_idx]).value.data = data_union::Logical(circle(
+                        pVals[0].data.dbl(),
+                        pVals[1].data.dbl(),
+                        pVals[2].data.dbl(),
+                        pVals[3].data.dbl(),
+                        pVals[4].data.dbl(),
+                    ));
                     current_block_139 = 7627602990488000394;
                 }
                 1028 => {
-                    (lParse.Nodes[this_node_idx]).value.data.log = saobox(
-                        pVals[0].data.dbl,
-                        pVals[1].data.dbl,
-                        pVals[2].data.dbl,
-                        pVals[3].data.dbl,
-                        pVals[4].data.dbl,
-                        pVals[5].data.dbl,
-                        pVals[6].data.dbl,
-                    );
+                    (lParse.Nodes[this_node_idx]).value.data = data_union::Logical(saobox(
+                        pVals[0].data.dbl(),
+                        pVals[1].data.dbl(),
+                        pVals[2].data.dbl(),
+                        pVals[3].data.dbl(),
+                        pVals[4].data.dbl(),
+                        pVals[5].data.dbl(),
+                        pVals[6].data.dbl(),
+                    ));
                     current_block_139 = 7627602990488000394;
                 }
                 1029 => {
-                    (lParse.Nodes[this_node_idx]).value.data.log = ellipse(
-                        pVals[0].data.dbl,
-                        pVals[1].data.dbl,
-                        pVals[2].data.dbl,
-                        pVals[3].data.dbl,
-                        pVals[4].data.dbl,
-                        pVals[5].data.dbl,
-                        pVals[6].data.dbl,
-                    );
+                    (lParse.Nodes[this_node_idx]).value.data = data_union::Logical(ellipse(
+                        pVals[0].data.dbl(),
+                        pVals[1].data.dbl(),
+                        pVals[2].data.dbl(),
+                        pVals[3].data.dbl(),
+                        pVals[4].data.dbl(),
+                        pVals[5].data.dbl(),
+                        pVals[6].data.dbl(),
+                    ));
                     current_block_139 = 7627602990488000394;
                 }
                 1034 => {
                     match (lParse.Nodes[this_node_idx]).ntype.into() {
                         fits_parser_yytokentype::BOOLEAN => {
-                            (lParse.Nodes[this_node_idx]).value.data.log =
-                                (if c_int::from(pVals[2].data.log) != 0 {
-                                    c_int::from(pVals[0].data.log)
+                            (lParse.Nodes[this_node_idx]).value.data = data_union::Logical(
+                                (if c_int::from(pVals[2].data.log()) != 0 {
+                                    c_int::from(pVals[0].data.log())
                                 } else {
-                                    c_int::from(pVals[1].data.log)
-                                }) as c_char;
+                                    c_int::from(pVals[1].data.log())
+                                }) as c_char,
+                            );
                         }
                         fits_parser_yytokentype::LONG => {
-                            (lParse.Nodes[this_node_idx]).value.data.lng =
-                                if c_int::from(pVals[2].data.log) != 0 {
-                                    pVals[0].data.lng
+                            (lParse.Nodes[this_node_idx]).value.data =
+                                data_union::Long(if c_int::from(pVals[2].data.log()) != 0 {
+                                    pVals[0].data.lng()
                                 } else {
-                                    pVals[1].data.lng
-                                };
+                                    pVals[1].data.lng()
+                                });
                         }
                         fits_parser_yytokentype::DOUBLE => {
-                            (lParse.Nodes[this_node_idx]).value.data.dbl =
-                                if c_int::from(pVals[2].data.log) != 0 {
-                                    pVals[0].data.dbl
+                            (lParse.Nodes[this_node_idx]).value.data =
+                                data_union::Double(if c_int::from(pVals[2].data.log()) != 0 {
+                                    pVals[0].data.dbl()
                                 } else {
-                                    pVals[1].data.dbl
-                                };
+                                    pVals[1].data.dbl()
+                                });
                         }
                         fits_parser_yytokentype::STRING => {
                             strcpy(
                                 ((lParse.Nodes[this_node_idx]).value.data.astr_mut()).as_mut_ptr(),
-                                if c_int::from(pVals[2].data.log) != 0 {
-                                    (pVals[0].data.astr).as_mut_ptr()
+                                if c_int::from(pVals[2].data.log()) != 0 {
+                                    (pVals[0].data.astr_mut()).as_mut_ptr()
                                 } else {
-                                    (pVals[1].data.astr).as_mut_ptr()
+                                    (pVals[1].data.astr_mut()).as_mut_ptr()
                                 },
                             );
                         }
@@ -10041,22 +10116,23 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                         lParse,
                         dest_str,
                         dest_len,
-                        (pVals[0].data.astr).as_mut_ptr(),
+                        (pVals[0].data.astr_mut()).as_mut_ptr(),
                         pVals[0].nelem as c_int,
-                        pVals[1].data.lng as c_int,
+                        pVals[1].data.lng() as c_int,
                     );
                     current_block_139 = 7627602990488000394;
                 }
                 1045 => {
                     let res: *mut c_char = strstr(
-                        (pVals[0].data.astr).as_mut_ptr(),
-                        (pVals[1].data.astr).as_mut_ptr(),
+                        (pVals[0].data.astr_mut()).as_mut_ptr(),
+                        (pVals[1].data.astr_mut()).as_mut_ptr(),
                     );
                     if res.is_null() {
-                        (lParse.Nodes[this_node_idx]).value.data.lng = 0;
+                        (lParse.Nodes[this_node_idx]).value.data = data_union::Long(0);
                     } else {
-                        (lParse.Nodes[this_node_idx]).value.data.lng =
-                            res.offset_from((pVals[0].data.astr).as_mut_ptr()) as c_long + 1;
+                        (lParse.Nodes[this_node_idx]).value.data = data_union::Long(
+                            res.offset_from((pVals[0].data.astr_mut()).as_mut_ptr()) as c_long + 1,
+                        );
                     }
                     current_block_139 = 7627602990488000394;
                 }
@@ -10066,17 +10142,19 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
             }
             if current_block_139 == 15934000668868306918 {
                 if (lParse.Nodes[this_node_idx]).ntype == fits_parser_yytokentype::DOUBLE as c_int {
-                    (lParse.Nodes[this_node_idx]).value.data.dbl = pVals[0].data.dbl;
+                    (lParse.Nodes[this_node_idx]).value.data =
+                        data_union::Double(pVals[0].data.dbl());
                 } else if (lParse.Nodes[this_node_idx]).ntype
                     == fits_parser_yytokentype::LONG as c_int
                 {
-                    (lParse.Nodes[this_node_idx]).value.data.lng = pVals[0].data.lng;
+                    (lParse.Nodes[this_node_idx]).value.data =
+                        data_union::Long(pVals[0].data.lng());
                 } else if (lParse.Nodes[this_node_idx]).ntype
                     == fits_parser_yytokentype::BITSTR as c_int
                 {
                     strcpy(
                         ((lParse.Nodes[this_node_idx]).value.data.astr_mut()).as_mut_ptr(),
-                        (pVals[0].data.astr).as_mut_ptr(),
+                        (pVals[0].data.astr_mut()).as_mut_ptr(),
                     );
                 }
             }
@@ -10132,7 +10210,7 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                     1050 => {
                         let mut ielem: c_long = 0;
                         let mut iaxis: [c_long; 5] = [1, 1, 1, 1, 1];
-                        let ipos: c_long = pVals[1].data.lng - 1;
+                        let ipos: c_long = pVals[1].data.lng() - 1;
                         let naxis: c_int = (lParse.Nodes[this_node_idx]).value.naxis;
                         let mut j: c_int = 0;
                         if ipos < 0 || ipos >= 5 as c_long {
@@ -10218,14 +10296,14 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                                     }
                                     *((lParse.Nodes[this_node_idx]).value.undef)
                                         .offset(elem as isize) =
-                                        if pVals[0].data.dbl < 0.0 { 1 } else { 0 };
+                                        if pVals[0].data.dbl() < 0.0 { 1 } else { 0 };
                                     if *((lParse.Nodes[this_node_idx]).value.undef)
                                         .offset(elem as isize)
                                         == 0
                                     {
                                         *((lParse.Nodes[this_node_idx]).value.data.lngptr())
                                             .offset(elem as isize) =
-                                            c_long::from(simplerng_getpoisson(pVals[0].data.dbl));
+                                            c_long::from(simplerng_getpoisson(pVals[0].data.dbl()));
                                     }
                                 }
                             } else {
@@ -10268,14 +10346,14 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                                 }
                                 *((lParse.Nodes[this_node_idx]).value.undef)
                                     .offset(elem as isize) =
-                                    if pVals[0].data.lng < 0 { 1 } else { 0 };
+                                    if pVals[0].data.lng() < 0 { 1 } else { 0 };
                                 if *((lParse.Nodes[this_node_idx]).value.undef)
                                     .offset(elem as isize)
                                     == 0
                                 {
                                     *((lParse.Nodes[this_node_idx]).value.data.lngptr())
                                         .offset(elem as isize) = c_long::from(
-                                        simplerng_getpoisson(pVals[0].data.lng as c_double),
+                                        simplerng_getpoisson(pVals[0].data.lng() as c_double),
                                     );
                                 }
                             }
@@ -10924,34 +11002,36 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                                         pNull[i as usize] =
                                             *((lParse.Nodes[theParams[i as usize]]).value.undef)
                                                 .offset(elem as isize);
-                                        pVals[i as usize].data.log = *((lParse.Nodes
-                                            [theParams[i as usize]])
-                                            .value
-                                            .data
-                                            .logptr)
-                                            .offset(elem as isize);
+                                        pVals[i as usize].data = data_union::Logical(
+                                            *((lParse.Nodes[theParams[i as usize]])
+                                                .value
+                                                .data
+                                                .logptr())
+                                            .offset(elem as isize),
+                                        );
                                     } else if vector[i as usize] != 0 {
                                         pNull[i as usize] =
                                             *((lParse.Nodes[theParams[i as usize]]).value.undef)
                                                 .offset(row as isize);
-                                        pVals[i as usize].data.log = *((lParse.Nodes
-                                            [theParams[i as usize]])
-                                            .value
-                                            .data
-                                            .logptr)
-                                            .offset(row as isize);
+                                        pVals[i as usize].data = data_union::Logical(
+                                            *((lParse.Nodes[theParams[i as usize]])
+                                                .value
+                                                .data
+                                                .logptr())
+                                            .offset(row as isize),
+                                        );
                                     }
                                 }
                                 if pNull[0] != 0 {
                                     *((lParse.Nodes[this_node_idx]).value.undef)
                                         .offset(elem as isize) = pNull[1];
                                     *((lParse.Nodes[this_node_idx]).value.data.logptr())
-                                        .offset(elem as isize) = pVals[1].data.log;
+                                        .offset(elem as isize) = pVals[1].data.log();
                                 } else {
                                     *((lParse.Nodes[this_node_idx]).value.undef)
                                         .offset(elem as isize) = 0;
                                     *((lParse.Nodes[this_node_idx]).value.data.logptr())
-                                        .offset(elem as isize) = pVals[0].data.log;
+                                        .offset(elem as isize) = pVals[0].data.log();
                                 }
                             }
                         },
@@ -10981,34 +11061,36 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                                         pNull[i as usize] =
                                             *((lParse.Nodes[theParams[i as usize]]).value.undef)
                                                 .offset(elem as isize);
-                                        pVals[i as usize].data.lng = *((lParse.Nodes
-                                            [theParams[i as usize]])
-                                            .value
-                                            .data
-                                            .lngptr)
-                                            .offset(elem as isize);
+                                        pVals[i as usize].data = data_union::Long(
+                                            *((lParse.Nodes[theParams[i as usize]])
+                                                .value
+                                                .data
+                                                .lngptr())
+                                            .offset(elem as isize),
+                                        );
                                     } else if vector[i as usize] != 0 {
                                         pNull[i as usize] =
                                             *((lParse.Nodes[theParams[i as usize]]).value.undef)
                                                 .offset(row as isize);
-                                        pVals[i as usize].data.lng = *((lParse.Nodes
-                                            [theParams[i as usize]])
-                                            .value
-                                            .data
-                                            .lngptr)
-                                            .offset(row as isize);
+                                        pVals[i as usize].data = data_union::Long(
+                                            *((lParse.Nodes[theParams[i as usize]])
+                                                .value
+                                                .data
+                                                .lngptr())
+                                            .offset(row as isize),
+                                        );
                                     }
                                 }
                                 if pNull[0] != 0 {
                                     *((lParse.Nodes[this_node_idx]).value.undef)
                                         .offset(elem as isize) = pNull[1];
                                     *((lParse.Nodes[this_node_idx]).value.data.lngptr())
-                                        .offset(elem as isize) = pVals[1].data.lng;
+                                        .offset(elem as isize) = pVals[1].data.lng();
                                 } else {
                                     *((lParse.Nodes[this_node_idx]).value.undef)
                                         .offset(elem as isize) = 0;
                                     *((lParse.Nodes[this_node_idx]).value.data.lngptr())
-                                        .offset(elem as isize) = pVals[0].data.lng;
+                                        .offset(elem as isize) = pVals[0].data.lng();
                                 }
                             }
                         },
@@ -11038,34 +11120,36 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                                         pNull[i as usize] =
                                             *((lParse.Nodes[theParams[i as usize]]).value.undef)
                                                 .offset(elem as isize);
-                                        pVals[i as usize].data.dbl = *((lParse.Nodes
-                                            [theParams[i as usize]])
-                                            .value
-                                            .data
-                                            .dblptr)
-                                            .offset(elem as isize);
+                                        pVals[i as usize].data = data_union::Double(
+                                            *((lParse.Nodes[theParams[i as usize]])
+                                                .value
+                                                .data
+                                                .dblptr())
+                                            .offset(elem as isize),
+                                        );
                                     } else if vector[i as usize] != 0 {
                                         pNull[i as usize] =
                                             *((lParse.Nodes[theParams[i as usize]]).value.undef)
                                                 .offset(row as isize);
-                                        pVals[i as usize].data.dbl = *((lParse.Nodes
-                                            [theParams[i as usize]])
-                                            .value
-                                            .data
-                                            .dblptr)
-                                            .offset(row as isize);
+                                        pVals[i as usize].data = data_union::Double(
+                                            *((lParse.Nodes[theParams[i as usize]])
+                                                .value
+                                                .data
+                                                .dblptr())
+                                            .offset(row as isize),
+                                        );
                                     }
                                 }
                                 if pNull[0] != 0 {
                                     *((lParse.Nodes[this_node_idx]).value.undef)
                                         .offset(elem as isize) = pNull[1];
                                     *((lParse.Nodes[this_node_idx]).value.data.dblptr())
-                                        .offset(elem as isize) = pVals[1].data.dbl;
+                                        .offset(elem as isize) = pVals[1].data.dbl();
                                 } else {
                                     *((lParse.Nodes[this_node_idx]).value.undef)
                                         .offset(elem as isize) = 0;
                                     *((lParse.Nodes[this_node_idx]).value.data.dblptr())
-                                        .offset(elem as isize) = pVals[0].data.dbl;
+                                        .offset(elem as isize) = pVals[0].data.dbl();
                                 }
                             }
                         },
@@ -11087,7 +11171,7 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                                         *((lParse.Nodes[theParams[i as usize]]).value.undef)
                                             .offset(row as isize);
                                     strcpy(
-                                        (pVals[i as usize].data.astr).as_mut_ptr(),
+                                        (pVals[i as usize].data.astr_mut()).as_mut_ptr(),
                                         *((lParse.Nodes[theParams[i as usize]])
                                             .value
                                             .data
@@ -11102,7 +11186,7 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                                 strcpy(
                                     *((lParse.Nodes[this_node_idx]).value.data.strptr())
                                         .offset(row as isize),
-                                    (pVals[1].data.astr).as_mut_ptr(),
+                                    (pVals[1].data.astr_mut()).as_mut_ptr(),
                                 );
                             } else {
                                 *((lParse.Nodes[this_node_idx]).value.undef)
@@ -11110,7 +11194,7 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                                 strcpy(
                                     *((lParse.Nodes[this_node_idx]).value.data.strptr())
                                         .offset(row as isize),
-                                    (pVals[0].data.astr).as_mut_ptr(),
+                                    (pVals[0].data.astr_mut()).as_mut_ptr(),
                                 );
                             }
                         },
@@ -11506,22 +11590,24 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                                     break;
                                 }
                                 if vector[i as usize] > 1 {
-                                    pVals[i as usize].data.dbl = *((lParse.Nodes
-                                        [theParams[i as usize]])
-                                        .value
-                                        .data
-                                        .dblptr())
-                                    .offset(elem as isize);
+                                    pVals[i as usize].data = data_union::Double(
+                                        *((lParse.Nodes[theParams[i as usize]])
+                                            .value
+                                            .data
+                                            .dblptr())
+                                        .offset(elem as isize),
+                                    );
                                     pNull[i as usize] =
                                         *((lParse.Nodes[theParams[i as usize]]).value.undef)
                                             .offset(elem as isize);
                                 } else if vector[i as usize] != 0 {
-                                    pVals[i as usize].data.dbl = *((lParse.Nodes
-                                        [theParams[i as usize]])
-                                        .value
-                                        .data
-                                        .dblptr())
-                                    .offset(row as isize);
+                                    pVals[i as usize].data = data_union::Double(
+                                        *((lParse.Nodes[theParams[i as usize]])
+                                            .value
+                                            .data
+                                            .dblptr())
+                                        .offset(row as isize),
+                                    );
                                     pNull[i as usize] =
                                         *((lParse.Nodes[theParams[i as usize]]).value.undef)
                                             .offset(row as isize);
@@ -11538,7 +11624,7 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                             if *fresh138 == 0 {
                                 *((lParse.Nodes[this_node_idx]).value.data.dblptr())
                                     .offset(elem as isize) =
-                                    atan2(pVals[0].data.dbl, pVals[1].data.dbl);
+                                    atan2(pVals[0].data.dbl(), pVals[1].data.dbl());
                             }
                         }
                     },
@@ -11564,22 +11650,24 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                                     break;
                                 }
                                 if vector[i as usize] > 1 {
-                                    pVals[i as usize].data.dbl = *((lParse.Nodes
-                                        [theParams[i as usize]])
-                                        .value
-                                        .data
-                                        .dblptr())
-                                    .offset(elem as isize);
+                                    pVals[i as usize].data = data_union::Double(
+                                        *((lParse.Nodes[theParams[i as usize]])
+                                            .value
+                                            .data
+                                            .dblptr())
+                                        .offset(elem as isize),
+                                    );
                                     pNull[i as usize] =
                                         *((lParse.Nodes[theParams[i as usize]]).value.undef)
                                             .offset(elem as isize);
                                 } else if vector[i as usize] != 0 {
-                                    pVals[i as usize].data.dbl = *((lParse.Nodes
-                                        [theParams[i as usize]])
-                                        .value
-                                        .data
-                                        .dblptr())
-                                    .offset(row as isize);
+                                    pVals[i as usize].data = data_union::Double(
+                                        *((lParse.Nodes[theParams[i as usize]])
+                                            .value
+                                            .data
+                                            .dblptr())
+                                        .offset(row as isize),
+                                    );
                                     pNull[i as usize] =
                                         *((lParse.Nodes[theParams[i as usize]]).value.undef)
                                             .offset(row as isize);
@@ -11596,10 +11684,10 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                             if *fresh142 == 0 {
                                 *((lParse.Nodes[this_node_idx]).value.data.dblptr())
                                     .offset(elem as isize) = angsep_calc(
-                                    pVals[0].data.dbl,
-                                    pVals[1].data.dbl,
-                                    pVals[2].data.dbl,
-                                    pVals[3].data.dbl,
+                                    pVals[0].data.dbl(),
+                                    pVals[1].data.dbl(),
+                                    pVals[2].data.dbl(),
+                                    pVals[3].data.dbl(),
                                 );
                             }
                         }
@@ -11763,24 +11851,26 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                                             break;
                                         }
                                         if vector[i as usize] > 1 {
-                                            pVals[i as usize].data.lng = *((lParse.Nodes
-                                                [theParams[i as usize]])
-                                                .value
-                                                .data
-                                                .lngptr)
-                                                .offset(elem as isize);
+                                            pVals[i as usize].data = data_union::Long(
+                                                *((lParse.Nodes[theParams[i as usize]])
+                                                    .value
+                                                    .data
+                                                    .lngptr())
+                                                .offset(elem as isize),
+                                            );
                                             pNull[i as usize] = *((lParse.Nodes
                                                 [theParams[i as usize]])
                                                 .value
                                                 .undef)
                                                 .offset(elem as isize);
                                         } else if vector[i as usize] != 0 {
-                                            pVals[i as usize].data.lng = *((lParse.Nodes
-                                                [theParams[i as usize]])
-                                                .value
-                                                .data
-                                                .lngptr)
-                                                .offset(row as isize);
+                                            pVals[i as usize].data = data_union::Long(
+                                                *((lParse.Nodes[theParams[i as usize]])
+                                                    .value
+                                                    .data
+                                                    .lngptr())
+                                                .offset(row as isize),
+                                            );
                                             pNull[i as usize] = *((lParse.Nodes
                                                 [theParams[i as usize]])
                                                 .value
@@ -11797,21 +11887,21 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                                         *((lParse.Nodes[this_node_idx]).value.undef)
                                             .offset(elem as isize) = 0;
                                         *((lParse.Nodes[this_node_idx]).value.data.lngptr())
-                                            .offset(elem as isize) = pVals[1].data.lng;
+                                            .offset(elem as isize) = pVals[1].data.lng();
                                     } else if pNull[1] != 0 {
                                         *((lParse.Nodes[this_node_idx]).value.undef)
                                             .offset(elem as isize) = 0;
                                         *((lParse.Nodes[this_node_idx]).value.data.lngptr())
-                                            .offset(elem as isize) = pVals[0].data.lng;
+                                            .offset(elem as isize) = pVals[0].data.lng();
                                     } else {
                                         *((lParse.Nodes[this_node_idx]).value.undef)
                                             .offset(elem as isize) = 0;
                                         *((lParse.Nodes[this_node_idx]).value.data.lngptr())
                                             .offset(elem as isize) =
-                                            if pVals[0].data.lng < pVals[1].data.lng {
-                                                pVals[0].data.lng
+                                            if pVals[0].data.lng() < pVals[1].data.lng() {
+                                                pVals[0].data.lng()
                                             } else {
-                                                pVals[1].data.lng
+                                                pVals[1].data.lng()
                                             };
                                     }
                                 }
@@ -11841,24 +11931,26 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                                             break;
                                         }
                                         if vector[i as usize] > 1 {
-                                            pVals[i as usize].data.dbl = *((lParse.Nodes
-                                                [theParams[i as usize]])
-                                                .value
-                                                .data
-                                                .dblptr)
-                                                .offset(elem as isize);
+                                            pVals[i as usize].data = data_union::Double(
+                                                *((lParse.Nodes[theParams[i as usize]])
+                                                    .value
+                                                    .data
+                                                    .dblptr())
+                                                .offset(elem as isize),
+                                            );
                                             pNull[i as usize] = *((lParse.Nodes
                                                 [theParams[i as usize]])
                                                 .value
                                                 .undef)
                                                 .offset(elem as isize);
                                         } else if vector[i as usize] != 0 {
-                                            pVals[i as usize].data.dbl = *((lParse.Nodes
-                                                [theParams[i as usize]])
-                                                .value
-                                                .data
-                                                .dblptr)
-                                                .offset(row as isize);
+                                            pVals[i as usize].data = data_union::Double(
+                                                *((lParse.Nodes[theParams[i as usize]])
+                                                    .value
+                                                    .data
+                                                    .dblptr())
+                                                .offset(row as isize),
+                                            );
                                             pNull[i as usize] = *((lParse.Nodes
                                                 [theParams[i as usize]])
                                                 .value
@@ -11875,21 +11967,21 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                                         *((lParse.Nodes[this_node_idx]).value.undef)
                                             .offset(elem as isize) = 0;
                                         *((lParse.Nodes[this_node_idx]).value.data.dblptr())
-                                            .offset(elem as isize) = pVals[1].data.dbl;
+                                            .offset(elem as isize) = pVals[1].data.dbl();
                                     } else if pNull[1] != 0 {
                                         *((lParse.Nodes[this_node_idx]).value.undef)
                                             .offset(elem as isize) = 0;
                                         *((lParse.Nodes[this_node_idx]).value.data.dblptr())
-                                            .offset(elem as isize) = pVals[0].data.dbl;
+                                            .offset(elem as isize) = pVals[0].data.dbl();
                                     } else {
                                         *((lParse.Nodes[this_node_idx]).value.undef)
                                             .offset(elem as isize) = 0;
                                         *((lParse.Nodes[this_node_idx]).value.data.dblptr())
                                             .offset(elem as isize) =
-                                            if pVals[0].data.dbl < pVals[1].data.dbl {
-                                                pVals[0].data.dbl
+                                            if pVals[0].data.dbl() < pVals[1].data.dbl() {
+                                                pVals[0].data.dbl()
                                             } else {
-                                                pVals[1].data.dbl
+                                                pVals[1].data.dbl()
                                             };
                                     }
                                 }
@@ -12055,24 +12147,26 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                                             break;
                                         }
                                         if vector[i as usize] > 1 {
-                                            pVals[i as usize].data.lng = *((lParse.Nodes
-                                                [theParams[i as usize]])
-                                                .value
-                                                .data
-                                                .lngptr)
-                                                .offset(elem as isize);
+                                            pVals[i as usize].data = data_union::Long(
+                                                *((lParse.Nodes[theParams[i as usize]])
+                                                    .value
+                                                    .data
+                                                    .lngptr())
+                                                .offset(elem as isize),
+                                            );
                                             pNull[i as usize] = *((lParse.Nodes
                                                 [theParams[i as usize]])
                                                 .value
                                                 .undef)
                                                 .offset(elem as isize);
                                         } else if vector[i as usize] != 0 {
-                                            pVals[i as usize].data.lng = *((lParse.Nodes
-                                                [theParams[i as usize]])
-                                                .value
-                                                .data
-                                                .lngptr)
-                                                .offset(row as isize);
+                                            pVals[i as usize].data = data_union::Long(
+                                                *((lParse.Nodes[theParams[i as usize]])
+                                                    .value
+                                                    .data
+                                                    .lngptr())
+                                                .offset(row as isize),
+                                            );
                                             pNull[i as usize] = *((lParse.Nodes
                                                 [theParams[i as usize]])
                                                 .value
@@ -12089,21 +12183,21 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                                         *((lParse.Nodes[this_node_idx]).value.undef)
                                             .offset(elem as isize) = 0;
                                         *((lParse.Nodes[this_node_idx]).value.data.lngptr())
-                                            .offset(elem as isize) = pVals[1].data.lng;
+                                            .offset(elem as isize) = pVals[1].data.lng();
                                     } else if pNull[1] != 0 {
                                         *((lParse.Nodes[this_node_idx]).value.undef)
                                             .offset(elem as isize) = 0;
                                         *((lParse.Nodes[this_node_idx]).value.data.lngptr())
-                                            .offset(elem as isize) = pVals[0].data.lng;
+                                            .offset(elem as isize) = pVals[0].data.lng();
                                     } else {
                                         *((lParse.Nodes[this_node_idx]).value.undef)
                                             .offset(elem as isize) = 0;
                                         *((lParse.Nodes[this_node_idx]).value.data.lngptr())
                                             .offset(elem as isize) =
-                                            if pVals[0].data.lng > pVals[1].data.lng {
-                                                pVals[0].data.lng
+                                            if pVals[0].data.lng() > pVals[1].data.lng() {
+                                                pVals[0].data.lng()
                                             } else {
-                                                pVals[1].data.lng
+                                                pVals[1].data.lng()
                                             };
                                     }
                                 }
@@ -12133,24 +12227,26 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                                             break;
                                         }
                                         if vector[i as usize] > 1 {
-                                            pVals[i as usize].data.dbl = *((lParse.Nodes
-                                                [theParams[i as usize]])
-                                                .value
-                                                .data
-                                                .dblptr)
-                                                .offset(elem as isize);
+                                            pVals[i as usize].data = data_union::Double(
+                                                *((lParse.Nodes[theParams[i as usize]])
+                                                    .value
+                                                    .data
+                                                    .dblptr())
+                                                .offset(elem as isize),
+                                            );
                                             pNull[i as usize] = *((lParse.Nodes
                                                 [theParams[i as usize]])
                                                 .value
                                                 .undef)
                                                 .offset(elem as isize);
                                         } else if vector[i as usize] != 0 {
-                                            pVals[i as usize].data.dbl = *((lParse.Nodes
-                                                [theParams[i as usize]])
-                                                .value
-                                                .data
-                                                .dblptr)
-                                                .offset(row as isize);
+                                            pVals[i as usize].data = data_union::Double(
+                                                *((lParse.Nodes[theParams[i as usize]])
+                                                    .value
+                                                    .data
+                                                    .dblptr())
+                                                .offset(row as isize),
+                                            );
                                             pNull[i as usize] = *((lParse.Nodes
                                                 [theParams[i as usize]])
                                                 .value
@@ -12167,21 +12263,21 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                                         *((lParse.Nodes[this_node_idx]).value.undef)
                                             .offset(elem as isize) = 0;
                                         *((lParse.Nodes[this_node_idx]).value.data.dblptr())
-                                            .offset(elem as isize) = pVals[1].data.dbl;
+                                            .offset(elem as isize) = pVals[1].data.dbl();
                                     } else if pNull[1] != 0 {
                                         *((lParse.Nodes[this_node_idx]).value.undef)
                                             .offset(elem as isize) = 0;
                                         *((lParse.Nodes[this_node_idx]).value.data.dblptr())
-                                            .offset(elem as isize) = pVals[0].data.dbl;
+                                            .offset(elem as isize) = pVals[0].data.dbl();
                                     } else {
                                         *((lParse.Nodes[this_node_idx]).value.undef)
                                             .offset(elem as isize) = 0;
                                         *((lParse.Nodes[this_node_idx]).value.data.dblptr())
                                             .offset(elem as isize) =
-                                            if pVals[0].data.dbl > pVals[1].data.dbl {
-                                                pVals[0].data.dbl
+                                            if pVals[0].data.dbl() > pVals[1].data.dbl() {
+                                                pVals[0].data.dbl()
                                             } else {
-                                                pVals[1].data.dbl
+                                                pVals[1].data.dbl()
                                             };
                                     }
                                 }
@@ -12210,22 +12306,24 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                                     break;
                                 }
                                 if vector[i as usize] > 1 {
-                                    pVals[i as usize].data.dbl = *((lParse.Nodes
-                                        [theParams[i as usize]])
-                                        .value
-                                        .data
-                                        .dblptr())
-                                    .offset(elem as isize);
+                                    pVals[i as usize].data = data_union::Double(
+                                        *((lParse.Nodes[theParams[i as usize]])
+                                            .value
+                                            .data
+                                            .dblptr())
+                                        .offset(elem as isize),
+                                    );
                                     pNull[i as usize] =
                                         *((lParse.Nodes[theParams[i as usize]]).value.undef)
                                             .offset(elem as isize);
                                 } else if vector[i as usize] != 0 {
-                                    pVals[i as usize].data.dbl = *((lParse.Nodes
-                                        [theParams[i as usize]])
-                                        .value
-                                        .data
-                                        .dblptr())
-                                    .offset(row as isize);
+                                    pVals[i as usize].data = data_union::Double(
+                                        *((lParse.Nodes[theParams[i as usize]])
+                                            .value
+                                            .data
+                                            .dblptr())
+                                        .offset(row as isize),
+                                    );
                                     pNull[i as usize] =
                                         *((lParse.Nodes[theParams[i as usize]]).value.undef)
                                             .offset(row as isize);
@@ -12240,8 +12338,11 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                             ) as c_char;
                             if *fresh168 == 0 {
                                 *((lParse.Nodes[this_node_idx]).value.data.logptr())
-                                    .offset(elem as isize) =
-                                    bnear(pVals[0].data.dbl, pVals[1].data.dbl, pVals[2].data.dbl);
+                                    .offset(elem as isize) = bnear(
+                                    pVals[0].data.dbl(),
+                                    pVals[1].data.dbl(),
+                                    pVals[2].data.dbl(),
+                                );
                             }
                         }
                     },
@@ -12267,22 +12368,24 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                                     break;
                                 }
                                 if vector[i as usize] > 1 {
-                                    pVals[i as usize].data.dbl = *((lParse.Nodes
-                                        [theParams[i as usize]])
-                                        .value
-                                        .data
-                                        .dblptr())
-                                    .offset(elem as isize);
+                                    pVals[i as usize].data = data_union::Double(
+                                        *((lParse.Nodes[theParams[i as usize]])
+                                            .value
+                                            .data
+                                            .dblptr())
+                                        .offset(elem as isize),
+                                    );
                                     pNull[i as usize] =
                                         *((lParse.Nodes[theParams[i as usize]]).value.undef)
                                             .offset(elem as isize);
                                 } else if vector[i as usize] != 0 {
-                                    pVals[i as usize].data.dbl = *((lParse.Nodes
-                                        [theParams[i as usize]])
-                                        .value
-                                        .data
-                                        .dblptr())
-                                    .offset(row as isize);
+                                    pVals[i as usize].data = data_union::Double(
+                                        *((lParse.Nodes[theParams[i as usize]])
+                                            .value
+                                            .data
+                                            .dblptr())
+                                        .offset(row as isize),
+                                    );
                                     pNull[i as usize] =
                                         *((lParse.Nodes[theParams[i as usize]]).value.undef)
                                             .offset(row as isize);
@@ -12300,11 +12403,11 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                             if *fresh172 == 0 {
                                 *((lParse.Nodes[this_node_idx]).value.data.logptr())
                                     .offset(elem as isize) = circle(
-                                    pVals[0].data.dbl,
-                                    pVals[1].data.dbl,
-                                    pVals[2].data.dbl,
-                                    pVals[3].data.dbl,
-                                    pVals[4].data.dbl,
+                                    pVals[0].data.dbl(),
+                                    pVals[1].data.dbl(),
+                                    pVals[2].data.dbl(),
+                                    pVals[3].data.dbl(),
+                                    pVals[4].data.dbl(),
                                 );
                             }
                         }
@@ -12331,22 +12434,24 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                                     break;
                                 }
                                 if vector[i as usize] > 1 {
-                                    pVals[i as usize].data.dbl = *((lParse.Nodes
-                                        [theParams[i as usize]])
-                                        .value
-                                        .data
-                                        .dblptr())
-                                    .offset(elem as isize);
+                                    pVals[i as usize].data = data_union::Double(
+                                        *((lParse.Nodes[theParams[i as usize]])
+                                            .value
+                                            .data
+                                            .dblptr())
+                                        .offset(elem as isize),
+                                    );
                                     pNull[i as usize] =
                                         *((lParse.Nodes[theParams[i as usize]]).value.undef)
                                             .offset(elem as isize);
                                 } else if vector[i as usize] != 0 {
-                                    pVals[i as usize].data.dbl = *((lParse.Nodes
-                                        [theParams[i as usize]])
-                                        .value
-                                        .data
-                                        .dblptr())
-                                    .offset(row as isize);
+                                    pVals[i as usize].data = data_union::Double(
+                                        *((lParse.Nodes[theParams[i as usize]])
+                                            .value
+                                            .data
+                                            .dblptr())
+                                        .offset(row as isize),
+                                    );
                                     pNull[i as usize] =
                                         *((lParse.Nodes[theParams[i as usize]]).value.undef)
                                             .offset(row as isize);
@@ -12366,13 +12471,13 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                             if *fresh176 == 0 {
                                 *((lParse.Nodes[this_node_idx]).value.data.logptr())
                                     .offset(elem as isize) = saobox(
-                                    pVals[0].data.dbl,
-                                    pVals[1].data.dbl,
-                                    pVals[2].data.dbl,
-                                    pVals[3].data.dbl,
-                                    pVals[4].data.dbl,
-                                    pVals[5].data.dbl,
-                                    pVals[6].data.dbl,
+                                    pVals[0].data.dbl(),
+                                    pVals[1].data.dbl(),
+                                    pVals[2].data.dbl(),
+                                    pVals[3].data.dbl(),
+                                    pVals[4].data.dbl(),
+                                    pVals[5].data.dbl(),
+                                    pVals[6].data.dbl(),
                                 );
                             }
                         }
@@ -12399,22 +12504,24 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                                     break;
                                 }
                                 if vector[i as usize] > 1 {
-                                    pVals[i as usize].data.dbl = *((lParse.Nodes
-                                        [theParams[i as usize]])
-                                        .value
-                                        .data
-                                        .dblptr())
-                                    .offset(elem as isize);
+                                    pVals[i as usize].data = data_union::Double(
+                                        *((lParse.Nodes[theParams[i as usize]])
+                                            .value
+                                            .data
+                                            .dblptr())
+                                        .offset(elem as isize),
+                                    );
                                     pNull[i as usize] =
                                         *((lParse.Nodes[theParams[i as usize]]).value.undef)
                                             .offset(elem as isize);
                                 } else if vector[i as usize] != 0 {
-                                    pVals[i as usize].data.dbl = *((lParse.Nodes
-                                        [theParams[i as usize]])
-                                        .value
-                                        .data
-                                        .dblptr())
-                                    .offset(row as isize);
+                                    pVals[i as usize].data = data_union::Double(
+                                        *((lParse.Nodes[theParams[i as usize]])
+                                            .value
+                                            .data
+                                            .dblptr())
+                                        .offset(row as isize),
+                                    );
                                     pNull[i as usize] =
                                         *((lParse.Nodes[theParams[i as usize]]).value.undef)
                                             .offset(row as isize);
@@ -12434,13 +12541,13 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                             if *fresh180 == 0 {
                                 *((lParse.Nodes[this_node_idx]).value.data.logptr())
                                     .offset(elem as isize) = ellipse(
-                                    pVals[0].data.dbl,
-                                    pVals[1].data.dbl,
-                                    pVals[2].data.dbl,
-                                    pVals[3].data.dbl,
-                                    pVals[4].data.dbl,
-                                    pVals[5].data.dbl,
-                                    pVals[6].data.dbl,
+                                    pVals[0].data.dbl(),
+                                    pVals[1].data.dbl(),
+                                    pVals[2].data.dbl(),
+                                    pVals[3].data.dbl(),
+                                    pVals[4].data.dbl(),
+                                    pVals[5].data.dbl(),
+                                    pVals[6].data.dbl(),
                                 );
                             }
                         }
@@ -12461,15 +12568,17 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                                 }
                                 elem -= 1;
                                 if vector[2] > 1 {
-                                    pVals[2].data.log =
+                                    pVals[2].data = data_union::Logical(
                                         *((lParse.Nodes[theParams[2]]).value.data.logptr())
-                                            .offset(elem as isize);
+                                            .offset(elem as isize),
+                                    );
                                     pNull[2] = *((lParse.Nodes[theParams[2]]).value.undef)
                                         .offset(elem as isize);
                                 } else if vector[2] != 0 {
-                                    pVals[2].data.log =
+                                    pVals[2].data = data_union::Logical(
                                         *((lParse.Nodes[theParams[2]]).value.data.logptr())
-                                            .offset(row as isize);
+                                            .offset(row as isize),
+                                    );
                                     pNull[2] = *((lParse.Nodes[theParams[2]]).value.undef)
                                         .offset(row as isize);
                                 }
@@ -12481,22 +12590,24 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                                         break;
                                     }
                                     if vector[i as usize] > 1 {
-                                        pVals[i as usize].data.log = *((lParse.Nodes
-                                            [theParams[i as usize]])
-                                            .value
-                                            .data
-                                            .logptr)
-                                            .offset(elem as isize);
+                                        pVals[i as usize].data = data_union::Logical(
+                                            *((lParse.Nodes[theParams[i as usize]])
+                                                .value
+                                                .data
+                                                .logptr())
+                                            .offset(elem as isize),
+                                        );
                                         pNull[i as usize] =
                                             *((lParse.Nodes[theParams[i as usize]]).value.undef)
                                                 .offset(elem as isize);
                                     } else if vector[i as usize] != 0 {
-                                        pVals[i as usize].data.log = *((lParse.Nodes
-                                            [theParams[i as usize]])
-                                            .value
-                                            .data
-                                            .logptr)
-                                            .offset(row as isize);
+                                        pVals[i as usize].data = data_union::Logical(
+                                            *((lParse.Nodes[theParams[i as usize]])
+                                                .value
+                                                .data
+                                                .logptr())
+                                            .offset(row as isize),
+                                        );
                                         pNull[i as usize] =
                                             *((lParse.Nodes[theParams[i as usize]]).value.undef)
                                                 .offset(row as isize);
@@ -12506,14 +12617,14 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                                     .offset(elem as isize);
                                 *fresh184 = pNull[2];
                                 if *fresh184 == 0 {
-                                    if pVals[2].data.log != 0 {
+                                    if pVals[2].data.log() != 0 {
                                         *((lParse.Nodes[this_node_idx]).value.data.logptr())
-                                            .offset(elem as isize) = pVals[0].data.log;
+                                            .offset(elem as isize) = pVals[0].data.log();
                                         *((lParse.Nodes[this_node_idx]).value.undef)
                                             .offset(elem as isize) = pNull[0];
                                     } else {
                                         *((lParse.Nodes[this_node_idx]).value.data.logptr())
-                                            .offset(elem as isize) = pVals[1].data.log;
+                                            .offset(elem as isize) = pVals[1].data.log();
                                         *((lParse.Nodes[this_node_idx]).value.undef)
                                             .offset(elem as isize) = pNull[1];
                                     }
@@ -12535,15 +12646,17 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                                 }
                                 elem -= 1;
                                 if vector[2] > 1 {
-                                    pVals[2].data.log =
+                                    pVals[2].data = data_union::Logical(
                                         *((lParse.Nodes[theParams[2]]).value.data.logptr())
-                                            .offset(elem as isize);
+                                            .offset(elem as isize),
+                                    );
                                     pNull[2] = *((lParse.Nodes[theParams[2]]).value.undef)
                                         .offset(elem as isize);
                                 } else if vector[2] != 0 {
-                                    pVals[2].data.log =
+                                    pVals[2].data = data_union::Logical(
                                         *((lParse.Nodes[theParams[2]]).value.data.logptr())
-                                            .offset(row as isize);
+                                            .offset(row as isize),
+                                    );
                                     pNull[2] = *((lParse.Nodes[theParams[2]]).value.undef)
                                         .offset(row as isize);
                                 }
@@ -12555,22 +12668,24 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                                         break;
                                     }
                                     if vector[i as usize] > 1 {
-                                        pVals[i as usize].data.lng = *((lParse.Nodes
-                                            [theParams[i as usize]])
-                                            .value
-                                            .data
-                                            .lngptr)
-                                            .offset(elem as isize);
+                                        pVals[i as usize].data = data_union::Long(
+                                            *((lParse.Nodes[theParams[i as usize]])
+                                                .value
+                                                .data
+                                                .lngptr())
+                                            .offset(elem as isize),
+                                        );
                                         pNull[i as usize] =
                                             *((lParse.Nodes[theParams[i as usize]]).value.undef)
                                                 .offset(elem as isize);
                                     } else if vector[i as usize] != 0 {
-                                        pVals[i as usize].data.lng = *((lParse.Nodes
-                                            [theParams[i as usize]])
-                                            .value
-                                            .data
-                                            .lngptr)
-                                            .offset(row as isize);
+                                        pVals[i as usize].data = data_union::Long(
+                                            *((lParse.Nodes[theParams[i as usize]])
+                                                .value
+                                                .data
+                                                .lngptr())
+                                            .offset(row as isize),
+                                        );
                                         pNull[i as usize] =
                                             *((lParse.Nodes[theParams[i as usize]]).value.undef)
                                                 .offset(row as isize);
@@ -12580,14 +12695,14 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                                     .offset(elem as isize);
                                 *fresh188 = pNull[2];
                                 if *fresh188 == 0 {
-                                    if pVals[2].data.log != 0 {
+                                    if pVals[2].data.log() != 0 {
                                         *((lParse.Nodes[this_node_idx]).value.data.lngptr())
-                                            .offset(elem as isize) = pVals[0].data.lng;
+                                            .offset(elem as isize) = pVals[0].data.lng();
                                         *((lParse.Nodes[this_node_idx]).value.undef)
                                             .offset(elem as isize) = pNull[0];
                                     } else {
                                         *((lParse.Nodes[this_node_idx]).value.data.lngptr())
-                                            .offset(elem as isize) = pVals[1].data.lng;
+                                            .offset(elem as isize) = pVals[1].data.lng();
                                         *((lParse.Nodes[this_node_idx]).value.undef)
                                             .offset(elem as isize) = pNull[1];
                                     }
@@ -12609,15 +12724,17 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                                 }
                                 elem -= 1;
                                 if vector[2] > 1 {
-                                    pVals[2].data.log =
+                                    pVals[2].data = data_union::Logical(
                                         *((lParse.Nodes[theParams[2]]).value.data.logptr())
-                                            .offset(elem as isize);
+                                            .offset(elem as isize),
+                                    );
                                     pNull[2] = *((lParse.Nodes[theParams[2]]).value.undef)
                                         .offset(elem as isize);
                                 } else if vector[2] != 0 {
-                                    pVals[2].data.log =
+                                    pVals[2].data = data_union::Logical(
                                         *((lParse.Nodes[theParams[2]]).value.data.logptr())
-                                            .offset(row as isize);
+                                            .offset(row as isize),
+                                    );
                                     pNull[2] = *((lParse.Nodes[theParams[2]]).value.undef)
                                         .offset(row as isize);
                                 }
@@ -12629,22 +12746,24 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                                         break;
                                     }
                                     if vector[i as usize] > 1 {
-                                        pVals[i as usize].data.dbl = *((lParse.Nodes
-                                            [theParams[i as usize]])
-                                            .value
-                                            .data
-                                            .dblptr)
-                                            .offset(elem as isize);
+                                        pVals[i as usize].data = data_union::Double(
+                                            *((lParse.Nodes[theParams[i as usize]])
+                                                .value
+                                                .data
+                                                .dblptr())
+                                            .offset(elem as isize),
+                                        );
                                         pNull[i as usize] =
                                             *((lParse.Nodes[theParams[i as usize]]).value.undef)
                                                 .offset(elem as isize);
                                     } else if vector[i as usize] != 0 {
-                                        pVals[i as usize].data.dbl = *((lParse.Nodes
-                                            [theParams[i as usize]])
-                                            .value
-                                            .data
-                                            .dblptr)
-                                            .offset(row as isize);
+                                        pVals[i as usize].data = data_union::Double(
+                                            *((lParse.Nodes[theParams[i as usize]])
+                                                .value
+                                                .data
+                                                .dblptr())
+                                            .offset(row as isize),
+                                        );
                                         pNull[i as usize] =
                                             *((lParse.Nodes[theParams[i as usize]]).value.undef)
                                                 .offset(row as isize);
@@ -12654,14 +12773,14 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                                     .offset(elem as isize);
                                 *fresh192 = pNull[2];
                                 if *fresh192 == 0 {
-                                    if pVals[2].data.log != 0 {
+                                    if pVals[2].data.log() != 0 {
                                         *((lParse.Nodes[this_node_idx]).value.data.dblptr())
-                                            .offset(elem as isize) = pVals[0].data.dbl;
+                                            .offset(elem as isize) = pVals[0].data.dbl();
                                         *((lParse.Nodes[this_node_idx]).value.undef)
                                             .offset(elem as isize) = pNull[0];
                                     } else {
                                         *((lParse.Nodes[this_node_idx]).value.data.dblptr())
-                                            .offset(elem as isize) = pVals[1].data.dbl;
+                                            .offset(elem as isize) = pVals[1].data.dbl();
                                         *((lParse.Nodes[this_node_idx]).value.undef)
                                             .offset(elem as isize) = pNull[1];
                                     }
@@ -12675,9 +12794,10 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                                 break;
                             }
                             if vector[2] != 0 {
-                                pVals[2].data.log =
+                                pVals[2].data = data_union::Logical(
                                     *((lParse.Nodes[theParams[2]]).value.data.logptr())
-                                        .offset(row as isize);
+                                        .offset(row as isize),
+                                );
                                 pNull[2] = *((lParse.Nodes[theParams[2]]).value.undef)
                                     .offset(row as isize);
                             }
@@ -12690,7 +12810,7 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                                 }
                                 if vector[i as usize] != 0 {
                                     strcpy(
-                                        (pVals[i as usize].data.astr).as_mut_ptr(),
+                                        (pVals[i as usize].data.astr_mut()).as_mut_ptr(),
                                         *((lParse.Nodes[theParams[i as usize]])
                                             .value
                                             .data
@@ -12706,11 +12826,11 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                                 .offset(row as isize);
                             *fresh195 = pNull[2];
                             if *fresh195 == 0 {
-                                if pVals[2].data.log != 0 {
+                                if pVals[2].data.log() != 0 {
                                     strcpy(
                                         *((lParse.Nodes[this_node_idx]).value.data.strptr())
                                             .offset(row as isize),
-                                        (pVals[0].data.astr).as_mut_ptr(),
+                                        (pVals[0].data.astr_mut()).as_mut_ptr(),
                                     );
                                     *((lParse.Nodes[this_node_idx]).value.undef)
                                         .offset(row as isize) = pNull[0];
@@ -12718,7 +12838,7 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                                     strcpy(
                                         *((lParse.Nodes[this_node_idx]).value.data.strptr())
                                             .offset(row as isize),
-                                        (pVals[1].data.astr).as_mut_ptr(),
+                                        (pVals[1].data.astr_mut()).as_mut_ptr(),
                                     );
                                     *((lParse.Nodes[this_node_idx]).value.undef)
                                         .offset(row as isize) = pNull[1];
@@ -13009,7 +13129,7 @@ fn Do_Deref(lParse: &mut ParseData, this_node_idx: usize) {
                 } else {
                     fits_parser_yyerror(lParse, cs!(c"Index out of range"));
                     free_node_data(lParse, this_node_idx);
-                    (lParse.Nodes[this_node_idx]).value.data.ptr = ptr::null_mut();
+                    (lParse.Nodes[this_node_idx]).value.data = data_union::Buffer(ptr::null_mut());
                 }
             } else if allConst != 0 && nDims == 1 {
                 /* Reduce dimensions by 1, using a constant index */
@@ -13021,7 +13141,7 @@ fn Do_Deref(lParse: &mut ParseData, this_node_idx: usize) {
                 {
                     fits_parser_yyerror(lParse, cs!(c"Index out of range"));
                     free_node_data(lParse, this_node_idx);
-                    (lParse.Nodes[this_node_idx]).value.data.ptr = ptr::null_mut();
+                    (lParse.Nodes[this_node_idx]).value.data = data_union::Buffer(ptr::null_mut());
                 } else if (lParse.Nodes[this_node_idx]).ntype
                     == fits_parser_yytokentype::BITSTR as c_int
                     || (lParse.Nodes[this_node_idx]).ntype
@@ -13080,7 +13200,7 @@ fn Do_Deref(lParse: &mut ParseData, this_node_idx: usize) {
                             (lParse.Nodes[this_node_idx])
                                 .value
                                 .data
-                                .ptr
+                                .ptr()
                                 .cast::<c_char>()
                                 .offset(
                                     (row * dsize * (lParse.Nodes[this_node_idx]).value.nelem)
@@ -13090,7 +13210,7 @@ fn Do_Deref(lParse: &mut ParseData, this_node_idx: usize) {
                             (lParse.Nodes[theVar])
                                 .value
                                 .data
-                                .ptr
+                                .ptr()
                                 .cast::<c_char>()
                                 .offset((elem * dsize) as isize)
                                 as *const c_void,
@@ -13118,7 +13238,8 @@ fn Do_Deref(lParse: &mut ParseData, this_node_idx: usize) {
                                     cs!(c"Null encountered as vector index"),
                                 );
                                 free_node_data(lParse, this_node_idx);
-                                (lParse.Nodes[this_node_idx]).value.data.ptr = ptr::null_mut();
+                                (lParse.Nodes[this_node_idx]).value.data =
+                                    data_union::Buffer(ptr::null_mut());
                                 break;
                             } else {
                                 dimVals[i as usize] =
@@ -13196,7 +13317,8 @@ fn Do_Deref(lParse: &mut ParseData, this_node_idx: usize) {
                     } else {
                         fits_parser_yyerror(lParse, cs!(c"Index out of range"));
                         free_node_data(lParse, this_node_idx);
-                        (lParse.Nodes[this_node_idx]).value.data.ptr = ptr::null_mut();
+                        (lParse.Nodes[this_node_idx]).value.data =
+                            data_union::Buffer(ptr::null_mut());
                     }
                     row += 1;
                 }
@@ -13208,7 +13330,8 @@ fn Do_Deref(lParse: &mut ParseData, this_node_idx: usize) {
                     if *((lParse.Nodes[theDims[0]]).value.undef).offset(row as isize) != 0 {
                         fits_parser_yyerror(lParse, cs!(c"Null encountered as vector index"));
                         free_node_data(lParse, this_node_idx);
-                        (lParse.Nodes[this_node_idx]).value.data.ptr = ptr::null_mut();
+                        (lParse.Nodes[this_node_idx]).value.data =
+                            data_union::Buffer(ptr::null_mut());
                         break;
                     } else {
                         dimVals[0] =
@@ -13220,7 +13343,8 @@ fn Do_Deref(lParse: &mut ParseData, this_node_idx: usize) {
                         {
                             fits_parser_yyerror(lParse, cs!(c"Index out of range"));
                             free_node_data(lParse, this_node_idx);
-                            (lParse.Nodes[this_node_idx]).value.data.ptr = ptr::null_mut();
+                            (lParse.Nodes[this_node_idx]).value.data =
+                                data_union::Buffer(ptr::null_mut());
                         } else if (lParse.Nodes[this_node_idx]).ntype
                             == fits_parser_yytokentype::BITSTR as c_int
                             || (lParse.Nodes[this_node_idx]).ntype
@@ -13278,7 +13402,7 @@ fn Do_Deref(lParse: &mut ParseData, this_node_idx: usize) {
                                 (lParse.Nodes[this_node_idx])
                                     .value
                                     .data
-                                    .ptr
+                                    .ptr()
                                     .cast::<c_char>()
                                     .offset(
                                         (row * dsize * (lParse.Nodes[this_node_idx]).value.nelem)
@@ -13288,7 +13412,7 @@ fn Do_Deref(lParse: &mut ParseData, this_node_idx: usize) {
                                 (lParse.Nodes[theVar])
                                     .value
                                     .data
-                                    .ptr
+                                    .ptr()
                                     .cast::<c_char>()
                                     .offset((elem * dsize) as isize)
                                     as *const c_void,
@@ -13347,10 +13471,11 @@ fn Do_GTI(lParse: &mut ParseData, this_node_idx: usize) {
                 core::ptr::null_mut::<c_long>(),
             );
             if dorow != 0 {
-                (lParse.Nodes[this_node_idx]).value.data.lng =
-                    if gti >= 0 { gti + 1 } else { -(1) as c_long };
+                (lParse.Nodes[this_node_idx]).value.data =
+                    data_union::Long(if gti >= 0 { gti + 1 } else { -(1) as c_long });
             } else {
-                (lParse.Nodes[this_node_idx]).value.data.log = if gti >= 0 { 1 } else { 0 };
+                (lParse.Nodes[this_node_idx]).value.data =
+                    data_union::Logical(if gti >= 0 { 1 } else { 0 });
             }
             (lParse.Nodes[this_node_idx]).operation = CONST_OP;
         } else {
@@ -13450,14 +13575,14 @@ fn Do_GTI_Over(lParse: &mut ParseData, this_node_idx: usize) {
         if (lParse.Nodes[theStart]).operation == CONST_OP
             && (lParse.Nodes[theStop]).operation == CONST_OP
         {
-            (lParse.Nodes[this_node_idx]).value.data.dbl = GTI_Over(
+            (lParse.Nodes[this_node_idx]).value.data = data_union::Double(GTI_Over(
                 (lParse.Nodes[theStart]).value.data.dbl(),
                 (lParse.Nodes[theStop]).value.data.dbl(),
                 nGTI,
                 gtiStart,
                 gtiStop,
                 &mut gti,
-            );
+            ));
             (lParse.Nodes[this_node_idx]).operation = CONST_OP;
         } else {
             let mut undefStart: c_char = 0;
@@ -13702,20 +13827,22 @@ fn Do_REG(lParse: &mut ParseData, this_node_idx: usize) {
             Yval = (lParse.Nodes[theY]).value.data.dbl();
         }
         if Xvector == 0 && Yvector == 0 {
-            (lParse.Nodes[this_node_idx]).value.data.log = if fits_in_region(
-                Xval,
-                Yval,
-                &mut *(lParse.Nodes[theRegion])
-                    .value
-                    .data
-                    .ptr()
-                    .cast::<SAORegion>(),
-            ) != 0
-            {
-                1
-            } else {
-                0
-            };
+            (lParse.Nodes[this_node_idx]).value.data = data_union::Logical(
+                if fits_in_region(
+                    Xval,
+                    Yval,
+                    &mut *(lParse.Nodes[theRegion])
+                        .value
+                        .data
+                        .ptr()
+                        .cast::<SAORegion>(),
+                ) != 0
+                {
+                    1
+                } else {
+                    0
+                },
+            );
             (lParse.Nodes[this_node_idx]).operation = CONST_OP;
         } else {
             Allocate_Ptrs(lParse, this_node_idx);
@@ -13971,7 +14098,7 @@ fn Do_Vector(lParse: &mut ParseData, this_node_idx: usize) {
                         [(lParse.Nodes[this_node_idx]).SubNodes[node as usize] as usize])
                         .value
                         .data
-                        .ptr,
+                        .ptr(),
                 );
             }
             node += 1;
@@ -14090,7 +14217,7 @@ fn Do_Array(lParse: &mut ParseData, this_node_idx: usize) {
                     ((lParse.Nodes)[lParse.Nodes[this_node_idx].SubNodes[0]])
                         .value
                         .data
-                        .ptr,
+                        .ptr(),
                 );
             }
         }
@@ -14608,7 +14735,7 @@ mod node_buffer_tests {
         // Simulate a legacy malloc'd buffer (as gtifilt would produce).
         let raw = unsafe { libc::malloc(64) };
         assert!(!raw.is_null());
-        node.value.data.ptr = raw;
+        node.value.data = data_union::Buffer(raw);
         lparse.Nodes.push(node);
         // No side-table entry for this node -> legacy path.
         assert!(lparse.node_buffers.is_empty());
@@ -14655,7 +14782,7 @@ mod node_buffer_tests {
 
         let n_bytes = 2 * nrows * core::mem::size_of::<f64>();
         let p = alloc_node_data(&mut lparse, idx, n_bytes);
-        lparse.Nodes[idx].value.data.ptr = p;
+        lparse.Nodes[idx].value.data = data_union::Buffer(p);
         assert!(!p.is_null());
 
         unsafe {

--- a/src/eval_y.rs
+++ b/src/eval_y.rs
@@ -1439,53 +1439,53 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         }
                         5 => {
                             /* line: expr '\n'  */
-                            if yyvs[yyvsp - 1].Node < 0 {
+                            if yyvs[yyvsp - 1].node() < 0 {
                                 fits_parser_yyerror(
                                     lParse,
                                     cs!(c"Couldn't build node structure: out of memory?"),
                                 );
                                 current_block = Block::YyErrLab;
                             } else {
-                                lParse.resultNode = yyvs[yyvsp - 1].Node;
+                                lParse.resultNode = yyvs[yyvsp - 1].node();
                                 current_block = Block::ReduceDone;
                             }
                         }
                         6 => {
                             /* line: bexpr '\n'  */
-                            if yyvs[yyvsp - 1].Node < 0 {
+                            if yyvs[yyvsp - 1].node() < 0 {
                                 fits_parser_yyerror(
                                     lParse,
                                     cs!(c"Couldn't build node structure: out of memory?"),
                                 );
                                 current_block = Block::YyErrLab;
                             } else {
-                                lParse.resultNode = yyvs[yyvsp - 1].Node;
+                                lParse.resultNode = yyvs[yyvsp - 1].node();
                                 current_block = Block::ReduceDone;
                             }
                         }
                         7 => {
                             /* line: sexpr '\n'  */
-                            if yyvs[yyvsp - 1].Node < 0 {
+                            if yyvs[yyvsp - 1].node() < 0 {
                                 fits_parser_yyerror(
                                     lParse,
                                     cs!(c"Couldn't build node structure: out of memory?"),
                                 );
                                 current_block = Block::YyErrLab;
                             } else {
-                                lParse.resultNode = yyvs[yyvsp - 1].Node;
+                                lParse.resultNode = yyvs[yyvsp - 1].node();
                                 current_block = Block::ReduceDone;
                             }
                         }
                         8 => {
                             /* line: bits '\n'  */
-                            if yyvs[yyvsp - 1].Node < 0 {
+                            if yyvs[yyvsp - 1].node() < 0 {
                                 fits_parser_yyerror(
                                     lParse,
                                     cs!(c"Couldn't build node structure: out of memory?"),
                                 );
                                 current_block = Block::YyErrLab;
                             } else {
-                                lParse.resultNode = yyvs[yyvsp - 1].Node;
+                                lParse.resultNode = yyvs[yyvsp - 1].node();
                                 current_block = Block::ReduceDone;
                             }
                         }
@@ -1496,8 +1496,8 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         }
                         10 => {
                             /* bvector: '{' bexpr  */
-                            yyval.Node = New_Vector(lParse, yyvs[yyvsp].Node);
-                            if yyval.Node < 0 {
+                            yyval.Node = New_Vector(lParse, yyvs[yyvsp].node());
+                            if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
                                 current_block = Block::ReduceDone;
@@ -1505,41 +1505,41 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         }
                         11 => {
                             /* bvector: bvector ',' bexpr  */
-                            if (lParse.Nodes[yyvs[yyvsp - 2].Node as usize]).nSubNodes
+                            if (lParse.Nodes[yyvs[yyvsp - 2].node() as usize]).nSubNodes
                                 >= 10 as c_int
                             {
-                                yyvs[yyvsp - 2].Node = Close_Vec(lParse, yyvs[yyvsp - 2].Node);
-                                if yyvs[yyvsp - 2].Node < 0 {
+                                yyvs[yyvsp - 2].Node = Close_Vec(lParse, yyvs[yyvsp - 2].node());
+                                if yyvs[yyvsp - 2].node() < 0 {
                                     current_block = Block::YyErrLab;
                                 } else {
-                                    yyval.Node = New_Vector(lParse, yyvs[yyvsp - 2].Node);
-                                    if yyval.Node < 0 {
+                                    yyval.Node = New_Vector(lParse, yyvs[yyvsp - 2].node());
+                                    if yyval.node() < 0 {
                                         current_block = Block::YyErrLab;
                                     } else {
                                         current_block = Block::ReduceJoin10;
                                     }
                                 }
                             } else {
-                                yyval.Node = yyvs[yyvsp - 2].Node;
+                                yyval.Node = yyvs[yyvsp - 2].node();
                                 current_block = Block::ReduceJoin10;
                             }
                             match current_block {
                                 Block::YyErrLab => {}
                                 _ => {
                                     let fresh2 =
-                                        &mut ((lParse.Nodes)[yyval.Node as usize]).nSubNodes;
+                                        &mut ((lParse.Nodes)[yyval.node() as usize]).nSubNodes;
                                     let fresh3 = *fresh2;
                                     *fresh2 += 1;
-                                    ((lParse.Nodes)[yyval.Node as usize]).SubNodes
-                                        [fresh3 as usize] = yyvs[yyvsp].Node.try_into().unwrap();
+                                    ((lParse.Nodes)[yyval.node() as usize]).SubNodes
+                                        [fresh3 as usize] = yyvs[yyvsp].node().try_into().unwrap();
                                     current_block = Block::ReduceDone;
                                 }
                             }
                         }
                         12 => {
                             /* vector: '{' expr  */
-                            yyval.Node = New_Vector(lParse, yyvs[yyvsp].Node);
-                            if yyval.Node < 0 {
+                            yyval.Node = New_Vector(lParse, yyvs[yyvsp].node());
+                            if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
                                 current_block = Block::ReduceDone;
@@ -1547,115 +1547,115 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         }
                         13 => {
                             /* vector: vector ',' expr  */
-                            if (lParse.Nodes[yyvs[yyvsp - 2].Node as usize]).ntype
-                                < (lParse.Nodes[yyvs[yyvsp].Node as usize]).ntype
+                            if (lParse.Nodes[yyvs[yyvsp - 2].node() as usize]).ntype
+                                < (lParse.Nodes[yyvs[yyvsp].node() as usize]).ntype
                             {
-                                (lParse.Nodes[yyvs[yyvsp - 2].Node as usize]).ntype =
-                                    ((lParse.Nodes)[yyvs[yyvsp].Node as usize]).ntype;
+                                (lParse.Nodes[yyvs[yyvsp - 2].node() as usize]).ntype =
+                                    ((lParse.Nodes)[yyvs[yyvsp].node() as usize]).ntype;
                             }
-                            if (lParse.Nodes[yyvs[yyvsp - 2].Node as usize]).nSubNodes
+                            if (lParse.Nodes[yyvs[yyvsp - 2].node() as usize]).nSubNodes
                                 >= 10 as c_int
                             {
-                                yyvs[yyvsp - 2].Node = Close_Vec(lParse, yyvs[yyvsp - 2].Node);
-                                if yyvs[yyvsp - 2].Node < 0 {
+                                yyvs[yyvsp - 2].Node = Close_Vec(lParse, yyvs[yyvsp - 2].node());
+                                if yyvs[yyvsp - 2].node() < 0 {
                                     current_block = Block::YyErrLab;
                                 } else {
-                                    yyval.Node = New_Vector(lParse, yyvs[yyvsp - 2].Node);
-                                    if yyval.Node < 0 {
+                                    yyval.Node = New_Vector(lParse, yyvs[yyvsp - 2].node());
+                                    if yyval.node() < 0 {
                                         current_block = Block::YyErrLab;
                                     } else {
                                         current_block = Block::ReduceJoin11;
                                     }
                                 }
                             } else {
-                                yyval.Node = yyvs[yyvsp - 2].Node;
+                                yyval.Node = yyvs[yyvsp - 2].node();
                                 current_block = Block::ReduceJoin11;
                             }
                             match current_block {
                                 Block::YyErrLab => {}
                                 _ => {
                                     let fresh4 =
-                                        &mut ((lParse.Nodes)[yyval.Node as usize]).nSubNodes;
+                                        &mut ((lParse.Nodes)[yyval.node() as usize]).nSubNodes;
                                     let fresh5 = *fresh4;
                                     *fresh4 += 1;
-                                    ((lParse.Nodes)[yyval.Node as usize]).SubNodes
-                                        [fresh5 as usize] = yyvs[yyvsp].Node.try_into().unwrap();
+                                    ((lParse.Nodes)[yyval.node() as usize]).SubNodes
+                                        [fresh5 as usize] = yyvs[yyvsp].node().try_into().unwrap();
                                     current_block = Block::ReduceDone;
                                 }
                             }
                         }
                         14 => {
                             /* vector: vector ',' bexpr  */
-                            if (lParse.Nodes[yyvs[yyvsp - 2].Node as usize]).nSubNodes
+                            if (lParse.Nodes[yyvs[yyvsp - 2].node() as usize]).nSubNodes
                                 >= MAXSUBS as c_int
                             {
-                                yyvs[yyvsp - 2].Node = Close_Vec(lParse, yyvs[yyvsp - 2].Node);
-                                if yyvs[yyvsp - 2].Node < 0 {
+                                yyvs[yyvsp - 2].Node = Close_Vec(lParse, yyvs[yyvsp - 2].node());
+                                if yyvs[yyvsp - 2].node() < 0 {
                                     current_block = Block::YyErrLab;
                                 } else {
-                                    yyval.Node = New_Vector(lParse, yyvs[yyvsp - 2].Node);
-                                    if yyval.Node < 0 {
+                                    yyval.Node = New_Vector(lParse, yyvs[yyvsp - 2].node());
+                                    if yyval.node() < 0 {
                                         current_block = Block::YyErrLab;
                                     } else {
                                         current_block = Block::ReduceJoin9;
                                     }
                                 }
                             } else {
-                                yyval.Node = yyvs[yyvsp - 2].Node;
+                                yyval.Node = yyvs[yyvsp - 2].node();
                                 current_block = Block::ReduceJoin9;
                             }
                             match current_block {
                                 Block::YyErrLab => {}
                                 _ => {
                                     let fresh6 =
-                                        &mut ((lParse.Nodes)[yyval.Node as usize]).nSubNodes;
+                                        &mut ((lParse.Nodes)[yyval.node() as usize]).nSubNodes;
                                     let fresh7 = *fresh6;
                                     *fresh6 += 1;
-                                    ((lParse.Nodes)[yyval.Node as usize]).SubNodes
-                                        [fresh7 as usize] = yyvs[yyvsp].Node.try_into().unwrap();
+                                    ((lParse.Nodes)[yyval.node() as usize]).SubNodes
+                                        [fresh7 as usize] = yyvs[yyvsp].node().try_into().unwrap();
                                     current_block = Block::ReduceDone;
                                 }
                             }
                         }
                         15 => {
                             /* vector: bvector ',' expr  */
-                            (lParse.Nodes[yyvs[yyvsp - 2].Node as usize]).ntype =
-                                (lParse.Nodes[yyvs[yyvsp].Node as usize]).ntype;
-                            if (lParse.Nodes[yyvs[yyvsp - 2].Node as usize]).nSubNodes
+                            (lParse.Nodes[yyvs[yyvsp - 2].node() as usize]).ntype =
+                                (lParse.Nodes[yyvs[yyvsp].node() as usize]).ntype;
+                            if (lParse.Nodes[yyvs[yyvsp - 2].node() as usize]).nSubNodes
                                 >= 10 as c_int
                             {
-                                yyvs[yyvsp - 2].Node = Close_Vec(lParse, yyvs[yyvsp - 2].Node);
-                                if yyvs[yyvsp - 2].Node < 0 {
+                                yyvs[yyvsp - 2].Node = Close_Vec(lParse, yyvs[yyvsp - 2].node());
+                                if yyvs[yyvsp - 2].node() < 0 {
                                     current_block = Block::YyErrLab;
                                 } else {
-                                    yyval.Node = New_Vector(lParse, yyvs[yyvsp - 2].Node);
-                                    if yyval.Node < 0 {
+                                    yyval.Node = New_Vector(lParse, yyvs[yyvsp - 2].node());
+                                    if yyval.node() < 0 {
                                         current_block = Block::YyErrLab;
                                     } else {
                                         current_block = Block::ReduceJoin13;
                                     }
                                 }
                             } else {
-                                yyval.Node = yyvs[yyvsp - 2].Node;
+                                yyval.Node = yyvs[yyvsp - 2].node();
                                 current_block = Block::ReduceJoin13;
                             }
                             match current_block {
                                 Block::YyErrLab => {}
                                 _ => {
                                     let fresh8 =
-                                        &mut ((lParse.Nodes)[yyval.Node as usize]).nSubNodes;
+                                        &mut ((lParse.Nodes)[yyval.node() as usize]).nSubNodes;
                                     let fresh9 = *fresh8;
                                     *fresh8 += 1;
-                                    ((lParse.Nodes)[yyval.Node as usize]).SubNodes
-                                        [fresh9 as usize] = yyvs[yyvsp].Node.try_into().unwrap();
+                                    ((lParse.Nodes)[yyval.node() as usize]).SubNodes
+                                        [fresh9 as usize] = yyvs[yyvsp].node().try_into().unwrap();
                                     current_block = Block::ReduceDone;
                                 }
                             }
                         }
                         16 => {
                             /* expr: vector '}'  */
-                            yyval.Node = Close_Vec(lParse, yyvs[yyvsp - 1].Node);
-                            if yyval.Node < 0 {
+                            yyval.Node = Close_Vec(lParse, yyvs[yyvsp - 1].node());
+                            if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
                                 current_block = Block::ReduceDone;
@@ -1663,8 +1663,8 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         }
                         17 => {
                             /* bexpr: bvector '}'  */
-                            yyval.Node = Close_Vec(lParse, yyvs[yyvsp - 1].Node);
-                            if yyval.Node < 0 {
+                            yyval.Node = Close_Vec(lParse, yyvs[yyvsp - 1].node());
+                            if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
                                 current_block = Block::ReduceDone;
@@ -1675,22 +1675,22 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             yyval.Node = New_Const(
                                 lParse,
                                 fits_parser_yytokentype::BITSTR as c_int,
-                                (yyvs[yyvsp].astr).as_mut_ptr().cast::<c_void>(),
-                                (astr_len(&yyvs[yyvsp].astr)).wrapping_add((1).try_into().unwrap())
+                                (yyvs[yyvsp].astr_mut()).as_mut_ptr().cast::<c_void>(),
+                                (astr_len(yyvs[yyvsp].astr())).wrapping_add((1).try_into().unwrap())
                                     as c_long,
                             );
-                            if yyval.Node < 0 {
+                            if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
-                                (((lParse.Nodes)[yyval.Node as usize]).value).nelem =
-                                    astr_len(&yyvs[yyvsp].astr) as c_long;
+                                (((lParse.Nodes)[yyval.node() as usize]).value).nelem =
+                                    astr_len(yyvs[yyvsp].astr()) as c_long;
                                 current_block = Block::ReduceDone;
                             }
                         }
                         19 => {
                             /* bits: BITCOL  */
-                            yyval.Node = New_Column(lParse, yyvs[yyvsp].lng as c_int);
-                            if yyval.Node < 0 {
+                            yyval.Node = New_Column(lParse, yyvs[yyvsp].lng() as c_int);
+                            if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
                                 current_block = Block::ReduceDone;
@@ -1698,9 +1698,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         }
                         20 => {
                             /* bits: BITCOL '{' expr '}'  */
-                            if ((lParse.Nodes)[yyvs[yyvsp - 1].Node as usize]).ntype
+                            if ((lParse.Nodes)[yyvs[yyvsp - 1].node() as usize]).ntype
                                 != fits_parser_yytokentype::LONG as c_int
-                                || ((lParse.Nodes)[yyvs[yyvsp - 1].Node as usize]).operation
+                                || ((lParse.Nodes)[yyvs[yyvsp - 1].node() as usize]).operation
                                     != CONST_OP
                             {
                                 fits_parser_yyerror(
@@ -1711,10 +1711,10 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             } else {
                                 yyval.Node = New_Offset(
                                     lParse,
-                                    yyvs[yyvsp - 3].lng as c_int,
-                                    yyvs[yyvsp - 1].Node,
+                                    yyvs[yyvsp - 3].lng() as c_int,
+                                    yyvs[yyvsp - 1].node(),
                                 );
-                                if yyval.Node < 0 {
+                                if yyval.node() < 0 {
                                     current_block = Block::YyErrLab;
                                 } else {
                                     current_block = Block::ReduceDone;
@@ -1726,20 +1726,23 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             yyval.Node = New_BinOp(
                                 lParse,
                                 fits_parser_yytokentype::BITSTR as c_int,
-                                yyvs[yyvsp - 2].Node,
+                                yyvs[yyvsp - 2].node(),
                                 '&' as i32,
-                                yyvs[yyvsp].Node,
+                                yyvs[yyvsp].node(),
                             );
-                            if yyval.Node < 0 {
+                            if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
-                                (((lParse.Nodes)[yyval.Node as usize]).value).nelem =
-                                    if (((lParse.Nodes)[yyvs[yyvsp - 2].Node as usize]).value).nelem
-                                        > (lParse.Nodes[yyvs[yyvsp].Node as usize]).value.nelem
+                                (((lParse.Nodes)[yyval.node() as usize]).value).nelem =
+                                    if (((lParse.Nodes)[yyvs[yyvsp - 2].node() as usize]).value)
+                                        .nelem
+                                        > (lParse.Nodes[yyvs[yyvsp].node() as usize]).value.nelem
                                     {
-                                        ((lParse.Nodes)[yyvs[yyvsp - 2].Node as usize]).value.nelem
+                                        ((lParse.Nodes)[yyvs[yyvsp - 2].node() as usize])
+                                            .value
+                                            .nelem
                                     } else {
-                                        (lParse.Nodes[yyvs[yyvsp].Node as usize]).value.nelem
+                                        (lParse.Nodes[yyvs[yyvsp].node() as usize]).value.nelem
                                     };
                                 current_block = Block::ReduceDone;
                             }
@@ -1749,28 +1752,31 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             yyval.Node = New_BinOp(
                                 lParse,
                                 fits_parser_yytokentype::BITSTR as c_int,
-                                yyvs[yyvsp - 2].Node,
+                                yyvs[yyvsp - 2].node(),
                                 '|' as i32,
-                                yyvs[yyvsp].Node,
+                                yyvs[yyvsp].node(),
                             );
-                            if yyval.Node < 0 {
+                            if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
-                                (((lParse.Nodes)[yyval.Node as usize]).value).nelem =
-                                    if (((lParse.Nodes)[yyvs[yyvsp - 2].Node as usize]).value).nelem
-                                        > (lParse.Nodes[yyvs[yyvsp].Node as usize]).value.nelem
+                                (((lParse.Nodes)[yyval.node() as usize]).value).nelem =
+                                    if (((lParse.Nodes)[yyvs[yyvsp - 2].node() as usize]).value)
+                                        .nelem
+                                        > (lParse.Nodes[yyvs[yyvsp].node() as usize]).value.nelem
                                     {
-                                        ((lParse.Nodes)[yyvs[yyvsp - 2].Node as usize]).value.nelem
+                                        ((lParse.Nodes)[yyvs[yyvsp - 2].node() as usize])
+                                            .value
+                                            .nelem
                                     } else {
-                                        (lParse.Nodes[yyvs[yyvsp].Node as usize]).value.nelem
+                                        (lParse.Nodes[yyvs[yyvsp].node() as usize]).value.nelem
                                     };
                                 current_block = Block::ReduceDone;
                             }
                         }
                         23 => {
                             /* bits: bits '+' bits  */
-                            if (lParse.Nodes[yyvs[yyvsp - 2].Node as usize]).value.nelem
-                                + (lParse.Nodes[yyvs[yyvsp].Node as usize]).value.nelem
+                            if (lParse.Nodes[yyvs[yyvsp - 2].node() as usize]).value.nelem
+                                + (lParse.Nodes[yyvs[yyvsp].node() as usize]).value.nelem
                                 >= 256 as c_long
                             {
                                 fits_parser_yyerror(
@@ -1782,16 +1788,18 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 yyval.Node = New_BinOp(
                                     lParse,
                                     fits_parser_yytokentype::BITSTR as c_int,
-                                    yyvs[yyvsp - 2].Node,
+                                    yyvs[yyvsp - 2].node(),
                                     '+' as i32,
-                                    yyvs[yyvsp].Node,
+                                    yyvs[yyvsp].node(),
                                 );
-                                if yyval.Node < 0 {
+                                if yyval.node() < 0 {
                                     current_block = Block::YyErrLab;
                                 } else {
-                                    (((lParse.Nodes)[yyval.Node as usize]).value).nelem =
-                                        ((lParse.Nodes)[yyvs[yyvsp - 2].Node as usize]).value.nelem
-                                            + ((lParse.Nodes)[yyvs[yyvsp].Node as usize])
+                                    (((lParse.Nodes)[yyval.node() as usize]).value).nelem =
+                                        ((lParse.Nodes)[yyvs[yyvsp - 2].node() as usize])
+                                            .value
+                                            .nelem
+                                            + ((lParse.Nodes)[yyvs[yyvsp].node() as usize])
                                                 .value
                                                 .nelem;
                                     current_block = Block::ReduceDone;
@@ -1802,15 +1810,15 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             /* bits: bits '[' expr ']'  */
                             yyval.Node = New_Deref(
                                 lParse,
-                                yyvs[yyvsp - 3].Node,
+                                yyvs[yyvsp - 3].node(),
                                 1,
-                                yyvs[yyvsp - 1].Node,
+                                yyvs[yyvsp - 1].node(),
                                 0,
                                 0,
                                 0,
                                 0,
                             );
-                            if yyval.Node < 0 {
+                            if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
                                 current_block = Block::ReduceDone;
@@ -1820,15 +1828,15 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             /* bits: bits '[' expr ',' expr ']'  */
                             yyval.Node = New_Deref(
                                 lParse,
-                                yyvs[yyvsp - 5].Node,
+                                yyvs[yyvsp - 5].node(),
                                 2,
-                                yyvs[yyvsp - 3].Node,
-                                yyvs[yyvsp - 1].Node,
+                                yyvs[yyvsp - 3].node(),
+                                yyvs[yyvsp - 1].node(),
                                 0,
                                 0,
                                 0,
                             );
-                            if yyval.Node < 0 {
+                            if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
                                 current_block = Block::ReduceDone;
@@ -1838,15 +1846,15 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             /* bits: bits '[' expr ',' expr ',' expr ']'  */
                             yyval.Node = New_Deref(
                                 lParse,
-                                yyvs[yyvsp - 7].Node,
+                                yyvs[yyvsp - 7].node(),
                                 3 as c_int,
-                                yyvs[yyvsp - 5].Node,
-                                yyvs[yyvsp - 3].Node,
-                                yyvs[yyvsp - 1].Node,
+                                yyvs[yyvsp - 5].node(),
+                                yyvs[yyvsp - 3].node(),
+                                yyvs[yyvsp - 1].node(),
                                 0,
                                 0,
                             );
-                            if yyval.Node < 0 {
+                            if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
                                 current_block = Block::ReduceDone;
@@ -1856,15 +1864,15 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             /* bits: bits '[' expr ',' expr ',' expr ',' expr ']'  */
                             yyval.Node = New_Deref(
                                 lParse,
-                                yyvs[yyvsp - 9].Node,
+                                yyvs[yyvsp - 9].node(),
                                 4 as c_int,
-                                yyvs[yyvsp - 7].Node,
-                                yyvs[yyvsp - 5].Node,
-                                yyvs[yyvsp - 3].Node,
-                                yyvs[yyvsp - 1].Node,
+                                yyvs[yyvsp - 7].node(),
+                                yyvs[yyvsp - 5].node(),
+                                yyvs[yyvsp - 3].node(),
+                                yyvs[yyvsp - 1].node(),
                                 0,
                             );
-                            if yyval.Node < 0 {
+                            if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
                                 current_block = Block::ReduceDone;
@@ -1874,15 +1882,15 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             /* bits: bits '[' expr ',' expr ',' expr ',' expr ',' expr ']'  */
                             yyval.Node = New_Deref(
                                 lParse,
-                                yyvs[yyvsp - 11].Node,
+                                yyvs[yyvsp - 11].node(),
                                 5 as c_int,
-                                yyvs[yyvsp - 9].Node,
-                                yyvs[yyvsp - 7].Node,
-                                yyvs[yyvsp - 5].Node,
-                                yyvs[yyvsp - 3].Node,
-                                yyvs[yyvsp - 1].Node,
+                                yyvs[yyvsp - 9].node(),
+                                yyvs[yyvsp - 7].node(),
+                                yyvs[yyvsp - 5].node(),
+                                yyvs[yyvsp - 3].node(),
+                                yyvs[yyvsp - 1].node(),
                             );
-                            if yyval.Node < 0 {
+                            if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
                                 current_block = Block::ReduceDone;
@@ -1894,9 +1902,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 lParse,
                                 fits_parser_yytokentype::BITSTR as c_int,
                                 fits_parser_yytokentype::NOT as c_int,
-                                yyvs[yyvsp].Node,
+                                yyvs[yyvsp].node(),
                             );
-                            if yyval.Node < 0 {
+                            if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
                                 current_block = Block::ReduceDone;
@@ -1904,7 +1912,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         }
                         30 => {
                             /* bits: '(' bits ')'  */
-                            yyval.Node = yyvs[yyvsp - 1].Node;
+                            yyval.Node = yyvs[yyvsp - 1].node();
                             current_block = Block::ReduceDone;
                         }
                         31 => {
@@ -1912,10 +1920,10 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             yyval.Node = New_Const(
                                 lParse,
                                 fits_parser_yytokentype::LONG as c_int,
-                                (&mut yyvs[yyvsp].lng as *mut c_long).cast::<c_void>(),
+                                (&mut yyvs[yyvsp].lng() as *mut c_long).cast::<c_void>(),
                                 ::core::mem::size_of::<c_long>() as c_ulong as c_long,
                             );
-                            if yyval.Node < 0 {
+                            if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
                                 current_block = Block::ReduceDone;
@@ -1926,10 +1934,10 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             yyval.Node = New_Const(
                                 lParse,
                                 fits_parser_yytokentype::DOUBLE as c_int,
-                                (&mut yyvs[yyvsp].dbl as *mut c_double).cast::<c_void>(),
+                                (&mut yyvs[yyvsp].dbl() as *mut c_double).cast::<c_void>(),
                                 ::core::mem::size_of::<c_double>() as c_ulong as c_long,
                             );
-                            if yyval.Node < 0 {
+                            if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
                                 current_block = Block::ReduceDone;
@@ -1937,8 +1945,8 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         }
                         33 => {
                             /* expr: COLUMN  */
-                            yyval.Node = New_Column(lParse, yyvs[yyvsp].lng as c_int);
-                            if yyval.Node < 0 {
+                            yyval.Node = New_Column(lParse, yyvs[yyvsp].lng() as c_int);
+                            if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
                                 current_block = Block::ReduceDone;
@@ -1946,9 +1954,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         }
                         34 => {
                             /* expr: COLUMN '{' expr '}'  */
-                            if ((lParse.Nodes)[yyvs[yyvsp - 1].Node as usize]).ntype
+                            if ((lParse.Nodes)[yyvs[yyvsp - 1].node() as usize]).ntype
                                 != fits_parser_yytokentype::LONG as c_int
-                                || ((lParse.Nodes)[yyvs[yyvsp - 1].Node as usize]).operation
+                                || ((lParse.Nodes)[yyvs[yyvsp - 1].node() as usize]).operation
                                     != CONST_OP
                             {
                                 fits_parser_yyerror(
@@ -1959,10 +1967,10 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             } else {
                                 yyval.Node = New_Offset(
                                     lParse,
-                                    yyvs[yyvsp - 3].lng as c_int,
-                                    yyvs[yyvsp - 1].Node,
+                                    yyvs[yyvsp - 3].lng() as c_int,
+                                    yyvs[yyvsp - 1].node(),
                                 );
-                                if yyval.Node < 0 {
+                                if yyval.node() < 0 {
                                     current_block = Block::YyErrLab;
                                 } else {
                                     current_block = Block::ReduceDone;
@@ -2005,33 +2013,33 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         }
                         37 => {
                             /* expr: expr '%' expr  */
-                            if (lParse.Nodes[yyvs[yyvsp - 2].Node as usize]).ntype
-                                > (lParse.Nodes[yyvs[yyvsp].Node as usize]).ntype
+                            if (lParse.Nodes[yyvs[yyvsp - 2].node() as usize]).ntype
+                                > (lParse.Nodes[yyvs[yyvsp].node() as usize]).ntype
                             {
                                 yyvs[yyvsp].Node = New_Unary(
                                     lParse,
-                                    ((lParse.Nodes)[yyvs[yyvsp - 2].Node as usize]).ntype,
+                                    ((lParse.Nodes)[yyvs[yyvsp - 2].node() as usize]).ntype,
                                     0,
-                                    yyvs[yyvsp].Node,
+                                    yyvs[yyvsp].node(),
                                 );
-                            } else if ((lParse.Nodes)[yyvs[yyvsp - 2].Node as usize]).ntype
-                                < (lParse.Nodes[yyvs[yyvsp].Node as usize]).ntype
+                            } else if ((lParse.Nodes)[yyvs[yyvsp - 2].node() as usize]).ntype
+                                < (lParse.Nodes[yyvs[yyvsp].node() as usize]).ntype
                             {
                                 yyvs[yyvsp - 2].Node = New_Unary(
                                     lParse,
-                                    (lParse.Nodes[yyvs[yyvsp].Node as usize]).ntype,
+                                    (lParse.Nodes[yyvs[yyvsp].node() as usize]).ntype,
                                     0,
-                                    yyvs[yyvsp - 2].Node,
+                                    yyvs[yyvsp - 2].node(),
                                 );
                             }
                             yyval.Node = New_BinOp(
                                 lParse,
-                                (lParse.Nodes[yyvs[yyvsp - 2].Node as usize]).ntype,
-                                yyvs[yyvsp - 2].Node,
+                                (lParse.Nodes[yyvs[yyvsp - 2].node() as usize]).ntype,
+                                yyvs[yyvsp - 2].node(),
                                 '%' as i32,
-                                yyvs[yyvsp].Node,
+                                yyvs[yyvsp].node(),
                             );
-                            if yyval.Node < 0 {
+                            if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
                                 current_block = Block::ReduceDone;
@@ -2039,33 +2047,33 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         }
                         38 => {
                             /* expr: expr '+' expr  */
-                            if (lParse.Nodes[yyvs[yyvsp - 2].Node as usize]).ntype
-                                > (lParse.Nodes[yyvs[yyvsp].Node as usize]).ntype
+                            if (lParse.Nodes[yyvs[yyvsp - 2].node() as usize]).ntype
+                                > (lParse.Nodes[yyvs[yyvsp].node() as usize]).ntype
                             {
                                 yyvs[yyvsp].Node = New_Unary(
                                     lParse,
-                                    ((lParse.Nodes)[yyvs[yyvsp - 2].Node as usize]).ntype,
+                                    ((lParse.Nodes)[yyvs[yyvsp - 2].node() as usize]).ntype,
                                     0,
-                                    yyvs[yyvsp].Node,
+                                    yyvs[yyvsp].node(),
                                 );
-                            } else if ((lParse.Nodes)[yyvs[yyvsp - 2].Node as usize]).ntype
-                                < (lParse.Nodes[yyvs[yyvsp].Node as usize]).ntype
+                            } else if ((lParse.Nodes)[yyvs[yyvsp - 2].node() as usize]).ntype
+                                < (lParse.Nodes[yyvs[yyvsp].node() as usize]).ntype
                             {
                                 yyvs[yyvsp - 2].Node = New_Unary(
                                     lParse,
-                                    (lParse.Nodes[yyvs[yyvsp].Node as usize]).ntype,
+                                    (lParse.Nodes[yyvs[yyvsp].node() as usize]).ntype,
                                     0,
-                                    yyvs[yyvsp - 2].Node,
+                                    yyvs[yyvsp - 2].node(),
                                 );
                             }
                             yyval.Node = New_BinOp(
                                 lParse,
-                                (lParse.Nodes[yyvs[yyvsp - 2].Node as usize]).ntype,
-                                yyvs[yyvsp - 2].Node,
+                                (lParse.Nodes[yyvs[yyvsp - 2].node() as usize]).ntype,
+                                yyvs[yyvsp - 2].node(),
                                 '+' as i32,
-                                yyvs[yyvsp].Node,
+                                yyvs[yyvsp].node(),
                             );
-                            if yyval.Node < 0 {
+                            if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
                                 current_block = Block::ReduceDone;
@@ -2073,33 +2081,33 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         }
                         39 => {
                             /* expr: expr '-' expr  */
-                            if (lParse.Nodes[yyvs[yyvsp - 2].Node as usize]).ntype
-                                > (lParse.Nodes[yyvs[yyvsp].Node as usize]).ntype
+                            if (lParse.Nodes[yyvs[yyvsp - 2].node() as usize]).ntype
+                                > (lParse.Nodes[yyvs[yyvsp].node() as usize]).ntype
                             {
                                 yyvs[yyvsp].Node = New_Unary(
                                     lParse,
-                                    ((lParse.Nodes)[yyvs[yyvsp - 2].Node as usize]).ntype,
+                                    ((lParse.Nodes)[yyvs[yyvsp - 2].node() as usize]).ntype,
                                     0,
-                                    yyvs[yyvsp].Node,
+                                    yyvs[yyvsp].node(),
                                 );
-                            } else if ((lParse.Nodes)[yyvs[yyvsp - 2].Node as usize]).ntype
-                                < (lParse.Nodes[yyvs[yyvsp].Node as usize]).ntype
+                            } else if ((lParse.Nodes)[yyvs[yyvsp - 2].node() as usize]).ntype
+                                < (lParse.Nodes[yyvs[yyvsp].node() as usize]).ntype
                             {
                                 yyvs[yyvsp - 2].Node = New_Unary(
                                     lParse,
-                                    (lParse.Nodes[yyvs[yyvsp].Node as usize]).ntype,
+                                    (lParse.Nodes[yyvs[yyvsp].node() as usize]).ntype,
                                     0,
-                                    yyvs[yyvsp - 2].Node,
+                                    yyvs[yyvsp - 2].node(),
                                 );
                             }
                             yyval.Node = New_BinOp(
                                 lParse,
-                                (lParse.Nodes[yyvs[yyvsp - 2].Node as usize]).ntype,
-                                yyvs[yyvsp - 2].Node,
+                                (lParse.Nodes[yyvs[yyvsp - 2].node() as usize]).ntype,
+                                yyvs[yyvsp - 2].node(),
                                 '-' as i32,
-                                yyvs[yyvsp].Node,
+                                yyvs[yyvsp].node(),
                             );
-                            if yyval.Node < 0 {
+                            if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
                                 current_block = Block::ReduceDone;
@@ -2107,33 +2115,33 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         }
                         40 => {
                             /* expr: expr '*' expr  */
-                            if (lParse.Nodes[yyvs[yyvsp - 2].Node as usize]).ntype
-                                > (lParse.Nodes[yyvs[yyvsp].Node as usize]).ntype
+                            if (lParse.Nodes[yyvs[yyvsp - 2].node() as usize]).ntype
+                                > (lParse.Nodes[yyvs[yyvsp].node() as usize]).ntype
                             {
                                 yyvs[yyvsp].Node = New_Unary(
                                     lParse,
-                                    ((lParse.Nodes)[yyvs[yyvsp - 2].Node as usize]).ntype,
+                                    ((lParse.Nodes)[yyvs[yyvsp - 2].node() as usize]).ntype,
                                     0,
-                                    yyvs[yyvsp].Node,
+                                    yyvs[yyvsp].node(),
                                 );
-                            } else if ((lParse.Nodes)[yyvs[yyvsp - 2].Node as usize]).ntype
-                                < (lParse.Nodes[yyvs[yyvsp].Node as usize]).ntype
+                            } else if ((lParse.Nodes)[yyvs[yyvsp - 2].node() as usize]).ntype
+                                < (lParse.Nodes[yyvs[yyvsp].node() as usize]).ntype
                             {
                                 yyvs[yyvsp - 2].Node = New_Unary(
                                     lParse,
-                                    (lParse.Nodes[yyvs[yyvsp].Node as usize]).ntype,
+                                    (lParse.Nodes[yyvs[yyvsp].node() as usize]).ntype,
                                     0,
-                                    yyvs[yyvsp - 2].Node,
+                                    yyvs[yyvsp - 2].node(),
                                 );
                             }
                             yyval.Node = New_BinOp(
                                 lParse,
-                                (lParse.Nodes[yyvs[yyvsp - 2].Node as usize]).ntype,
-                                yyvs[yyvsp - 2].Node,
+                                (lParse.Nodes[yyvs[yyvsp - 2].node() as usize]).ntype,
+                                yyvs[yyvsp - 2].node(),
                                 '*' as i32,
-                                yyvs[yyvsp].Node,
+                                yyvs[yyvsp].node(),
                             );
-                            if yyval.Node < 0 {
+                            if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
                                 current_block = Block::ReduceDone;
@@ -2141,33 +2149,33 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         }
                         41 => {
                             /* expr: expr '/' expr  */
-                            if (lParse.Nodes[yyvs[yyvsp - 2].Node as usize]).ntype
-                                > (lParse.Nodes[yyvs[yyvsp].Node as usize]).ntype
+                            if (lParse.Nodes[yyvs[yyvsp - 2].node() as usize]).ntype
+                                > (lParse.Nodes[yyvs[yyvsp].node() as usize]).ntype
                             {
                                 yyvs[yyvsp].Node = New_Unary(
                                     lParse,
-                                    ((lParse.Nodes)[yyvs[yyvsp - 2].Node as usize]).ntype,
+                                    ((lParse.Nodes)[yyvs[yyvsp - 2].node() as usize]).ntype,
                                     0,
-                                    yyvs[yyvsp].Node,
+                                    yyvs[yyvsp].node(),
                                 );
-                            } else if ((lParse.Nodes)[yyvs[yyvsp - 2].Node as usize]).ntype
-                                < (lParse.Nodes[yyvs[yyvsp].Node as usize]).ntype
+                            } else if ((lParse.Nodes)[yyvs[yyvsp - 2].node() as usize]).ntype
+                                < (lParse.Nodes[yyvs[yyvsp].node() as usize]).ntype
                             {
                                 yyvs[yyvsp - 2].Node = New_Unary(
                                     lParse,
-                                    (lParse.Nodes[yyvs[yyvsp].Node as usize]).ntype,
+                                    (lParse.Nodes[yyvs[yyvsp].node() as usize]).ntype,
                                     0,
-                                    yyvs[yyvsp - 2].Node,
+                                    yyvs[yyvsp - 2].node(),
                                 );
                             }
                             yyval.Node = New_BinOp(
                                 lParse,
-                                (lParse.Nodes[yyvs[yyvsp - 2].Node as usize]).ntype,
-                                yyvs[yyvsp - 2].Node,
+                                (lParse.Nodes[yyvs[yyvsp - 2].node() as usize]).ntype,
+                                yyvs[yyvsp - 2].node(),
                                 '/' as i32,
-                                yyvs[yyvsp].Node,
+                                yyvs[yyvsp].node(),
                             );
-                            if yyval.Node < 0 {
+                            if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
                                 current_block = Block::ReduceDone;
@@ -2175,9 +2183,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         }
                         42 => {
                             /* expr: expr '&' expr  */
-                            if (lParse.Nodes[yyvs[yyvsp - 2].Node as usize]).ntype
+                            if (lParse.Nodes[yyvs[yyvsp - 2].node() as usize]).ntype
                                 != fits_parser_yytokentype::LONG as c_int
-                                || (lParse.Nodes[yyvs[yyvsp].Node as usize]).ntype
+                                || (lParse.Nodes[yyvs[yyvsp].node() as usize]).ntype
                                     != fits_parser_yytokentype::LONG as c_int
                             {
                                 fits_parser_yyerror(lParse, cs!(c"Bitwise operations with incompatible types; only (bit OP bit) and (int OP int) are allowed"));
@@ -2185,19 +2193,19 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             } else {
                                 yyval.Node = New_BinOp(
                                     lParse,
-                                    ((lParse.Nodes)[yyvs[yyvsp - 2].Node as usize]).ntype,
-                                    yyvs[yyvsp - 2].Node,
+                                    ((lParse.Nodes)[yyvs[yyvsp - 2].node() as usize]).ntype,
+                                    yyvs[yyvsp - 2].node(),
                                     '&' as i32,
-                                    yyvs[yyvsp].Node,
+                                    yyvs[yyvsp].node(),
                                 );
                                 current_block = Block::ReduceDone;
                             }
                         }
                         43 => {
                             /* expr: expr '|' expr  */
-                            if (lParse.Nodes[yyvs[yyvsp - 2].Node as usize]).ntype
+                            if (lParse.Nodes[yyvs[yyvsp - 2].node() as usize]).ntype
                                 != fits_parser_yytokentype::LONG as c_int
-                                || (lParse.Nodes[yyvs[yyvsp].Node as usize]).ntype
+                                || (lParse.Nodes[yyvs[yyvsp].node() as usize]).ntype
                                     != fits_parser_yytokentype::LONG as c_int
                             {
                                 fits_parser_yyerror(lParse, cs!(c"Bitwise operations with incompatible types; only (bit OP bit) and (int OP int) are allowed"));
@@ -2205,19 +2213,19 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             } else {
                                 yyval.Node = New_BinOp(
                                     lParse,
-                                    ((lParse.Nodes)[yyvs[yyvsp - 2].Node as usize]).ntype,
-                                    yyvs[yyvsp - 2].Node,
+                                    ((lParse.Nodes)[yyvs[yyvsp - 2].node() as usize]).ntype,
+                                    yyvs[yyvsp - 2].node(),
                                     '|' as i32,
-                                    yyvs[yyvsp].Node,
+                                    yyvs[yyvsp].node(),
                                 );
                                 current_block = Block::ReduceDone;
                             }
                         }
                         44 => {
                             /* expr: expr XOR expr  */
-                            if (lParse.Nodes[yyvs[yyvsp - 2].Node as usize]).ntype
+                            if (lParse.Nodes[yyvs[yyvsp - 2].node() as usize]).ntype
                                 != fits_parser_yytokentype::LONG as c_int
-                                || (lParse.Nodes[yyvs[yyvsp].Node as usize]).ntype
+                                || (lParse.Nodes[yyvs[yyvsp].node() as usize]).ntype
                                     != fits_parser_yytokentype::LONG as c_int
                             {
                                 fits_parser_yyerror(lParse, cs!(c"Bitwise operations with incompatible types; only (bit OP bit) and (int OP int) are allowed"));
@@ -2225,43 +2233,43 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             } else {
                                 yyval.Node = New_BinOp(
                                     lParse,
-                                    ((lParse.Nodes)[yyvs[yyvsp - 2].Node as usize]).ntype,
-                                    yyvs[yyvsp - 2].Node,
+                                    ((lParse.Nodes)[yyvs[yyvsp - 2].node() as usize]).ntype,
+                                    yyvs[yyvsp - 2].node(),
                                     '^' as i32,
-                                    yyvs[yyvsp].Node,
+                                    yyvs[yyvsp].node(),
                                 );
                                 current_block = Block::ReduceDone;
                             }
                         }
                         45 => {
                             /* expr: expr POWER expr  */
-                            if (lParse.Nodes[yyvs[yyvsp - 2].Node as usize]).ntype
-                                > (lParse.Nodes[yyvs[yyvsp].Node as usize]).ntype
+                            if (lParse.Nodes[yyvs[yyvsp - 2].node() as usize]).ntype
+                                > (lParse.Nodes[yyvs[yyvsp].node() as usize]).ntype
                             {
                                 yyvs[yyvsp].Node = New_Unary(
                                     lParse,
-                                    ((lParse.Nodes)[yyvs[yyvsp - 2].Node as usize]).ntype,
+                                    ((lParse.Nodes)[yyvs[yyvsp - 2].node() as usize]).ntype,
                                     0,
-                                    yyvs[yyvsp].Node,
+                                    yyvs[yyvsp].node(),
                                 );
-                            } else if ((lParse.Nodes)[yyvs[yyvsp - 2].Node as usize]).ntype
-                                < (lParse.Nodes[yyvs[yyvsp].Node as usize]).ntype
+                            } else if ((lParse.Nodes)[yyvs[yyvsp - 2].node() as usize]).ntype
+                                < (lParse.Nodes[yyvs[yyvsp].node() as usize]).ntype
                             {
                                 yyvs[yyvsp - 2].Node = New_Unary(
                                     lParse,
-                                    (lParse.Nodes[yyvs[yyvsp].Node as usize]).ntype,
+                                    (lParse.Nodes[yyvs[yyvsp].node() as usize]).ntype,
                                     0,
-                                    yyvs[yyvsp - 2].Node,
+                                    yyvs[yyvsp - 2].node(),
                                 );
                             }
                             yyval.Node = New_BinOp(
                                 lParse,
-                                (lParse.Nodes[yyvs[yyvsp - 2].Node as usize]).ntype,
-                                yyvs[yyvsp - 2].Node,
+                                (lParse.Nodes[yyvs[yyvsp - 2].node() as usize]).ntype,
+                                yyvs[yyvsp - 2].node(),
                                 fits_parser_yytokentype::POWER as c_int,
-                                yyvs[yyvsp].Node,
+                                yyvs[yyvsp].node(),
                             );
-                            if yyval.Node < 0 {
+                            if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
                                 current_block = Block::ReduceDone;
@@ -2269,18 +2277,18 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         }
                         46 => {
                             /* expr: '+' expr  */
-                            yyval.Node = yyvs[yyvsp].Node;
+                            yyval.Node = yyvs[yyvsp].node();
                             current_block = Block::ReduceDone;
                         }
                         47 => {
                             /* expr: '-' expr  */
                             yyval.Node = New_Unary(
                                 lParse,
-                                (lParse.Nodes[yyvs[yyvsp].Node as usize]).ntype,
+                                (lParse.Nodes[yyvs[yyvsp].node() as usize]).ntype,
                                 fits_parser_yytokentype::UMINUS as c_int,
-                                yyvs[yyvsp].Node,
+                                yyvs[yyvsp].node(),
                             );
-                            if yyval.Node < 0 {
+                            if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
                                 current_block = Block::ReduceDone;
@@ -2288,25 +2296,25 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         }
                         48 => {
                             /* expr: '(' expr ')'  */
-                            yyval.Node = yyvs[yyvsp - 1].Node;
+                            yyval.Node = yyvs[yyvsp - 1].node();
                             current_block = Block::ReduceDone;
                         }
                         49 => {
                             /* expr: expr '*' bexpr  */
                             yyvs[yyvsp].Node = New_Unary(
                                 lParse,
-                                (lParse.Nodes[yyvs[yyvsp - 2].Node as usize]).ntype,
+                                (lParse.Nodes[yyvs[yyvsp - 2].node() as usize]).ntype,
                                 0,
-                                yyvs[yyvsp].Node,
+                                yyvs[yyvsp].node(),
                             );
                             yyval.Node = New_BinOp(
                                 lParse,
-                                (lParse.Nodes[yyvs[yyvsp - 2].Node as usize]).ntype,
-                                yyvs[yyvsp - 2].Node,
+                                (lParse.Nodes[yyvs[yyvsp - 2].node() as usize]).ntype,
+                                yyvs[yyvsp - 2].node(),
                                 '*' as i32,
-                                yyvs[yyvsp].Node,
+                                yyvs[yyvsp].node(),
                             );
-                            if yyval.Node < 0 {
+                            if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
                                 current_block = Block::ReduceDone;
@@ -2316,18 +2324,18 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             /* expr: bexpr '*' expr  */
                             yyvs[yyvsp - 2].Node = New_Unary(
                                 lParse,
-                                (lParse.Nodes[yyvs[yyvsp].Node as usize]).ntype,
+                                (lParse.Nodes[yyvs[yyvsp].node() as usize]).ntype,
                                 0,
-                                yyvs[yyvsp - 2].Node,
+                                yyvs[yyvsp - 2].node(),
                             );
                             yyval.Node = New_BinOp(
                                 lParse,
-                                (lParse.Nodes[yyvs[yyvsp].Node as usize]).ntype,
-                                yyvs[yyvsp - 2].Node,
+                                (lParse.Nodes[yyvs[yyvsp].node() as usize]).ntype,
+                                yyvs[yyvsp - 2].node(),
                                 '*' as i32,
-                                yyvs[yyvsp].Node,
+                                yyvs[yyvsp].node(),
                             );
-                            if yyval.Node < 0 {
+                            if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
                                 current_block = Block::ReduceDone;
@@ -2335,26 +2343,26 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         }
                         51 => {
                             /* expr: bexpr '?' expr ':' expr  */
-                            if (lParse.Nodes[yyvs[yyvsp - 2].Node as usize]).ntype
-                                > (lParse.Nodes[yyvs[yyvsp].Node as usize]).ntype
+                            if (lParse.Nodes[yyvs[yyvsp - 2].node() as usize]).ntype
+                                > (lParse.Nodes[yyvs[yyvsp].node() as usize]).ntype
                             {
                                 yyvs[yyvsp].Node = New_Unary(
                                     lParse,
-                                    ((lParse.Nodes)[yyvs[yyvsp - 2].Node as usize]).ntype,
+                                    ((lParse.Nodes)[yyvs[yyvsp - 2].node() as usize]).ntype,
                                     0,
-                                    yyvs[yyvsp].Node,
+                                    yyvs[yyvsp].node(),
                                 );
-                            } else if ((lParse.Nodes)[yyvs[yyvsp - 2].Node as usize]).ntype
-                                < (lParse.Nodes[yyvs[yyvsp].Node as usize]).ntype
+                            } else if ((lParse.Nodes)[yyvs[yyvsp - 2].node() as usize]).ntype
+                                < (lParse.Nodes[yyvs[yyvsp].node() as usize]).ntype
                             {
                                 yyvs[yyvsp - 2].Node = New_Unary(
                                     lParse,
-                                    (lParse.Nodes[yyvs[yyvsp].Node as usize]).ntype,
+                                    (lParse.Nodes[yyvs[yyvsp].node() as usize]).ntype,
                                     0,
-                                    yyvs[yyvsp - 2].Node,
+                                    yyvs[yyvsp - 2].node(),
                                 );
                             }
-                            if Test_Dims(lParse, yyvs[yyvsp - 2].Node, yyvs[yyvsp].Node) == 0 {
+                            if Test_Dims(lParse, yyvs[yyvsp - 2].node(), yyvs[yyvsp].node()) == 0 {
                                 fits_parser_yyerror(
                                     lParse,
                                     cs!(c"Incompatible dimensions in '?:' arguments"),
@@ -2366,39 +2374,42 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     0,
                                     IFTHENELSE_FCT,
                                     3 as c_int,
-                                    yyvs[yyvsp - 2].Node,
-                                    yyvs[yyvsp].Node,
-                                    yyvs[yyvsp - 4].Node,
+                                    yyvs[yyvsp - 2].node(),
+                                    yyvs[yyvsp].node(),
+                                    yyvs[yyvsp - 4].node(),
                                     0,
                                     0,
                                     0,
                                     0,
                                 );
-                                if yyval.Node < 0 {
+                                if yyval.node() < 0 {
                                     current_block = Block::YyErrLab;
                                 } else {
-                                    if ((lParse.Nodes)[yyvs[yyvsp - 2].Node as usize]).value.nelem
-                                        < (lParse.Nodes[yyvs[yyvsp].Node as usize]).value.nelem
+                                    if ((lParse.Nodes)[yyvs[yyvsp - 2].node() as usize])
+                                        .value
+                                        .nelem
+                                        < (lParse.Nodes[yyvs[yyvsp].node() as usize]).value.nelem
                                     {
-                                        Copy_Dims(lParse, yyval.Node, yyvs[yyvsp].Node);
+                                        Copy_Dims(lParse, yyval.node(), yyvs[yyvsp].node());
                                     }
-                                    ((lParse.Nodes)[yyvs[yyvsp - 4].Node as usize]).ntype =
-                                        ((lParse.Nodes)[yyvs[yyvsp - 2].Node as usize]).ntype;
-                                    if Test_Dims(lParse, yyvs[yyvsp - 4].Node, yyval.Node) == 0 {
+                                    ((lParse.Nodes)[yyvs[yyvsp - 4].node() as usize]).ntype =
+                                        ((lParse.Nodes)[yyvs[yyvsp - 2].node() as usize]).ntype;
+                                    if Test_Dims(lParse, yyvs[yyvsp - 4].node(), yyval.node()) == 0
+                                    {
                                         fits_parser_yyerror(
                                             lParse,
                                             cs!(c"Incompatible dimensions in '?:' condition"),
                                         );
                                         current_block = Block::YyErrLab;
                                     } else {
-                                        ((lParse.Nodes)[yyvs[yyvsp - 4].Node as usize]).ntype =
+                                        ((lParse.Nodes)[yyvs[yyvsp - 4].node() as usize]).ntype =
                                             fits_parser_yytokentype::BOOLEAN as c_int;
-                                        if (((lParse.Nodes)[yyval.Node as usize]).value).nelem
-                                            < ((lParse.Nodes)[yyvs[yyvsp - 4].Node as usize])
+                                        if (((lParse.Nodes)[yyval.node() as usize]).value).nelem
+                                            < ((lParse.Nodes)[yyvs[yyvsp - 4].node() as usize])
                                                 .value
                                                 .nelem
                                         {
-                                            Copy_Dims(lParse, yyval.Node, yyvs[yyvsp - 4].Node);
+                                            Copy_Dims(lParse, yyval.node(), yyvs[yyvsp - 4].node());
                                         }
                                         current_block = Block::ReduceDone;
                                     }
@@ -2407,26 +2418,26 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         }
                         52 => {
                             /* expr: bexpr '?' bexpr ':' expr  */
-                            if (lParse.Nodes[yyvs[yyvsp - 2].Node as usize]).ntype
-                                > (lParse.Nodes[yyvs[yyvsp].Node as usize]).ntype
+                            if (lParse.Nodes[yyvs[yyvsp - 2].node() as usize]).ntype
+                                > (lParse.Nodes[yyvs[yyvsp].node() as usize]).ntype
                             {
                                 yyvs[yyvsp].Node = New_Unary(
                                     lParse,
-                                    ((lParse.Nodes)[yyvs[yyvsp - 2].Node as usize]).ntype,
+                                    ((lParse.Nodes)[yyvs[yyvsp - 2].node() as usize]).ntype,
                                     0,
-                                    yyvs[yyvsp].Node,
+                                    yyvs[yyvsp].node(),
                                 );
-                            } else if ((lParse.Nodes)[yyvs[yyvsp - 2].Node as usize]).ntype
-                                < (lParse.Nodes[yyvs[yyvsp].Node as usize]).ntype
+                            } else if ((lParse.Nodes)[yyvs[yyvsp - 2].node() as usize]).ntype
+                                < (lParse.Nodes[yyvs[yyvsp].node() as usize]).ntype
                             {
                                 yyvs[yyvsp - 2].Node = New_Unary(
                                     lParse,
-                                    (lParse.Nodes[yyvs[yyvsp].Node as usize]).ntype,
+                                    (lParse.Nodes[yyvs[yyvsp].node() as usize]).ntype,
                                     0,
-                                    yyvs[yyvsp - 2].Node,
+                                    yyvs[yyvsp - 2].node(),
                                 );
                             }
-                            if Test_Dims(lParse, yyvs[yyvsp - 2].Node, yyvs[yyvsp].Node) == 0 {
+                            if Test_Dims(lParse, yyvs[yyvsp - 2].node(), yyvs[yyvsp].node()) == 0 {
                                 fits_parser_yyerror(
                                     lParse,
                                     cs!(c"Incompatible dimensions in '?:' arguments"),
@@ -2438,39 +2449,42 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     0,
                                     IFTHENELSE_FCT,
                                     3 as c_int,
-                                    yyvs[yyvsp - 2].Node,
-                                    yyvs[yyvsp].Node,
-                                    yyvs[yyvsp - 4].Node,
+                                    yyvs[yyvsp - 2].node(),
+                                    yyvs[yyvsp].node(),
+                                    yyvs[yyvsp - 4].node(),
                                     0,
                                     0,
                                     0,
                                     0,
                                 );
-                                if yyval.Node < 0 {
+                                if yyval.node() < 0 {
                                     current_block = Block::YyErrLab;
                                 } else {
-                                    if ((lParse.Nodes)[yyvs[yyvsp - 2].Node as usize]).value.nelem
-                                        < (lParse.Nodes[yyvs[yyvsp].Node as usize]).value.nelem
+                                    if ((lParse.Nodes)[yyvs[yyvsp - 2].node() as usize])
+                                        .value
+                                        .nelem
+                                        < (lParse.Nodes[yyvs[yyvsp].node() as usize]).value.nelem
                                     {
-                                        Copy_Dims(lParse, yyval.Node, yyvs[yyvsp].Node);
+                                        Copy_Dims(lParse, yyval.node(), yyvs[yyvsp].node());
                                     }
-                                    ((lParse.Nodes)[yyvs[yyvsp - 4].Node as usize]).ntype =
-                                        ((lParse.Nodes)[yyvs[yyvsp - 2].Node as usize]).ntype;
-                                    if Test_Dims(lParse, yyvs[yyvsp - 4].Node, yyval.Node) == 0 {
+                                    ((lParse.Nodes)[yyvs[yyvsp - 4].node() as usize]).ntype =
+                                        ((lParse.Nodes)[yyvs[yyvsp - 2].node() as usize]).ntype;
+                                    if Test_Dims(lParse, yyvs[yyvsp - 4].node(), yyval.node()) == 0
+                                    {
                                         fits_parser_yyerror(
                                             lParse,
                                             cs!(c"Incompatible dimensions in '?:' condition"),
                                         );
                                         current_block = Block::YyErrLab;
                                     } else {
-                                        ((lParse.Nodes)[yyvs[yyvsp - 4].Node as usize]).ntype =
+                                        ((lParse.Nodes)[yyvs[yyvsp - 4].node() as usize]).ntype =
                                             fits_parser_yytokentype::BOOLEAN as c_int;
-                                        if (((lParse.Nodes)[yyval.Node as usize]).value).nelem
-                                            < ((lParse.Nodes)[yyvs[yyvsp - 4].Node as usize])
+                                        if (((lParse.Nodes)[yyval.node() as usize]).value).nelem
+                                            < ((lParse.Nodes)[yyvs[yyvsp - 4].node() as usize])
                                                 .value
                                                 .nelem
                                         {
-                                            Copy_Dims(lParse, yyval.Node, yyvs[yyvsp - 4].Node);
+                                            Copy_Dims(lParse, yyval.node(), yyvs[yyvsp - 4].node());
                                         }
                                         current_block = Block::ReduceDone;
                                     }
@@ -2479,26 +2493,26 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         }
                         53 => {
                             /* expr: bexpr '?' expr ':' bexpr  */
-                            if (lParse.Nodes[yyvs[yyvsp - 2].Node as usize]).ntype
-                                > (lParse.Nodes[yyvs[yyvsp].Node as usize]).ntype
+                            if (lParse.Nodes[yyvs[yyvsp - 2].node() as usize]).ntype
+                                > (lParse.Nodes[yyvs[yyvsp].node() as usize]).ntype
                             {
                                 yyvs[yyvsp].Node = New_Unary(
                                     lParse,
-                                    ((lParse.Nodes)[yyvs[yyvsp - 2].Node as usize]).ntype,
+                                    ((lParse.Nodes)[yyvs[yyvsp - 2].node() as usize]).ntype,
                                     0,
-                                    yyvs[yyvsp].Node,
+                                    yyvs[yyvsp].node(),
                                 );
-                            } else if ((lParse.Nodes)[yyvs[yyvsp - 2].Node as usize]).ntype
-                                < (lParse.Nodes[yyvs[yyvsp].Node as usize]).ntype
+                            } else if ((lParse.Nodes)[yyvs[yyvsp - 2].node() as usize]).ntype
+                                < (lParse.Nodes[yyvs[yyvsp].node() as usize]).ntype
                             {
                                 yyvs[yyvsp - 2].Node = New_Unary(
                                     lParse,
-                                    (lParse.Nodes[yyvs[yyvsp].Node as usize]).ntype,
+                                    (lParse.Nodes[yyvs[yyvsp].node() as usize]).ntype,
                                     0,
-                                    yyvs[yyvsp - 2].Node,
+                                    yyvs[yyvsp - 2].node(),
                                 );
                             }
-                            if Test_Dims(lParse, yyvs[yyvsp - 2].Node, yyvs[yyvsp].Node) == 0 {
+                            if Test_Dims(lParse, yyvs[yyvsp - 2].node(), yyvs[yyvsp].node()) == 0 {
                                 fits_parser_yyerror(
                                     lParse,
                                     cs!(c"Incompatible dimensions in '?:' arguments"),
@@ -2510,39 +2524,42 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     0,
                                     IFTHENELSE_FCT,
                                     3 as c_int,
-                                    yyvs[yyvsp - 2].Node,
-                                    yyvs[yyvsp].Node,
-                                    yyvs[yyvsp - 4].Node,
+                                    yyvs[yyvsp - 2].node(),
+                                    yyvs[yyvsp].node(),
+                                    yyvs[yyvsp - 4].node(),
                                     0,
                                     0,
                                     0,
                                     0,
                                 );
-                                if yyval.Node < 0 {
+                                if yyval.node() < 0 {
                                     current_block = Block::YyErrLab;
                                 } else {
-                                    if ((lParse.Nodes)[yyvs[yyvsp - 2].Node as usize]).value.nelem
-                                        < (lParse.Nodes[yyvs[yyvsp].Node as usize]).value.nelem
+                                    if ((lParse.Nodes)[yyvs[yyvsp - 2].node() as usize])
+                                        .value
+                                        .nelem
+                                        < (lParse.Nodes[yyvs[yyvsp].node() as usize]).value.nelem
                                     {
-                                        Copy_Dims(lParse, yyval.Node, yyvs[yyvsp].Node);
+                                        Copy_Dims(lParse, yyval.node(), yyvs[yyvsp].node());
                                     }
-                                    ((lParse.Nodes)[yyvs[yyvsp - 4].Node as usize]).ntype =
-                                        ((lParse.Nodes)[yyvs[yyvsp - 2].Node as usize]).ntype;
-                                    if Test_Dims(lParse, yyvs[yyvsp - 4].Node, yyval.Node) == 0 {
+                                    ((lParse.Nodes)[yyvs[yyvsp - 4].node() as usize]).ntype =
+                                        ((lParse.Nodes)[yyvs[yyvsp - 2].node() as usize]).ntype;
+                                    if Test_Dims(lParse, yyvs[yyvsp - 4].node(), yyval.node()) == 0
+                                    {
                                         fits_parser_yyerror(
                                             lParse,
                                             cs!(c"Incompatible dimensions in '?:' condition"),
                                         );
                                         current_block = Block::YyErrLab;
                                     } else {
-                                        ((lParse.Nodes)[yyvs[yyvsp - 4].Node as usize]).ntype =
+                                        ((lParse.Nodes)[yyvs[yyvsp - 4].node() as usize]).ntype =
                                             fits_parser_yytokentype::BOOLEAN as c_int;
-                                        if (((lParse.Nodes)[yyval.Node as usize]).value).nelem
-                                            < ((lParse.Nodes)[yyvs[yyvsp - 4].Node as usize])
+                                        if (((lParse.Nodes)[yyval.node() as usize]).value).nelem
+                                            < ((lParse.Nodes)[yyvs[yyvsp - 4].node() as usize])
                                                 .value
                                                 .nelem
                                         {
-                                            Copy_Dims(lParse, yyval.Node, yyvs[yyvsp - 4].Node);
+                                            Copy_Dims(lParse, yyval.node(), yyvs[yyvsp - 4].node());
                                         }
                                         current_block = Block::ReduceDone;
                                     }
@@ -2551,7 +2568,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         }
                         54 => {
                             /* expr: FUNCTION ')'  */
-                            if astr_eq(&yyvs[yyvsp - 1].astr, c"RANDOM(") {
+                            if astr_eq(yyvs[yyvsp - 1].astr(), c"RANDOM(") {
                                 yyval.Node = New_Func(
                                     lParse,
                                     fits_parser_yytokentype::DOUBLE as c_int,
@@ -2566,7 +2583,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     0,
                                 );
                                 current_block = Block::ReduceJoin7;
-                            } else if astr_eq(&yyvs[yyvsp - 1].astr, c"RANDOMN(") {
+                            } else if astr_eq(yyvs[yyvsp - 1].astr(), c"RANDOMN(") {
                                 yyval.Node = New_Func(
                                     lParse,
                                     fits_parser_yytokentype::DOUBLE as c_int,
@@ -2588,7 +2605,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             match current_block {
                                 Block::YyErrLab => {}
                                 _ => {
-                                    if yyval.Node < 0 {
+                                    if yyval.node() < 0 {
                                         current_block = Block::YyErrLab;
                                     } else {
                                         current_block = Block::ReduceDone;
@@ -2598,13 +2615,13 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         }
                         55 => {
                             /* expr: FUNCTION bexpr ')'  */
-                            if astr_eq(&yyvs[yyvsp - 2].astr, c"SUM(") {
+                            if astr_eq(yyvs[yyvsp - 2].astr(), c"SUM(") {
                                 yyval.Node = New_Func(
                                     lParse,
                                     fits_parser_yytokentype::LONG as c_int,
                                     SUM_FCT,
                                     1,
-                                    yyvs[yyvsp - 1].Node,
+                                    yyvs[yyvsp - 1].node(),
                                     0,
                                     0,
                                     0,
@@ -2613,17 +2630,19 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     0,
                                 );
                                 current_block = Block::ReduceJoin5;
-                            } else if astr_eq(&yyvs[yyvsp - 2].astr, c"NELEM(") {
+                            } else if astr_eq(yyvs[yyvsp - 2].astr(), c"NELEM(") {
                                 yyval.Node = New_Const(
                                     lParse,
                                     fits_parser_yytokentype::LONG as c_int,
-                                    (&((lParse.Nodes)[yyvs[yyvsp - 1].Node as usize]).value.nelem
+                                    (&((lParse.Nodes)[yyvs[yyvsp - 1].node() as usize])
+                                        .value
+                                        .nelem
                                         as *const c_long)
                                         .cast::<c_void>(),
                                     ::core::mem::size_of::<c_long>() as c_ulong as c_long,
                                 );
                                 current_block = Block::ReduceJoin5;
-                            } else if astr_eq(&yyvs[yyvsp - 2].astr, c"ACCUM(") {
+                            } else if astr_eq(yyvs[yyvsp - 2].astr(), c"ACCUM(") {
                                 let mut zero: c_long = 0;
                                 let new_node = New_Const(
                                     lParse,
@@ -2635,7 +2654,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 yyval.Node = New_BinOp(
                                     lParse,
                                     fits_parser_yytokentype::LONG as c_int,
-                                    yyvs[yyvsp - 1].Node,
+                                    yyvs[yyvsp - 1].node(),
                                     fits_parser_yytokentype::ACCUM as c_int,
                                     new_node,
                                 );
@@ -2647,7 +2666,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             match current_block {
                                 Block::YyErrLab => {}
                                 _ => {
-                                    if yyval.Node < 0 {
+                                    if yyval.node() < 0 {
                                         current_block = Block::YyErrLab;
                                     } else {
                                         current_block = Block::ReduceDone;
@@ -2657,10 +2676,12 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         }
                         56 => {
                             /* expr: FUNCTION bexpr ',' expr ')'  */
-                            if astr_eq(&yyvs[yyvsp - 4].astr, c"AXISELEM(") {
-                                if ((lParse.Nodes)[yyvs[yyvsp - 1].Node as usize]).operation
+                            if astr_eq(yyvs[yyvsp - 4].astr(), c"AXISELEM(") {
+                                if ((lParse.Nodes)[yyvs[yyvsp - 1].node() as usize]).operation
                                     != CONST_OP
-                                    || ((lParse.Nodes)[yyvs[yyvsp - 1].Node as usize]).value.nelem
+                                    || ((lParse.Nodes)[yyvs[yyvsp - 1].node() as usize])
+                                        .value
+                                        .nelem
                                         != 1
                                 {
                                     fits_parser_yyerror(
@@ -2668,7 +2689,8 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         cs!(c"AXISELEM second argument must be a scalar constant"),
                                     );
                                     current_block = Block::YyErrLab;
-                                } else if ((lParse.Nodes)[yyvs[yyvsp - 3].Node as usize]).operation
+                                } else if ((lParse.Nodes)[yyvs[yyvsp - 3].node() as usize])
+                                    .operation
                                     == CONST_OP
                                 {
                                     let mut one: c_long = 1;
@@ -2680,14 +2702,14 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     );
                                     current_block = Block::ReduceJoin4;
                                 } else {
-                                    if ((lParse.Nodes)[yyvs[yyvsp - 1].Node as usize]).ntype
+                                    if ((lParse.Nodes)[yyvs[yyvsp - 1].node() as usize]).ntype
                                         != fits_parser_yytokentype::LONG as c_int
                                     {
                                         yyvs[yyvsp - 1].Node = New_Unary(
                                             lParse,
                                             fits_parser_yytokentype::LONG as c_int,
                                             0,
-                                            yyvs[yyvsp - 1].Node,
+                                            yyvs[yyvsp - 1].node(),
                                         );
                                     }
                                     yyval.Node = New_Func(
@@ -2695,26 +2717,28 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         0,
                                         AXISELEM_FCT,
                                         2,
-                                        yyvs[yyvsp - 3].Node,
-                                        yyvs[yyvsp - 1].Node,
+                                        yyvs[yyvsp - 3].node(),
+                                        yyvs[yyvsp - 1].node(),
                                         0,
                                         0,
                                         0,
                                         0,
                                         0,
                                     );
-                                    if yyval.Node < 0 {
+                                    if yyval.node() < 0 {
                                         current_block = Block::YyErrLab;
                                     } else {
-                                        ((lParse.Nodes)[yyval.Node as usize]).ntype =
+                                        ((lParse.Nodes)[yyval.node() as usize]).ntype =
                                             fits_parser_yytokentype::LONG as c_int;
                                         current_block = Block::ReduceJoin4;
                                     }
                                 }
-                            } else if astr_eq(&yyvs[yyvsp - 4].astr, c"NAXES(") {
-                                if ((lParse.Nodes)[yyvs[yyvsp - 1].Node as usize]).operation
+                            } else if astr_eq(yyvs[yyvsp - 4].astr(), c"NAXES(") {
+                                if ((lParse.Nodes)[yyvs[yyvsp - 1].node() as usize]).operation
                                     != CONST_OP
-                                    || ((lParse.Nodes)[yyvs[yyvsp - 1].Node as usize]).value.nelem
+                                    || ((lParse.Nodes)[yyvs[yyvsp - 1].node() as usize])
+                                        .value
+                                        .nelem
                                         != 1
                                 {
                                     fits_parser_yyerror(
@@ -2722,7 +2746,8 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         cs!(c"NAXES second argument must be a scalar constant"),
                                     );
                                     current_block = Block::YyErrLab;
-                                } else if ((lParse.Nodes)[yyvs[yyvsp - 3].Node as usize]).operation
+                                } else if ((lParse.Nodes)[yyvs[yyvsp - 3].node() as usize])
+                                    .operation
                                     == CONST_OP
                                 {
                                     let mut one_0: c_long = 1;
@@ -2736,26 +2761,27 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 } else {
                                     let mut iaxis: c_long = 0;
                                     let mut naxis: c_int = 0;
-                                    if ((lParse.Nodes)[yyvs[yyvsp - 1].Node as usize]).ntype
+                                    if ((lParse.Nodes)[yyvs[yyvsp - 1].node() as usize]).ntype
                                         != fits_parser_yytokentype::LONG as c_int
                                     {
                                         yyvs[yyvsp - 1].Node = New_Unary(
                                             lParse,
                                             fits_parser_yytokentype::LONG as c_int,
                                             0,
-                                            yyvs[yyvsp - 1].Node,
+                                            yyvs[yyvsp - 1].node(),
                                         );
                                     }
-                                    iaxis = ((lParse.Nodes)[yyvs[yyvsp - 1].Node as usize])
+                                    iaxis = ((lParse.Nodes)[yyvs[yyvsp - 1].node() as usize])
                                         .value
                                         .data
                                         .lng();
-                                    naxis =
-                                        ((lParse.Nodes)[yyvs[yyvsp - 3].Node as usize]).value.naxis;
+                                    naxis = ((lParse.Nodes)[yyvs[yyvsp - 3].node() as usize])
+                                        .value
+                                        .naxis;
                                     if iaxis == 0 {
                                         iaxis = c_long::from(naxis);
                                     } else if iaxis <= c_long::from(naxis) {
-                                        iaxis = ((lParse.Nodes)[yyvs[yyvsp - 3].Node as usize])
+                                        iaxis = ((lParse.Nodes)[yyvs[yyvsp - 3].node() as usize])
                                             .value
                                             .naxes
                                             [(iaxis - 1) as usize];
@@ -2768,16 +2794,19 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         (&mut iaxis as *mut c_long).cast::<c_void>(),
                                         ::core::mem::size_of::<c_long>() as c_ulong as c_long,
                                     );
-                                    if yyval.Node < 0 {
+                                    if yyval.node() < 0 {
                                         current_block = Block::YyErrLab;
                                     } else {
                                         current_block = Block::ReduceJoin4;
                                     }
                                 }
-                            } else if astr_eq(&yyvs[yyvsp - 4].astr, c"ARRAY(") {
-                                yyval.Node =
-                                    New_Array(lParse, yyvs[yyvsp - 3].Node, yyvs[yyvsp - 1].Node);
-                                if yyval.Node < 0 {
+                            } else if astr_eq(yyvs[yyvsp - 4].astr(), c"ARRAY(") {
+                                yyval.Node = New_Array(
+                                    lParse,
+                                    yyvs[yyvsp - 3].node(),
+                                    yyvs[yyvsp - 1].node(),
+                                );
+                                if yyval.node() < 0 {
                                     current_block = Block::YyErrLab;
                                 } else {
                                     current_block = Block::ReduceJoin4;
@@ -2792,7 +2821,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             match current_block {
                                 Block::YyErrLab => {}
                                 _ => {
-                                    if yyval.Node < 0 {
+                                    if yyval.node() < 0 {
                                         current_block = Block::YyErrLab;
                                     } else {
                                         current_block = Block::ReduceDone;
@@ -2802,23 +2831,25 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         }
                         57 => {
                             /* expr: FUNCTION sexpr ')'  */
-                            if astr_eq(&yyvs[yyvsp - 2].astr, c"NELEM(") {
+                            if astr_eq(yyvs[yyvsp - 2].astr(), c"NELEM(") {
                                 yyval.Node = New_Const(
                                     lParse,
                                     fits_parser_yytokentype::LONG as c_int,
-                                    (&((lParse.Nodes)[yyvs[yyvsp - 1].Node as usize]).value.nelem
+                                    (&((lParse.Nodes)[yyvs[yyvsp - 1].node() as usize])
+                                        .value
+                                        .nelem
                                         as *const c_long)
                                         .cast::<c_void>(),
                                     ::core::mem::size_of::<c_long>() as c_ulong as c_long,
                                 );
                                 current_block = Block::ReduceJoin8;
-                            } else if astr_eq(&yyvs[yyvsp - 2].astr, c"NVALID(") {
+                            } else if astr_eq(yyvs[yyvsp - 2].astr(), c"NVALID(") {
                                 yyval.Node = New_Func(
                                     lParse,
                                     fits_parser_yytokentype::LONG as c_int,
                                     NONNULL_FCT,
                                     1,
-                                    yyvs[yyvsp - 1].Node,
+                                    yyvs[yyvsp - 1].node(),
                                     0,
                                     0,
                                     0,
@@ -2834,7 +2865,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             match current_block {
                                 Block::YyErrLab => {}
                                 _ => {
-                                    if yyval.Node < 0 {
+                                    if yyval.node() < 0 {
                                         current_block = Block::YyErrLab;
                                     } else {
                                         current_block = Block::ReduceDone;
@@ -2844,33 +2875,37 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         }
                         58 => {
                             /* expr: FUNCTION bits ')'  */
-                            if astr_eq(&yyvs[yyvsp - 2].astr, c"NELEM(") {
+                            if astr_eq(yyvs[yyvsp - 2].astr(), c"NELEM(") {
                                 yyval.Node = New_Const(
                                     lParse,
                                     fits_parser_yytokentype::LONG as c_int,
-                                    (&((lParse.Nodes)[yyvs[yyvsp - 1].Node as usize]).value.nelem
+                                    (&((lParse.Nodes)[yyvs[yyvsp - 1].node() as usize])
+                                        .value
+                                        .nelem
                                         as *const c_long)
                                         .cast::<c_void>(),
                                     ::core::mem::size_of::<c_long>() as c_ulong as c_long,
                                 );
                                 current_block = Block::ReduceJoin3;
-                            } else if astr_eq(&yyvs[yyvsp - 2].astr, c"NVALID(") {
+                            } else if astr_eq(yyvs[yyvsp - 2].astr(), c"NVALID(") {
                                 yyval.Node = New_Const(
                                     lParse,
                                     fits_parser_yytokentype::LONG as c_int,
-                                    (&((lParse.Nodes)[yyvs[yyvsp - 1].Node as usize]).value.nelem
+                                    (&((lParse.Nodes)[yyvs[yyvsp - 1].node() as usize])
+                                        .value
+                                        .nelem
                                         as *const c_long)
                                         .cast::<c_void>(),
                                     ::core::mem::size_of::<c_long>() as c_ulong as c_long,
                                 );
                                 current_block = Block::ReduceJoin3;
-                            } else if astr_eq(&yyvs[yyvsp - 2].astr, c"SUM(") {
+                            } else if astr_eq(yyvs[yyvsp - 2].astr(), c"SUM(") {
                                 yyval.Node = New_Func(
                                     lParse,
                                     fits_parser_yytokentype::LONG as c_int,
                                     SUM_FCT,
                                     1,
-                                    yyvs[yyvsp - 1].Node,
+                                    yyvs[yyvsp - 1].node(),
                                     0,
                                     0,
                                     0,
@@ -2879,13 +2914,13 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     0,
                                 );
                                 current_block = Block::ReduceJoin3;
-                            } else if astr_eq(&yyvs[yyvsp - 2].astr, c"MIN(") {
+                            } else if astr_eq(yyvs[yyvsp - 2].astr(), c"MIN(") {
                                 yyval.Node = New_Func(
                                     lParse,
-                                    ((lParse.Nodes)[yyvs[yyvsp - 1].Node as usize]).ntype,
+                                    ((lParse.Nodes)[yyvs[yyvsp - 1].node() as usize]).ntype,
                                     MIN1_FCT,
                                     1,
-                                    yyvs[yyvsp - 1].Node,
+                                    yyvs[yyvsp - 1].node(),
                                     0,
                                     0,
                                     0,
@@ -2893,9 +2928,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     0,
                                     0,
                                 );
-                                (((lParse.Nodes)[yyval.Node as usize]).value).nelem = 1;
+                                (((lParse.Nodes)[yyval.node() as usize]).value).nelem = 1;
                                 current_block = Block::ReduceJoin3;
-                            } else if astr_eq(&yyvs[yyvsp - 2].astr, c"ACCUM(") {
+                            } else if astr_eq(yyvs[yyvsp - 2].astr(), c"ACCUM(") {
                                 let mut zero_0: c_long = 0;
                                 let new_node = New_Const(
                                     lParse,
@@ -2907,18 +2942,18 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 yyval.Node = New_BinOp(
                                     lParse,
                                     fits_parser_yytokentype::LONG as c_int,
-                                    yyvs[yyvsp - 1].Node,
+                                    yyvs[yyvsp - 1].node(),
                                     fits_parser_yytokentype::ACCUM as c_int,
                                     new_node,
                                 );
                                 current_block = Block::ReduceJoin3;
-                            } else if astr_eq(&yyvs[yyvsp - 2].astr, c"MAX(") {
+                            } else if astr_eq(yyvs[yyvsp - 2].astr(), c"MAX(") {
                                 yyval.Node = New_Func(
                                     lParse,
-                                    ((lParse.Nodes)[yyvs[yyvsp - 1].Node as usize]).ntype,
+                                    ((lParse.Nodes)[yyvs[yyvsp - 1].node() as usize]).ntype,
                                     MAX1_FCT,
                                     1,
-                                    yyvs[yyvsp - 1].Node,
+                                    yyvs[yyvsp - 1].node(),
                                     0,
                                     0,
                                     0,
@@ -2926,7 +2961,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     0,
                                     0,
                                 );
-                                (((lParse.Nodes)[yyval.Node as usize]).value).nelem = 1;
+                                (((lParse.Nodes)[yyval.node() as usize]).value).nelem = 1;
                                 current_block = Block::ReduceJoin3;
                             } else {
                                 fits_parser_yyerror(lParse, cs!(c"Function(bits) not supported"));
@@ -2935,7 +2970,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             match current_block {
                                 Block::YyErrLab => {}
                                 _ => {
-                                    if yyval.Node < 0 {
+                                    if yyval.node() < 0 {
                                         current_block = Block::YyErrLab;
                                     } else {
                                         current_block = Block::ReduceDone;
@@ -2945,13 +2980,13 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         }
                         59 => {
                             /* expr: FUNCTION expr ')'  */
-                            if astr_eq(&yyvs[yyvsp - 2].astr, c"SUM(") {
+                            if astr_eq(yyvs[yyvsp - 2].astr(), c"SUM(") {
                                 yyval.Node = New_Func(
                                     lParse,
-                                    ((lParse.Nodes)[yyvs[yyvsp - 1].Node as usize]).ntype,
+                                    ((lParse.Nodes)[yyvs[yyvsp - 1].node() as usize]).ntype,
                                     SUM_FCT,
                                     1,
-                                    yyvs[yyvsp - 1].Node,
+                                    yyvs[yyvsp - 1].node(),
                                     0,
                                     0,
                                     0,
@@ -2960,13 +2995,13 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     0,
                                 );
                                 current_block = Block::ReduceJoin1;
-                            } else if astr_eq(&yyvs[yyvsp - 2].astr, c"AVERAGE(") {
+                            } else if astr_eq(yyvs[yyvsp - 2].astr(), c"AVERAGE(") {
                                 yyval.Node = New_Func(
                                     lParse,
                                     fits_parser_yytokentype::DOUBLE as c_int,
                                     AVERAGE_FCT,
                                     1,
-                                    yyvs[yyvsp - 1].Node,
+                                    yyvs[yyvsp - 1].node(),
                                     0,
                                     0,
                                     0,
@@ -2975,13 +3010,13 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     0,
                                 );
                                 current_block = Block::ReduceJoin1;
-                            } else if astr_eq(&yyvs[yyvsp - 2].astr, c"STDDEV(") {
+                            } else if astr_eq(yyvs[yyvsp - 2].astr(), c"STDDEV(") {
                                 yyval.Node = New_Func(
                                     lParse,
                                     fits_parser_yytokentype::DOUBLE as c_int,
                                     STDDEV_FCT,
                                     1,
-                                    yyvs[yyvsp - 1].Node,
+                                    yyvs[yyvsp - 1].node(),
                                     0,
                                     0,
                                     0,
@@ -2990,13 +3025,13 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     0,
                                 );
                                 current_block = Block::ReduceJoin1;
-                            } else if astr_eq(&yyvs[yyvsp - 2].astr, c"MEDIAN(") {
+                            } else if astr_eq(yyvs[yyvsp - 2].astr(), c"MEDIAN(") {
                                 yyval.Node = New_Func(
                                     lParse,
-                                    ((lParse.Nodes)[yyvs[yyvsp - 1].Node as usize]).ntype,
+                                    ((lParse.Nodes)[yyvs[yyvsp - 1].node() as usize]).ntype,
                                     MEDIAN_FCT,
                                     1,
-                                    yyvs[yyvsp - 1].Node,
+                                    yyvs[yyvsp - 1].node(),
                                     0,
                                     0,
                                     0,
@@ -3005,23 +3040,25 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     0,
                                 );
                                 current_block = Block::ReduceJoin1;
-                            } else if astr_eq(&yyvs[yyvsp - 2].astr, c"NELEM(") {
+                            } else if astr_eq(yyvs[yyvsp - 2].astr(), c"NELEM(") {
                                 yyval.Node = New_Const(
                                     lParse,
                                     fits_parser_yytokentype::LONG as c_int,
-                                    (&((lParse.Nodes)[yyvs[yyvsp - 1].Node as usize]).value.nelem
+                                    (&((lParse.Nodes)[yyvs[yyvsp - 1].node() as usize])
+                                        .value
+                                        .nelem
                                         as *const c_long)
                                         .cast::<c_void>(),
                                     ::core::mem::size_of::<c_long>() as c_ulong as c_long,
                                 );
                                 current_block = Block::ReduceJoin1;
-                            } else if astr_eq(&yyvs[yyvsp - 2].astr, c"NVALID(") {
+                            } else if astr_eq(yyvs[yyvsp - 2].astr(), c"NVALID(") {
                                 yyval.Node = New_Func(
                                     lParse,
                                     fits_parser_yytokentype::LONG as c_int,
                                     NONNULL_FCT,
                                     1,
-                                    yyvs[yyvsp - 1].Node,
+                                    yyvs[yyvsp - 1].node(),
                                     0,
                                     0,
                                     0,
@@ -3030,8 +3067,8 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     0,
                                 );
                                 current_block = Block::ReduceJoin1;
-                            } else if astr_eq(&yyvs[yyvsp - 2].astr, c"ACCUM(")
-                                && ((lParse.Nodes)[yyvs[yyvsp - 1].Node as usize]).ntype
+                            } else if astr_eq(yyvs[yyvsp - 2].astr(), c"ACCUM(")
+                                && ((lParse.Nodes)[yyvs[yyvsp - 1].node() as usize]).ntype
                                     == fits_parser_yytokentype::LONG as c_int
                             {
                                 let mut zero_1: c_long = 0;
@@ -3048,13 +3085,13 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 yyval.Node = New_BinOp(
                                     lParse,
                                     fits_parser_yytokentype::LONG as c_int,
-                                    yyvs[yyvsp - 1].Node,
+                                    yyvs[yyvsp - 1].node(),
                                     fits_parser_yytokentype::ACCUM as c_int,
                                     new_node,
                                 );
                                 current_block = Block::ReduceJoin1;
-                            } else if astr_eq(&yyvs[yyvsp - 2].astr, c"ACCUM(")
-                                && ((lParse.Nodes)[yyvs[yyvsp - 1].Node as usize]).ntype
+                            } else if astr_eq(yyvs[yyvsp - 2].astr(), c"ACCUM(")
+                                && ((lParse.Nodes)[yyvs[yyvsp - 1].node() as usize]).ntype
                                     == fits_parser_yytokentype::DOUBLE as c_int
                             {
                                 let mut zero_2: c_double = 0.0;
@@ -3068,13 +3105,13 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 yyval.Node = New_BinOp(
                                     lParse,
                                     fits_parser_yytokentype::DOUBLE as c_int,
-                                    yyvs[yyvsp - 1].Node,
+                                    yyvs[yyvsp - 1].node(),
                                     fits_parser_yytokentype::ACCUM as c_int,
                                     new_node,
                                 );
                                 current_block = Block::ReduceJoin1;
-                            } else if astr_eq(&yyvs[yyvsp - 2].astr, c"SEQDIFF(")
-                                && ((lParse.Nodes)[yyvs[yyvsp - 1].Node as usize]).ntype
+                            } else if astr_eq(yyvs[yyvsp - 2].astr(), c"SEQDIFF(")
+                                && ((lParse.Nodes)[yyvs[yyvsp - 1].node() as usize]).ntype
                                     == fits_parser_yytokentype::LONG as c_int
                             {
                                 let mut zero_3: c_long = 0;
@@ -3088,13 +3125,13 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 yyval.Node = New_BinOp(
                                     lParse,
                                     fits_parser_yytokentype::LONG as c_int,
-                                    yyvs[yyvsp - 1].Node,
+                                    yyvs[yyvsp - 1].node(),
                                     fits_parser_yytokentype::DIFF as c_int,
                                     new_node,
                                 );
                                 current_block = Block::ReduceJoin1;
-                            } else if astr_eq(&yyvs[yyvsp - 2].astr, c"SEQDIFF(")
-                                && ((lParse.Nodes)[yyvs[yyvsp - 1].Node as usize]).ntype
+                            } else if astr_eq(yyvs[yyvsp - 2].astr(), c"SEQDIFF(")
+                                && ((lParse.Nodes)[yyvs[yyvsp - 1].node() as usize]).ntype
                                     == fits_parser_yytokentype::DOUBLE as c_int
                             {
                                 let mut zero_4: c_double = 0.0;
@@ -3108,18 +3145,18 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 yyval.Node = New_BinOp(
                                     lParse,
                                     fits_parser_yytokentype::DOUBLE as c_int,
-                                    yyvs[yyvsp - 1].Node,
+                                    yyvs[yyvsp - 1].node(),
                                     fits_parser_yytokentype::DIFF as c_int,
                                     new_node,
                                 );
                                 current_block = Block::ReduceJoin1;
-                            } else if astr_eq(&yyvs[yyvsp - 2].astr, c"ABS(") {
+                            } else if astr_eq(yyvs[yyvsp - 2].astr(), c"ABS(") {
                                 yyval.Node = New_Func(
                                     lParse,
                                     0,
                                     ABS_FCT,
                                     1,
-                                    yyvs[yyvsp - 1].Node,
+                                    yyvs[yyvsp - 1].node(),
                                     0,
                                     0,
                                     0,
@@ -3128,13 +3165,13 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     0,
                                 );
                                 current_block = Block::ReduceJoin1;
-                            } else if astr_eq(&yyvs[yyvsp - 2].astr, c"MIN(") {
+                            } else if astr_eq(yyvs[yyvsp - 2].astr(), c"MIN(") {
                                 yyval.Node = New_Func(
                                     lParse,
-                                    ((lParse.Nodes)[yyvs[yyvsp - 1].Node as usize]).ntype,
+                                    ((lParse.Nodes)[yyvs[yyvsp - 1].node() as usize]).ntype,
                                     MIN1_FCT,
                                     1,
-                                    yyvs[yyvsp - 1].Node,
+                                    yyvs[yyvsp - 1].node(),
                                     0,
                                     0,
                                     0,
@@ -3143,13 +3180,13 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     0,
                                 );
                                 current_block = Block::ReduceJoin1;
-                            } else if astr_eq(&yyvs[yyvsp - 2].astr, c"MAX(") {
+                            } else if astr_eq(yyvs[yyvsp - 2].astr(), c"MAX(") {
                                 yyval.Node = New_Func(
                                     lParse,
-                                    ((lParse.Nodes)[yyvs[yyvsp - 1].Node as usize]).ntype,
+                                    ((lParse.Nodes)[yyvs[yyvsp - 1].node() as usize]).ntype,
                                     MAX1_FCT,
                                     1,
-                                    yyvs[yyvsp - 1].Node,
+                                    yyvs[yyvsp - 1].node(),
                                     0,
                                     0,
                                     0,
@@ -3158,13 +3195,13 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     0,
                                 );
                                 current_block = Block::ReduceJoin1;
-                            } else if astr_eq(&yyvs[yyvsp - 2].astr, c"RANDOM(") {
+                            } else if astr_eq(yyvs[yyvsp - 2].astr(), c"RANDOM(") {
                                 yyval.Node = New_Func(
                                     lParse,
                                     0,
                                     RND_FCT,
                                     1,
-                                    yyvs[yyvsp - 1].Node,
+                                    yyvs[yyvsp - 1].node(),
                                     0,
                                     0,
                                     0,
@@ -3172,20 +3209,20 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     0,
                                     0,
                                 );
-                                if yyval.Node < 0 {
+                                if yyval.node() < 0 {
                                     current_block = Block::YyErrLab;
                                 } else {
-                                    ((lParse.Nodes)[yyval.Node as usize]).ntype =
+                                    ((lParse.Nodes)[yyval.node() as usize]).ntype =
                                         fits_parser_yytokentype::DOUBLE as c_int;
                                     current_block = Block::ReduceJoin1;
                                 }
-                            } else if astr_eq(&yyvs[yyvsp - 2].astr, c"RANDOMN(") {
+                            } else if astr_eq(yyvs[yyvsp - 2].astr(), c"RANDOMN(") {
                                 yyval.Node = New_Func(
                                     lParse,
                                     0,
                                     GASRND_FCT,
                                     1,
-                                    yyvs[yyvsp - 1].Node,
+                                    yyvs[yyvsp - 1].node(),
                                     0,
                                     0,
                                     0,
@@ -3193,15 +3230,15 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     0,
                                     0,
                                 );
-                                if yyval.Node < 0 {
+                                if yyval.node() < 0 {
                                     current_block = Block::YyErrLab;
                                 } else {
-                                    ((lParse.Nodes)[yyval.Node as usize]).ntype =
+                                    ((lParse.Nodes)[yyval.node() as usize]).ntype =
                                         fits_parser_yytokentype::DOUBLE as c_int;
                                     current_block = Block::ReduceJoin1;
                                 }
-                            } else if astr_eq(&yyvs[yyvsp - 2].astr, c"ELEMENTNUM(") {
-                                if ((lParse.Nodes)[yyvs[yyvsp - 1].Node as usize]).operation
+                            } else if astr_eq(yyvs[yyvsp - 2].astr(), c"ELEMENTNUM(") {
+                                if ((lParse.Nodes)[yyvs[yyvsp - 1].node() as usize]).operation
                                     == CONST_OP
                                 {
                                     let mut one_1: c_long = 1;
@@ -3218,7 +3255,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         0,
                                         ELEMNUM_FCT,
                                         1,
-                                        yyvs[yyvsp - 1].Node,
+                                        yyvs[yyvsp - 1].node(),
                                         0,
                                         0,
                                         0,
@@ -3226,16 +3263,16 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         0,
                                         0,
                                     );
-                                    if yyval.Node < 0 {
+                                    if yyval.node() < 0 {
                                         current_block = Block::YyErrLab;
                                     } else {
-                                        ((lParse.Nodes)[yyval.Node as usize]).ntype =
+                                        ((lParse.Nodes)[yyval.node() as usize]).ntype =
                                             fits_parser_yytokentype::LONG as c_int;
                                         current_block = Block::ReduceJoin1;
                                     }
                                 }
-                            } else if astr_eq(&yyvs[yyvsp - 2].astr, c"NAXIS(") {
-                                if ((lParse.Nodes)[yyvs[yyvsp - 1].Node as usize]).operation
+                            } else if astr_eq(yyvs[yyvsp - 2].astr(), c"NAXIS(") {
+                                if ((lParse.Nodes)[yyvs[yyvsp - 1].node() as usize]).operation
                                     == CONST_OP
                                 {
                                     let mut one_2: c_long = 1;
@@ -3248,7 +3285,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     current_block = Block::ReduceJoin1;
                                 } else {
                                     let mut naxis_0: c_long = c_long::from(
-                                        ((lParse.Nodes)[yyvs[yyvsp - 1].Node as usize]).value.naxis,
+                                        ((lParse.Nodes)[yyvs[yyvsp - 1].node() as usize])
+                                            .value
+                                            .naxis,
                                     );
                                     yyval.Node = New_Const(
                                         lParse,
@@ -3256,30 +3295,30 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         (&mut naxis_0 as *mut c_long).cast::<c_void>(),
                                         ::core::mem::size_of::<c_long>() as c_ulong as c_long,
                                     );
-                                    if yyval.Node < 0 {
+                                    if yyval.node() < 0 {
                                         current_block = Block::YyErrLab;
                                     } else {
                                         current_block = Block::ReduceJoin1;
                                     }
                                 }
                             } else {
-                                if ((lParse.Nodes)[yyvs[yyvsp - 1].Node as usize]).ntype
+                                if ((lParse.Nodes)[yyvs[yyvsp - 1].node() as usize]).ntype
                                     != fits_parser_yytokentype::DOUBLE as c_int
                                 {
                                     yyvs[yyvsp - 1].Node = New_Unary(
                                         lParse,
                                         fits_parser_yytokentype::DOUBLE as c_int,
                                         0,
-                                        yyvs[yyvsp - 1].Node,
+                                        yyvs[yyvsp - 1].node(),
                                     );
                                 }
-                                if astr_eq(&yyvs[yyvsp - 2].astr, c"SIN(") {
+                                if astr_eq(yyvs[yyvsp - 2].astr(), c"SIN(") {
                                     yyval.Node = New_Func(
                                         lParse,
                                         0,
                                         SIN_FCT,
                                         1,
-                                        yyvs[yyvsp - 1].Node,
+                                        yyvs[yyvsp - 1].node(),
                                         0,
                                         0,
                                         0,
@@ -3288,13 +3327,13 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         0,
                                     );
                                     current_block = Block::ReduceJoin1;
-                                } else if astr_eq(&yyvs[yyvsp - 2].astr, c"COS(") {
+                                } else if astr_eq(yyvs[yyvsp - 2].astr(), c"COS(") {
                                     yyval.Node = New_Func(
                                         lParse,
                                         0,
                                         COS_FCT,
                                         1,
-                                        yyvs[yyvsp - 1].Node,
+                                        yyvs[yyvsp - 1].node(),
                                         0,
                                         0,
                                         0,
@@ -3303,13 +3342,13 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         0,
                                     );
                                     current_block = Block::ReduceJoin1;
-                                } else if astr_eq(&yyvs[yyvsp - 2].astr, c"TAN(") {
+                                } else if astr_eq(yyvs[yyvsp - 2].astr(), c"TAN(") {
                                     yyval.Node = New_Func(
                                         lParse,
                                         0,
                                         TAN_FCT,
                                         1,
-                                        yyvs[yyvsp - 1].Node,
+                                        yyvs[yyvsp - 1].node(),
                                         0,
                                         0,
                                         0,
@@ -3318,15 +3357,15 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         0,
                                     );
                                     current_block = Block::ReduceJoin1;
-                                } else if astr_eq(&yyvs[yyvsp - 2].astr, c"ARCSIN(")
-                                    || astr_eq(&yyvs[yyvsp - 2].astr, c"ASIN(")
+                                } else if astr_eq(yyvs[yyvsp - 2].astr(), c"ARCSIN(")
+                                    || astr_eq(yyvs[yyvsp - 2].astr(), c"ASIN(")
                                 {
                                     yyval.Node = New_Func(
                                         lParse,
                                         0,
                                         ASIN_FCT,
                                         1,
-                                        yyvs[yyvsp - 1].Node,
+                                        yyvs[yyvsp - 1].node(),
                                         0,
                                         0,
                                         0,
@@ -3335,15 +3374,15 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         0,
                                     );
                                     current_block = Block::ReduceJoin1;
-                                } else if astr_eq(&yyvs[yyvsp - 2].astr, c"ARCCOS(")
-                                    || astr_eq(&yyvs[yyvsp - 2].astr, c"ACOS(")
+                                } else if astr_eq(yyvs[yyvsp - 2].astr(), c"ARCCOS(")
+                                    || astr_eq(yyvs[yyvsp - 2].astr(), c"ACOS(")
                                 {
                                     yyval.Node = New_Func(
                                         lParse,
                                         0,
                                         ACOS_FCT,
                                         1,
-                                        yyvs[yyvsp - 1].Node,
+                                        yyvs[yyvsp - 1].node(),
                                         0,
                                         0,
                                         0,
@@ -3352,15 +3391,15 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         0,
                                     );
                                     current_block = Block::ReduceJoin1;
-                                } else if astr_eq(&yyvs[yyvsp - 2].astr, c"ARCTAN(")
-                                    || astr_eq(&yyvs[yyvsp - 2].astr, c"ATAN(")
+                                } else if astr_eq(yyvs[yyvsp - 2].astr(), c"ARCTAN(")
+                                    || astr_eq(yyvs[yyvsp - 2].astr(), c"ATAN(")
                                 {
                                     yyval.Node = New_Func(
                                         lParse,
                                         0,
                                         ATAN_FCT,
                                         1,
-                                        yyvs[yyvsp - 1].Node,
+                                        yyvs[yyvsp - 1].node(),
                                         0,
                                         0,
                                         0,
@@ -3369,13 +3408,13 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         0,
                                     );
                                     current_block = Block::ReduceJoin1;
-                                } else if astr_eq(&yyvs[yyvsp - 2].astr, c"SINH(") {
+                                } else if astr_eq(yyvs[yyvsp - 2].astr(), c"SINH(") {
                                     yyval.Node = New_Func(
                                         lParse,
                                         0,
                                         SINH_FCT,
                                         1,
-                                        yyvs[yyvsp - 1].Node,
+                                        yyvs[yyvsp - 1].node(),
                                         0,
                                         0,
                                         0,
@@ -3384,13 +3423,13 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         0,
                                     );
                                     current_block = Block::ReduceJoin1;
-                                } else if astr_eq(&yyvs[yyvsp - 2].astr, c"COSH(") {
+                                } else if astr_eq(yyvs[yyvsp - 2].astr(), c"COSH(") {
                                     yyval.Node = New_Func(
                                         lParse,
                                         0,
                                         COSH_FCT,
                                         1,
-                                        yyvs[yyvsp - 1].Node,
+                                        yyvs[yyvsp - 1].node(),
                                         0,
                                         0,
                                         0,
@@ -3399,13 +3438,13 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         0,
                                     );
                                     current_block = Block::ReduceJoin1;
-                                } else if astr_eq(&yyvs[yyvsp - 2].astr, c"TANH(") {
+                                } else if astr_eq(yyvs[yyvsp - 2].astr(), c"TANH(") {
                                     yyval.Node = New_Func(
                                         lParse,
                                         0,
                                         TANH_FCT,
                                         1,
-                                        yyvs[yyvsp - 1].Node,
+                                        yyvs[yyvsp - 1].node(),
                                         0,
                                         0,
                                         0,
@@ -3414,13 +3453,13 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         0,
                                     );
                                     current_block = Block::ReduceJoin1;
-                                } else if astr_eq(&yyvs[yyvsp - 2].astr, c"EXP(") {
+                                } else if astr_eq(yyvs[yyvsp - 2].astr(), c"EXP(") {
                                     yyval.Node = New_Func(
                                         lParse,
                                         0,
                                         EXP_FCT,
                                         1,
-                                        yyvs[yyvsp - 1].Node,
+                                        yyvs[yyvsp - 1].node(),
                                         0,
                                         0,
                                         0,
@@ -3429,13 +3468,13 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         0,
                                     );
                                     current_block = Block::ReduceJoin1;
-                                } else if astr_eq(&yyvs[yyvsp - 2].astr, c"LOG(") {
+                                } else if astr_eq(yyvs[yyvsp - 2].astr(), c"LOG(") {
                                     yyval.Node = New_Func(
                                         lParse,
                                         0,
                                         LOG_FCT,
                                         1,
-                                        yyvs[yyvsp - 1].Node,
+                                        yyvs[yyvsp - 1].node(),
                                         0,
                                         0,
                                         0,
@@ -3444,13 +3483,13 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         0,
                                     );
                                     current_block = Block::ReduceJoin1;
-                                } else if astr_eq(&yyvs[yyvsp - 2].astr, c"LOG10(") {
+                                } else if astr_eq(yyvs[yyvsp - 2].astr(), c"LOG10(") {
                                     yyval.Node = New_Func(
                                         lParse,
                                         0,
                                         LOG10_FCT,
                                         1,
-                                        yyvs[yyvsp - 1].Node,
+                                        yyvs[yyvsp - 1].node(),
                                         0,
                                         0,
                                         0,
@@ -3459,13 +3498,13 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         0,
                                     );
                                     current_block = Block::ReduceJoin1;
-                                } else if astr_eq(&yyvs[yyvsp - 2].astr, c"SQRT(") {
+                                } else if astr_eq(yyvs[yyvsp - 2].astr(), c"SQRT(") {
                                     yyval.Node = New_Func(
                                         lParse,
                                         0,
                                         SQRT_FCT,
                                         1,
-                                        yyvs[yyvsp - 1].Node,
+                                        yyvs[yyvsp - 1].node(),
                                         0,
                                         0,
                                         0,
@@ -3474,13 +3513,13 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         0,
                                     );
                                     current_block = Block::ReduceJoin1;
-                                } else if astr_eq(&yyvs[yyvsp - 2].astr, c"ROUND(") {
+                                } else if astr_eq(yyvs[yyvsp - 2].astr(), c"ROUND(") {
                                     yyval.Node = New_Func(
                                         lParse,
                                         0,
                                         ROUND_FCT,
                                         1,
-                                        yyvs[yyvsp - 1].Node,
+                                        yyvs[yyvsp - 1].node(),
                                         0,
                                         0,
                                         0,
@@ -3489,13 +3528,13 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         0,
                                     );
                                     current_block = Block::ReduceJoin1;
-                                } else if astr_eq(&yyvs[yyvsp - 2].astr, c"FLOOR(") {
+                                } else if astr_eq(yyvs[yyvsp - 2].astr(), c"FLOOR(") {
                                     yyval.Node = New_Func(
                                         lParse,
                                         0,
                                         FLOOR_FCT,
                                         1,
-                                        yyvs[yyvsp - 1].Node,
+                                        yyvs[yyvsp - 1].node(),
                                         0,
                                         0,
                                         0,
@@ -3504,13 +3543,13 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         0,
                                     );
                                     current_block = Block::ReduceJoin1;
-                                } else if astr_eq(&yyvs[yyvsp - 2].astr, c"CEIL(") {
+                                } else if astr_eq(yyvs[yyvsp - 2].astr(), c"CEIL(") {
                                     yyval.Node = New_Func(
                                         lParse,
                                         0,
                                         CEIL_FCT,
                                         1,
-                                        yyvs[yyvsp - 1].Node,
+                                        yyvs[yyvsp - 1].node(),
                                         0,
                                         0,
                                         0,
@@ -3519,13 +3558,13 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         0,
                                     );
                                     current_block = Block::ReduceJoin1;
-                                } else if astr_eq(&yyvs[yyvsp - 2].astr, c"RANDOMP(") {
+                                } else if astr_eq(yyvs[yyvsp - 2].astr(), c"RANDOMP(") {
                                     yyval.Node = New_Func(
                                         lParse,
                                         0,
                                         POIRND_FCT,
                                         1,
-                                        yyvs[yyvsp - 1].Node,
+                                        yyvs[yyvsp - 1].node(),
                                         0,
                                         0,
                                         0,
@@ -3533,7 +3572,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         0,
                                         0,
                                     );
-                                    ((lParse.Nodes)[yyval.Node as usize]).ntype =
+                                    ((lParse.Nodes)[yyval.node() as usize]).ntype =
                                         fits_parser_yytokentype::LONG as c_int;
                                     current_block = Block::ReduceJoin1;
                                 } else {
@@ -3547,7 +3586,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             match current_block {
                                 Block::YyErrLab => {}
                                 _ => {
-                                    if yyval.Node < 0 {
+                                    if yyval.node() < 0 {
                                         current_block = Block::YyErrLab;
                                     } else {
                                         current_block = Block::ReduceDone;
@@ -3557,21 +3596,21 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         }
                         60 => {
                             /* expr: IFUNCTION sexpr ',' sexpr ')'  */
-                            if astr_eq(&yyvs[yyvsp - 4].astr, c"STRSTR(") {
+                            if astr_eq(yyvs[yyvsp - 4].astr(), c"STRSTR(") {
                                 yyval.Node = New_Func(
                                     lParse,
                                     fits_parser_yytokentype::LONG as c_int,
                                     STRPOS_FCT,
                                     2,
-                                    yyvs[yyvsp - 3].Node,
-                                    yyvs[yyvsp - 1].Node,
+                                    yyvs[yyvsp - 3].node(),
+                                    yyvs[yyvsp - 1].node(),
                                     0,
                                     0,
                                     0,
                                     0,
                                     0,
                                 );
-                                if yyval.Node < 0 {
+                                if yyval.node() < 0 {
                                     current_block = Block::YyErrLab;
                                 } else {
                                     current_block = Block::ReduceJoin6;
@@ -3588,29 +3627,37 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         }
                         61 => {
                             /* expr: FUNCTION expr ',' expr ')'  */
-                            if astr_eq(&yyvs[yyvsp - 4].astr, c"DEFNULL(") {
-                                if ((lParse.Nodes)[yyvs[yyvsp - 3].Node as usize]).value.nelem
-                                    >= ((lParse.Nodes)[yyvs[yyvsp - 1].Node as usize]).value.nelem
-                                    && Test_Dims(lParse, yyvs[yyvsp - 3].Node, yyvs[yyvsp - 1].Node)
-                                        != 0
+                            if astr_eq(yyvs[yyvsp - 4].astr(), c"DEFNULL(") {
+                                if ((lParse.Nodes)[yyvs[yyvsp - 3].node() as usize])
+                                    .value
+                                    .nelem
+                                    >= ((lParse.Nodes)[yyvs[yyvsp - 1].node() as usize])
+                                        .value
+                                        .nelem
+                                    && Test_Dims(
+                                        lParse,
+                                        yyvs[yyvsp - 3].node(),
+                                        yyvs[yyvsp - 1].node(),
+                                    ) != 0
                                 {
-                                    if ((lParse.Nodes)[yyvs[yyvsp - 3].Node as usize]).ntype
-                                        > ((lParse.Nodes)[yyvs[yyvsp - 1].Node as usize]).ntype
+                                    if ((lParse.Nodes)[yyvs[yyvsp - 3].node() as usize]).ntype
+                                        > ((lParse.Nodes)[yyvs[yyvsp - 1].node() as usize]).ntype
                                     {
                                         yyvs[yyvsp - 1].Node = New_Unary(
                                             lParse,
-                                            ((lParse.Nodes)[yyvs[yyvsp - 3].Node as usize]).ntype,
+                                            ((lParse.Nodes)[yyvs[yyvsp - 3].node() as usize]).ntype,
                                             0,
-                                            yyvs[yyvsp - 1].Node,
+                                            yyvs[yyvsp - 1].node(),
                                         );
-                                    } else if ((lParse.Nodes)[yyvs[yyvsp - 3].Node as usize]).ntype
-                                        < ((lParse.Nodes)[yyvs[yyvsp - 1].Node as usize]).ntype
+                                    } else if ((lParse.Nodes)[yyvs[yyvsp - 3].node() as usize])
+                                        .ntype
+                                        < ((lParse.Nodes)[yyvs[yyvsp - 1].node() as usize]).ntype
                                     {
                                         yyvs[yyvsp - 3].Node = New_Unary(
                                             lParse,
-                                            ((lParse.Nodes)[yyvs[yyvsp - 1].Node as usize]).ntype,
+                                            ((lParse.Nodes)[yyvs[yyvsp - 1].node() as usize]).ntype,
                                             0,
-                                            yyvs[yyvsp - 3].Node,
+                                            yyvs[yyvsp - 3].node(),
                                         );
                                     }
                                     yyval.Node = New_Func(
@@ -3618,15 +3665,15 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         0,
                                         DEFNULL_FCT,
                                         2,
-                                        yyvs[yyvsp - 3].Node,
-                                        yyvs[yyvsp - 1].Node,
+                                        yyvs[yyvsp - 3].node(),
+                                        yyvs[yyvsp - 1].node(),
                                         0,
                                         0,
                                         0,
                                         0,
                                         0,
                                     );
-                                    if yyval.Node < 0 {
+                                    if yyval.node() < 0 {
                                         current_block = Block::YyErrLab;
                                     } else {
                                         current_block = Block::ReduceJoin2;
@@ -3638,28 +3685,28 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     );
                                     current_block = Block::YyErrLab;
                                 }
-                            } else if astr_eq(&yyvs[yyvsp - 4].astr, c"ARCTAN2(") {
-                                if ((lParse.Nodes)[yyvs[yyvsp - 3].Node as usize]).ntype
+                            } else if astr_eq(yyvs[yyvsp - 4].astr(), c"ARCTAN2(") {
+                                if ((lParse.Nodes)[yyvs[yyvsp - 3].node() as usize]).ntype
                                     != fits_parser_yytokentype::DOUBLE as c_int
                                 {
                                     yyvs[yyvsp - 3].Node = New_Unary(
                                         lParse,
                                         fits_parser_yytokentype::DOUBLE as c_int,
                                         0,
-                                        yyvs[yyvsp - 3].Node,
+                                        yyvs[yyvsp - 3].node(),
                                     );
                                 }
-                                if ((lParse.Nodes)[yyvs[yyvsp - 1].Node as usize]).ntype
+                                if ((lParse.Nodes)[yyvs[yyvsp - 1].node() as usize]).ntype
                                     != fits_parser_yytokentype::DOUBLE as c_int
                                 {
                                     yyvs[yyvsp - 1].Node = New_Unary(
                                         lParse,
                                         fits_parser_yytokentype::DOUBLE as c_int,
                                         0,
-                                        yyvs[yyvsp - 1].Node,
+                                        yyvs[yyvsp - 1].node(),
                                     );
                                 }
-                                if Test_Dims(lParse, yyvs[yyvsp - 3].Node, yyvs[yyvsp - 1].Node)
+                                if Test_Dims(lParse, yyvs[yyvsp - 3].node(), yyvs[yyvsp - 1].node())
                                     != 0
                                 {
                                     yyval.Node = New_Func(
@@ -3667,25 +3714,25 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         0,
                                         ATAN2_FCT,
                                         2,
-                                        yyvs[yyvsp - 3].Node,
-                                        yyvs[yyvsp - 1].Node,
+                                        yyvs[yyvsp - 3].node(),
+                                        yyvs[yyvsp - 1].node(),
                                         0,
                                         0,
                                         0,
                                         0,
                                         0,
                                     );
-                                    if yyval.Node < 0 {
+                                    if yyval.node() < 0 {
                                         current_block = Block::YyErrLab;
                                     } else {
-                                        if ((lParse.Nodes)[yyvs[yyvsp - 3].Node as usize])
+                                        if ((lParse.Nodes)[yyvs[yyvsp - 3].node() as usize])
                                             .value
                                             .nelem
-                                            < ((lParse.Nodes)[yyvs[yyvsp - 1].Node as usize])
+                                            < ((lParse.Nodes)[yyvs[yyvsp - 1].node() as usize])
                                                 .value
                                                 .nelem
                                         {
-                                            Copy_Dims(lParse, yyval.Node, yyvs[yyvsp - 1].Node);
+                                            Copy_Dims(lParse, yyval.node(), yyvs[yyvsp - 1].node());
                                         }
                                         current_block = Block::ReduceJoin2;
                                     }
@@ -3696,27 +3743,27 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     );
                                     current_block = Block::YyErrLab;
                                 }
-                            } else if astr_eq(&yyvs[yyvsp - 4].astr, c"MIN(") {
-                                if ((lParse.Nodes)[yyvs[yyvsp - 3].Node as usize]).ntype
-                                    > ((lParse.Nodes)[yyvs[yyvsp - 1].Node as usize]).ntype
+                            } else if astr_eq(yyvs[yyvsp - 4].astr(), c"MIN(") {
+                                if ((lParse.Nodes)[yyvs[yyvsp - 3].node() as usize]).ntype
+                                    > ((lParse.Nodes)[yyvs[yyvsp - 1].node() as usize]).ntype
                                 {
                                     yyvs[yyvsp - 1].Node = New_Unary(
                                         lParse,
-                                        ((lParse.Nodes)[yyvs[yyvsp - 3].Node as usize]).ntype,
+                                        ((lParse.Nodes)[yyvs[yyvsp - 3].node() as usize]).ntype,
                                         0,
-                                        yyvs[yyvsp - 1].Node,
+                                        yyvs[yyvsp - 1].node(),
                                     );
-                                } else if ((lParse.Nodes)[yyvs[yyvsp - 3].Node as usize]).ntype
-                                    < ((lParse.Nodes)[yyvs[yyvsp - 1].Node as usize]).ntype
+                                } else if ((lParse.Nodes)[yyvs[yyvsp - 3].node() as usize]).ntype
+                                    < ((lParse.Nodes)[yyvs[yyvsp - 1].node() as usize]).ntype
                                 {
                                     yyvs[yyvsp - 3].Node = New_Unary(
                                         lParse,
-                                        ((lParse.Nodes)[yyvs[yyvsp - 1].Node as usize]).ntype,
+                                        ((lParse.Nodes)[yyvs[yyvsp - 1].node() as usize]).ntype,
                                         0,
-                                        yyvs[yyvsp - 3].Node,
+                                        yyvs[yyvsp - 3].node(),
                                     );
                                 }
-                                if Test_Dims(lParse, yyvs[yyvsp - 3].Node, yyvs[yyvsp - 1].Node)
+                                if Test_Dims(lParse, yyvs[yyvsp - 3].node(), yyvs[yyvsp - 1].node())
                                     != 0
                                 {
                                     yyval.Node = New_Func(
@@ -3724,25 +3771,25 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         0,
                                         MIN2_FCT,
                                         2,
-                                        yyvs[yyvsp - 3].Node,
-                                        yyvs[yyvsp - 1].Node,
+                                        yyvs[yyvsp - 3].node(),
+                                        yyvs[yyvsp - 1].node(),
                                         0,
                                         0,
                                         0,
                                         0,
                                         0,
                                     );
-                                    if yyval.Node < 0 {
+                                    if yyval.node() < 0 {
                                         current_block = Block::YyErrLab;
                                     } else {
-                                        if ((lParse.Nodes)[yyvs[yyvsp - 3].Node as usize])
+                                        if ((lParse.Nodes)[yyvs[yyvsp - 3].node() as usize])
                                             .value
                                             .nelem
-                                            < ((lParse.Nodes)[yyvs[yyvsp - 1].Node as usize])
+                                            < ((lParse.Nodes)[yyvs[yyvsp - 1].node() as usize])
                                                 .value
                                                 .nelem
                                         {
-                                            Copy_Dims(lParse, yyval.Node, yyvs[yyvsp - 1].Node);
+                                            Copy_Dims(lParse, yyval.node(), yyvs[yyvsp - 1].node());
                                         }
                                         current_block = Block::ReduceJoin2;
                                     }
@@ -3753,27 +3800,27 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     );
                                     current_block = Block::YyErrLab;
                                 }
-                            } else if astr_eq(&yyvs[yyvsp - 4].astr, c"MAX(") {
-                                if ((lParse.Nodes)[yyvs[yyvsp - 3].Node as usize]).ntype
-                                    > ((lParse.Nodes)[yyvs[yyvsp - 1].Node as usize]).ntype
+                            } else if astr_eq(yyvs[yyvsp - 4].astr(), c"MAX(") {
+                                if ((lParse.Nodes)[yyvs[yyvsp - 3].node() as usize]).ntype
+                                    > ((lParse.Nodes)[yyvs[yyvsp - 1].node() as usize]).ntype
                                 {
                                     yyvs[yyvsp - 1].Node = New_Unary(
                                         lParse,
-                                        ((lParse.Nodes)[yyvs[yyvsp - 3].Node as usize]).ntype,
+                                        ((lParse.Nodes)[yyvs[yyvsp - 3].node() as usize]).ntype,
                                         0,
-                                        yyvs[yyvsp - 1].Node,
+                                        yyvs[yyvsp - 1].node(),
                                     );
-                                } else if ((lParse.Nodes)[yyvs[yyvsp - 3].Node as usize]).ntype
-                                    < ((lParse.Nodes)[yyvs[yyvsp - 1].Node as usize]).ntype
+                                } else if ((lParse.Nodes)[yyvs[yyvsp - 3].node() as usize]).ntype
+                                    < ((lParse.Nodes)[yyvs[yyvsp - 1].node() as usize]).ntype
                                 {
                                     yyvs[yyvsp - 3].Node = New_Unary(
                                         lParse,
-                                        ((lParse.Nodes)[yyvs[yyvsp - 1].Node as usize]).ntype,
+                                        ((lParse.Nodes)[yyvs[yyvsp - 1].node() as usize]).ntype,
                                         0,
-                                        yyvs[yyvsp - 3].Node,
+                                        yyvs[yyvsp - 3].node(),
                                     );
                                 }
-                                if Test_Dims(lParse, yyvs[yyvsp - 3].Node, yyvs[yyvsp - 1].Node)
+                                if Test_Dims(lParse, yyvs[yyvsp - 3].node(), yyvs[yyvsp - 1].node())
                                     != 0
                                 {
                                     yyval.Node = New_Func(
@@ -3781,25 +3828,25 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         0,
                                         MAX2_FCT,
                                         2,
-                                        yyvs[yyvsp - 3].Node,
-                                        yyvs[yyvsp - 1].Node,
+                                        yyvs[yyvsp - 3].node(),
+                                        yyvs[yyvsp - 1].node(),
                                         0,
                                         0,
                                         0,
                                         0,
                                         0,
                                     );
-                                    if yyval.Node < 0 {
+                                    if yyval.node() < 0 {
                                         current_block = Block::YyErrLab;
                                     } else {
-                                        if ((lParse.Nodes)[yyvs[yyvsp - 3].Node as usize])
+                                        if ((lParse.Nodes)[yyvs[yyvsp - 3].node() as usize])
                                             .value
                                             .nelem
-                                            < ((lParse.Nodes)[yyvs[yyvsp - 1].Node as usize])
+                                            < ((lParse.Nodes)[yyvs[yyvsp - 1].node() as usize])
                                                 .value
                                                 .nelem
                                         {
-                                            Copy_Dims(lParse, yyval.Node, yyvs[yyvsp - 1].Node);
+                                            Copy_Dims(lParse, yyval.node(), yyvs[yyvsp - 1].node());
                                         }
                                         current_block = Block::ReduceJoin2;
                                     }
@@ -3810,10 +3857,12 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     );
                                     current_block = Block::YyErrLab;
                                 }
-                            } else if astr_eq(&yyvs[yyvsp - 4].astr, c"SETNULL(") {
-                                if ((lParse.Nodes)[yyvs[yyvsp - 3].Node as usize]).operation
+                            } else if astr_eq(yyvs[yyvsp - 4].astr(), c"SETNULL(") {
+                                if ((lParse.Nodes)[yyvs[yyvsp - 3].node() as usize]).operation
                                     != CONST_OP
-                                    || ((lParse.Nodes)[yyvs[yyvsp - 3].Node as usize]).value.nelem
+                                    || ((lParse.Nodes)[yyvs[yyvsp - 3].node() as usize])
+                                        .value
+                                        .nelem
                                         != 1
                                 {
                                     fits_parser_yyerror(
@@ -3822,14 +3871,14 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     );
                                     current_block = Block::YyErrLab;
                                 } else {
-                                    if ((lParse.Nodes)[yyvs[yyvsp - 3].Node as usize]).ntype
-                                        != ((lParse.Nodes)[yyvs[yyvsp - 1].Node as usize]).ntype
+                                    if ((lParse.Nodes)[yyvs[yyvsp - 3].node() as usize]).ntype
+                                        != ((lParse.Nodes)[yyvs[yyvsp - 1].node() as usize]).ntype
                                     {
                                         yyvs[yyvsp - 3].Node = New_Unary(
                                             lParse,
-                                            ((lParse.Nodes)[yyvs[yyvsp - 1].Node as usize]).ntype,
+                                            ((lParse.Nodes)[yyvs[yyvsp - 1].node() as usize]).ntype,
                                             0,
-                                            yyvs[yyvsp - 3].Node,
+                                            yyvs[yyvsp - 3].node(),
                                         );
                                     }
                                     yyval.Node = New_Func(
@@ -3837,8 +3886,8 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         0,
                                         SETNULL_FCT,
                                         2,
-                                        yyvs[yyvsp - 1].Node,
-                                        yyvs[yyvsp - 3].Node,
+                                        yyvs[yyvsp - 1].node(),
+                                        yyvs[yyvsp - 3].node(),
                                         0,
                                         0,
                                         0,
@@ -3847,10 +3896,12 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     );
                                     current_block = Block::ReduceJoin2;
                                 }
-                            } else if astr_eq(&yyvs[yyvsp - 4].astr, c"AXISELEM(") {
-                                if ((lParse.Nodes)[yyvs[yyvsp - 1].Node as usize]).operation
+                            } else if astr_eq(yyvs[yyvsp - 4].astr(), c"AXISELEM(") {
+                                if ((lParse.Nodes)[yyvs[yyvsp - 1].node() as usize]).operation
                                     != CONST_OP
-                                    || ((lParse.Nodes)[yyvs[yyvsp - 1].Node as usize]).value.nelem
+                                    || ((lParse.Nodes)[yyvs[yyvsp - 1].node() as usize])
+                                        .value
+                                        .nelem
                                         != 1
                                 {
                                     fits_parser_yyerror(
@@ -3858,7 +3909,8 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         cs!(c"AXISELEM second argument must be a scalar constant"),
                                     );
                                     current_block = Block::YyErrLab;
-                                } else if ((lParse.Nodes)[yyvs[yyvsp - 3].Node as usize]).operation
+                                } else if ((lParse.Nodes)[yyvs[yyvsp - 3].node() as usize])
+                                    .operation
                                     == CONST_OP
                                 {
                                     let mut one_3: c_long = 1;
@@ -3870,14 +3922,14 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     );
                                     current_block = Block::ReduceJoin2;
                                 } else {
-                                    if ((lParse.Nodes)[yyvs[yyvsp - 1].Node as usize]).ntype
+                                    if ((lParse.Nodes)[yyvs[yyvsp - 1].node() as usize]).ntype
                                         != fits_parser_yytokentype::LONG as c_int
                                     {
                                         yyvs[yyvsp - 1].Node = New_Unary(
                                             lParse,
                                             fits_parser_yytokentype::LONG as c_int,
                                             0,
-                                            yyvs[yyvsp - 1].Node,
+                                            yyvs[yyvsp - 1].node(),
                                         );
                                     }
                                     yyval.Node = New_Func(
@@ -3885,26 +3937,28 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         0,
                                         AXISELEM_FCT,
                                         2,
-                                        yyvs[yyvsp - 3].Node,
-                                        yyvs[yyvsp - 1].Node,
+                                        yyvs[yyvsp - 3].node(),
+                                        yyvs[yyvsp - 1].node(),
                                         0,
                                         0,
                                         0,
                                         0,
                                         0,
                                     );
-                                    if yyval.Node < 0 {
+                                    if yyval.node() < 0 {
                                         current_block = Block::YyErrLab;
                                     } else {
-                                        ((lParse.Nodes)[yyval.Node as usize]).ntype =
+                                        ((lParse.Nodes)[yyval.node() as usize]).ntype =
                                             fits_parser_yytokentype::LONG as c_int;
                                         current_block = Block::ReduceJoin2;
                                     }
                                 }
-                            } else if astr_eq(&yyvs[yyvsp - 4].astr, c"NAXES(") {
-                                if ((lParse.Nodes)[yyvs[yyvsp - 1].Node as usize]).operation
+                            } else if astr_eq(yyvs[yyvsp - 4].astr(), c"NAXES(") {
+                                if ((lParse.Nodes)[yyvs[yyvsp - 1].node() as usize]).operation
                                     != CONST_OP
-                                    || ((lParse.Nodes)[yyvs[yyvsp - 1].Node as usize]).value.nelem
+                                    || ((lParse.Nodes)[yyvs[yyvsp - 1].node() as usize])
+                                        .value
+                                        .nelem
                                         != 1
                                 {
                                     fits_parser_yyerror(
@@ -3912,7 +3966,8 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         cs!(c"NAXES second argument must be a scalar constant"),
                                     );
                                     current_block = Block::YyErrLab;
-                                } else if ((lParse.Nodes)[yyvs[yyvsp - 3].Node as usize]).operation
+                                } else if ((lParse.Nodes)[yyvs[yyvsp - 3].node() as usize])
+                                    .operation
                                     == CONST_OP
                                 {
                                     let mut one_4: c_long = 1;
@@ -3926,26 +3981,27 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 } else {
                                     let mut iaxis_0: c_long = 0;
                                     let mut naxis_1: c_int = 0;
-                                    if ((lParse.Nodes)[yyvs[yyvsp - 1].Node as usize]).ntype
+                                    if ((lParse.Nodes)[yyvs[yyvsp - 1].node() as usize]).ntype
                                         != fits_parser_yytokentype::LONG as c_int
                                     {
                                         yyvs[yyvsp - 1].Node = New_Unary(
                                             lParse,
                                             fits_parser_yytokentype::LONG as c_int,
                                             0,
-                                            yyvs[yyvsp - 1].Node,
+                                            yyvs[yyvsp - 1].node(),
                                         );
                                     }
-                                    iaxis_0 = ((lParse.Nodes)[yyvs[yyvsp - 1].Node as usize])
+                                    iaxis_0 = ((lParse.Nodes)[yyvs[yyvsp - 1].node() as usize])
                                         .value
                                         .data
                                         .lng();
-                                    naxis_1 =
-                                        ((lParse.Nodes)[yyvs[yyvsp - 3].Node as usize]).value.naxis;
+                                    naxis_1 = ((lParse.Nodes)[yyvs[yyvsp - 3].node() as usize])
+                                        .value
+                                        .naxis;
                                     if iaxis_0 == 0 {
                                         iaxis_0 = c_long::from(naxis_1);
                                     } else if iaxis_0 <= c_long::from(naxis_1) {
-                                        iaxis_0 = ((lParse.Nodes)[yyvs[yyvsp - 3].Node as usize])
+                                        iaxis_0 = ((lParse.Nodes)[yyvs[yyvsp - 3].node() as usize])
                                             .value
                                             .naxes
                                             [(iaxis_0 - 1) as usize];
@@ -3958,16 +4014,19 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         (&mut iaxis_0 as *mut c_long).cast::<c_void>(),
                                         ::core::mem::size_of::<c_long>() as c_ulong as c_long,
                                     );
-                                    if yyval.Node < 0 {
+                                    if yyval.node() < 0 {
                                         current_block = Block::YyErrLab;
                                     } else {
                                         current_block = Block::ReduceJoin2;
                                     }
                                 }
-                            } else if astr_eq(&yyvs[yyvsp - 4].astr, c"ARRAY(") {
-                                yyval.Node =
-                                    New_Array(lParse, yyvs[yyvsp - 3].Node, yyvs[yyvsp - 1].Node);
-                                if yyval.Node < 0 {
+                            } else if astr_eq(yyvs[yyvsp - 4].astr(), c"ARRAY(") {
+                                yyval.Node = New_Array(
+                                    lParse,
+                                    yyvs[yyvsp - 3].node(),
+                                    yyvs[yyvsp - 1].node(),
+                                );
+                                if yyval.node() < 0 {
                                     current_block = Block::YyErrLab;
                                 } else {
                                     current_block = Block::ReduceJoin2;
@@ -3988,96 +4047,102 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         }
                         62 => {
                             /* expr: FUNCTION expr ',' expr ',' expr ',' expr ')'  */
-                            if astr_eq(&yyvs[yyvsp - 8].astr, c"ANGSEP(") {
-                                if ((lParse.Nodes)[yyvs[yyvsp - 7].Node as usize]).ntype
+                            if astr_eq(yyvs[yyvsp - 8].astr(), c"ANGSEP(") {
+                                if ((lParse.Nodes)[yyvs[yyvsp - 7].node() as usize]).ntype
                                     != fits_parser_yytokentype::DOUBLE as c_int
                                 {
                                     yyvs[yyvsp - 7].Node = New_Unary(
                                         lParse,
                                         fits_parser_yytokentype::DOUBLE as c_int,
                                         0,
-                                        yyvs[yyvsp - 7].Node,
+                                        yyvs[yyvsp - 7].node(),
                                     );
                                 }
-                                if ((lParse.Nodes)[yyvs[yyvsp - 5].Node as usize]).ntype
+                                if ((lParse.Nodes)[yyvs[yyvsp - 5].node() as usize]).ntype
                                     != fits_parser_yytokentype::DOUBLE as c_int
                                 {
                                     yyvs[yyvsp - 5].Node = New_Unary(
                                         lParse,
                                         fits_parser_yytokentype::DOUBLE as c_int,
                                         0,
-                                        yyvs[yyvsp - 5].Node,
+                                        yyvs[yyvsp - 5].node(),
                                     );
                                 }
-                                if ((lParse.Nodes)[yyvs[yyvsp - 3].Node as usize]).ntype
+                                if ((lParse.Nodes)[yyvs[yyvsp - 3].node() as usize]).ntype
                                     != fits_parser_yytokentype::DOUBLE as c_int
                                 {
                                     yyvs[yyvsp - 3].Node = New_Unary(
                                         lParse,
                                         fits_parser_yytokentype::DOUBLE as c_int,
                                         0,
-                                        yyvs[yyvsp - 3].Node,
+                                        yyvs[yyvsp - 3].node(),
                                     );
                                 }
-                                if ((lParse.Nodes)[yyvs[yyvsp - 1].Node as usize]).ntype
+                                if ((lParse.Nodes)[yyvs[yyvsp - 1].node() as usize]).ntype
                                     != fits_parser_yytokentype::DOUBLE as c_int
                                 {
                                     yyvs[yyvsp - 1].Node = New_Unary(
                                         lParse,
                                         fits_parser_yytokentype::DOUBLE as c_int,
                                         0,
-                                        yyvs[yyvsp - 1].Node,
+                                        yyvs[yyvsp - 1].node(),
                                     );
                                 }
-                                if Test_Dims(lParse, yyvs[yyvsp - 7].Node, yyvs[yyvsp - 5].Node)
+                                if Test_Dims(lParse, yyvs[yyvsp - 7].node(), yyvs[yyvsp - 5].node())
                                     != 0
-                                    && Test_Dims(lParse, yyvs[yyvsp - 5].Node, yyvs[yyvsp - 3].Node)
-                                        != 0
-                                    && Test_Dims(lParse, yyvs[yyvsp - 3].Node, yyvs[yyvsp - 1].Node)
-                                        != 0
+                                    && Test_Dims(
+                                        lParse,
+                                        yyvs[yyvsp - 5].node(),
+                                        yyvs[yyvsp - 3].node(),
+                                    ) != 0
+                                    && Test_Dims(
+                                        lParse,
+                                        yyvs[yyvsp - 3].node(),
+                                        yyvs[yyvsp - 1].node(),
+                                    ) != 0
                                 {
                                     yyval.Node = New_Func(
                                         lParse,
                                         0,
                                         ANGSEP_FCT,
                                         4 as c_int,
-                                        yyvs[yyvsp - 7].Node,
-                                        yyvs[yyvsp - 5].Node,
-                                        yyvs[yyvsp - 3].Node,
-                                        yyvs[yyvsp - 1].Node,
+                                        yyvs[yyvsp - 7].node(),
+                                        yyvs[yyvsp - 5].node(),
+                                        yyvs[yyvsp - 3].node(),
+                                        yyvs[yyvsp - 1].node(),
                                         0,
                                         0,
                                         0,
                                     );
-                                    if yyval.Node < 0 {
+                                    if yyval.node() < 0 {
                                         current_block = Block::YyErrLab;
                                     } else {
-                                        if ((lParse.Nodes)[yyvs[yyvsp - 7].Node as usize])
+                                        if ((lParse.Nodes)[yyvs[yyvsp - 7].node() as usize])
                                             .value
                                             .nelem
-                                            < ((lParse.Nodes)[yyvs[yyvsp - 5].Node as usize])
+                                            < ((lParse.Nodes)[yyvs[yyvsp - 5].node() as usize])
                                                 .value
                                                 .nelem
                                         {
-                                            Copy_Dims(lParse, yyval.Node, yyvs[yyvsp - 5].Node);
+                                            Copy_Dims(lParse, yyval.node(), yyvs[yyvsp - 5].node());
                                         }
-                                        if ((lParse.Nodes)[yyvs[yyvsp - 5].Node as usize])
+                                        if ((lParse.Nodes)[yyvs[yyvsp - 5].node() as usize])
                                             .value
                                             .nelem
-                                            < ((lParse.Nodes)[yyvs[yyvsp - 3].Node as usize])
+                                            < ((lParse.Nodes)[yyvs[yyvsp - 3].node() as usize])
                                                 .value
                                                 .nelem
                                         {
-                                            Copy_Dims(lParse, yyval.Node, yyvs[yyvsp - 3].Node);
+                                            Copy_Dims(lParse, yyval.node(), yyvs[yyvsp - 3].node());
                                         }
-                                        if ((lParse.Nodes)[yyvs[yyvsp - 3].Node as usize])
+                                        if ((lParse.Nodes)[yyvs[yyvsp - 3].node() as usize])
                                             .value
                                             .nelem
-                                            < ((lParse.Nodes)[yyvs[yyvsp - 1].Node as usize])
+                                            < ((lParse.Nodes)[yyvs[yyvsp - 1].node() as usize])
                                                 .value
                                                 .nelem
                                         {
-                                            Copy_Dims(lParse, yyval.Node, yyvs[yyvsp - 1].Node);
+                                            Copy_Dims(lParse, yyval.node(), yyvs[yyvsp - 1].node());
                                         }
                                         current_block = Block::ReduceDone;
                                     }
@@ -4101,13 +4166,13 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             yyval.Node = New_GTI(
                                 lParse,
                                 GTIOVER_FCT,
-                                (yyvs[yyvsp - 5].astr).as_mut_ptr(),
-                                yyvs[yyvsp - 3].Node,
-                                yyvs[yyvsp - 1].Node,
+                                (yyvs[yyvsp - 5].astr_mut()).as_mut_ptr(),
+                                yyvs[yyvsp - 3].node(),
+                                yyvs[yyvsp - 1].node(),
                                 c"*START*".as_ptr() as *mut c_char,
                                 c"*STOP*".as_ptr() as *mut c_char,
                             );
-                            if yyval.Node < 0 {
+                            if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
                                 current_block = Block::ReduceDone;
@@ -4118,13 +4183,13 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             yyval.Node = New_GTI(
                                 lParse,
                                 GTIOVER_FCT,
-                                (yyvs[yyvsp - 9].astr).as_mut_ptr(),
-                                yyvs[yyvsp - 7].Node,
-                                yyvs[yyvsp - 5].Node,
-                                (yyvs[yyvsp - 3].astr).as_mut_ptr(),
-                                (yyvs[yyvsp - 1].astr).as_mut_ptr(),
+                                (yyvs[yyvsp - 9].astr_mut()).as_mut_ptr(),
+                                yyvs[yyvsp - 7].node(),
+                                yyvs[yyvsp - 5].node(),
+                                (yyvs[yyvsp - 3].astr_mut()).as_mut_ptr(),
+                                (yyvs[yyvsp - 1].astr_mut()).as_mut_ptr(),
                             );
-                            if yyval.Node < 0 {
+                            if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
                                 current_block = Block::ReduceDone;
@@ -4134,15 +4199,15 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             /* expr: expr '[' expr ']'  */
                             yyval.Node = New_Deref(
                                 lParse,
-                                yyvs[yyvsp - 3].Node,
+                                yyvs[yyvsp - 3].node(),
                                 1,
-                                yyvs[yyvsp - 1].Node,
+                                yyvs[yyvsp - 1].node(),
                                 0,
                                 0,
                                 0,
                                 0,
                             );
-                            if yyval.Node < 0 {
+                            if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
                                 current_block = Block::ReduceDone;
@@ -4152,15 +4217,15 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             /* expr: expr '[' expr ',' expr ']'  */
                             yyval.Node = New_Deref(
                                 lParse,
-                                yyvs[yyvsp - 5].Node,
+                                yyvs[yyvsp - 5].node(),
                                 2,
-                                yyvs[yyvsp - 3].Node,
-                                yyvs[yyvsp - 1].Node,
+                                yyvs[yyvsp - 3].node(),
+                                yyvs[yyvsp - 1].node(),
                                 0,
                                 0,
                                 0,
                             );
-                            if yyval.Node < 0 {
+                            if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
                                 current_block = Block::ReduceDone;
@@ -4170,15 +4235,15 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             /* expr: expr '[' expr ',' expr ',' expr ']'  */
                             yyval.Node = New_Deref(
                                 lParse,
-                                yyvs[yyvsp - 7].Node,
+                                yyvs[yyvsp - 7].node(),
                                 3 as c_int,
-                                yyvs[yyvsp - 5].Node,
-                                yyvs[yyvsp - 3].Node,
-                                yyvs[yyvsp - 1].Node,
+                                yyvs[yyvsp - 5].node(),
+                                yyvs[yyvsp - 3].node(),
+                                yyvs[yyvsp - 1].node(),
                                 0,
                                 0,
                             );
-                            if yyval.Node < 0 {
+                            if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
                                 current_block = Block::ReduceDone;
@@ -4188,15 +4253,15 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             /* expr: expr '[' expr ',' expr ',' expr ',' expr ']'  */
                             yyval.Node = New_Deref(
                                 lParse,
-                                yyvs[yyvsp - 9].Node,
+                                yyvs[yyvsp - 9].node(),
                                 4 as c_int,
-                                yyvs[yyvsp - 7].Node,
-                                yyvs[yyvsp - 5].Node,
-                                yyvs[yyvsp - 3].Node,
-                                yyvs[yyvsp - 1].Node,
+                                yyvs[yyvsp - 7].node(),
+                                yyvs[yyvsp - 5].node(),
+                                yyvs[yyvsp - 3].node(),
+                                yyvs[yyvsp - 1].node(),
                                 0,
                             );
-                            if yyval.Node < 0 {
+                            if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
                                 current_block = Block::ReduceDone;
@@ -4206,15 +4271,15 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             /* expr: expr '[' expr ',' expr ',' expr ',' expr ',' expr ']'  */
                             yyval.Node = New_Deref(
                                 lParse,
-                                yyvs[yyvsp - 11].Node,
+                                yyvs[yyvsp - 11].node(),
                                 5 as c_int,
-                                yyvs[yyvsp - 9].Node,
-                                yyvs[yyvsp - 7].Node,
-                                yyvs[yyvsp - 5].Node,
-                                yyvs[yyvsp - 3].Node,
-                                yyvs[yyvsp - 1].Node,
+                                yyvs[yyvsp - 9].node(),
+                                yyvs[yyvsp - 7].node(),
+                                yyvs[yyvsp - 5].node(),
+                                yyvs[yyvsp - 3].node(),
+                                yyvs[yyvsp - 1].node(),
                             );
-                            if yyval.Node < 0 {
+                            if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
                                 current_block = Block::ReduceDone;
@@ -4226,9 +4291,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 lParse,
                                 fits_parser_yytokentype::LONG as c_int,
                                 fits_parser_yytokentype::INTCAST as c_int,
-                                yyvs[yyvsp].Node,
+                                yyvs[yyvsp].node(),
                             );
-                            if yyval.Node < 0 {
+                            if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
                                 current_block = Block::ReduceDone;
@@ -4240,9 +4305,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 lParse,
                                 fits_parser_yytokentype::LONG as c_int,
                                 fits_parser_yytokentype::INTCAST as c_int,
-                                yyvs[yyvsp].Node,
+                                yyvs[yyvsp].node(),
                             );
-                            if yyval.Node < 0 {
+                            if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
                                 current_block = Block::ReduceDone;
@@ -4254,9 +4319,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 lParse,
                                 fits_parser_yytokentype::DOUBLE as c_int,
                                 fits_parser_yytokentype::FLTCAST as c_int,
-                                yyvs[yyvsp].Node,
+                                yyvs[yyvsp].node(),
                             );
-                            if yyval.Node < 0 {
+                            if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
                                 current_block = Block::ReduceDone;
@@ -4268,9 +4333,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 lParse,
                                 fits_parser_yytokentype::DOUBLE as c_int,
                                 fits_parser_yytokentype::FLTCAST as c_int,
-                                yyvs[yyvsp].Node,
+                                yyvs[yyvsp].node(),
                             );
-                            if yyval.Node < 0 {
+                            if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
                                 current_block = Block::ReduceDone;
@@ -4281,10 +4346,10 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             yyval.Node = New_Const(
                                 lParse,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
-                                (&mut yyvs[yyvsp].log as *mut c_char).cast::<c_void>(),
+                                (&mut yyvs[yyvsp].log() as *mut c_char).cast::<c_void>(),
                                 ::core::mem::size_of::<c_char>() as c_ulong as c_long,
                             );
-                            if yyval.Node < 0 {
+                            if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
                                 current_block = Block::ReduceDone;
@@ -4292,8 +4357,8 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         }
                         75 => {
                             /* bexpr: BCOLUMN  */
-                            yyval.Node = New_Column(lParse, yyvs[yyvsp].lng as c_int);
-                            if yyval.Node < 0 {
+                            yyval.Node = New_Column(lParse, yyvs[yyvsp].lng() as c_int);
+                            if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
                                 current_block = Block::ReduceDone;
@@ -4301,9 +4366,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         }
                         76 => {
                             /* bexpr: BCOLUMN '{' expr '}'  */
-                            if ((lParse.Nodes)[yyvs[yyvsp - 1].Node as usize]).ntype
+                            if ((lParse.Nodes)[yyvs[yyvsp - 1].node() as usize]).ntype
                                 != fits_parser_yytokentype::LONG as c_int
-                                || ((lParse.Nodes)[yyvs[yyvsp - 1].Node as usize]).operation
+                                || ((lParse.Nodes)[yyvs[yyvsp - 1].node() as usize]).operation
                                     != CONST_OP
                             {
                                 fits_parser_yyerror(
@@ -4314,10 +4379,10 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             } else {
                                 yyval.Node = New_Offset(
                                     lParse,
-                                    yyvs[yyvsp - 3].lng as c_int,
-                                    yyvs[yyvsp - 1].Node,
+                                    yyvs[yyvsp - 3].lng() as c_int,
+                                    yyvs[yyvsp - 1].node(),
                                 );
-                                if yyval.Node < 0 {
+                                if yyval.node() < 0 {
                                     current_block = Block::YyErrLab;
                                 } else {
                                     current_block = Block::ReduceDone;
@@ -4329,14 +4394,14 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             yyval.Node = New_BinOp(
                                 lParse,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
-                                yyvs[yyvsp - 2].Node,
+                                yyvs[yyvsp - 2].node(),
                                 fits_parser_yytokentype::EQ as c_int,
-                                yyvs[yyvsp].Node,
+                                yyvs[yyvsp].node(),
                             );
-                            if yyval.Node < 0 {
+                            if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
-                                (((lParse.Nodes)[yyval.Node as usize]).value).nelem = 1;
+                                (((lParse.Nodes)[yyval.node() as usize]).value).nelem = 1;
                                 current_block = Block::ReduceDone;
                             }
                         }
@@ -4345,14 +4410,14 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             yyval.Node = New_BinOp(
                                 lParse,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
-                                yyvs[yyvsp - 2].Node,
+                                yyvs[yyvsp - 2].node(),
                                 fits_parser_yytokentype::NE as c_int,
-                                yyvs[yyvsp].Node,
+                                yyvs[yyvsp].node(),
                             );
-                            if yyval.Node < 0 {
+                            if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
-                                (((lParse.Nodes)[yyval.Node as usize]).value).nelem = 1;
+                                (((lParse.Nodes)[yyval.node() as usize]).value).nelem = 1;
                                 current_block = Block::ReduceDone;
                             }
                         }
@@ -4361,14 +4426,14 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             yyval.Node = New_BinOp(
                                 lParse,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
-                                yyvs[yyvsp - 2].Node,
+                                yyvs[yyvsp - 2].node(),
                                 fits_parser_yytokentype::LT as c_int,
-                                yyvs[yyvsp].Node,
+                                yyvs[yyvsp].node(),
                             );
-                            if yyval.Node < 0 {
+                            if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
-                                (((lParse.Nodes)[yyval.Node as usize]).value).nelem = 1;
+                                (((lParse.Nodes)[yyval.node() as usize]).value).nelem = 1;
                                 current_block = Block::ReduceDone;
                             }
                         }
@@ -4377,14 +4442,14 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             yyval.Node = New_BinOp(
                                 lParse,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
-                                yyvs[yyvsp - 2].Node,
+                                yyvs[yyvsp - 2].node(),
                                 fits_parser_yytokentype::LTE as c_int,
-                                yyvs[yyvsp].Node,
+                                yyvs[yyvsp].node(),
                             );
-                            if yyval.Node < 0 {
+                            if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
-                                (((lParse.Nodes)[yyval.Node as usize]).value).nelem = 1;
+                                (((lParse.Nodes)[yyval.node() as usize]).value).nelem = 1;
                                 current_block = Block::ReduceDone;
                             }
                         }
@@ -4393,14 +4458,14 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             yyval.Node = New_BinOp(
                                 lParse,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
-                                yyvs[yyvsp - 2].Node,
+                                yyvs[yyvsp - 2].node(),
                                 fits_parser_yytokentype::GT as c_int,
-                                yyvs[yyvsp].Node,
+                                yyvs[yyvsp].node(),
                             );
-                            if yyval.Node < 0 {
+                            if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
-                                (((lParse.Nodes)[yyval.Node as usize]).value).nelem = 1;
+                                (((lParse.Nodes)[yyval.node() as usize]).value).nelem = 1;
                                 current_block = Block::ReduceDone;
                             }
                         }
@@ -4409,46 +4474,46 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             yyval.Node = New_BinOp(
                                 lParse,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
-                                yyvs[yyvsp - 2].Node,
+                                yyvs[yyvsp - 2].node(),
                                 fits_parser_yytokentype::GTE as c_int,
-                                yyvs[yyvsp].Node,
+                                yyvs[yyvsp].node(),
                             );
-                            if yyval.Node < 0 {
+                            if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
-                                (((lParse.Nodes)[yyval.Node as usize]).value).nelem = 1;
+                                (((lParse.Nodes)[yyval.node() as usize]).value).nelem = 1;
                                 current_block = Block::ReduceDone;
                             }
                         }
                         83 => {
                             /* bexpr: expr GT expr  */
-                            if (lParse.Nodes[yyvs[yyvsp - 2].Node as usize]).ntype
-                                > (lParse.Nodes[yyvs[yyvsp].Node as usize]).ntype
+                            if (lParse.Nodes[yyvs[yyvsp - 2].node() as usize]).ntype
+                                > (lParse.Nodes[yyvs[yyvsp].node() as usize]).ntype
                             {
                                 yyvs[yyvsp].Node = New_Unary(
                                     lParse,
-                                    ((lParse.Nodes)[yyvs[yyvsp - 2].Node as usize]).ntype,
+                                    ((lParse.Nodes)[yyvs[yyvsp - 2].node() as usize]).ntype,
                                     0,
-                                    yyvs[yyvsp].Node,
+                                    yyvs[yyvsp].node(),
                                 );
-                            } else if ((lParse.Nodes)[yyvs[yyvsp - 2].Node as usize]).ntype
-                                < (lParse.Nodes[yyvs[yyvsp].Node as usize]).ntype
+                            } else if ((lParse.Nodes)[yyvs[yyvsp - 2].node() as usize]).ntype
+                                < (lParse.Nodes[yyvs[yyvsp].node() as usize]).ntype
                             {
                                 yyvs[yyvsp - 2].Node = New_Unary(
                                     lParse,
-                                    (lParse.Nodes[yyvs[yyvsp].Node as usize]).ntype,
+                                    (lParse.Nodes[yyvs[yyvsp].node() as usize]).ntype,
                                     0,
-                                    yyvs[yyvsp - 2].Node,
+                                    yyvs[yyvsp - 2].node(),
                                 );
                             }
                             yyval.Node = New_BinOp(
                                 lParse,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
-                                yyvs[yyvsp - 2].Node,
+                                yyvs[yyvsp - 2].node(),
                                 fits_parser_yytokentype::GT as c_int,
-                                yyvs[yyvsp].Node,
+                                yyvs[yyvsp].node(),
                             );
-                            if yyval.Node < 0 {
+                            if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
                                 current_block = Block::ReduceDone;
@@ -4456,33 +4521,33 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         }
                         84 => {
                             /* bexpr: expr LT expr  */
-                            if (lParse.Nodes[yyvs[yyvsp - 2].Node as usize]).ntype
-                                > (lParse.Nodes[yyvs[yyvsp].Node as usize]).ntype
+                            if (lParse.Nodes[yyvs[yyvsp - 2].node() as usize]).ntype
+                                > (lParse.Nodes[yyvs[yyvsp].node() as usize]).ntype
                             {
                                 yyvs[yyvsp].Node = New_Unary(
                                     lParse,
-                                    ((lParse.Nodes)[yyvs[yyvsp - 2].Node as usize]).ntype,
+                                    ((lParse.Nodes)[yyvs[yyvsp - 2].node() as usize]).ntype,
                                     0,
-                                    yyvs[yyvsp].Node,
+                                    yyvs[yyvsp].node(),
                                 );
-                            } else if ((lParse.Nodes)[yyvs[yyvsp - 2].Node as usize]).ntype
-                                < (lParse.Nodes[yyvs[yyvsp].Node as usize]).ntype
+                            } else if ((lParse.Nodes)[yyvs[yyvsp - 2].node() as usize]).ntype
+                                < (lParse.Nodes[yyvs[yyvsp].node() as usize]).ntype
                             {
                                 yyvs[yyvsp - 2].Node = New_Unary(
                                     lParse,
-                                    (lParse.Nodes[yyvs[yyvsp].Node as usize]).ntype,
+                                    (lParse.Nodes[yyvs[yyvsp].node() as usize]).ntype,
                                     0,
-                                    yyvs[yyvsp - 2].Node,
+                                    yyvs[yyvsp - 2].node(),
                                 );
                             }
                             yyval.Node = New_BinOp(
                                 lParse,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
-                                yyvs[yyvsp - 2].Node,
+                                yyvs[yyvsp - 2].node(),
                                 fits_parser_yytokentype::LT as c_int,
-                                yyvs[yyvsp].Node,
+                                yyvs[yyvsp].node(),
                             );
-                            if yyval.Node < 0 {
+                            if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
                                 current_block = Block::ReduceDone;
@@ -4490,33 +4555,33 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         }
                         85 => {
                             /* bexpr: expr GTE expr  */
-                            if (lParse.Nodes[yyvs[yyvsp - 2].Node as usize]).ntype
-                                > (lParse.Nodes[yyvs[yyvsp].Node as usize]).ntype
+                            if (lParse.Nodes[yyvs[yyvsp - 2].node() as usize]).ntype
+                                > (lParse.Nodes[yyvs[yyvsp].node() as usize]).ntype
                             {
                                 yyvs[yyvsp].Node = New_Unary(
                                     lParse,
-                                    ((lParse.Nodes)[yyvs[yyvsp - 2].Node as usize]).ntype,
+                                    ((lParse.Nodes)[yyvs[yyvsp - 2].node() as usize]).ntype,
                                     0,
-                                    yyvs[yyvsp].Node,
+                                    yyvs[yyvsp].node(),
                                 );
-                            } else if ((lParse.Nodes)[yyvs[yyvsp - 2].Node as usize]).ntype
-                                < (lParse.Nodes[yyvs[yyvsp].Node as usize]).ntype
+                            } else if ((lParse.Nodes)[yyvs[yyvsp - 2].node() as usize]).ntype
+                                < (lParse.Nodes[yyvs[yyvsp].node() as usize]).ntype
                             {
                                 yyvs[yyvsp - 2].Node = New_Unary(
                                     lParse,
-                                    (lParse.Nodes[yyvs[yyvsp].Node as usize]).ntype,
+                                    (lParse.Nodes[yyvs[yyvsp].node() as usize]).ntype,
                                     0,
-                                    yyvs[yyvsp - 2].Node,
+                                    yyvs[yyvsp - 2].node(),
                                 );
                             }
                             yyval.Node = New_BinOp(
                                 lParse,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
-                                yyvs[yyvsp - 2].Node,
+                                yyvs[yyvsp - 2].node(),
                                 fits_parser_yytokentype::GTE as c_int,
-                                yyvs[yyvsp].Node,
+                                yyvs[yyvsp].node(),
                             );
-                            if yyval.Node < 0 {
+                            if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
                                 current_block = Block::ReduceDone;
@@ -4524,33 +4589,33 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         }
                         86 => {
                             /* bexpr: expr LTE expr  */
-                            if (lParse.Nodes[yyvs[yyvsp - 2].Node as usize]).ntype
-                                > (lParse.Nodes[yyvs[yyvsp].Node as usize]).ntype
+                            if (lParse.Nodes[yyvs[yyvsp - 2].node() as usize]).ntype
+                                > (lParse.Nodes[yyvs[yyvsp].node() as usize]).ntype
                             {
                                 yyvs[yyvsp].Node = New_Unary(
                                     lParse,
-                                    ((lParse.Nodes)[yyvs[yyvsp - 2].Node as usize]).ntype,
+                                    ((lParse.Nodes)[yyvs[yyvsp - 2].node() as usize]).ntype,
                                     0,
-                                    yyvs[yyvsp].Node,
+                                    yyvs[yyvsp].node(),
                                 );
-                            } else if ((lParse.Nodes)[yyvs[yyvsp - 2].Node as usize]).ntype
-                                < (lParse.Nodes[yyvs[yyvsp].Node as usize]).ntype
+                            } else if ((lParse.Nodes)[yyvs[yyvsp - 2].node() as usize]).ntype
+                                < (lParse.Nodes[yyvs[yyvsp].node() as usize]).ntype
                             {
                                 yyvs[yyvsp - 2].Node = New_Unary(
                                     lParse,
-                                    (lParse.Nodes[yyvs[yyvsp].Node as usize]).ntype,
+                                    (lParse.Nodes[yyvs[yyvsp].node() as usize]).ntype,
                                     0,
-                                    yyvs[yyvsp - 2].Node,
+                                    yyvs[yyvsp - 2].node(),
                                 );
                             }
                             yyval.Node = New_BinOp(
                                 lParse,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
-                                yyvs[yyvsp - 2].Node,
+                                yyvs[yyvsp - 2].node(),
                                 fits_parser_yytokentype::LTE as c_int,
-                                yyvs[yyvsp].Node,
+                                yyvs[yyvsp].node(),
                             );
-                            if yyval.Node < 0 {
+                            if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
                                 current_block = Block::ReduceDone;
@@ -4558,33 +4623,33 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         }
                         87 => {
                             /* bexpr: expr '~' expr  */
-                            if (lParse.Nodes[yyvs[yyvsp - 2].Node as usize]).ntype
-                                > (lParse.Nodes[yyvs[yyvsp].Node as usize]).ntype
+                            if (lParse.Nodes[yyvs[yyvsp - 2].node() as usize]).ntype
+                                > (lParse.Nodes[yyvs[yyvsp].node() as usize]).ntype
                             {
                                 yyvs[yyvsp].Node = New_Unary(
                                     lParse,
-                                    ((lParse.Nodes)[yyvs[yyvsp - 2].Node as usize]).ntype,
+                                    ((lParse.Nodes)[yyvs[yyvsp - 2].node() as usize]).ntype,
                                     0,
-                                    yyvs[yyvsp].Node,
+                                    yyvs[yyvsp].node(),
                                 );
-                            } else if ((lParse.Nodes)[yyvs[yyvsp - 2].Node as usize]).ntype
-                                < (lParse.Nodes[yyvs[yyvsp].Node as usize]).ntype
+                            } else if ((lParse.Nodes)[yyvs[yyvsp - 2].node() as usize]).ntype
+                                < (lParse.Nodes[yyvs[yyvsp].node() as usize]).ntype
                             {
                                 yyvs[yyvsp - 2].Node = New_Unary(
                                     lParse,
-                                    (lParse.Nodes[yyvs[yyvsp].Node as usize]).ntype,
+                                    (lParse.Nodes[yyvs[yyvsp].node() as usize]).ntype,
                                     0,
-                                    yyvs[yyvsp - 2].Node,
+                                    yyvs[yyvsp - 2].node(),
                                 );
                             }
                             yyval.Node = New_BinOp(
                                 lParse,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
-                                yyvs[yyvsp - 2].Node,
+                                yyvs[yyvsp - 2].node(),
                                 '~' as i32,
-                                yyvs[yyvsp].Node,
+                                yyvs[yyvsp].node(),
                             );
-                            if yyval.Node < 0 {
+                            if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
                                 current_block = Block::ReduceDone;
@@ -4592,33 +4657,33 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         }
                         88 => {
                             /* bexpr: expr EQ expr  */
-                            if (lParse.Nodes[yyvs[yyvsp - 2].Node as usize]).ntype
-                                > (lParse.Nodes[yyvs[yyvsp].Node as usize]).ntype
+                            if (lParse.Nodes[yyvs[yyvsp - 2].node() as usize]).ntype
+                                > (lParse.Nodes[yyvs[yyvsp].node() as usize]).ntype
                             {
                                 yyvs[yyvsp].Node = New_Unary(
                                     lParse,
-                                    ((lParse.Nodes)[yyvs[yyvsp - 2].Node as usize]).ntype,
+                                    ((lParse.Nodes)[yyvs[yyvsp - 2].node() as usize]).ntype,
                                     0,
-                                    yyvs[yyvsp].Node,
+                                    yyvs[yyvsp].node(),
                                 );
-                            } else if ((lParse.Nodes)[yyvs[yyvsp - 2].Node as usize]).ntype
-                                < (lParse.Nodes[yyvs[yyvsp].Node as usize]).ntype
+                            } else if ((lParse.Nodes)[yyvs[yyvsp - 2].node() as usize]).ntype
+                                < (lParse.Nodes[yyvs[yyvsp].node() as usize]).ntype
                             {
                                 yyvs[yyvsp - 2].Node = New_Unary(
                                     lParse,
-                                    (lParse.Nodes[yyvs[yyvsp].Node as usize]).ntype,
+                                    (lParse.Nodes[yyvs[yyvsp].node() as usize]).ntype,
                                     0,
-                                    yyvs[yyvsp - 2].Node,
+                                    yyvs[yyvsp - 2].node(),
                                 );
                             }
                             yyval.Node = New_BinOp(
                                 lParse,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
-                                yyvs[yyvsp - 2].Node,
+                                yyvs[yyvsp - 2].node(),
                                 fits_parser_yytokentype::EQ as c_int,
-                                yyvs[yyvsp].Node,
+                                yyvs[yyvsp].node(),
                             );
-                            if yyval.Node < 0 {
+                            if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
                                 current_block = Block::ReduceDone;
@@ -4626,33 +4691,33 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         }
                         89 => {
                             /* bexpr: expr NE expr  */
-                            if (lParse.Nodes[yyvs[yyvsp - 2].Node as usize]).ntype
-                                > (lParse.Nodes[yyvs[yyvsp].Node as usize]).ntype
+                            if (lParse.Nodes[yyvs[yyvsp - 2].node() as usize]).ntype
+                                > (lParse.Nodes[yyvs[yyvsp].node() as usize]).ntype
                             {
                                 yyvs[yyvsp].Node = New_Unary(
                                     lParse,
-                                    ((lParse.Nodes)[yyvs[yyvsp - 2].Node as usize]).ntype,
+                                    ((lParse.Nodes)[yyvs[yyvsp - 2].node() as usize]).ntype,
                                     0,
-                                    yyvs[yyvsp].Node,
+                                    yyvs[yyvsp].node(),
                                 );
-                            } else if ((lParse.Nodes)[yyvs[yyvsp - 2].Node as usize]).ntype
-                                < (lParse.Nodes[yyvs[yyvsp].Node as usize]).ntype
+                            } else if ((lParse.Nodes)[yyvs[yyvsp - 2].node() as usize]).ntype
+                                < (lParse.Nodes[yyvs[yyvsp].node() as usize]).ntype
                             {
                                 yyvs[yyvsp - 2].Node = New_Unary(
                                     lParse,
-                                    (lParse.Nodes[yyvs[yyvsp].Node as usize]).ntype,
+                                    (lParse.Nodes[yyvs[yyvsp].node() as usize]).ntype,
                                     0,
-                                    yyvs[yyvsp - 2].Node,
+                                    yyvs[yyvsp - 2].node(),
                                 );
                             }
                             yyval.Node = New_BinOp(
                                 lParse,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
-                                yyvs[yyvsp - 2].Node,
+                                yyvs[yyvsp - 2].node(),
                                 fits_parser_yytokentype::NE as c_int,
-                                yyvs[yyvsp].Node,
+                                yyvs[yyvsp].node(),
                             );
-                            if yyval.Node < 0 {
+                            if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
                                 current_block = Block::ReduceDone;
@@ -4663,14 +4728,14 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             yyval.Node = New_BinOp(
                                 lParse,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
-                                yyvs[yyvsp - 2].Node,
+                                yyvs[yyvsp - 2].node(),
                                 fits_parser_yytokentype::EQ as c_int,
-                                yyvs[yyvsp].Node,
+                                yyvs[yyvsp].node(),
                             );
-                            if yyval.Node < 0 {
+                            if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
-                                (((lParse.Nodes)[yyval.Node as usize]).value).nelem = 1;
+                                (((lParse.Nodes)[yyval.node() as usize]).value).nelem = 1;
                                 current_block = Block::ReduceDone;
                             }
                         }
@@ -4679,14 +4744,14 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             yyval.Node = New_BinOp(
                                 lParse,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
-                                yyvs[yyvsp - 2].Node,
+                                yyvs[yyvsp - 2].node(),
                                 fits_parser_yytokentype::NE as c_int,
-                                yyvs[yyvsp].Node,
+                                yyvs[yyvsp].node(),
                             );
-                            if yyval.Node < 0 {
+                            if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
-                                (((lParse.Nodes)[yyval.Node as usize]).value).nelem = 1;
+                                (((lParse.Nodes)[yyval.node() as usize]).value).nelem = 1;
                                 current_block = Block::ReduceDone;
                             }
                         }
@@ -4695,14 +4760,14 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             yyval.Node = New_BinOp(
                                 lParse,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
-                                yyvs[yyvsp - 2].Node,
+                                yyvs[yyvsp - 2].node(),
                                 fits_parser_yytokentype::GT as c_int,
-                                yyvs[yyvsp].Node,
+                                yyvs[yyvsp].node(),
                             );
-                            if yyval.Node < 0 {
+                            if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
-                                (((lParse.Nodes)[yyval.Node as usize]).value).nelem = 1;
+                                (((lParse.Nodes)[yyval.node() as usize]).value).nelem = 1;
                                 current_block = Block::ReduceDone;
                             }
                         }
@@ -4711,14 +4776,14 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             yyval.Node = New_BinOp(
                                 lParse,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
-                                yyvs[yyvsp - 2].Node,
+                                yyvs[yyvsp - 2].node(),
                                 fits_parser_yytokentype::GTE as c_int,
-                                yyvs[yyvsp].Node,
+                                yyvs[yyvsp].node(),
                             );
-                            if yyval.Node < 0 {
+                            if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
-                                (((lParse.Nodes)[yyval.Node as usize]).value).nelem = 1;
+                                (((lParse.Nodes)[yyval.node() as usize]).value).nelem = 1;
                                 current_block = Block::ReduceDone;
                             }
                         }
@@ -4727,14 +4792,14 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             yyval.Node = New_BinOp(
                                 lParse,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
-                                yyvs[yyvsp - 2].Node,
+                                yyvs[yyvsp - 2].node(),
                                 fits_parser_yytokentype::LT as c_int,
-                                yyvs[yyvsp].Node,
+                                yyvs[yyvsp].node(),
                             );
-                            if yyval.Node < 0 {
+                            if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
-                                (((lParse.Nodes)[yyval.Node as usize]).value).nelem = 1;
+                                (((lParse.Nodes)[yyval.node() as usize]).value).nelem = 1;
                                 current_block = Block::ReduceDone;
                             }
                         }
@@ -4743,14 +4808,14 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             yyval.Node = New_BinOp(
                                 lParse,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
-                                yyvs[yyvsp - 2].Node,
+                                yyvs[yyvsp - 2].node(),
                                 fits_parser_yytokentype::LTE as c_int,
-                                yyvs[yyvsp].Node,
+                                yyvs[yyvsp].node(),
                             );
-                            if yyval.Node < 0 {
+                            if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
-                                (((lParse.Nodes)[yyval.Node as usize]).value).nelem = 1;
+                                (((lParse.Nodes)[yyval.node() as usize]).value).nelem = 1;
                                 current_block = Block::ReduceDone;
                             }
                         }
@@ -4759,11 +4824,11 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             yyval.Node = New_BinOp(
                                 lParse,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
-                                yyvs[yyvsp - 2].Node,
+                                yyvs[yyvsp - 2].node(),
                                 fits_parser_yytokentype::AND as c_int,
-                                yyvs[yyvsp].Node,
+                                yyvs[yyvsp].node(),
                             );
-                            if yyval.Node < 0 {
+                            if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
                                 current_block = Block::ReduceDone;
@@ -4774,11 +4839,11 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             yyval.Node = New_BinOp(
                                 lParse,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
-                                yyvs[yyvsp - 2].Node,
+                                yyvs[yyvsp - 2].node(),
                                 fits_parser_yytokentype::OR as c_int,
-                                yyvs[yyvsp].Node,
+                                yyvs[yyvsp].node(),
                             );
-                            if yyval.Node < 0 {
+                            if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
                                 current_block = Block::ReduceDone;
@@ -4789,11 +4854,11 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             yyval.Node = New_BinOp(
                                 lParse,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
-                                yyvs[yyvsp - 2].Node,
+                                yyvs[yyvsp - 2].node(),
                                 fits_parser_yytokentype::EQ as c_int,
-                                yyvs[yyvsp].Node,
+                                yyvs[yyvsp].node(),
                             );
-                            if yyval.Node < 0 {
+                            if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
                                 current_block = Block::ReduceDone;
@@ -4804,11 +4869,11 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             yyval.Node = New_BinOp(
                                 lParse,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
-                                yyvs[yyvsp - 2].Node,
+                                yyvs[yyvsp - 2].node(),
                                 fits_parser_yytokentype::NE as c_int,
-                                yyvs[yyvsp].Node,
+                                yyvs[yyvsp].node(),
                             );
-                            if yyval.Node < 0 {
+                            if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
                                 current_block = Block::ReduceDone;
@@ -4816,85 +4881,85 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         }
                         100 => {
                             /* bexpr: expr '=' expr ':' expr  */
-                            if ((lParse.Nodes)[yyvs[yyvsp - 4].Node as usize]).ntype
-                                > (lParse.Nodes[yyvs[yyvsp - 2].Node as usize]).ntype
+                            if ((lParse.Nodes)[yyvs[yyvsp - 4].node() as usize]).ntype
+                                > (lParse.Nodes[yyvs[yyvsp - 2].node() as usize]).ntype
                             {
                                 yyvs[yyvsp - 2].Node = New_Unary(
                                     lParse,
-                                    ((lParse.Nodes)[yyvs[yyvsp - 4].Node as usize]).ntype,
+                                    ((lParse.Nodes)[yyvs[yyvsp - 4].node() as usize]).ntype,
                                     0,
-                                    yyvs[yyvsp - 2].Node,
+                                    yyvs[yyvsp - 2].node(),
                                 );
-                            } else if ((lParse.Nodes)[yyvs[yyvsp - 4].Node as usize]).ntype
-                                < (lParse.Nodes[yyvs[yyvsp - 2].Node as usize]).ntype
+                            } else if ((lParse.Nodes)[yyvs[yyvsp - 4].node() as usize]).ntype
+                                < (lParse.Nodes[yyvs[yyvsp - 2].node() as usize]).ntype
                             {
                                 yyvs[yyvsp - 4].Node = New_Unary(
                                     lParse,
-                                    ((lParse.Nodes)[yyvs[yyvsp - 2].Node as usize]).ntype,
+                                    ((lParse.Nodes)[yyvs[yyvsp - 2].node() as usize]).ntype,
                                     0,
-                                    yyvs[yyvsp - 4].Node,
+                                    yyvs[yyvsp - 4].node(),
                                 );
                             }
-                            if ((lParse.Nodes)[yyvs[yyvsp - 4].Node as usize]).ntype
-                                > (lParse.Nodes[yyvs[yyvsp].Node as usize]).ntype
+                            if ((lParse.Nodes)[yyvs[yyvsp - 4].node() as usize]).ntype
+                                > (lParse.Nodes[yyvs[yyvsp].node() as usize]).ntype
                             {
                                 yyvs[yyvsp].Node = New_Unary(
                                     lParse,
-                                    ((lParse.Nodes)[yyvs[yyvsp - 4].Node as usize]).ntype,
+                                    ((lParse.Nodes)[yyvs[yyvsp - 4].node() as usize]).ntype,
                                     0,
-                                    yyvs[yyvsp].Node,
+                                    yyvs[yyvsp].node(),
                                 );
-                            } else if ((lParse.Nodes)[yyvs[yyvsp - 4].Node as usize]).ntype
-                                < (lParse.Nodes[yyvs[yyvsp].Node as usize]).ntype
+                            } else if ((lParse.Nodes)[yyvs[yyvsp - 4].node() as usize]).ntype
+                                < (lParse.Nodes[yyvs[yyvsp].node() as usize]).ntype
                             {
                                 yyvs[yyvsp - 4].Node = New_Unary(
                                     lParse,
-                                    (lParse.Nodes[yyvs[yyvsp].Node as usize]).ntype,
+                                    (lParse.Nodes[yyvs[yyvsp].node() as usize]).ntype,
                                     0,
-                                    yyvs[yyvsp - 4].Node,
+                                    yyvs[yyvsp - 4].node(),
                                 );
                             }
-                            if (lParse.Nodes[yyvs[yyvsp - 2].Node as usize]).ntype
-                                > (lParse.Nodes[yyvs[yyvsp].Node as usize]).ntype
+                            if (lParse.Nodes[yyvs[yyvsp - 2].node() as usize]).ntype
+                                > (lParse.Nodes[yyvs[yyvsp].node() as usize]).ntype
                             {
                                 yyvs[yyvsp].Node = New_Unary(
                                     lParse,
-                                    ((lParse.Nodes)[yyvs[yyvsp - 2].Node as usize]).ntype,
+                                    ((lParse.Nodes)[yyvs[yyvsp - 2].node() as usize]).ntype,
                                     0,
-                                    yyvs[yyvsp].Node,
+                                    yyvs[yyvsp].node(),
                                 );
-                            } else if ((lParse.Nodes)[yyvs[yyvsp - 2].Node as usize]).ntype
-                                < (lParse.Nodes[yyvs[yyvsp].Node as usize]).ntype
+                            } else if ((lParse.Nodes)[yyvs[yyvsp - 2].node() as usize]).ntype
+                                < (lParse.Nodes[yyvs[yyvsp].node() as usize]).ntype
                             {
                                 yyvs[yyvsp - 2].Node = New_Unary(
                                     lParse,
-                                    (lParse.Nodes[yyvs[yyvsp].Node as usize]).ntype,
+                                    (lParse.Nodes[yyvs[yyvsp].node() as usize]).ntype,
                                     0,
-                                    yyvs[yyvsp - 2].Node,
+                                    yyvs[yyvsp - 2].node(),
                                 );
                             }
                             yyvs[yyvsp - 2].Node = New_BinOp(
                                 lParse,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
-                                yyvs[yyvsp - 2].Node,
+                                yyvs[yyvsp - 2].node(),
                                 fits_parser_yytokentype::LTE as c_int,
-                                yyvs[yyvsp - 4].Node,
+                                yyvs[yyvsp - 4].node(),
                             );
                             yyvs[yyvsp].Node = New_BinOp(
                                 lParse,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
-                                yyvs[yyvsp - 4].Node,
+                                yyvs[yyvsp - 4].node(),
                                 fits_parser_yytokentype::LTE as c_int,
-                                yyvs[yyvsp].Node,
+                                yyvs[yyvsp].node(),
                             );
                             yyval.Node = New_BinOp(
                                 lParse,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
-                                yyvs[yyvsp - 2].Node,
+                                yyvs[yyvsp - 2].node(),
                                 fits_parser_yytokentype::AND as c_int,
-                                yyvs[yyvsp].Node,
+                                yyvs[yyvsp].node(),
                             );
-                            if yyval.Node < 0 {
+                            if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
                                 current_block = Block::ReduceDone;
@@ -4902,7 +4967,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         }
                         101 => {
                             /* bexpr: bexpr '?' bexpr ':' bexpr  */
-                            if Test_Dims(lParse, yyvs[yyvsp - 2].Node, yyvs[yyvsp].Node) == 0 {
+                            if Test_Dims(lParse, yyvs[yyvsp - 2].node(), yyvs[yyvsp].node()) == 0 {
                                 fits_parser_yyerror(
                                     lParse,
                                     cs!(c"Incompatible dimensions in '?:' arguments"),
@@ -4914,35 +4979,38 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     0,
                                     IFTHENELSE_FCT,
                                     3 as c_int,
-                                    yyvs[yyvsp - 2].Node,
-                                    yyvs[yyvsp].Node,
-                                    yyvs[yyvsp - 4].Node,
+                                    yyvs[yyvsp - 2].node(),
+                                    yyvs[yyvsp].node(),
+                                    yyvs[yyvsp - 4].node(),
                                     0,
                                     0,
                                     0,
                                     0,
                                 );
-                                if yyval.Node < 0 {
+                                if yyval.node() < 0 {
                                     current_block = Block::YyErrLab;
                                 } else {
-                                    if ((lParse.Nodes)[yyvs[yyvsp - 2].Node as usize]).value.nelem
-                                        < (lParse.Nodes[yyvs[yyvsp].Node as usize]).value.nelem
+                                    if ((lParse.Nodes)[yyvs[yyvsp - 2].node() as usize])
+                                        .value
+                                        .nelem
+                                        < (lParse.Nodes[yyvs[yyvsp].node() as usize]).value.nelem
                                     {
-                                        Copy_Dims(lParse, yyval.Node, yyvs[yyvsp].Node);
+                                        Copy_Dims(lParse, yyval.node(), yyvs[yyvsp].node());
                                     }
-                                    if Test_Dims(lParse, yyvs[yyvsp - 4].Node, yyval.Node) == 0 {
+                                    if Test_Dims(lParse, yyvs[yyvsp - 4].node(), yyval.node()) == 0
+                                    {
                                         fits_parser_yyerror(
                                             lParse,
                                             cs!(c"Incompatible dimensions in '?:' condition"),
                                         );
                                         current_block = Block::YyErrLab;
                                     } else {
-                                        if (((lParse.Nodes)[yyval.Node as usize]).value).nelem
-                                            < ((lParse.Nodes)[yyvs[yyvsp - 4].Node as usize])
+                                        if (((lParse.Nodes)[yyval.node() as usize]).value).nelem
+                                            < ((lParse.Nodes)[yyvs[yyvsp - 4].node() as usize])
                                                 .value
                                                 .nelem
                                         {
-                                            Copy_Dims(lParse, yyval.Node, yyvs[yyvsp - 4].Node);
+                                            Copy_Dims(lParse, yyval.node(), yyvs[yyvsp - 4].node());
                                         }
                                         current_block = Block::ReduceDone;
                                     }
@@ -4951,13 +5019,13 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         }
                         102 => {
                             /* bexpr: BFUNCTION expr ')'  */
-                            if astr_eq(&yyvs[yyvsp - 2].astr, c"ISNULL(") {
+                            if astr_eq(yyvs[yyvsp - 2].astr(), c"ISNULL(") {
                                 yyval.Node = New_Func(
                                     lParse,
                                     0,
                                     ISNULL_FCT,
                                     1,
-                                    yyvs[yyvsp - 1].Node,
+                                    yyvs[yyvsp - 1].node(),
                                     0,
                                     0,
                                     0,
@@ -4965,10 +5033,10 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     0,
                                     0,
                                 );
-                                if yyval.Node < 0 {
+                                if yyval.node() < 0 {
                                     current_block = Block::YyErrLab;
                                 } else {
-                                    ((lParse.Nodes)[yyval.Node as usize]).ntype =
+                                    ((lParse.Nodes)[yyval.node() as usize]).ntype =
                                         fits_parser_yytokentype::BOOLEAN as c_int;
                                     current_block = Block::ReduceDone;
                                 }
@@ -4982,13 +5050,13 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         }
                         103 => {
                             /* bexpr: BFUNCTION bexpr ')'  */
-                            if astr_eq(&yyvs[yyvsp - 2].astr, c"ISNULL(") {
+                            if astr_eq(yyvs[yyvsp - 2].astr(), c"ISNULL(") {
                                 yyval.Node = New_Func(
                                     lParse,
                                     0,
                                     ISNULL_FCT,
                                     1,
-                                    yyvs[yyvsp - 1].Node,
+                                    yyvs[yyvsp - 1].node(),
                                     0,
                                     0,
                                     0,
@@ -4996,10 +5064,10 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     0,
                                     0,
                                 );
-                                if yyval.Node < 0 {
+                                if yyval.node() < 0 {
                                     current_block = Block::YyErrLab;
                                 } else {
-                                    ((lParse.Nodes)[yyval.Node as usize]).ntype =
+                                    ((lParse.Nodes)[yyval.node() as usize]).ntype =
                                         fits_parser_yytokentype::BOOLEAN as c_int;
                                     current_block = Block::ReduceDone;
                                 }
@@ -5013,13 +5081,13 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         }
                         104 => {
                             /* bexpr: BFUNCTION sexpr ')'  */
-                            if astr_eq(&yyvs[yyvsp - 2].astr, c"ISNULL(") {
+                            if astr_eq(yyvs[yyvsp - 2].astr(), c"ISNULL(") {
                                 yyval.Node = New_Func(
                                     lParse,
                                     fits_parser_yytokentype::BOOLEAN as c_int,
                                     ISNULL_FCT,
                                     1,
-                                    yyvs[yyvsp - 1].Node,
+                                    yyvs[yyvsp - 1].node(),
                                     0,
                                     0,
                                     0,
@@ -5027,7 +5095,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     0,
                                     0,
                                 );
-                                if yyval.Node < 0 {
+                                if yyval.node() < 0 {
                                     current_block = Block::YyErrLab;
                                 } else {
                                     current_block = Block::ReduceDone;
@@ -5042,26 +5110,33 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         }
                         105 => {
                             /* bexpr: FUNCTION bexpr ',' bexpr ')'  */
-                            if astr_eq(&yyvs[yyvsp - 4].astr, c"DEFNULL(") {
-                                if ((lParse.Nodes)[yyvs[yyvsp - 3].Node as usize]).value.nelem
-                                    >= ((lParse.Nodes)[yyvs[yyvsp - 1].Node as usize]).value.nelem
-                                    && Test_Dims(lParse, yyvs[yyvsp - 3].Node, yyvs[yyvsp - 1].Node)
-                                        != 0
+                            if astr_eq(yyvs[yyvsp - 4].astr(), c"DEFNULL(") {
+                                if ((lParse.Nodes)[yyvs[yyvsp - 3].node() as usize])
+                                    .value
+                                    .nelem
+                                    >= ((lParse.Nodes)[yyvs[yyvsp - 1].node() as usize])
+                                        .value
+                                        .nelem
+                                    && Test_Dims(
+                                        lParse,
+                                        yyvs[yyvsp - 3].node(),
+                                        yyvs[yyvsp - 1].node(),
+                                    ) != 0
                                 {
                                     yyval.Node = New_Func(
                                         lParse,
                                         0,
                                         DEFNULL_FCT,
                                         2,
-                                        yyvs[yyvsp - 3].Node,
-                                        yyvs[yyvsp - 1].Node,
+                                        yyvs[yyvsp - 3].node(),
+                                        yyvs[yyvsp - 1].node(),
                                         0,
                                         0,
                                         0,
                                         0,
                                         0,
                                     );
-                                    if yyval.Node < 0 {
+                                    if yyval.node() < 0 {
                                         current_block = Block::YyErrLab;
                                     } else {
                                         current_block = Block::ReduceDone;
@@ -5083,82 +5158,90 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         }
                         106 => {
                             /* bexpr: BFUNCTION expr ',' expr ',' expr ')'  */
-                            if ((lParse.Nodes)[yyvs[yyvsp - 5].Node as usize]).ntype
+                            if ((lParse.Nodes)[yyvs[yyvsp - 5].node() as usize]).ntype
                                 != fits_parser_yytokentype::DOUBLE as c_int
                             {
                                 yyvs[yyvsp - 5].Node = New_Unary(
                                     lParse,
                                     fits_parser_yytokentype::DOUBLE as c_int,
                                     0,
-                                    yyvs[yyvsp - 5].Node,
+                                    yyvs[yyvsp - 5].node(),
                                 );
                             }
-                            if ((lParse.Nodes)[yyvs[yyvsp - 3].Node as usize]).ntype
+                            if ((lParse.Nodes)[yyvs[yyvsp - 3].node() as usize]).ntype
                                 != fits_parser_yytokentype::DOUBLE as c_int
                             {
                                 yyvs[yyvsp - 3].Node = New_Unary(
                                     lParse,
                                     fits_parser_yytokentype::DOUBLE as c_int,
                                     0,
-                                    yyvs[yyvsp - 3].Node,
+                                    yyvs[yyvsp - 3].node(),
                                 );
                             }
-                            if ((lParse.Nodes)[yyvs[yyvsp - 1].Node as usize]).ntype
+                            if ((lParse.Nodes)[yyvs[yyvsp - 1].node() as usize]).ntype
                                 != fits_parser_yytokentype::DOUBLE as c_int
                             {
                                 yyvs[yyvsp - 1].Node = New_Unary(
                                     lParse,
                                     fits_parser_yytokentype::DOUBLE as c_int,
                                     0,
-                                    yyvs[yyvsp - 1].Node,
+                                    yyvs[yyvsp - 1].node(),
                                 );
                             }
-                            if !(Test_Dims(lParse, yyvs[yyvsp - 5].Node, yyvs[yyvsp - 3].Node) != 0
-                                && Test_Dims(lParse, yyvs[yyvsp - 3].Node, yyvs[yyvsp - 1].Node)
-                                    != 0)
+                            if !(Test_Dims(lParse, yyvs[yyvsp - 5].node(), yyvs[yyvsp - 3].node())
+                                != 0
+                                && Test_Dims(
+                                    lParse,
+                                    yyvs[yyvsp - 3].node(),
+                                    yyvs[yyvsp - 1].node(),
+                                ) != 0)
                             {
                                 fits_parser_yyerror(
                                     lParse,
                                     cs!(c"Dimensions of NEAR arguments are not compatible"),
                                 );
                                 current_block = Block::YyErrLab;
-                            } else if astr_eq(&yyvs[yyvsp - 6].astr, c"NEAR(") {
+                            } else if astr_eq(yyvs[yyvsp - 6].astr(), c"NEAR(") {
                                 yyval.Node = New_Func(
                                     lParse,
                                     fits_parser_yytokentype::BOOLEAN as c_int,
                                     NEAR_FCT,
                                     3 as c_int,
-                                    yyvs[yyvsp - 5].Node,
-                                    yyvs[yyvsp - 3].Node,
-                                    yyvs[yyvsp - 1].Node,
+                                    yyvs[yyvsp - 5].node(),
+                                    yyvs[yyvsp - 3].node(),
+                                    yyvs[yyvsp - 1].node(),
                                     0,
                                     0,
                                     0,
                                     0,
                                 );
-                                if yyval.Node < 0 {
+                                if yyval.node() < 0 {
                                     current_block = Block::YyErrLab;
                                 } else {
-                                    if (((lParse.Nodes)[yyval.Node as usize]).value).nelem
-                                        < ((lParse.Nodes)[yyvs[yyvsp - 5].Node as usize])
+                                    if (((lParse.Nodes)[yyval.node() as usize]).value).nelem
+                                        < ((lParse.Nodes)[yyvs[yyvsp - 5].node() as usize])
                                             .value
                                             .nelem
                                     {
-                                        Copy_Dims(lParse, yyval.Node, yyvs[yyvsp - 5].Node);
+                                        Copy_Dims(lParse, yyval.node(), yyvs[yyvsp - 5].node());
                                     }
-                                    if ((lParse.Nodes)[yyvs[yyvsp - 5].Node as usize]).value.nelem
-                                        < ((lParse.Nodes)[yyvs[yyvsp - 3].Node as usize])
+                                    if ((lParse.Nodes)[yyvs[yyvsp - 5].node() as usize])
+                                        .value
+                                        .nelem
+                                        < ((lParse.Nodes)[yyvs[yyvsp - 3].node() as usize])
                                             .value
                                             .nelem
                                     {
-                                        Copy_Dims(lParse, yyval.Node, yyvs[yyvsp - 3].Node);
+                                        Copy_Dims(lParse, yyval.node(), yyvs[yyvsp - 3].node());
                                     }
-                                    if ((lParse.Nodes)[yyvs[yyvsp - 3].Node as usize]).value.nelem
-                                        < ((lParse.Nodes)[yyvs[yyvsp - 1].Node as usize])
+                                    if ((lParse.Nodes)[yyvs[yyvsp - 3].node() as usize])
+                                        .value
+                                        .nelem
+                                        < ((lParse.Nodes)[yyvs[yyvsp - 1].node() as usize])
                                             .value
                                             .nelem
                                     {
-                                        Copy_Dims(lParse, yyval.Node, yyvs[yyvsp - 1].Node);
+                                        Copy_Dims(lParse, yyval.node(), yyvs[yyvsp - 1].node());
                                     }
                                     current_block = Block::ReduceDone;
                                 }
@@ -5169,120 +5252,138 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         }
                         107 => {
                             /* bexpr: BFUNCTION expr ',' expr ',' expr ',' expr ',' expr ')'  */
-                            if ((lParse.Nodes)[yyvs[yyvsp - 9].Node as usize]).ntype
+                            if ((lParse.Nodes)[yyvs[yyvsp - 9].node() as usize]).ntype
                                 != fits_parser_yytokentype::DOUBLE as c_int
                             {
                                 yyvs[yyvsp - 9].Node = New_Unary(
                                     lParse,
                                     fits_parser_yytokentype::DOUBLE as c_int,
                                     0,
-                                    yyvs[yyvsp - 9].Node,
+                                    yyvs[yyvsp - 9].node(),
                                 );
                             }
-                            if ((lParse.Nodes)[yyvs[yyvsp - 7].Node as usize]).ntype
+                            if ((lParse.Nodes)[yyvs[yyvsp - 7].node() as usize]).ntype
                                 != fits_parser_yytokentype::DOUBLE as c_int
                             {
                                 yyvs[yyvsp - 7].Node = New_Unary(
                                     lParse,
                                     fits_parser_yytokentype::DOUBLE as c_int,
                                     0,
-                                    yyvs[yyvsp - 7].Node,
+                                    yyvs[yyvsp - 7].node(),
                                 );
                             }
-                            if ((lParse.Nodes)[yyvs[yyvsp - 5].Node as usize]).ntype
+                            if ((lParse.Nodes)[yyvs[yyvsp - 5].node() as usize]).ntype
                                 != fits_parser_yytokentype::DOUBLE as c_int
                             {
                                 yyvs[yyvsp - 5].Node = New_Unary(
                                     lParse,
                                     fits_parser_yytokentype::DOUBLE as c_int,
                                     0,
-                                    yyvs[yyvsp - 5].Node,
+                                    yyvs[yyvsp - 5].node(),
                                 );
                             }
-                            if ((lParse.Nodes)[yyvs[yyvsp - 3].Node as usize]).ntype
+                            if ((lParse.Nodes)[yyvs[yyvsp - 3].node() as usize]).ntype
                                 != fits_parser_yytokentype::DOUBLE as c_int
                             {
                                 yyvs[yyvsp - 3].Node = New_Unary(
                                     lParse,
                                     fits_parser_yytokentype::DOUBLE as c_int,
                                     0,
-                                    yyvs[yyvsp - 3].Node,
+                                    yyvs[yyvsp - 3].node(),
                                 );
                             }
-                            if ((lParse.Nodes)[yyvs[yyvsp - 1].Node as usize]).ntype
+                            if ((lParse.Nodes)[yyvs[yyvsp - 1].node() as usize]).ntype
                                 != fits_parser_yytokentype::DOUBLE as c_int
                             {
                                 yyvs[yyvsp - 1].Node = New_Unary(
                                     lParse,
                                     fits_parser_yytokentype::DOUBLE as c_int,
                                     0,
-                                    yyvs[yyvsp - 1].Node,
+                                    yyvs[yyvsp - 1].node(),
                                 );
                             }
-                            if !(Test_Dims(lParse, yyvs[yyvsp - 9].Node, yyvs[yyvsp - 7].Node) != 0
-                                && Test_Dims(lParse, yyvs[yyvsp - 7].Node, yyvs[yyvsp - 5].Node)
-                                    != 0
-                                && Test_Dims(lParse, yyvs[yyvsp - 5].Node, yyvs[yyvsp - 3].Node)
-                                    != 0
-                                && Test_Dims(lParse, yyvs[yyvsp - 3].Node, yyvs[yyvsp - 1].Node)
-                                    != 0)
+                            if !(Test_Dims(lParse, yyvs[yyvsp - 9].node(), yyvs[yyvsp - 7].node())
+                                != 0
+                                && Test_Dims(
+                                    lParse,
+                                    yyvs[yyvsp - 7].node(),
+                                    yyvs[yyvsp - 5].node(),
+                                ) != 0
+                                && Test_Dims(
+                                    lParse,
+                                    yyvs[yyvsp - 5].node(),
+                                    yyvs[yyvsp - 3].node(),
+                                ) != 0
+                                && Test_Dims(
+                                    lParse,
+                                    yyvs[yyvsp - 3].node(),
+                                    yyvs[yyvsp - 1].node(),
+                                ) != 0)
                             {
                                 fits_parser_yyerror(
                                     lParse,
                                     cs!(c"Dimensions of CIRCLE arguments are not compatible"),
                                 );
                                 current_block = Block::YyErrLab;
-                            } else if astr_eq(&yyvs[yyvsp - 10].astr, c"CIRCLE(") {
+                            } else if astr_eq(yyvs[yyvsp - 10].astr(), c"CIRCLE(") {
                                 yyval.Node = New_Func(
                                     lParse,
                                     fits_parser_yytokentype::BOOLEAN as c_int,
                                     CIRCLE_FCT,
                                     5 as c_int,
-                                    yyvs[yyvsp - 9].Node,
-                                    yyvs[yyvsp - 7].Node,
-                                    yyvs[yyvsp - 5].Node,
-                                    yyvs[yyvsp - 3].Node,
-                                    yyvs[yyvsp - 1].Node,
+                                    yyvs[yyvsp - 9].node(),
+                                    yyvs[yyvsp - 7].node(),
+                                    yyvs[yyvsp - 5].node(),
+                                    yyvs[yyvsp - 3].node(),
+                                    yyvs[yyvsp - 1].node(),
                                     0,
                                     0,
                                 );
-                                if yyval.Node < 0 {
+                                if yyval.node() < 0 {
                                     current_block = Block::YyErrLab;
                                 } else {
-                                    if (((lParse.Nodes)[yyval.Node as usize]).value).nelem
-                                        < ((lParse.Nodes)[yyvs[yyvsp - 9].Node as usize])
+                                    if (((lParse.Nodes)[yyval.node() as usize]).value).nelem
+                                        < ((lParse.Nodes)[yyvs[yyvsp - 9].node() as usize])
                                             .value
                                             .nelem
                                     {
-                                        Copy_Dims(lParse, yyval.Node, yyvs[yyvsp - 9].Node);
+                                        Copy_Dims(lParse, yyval.node(), yyvs[yyvsp - 9].node());
                                     }
-                                    if ((lParse.Nodes)[yyvs[yyvsp - 9].Node as usize]).value.nelem
-                                        < ((lParse.Nodes)[yyvs[yyvsp - 7].Node as usize])
+                                    if ((lParse.Nodes)[yyvs[yyvsp - 9].node() as usize])
+                                        .value
+                                        .nelem
+                                        < ((lParse.Nodes)[yyvs[yyvsp - 7].node() as usize])
                                             .value
                                             .nelem
                                     {
-                                        Copy_Dims(lParse, yyval.Node, yyvs[yyvsp - 7].Node);
+                                        Copy_Dims(lParse, yyval.node(), yyvs[yyvsp - 7].node());
                                     }
-                                    if ((lParse.Nodes)[yyvs[yyvsp - 7].Node as usize]).value.nelem
-                                        < ((lParse.Nodes)[yyvs[yyvsp - 5].Node as usize])
+                                    if ((lParse.Nodes)[yyvs[yyvsp - 7].node() as usize])
+                                        .value
+                                        .nelem
+                                        < ((lParse.Nodes)[yyvs[yyvsp - 5].node() as usize])
                                             .value
                                             .nelem
                                     {
-                                        Copy_Dims(lParse, yyval.Node, yyvs[yyvsp - 5].Node);
+                                        Copy_Dims(lParse, yyval.node(), yyvs[yyvsp - 5].node());
                                     }
-                                    if ((lParse.Nodes)[yyvs[yyvsp - 5].Node as usize]).value.nelem
-                                        < ((lParse.Nodes)[yyvs[yyvsp - 3].Node as usize])
+                                    if ((lParse.Nodes)[yyvs[yyvsp - 5].node() as usize])
+                                        .value
+                                        .nelem
+                                        < ((lParse.Nodes)[yyvs[yyvsp - 3].node() as usize])
                                             .value
                                             .nelem
                                     {
-                                        Copy_Dims(lParse, yyval.Node, yyvs[yyvsp - 3].Node);
+                                        Copy_Dims(lParse, yyval.node(), yyvs[yyvsp - 3].node());
                                     }
-                                    if ((lParse.Nodes)[yyvs[yyvsp - 3].Node as usize]).value.nelem
-                                        < ((lParse.Nodes)[yyvs[yyvsp - 1].Node as usize])
+                                    if ((lParse.Nodes)[yyvs[yyvsp - 3].node() as usize])
+                                        .value
+                                        .nelem
+                                        < ((lParse.Nodes)[yyvs[yyvsp - 1].node() as usize])
                                             .value
                                             .nelem
                                     {
-                                        Copy_Dims(lParse, yyval.Node, yyvs[yyvsp - 1].Node);
+                                        Copy_Dims(lParse, yyval.node(), yyvs[yyvsp - 1].node());
                                     }
                                     current_block = Block::ReduceDone;
                                 }
@@ -5293,120 +5394,138 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         }
                         108 => {
                             /* bexpr: BFUNCTION expr ',' expr ',' expr ',' expr ',' expr ',' expr ',' expr ')'  */
-                            if ((lParse.Nodes)[yyvs[yyvsp - 13].Node as usize]).ntype
+                            if ((lParse.Nodes)[yyvs[yyvsp - 13].node() as usize]).ntype
                                 != fits_parser_yytokentype::DOUBLE as c_int
                             {
                                 yyvs[yyvsp - 13].Node = New_Unary(
                                     lParse,
                                     fits_parser_yytokentype::DOUBLE as c_int,
                                     0,
-                                    yyvs[yyvsp - 13].Node,
+                                    yyvs[yyvsp - 13].node(),
                                 );
                             }
-                            if ((lParse.Nodes)[yyvs[yyvsp - 11].Node as usize]).ntype
+                            if ((lParse.Nodes)[yyvs[yyvsp - 11].node() as usize]).ntype
                                 != fits_parser_yytokentype::DOUBLE as c_int
                             {
                                 yyvs[yyvsp - 11].Node = New_Unary(
                                     lParse,
                                     fits_parser_yytokentype::DOUBLE as c_int,
                                     0,
-                                    yyvs[yyvsp - 11].Node,
+                                    yyvs[yyvsp - 11].node(),
                                 );
                             }
-                            if ((lParse.Nodes)[yyvs[yyvsp - 9].Node as usize]).ntype
+                            if ((lParse.Nodes)[yyvs[yyvsp - 9].node() as usize]).ntype
                                 != fits_parser_yytokentype::DOUBLE as c_int
                             {
                                 yyvs[yyvsp - 9].Node = New_Unary(
                                     lParse,
                                     fits_parser_yytokentype::DOUBLE as c_int,
                                     0,
-                                    yyvs[yyvsp - 9].Node,
+                                    yyvs[yyvsp - 9].node(),
                                 );
                             }
-                            if ((lParse.Nodes)[yyvs[yyvsp - 7].Node as usize]).ntype
+                            if ((lParse.Nodes)[yyvs[yyvsp - 7].node() as usize]).ntype
                                 != fits_parser_yytokentype::DOUBLE as c_int
                             {
                                 yyvs[yyvsp - 7].Node = New_Unary(
                                     lParse,
                                     fits_parser_yytokentype::DOUBLE as c_int,
                                     0,
-                                    yyvs[yyvsp - 7].Node,
+                                    yyvs[yyvsp - 7].node(),
                                 );
                             }
-                            if ((lParse.Nodes)[yyvs[yyvsp - 5].Node as usize]).ntype
+                            if ((lParse.Nodes)[yyvs[yyvsp - 5].node() as usize]).ntype
                                 != fits_parser_yytokentype::DOUBLE as c_int
                             {
                                 yyvs[yyvsp - 5].Node = New_Unary(
                                     lParse,
                                     fits_parser_yytokentype::DOUBLE as c_int,
                                     0,
-                                    yyvs[yyvsp - 5].Node,
+                                    yyvs[yyvsp - 5].node(),
                                 );
                             }
-                            if ((lParse.Nodes)[yyvs[yyvsp - 3].Node as usize]).ntype
+                            if ((lParse.Nodes)[yyvs[yyvsp - 3].node() as usize]).ntype
                                 != fits_parser_yytokentype::DOUBLE as c_int
                             {
                                 yyvs[yyvsp - 3].Node = New_Unary(
                                     lParse,
                                     fits_parser_yytokentype::DOUBLE as c_int,
                                     0,
-                                    yyvs[yyvsp - 3].Node,
+                                    yyvs[yyvsp - 3].node(),
                                 );
                             }
-                            if ((lParse.Nodes)[yyvs[yyvsp - 1].Node as usize]).ntype
+                            if ((lParse.Nodes)[yyvs[yyvsp - 1].node() as usize]).ntype
                                 != fits_parser_yytokentype::DOUBLE as c_int
                             {
                                 yyvs[yyvsp - 1].Node = New_Unary(
                                     lParse,
                                     fits_parser_yytokentype::DOUBLE as c_int,
                                     0,
-                                    yyvs[yyvsp - 1].Node,
+                                    yyvs[yyvsp - 1].node(),
                                 );
                             }
-                            if !(Test_Dims(lParse, yyvs[yyvsp - 13].Node, yyvs[yyvsp - 11].Node)
-                                != 0
-                                && Test_Dims(lParse, yyvs[yyvsp - 11].Node, yyvs[yyvsp - 9].Node)
-                                    != 0
-                                && Test_Dims(lParse, yyvs[yyvsp - 9].Node, yyvs[yyvsp - 7].Node)
-                                    != 0
-                                && Test_Dims(lParse, yyvs[yyvsp - 7].Node, yyvs[yyvsp - 5].Node)
-                                    != 0
-                                && Test_Dims(lParse, yyvs[yyvsp - 5].Node, yyvs[yyvsp - 3].Node)
-                                    != 0
-                                && Test_Dims(lParse, yyvs[yyvsp - 3].Node, yyvs[yyvsp - 1].Node)
-                                    != 0)
+                            if !(Test_Dims(
+                                lParse,
+                                yyvs[yyvsp - 13].node(),
+                                yyvs[yyvsp - 11].node(),
+                            ) != 0
+                                && Test_Dims(
+                                    lParse,
+                                    yyvs[yyvsp - 11].node(),
+                                    yyvs[yyvsp - 9].node(),
+                                ) != 0
+                                && Test_Dims(
+                                    lParse,
+                                    yyvs[yyvsp - 9].node(),
+                                    yyvs[yyvsp - 7].node(),
+                                ) != 0
+                                && Test_Dims(
+                                    lParse,
+                                    yyvs[yyvsp - 7].node(),
+                                    yyvs[yyvsp - 5].node(),
+                                ) != 0
+                                && Test_Dims(
+                                    lParse,
+                                    yyvs[yyvsp - 5].node(),
+                                    yyvs[yyvsp - 3].node(),
+                                ) != 0
+                                && Test_Dims(
+                                    lParse,
+                                    yyvs[yyvsp - 3].node(),
+                                    yyvs[yyvsp - 1].node(),
+                                ) != 0)
                             {
                                 fits_parser_yyerror(lParse, cs!(c"Dimensions of BOX or ELLIPSE arguments are not compatible"));
                                 current_block = Block::YyErrLab;
                             } else {
-                                if astr_eq(&yyvs[yyvsp - 14].astr, c"BOX(") {
+                                if astr_eq(yyvs[yyvsp - 14].astr(), c"BOX(") {
                                     yyval.Node = New_Func(
                                         lParse,
                                         fits_parser_yytokentype::BOOLEAN as c_int,
                                         BOX_FCT,
                                         7 as c_int,
-                                        yyvs[yyvsp - 13].Node,
-                                        yyvs[yyvsp - 11].Node,
-                                        yyvs[yyvsp - 9].Node,
-                                        yyvs[yyvsp - 7].Node,
-                                        yyvs[yyvsp - 5].Node,
-                                        yyvs[yyvsp - 3].Node,
-                                        yyvs[yyvsp - 1].Node,
+                                        yyvs[yyvsp - 13].node(),
+                                        yyvs[yyvsp - 11].node(),
+                                        yyvs[yyvsp - 9].node(),
+                                        yyvs[yyvsp - 7].node(),
+                                        yyvs[yyvsp - 5].node(),
+                                        yyvs[yyvsp - 3].node(),
+                                        yyvs[yyvsp - 1].node(),
                                     );
                                     current_block = Block::ReduceJoin12;
-                                } else if astr_eq(&yyvs[yyvsp - 14].astr, c"ELLIPSE(") {
+                                } else if astr_eq(yyvs[yyvsp - 14].astr(), c"ELLIPSE(") {
                                     yyval.Node = New_Func(
                                         lParse,
                                         fits_parser_yytokentype::BOOLEAN as c_int,
                                         ELPS_FCT,
                                         7 as c_int,
-                                        yyvs[yyvsp - 13].Node,
-                                        yyvs[yyvsp - 11].Node,
-                                        yyvs[yyvsp - 9].Node,
-                                        yyvs[yyvsp - 7].Node,
-                                        yyvs[yyvsp - 5].Node,
-                                        yyvs[yyvsp - 3].Node,
-                                        yyvs[yyvsp - 1].Node,
+                                        yyvs[yyvsp - 13].node(),
+                                        yyvs[yyvsp - 11].node(),
+                                        yyvs[yyvsp - 9].node(),
+                                        yyvs[yyvsp - 7].node(),
+                                        yyvs[yyvsp - 5].node(),
+                                        yyvs[yyvsp - 3].node(),
+                                        yyvs[yyvsp - 1].node(),
                                     );
                                     current_block = Block::ReduceJoin12;
                                 } else {
@@ -5419,77 +5538,97 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 match current_block {
                                     Block::YyErrLab => {}
                                     _ => {
-                                        if yyval.Node < 0 {
+                                        if yyval.node() < 0 {
                                             current_block = Block::YyErrLab;
                                         } else {
-                                            if (((lParse.Nodes)[yyval.Node as usize]).value).nelem
-                                                < ((lParse.Nodes)[yyvs[yyvsp - 13].Node as usize])
+                                            if (((lParse.Nodes)[yyval.node() as usize]).value).nelem
+                                                < ((lParse.Nodes)[yyvs[yyvsp - 13].node() as usize])
                                                     .value
                                                     .nelem
                                             {
                                                 Copy_Dims(
                                                     lParse,
-                                                    yyval.Node,
-                                                    yyvs[yyvsp - 13].Node,
+                                                    yyval.node(),
+                                                    yyvs[yyvsp - 13].node(),
                                                 );
                                             }
-                                            if ((lParse.Nodes)[yyvs[yyvsp - 13].Node as usize])
+                                            if ((lParse.Nodes)[yyvs[yyvsp - 13].node() as usize])
                                                 .value
                                                 .nelem
-                                                < ((lParse.Nodes)[yyvs[yyvsp - 11].Node as usize])
+                                                < ((lParse.Nodes)[yyvs[yyvsp - 11].node() as usize])
                                                     .value
                                                     .nelem
                                             {
                                                 Copy_Dims(
                                                     lParse,
-                                                    yyval.Node,
-                                                    yyvs[yyvsp - 11].Node,
+                                                    yyval.node(),
+                                                    yyvs[yyvsp - 11].node(),
                                                 );
                                             }
-                                            if ((lParse.Nodes)[yyvs[yyvsp - 11].Node as usize])
+                                            if ((lParse.Nodes)[yyvs[yyvsp - 11].node() as usize])
                                                 .value
                                                 .nelem
-                                                < ((lParse.Nodes)[yyvs[yyvsp - 9].Node as usize])
+                                                < ((lParse.Nodes)[yyvs[yyvsp - 9].node() as usize])
                                                     .value
                                                     .nelem
                                             {
-                                                Copy_Dims(lParse, yyval.Node, yyvs[yyvsp - 9].Node);
+                                                Copy_Dims(
+                                                    lParse,
+                                                    yyval.node(),
+                                                    yyvs[yyvsp - 9].node(),
+                                                );
                                             }
-                                            if ((lParse.Nodes)[yyvs[yyvsp - 9].Node as usize])
+                                            if ((lParse.Nodes)[yyvs[yyvsp - 9].node() as usize])
                                                 .value
                                                 .nelem
-                                                < ((lParse.Nodes)[yyvs[yyvsp - 7].Node as usize])
+                                                < ((lParse.Nodes)[yyvs[yyvsp - 7].node() as usize])
                                                     .value
                                                     .nelem
                                             {
-                                                Copy_Dims(lParse, yyval.Node, yyvs[yyvsp - 7].Node);
+                                                Copy_Dims(
+                                                    lParse,
+                                                    yyval.node(),
+                                                    yyvs[yyvsp - 7].node(),
+                                                );
                                             }
-                                            if ((lParse.Nodes)[yyvs[yyvsp - 7].Node as usize])
+                                            if ((lParse.Nodes)[yyvs[yyvsp - 7].node() as usize])
                                                 .value
                                                 .nelem
-                                                < ((lParse.Nodes)[yyvs[yyvsp - 5].Node as usize])
+                                                < ((lParse.Nodes)[yyvs[yyvsp - 5].node() as usize])
                                                     .value
                                                     .nelem
                                             {
-                                                Copy_Dims(lParse, yyval.Node, yyvs[yyvsp - 5].Node);
+                                                Copy_Dims(
+                                                    lParse,
+                                                    yyval.node(),
+                                                    yyvs[yyvsp - 5].node(),
+                                                );
                                             }
-                                            if ((lParse.Nodes)[yyvs[yyvsp - 5].Node as usize])
+                                            if ((lParse.Nodes)[yyvs[yyvsp - 5].node() as usize])
                                                 .value
                                                 .nelem
-                                                < ((lParse.Nodes)[yyvs[yyvsp - 3].Node as usize])
+                                                < ((lParse.Nodes)[yyvs[yyvsp - 3].node() as usize])
                                                     .value
                                                     .nelem
                                             {
-                                                Copy_Dims(lParse, yyval.Node, yyvs[yyvsp - 3].Node);
+                                                Copy_Dims(
+                                                    lParse,
+                                                    yyval.node(),
+                                                    yyvs[yyvsp - 3].node(),
+                                                );
                                             }
-                                            if ((lParse.Nodes)[yyvs[yyvsp - 3].Node as usize])
+                                            if ((lParse.Nodes)[yyvs[yyvsp - 3].node() as usize])
                                                 .value
                                                 .nelem
-                                                < ((lParse.Nodes)[yyvs[yyvsp - 1].Node as usize])
+                                                < ((lParse.Nodes)[yyvs[yyvsp - 1].node() as usize])
                                                     .value
                                                     .nelem
                                             {
-                                                Copy_Dims(lParse, yyval.Node, yyvs[yyvsp - 1].Node);
+                                                Copy_Dims(
+                                                    lParse,
+                                                    yyval.node(),
+                                                    yyvs[yyvsp - 1].node(),
+                                                );
                                             }
                                             current_block = Block::ReduceDone;
                                         }
@@ -5509,7 +5648,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 c"*START*".as_ptr() as *mut c_char,
                                 c"*STOP*".as_ptr() as *mut c_char,
                             );
-                            if yyval.Node < 0 {
+                            if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
                                 current_block = Block::ReduceDone;
@@ -5521,13 +5660,13 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             yyval.Node = New_GTI(
                                 lParse,
                                 GTIFILT_FCT,
-                                (yyvs[yyvsp - 1].astr).as_mut_ptr(),
+                                (yyvs[yyvsp - 1].astr_mut()).as_mut_ptr(),
                                 -99,
                                 -99,
                                 c"*START*".as_ptr() as *mut c_char,
                                 c"*STOP*".as_ptr() as *mut c_char,
                             );
-                            if yyval.Node < 0 {
+                            if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
                                 current_block = Block::ReduceDone;
@@ -5538,13 +5677,13 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             yyval.Node = New_GTI(
                                 lParse,
                                 GTIFILT_FCT,
-                                (yyvs[yyvsp - 3].astr).as_mut_ptr(),
-                                yyvs[yyvsp - 1].Node,
+                                (yyvs[yyvsp - 3].astr_mut()).as_mut_ptr(),
+                                yyvs[yyvsp - 1].node(),
                                 -99,
                                 c"*START*".as_ptr() as *mut c_char,
                                 c"*STOP*".as_ptr() as *mut c_char,
                             );
-                            if yyval.Node < 0 {
+                            if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
                                 current_block = Block::ReduceDone;
@@ -5555,13 +5694,13 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             yyval.Node = New_GTI(
                                 lParse,
                                 GTIFILT_FCT,
-                                (yyvs[yyvsp - 7].astr).as_mut_ptr(),
-                                yyvs[yyvsp - 5].Node,
+                                (yyvs[yyvsp - 7].astr_mut()).as_mut_ptr(),
+                                yyvs[yyvsp - 5].node(),
                                 -99,
-                                (yyvs[yyvsp - 3].astr).as_mut_ptr(),
-                                (yyvs[yyvsp - 1].astr).as_mut_ptr(),
+                                (yyvs[yyvsp - 3].astr_mut()).as_mut_ptr(),
+                                (yyvs[yyvsp - 1].astr_mut()).as_mut_ptr(),
                             );
-                            if yyval.Node < 0 {
+                            if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
                                 current_block = Block::ReduceDone;
@@ -5579,7 +5718,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 c"*START*".as_ptr() as *mut c_char,
                                 c"*STOP*".as_ptr() as *mut c_char,
                             );
-                            if yyval.Node < 0 {
+                            if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
                                 current_block = Block::ReduceDone;
@@ -5590,13 +5729,13 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             yyval.Node = New_GTI(
                                 lParse,
                                 GTIFIND_FCT,
-                                (yyvs[yyvsp - 1].astr).as_mut_ptr(),
+                                (yyvs[yyvsp - 1].astr_mut()).as_mut_ptr(),
                                 -99,
                                 -99,
                                 c"*START*".as_ptr() as *mut c_char,
                                 c"*STOP*".as_ptr() as *mut c_char,
                             );
-                            if yyval.Node < 0 {
+                            if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
                                 current_block = Block::ReduceDone;
@@ -5607,13 +5746,13 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             yyval.Node = New_GTI(
                                 lParse,
                                 GTIFIND_FCT,
-                                (yyvs[yyvsp - 3].astr).as_mut_ptr(),
-                                yyvs[yyvsp - 1].Node,
+                                (yyvs[yyvsp - 3].astr_mut()).as_mut_ptr(),
+                                yyvs[yyvsp - 1].node(),
                                 -99,
                                 c"*START*".as_ptr() as *mut c_char,
                                 c"*STOP*".as_ptr() as *mut c_char,
                             );
-                            if yyval.Node < 0 {
+                            if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
                                 current_block = Block::ReduceDone;
@@ -5624,13 +5763,13 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             yyval.Node = New_GTI(
                                 lParse,
                                 GTIFIND_FCT,
-                                (yyvs[yyvsp - 7].astr).as_mut_ptr(),
-                                yyvs[yyvsp - 5].Node,
+                                (yyvs[yyvsp - 7].astr_mut()).as_mut_ptr(),
+                                yyvs[yyvsp - 5].node(),
                                 -99,
-                                (yyvs[yyvsp - 3].astr).as_mut_ptr(),
-                                (yyvs[yyvsp - 1].astr).as_mut_ptr(),
+                                (yyvs[yyvsp - 3].astr_mut()).as_mut_ptr(),
+                                (yyvs[yyvsp - 1].astr_mut()).as_mut_ptr(),
                             );
-                            if yyval.Node < 0 {
+                            if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
                                 current_block = Block::ReduceDone;
@@ -5641,12 +5780,12 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             let mut dummy = [0];
                             yyval.Node = New_REG(
                                 lParse,
-                                (yyvs[yyvsp - 1].astr).as_mut_ptr(),
+                                (yyvs[yyvsp - 1].astr_mut()).as_mut_ptr(),
                                 -99,
                                 -99,
                                 dummy.as_mut_ptr(),
                             );
-                            if yyval.Node < 0 {
+                            if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
                                 current_block = Block::ReduceDone;
@@ -5657,12 +5796,12 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             let mut dummy = [0];
                             yyval.Node = New_REG(
                                 lParse,
-                                (yyvs[yyvsp - 5].astr).as_mut_ptr(),
-                                yyvs[yyvsp - 3].Node,
-                                yyvs[yyvsp - 1].Node,
+                                (yyvs[yyvsp - 5].astr_mut()).as_mut_ptr(),
+                                yyvs[yyvsp - 3].node(),
+                                yyvs[yyvsp - 1].node(),
                                 dummy.as_mut_ptr(),
                             );
-                            if yyval.Node < 0 {
+                            if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
                                 current_block = Block::ReduceDone;
@@ -5672,12 +5811,12 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             /* bexpr: REGFILTER STRING ',' expr ',' expr ',' STRING ')'  */
                             yyval.Node = New_REG(
                                 lParse,
-                                (yyvs[yyvsp - 7].astr).as_mut_ptr(),
-                                yyvs[yyvsp - 5].Node,
-                                yyvs[yyvsp - 3].Node,
-                                (yyvs[yyvsp - 1].astr).as_mut_ptr(),
+                                (yyvs[yyvsp - 7].astr_mut()).as_mut_ptr(),
+                                yyvs[yyvsp - 5].node(),
+                                yyvs[yyvsp - 3].node(),
+                                (yyvs[yyvsp - 1].astr_mut()).as_mut_ptr(),
                             );
-                            if yyval.Node < 0 {
+                            if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
                                 current_block = Block::ReduceDone;
@@ -5687,15 +5826,15 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             /* bexpr: bexpr '[' expr ']'  */
                             yyval.Node = New_Deref(
                                 lParse,
-                                yyvs[yyvsp - 3].Node,
+                                yyvs[yyvsp - 3].node(),
                                 1,
-                                yyvs[yyvsp - 1].Node,
+                                yyvs[yyvsp - 1].node(),
                                 0,
                                 0,
                                 0,
                                 0,
                             );
-                            if yyval.Node < 0 {
+                            if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
                                 current_block = Block::ReduceDone;
@@ -5705,15 +5844,15 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             /* bexpr: bexpr '[' expr ',' expr ']'  */
                             yyval.Node = New_Deref(
                                 lParse,
-                                yyvs[yyvsp - 5].Node,
+                                yyvs[yyvsp - 5].node(),
                                 2,
-                                yyvs[yyvsp - 3].Node,
-                                yyvs[yyvsp - 1].Node,
+                                yyvs[yyvsp - 3].node(),
+                                yyvs[yyvsp - 1].node(),
                                 0,
                                 0,
                                 0,
                             );
-                            if yyval.Node < 0 {
+                            if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
                                 current_block = Block::ReduceDone;
@@ -5723,15 +5862,15 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             /* bexpr: bexpr '[' expr ',' expr ',' expr ']'  */
                             yyval.Node = New_Deref(
                                 lParse,
-                                yyvs[yyvsp - 7].Node,
+                                yyvs[yyvsp - 7].node(),
                                 3 as c_int,
-                                yyvs[yyvsp - 5].Node,
-                                yyvs[yyvsp - 3].Node,
-                                yyvs[yyvsp - 1].Node,
+                                yyvs[yyvsp - 5].node(),
+                                yyvs[yyvsp - 3].node(),
+                                yyvs[yyvsp - 1].node(),
                                 0,
                                 0,
                             );
-                            if yyval.Node < 0 {
+                            if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
                                 current_block = Block::ReduceDone;
@@ -5741,15 +5880,15 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             /* bexpr: bexpr '[' expr ',' expr ',' expr ',' expr ']'  */
                             yyval.Node = New_Deref(
                                 lParse,
-                                yyvs[yyvsp - 9].Node,
+                                yyvs[yyvsp - 9].node(),
                                 4 as c_int,
-                                yyvs[yyvsp - 7].Node,
-                                yyvs[yyvsp - 5].Node,
-                                yyvs[yyvsp - 3].Node,
-                                yyvs[yyvsp - 1].Node,
+                                yyvs[yyvsp - 7].node(),
+                                yyvs[yyvsp - 5].node(),
+                                yyvs[yyvsp - 3].node(),
+                                yyvs[yyvsp - 1].node(),
                                 0,
                             );
-                            if yyval.Node < 0 {
+                            if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
                                 current_block = Block::ReduceDone;
@@ -5759,15 +5898,15 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             /* bexpr: bexpr '[' expr ',' expr ',' expr ',' expr ',' expr ']'  */
                             yyval.Node = New_Deref(
                                 lParse,
-                                yyvs[yyvsp - 11].Node,
+                                yyvs[yyvsp - 11].node(),
                                 5 as c_int,
-                                yyvs[yyvsp - 9].Node,
-                                yyvs[yyvsp - 7].Node,
-                                yyvs[yyvsp - 5].Node,
-                                yyvs[yyvsp - 3].Node,
-                                yyvs[yyvsp - 1].Node,
+                                yyvs[yyvsp - 9].node(),
+                                yyvs[yyvsp - 7].node(),
+                                yyvs[yyvsp - 5].node(),
+                                yyvs[yyvsp - 3].node(),
+                                yyvs[yyvsp - 1].node(),
                             );
-                            if yyval.Node < 0 {
+                            if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
                                 current_block = Block::ReduceDone;
@@ -5779,9 +5918,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 lParse,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
                                 fits_parser_yytokentype::NOT as c_int,
-                                yyvs[yyvsp].Node,
+                                yyvs[yyvsp].node(),
                             );
-                            if yyval.Node < 0 {
+                            if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
                                 current_block = Block::ReduceDone;
@@ -5789,7 +5928,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         }
                         126 => {
                             /* bexpr: '(' bexpr ')'  */
-                            yyval.Node = yyvs[yyvsp - 1].Node;
+                            yyval.Node = yyvs[yyvsp - 1].node();
                             current_block = Block::ReduceDone;
                         }
                         127 => {
@@ -5797,22 +5936,22 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             yyval.Node = New_Const(
                                 lParse,
                                 fits_parser_yytokentype::STRING as c_int,
-                                (yyvs[yyvsp].astr).as_mut_ptr().cast::<c_void>(),
-                                (astr_len(&yyvs[yyvsp].astr)).wrapping_add((1).try_into().unwrap())
+                                (yyvs[yyvsp].astr_mut()).as_mut_ptr().cast::<c_void>(),
+                                (astr_len(yyvs[yyvsp].astr())).wrapping_add((1).try_into().unwrap())
                                     as c_long,
                             );
-                            if yyval.Node < 0 {
+                            if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
-                                (((lParse.Nodes)[yyval.Node as usize]).value).nelem =
-                                    astr_len(&yyvs[yyvsp].astr) as c_long;
+                                (((lParse.Nodes)[yyval.node() as usize]).value).nelem =
+                                    astr_len(yyvs[yyvsp].astr()) as c_long;
                                 current_block = Block::ReduceDone;
                             }
                         }
                         128 => {
                             /* sexpr: SCOLUMN  */
-                            yyval.Node = New_Column(lParse, yyvs[yyvsp].lng as c_int);
-                            if yyval.Node < 0 {
+                            yyval.Node = New_Column(lParse, yyvs[yyvsp].lng() as c_int);
+                            if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
                                 current_block = Block::ReduceDone;
@@ -5820,9 +5959,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         }
                         129 => {
                             /* sexpr: SCOLUMN '{' expr '}'  */
-                            if ((lParse.Nodes)[yyvs[yyvsp - 1].Node as usize]).ntype
+                            if ((lParse.Nodes)[yyvs[yyvsp - 1].node() as usize]).ntype
                                 != fits_parser_yytokentype::LONG as c_int
-                                || ((lParse.Nodes)[yyvs[yyvsp - 1].Node as usize]).operation
+                                || ((lParse.Nodes)[yyvs[yyvsp - 1].node() as usize]).operation
                                     != CONST_OP
                             {
                                 fits_parser_yyerror(
@@ -5833,10 +5972,10 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             } else {
                                 yyval.Node = New_Offset(
                                     lParse,
-                                    yyvs[yyvsp - 3].lng as c_int,
-                                    yyvs[yyvsp - 1].Node,
+                                    yyvs[yyvsp - 3].lng() as c_int,
+                                    yyvs[yyvsp - 1].node(),
                                 );
-                                if yyval.Node < 0 {
+                                if yyval.node() < 0 {
                                     current_block = Block::YyErrLab;
                                 } else {
                                     current_block = Block::ReduceDone;
@@ -5862,13 +6001,13 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         }
                         131 => {
                             /* sexpr: '(' sexpr ')'  */
-                            yyval.Node = yyvs[yyvsp - 1].Node;
+                            yyval.Node = yyvs[yyvsp - 1].node();
                             current_block = Block::ReduceDone;
                         }
                         132 => {
                             /* sexpr: sexpr '+' sexpr  */
-                            if (lParse.Nodes[yyvs[yyvsp - 2].Node as usize]).value.nelem
-                                + (lParse.Nodes[yyvs[yyvsp].Node as usize]).value.nelem
+                            if (lParse.Nodes[yyvs[yyvsp - 2].node() as usize]).value.nelem
+                                + (lParse.Nodes[yyvs[yyvsp].node() as usize]).value.nelem
                                 >= 256 as c_long
                             {
                                 fits_parser_yyerror(
@@ -5880,16 +6019,18 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 yyval.Node = New_BinOp(
                                     lParse,
                                     fits_parser_yytokentype::STRING as c_int,
-                                    yyvs[yyvsp - 2].Node,
+                                    yyvs[yyvsp - 2].node(),
                                     '+' as i32,
-                                    yyvs[yyvsp].Node,
+                                    yyvs[yyvsp].node(),
                                 );
-                                if yyval.Node < 0 {
+                                if yyval.node() < 0 {
                                     current_block = Block::YyErrLab;
                                 } else {
-                                    (((lParse.Nodes)[yyval.Node as usize]).value).nelem =
-                                        ((lParse.Nodes)[yyvs[yyvsp - 2].Node as usize]).value.nelem
-                                            + ((lParse.Nodes)[yyvs[yyvsp].Node as usize])
+                                    (((lParse.Nodes)[yyval.node() as usize]).value).nelem =
+                                        ((lParse.Nodes)[yyvs[yyvsp - 2].node() as usize])
+                                            .value
+                                            .nelem
+                                            + ((lParse.Nodes)[yyvs[yyvsp].node() as usize])
                                                 .value
                                                 .nelem;
                                     current_block = Block::ReduceDone;
@@ -5899,7 +6040,11 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         133 => {
                             /* sexpr: bexpr '?' sexpr ':' sexpr  */
                             let mut outSize: c_int = 0;
-                            if ((lParse.Nodes)[yyvs[yyvsp - 4].Node as usize]).value.nelem != 1 {
+                            if ((lParse.Nodes)[yyvs[yyvsp - 4].node() as usize])
+                                .value
+                                .nelem
+                                != 1
+                            {
                                 fits_parser_yyerror(
                                     lParse,
                                     cs!(c"Cannot have a vector string column"),
@@ -5910,13 +6055,13 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 scalar, we must precalculate the output size, in
                                 order to avoid an overflow. */
 
-                                outSize = (((lParse.Nodes)[yyvs[yyvsp - 2].Node as usize]).value)
+                                outSize = (((lParse.Nodes)[yyvs[yyvsp - 2].node() as usize]).value)
                                     .nelem as c_int;
-                                if (lParse.Nodes[yyvs[yyvsp].Node as usize]).value.nelem
+                                if (lParse.Nodes[yyvs[yyvsp].node() as usize]).value.nelem
                                     > c_long::from(outSize)
                                 {
                                     outSize =
-                                        ((lParse.Nodes)[yyvs[yyvsp].Node as usize]).value.nelem
+                                        ((lParse.Nodes)[yyvs[yyvsp].node() as usize]).value.nelem
                                             as c_int;
                                 }
                                 yyval.Node = New_FuncSize(
@@ -5924,22 +6069,24 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     0,
                                     IFTHENELSE_FCT,
                                     3 as c_int,
-                                    yyvs[yyvsp - 2].Node,
-                                    yyvs[yyvsp].Node,
-                                    yyvs[yyvsp - 4].Node,
+                                    yyvs[yyvsp - 2].node(),
+                                    yyvs[yyvsp].node(),
+                                    yyvs[yyvsp - 4].node(),
                                     0,
                                     0,
                                     0,
                                     0,
                                     outSize,
                                 );
-                                if yyval.Node < 0 {
+                                if yyval.node() < 0 {
                                     current_block = Block::YyErrLab;
                                 } else {
-                                    if ((lParse.Nodes)[yyvs[yyvsp - 2].Node as usize]).value.nelem
-                                        < (lParse.Nodes[yyvs[yyvsp].Node as usize]).value.nelem
+                                    if ((lParse.Nodes)[yyvs[yyvsp - 2].node() as usize])
+                                        .value
+                                        .nelem
+                                        < (lParse.Nodes[yyvs[yyvsp].node() as usize]).value.nelem
                                     {
-                                        Copy_Dims(lParse, yyval.Node, yyvs[yyvsp].Node);
+                                        Copy_Dims(lParse, yyval.node(), yyvs[yyvsp].node());
                                     }
                                     current_block = Block::ReduceDone;
                                 }
@@ -5947,29 +6094,32 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         }
                         134 => {
                             /* sexpr: FUNCTION sexpr ',' sexpr ')'  */
-                            if astr_eq(&yyvs[yyvsp - 4].astr, c"DEFNULL(") {
+                            if astr_eq(yyvs[yyvsp - 4].astr(), c"DEFNULL(") {
                                 /* Since the output can be calculated now, as a constant
                                 scalar, we must precalculate the output size, in
                                 order to avoid an overflow. */
 
                                 let mut outSize_0: c_int = 0;
-                                outSize_0 = ((lParse.Nodes)[yyvs[yyvsp - 3].Node as usize])
+                                outSize_0 = ((lParse.Nodes)[yyvs[yyvsp - 3].node() as usize])
                                     .value
                                     .nelem as c_int;
-                                if ((lParse.Nodes)[yyvs[yyvsp - 1].Node as usize]).value.nelem
+                                if ((lParse.Nodes)[yyvs[yyvsp - 1].node() as usize])
+                                    .value
+                                    .nelem
                                     > c_long::from(outSize_0)
                                 {
-                                    outSize_0 =
-                                        ((lParse.Nodes)[yyvs[yyvsp - 1].Node as usize]).value.nelem
-                                            as c_int;
+                                    outSize_0 = ((lParse.Nodes)[yyvs[yyvsp - 1].node() as usize])
+                                        .value
+                                        .nelem
+                                        as c_int;
                                 }
                                 yyval.Node = New_FuncSize(
                                     lParse,
                                     0,
                                     DEFNULL_FCT,
                                     2,
-                                    yyvs[yyvsp - 3].Node,
-                                    yyvs[yyvsp - 1].Node,
+                                    yyvs[yyvsp - 3].node(),
+                                    yyvs[yyvsp - 1].node(),
                                     0,
                                     0,
                                     0,
@@ -5977,16 +6127,18 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     0,
                                     outSize_0,
                                 );
-                                if yyval.Node < 0 {
+                                if yyval.node() < 0 {
                                     current_block = Block::YyErrLab;
                                 } else {
-                                    if ((lParse.Nodes)[yyvs[yyvsp - 1].Node as usize]).value.nelem
-                                        > ((lParse.Nodes)[yyvs[yyvsp - 3].Node as usize])
+                                    if ((lParse.Nodes)[yyvs[yyvsp - 1].node() as usize])
+                                        .value
+                                        .nelem
+                                        > ((lParse.Nodes)[yyvs[yyvsp - 3].node() as usize])
                                             .value
                                             .nelem
                                     {
-                                        (((lParse.Nodes)[yyval.Node as usize]).value).nelem =
-                                            ((lParse.Nodes)[yyvs[yyvsp - 1].Node as usize])
+                                        (((lParse.Nodes)[yyval.node() as usize]).value).nelem =
+                                            ((lParse.Nodes)[yyvs[yyvsp - 1].node() as usize])
                                                 .value
                                                 .nelem;
                                     }
@@ -6002,32 +6154,36 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         }
                         135 => {
                             /* sexpr: FUNCTION sexpr ',' expr ',' expr ')'  */
-                            if astr_eq(&yyvs[yyvsp - 6].astr, c"STRMID(") {
+                            if astr_eq(yyvs[yyvsp - 6].astr(), c"STRMID(") {
                                 let mut len: c_int = 0;
-                                if ((lParse.Nodes)[yyvs[yyvsp - 3].Node as usize]).ntype
+                                if ((lParse.Nodes)[yyvs[yyvsp - 3].node() as usize]).ntype
                                     != fits_parser_yytokentype::LONG as c_int
-                                    || ((lParse.Nodes)[yyvs[yyvsp - 3].Node as usize]).value.nelem
+                                    || ((lParse.Nodes)[yyvs[yyvsp - 3].node() as usize])
+                                        .value
+                                        .nelem
                                         != 1
-                                    || ((lParse.Nodes)[yyvs[yyvsp - 1].Node as usize]).ntype
+                                    || ((lParse.Nodes)[yyvs[yyvsp - 1].node() as usize]).ntype
                                         != fits_parser_yytokentype::LONG as c_int
-                                    || ((lParse.Nodes)[yyvs[yyvsp - 1].Node as usize]).value.nelem
+                                    || ((lParse.Nodes)[yyvs[yyvsp - 1].node() as usize])
+                                        .value
+                                        .nelem
                                         != 1
                                 {
                                     fits_parser_yyerror(lParse, cs!(c"When using STRMID(S,P,N), P and N must be integers (and not vector columns)"));
                                     current_block = Block::YyErrLab;
                                 } else {
-                                    if ((lParse.Nodes)[yyvs[yyvsp - 1].Node as usize]).operation
+                                    if ((lParse.Nodes)[yyvs[yyvsp - 1].node() as usize]).operation
                                         == CONST_OP
                                     {
                                         /* Constant value: use that directly */
-                                        len = ((lParse.Nodes)[yyvs[yyvsp - 1].Node as usize])
+                                        len = ((lParse.Nodes)[yyvs[yyvsp - 1].node() as usize])
                                             .value
                                             .data
                                             .lng()
                                             as c_int;
                                     } else {
                                         /* Variable value: use the maximum possible (from $2) */
-                                        len = ((lParse.Nodes)[yyvs[yyvsp - 5].Node as usize])
+                                        len = ((lParse.Nodes)[yyvs[yyvsp - 5].node() as usize])
                                             .value
                                             .nelem
                                             as c_int;
@@ -6044,16 +6200,16 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                             0,
                                             STRMID_FCT,
                                             3 as c_int,
-                                            yyvs[yyvsp - 5].Node,
-                                            yyvs[yyvsp - 3].Node,
-                                            yyvs[yyvsp - 1].Node,
+                                            yyvs[yyvsp - 5].node(),
+                                            yyvs[yyvsp - 3].node(),
+                                            yyvs[yyvsp - 1].node(),
                                             0,
                                             0,
                                             0,
                                             0,
                                             len,
                                         );
-                                        if yyval.Node < 0 {
+                                        if yyval.node() < 0 {
                                             current_block = Block::YyErrLab;
                                         } else {
                                             current_block = Block::ReduceDone;
@@ -6381,7 +6537,7 @@ fn New_GTI(
         {
             type_0 = fits_parser_yyGetVariable(lParse, cs!(c"TIME"), &mut colVal);
             if type_0 == fits_parser_yytokentype::COLUMN as c_int {
-                Node1 = New_Column(lParse, colVal.lng as c_int);
+                Node1 = New_Column(lParse, colVal.lng() as c_int);
             } else {
                 fits_parser_yyerror(
                     lParse,
@@ -6792,7 +6948,7 @@ fn New_REG(
         if NodeX == -99 {
             type_0 = fits_parser_yyGetVariable(lParse, cs!(c"X"), &mut colVal);
             if type_0 == fits_parser_yytokentype::COLUMN as c_int {
-                NodeX = New_Column(lParse, colVal.lng as c_int);
+                NodeX = New_Column(lParse, colVal.lng() as c_int);
             } else {
                 fits_parser_yyerror(lParse, cs!(c"Could not build X column for REGFILTER"));
                 return -(1);
@@ -6801,7 +6957,7 @@ fn New_REG(
         if NodeY == -99 {
             type_0 = fits_parser_yyGetVariable(lParse, cs!(c"Y"), &mut colVal);
             if type_0 == fits_parser_yytokentype::COLUMN as c_int {
-                NodeY = New_Column(lParse, colVal.lng as c_int);
+                NodeY = New_Column(lParse, colVal.lng() as c_int);
             } else {
                 fits_parser_yyerror(lParse, cs!(c"Could not build Y column for REGFILTER"));
                 return -(1);

--- a/src/eval_y.rs
+++ b/src/eval_y.rs
@@ -6774,7 +6774,6 @@ fn New_REG(
             rot: 0.,
             dtype: [0; 5],
         };
-        let Rgn: *mut SAORegion = ptr::null_mut();
         let mut cX: *mut c_char = ptr::null_mut();
         let mut cY: *mut c_char = ptr::null_mut();
         let mut colVal: FITS_PARSER_YYSTYPE = FITS_PARSER_YYSTYPE { Node: 0 };
@@ -6930,18 +6929,32 @@ fn New_REG(
             }
 
             let fname_slice = CStr::from_ptr(fname);
-            let rgn_box = Box::from_raw(Rgn);
+            // fits_read_rgnfile allocates the region and stores it in this
+            // Option (replacing whatever was passed). The previous code passed a
+            // `Box::from_raw(null)` and then read back the still-null `Rgn`,
+            // which both dropped a null Box (UB) and left the node's region
+            // pointer null. Capture the real region and hand its ownership to
+            // the node as a raw pointer (ffcprs reclaims it via
+            // fits_free_region(Box::from_raw(...))).
+            let mut rgn_opt: Option<Box<SAORegion>> = None;
             fits_read_rgnfile(
                 cast_slice(fname_slice.to_bytes_with_nul()),
                 &mut wcs,
-                &mut Some(rgn_box),
+                &mut rgn_opt,
                 &mut lParse.status,
             );
             if lParse.status != 0 {
                 Free_Last_Node(lParse);
                 return -(1);
             }
-            (lParse.Nodes[that0_idx]).value.data.ptr = Rgn.cast::<c_void>();
+            let rgn_box = match rgn_opt {
+                Some(b) => b,
+                None => {
+                    Free_Last_Node(lParse);
+                    return -(1);
+                }
+            };
+            (lParse.Nodes[that0_idx]).value.data.ptr = Box::into_raw(rgn_box).cast::<c_void>();
             if ((lParse.Nodes)[NodeX as usize]).operation == CONST_OP
                 && ((lParse.Nodes)[NodeY as usize]).operation == CONST_OP
             {

--- a/src/eval_y.rs
+++ b/src/eval_y.rs
@@ -6535,8 +6535,10 @@ fn New_GTI(
         }
 
         /*  Locate START/STOP Columns  */
-        let start_str = CStr::from_ptr(start).to_bytes();
-        let stop_str = CStr::from_ptr(stop).to_bytes();
+        // ffgcno_safe expects a NUL-terminated column-name template; include the
+        // terminator so the wildcard match doesn't read past the slice.
+        let start_str = CStr::from_ptr(start).to_bytes_with_nul();
+        let stop_str = CStr::from_ptr(stop).to_bytes_with_nul();
         ffgcno_safe(
             fptr,
             0,

--- a/src/eval_y.rs
+++ b/src/eval_y.rs
@@ -14283,31 +14283,24 @@ fn bitor(mut result: *mut c_char, mut bitstrm1: *mut c_char, mut bitstrm2: *mut 
         *result = 0;
     }
 }
-fn bitnot(mut result: *mut c_char, mut bits: *mut c_char) {
+fn bitnot(result: *mut c_char, bits: *mut c_char) {
     unsafe {
-        let mut length: c_int = 0;
-        let mut chr: c_char = 0;
-        length = strlen(bits) as c_int;
-        loop {
-            let fresh253 = length;
-            length -= 1;
-            if fresh253 == 0 {
-                break;
-            }
-            let fresh254 = bits;
-            bits = bits.offset(1);
-            chr = *fresh254;
-            let fresh255 = result;
-            result = result.offset(1);
-            *fresh255 = (if c_int::from(chr) == '1' as i32 {
-                '0' as i32
-            } else if c_int::from(chr) == '0' as i32 {
-                '1' as i32
+        // Confine unsafe to building slices from the NUL-terminated bit strings;
+        // the inversion itself is bounded safe indexing.
+        let length = strlen(bits) as usize;
+        let bits = core::slice::from_raw_parts(bits, length);
+        let result = core::slice::from_raw_parts_mut(result, length + 1);
+        for i in 0..length {
+            let chr = bits[i];
+            result[i] = if chr == b'1' as c_char {
+                b'0' as c_char
+            } else if chr == b'0' as c_char {
+                b'1' as c_char
             } else {
-                c_int::from(chr)
-            }) as c_char;
+                chr
+            };
         }
-        *result = 0;
+        result[length] = 0;
     }
 }
 

--- a/src/eval_y.rs
+++ b/src/eval_y.rs
@@ -6643,8 +6643,8 @@ fn New_GTI(
                     lParse.status = 113 as c_int;
                     return -(1);
                 }
-                startptr = (lParse.Nodes[that0_idx]).value.data.dblptr;
-                stopptr = ((lParse.Nodes[that0_idx]).value.data.dblptr).offset(nrows as isize);
+                startptr = (lParse.Nodes[that0_idx]).value.data.dblptr();
+                stopptr = ((lParse.Nodes[that0_idx]).value.data.dblptr()).offset(nrows as isize);
                 ffgcvd_safe(
                     fptr,
                     startCol,
@@ -7418,7 +7418,7 @@ pub(crate) fn free_node_data(lParse: &mut ParseData, idx: usize) {
         lParse.node_buffers[idx] = None; // drops the NodeBuf (frees the buffer)
     } else {
         // Legacy malloc'd pointer (e.g. GTI data); free with libc.
-        unsafe { free((lParse.Nodes[idx]).value.data.ptr) };
+        unsafe { free((lParse.Nodes[idx]).value.data.ptr()) };
     }
     (lParse.Nodes[idx]).value.data.ptr = core::ptr::null_mut();
 }
@@ -7520,9 +7520,10 @@ fn Do_Unary(lParse: &mut ParseData, this_node_idx: usize) {
                     || x == fits_parser_yytokentype::FLTCAST as c_int =>
                 {
                     if that_node.ntype == fits_parser_yytokentype::LONG as c_int {
-                        (this_node).value.data.dbl = that_node.value.data.lng as c_double;
+                        (this_node).value.data.dbl = that_node.value.data.lng() as c_double;
                     } else if that_node.ntype == fits_parser_yytokentype::BOOLEAN as c_int {
-                        (this_node).value.data.dbl = if c_int::from(that_node.value.data.log) != 0 {
+                        (this_node).value.data.dbl = if c_int::from(that_node.value.data.log()) != 0
+                        {
                             1.0
                         } else {
                             0.0
@@ -7533,9 +7534,10 @@ fn Do_Unary(lParse: &mut ParseData, this_node_idx: usize) {
                     || x == fits_parser_yytokentype::INTCAST as c_int =>
                 {
                     if that_node.ntype == fits_parser_yytokentype::DOUBLE as c_int {
-                        (this_node).value.data.lng = that_node.value.data.dbl as c_long;
+                        (this_node).value.data.lng = that_node.value.data.dbl() as c_long;
                     } else if that_node.ntype == fits_parser_yytokentype::BOOLEAN as c_int {
-                        (this_node).value.data.lng = if c_int::from(that_node.value.data.log) != 0 {
+                        (this_node).value.data.lng = if c_int::from(that_node.value.data.log()) != 0
+                        {
                             1
                         } else {
                             0
@@ -7544,31 +7546,37 @@ fn Do_Unary(lParse: &mut ParseData, this_node_idx: usize) {
                 }
                 x if x == fits_parser_yytokentype::BOOLEAN as c_int => {
                     if that_node.ntype == fits_parser_yytokentype::DOUBLE as c_int {
-                        (this_node).value.data.log = if that_node.value.data.dbl != 0.0 {
+                        (this_node).value.data.log = if that_node.value.data.dbl() != 0.0 {
                             1
                         } else {
                             0
                         };
                     } else if that_node.ntype == fits_parser_yytokentype::LONG as c_int {
-                        (this_node).value.data.log =
-                            if that_node.value.data.lng != 0 { 1 } else { 0 };
+                        (this_node).value.data.log = if that_node.value.data.lng() != 0 {
+                            1
+                        } else {
+                            0
+                        };
                     }
                 }
                 x if x == fits_parser_yytokentype::UMINUS as c_int => {
                     if that_node.ntype == fits_parser_yytokentype::DOUBLE as c_int {
-                        (this_node).value.data.dbl = -that_node.value.data.dbl;
+                        (this_node).value.data.dbl = -that_node.value.data.dbl();
                     } else if that_node.ntype == fits_parser_yytokentype::LONG as c_int {
-                        (this_node).value.data.lng = -that_node.value.data.lng;
+                        (this_node).value.data.lng = -that_node.value.data.lng();
                     }
                 }
                 x if x == fits_parser_yytokentype::NOT as c_int => {
                     if that_node.ntype == fits_parser_yytokentype::BOOLEAN as c_int {
-                        (this_node).value.data.log =
-                            if that_node.value.data.log == 0 { 1 } else { 0 };
+                        (this_node).value.data.log = if that_node.value.data.log() == 0 {
+                            1
+                        } else {
+                            0
+                        };
                     } else if that_node.ntype == fits_parser_yytokentype::BITSTR as c_int {
                         bitnot(
-                            ((this_node).value.data.astr).as_mut_ptr(),
-                            (that_node.value.data.astr).as_mut_ptr(),
+                            ((this_node).value.data.astr_mut()).as_mut_ptr(),
+                            (that_node.value.data.astr_mut()).as_mut_ptr(),
                         );
                     }
                 }
@@ -7606,8 +7614,9 @@ fn Do_Unary(lParse: &mut ParseData, this_node_idx: usize) {
                                 if fresh23 == 0 {
                                     break;
                                 }
-                                *((this_node).value.data.logptr).offset(elem as isize) =
-                                    if *(that_node.value.data.dblptr).offset(elem as isize) != 0.0 {
+                                *((this_node).value.data.logptr()).offset(elem as isize) =
+                                    if *(that_node.value.data.dblptr()).offset(elem as isize) != 0.0
+                                    {
                                         1
                                     } else {
                                         0
@@ -7620,8 +7629,8 @@ fn Do_Unary(lParse: &mut ParseData, this_node_idx: usize) {
                                 if fresh24 == 0 {
                                     break;
                                 }
-                                *((this_node).value.data.logptr).offset(elem as isize) =
-                                    if *(that_node.value.data.lngptr).offset(elem as isize) != 0 {
+                                *((this_node).value.data.logptr()).offset(elem as isize) =
+                                    if *(that_node.value.data.lngptr()).offset(elem as isize) != 0 {
                                         1
                                     } else {
                                         0
@@ -7637,8 +7646,8 @@ fn Do_Unary(lParse: &mut ParseData, this_node_idx: usize) {
                                 if fresh25 == 0 {
                                     break;
                                 }
-                                *((this_node).value.data.dblptr).offset(elem as isize) =
-                                    *(that_node.value.data.lngptr).offset(elem as isize)
+                                *((this_node).value.data.dblptr()).offset(elem as isize) =
+                                    *(that_node.value.data.lngptr()).offset(elem as isize)
                                         as c_double;
                             }
                         } else if that_node.ntype == fits_parser_yytokentype::BOOLEAN as c_int {
@@ -7648,9 +7657,9 @@ fn Do_Unary(lParse: &mut ParseData, this_node_idx: usize) {
                                 if fresh26 == 0 {
                                     break;
                                 }
-                                *((this_node).value.data.dblptr).offset(elem as isize) =
+                                *((this_node).value.data.dblptr()).offset(elem as isize) =
                                     if c_int::from(
-                                        *(that_node.value.data.logptr).offset(elem as isize),
+                                        *(that_node.value.data.logptr()).offset(elem as isize),
                                     ) != 0
                                     {
                                         1.0
@@ -7668,8 +7677,9 @@ fn Do_Unary(lParse: &mut ParseData, this_node_idx: usize) {
                                 if fresh27 == 0 {
                                     break;
                                 }
-                                *((this_node).value.data.lngptr).offset(elem as isize) =
-                                    *(that_node.value.data.dblptr).offset(elem as isize) as c_long;
+                                *((this_node).value.data.lngptr()).offset(elem as isize) =
+                                    *(that_node.value.data.dblptr()).offset(elem as isize)
+                                        as c_long;
                             }
                         } else if that_node.ntype == fits_parser_yytokentype::BOOLEAN as c_int {
                             loop {
@@ -7678,9 +7688,9 @@ fn Do_Unary(lParse: &mut ParseData, this_node_idx: usize) {
                                 if fresh28 == 0 {
                                     break;
                                 }
-                                *((this_node).value.data.lngptr).offset(elem as isize) =
+                                *((this_node).value.data.lngptr()).offset(elem as isize) =
                                     if c_int::from(
-                                        *(that_node.value.data.logptr).offset(elem as isize),
+                                        *(that_node.value.data.logptr()).offset(elem as isize),
                                     ) != 0
                                     {
                                         1
@@ -7698,8 +7708,8 @@ fn Do_Unary(lParse: &mut ParseData, this_node_idx: usize) {
                                 if fresh29 == 0 {
                                     break;
                                 }
-                                *((this_node).value.data.dblptr).offset(elem as isize) =
-                                    -*(that_node.value.data.dblptr).offset(elem as isize);
+                                *((this_node).value.data.dblptr()).offset(elem as isize) =
+                                    -*(that_node.value.data.dblptr()).offset(elem as isize);
                             }
                         } else if that_node.ntype == fits_parser_yytokentype::LONG as c_int {
                             loop {
@@ -7708,8 +7718,8 @@ fn Do_Unary(lParse: &mut ParseData, this_node_idx: usize) {
                                 if fresh30 == 0 {
                                     break;
                                 }
-                                *((this_node).value.data.lngptr).offset(elem as isize) =
-                                    -*(that_node.value.data.lngptr).offset(elem as isize);
+                                *((this_node).value.data.lngptr()).offset(elem as isize) =
+                                    -*(that_node.value.data.lngptr()).offset(elem as isize);
                             }
                         }
                     }
@@ -7721,10 +7731,10 @@ fn Do_Unary(lParse: &mut ParseData, this_node_idx: usize) {
                                 if fresh31 == 0 {
                                     break;
                                 }
-                                *((this_node).value.data.logptr).offset(elem as isize) = c_int::from(
-                                    *(that_node.value.data.logptr).offset(elem as isize) == 0,
-                                )
-                                    as c_char;
+                                *((this_node).value.data.logptr()).offset(elem as isize) =
+                                    c_int::from(
+                                        *(that_node.value.data.logptr()).offset(elem as isize) == 0,
+                                    ) as c_char;
                             }
                         } else if that_node.ntype == fits_parser_yytokentype::BITSTR as c_int {
                             elem = lParse.nRows;
@@ -7735,8 +7745,8 @@ fn Do_Unary(lParse: &mut ParseData, this_node_idx: usize) {
                                     break;
                                 }
                                 bitnot(
-                                    *((this_node).value.data.strptr).offset(elem as isize),
-                                    *(that_node.value.data.strptr).offset(elem as isize),
+                                    *((this_node).value.data.strptr()).offset(elem as isize),
+                                    *(that_node.value.data.strptr()).offset(elem as isize),
                                 );
                             }
                         }
@@ -7809,15 +7819,16 @@ fn Do_Offset(lParse: &mut ParseData, this_node_idx: usize) {
             while fRow < 1 && nRowReload > 0 {
                 if (lParse.Nodes[this_node_idx]).ntype == fits_parser_yytokentype::BITSTR as c_int {
                     nelem = (lParse.Nodes[this_node_idx]).value.nelem;
-                    *(*((lParse.Nodes[this_node_idx]).value.data.strptr).offset(offset as isize))
-                        .offset(nelem as isize) = 0;
+                    *(*((lParse.Nodes[this_node_idx]).value.data.strptr())
+                        .offset(offset as isize))
+                    .offset(nelem as isize) = 0;
                     loop {
                         let fresh33 = nelem;
                         nelem -= 1;
                         if fresh33 == 0 {
                             break;
                         }
-                        *(*((lParse.Nodes[this_node_idx]).value.data.strptr)
+                        *(*((lParse.Nodes[this_node_idx]).value.data.strptr())
                             .offset(offset as isize))
                         .offset(nelem as isize) = b'0' as c_char;
                     }
@@ -7879,7 +7890,7 @@ fn Do_Offset(lParse: &mut ParseData, this_node_idx: usize) {
                 if (lParse.Nodes[this_node_idx]).ntype == fits_parser_yytokentype::BITSTR as c_int {
                     nelem = (lParse.Nodes[this_node_idx]).value.nelem;
                     elem -= 1;
-                    *(*((lParse.Nodes[this_node_idx]).value.data.strptr).offset(elem as isize))
+                    *(*((lParse.Nodes[this_node_idx]).value.data.strptr()).offset(elem as isize))
                         .offset(nelem as isize) = 0;
                     loop {
                         let fresh36 = nelem;
@@ -7887,7 +7898,7 @@ fn Do_Offset(lParse: &mut ParseData, this_node_idx: usize) {
                         if fresh36 == 0 {
                             break;
                         }
-                        *(*((lParse.Nodes[this_node_idx]).value.data.strptr)
+                        *(*((lParse.Nodes[this_node_idx]).value.data.strptr())
                             .offset(elem as isize))
                         .offset(nelem as isize) = b'0' as c_char;
                     }
@@ -7918,7 +7929,7 @@ fn Do_Offset(lParse: &mut ParseData, this_node_idx: usize) {
                         -(lParse.Nodes[col_idx]).operation,
                         fRow,
                         nRowReload,
-                        ((lParse.Nodes[this_node_idx]).value.data.strptr)
+                        ((lParse.Nodes[this_node_idx]).value.data.strptr())
                             .offset(offset as isize)
                             .cast::<c_void>(),
                         ((lParse.Nodes[this_node_idx]).value.undef).offset(offset as isize),
@@ -7930,7 +7941,7 @@ fn Do_Offset(lParse: &mut ParseData, this_node_idx: usize) {
                         -(lParse.Nodes[col_idx]).operation,
                         fRow,
                         nRowReload,
-                        ((lParse.Nodes[this_node_idx]).value.data.logptr)
+                        ((lParse.Nodes[this_node_idx]).value.data.logptr())
                             .offset(offset as isize)
                             .cast::<c_void>(),
                         ((lParse.Nodes[this_node_idx]).value.undef).offset(offset as isize),
@@ -7942,7 +7953,7 @@ fn Do_Offset(lParse: &mut ParseData, this_node_idx: usize) {
                         -(lParse.Nodes[col_idx]).operation,
                         fRow,
                         nRowReload,
-                        ((lParse.Nodes[this_node_idx]).value.data.lngptr)
+                        ((lParse.Nodes[this_node_idx]).value.data.lngptr())
                             .offset(offset as isize)
                             .cast::<c_void>(),
                         ((lParse.Nodes[this_node_idx]).value.undef).offset(offset as isize),
@@ -7954,7 +7965,7 @@ fn Do_Offset(lParse: &mut ParseData, this_node_idx: usize) {
                         -(lParse.Nodes[col_idx]).operation,
                         fRow,
                         nRowReload,
-                        ((lParse.Nodes[this_node_idx]).value.data.dblptr)
+                        ((lParse.Nodes[this_node_idx]).value.data.dblptr())
                             .offset(offset as isize)
                             .cast::<c_void>(),
                         ((lParse.Nodes[this_node_idx]).value.undef).offset(offset as isize),
@@ -7993,34 +8004,34 @@ fn Do_Offset(lParse: &mut ParseData, this_node_idx: usize) {
                 match (lParse.Nodes[this_node_idx]).ntype.into() {
                     fits_parser_yytokentype::BITSTR => {
                         strcpy(
-                            *((lParse.Nodes[this_node_idx]).value.data.strptr)
+                            *((lParse.Nodes[this_node_idx]).value.data.strptr())
                                 .offset(elem as isize),
-                            *((lParse.Nodes[col_idx]).value.data.strptr)
+                            *((lParse.Nodes[col_idx]).value.data.strptr())
                                 .offset((elem + offset) as isize),
                         );
                     }
                     fits_parser_yytokentype::STRING => {
                         strcpy(
-                            *((lParse.Nodes[this_node_idx]).value.data.strptr)
+                            *((lParse.Nodes[this_node_idx]).value.data.strptr())
                                 .offset(elem as isize),
-                            *((lParse.Nodes[col_idx]).value.data.strptr)
+                            *((lParse.Nodes[col_idx]).value.data.strptr())
                                 .offset((elem + offset) as isize),
                         );
                     }
                     fits_parser_yytokentype::BOOLEAN => {
-                        *((lParse.Nodes[this_node_idx]).value.data.logptr).offset(elem as isize) =
-                            *((lParse.Nodes[col_idx]).value.data.logptr)
-                                .offset((elem + offset) as isize);
+                        *((lParse.Nodes[this_node_idx]).value.data.logptr())
+                            .offset(elem as isize) = *((lParse.Nodes[col_idx]).value.data.logptr())
+                            .offset((elem + offset) as isize);
                     }
                     fits_parser_yytokentype::LONG => {
-                        *((lParse.Nodes[this_node_idx]).value.data.lngptr).offset(elem as isize) =
-                            *((lParse.Nodes[col_idx]).value.data.lngptr)
-                                .offset((elem + offset) as isize);
+                        *((lParse.Nodes[this_node_idx]).value.data.lngptr())
+                            .offset(elem as isize) = *((lParse.Nodes[col_idx]).value.data.lngptr())
+                            .offset((elem + offset) as isize);
                     }
                     fits_parser_yytokentype::DOUBLE => {
-                        *((lParse.Nodes[this_node_idx]).value.data.dblptr).offset(elem as isize) =
-                            *((lParse.Nodes[col_idx]).value.data.dblptr)
-                                .offset((elem + offset) as isize);
+                        *((lParse.Nodes[this_node_idx]).value.data.dblptr())
+                            .offset(elem as isize) = *((lParse.Nodes[col_idx]).value.data.dblptr())
+                            .offset((elem + offset) as isize);
                     }
                     _ => {}
                 }
@@ -8045,12 +8056,12 @@ fn Do_BinOp_bit(lParse: &mut ParseData, this_node_idx: usize) {
         const1 = c_int::from((lParse.Nodes[that1_idx]).operation == CONST_OP);
         const2 = c_int::from((lParse.Nodes[that2_idx]).operation == CONST_OP);
         sptr1 = if const1 != 0 {
-            ((lParse.Nodes[that1_idx]).value.data.astr).as_mut_ptr()
+            ((lParse.Nodes[that1_idx]).value.data.astr_mut()).as_mut_ptr()
         } else {
             core::ptr::null_mut::<c_char>()
         };
         sptr2 = if const2 != 0 {
-            ((lParse.Nodes[that2_idx]).value.data.astr).as_mut_ptr()
+            ((lParse.Nodes[that2_idx]).value.data.astr_mut()).as_mut_ptr()
         } else {
             core::ptr::null_mut::<c_char>()
         };
@@ -8069,25 +8080,25 @@ fn Do_BinOp_bit(lParse: &mut ParseData, this_node_idx: usize) {
                 }
                 124 => {
                     bitor(
-                        ((lParse.Nodes[this_node_idx]).value.data.astr).as_mut_ptr(),
+                        ((lParse.Nodes[this_node_idx]).value.data.astr_mut()).as_mut_ptr(),
                         sptr1,
                         sptr2,
                     );
                 }
                 38 => {
                     bitand(
-                        ((lParse.Nodes[this_node_idx]).value.data.astr).as_mut_ptr(),
+                        ((lParse.Nodes[this_node_idx]).value.data.astr_mut()).as_mut_ptr(),
                         sptr1,
                         sptr2,
                     );
                 }
                 43 => {
                     strcpy(
-                        ((lParse.Nodes[this_node_idx]).value.data.astr).as_mut_ptr(),
+                        ((lParse.Nodes[this_node_idx]).value.data.astr_mut()).as_mut_ptr(),
                         sptr1,
                     );
                     strcat(
-                        ((lParse.Nodes[this_node_idx]).value.data.astr).as_mut_ptr(),
+                        ((lParse.Nodes[this_node_idx]).value.data.astr_mut()).as_mut_ptr(),
                         sptr2,
                     );
                 }
@@ -8096,7 +8107,7 @@ fn Do_BinOp_bit(lParse: &mut ParseData, this_node_idx: usize) {
                     while *sptr1 != 0 {
                         if c_int::from(*sptr1) == '1' as i32 {
                             (lParse.Nodes[this_node_idx]).value.data.lng += 1;
-                            (lParse.Nodes[this_node_idx]).value.data.lng;
+                            (lParse.Nodes[this_node_idx]).value.data.lng();
                         }
                         sptr1 = sptr1.offset(1);
                     }
@@ -8116,25 +8127,25 @@ fn Do_BinOp_bit(lParse: &mut ParseData, this_node_idx: usize) {
                             break;
                         }
                         if const1 == 0 {
-                            sptr1 = *((lParse.Nodes[that1_idx]).value.data.strptr)
+                            sptr1 = *((lParse.Nodes[that1_idx]).value.data.strptr())
                                 .offset(rows as isize);
                         }
                         if const2 == 0 {
-                            sptr2 = *((lParse.Nodes[that2_idx]).value.data.strptr)
+                            sptr2 = *((lParse.Nodes[that2_idx]).value.data.strptr())
                                 .offset(rows as isize);
                         }
                         match (lParse.Nodes[this_node_idx]).operation {
                             280 => {
-                                *((lParse.Nodes[this_node_idx]).value.data.logptr)
+                                *((lParse.Nodes[this_node_idx]).value.data.logptr())
                                     .offset(rows as isize) =
                                     if bitcmp(sptr1, sptr2) == 0 { 1 } else { 0 };
                             }
                             279 => {
-                                *((lParse.Nodes[this_node_idx]).value.data.logptr)
+                                *((lParse.Nodes[this_node_idx]).value.data.logptr())
                                     .offset(rows as isize) = bitcmp(sptr1, sptr2);
                             }
                             281..=284 => {
-                                *((lParse.Nodes[this_node_idx]).value.data.logptr)
+                                *((lParse.Nodes[this_node_idx]).value.data.logptr())
                                     .offset(rows as isize) =
                                     bitlgte(sptr1, (lParse.Nodes[this_node_idx]).operation, sptr2);
                             }
@@ -8149,35 +8160,35 @@ fn Do_BinOp_bit(lParse: &mut ParseData, this_node_idx: usize) {
                             break;
                         }
                         if const1 == 0 {
-                            sptr1 = *((lParse.Nodes[that1_idx]).value.data.strptr)
+                            sptr1 = *((lParse.Nodes[that1_idx]).value.data.strptr())
                                 .offset(rows as isize);
                         }
                         if const2 == 0 {
-                            sptr2 = *((lParse.Nodes[that2_idx]).value.data.strptr)
+                            sptr2 = *((lParse.Nodes[that2_idx]).value.data.strptr())
                                 .offset(rows as isize);
                         }
                         if (lParse.Nodes[this_node_idx]).operation == '|' as i32 {
                             bitor(
-                                *((lParse.Nodes[this_node_idx]).value.data.strptr)
+                                *((lParse.Nodes[this_node_idx]).value.data.strptr())
                                     .offset(rows as isize),
                                 sptr1,
                                 sptr2,
                             );
                         } else if (lParse.Nodes[this_node_idx]).operation == '&' as i32 {
                             bitand(
-                                *((lParse.Nodes[this_node_idx]).value.data.strptr)
+                                *((lParse.Nodes[this_node_idx]).value.data.strptr())
                                     .offset(rows as isize),
                                 sptr1,
                                 sptr2,
                             );
                         } else {
                             strcpy(
-                                *((lParse.Nodes[this_node_idx]).value.data.strptr)
+                                *((lParse.Nodes[this_node_idx]).value.data.strptr())
                                     .offset(rows as isize),
                                 sptr1,
                             );
                             strcat(
-                                *((lParse.Nodes[this_node_idx]).value.data.strptr)
+                                *((lParse.Nodes[this_node_idx]).value.data.strptr())
                                     .offset(rows as isize),
                                 sptr2,
                             );
@@ -8187,11 +8198,11 @@ fn Do_BinOp_bit(lParse: &mut ParseData, this_node_idx: usize) {
                         let mut i: c_long = 0;
                         let mut previous: c_long = 0;
                         let mut curr: c_long = 0;
-                        previous = (lParse.Nodes[that2_idx]).value.data.lng;
+                        previous = (lParse.Nodes[that2_idx]).value.data.lng();
                         i = 0;
                         while i < rows {
                             sptr1 =
-                                *((lParse.Nodes[that1_idx]).value.data.strptr).offset(i as isize);
+                                *((lParse.Nodes[that1_idx]).value.data.strptr()).offset(i as isize);
                             curr = 0;
                             while *sptr1 != 0 {
                                 if c_int::from(*sptr1) == '1' as i32 {
@@ -8200,8 +8211,8 @@ fn Do_BinOp_bit(lParse: &mut ParseData, this_node_idx: usize) {
                                 sptr1 = sptr1.offset(1);
                             }
                             previous += curr;
-                            *((lParse.Nodes[this_node_idx]).value.data.lngptr).offset(i as isize) =
-                                previous;
+                            *((lParse.Nodes[this_node_idx]).value.data.lngptr())
+                                .offset(i as isize) = previous;
                             *((lParse.Nodes[this_node_idx]).value.undef).offset(i as isize) = 0;
                             i += 1;
                         }
@@ -8239,12 +8250,12 @@ fn Do_BinOp_str(lParse: &mut ParseData, this_node_idx: usize) {
         const1 = c_int::from((lParse.Nodes[that1_idx]).operation == CONST_OP);
         const2 = c_int::from((lParse.Nodes[that2_idx]).operation == CONST_OP);
         sptr1 = if const1 != 0 {
-            ((lParse.Nodes[that1_idx]).value.data.astr).as_mut_ptr()
+            ((lParse.Nodes[that1_idx]).value.data.astr_mut()).as_mut_ptr()
         } else {
             core::ptr::null_mut::<c_char>()
         };
         sptr2 = if const2 != 0 {
-            ((lParse.Nodes[that2_idx]).value.data.astr).as_mut_ptr()
+            ((lParse.Nodes[that2_idx]).value.data.astr_mut()).as_mut_ptr()
         } else {
             core::ptr::null_mut::<c_char>()
         };
@@ -8331,11 +8342,11 @@ fn Do_BinOp_str(lParse: &mut ParseData, this_node_idx: usize) {
                 }
                 43 => {
                     strcpy(
-                        ((lParse.Nodes[this_node_idx]).value.data.astr).as_mut_ptr(),
+                        ((lParse.Nodes[this_node_idx]).value.data.astr_mut()).as_mut_ptr(),
                         sptr1,
                     );
                     strcat(
-                        ((lParse.Nodes[this_node_idx]).value.data.astr).as_mut_ptr(),
+                        ((lParse.Nodes[this_node_idx]).value.data.astr_mut()).as_mut_ptr(),
                         sptr2,
                     );
                 }
@@ -8367,11 +8378,11 @@ fn Do_BinOp_str(lParse: &mut ParseData, this_node_idx: usize) {
                             };
                         if *((lParse.Nodes[this_node_idx]).value.undef).offset(rows as isize) == 0 {
                             if const1 == 0 {
-                                sptr1 = *((lParse.Nodes[that1_idx]).value.data.strptr)
+                                sptr1 = *((lParse.Nodes[that1_idx]).value.data.strptr())
                                     .offset(rows as isize);
                             }
                             if const2 == 0 {
-                                sptr2 = *((lParse.Nodes[that2_idx]).value.data.strptr)
+                                sptr2 = *((lParse.Nodes[that2_idx]).value.data.strptr())
                                     .offset(rows as isize);
                             }
                             val = c_int::from(
@@ -8385,7 +8396,7 @@ fn Do_BinOp_str(lParse: &mut ParseData, this_node_idx: usize) {
                                     strcmp(sptr1, sptr2)
                                 }) == 0,
                             );
-                            *((lParse.Nodes[this_node_idx]).value.data.logptr)
+                            *((lParse.Nodes[this_node_idx]).value.data.logptr())
                                 .offset(rows as isize) = (if (lParse.Nodes[this_node_idx]).operation
                                 == fits_parser_yytokentype::EQ as c_int
                             {
@@ -8415,11 +8426,11 @@ fn Do_BinOp_str(lParse: &mut ParseData, this_node_idx: usize) {
                             };
                         if *((lParse.Nodes[this_node_idx]).value.undef).offset(rows as isize) == 0 {
                             if const1 == 0 {
-                                sptr1 = *((lParse.Nodes[that1_idx]).value.data.strptr)
+                                sptr1 = *((lParse.Nodes[that1_idx]).value.data.strptr())
                                     .offset(rows as isize);
                             }
                             if const2 == 0 {
-                                sptr2 = *((lParse.Nodes[that2_idx]).value.data.strptr)
+                                sptr2 = *((lParse.Nodes[that2_idx]).value.data.strptr())
                                     .offset(rows as isize);
                             }
                             val = if c_int::from(*sptr1.offset(0)) < c_int::from(*sptr2.offset(0)) {
@@ -8430,7 +8441,7 @@ fn Do_BinOp_str(lParse: &mut ParseData, this_node_idx: usize) {
                             } else {
                                 strcmp(sptr1, sptr2)
                             };
-                            *((lParse.Nodes[this_node_idx]).value.data.logptr)
+                            *((lParse.Nodes[this_node_idx]).value.data.logptr())
                                 .offset(rows as isize) = (if (lParse.Nodes[this_node_idx]).operation
                                 == fits_parser_yytokentype::GT as c_int
                             {
@@ -8460,11 +8471,11 @@ fn Do_BinOp_str(lParse: &mut ParseData, this_node_idx: usize) {
                             };
                         if *((lParse.Nodes[this_node_idx]).value.undef).offset(rows as isize) == 0 {
                             if const1 == 0 {
-                                sptr1 = *((lParse.Nodes[that1_idx]).value.data.strptr)
+                                sptr1 = *((lParse.Nodes[that1_idx]).value.data.strptr())
                                     .offset(rows as isize);
                             }
                             if const2 == 0 {
-                                sptr2 = *((lParse.Nodes[that2_idx]).value.data.strptr)
+                                sptr2 = *((lParse.Nodes[that2_idx]).value.data.strptr())
                                     .offset(rows as isize);
                             }
                             val = if c_int::from(*sptr1.offset(0)) < c_int::from(*sptr2.offset(0)) {
@@ -8475,7 +8486,7 @@ fn Do_BinOp_str(lParse: &mut ParseData, this_node_idx: usize) {
                             } else {
                                 strcmp(sptr1, sptr2)
                             };
-                            *((lParse.Nodes[this_node_idx]).value.data.logptr)
+                            *((lParse.Nodes[this_node_idx]).value.data.logptr())
                                 .offset(rows as isize) = (if (lParse.Nodes[this_node_idx]).operation
                                 == fits_parser_yytokentype::GTE as c_int
                             {
@@ -8505,20 +8516,20 @@ fn Do_BinOp_str(lParse: &mut ParseData, this_node_idx: usize) {
                             };
                         if *((lParse.Nodes[this_node_idx]).value.undef).offset(rows as isize) == 0 {
                             if const1 == 0 {
-                                sptr1 = *((lParse.Nodes[that1_idx]).value.data.strptr)
+                                sptr1 = *((lParse.Nodes[that1_idx]).value.data.strptr())
                                     .offset(rows as isize);
                             }
                             if const2 == 0 {
-                                sptr2 = *((lParse.Nodes[that2_idx]).value.data.strptr)
+                                sptr2 = *((lParse.Nodes[that2_idx]).value.data.strptr())
                                     .offset(rows as isize);
                             }
                             strcpy(
-                                *((lParse.Nodes[this_node_idx]).value.data.strptr)
+                                *((lParse.Nodes[this_node_idx]).value.data.strptr())
                                     .offset(rows as isize),
                                 sptr1,
                             );
                             strcat(
-                                *((lParse.Nodes[this_node_idx]).value.data.strptr)
+                                *((lParse.Nodes[this_node_idx]).value.data.strptr())
                                     .offset(rows as isize),
                                 sptr2,
                             );
@@ -8556,13 +8567,13 @@ fn Do_BinOp_log(lParse: &mut ParseData, this_node_idx: usize) {
         if vector1 != 0 {
             vector1 = (lParse.Nodes[that1_idx]).value.nelem as c_int;
         } else {
-            val1 = (lParse.Nodes[that1_idx]).value.data.log;
+            val1 = (lParse.Nodes[that1_idx]).value.data.log();
         }
         vector2 = c_int::from((lParse.Nodes[that2_idx]).operation != CONST_OP);
         if vector2 != 0 {
             vector2 = (lParse.Nodes[that2_idx]).value.nelem as c_int;
         } else {
-            val2 = (lParse.Nodes[that2_idx]).value.data.log;
+            val2 = (lParse.Nodes[that2_idx]).value.data.log();
         }
         if vector1 == 0 && vector2 == 0 {
             match (lParse.Nodes[this_node_idx]).operation {
@@ -8613,16 +8624,16 @@ fn Do_BinOp_log(lParse: &mut ParseData, this_node_idx: usize) {
             elem = (lParse.Nodes[this_node_idx]).value.nelem * rows;
             Allocate_Ptrs(lParse, this_node_idx);
             if lParse.status == 0 {
-                previous = (lParse.Nodes[that2_idx]).value.data.lng;
+                previous = (lParse.Nodes[that2_idx]).value.data.lng();
                 i = 0;
                 while i < elem {
                     if *((lParse.Nodes[that1_idx]).value.undef).offset(i as isize) == 0 {
                         curr = c_long::from(
-                            *((lParse.Nodes[that1_idx]).value.data.logptr).offset(i as isize),
+                            *((lParse.Nodes[that1_idx]).value.data.logptr()).offset(i as isize),
                         );
                         previous += curr;
                     }
-                    *((lParse.Nodes[this_node_idx]).value.data.lngptr).offset(i as isize) =
+                    *((lParse.Nodes[this_node_idx]).value.data.lngptr()).offset(i as isize) =
                         previous;
                     *((lParse.Nodes[this_node_idx]).value.undef).offset(i as isize) = 0;
                     i += 1;
@@ -8641,16 +8652,17 @@ fn Do_BinOp_log(lParse: &mut ParseData, this_node_idx: usize) {
                     let mut i_0: c_long = 0;
                     let mut previous_0: c_long = 0;
                     let mut curr_0: c_long = 0;
-                    previous_0 = (lParse.Nodes[that2_idx]).value.data.lng;
+                    previous_0 = (lParse.Nodes[that2_idx]).value.data.lng();
                     i_0 = 0;
                     while i_0 < elem {
                         if *((lParse.Nodes[that1_idx]).value.undef).offset(i_0 as isize) == 0 {
                             curr_0 = c_long::from(
-                                *((lParse.Nodes[that1_idx]).value.data.logptr).offset(i_0 as isize),
+                                *((lParse.Nodes[that1_idx]).value.data.logptr())
+                                    .offset(i_0 as isize),
                             );
                             previous_0 += curr_0;
                         }
-                        *((lParse.Nodes[this_node_idx]).value.data.lngptr).offset(i_0 as isize) =
+                        *((lParse.Nodes[this_node_idx]).value.data.lngptr()).offset(i_0 as isize) =
                             previous_0;
                         *((lParse.Nodes[this_node_idx]).value.undef).offset(i_0 as isize) = 0;
                         i_0 += 1;
@@ -8671,20 +8683,20 @@ fn Do_BinOp_log(lParse: &mut ParseData, this_node_idx: usize) {
                         }
                         elem -= 1;
                         if vector1 > 1 {
-                            val1 = *((lParse.Nodes[that1_idx]).value.data.logptr)
+                            val1 = *((lParse.Nodes[that1_idx]).value.data.logptr())
                                 .offset(elem as isize);
                             null1 = *((lParse.Nodes[that1_idx]).value.undef).offset(elem as isize);
                         } else if vector1 != 0 {
-                            val1 = *((lParse.Nodes[that1_idx]).value.data.logptr)
+                            val1 = *((lParse.Nodes[that1_idx]).value.data.logptr())
                                 .offset(rows as isize);
                             null1 = *((lParse.Nodes[that1_idx]).value.undef).offset(rows as isize);
                         }
                         if vector2 > 1 {
-                            val2 = *((lParse.Nodes[that2_idx]).value.data.logptr)
+                            val2 = *((lParse.Nodes[that2_idx]).value.data.logptr())
                                 .offset(elem as isize);
                             null2 = *((lParse.Nodes[that2_idx]).value.undef).offset(elem as isize);
                         } else if vector2 != 0 {
-                            val2 = *((lParse.Nodes[that2_idx]).value.data.logptr)
+                            val2 = *((lParse.Nodes[that2_idx]).value.data.logptr())
                                 .offset(rows as isize);
                             null2 = *((lParse.Nodes[that2_idx]).value.undef).offset(rows as isize);
                         }
@@ -8697,7 +8709,7 @@ fn Do_BinOp_log(lParse: &mut ParseData, this_node_idx: usize) {
                         match (lParse.Nodes[this_node_idx]).operation {
                             277 => {
                                 if null1 == 0 && null2 == 0 {
-                                    *((lParse.Nodes[this_node_idx]).value.data.logptr)
+                                    *((lParse.Nodes[this_node_idx]).value.data.logptr())
                                         .offset(elem as isize) =
                                         if c_int::from(val1) != 0 || c_int::from(val2) != 0 {
                                             1
@@ -8711,7 +8723,7 @@ fn Do_BinOp_log(lParse: &mut ParseData, this_node_idx: usize) {
                                         && c_int::from(null2) != 0
                                         && c_int::from(val1) != 0
                                 {
-                                    *((lParse.Nodes[this_node_idx]).value.data.logptr)
+                                    *((lParse.Nodes[this_node_idx]).value.data.logptr())
                                         .offset(elem as isize) = 1;
                                     *((lParse.Nodes[this_node_idx]).value.undef)
                                         .offset(elem as isize) = 0;
@@ -8719,7 +8731,7 @@ fn Do_BinOp_log(lParse: &mut ParseData, this_node_idx: usize) {
                             }
                             278 => {
                                 if null1 == 0 && null2 == 0 {
-                                    *((lParse.Nodes[this_node_idx]).value.data.logptr)
+                                    *((lParse.Nodes[this_node_idx]).value.data.logptr())
                                         .offset(elem as isize) =
                                         if c_int::from(val1) != 0 && c_int::from(val2) != 0 {
                                             1
@@ -8729,14 +8741,14 @@ fn Do_BinOp_log(lParse: &mut ParseData, this_node_idx: usize) {
                                 } else if c_int::from(null1) != 0 && null2 == 0 && val2 == 0
                                     || null1 == 0 && c_int::from(null2) != 0 && val1 == 0
                                 {
-                                    *((lParse.Nodes[this_node_idx]).value.data.logptr)
+                                    *((lParse.Nodes[this_node_idx]).value.data.logptr())
                                         .offset(elem as isize) = 0;
                                     *((lParse.Nodes[this_node_idx]).value.undef)
                                         .offset(elem as isize) = 0;
                                 }
                             }
                             279 => {
-                                *((lParse.Nodes[this_node_idx]).value.data.logptr)
+                                *((lParse.Nodes[this_node_idx]).value.data.logptr())
                                     .offset(elem as isize) = c_int::from(
                                     c_int::from(val1) != 0 && c_int::from(val2) != 0
                                         || val1 == 0 && val2 == 0,
@@ -8744,7 +8756,7 @@ fn Do_BinOp_log(lParse: &mut ParseData, this_node_idx: usize) {
                                     as c_char;
                             }
                             280 => {
-                                *((lParse.Nodes[this_node_idx]).value.data.logptr)
+                                *((lParse.Nodes[this_node_idx]).value.data.logptr())
                                     .offset(elem as isize) = c_int::from(
                                     c_int::from(val1) != 0 && val2 == 0
                                         || val1 == 0 && c_int::from(val2) != 0,
@@ -8786,14 +8798,14 @@ fn Do_BinOp_lng(lParse: &mut ParseData, this_node_idx: usize) {
         if vector1 != 0 {
             vector1 = (lParse.Nodes[that1_idx]).value.nelem as c_int;
         } else {
-            val1 = (lParse.Nodes[that1_idx]).value.data.lng;
+            val1 = (lParse.Nodes[that1_idx]).value.data.lng();
         }
 
         vector2 = c_int::from((lParse.Nodes[that2_idx]).operation != CONST_OP);
         if vector2 != 0 {
             vector2 = (lParse.Nodes[that2_idx]).value.nelem as c_int;
         } else {
-            val2 = (lParse.Nodes[that2_idx]).value.data.lng;
+            val2 = (lParse.Nodes[that2_idx]).value.data.lng();
         }
 
         if vector1 == 0 && vector2 == 0 {
@@ -8891,7 +8903,7 @@ fn Do_BinOp_lng(lParse: &mut ParseData, this_node_idx: usize) {
             elem = (lParse.Nodes[this_node_idx]).value.nelem * rows;
             Allocate_Ptrs(lParse, this_node_idx);
             if lParse.status == 0 {
-                previous = (lParse.Nodes[that2_idx]).value.data.lng;
+                previous = (lParse.Nodes[that2_idx]).value.data.lng();
                 undef = c_long::from(*(lParse.Nodes[that2_idx]).value.undef);
                 if (lParse.Nodes[this_node_idx]).operation
                     == fits_parser_yytokentype::ACCUM as c_int
@@ -8900,10 +8912,10 @@ fn Do_BinOp_lng(lParse: &mut ParseData, this_node_idx: usize) {
                     while i < elem {
                         if *((lParse.Nodes[that1_idx]).value.undef).offset(i as isize) == 0 {
                             curr =
-                                *((lParse.Nodes[that1_idx]).value.data.lngptr).offset(i as isize);
+                                *((lParse.Nodes[that1_idx]).value.data.lngptr()).offset(i as isize);
                             previous += curr;
                         }
-                        *((lParse.Nodes[this_node_idx]).value.data.lngptr).offset(i as isize) =
+                        *((lParse.Nodes[this_node_idx]).value.data.lngptr()).offset(i as isize) =
                             previous;
                         *((lParse.Nodes[this_node_idx]).value.undef).offset(i as isize) = 0;
                         i += 1;
@@ -8911,17 +8923,17 @@ fn Do_BinOp_lng(lParse: &mut ParseData, this_node_idx: usize) {
                 } else {
                     i = 0;
                     while i < elem {
-                        curr = *((lParse.Nodes[that1_idx]).value.data.lngptr).offset(i as isize);
+                        curr = *((lParse.Nodes[that1_idx]).value.data.lngptr()).offset(i as isize);
                         if c_int::from(*((lParse.Nodes[that1_idx]).value.undef).offset(i as isize))
                             != 0
                             || undef != 0
                         {
-                            *((lParse.Nodes[this_node_idx]).value.data.lngptr).offset(i as isize) =
-                                0;
+                            *((lParse.Nodes[this_node_idx]).value.data.lngptr())
+                                .offset(i as isize) = 0;
                             *((lParse.Nodes[this_node_idx]).value.undef).offset(i as isize) = 1;
                         } else {
-                            *((lParse.Nodes[this_node_idx]).value.data.lngptr).offset(i as isize) =
-                                curr - previous;
+                            *((lParse.Nodes[this_node_idx]).value.data.lngptr())
+                                .offset(i as isize) = curr - previous;
                             *((lParse.Nodes[this_node_idx]).value.undef).offset(i as isize) = 0;
                         }
                         previous = curr;
@@ -8954,17 +8966,21 @@ fn Do_BinOp_lng(lParse: &mut ParseData, this_node_idx: usize) {
                     elem -= 1;
 
                     if vector1 > 1 {
-                        val1 = *((lParse.Nodes[that1_idx]).value.data.lngptr).offset(elem as isize);
+                        val1 =
+                            *((lParse.Nodes[that1_idx]).value.data.lngptr()).offset(elem as isize);
                         null1 = *((lParse.Nodes[that1_idx]).value.undef).offset(elem as isize);
                     } else if vector1 != 0 {
-                        val1 = *((lParse.Nodes[that1_idx]).value.data.lngptr).offset(rows as isize);
+                        val1 =
+                            *((lParse.Nodes[that1_idx]).value.data.lngptr()).offset(rows as isize);
                         null1 = *((lParse.Nodes[that1_idx]).value.undef).offset(rows as isize);
                     }
                     if vector2 > 1 {
-                        val2 = *((lParse.Nodes[that2_idx]).value.data.lngptr).offset(elem as isize);
+                        val2 =
+                            *((lParse.Nodes[that2_idx]).value.data.lngptr()).offset(elem as isize);
                         null2 = *((lParse.Nodes[that2_idx]).value.undef).offset(elem as isize);
                     } else if vector2 != 0 {
-                        val2 = *((lParse.Nodes[that2_idx]).value.data.lngptr).offset(rows as isize);
+                        val2 =
+                            *((lParse.Nodes[that2_idx]).value.data.lngptr()).offset(rows as isize);
                         null2 = *((lParse.Nodes[that2_idx]).value.undef).offset(rows as isize);
                     }
                     *((lParse.Nodes[this_node_idx]).value.undef).offset(elem as isize) =
@@ -8975,59 +8991,59 @@ fn Do_BinOp_lng(lParse: &mut ParseData, this_node_idx: usize) {
                         };
                     match (lParse.Nodes[this_node_idx]).operation {
                         126 | 279 => {
-                            *((lParse.Nodes[this_node_idx]).value.data.logptr)
+                            *((lParse.Nodes[this_node_idx]).value.data.logptr())
                                 .offset(elem as isize) = if val1 == val2 { 1 } else { 0 };
                         }
                         280 => {
-                            *((lParse.Nodes[this_node_idx]).value.data.logptr)
+                            *((lParse.Nodes[this_node_idx]).value.data.logptr())
                                 .offset(elem as isize) = if val1 != val2 { 1 } else { 0 };
                         }
                         281 => {
-                            *((lParse.Nodes[this_node_idx]).value.data.logptr)
+                            *((lParse.Nodes[this_node_idx]).value.data.logptr())
                                 .offset(elem as isize) = if val1 > val2 { 1 } else { 0 };
                         }
                         282 => {
-                            *((lParse.Nodes[this_node_idx]).value.data.logptr)
+                            *((lParse.Nodes[this_node_idx]).value.data.logptr())
                                 .offset(elem as isize) = if val1 < val2 { 1 } else { 0 };
                         }
                         283 => {
-                            *((lParse.Nodes[this_node_idx]).value.data.logptr)
+                            *((lParse.Nodes[this_node_idx]).value.data.logptr())
                                 .offset(elem as isize) = if val1 <= val2 { 1 } else { 0 };
                         }
                         284 => {
-                            *((lParse.Nodes[this_node_idx]).value.data.logptr)
+                            *((lParse.Nodes[this_node_idx]).value.data.logptr())
                                 .offset(elem as isize) = if val1 >= val2 { 1 } else { 0 };
                         }
                         43 => {
-                            *((lParse.Nodes[this_node_idx]).value.data.lngptr)
+                            *((lParse.Nodes[this_node_idx]).value.data.lngptr())
                                 .offset(elem as isize) = val1 + val2;
                         }
                         45 => {
-                            *((lParse.Nodes[this_node_idx]).value.data.lngptr)
+                            *((lParse.Nodes[this_node_idx]).value.data.lngptr())
                                 .offset(elem as isize) = val1 - val2;
                         }
                         42 => {
-                            *((lParse.Nodes[this_node_idx]).value.data.lngptr)
+                            *((lParse.Nodes[this_node_idx]).value.data.lngptr())
                                 .offset(elem as isize) = val1 * val2;
                         }
                         38 => {
-                            *((lParse.Nodes[this_node_idx]).value.data.lngptr)
+                            *((lParse.Nodes[this_node_idx]).value.data.lngptr())
                                 .offset(elem as isize) = val1 & val2;
                         }
                         124 => {
-                            *((lParse.Nodes[this_node_idx]).value.data.lngptr)
+                            *((lParse.Nodes[this_node_idx]).value.data.lngptr())
                                 .offset(elem as isize) = val1 | val2;
                         }
                         94 => {
-                            *((lParse.Nodes[this_node_idx]).value.data.lngptr)
+                            *((lParse.Nodes[this_node_idx]).value.data.lngptr())
                                 .offset(elem as isize) = val1 ^ val2;
                         }
                         37 => {
                             if val2 != 0 {
-                                *((lParse.Nodes[this_node_idx]).value.data.lngptr)
+                                *((lParse.Nodes[this_node_idx]).value.data.lngptr())
                                     .offset(elem as isize) = val1 % val2;
                             } else {
-                                *((lParse.Nodes[this_node_idx]).value.data.lngptr)
+                                *((lParse.Nodes[this_node_idx]).value.data.lngptr())
                                     .offset(elem as isize) = 0;
                                 *((lParse.Nodes[this_node_idx]).value.undef)
                                     .offset(elem as isize) = 1;
@@ -9035,17 +9051,17 @@ fn Do_BinOp_lng(lParse: &mut ParseData, this_node_idx: usize) {
                         }
                         47 => {
                             if val2 != 0 {
-                                *((lParse.Nodes[this_node_idx]).value.data.lngptr)
+                                *((lParse.Nodes[this_node_idx]).value.data.lngptr())
                                     .offset(elem as isize) = val1 / val2;
                             } else {
-                                *((lParse.Nodes[this_node_idx]).value.data.lngptr)
+                                *((lParse.Nodes[this_node_idx]).value.data.lngptr())
                                     .offset(elem as isize) = 0;
                                 *((lParse.Nodes[this_node_idx]).value.undef)
                                     .offset(elem as isize) = 1;
                             }
                         }
                         286 => {
-                            *((lParse.Nodes[this_node_idx]).value.data.lngptr)
+                            *((lParse.Nodes[this_node_idx]).value.data.lngptr())
                                 .offset(elem as isize) =
                                 pow(val1 as c_double, val2 as c_double) as c_long;
                         }
@@ -9065,7 +9081,7 @@ fn Do_BinOp_lng(lParse: &mut ParseData, this_node_idx: usize) {
 }
 
 fn validate_double_vector(lParse: &mut ParseData, node_idx: usize) -> c_int {
-    let data = unsafe { (lParse.Nodes[node_idx]).value.data.dblptr };
+    let data = unsafe { (lParse.Nodes[node_idx]).value.data.dblptr() };
     let undef = unsafe { (lParse.Nodes[node_idx]).value.undef };
 
     if data.is_null()
@@ -9104,14 +9120,14 @@ fn Do_BinOp_dbl(lParse: &mut ParseData, this_node_idx: usize) {
         if vector1 != 0 {
             vector1 = (lParse.Nodes[that1_idx]).value.nelem as c_int;
         } else {
-            val1 = (lParse.Nodes[that1_idx]).value.data.dbl;
+            val1 = (lParse.Nodes[that1_idx]).value.data.dbl();
         }
 
         vector2 = c_int::from((lParse.Nodes[that2_idx]).operation != CONST_OP);
         if vector2 != 0 {
             vector2 = (lParse.Nodes[that2_idx]).value.nelem as c_int;
         } else {
-            val2 = (lParse.Nodes[that2_idx]).value.data.dbl;
+            val2 = (lParse.Nodes[that2_idx]).value.data.dbl();
         }
 
         if vector1 != 0 && validate_double_vector(lParse, that1_idx) == 0 {
@@ -9198,7 +9214,7 @@ fn Do_BinOp_dbl(lParse: &mut ParseData, this_node_idx: usize) {
             Allocate_Ptrs(lParse, this_node_idx);
 
             if lParse.status == 0 {
-                previous = (lParse.Nodes[that2_idx]).value.data.dbl;
+                previous = (lParse.Nodes[that2_idx]).value.data.dbl();
                 undef = (lParse.Nodes[that2_idx]).value.undef as c_long;
                 if (lParse.Nodes[this_node_idx]).operation
                     == fits_parser_yytokentype::ACCUM as c_int
@@ -9207,27 +9223,27 @@ fn Do_BinOp_dbl(lParse: &mut ParseData, this_node_idx: usize) {
                     for i in 0..elem {
                         if *((lParse.Nodes[that1_idx]).value.undef).offset(i as isize) == 0 {
                             curr =
-                                *((lParse.Nodes[that1_idx]).value.data.dblptr).offset(i as isize);
+                                *((lParse.Nodes[that1_idx]).value.data.dblptr()).offset(i as isize);
                             previous += curr;
                         }
-                        *((lParse.Nodes[this_node_idx]).value.data.dblptr).offset(i as isize) =
+                        *((lParse.Nodes[this_node_idx]).value.data.dblptr()).offset(i as isize) =
                             previous;
                         *((lParse.Nodes[this_node_idx]).value.undef).offset(i as isize) = 0;
                     }
                 } else {
                     i = 0;
                     while i < elem {
-                        curr = *((lParse.Nodes[that1_idx]).value.data.dblptr).offset(i as isize);
+                        curr = *((lParse.Nodes[that1_idx]).value.data.dblptr()).offset(i as isize);
                         if c_int::from(*((lParse.Nodes[that1_idx]).value.undef).offset(i as isize))
                             != 0
                             || undef != 0
                         {
-                            *((lParse.Nodes[this_node_idx]).value.data.dblptr).offset(i as isize) =
-                                0.0;
+                            *((lParse.Nodes[this_node_idx]).value.data.dblptr())
+                                .offset(i as isize) = 0.0;
                             *((lParse.Nodes[this_node_idx]).value.undef).offset(i as isize) = 1;
                         } else {
-                            *((lParse.Nodes[this_node_idx]).value.data.dblptr).offset(i as isize) =
-                                curr - previous;
+                            *((lParse.Nodes[this_node_idx]).value.data.dblptr())
+                                .offset(i as isize) = curr - previous;
                             *((lParse.Nodes[this_node_idx]).value.undef).offset(i as isize) = 0;
                         }
                         previous = curr;
@@ -9260,17 +9276,21 @@ fn Do_BinOp_dbl(lParse: &mut ParseData, this_node_idx: usize) {
                     elem -= 1;
 
                     if vector1 > 1 {
-                        val1 = *((lParse.Nodes[that1_idx]).value.data.dblptr).offset(elem as isize);
+                        val1 =
+                            *((lParse.Nodes[that1_idx]).value.data.dblptr()).offset(elem as isize);
                         null1 = *((lParse.Nodes[that1_idx]).value.undef).offset(elem as isize);
                     } else if vector1 != 0 {
-                        val1 = *((lParse.Nodes[that1_idx]).value.data.dblptr).offset(rows as isize);
+                        val1 =
+                            *((lParse.Nodes[that1_idx]).value.data.dblptr()).offset(rows as isize);
                         null1 = *((lParse.Nodes[that1_idx]).value.undef).offset(rows as isize);
                     }
                     if vector2 > 1 {
-                        val2 = *((lParse.Nodes[that2_idx]).value.data.dblptr).offset(elem as isize);
+                        val2 =
+                            *((lParse.Nodes[that2_idx]).value.data.dblptr()).offset(elem as isize);
                         null2 = *((lParse.Nodes[that2_idx]).value.undef).offset(elem as isize);
                     } else if vector2 != 0 {
-                        val2 = *((lParse.Nodes[that2_idx]).value.data.dblptr).offset(rows as isize);
+                        val2 =
+                            *((lParse.Nodes[that2_idx]).value.data.dblptr()).offset(rows as isize);
                         null2 = *((lParse.Nodes[that2_idx]).value.undef).offset(rows as isize);
                     }
                     *((lParse.Nodes[this_node_idx]).value.undef).offset(elem as isize) =
@@ -9281,53 +9301,53 @@ fn Do_BinOp_dbl(lParse: &mut ParseData, this_node_idx: usize) {
                         };
                     match (lParse.Nodes[this_node_idx]).operation {
                         126 => {
-                            *((lParse.Nodes[this_node_idx]).value.data.logptr)
+                            *((lParse.Nodes[this_node_idx]).value.data.logptr())
                                 .offset(elem as isize) =
                                 if fabs(val1 - val2) < APPROX { 1 } else { 0 };
                         }
                         279 => {
-                            *((lParse.Nodes[this_node_idx]).value.data.logptr)
+                            *((lParse.Nodes[this_node_idx]).value.data.logptr())
                                 .offset(elem as isize) = if val1 == val2 { 1 } else { 0 };
                         }
                         280 => {
-                            *((lParse.Nodes[this_node_idx]).value.data.logptr)
+                            *((lParse.Nodes[this_node_idx]).value.data.logptr())
                                 .offset(elem as isize) = if val1 != val2 { 1 } else { 0 };
                         }
                         281 => {
-                            *((lParse.Nodes[this_node_idx]).value.data.logptr)
+                            *((lParse.Nodes[this_node_idx]).value.data.logptr())
                                 .offset(elem as isize) = if val1 > val2 { 1 } else { 0 };
                         }
                         282 => {
-                            *((lParse.Nodes[this_node_idx]).value.data.logptr)
+                            *((lParse.Nodes[this_node_idx]).value.data.logptr())
                                 .offset(elem as isize) = if val1 < val2 { 1 } else { 0 };
                         }
                         283 => {
-                            *((lParse.Nodes[this_node_idx]).value.data.logptr)
+                            *((lParse.Nodes[this_node_idx]).value.data.logptr())
                                 .offset(elem as isize) = if val1 <= val2 { 1 } else { 0 };
                         }
                         284 => {
-                            *((lParse.Nodes[this_node_idx]).value.data.logptr)
+                            *((lParse.Nodes[this_node_idx]).value.data.logptr())
                                 .offset(elem as isize) = if val1 >= val2 { 1 } else { 0 };
                         }
                         43 => {
-                            *((lParse.Nodes[this_node_idx]).value.data.dblptr)
+                            *((lParse.Nodes[this_node_idx]).value.data.dblptr())
                                 .offset(elem as isize) = val1 + val2;
                         }
                         45 => {
-                            *((lParse.Nodes[this_node_idx]).value.data.dblptr)
+                            *((lParse.Nodes[this_node_idx]).value.data.dblptr())
                                 .offset(elem as isize) = val1 - val2;
                         }
                         42 => {
-                            *((lParse.Nodes[this_node_idx]).value.data.dblptr)
+                            *((lParse.Nodes[this_node_idx]).value.data.dblptr())
                                 .offset(elem as isize) = val1 * val2;
                         }
                         37 => {
                             if val2 != 0. {
-                                *((lParse.Nodes[this_node_idx]).value.data.dblptr)
+                                *((lParse.Nodes[this_node_idx]).value.data.dblptr())
                                     .offset(elem as isize) =
                                     val1 - val2 * c_double::from((val1 / val2) as c_int);
                             } else {
-                                *((lParse.Nodes[this_node_idx]).value.data.dblptr)
+                                *((lParse.Nodes[this_node_idx]).value.data.dblptr())
                                     .offset(elem as isize) = 0.0;
                                 *((lParse.Nodes[this_node_idx]).value.undef)
                                     .offset(elem as isize) = 1;
@@ -9335,17 +9355,17 @@ fn Do_BinOp_dbl(lParse: &mut ParseData, this_node_idx: usize) {
                         }
                         47 => {
                             if val2 != 0. {
-                                *((lParse.Nodes[this_node_idx]).value.data.dblptr)
+                                *((lParse.Nodes[this_node_idx]).value.data.dblptr())
                                     .offset(elem as isize) = val1 / val2;
                             } else {
-                                *((lParse.Nodes[this_node_idx]).value.data.dblptr)
+                                *((lParse.Nodes[this_node_idx]).value.data.dblptr())
                                     .offset(elem as isize) = 0.0;
                                 *((lParse.Nodes[this_node_idx]).value.undef)
                                     .offset(elem as isize) = 1;
                             }
                         }
                         286 => {
-                            *((lParse.Nodes[this_node_idx]).value.data.dblptr)
+                            *((lParse.Nodes[this_node_idx]).value.data.dblptr())
                                 .offset(elem as isize) = pow(val1, val2);
                         }
                         _ => {}
@@ -9586,21 +9606,21 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                     == fits_parser_yytokentype::DOUBLE as c_int
                 {
                     pVals[i as usize].data.dbl =
-                        (lParse.Nodes[theParams[i as usize]]).value.data.dbl;
+                        (lParse.Nodes[theParams[i as usize]]).value.data.dbl();
                 } else if (lParse.Nodes[theParams[i as usize]]).ntype
                     == fits_parser_yytokentype::LONG as c_int
                 {
                     pVals[i as usize].data.lng =
-                        (lParse.Nodes[theParams[i as usize]]).value.data.lng;
+                        (lParse.Nodes[theParams[i as usize]]).value.data.lng();
                 } else if (lParse.Nodes[theParams[i as usize]]).ntype
                     == fits_parser_yytokentype::BOOLEAN as c_int
                 {
                     pVals[i as usize].data.log =
-                        (lParse.Nodes[theParams[i as usize]]).value.data.log;
+                        (lParse.Nodes[theParams[i as usize]]).value.data.log();
                 } else {
                     strcpy(
                         (pVals[i as usize].data.astr).as_mut_ptr(),
-                        ((lParse.Nodes[theParams[i as usize]]).value.data.astr).as_mut_ptr(),
+                        ((lParse.Nodes[theParams[i as usize]]).value.data.astr_mut()).as_mut_ptr(),
                     );
                 }
                 pNull[i as usize] = 0;
@@ -9643,7 +9663,7 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                         == fits_parser_yytokentype::BITSTR as c_int
                     {
                         strcpy(
-                            ((lParse.Nodes[this_node_idx]).value.data.astr).as_mut_ptr(),
+                            ((lParse.Nodes[this_node_idx]).value.data.astr_mut()).as_mut_ptr(),
                             (pVals[0].data.astr).as_mut_ptr(),
                         );
                     }
@@ -9735,7 +9755,7 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                         == fits_parser_yytokentype::STRING as c_int
                     {
                         strcpy(
-                            ((lParse.Nodes[this_node_idx]).value.data.astr).as_mut_ptr(),
+                            ((lParse.Nodes[this_node_idx]).value.data.astr_mut()).as_mut_ptr(),
                             (pVals[0].data.astr).as_mut_ptr(),
                         );
                     }
@@ -9893,7 +9913,7 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                         == fits_parser_yytokentype::BITSTR as c_int
                     {
                         strcpy(
-                            ((lParse.Nodes[this_node_idx]).value.data.astr).as_mut_ptr(),
+                            ((lParse.Nodes[this_node_idx]).value.data.astr_mut()).as_mut_ptr(),
                             (pVals[0].data.astr).as_mut_ptr(),
                         );
                     }
@@ -9988,7 +10008,7 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                         }
                         fits_parser_yytokentype::STRING => {
                             strcpy(
-                                ((lParse.Nodes[this_node_idx]).value.data.astr).as_mut_ptr(),
+                                ((lParse.Nodes[this_node_idx]).value.data.astr_mut()).as_mut_ptr(),
                                 if c_int::from(pVals[2].data.log) != 0 {
                                     (pVals[0].data.astr).as_mut_ptr()
                                 } else {
@@ -10001,7 +10021,8 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                     current_block_139 = 7627602990488000394;
                 }
                 STRMID_FCT => {
-                    let dest_str = ((lParse.Nodes[this_node_idx]).value.data.astr).as_mut_ptr();
+                    let dest_str =
+                        ((lParse.Nodes[this_node_idx]).value.data.astr_mut()).as_mut_ptr();
                     let dest_len = (lParse.Nodes[this_node_idx]).value.nelem as c_int;
                     cstrmid(
                         lParse,
@@ -10041,7 +10062,7 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                     == fits_parser_yytokentype::BITSTR as c_int
                 {
                     strcpy(
-                        ((lParse.Nodes[this_node_idx]).value.data.astr).as_mut_ptr(),
+                        ((lParse.Nodes[this_node_idx]).value.data.astr_mut()).as_mut_ptr(),
                         (pVals[0].data.astr).as_mut_ptr(),
                     );
                 }
@@ -10059,7 +10080,7 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                         if fresh53 == 0 {
                             break;
                         }
-                        *((lParse.Nodes[this_node_idx]).value.data.lngptr).offset(row as isize) =
+                        *((lParse.Nodes[this_node_idx]).value.data.lngptr()).offset(row as isize) =
                             lParse.firstRow + row;
                         *((lParse.Nodes[this_node_idx]).value.undef).offset(row as isize) = 0;
                     },
@@ -10073,7 +10094,7 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                                 if fresh54 == 0 {
                                     break;
                                 }
-                                *((lParse.Nodes[this_node_idx]).value.data.lngptr)
+                                *((lParse.Nodes[this_node_idx]).value.data.lngptr())
                                     .offset(row as isize) = 0;
                                 *((lParse.Nodes[this_node_idx]).value.undef).offset(row as isize) =
                                     1;
@@ -10087,7 +10108,7 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                                 if fresh55 == 0 {
                                     break;
                                 }
-                                *(*((lParse.Nodes[this_node_idx]).value.data.strptr)
+                                *(*((lParse.Nodes[this_node_idx]).value.data.strptr())
                                     .offset(row as isize))
                                 .offset(0) = 0;
                                 *((lParse.Nodes[this_node_idx]).value.undef).offset(row as isize) =
@@ -10110,7 +10131,7 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                         } else {
                             ielem = 0;
                             while ielem < elem {
-                                *((lParse.Nodes[this_node_idx]).value.data.lngptr)
+                                *((lParse.Nodes[this_node_idx]).value.data.lngptr())
                                     .offset(ielem as isize) = iaxis[ipos as usize];
                                 *((lParse.Nodes[this_node_idx]).value.undef)
                                     .offset(ielem as isize) = 0;
@@ -10140,7 +10161,7 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                         let j_0: c_int = 0;
                         ielem_0 = 0;
                         while ielem_0 < elem {
-                            *((lParse.Nodes[this_node_idx]).value.data.lngptr)
+                            *((lParse.Nodes[this_node_idx]).value.data.lngptr())
                                 .offset(ielem_0 as isize) = elemnum;
                             *((lParse.Nodes[this_node_idx]).value.undef).offset(ielem_0 as isize) =
                                 0;
@@ -10157,8 +10178,8 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                         if fresh56 == 0 {
                             break;
                         }
-                        *((lParse.Nodes[this_node_idx]).value.data.dblptr).offset(elem as isize) =
-                            simplerng_getuniform();
+                        *((lParse.Nodes[this_node_idx]).value.data.dblptr())
+                            .offset(elem as isize) = simplerng_getuniform();
                         *((lParse.Nodes[this_node_idx]).value.undef).offset(elem as isize) = 0;
                     },
                     1042 => loop {
@@ -10167,8 +10188,8 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                         if fresh57 == 0 {
                             break;
                         }
-                        *((lParse.Nodes[this_node_idx]).value.data.dblptr).offset(elem as isize) =
-                            simplerng_getnorm();
+                        *((lParse.Nodes[this_node_idx]).value.data.dblptr())
+                            .offset(elem as isize) = simplerng_getnorm();
                         *((lParse.Nodes[this_node_idx]).value.undef).offset(elem as isize) = 0;
                     },
                     1043 => {
@@ -10189,7 +10210,7 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                                         .offset(elem as isize)
                                         == 0
                                     {
-                                        *((lParse.Nodes[this_node_idx]).value.data.lngptr)
+                                        *((lParse.Nodes[this_node_idx]).value.data.lngptr())
                                             .offset(elem as isize) =
                                             c_long::from(simplerng_getpoisson(pVals[0].data.dbl));
                                     }
@@ -10205,7 +10226,7 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                                         .offset(elem as isize) =
                                         *((lParse.Nodes[theParams[0]]).value.undef)
                                             .offset(elem as isize);
-                                    if *((lParse.Nodes[theParams[0]]).value.data.dblptr)
+                                    if *((lParse.Nodes[theParams[0]]).value.data.dblptr())
                                         .offset(elem as isize)
                                         < 0.0
                                     {
@@ -10216,10 +10237,10 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                                         .offset(elem as isize)
                                         == 0
                                     {
-                                        *((lParse.Nodes[this_node_idx]).value.data.lngptr)
+                                        *((lParse.Nodes[this_node_idx]).value.data.lngptr())
                                             .offset(elem as isize) =
                                             c_long::from(simplerng_getpoisson(
-                                                *((lParse.Nodes[theParams[0]]).value.data.dblptr)
+                                                *((lParse.Nodes[theParams[0]]).value.data.dblptr())
                                                     .offset(elem as isize),
                                             ));
                                     }
@@ -10239,7 +10260,7 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                                     .offset(elem as isize)
                                     == 0
                                 {
-                                    *((lParse.Nodes[this_node_idx]).value.data.lngptr)
+                                    *((lParse.Nodes[this_node_idx]).value.data.lngptr())
                                         .offset(elem as isize) = c_long::from(
                                         simplerng_getpoisson(pVals[0].data.lng as c_double),
                                     );
@@ -10256,7 +10277,7 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                                     .offset(elem as isize) =
                                     *((lParse.Nodes[theParams[0]]).value.undef)
                                         .offset(elem as isize);
-                                if *((lParse.Nodes[theParams[0]]).value.data.lngptr)
+                                if *((lParse.Nodes[theParams[0]]).value.data.lngptr())
                                     .offset(elem as isize)
                                     < 0
                                 {
@@ -10267,10 +10288,10 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                                     .offset(elem as isize)
                                     == 0
                                 {
-                                    *((lParse.Nodes[this_node_idx]).value.data.lngptr)
+                                    *((lParse.Nodes[this_node_idx]).value.data.lngptr())
                                         .offset(elem as isize) =
                                         c_long::from(simplerng_getpoisson(
-                                            *((lParse.Nodes[theParams[0]]).value.data.lngptr)
+                                            *((lParse.Nodes[theParams[0]]).value.data.lngptr())
                                                 .offset(elem as isize)
                                                 as c_double,
                                         ));
@@ -10289,7 +10310,7 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                                 if fresh62 == 0 {
                                     break;
                                 }
-                                *((lParse.Nodes[this_node_idx]).value.data.lngptr)
+                                *((lParse.Nodes[this_node_idx]).value.data.lngptr())
                                     .offset(row as isize) = 0;
                                 *((lParse.Nodes[this_node_idx]).value.undef).offset(row as isize) =
                                     1;
@@ -10306,10 +10327,10 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                                         .offset(elem as isize)
                                         == 0
                                     {
-                                        *((lParse.Nodes[this_node_idx]).value.data.lngptr)
+                                        *((lParse.Nodes[this_node_idx]).value.data.lngptr())
                                             .offset(row as isize) += c_long::from(
                                             if c_int::from(
-                                                *((lParse.Nodes[theParams[0]]).value.data.logptr)
+                                                *((lParse.Nodes[theParams[0]]).value.data.logptr())
                                                     .offset(elem as isize),
                                             ) != 0
                                             {
@@ -10332,7 +10353,7 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                                 if fresh64 == 0 {
                                     break;
                                 }
-                                *((lParse.Nodes[this_node_idx]).value.data.lngptr)
+                                *((lParse.Nodes[this_node_idx]).value.data.lngptr())
                                     .offset(row as isize) = 0;
                                 *((lParse.Nodes[this_node_idx]).value.undef).offset(row as isize) =
                                     1;
@@ -10349,9 +10370,9 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                                         .offset(elem as isize)
                                         == 0
                                     {
-                                        *((lParse.Nodes[this_node_idx]).value.data.lngptr)
+                                        *((lParse.Nodes[this_node_idx]).value.data.lngptr())
                                             .offset(row as isize) +=
-                                            *((lParse.Nodes[theParams[0]]).value.data.lngptr)
+                                            *((lParse.Nodes[theParams[0]]).value.data.lngptr())
                                                 .offset(elem as isize);
                                         *((lParse.Nodes[this_node_idx]).value.undef)
                                             .offset(row as isize) = 0;
@@ -10367,7 +10388,7 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                                 if fresh66 == 0 {
                                     break;
                                 }
-                                *((lParse.Nodes[this_node_idx]).value.data.dblptr)
+                                *((lParse.Nodes[this_node_idx]).value.data.dblptr())
                                     .offset(row as isize) = 0.0;
                                 *((lParse.Nodes[this_node_idx]).value.undef).offset(row as isize) =
                                     1;
@@ -10384,9 +10405,9 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                                         .offset(elem as isize)
                                         == 0
                                     {
-                                        *((lParse.Nodes[this_node_idx]).value.data.dblptr)
+                                        *((lParse.Nodes[this_node_idx]).value.data.dblptr())
                                             .offset(row as isize) +=
-                                            *((lParse.Nodes[theParams[0]]).value.data.dblptr)
+                                            *((lParse.Nodes[theParams[0]]).value.data.dblptr())
                                                 .offset(elem as isize);
                                         *((lParse.Nodes[this_node_idx]).value.undef)
                                             .offset(row as isize) = 0;
@@ -10402,17 +10423,19 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                                     break;
                                 }
                                 let mut sptr1: *mut c_char =
-                                    *((lParse.Nodes[theParams[0]]).value.data.strptr)
+                                    *((lParse.Nodes[theParams[0]]).value.data.strptr())
                                         .offset(row as isize);
-                                *((lParse.Nodes[this_node_idx]).value.data.lngptr)
+                                *((lParse.Nodes[this_node_idx]).value.data.lngptr())
                                     .offset(row as isize) = 0;
                                 *((lParse.Nodes[this_node_idx]).value.undef).offset(row as isize) =
                                     0;
                                 while *sptr1 != 0 {
                                     if c_int::from(*sptr1) == '1' as i32 {
-                                        let fresh69 =
-                                            &mut *((lParse.Nodes[this_node_idx]).value.data.lngptr)
-                                                .offset(row as isize);
+                                        let fresh69 = &mut *((lParse.Nodes[this_node_idx])
+                                            .value
+                                            .data
+                                            .lngptr())
+                                        .offset(row as isize);
                                         *fresh69 += 1;
                                     }
                                     sptr1 = sptr1.offset(1);
@@ -10432,7 +10455,7 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                                     break;
                                 }
                                 let mut count: c_int = 0;
-                                *((lParse.Nodes[this_node_idx]).value.data.dblptr)
+                                *((lParse.Nodes[this_node_idx]).value.data.dblptr())
                                     .offset(row as isize) = 0.0;
                                 nelem = (lParse.Nodes[theParams[0]]).value.nelem;
                                 loop {
@@ -10448,9 +10471,9 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                                             .offset(elem as isize),
                                     ) == 0
                                     {
-                                        *((lParse.Nodes[this_node_idx]).value.data.dblptr)
+                                        *((lParse.Nodes[this_node_idx]).value.data.dblptr())
                                             .offset(row as isize) +=
-                                            *((lParse.Nodes[theParams[0]]).value.data.lngptr)
+                                            *((lParse.Nodes[theParams[0]]).value.data.lngptr())
                                                 .offset(elem as isize)
                                                 as c_double;
                                         count += 1;
@@ -10462,7 +10485,7 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                                 } else {
                                     *((lParse.Nodes[this_node_idx]).value.undef)
                                         .offset(row as isize) = 0;
-                                    *((lParse.Nodes[this_node_idx]).value.data.dblptr)
+                                    *((lParse.Nodes[this_node_idx]).value.data.dblptr())
                                         .offset(row as isize) /= c_double::from(count);
                                 }
                             }
@@ -10476,7 +10499,7 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                                     break;
                                 }
                                 let mut count_0: c_int = 0;
-                                *((lParse.Nodes[this_node_idx]).value.data.dblptr)
+                                *((lParse.Nodes[this_node_idx]).value.data.dblptr())
                                     .offset(row as isize) = 0.0;
                                 nelem = (lParse.Nodes[theParams[0]]).value.nelem;
                                 loop {
@@ -10492,9 +10515,9 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                                             .offset(elem as isize),
                                     ) == 0
                                     {
-                                        *((lParse.Nodes[this_node_idx]).value.data.dblptr)
+                                        *((lParse.Nodes[this_node_idx]).value.data.dblptr())
                                             .offset(row as isize) +=
-                                            *((lParse.Nodes[theParams[0]]).value.data.dblptr)
+                                            *((lParse.Nodes[theParams[0]]).value.data.dblptr())
                                                 .offset(elem as isize);
                                         count_0 += 1;
                                     }
@@ -10505,7 +10528,7 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                                 } else {
                                     *((lParse.Nodes[this_node_idx]).value.undef)
                                         .offset(row as isize) = 0;
-                                    *((lParse.Nodes[this_node_idx]).value.data.dblptr)
+                                    *((lParse.Nodes[this_node_idx]).value.data.dblptr())
                                         .offset(row as isize) /= c_double::from(count_0);
                                 }
                             }
@@ -10539,7 +10562,7 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                                             .offset(elem as isize),
                                     ) == 0
                                     {
-                                        sum += *((lParse.Nodes[theParams[0]]).value.data.lngptr)
+                                        sum += *((lParse.Nodes[theParams[0]]).value.data.lngptr())
                                             .offset(elem as isize)
                                             as c_double;
                                         count_1 += 1;
@@ -10563,7 +10586,7 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                                         ) == 0
                                         {
                                             let dx: c_double =
-                                                *((lParse.Nodes[theParams[0]]).value.data.lngptr)
+                                                *((lParse.Nodes[theParams[0]]).value.data.lngptr())
                                                     .offset(elem as isize)
                                                     as c_double
                                                     - sum;
@@ -10573,12 +10596,12 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                                     sum2 /= c_double::from(count_1) - c_double::from(1);
                                     *((lParse.Nodes[this_node_idx]).value.undef)
                                         .offset(row as isize) = 0;
-                                    *((lParse.Nodes[this_node_idx]).value.data.dblptr)
+                                    *((lParse.Nodes[this_node_idx]).value.data.dblptr())
                                         .offset(row as isize) = sqrt(sum2);
                                 } else {
                                     *((lParse.Nodes[this_node_idx]).value.undef)
                                         .offset(row as isize) = 0;
-                                    *((lParse.Nodes[this_node_idx]).value.data.dblptr)
+                                    *((lParse.Nodes[this_node_idx]).value.data.dblptr())
                                         .offset(row as isize) = 0.0;
                                 }
                             }
@@ -10608,8 +10631,9 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                                             .offset(elem as isize),
                                     ) == 0
                                     {
-                                        sum_0 += *((lParse.Nodes[theParams[0]]).value.data.dblptr)
-                                            .offset(elem as isize);
+                                        sum_0 +=
+                                            *((lParse.Nodes[theParams[0]]).value.data.dblptr())
+                                                .offset(elem as isize);
                                         count_2 += 1;
                                     }
                                 }
@@ -10631,7 +10655,7 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                                         ) == 0
                                         {
                                             let dx_0: c_double =
-                                                *((lParse.Nodes[theParams[0]]).value.data.dblptr)
+                                                *((lParse.Nodes[theParams[0]]).value.data.dblptr())
                                                     .offset(elem as isize)
                                                     - sum_0;
                                             sum2_0 += dx_0 * dx_0;
@@ -10640,12 +10664,12 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                                     sum2_0 /= c_double::from(count_2) - c_double::from(1);
                                     *((lParse.Nodes[this_node_idx]).value.undef)
                                         .offset(row as isize) = 0;
-                                    *((lParse.Nodes[this_node_idx]).value.data.dblptr)
+                                    *((lParse.Nodes[this_node_idx]).value.data.dblptr())
                                         .offset(row as isize) = sqrt(sum2_0);
                                 } else {
                                     *((lParse.Nodes[this_node_idx]).value.undef)
                                         .offset(row as isize) = 0;
-                                    *((lParse.Nodes[this_node_idx]).value.data.dblptr)
+                                    *((lParse.Nodes[this_node_idx]).value.data.dblptr())
                                         .offset(row as isize) = 0.0;
                                 }
                             }
@@ -10658,7 +10682,7 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                             == fits_parser_yytokentype::LONG as c_int
                         {
                             let mut dptr: *mut c_long =
-                                (lParse.Nodes[theParams[0]]).value.data.lngptr;
+                                (lParse.Nodes[theParams[0]]).value.data.lngptr();
                             let mut uptr: *mut c_char = (lParse.Nodes[theParams[0]]).value.undef;
                             let mut mptr_buf: Vec<c_long> = Vec::new();
                             let mptr: *mut c_long =
@@ -10698,13 +10722,13 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                                     if nelem1 > 0 {
                                         *((lParse.Nodes[this_node_idx]).value.undef)
                                             .offset(irow as isize) = 0;
-                                        *((lParse.Nodes[this_node_idx]).value.data.lngptr)
+                                        *((lParse.Nodes[this_node_idx]).value.data.lngptr())
                                             .offset(irow as isize) =
                                             qselect_median_lng(mptr, nelem1);
                                     } else {
                                         *((lParse.Nodes[this_node_idx]).value.undef)
                                             .offset(irow as isize) = 1;
-                                        *((lParse.Nodes[this_node_idx]).value.data.lngptr)
+                                        *((lParse.Nodes[this_node_idx]).value.data.lngptr())
                                             .offset(irow as isize) = 0;
                                     }
                                     irow += 1;
@@ -10712,7 +10736,7 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                             }
                         } else {
                             let mut dptr_0: *mut c_double =
-                                (lParse.Nodes[theParams[0]]).value.data.dblptr;
+                                (lParse.Nodes[theParams[0]]).value.data.dblptr();
                             let mut uptr_0: *mut c_char = (lParse.Nodes[theParams[0]]).value.undef;
                             let mut mptr_0_buf: Vec<c_double> = Vec::new();
                             let mptr_0: *mut c_double =
@@ -10752,13 +10776,13 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                                     if nelem1_0 > 0 {
                                         *((lParse.Nodes[this_node_idx]).value.undef)
                                             .offset(irow_0 as isize) = 0;
-                                        *((lParse.Nodes[this_node_idx]).value.data.dblptr)
+                                        *((lParse.Nodes[this_node_idx]).value.data.dblptr())
                                             .offset(irow_0 as isize) =
                                             qselect_median_dbl(mptr_0, nelem1_0);
                                     } else {
                                         *((lParse.Nodes[this_node_idx]).value.undef)
                                             .offset(irow_0 as isize) = 1;
-                                        *((lParse.Nodes[this_node_idx]).value.data.dblptr)
+                                        *((lParse.Nodes[this_node_idx]).value.data.dblptr())
                                             .offset(irow_0 as isize) = 0.0;
                                     }
                                     irow_0 += 1;
@@ -10776,9 +10800,9 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                                 if fresh84 == 0 {
                                     break;
                                 }
-                                dval = *((lParse.Nodes[theParams[0]]).value.data.dblptr)
+                                dval = *((lParse.Nodes[theParams[0]]).value.data.dblptr())
                                     .offset(elem as isize);
-                                *((lParse.Nodes[this_node_idx]).value.data.dblptr)
+                                *((lParse.Nodes[this_node_idx]).value.data.dblptr())
                                     .offset(elem as isize) = if dval > 0.0 { dval } else { -dval };
                                 *((lParse.Nodes[this_node_idx]).value.undef)
                                     .offset(elem as isize) =
@@ -10792,9 +10816,9 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                                 if fresh85 == 0 {
                                     break;
                                 }
-                                ival = *((lParse.Nodes[theParams[0]]).value.data.lngptr)
+                                ival = *((lParse.Nodes[theParams[0]]).value.data.lngptr())
                                     .offset(elem as isize);
-                                *((lParse.Nodes[this_node_idx]).value.data.lngptr)
+                                *((lParse.Nodes[this_node_idx]).value.data.lngptr())
                                     .offset(elem as isize) = if ival > 0 { ival } else { -ival };
                                 *((lParse.Nodes[this_node_idx]).value.undef)
                                     .offset(elem as isize) =
@@ -10819,7 +10843,7 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                             }
                             let mut nelem1_1: c_int = nelem as c_int;
                             *((lParse.Nodes[this_node_idx]).value.undef).offset(row as isize) = 0;
-                            *((lParse.Nodes[this_node_idx]).value.data.lngptr)
+                            *((lParse.Nodes[this_node_idx]).value.data.lngptr())
                                 .offset(row as isize) = 0;
                             loop {
                                 let fresh87 = nelem1_1;
@@ -10835,7 +10859,7 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                                 ) == 0
                                 {
                                     let fresh88 =
-                                        &mut *((lParse.Nodes[this_node_idx]).value.data.lngptr)
+                                        &mut *((lParse.Nodes[this_node_idx]).value.data.lngptr())
                                             .offset(row as isize);
                                     *fresh88 += 1;
                                 }
@@ -10854,7 +10878,7 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                             if fresh89 == 0 {
                                 break;
                             }
-                            *((lParse.Nodes[this_node_idx]).value.data.logptr)
+                            *((lParse.Nodes[this_node_idx]).value.data.logptr())
                                 .offset(elem as isize) =
                                 *((lParse.Nodes[theParams[0]]).value.undef).offset(elem as isize);
                             *((lParse.Nodes[this_node_idx]).value.undef).offset(elem as isize) = 0;
@@ -10908,12 +10932,12 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                                 if pNull[0] != 0 {
                                     *((lParse.Nodes[this_node_idx]).value.undef)
                                         .offset(elem as isize) = pNull[1];
-                                    *((lParse.Nodes[this_node_idx]).value.data.logptr)
+                                    *((lParse.Nodes[this_node_idx]).value.data.logptr())
                                         .offset(elem as isize) = pVals[1].data.log;
                                 } else {
                                     *((lParse.Nodes[this_node_idx]).value.undef)
                                         .offset(elem as isize) = 0;
-                                    *((lParse.Nodes[this_node_idx]).value.data.logptr)
+                                    *((lParse.Nodes[this_node_idx]).value.data.logptr())
                                         .offset(elem as isize) = pVals[0].data.log;
                                 }
                             }
@@ -10965,12 +10989,12 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                                 if pNull[0] != 0 {
                                     *((lParse.Nodes[this_node_idx]).value.undef)
                                         .offset(elem as isize) = pNull[1];
-                                    *((lParse.Nodes[this_node_idx]).value.data.lngptr)
+                                    *((lParse.Nodes[this_node_idx]).value.data.lngptr())
                                         .offset(elem as isize) = pVals[1].data.lng;
                                 } else {
                                     *((lParse.Nodes[this_node_idx]).value.undef)
                                         .offset(elem as isize) = 0;
-                                    *((lParse.Nodes[this_node_idx]).value.data.lngptr)
+                                    *((lParse.Nodes[this_node_idx]).value.data.lngptr())
                                         .offset(elem as isize) = pVals[0].data.lng;
                                 }
                             }
@@ -11022,12 +11046,12 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                                 if pNull[0] != 0 {
                                     *((lParse.Nodes[this_node_idx]).value.undef)
                                         .offset(elem as isize) = pNull[1];
-                                    *((lParse.Nodes[this_node_idx]).value.data.dblptr)
+                                    *((lParse.Nodes[this_node_idx]).value.data.dblptr())
                                         .offset(elem as isize) = pVals[1].data.dbl;
                                 } else {
                                     *((lParse.Nodes[this_node_idx]).value.undef)
                                         .offset(elem as isize) = 0;
-                                    *((lParse.Nodes[this_node_idx]).value.data.dblptr)
+                                    *((lParse.Nodes[this_node_idx]).value.data.dblptr())
                                         .offset(elem as isize) = pVals[0].data.dbl;
                                 }
                             }
@@ -11051,8 +11075,11 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                                             .offset(row as isize);
                                     strcpy(
                                         (pVals[i as usize].data.astr).as_mut_ptr(),
-                                        *((lParse.Nodes[theParams[i as usize]]).value.data.strptr)
-                                            .offset(row as isize),
+                                        *((lParse.Nodes[theParams[i as usize]])
+                                            .value
+                                            .data
+                                            .strptr())
+                                        .offset(row as isize),
                                     );
                                 }
                             }
@@ -11060,7 +11087,7 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                                 *((lParse.Nodes[this_node_idx]).value.undef).offset(row as isize) =
                                     pNull[1];
                                 strcpy(
-                                    *((lParse.Nodes[this_node_idx]).value.data.strptr)
+                                    *((lParse.Nodes[this_node_idx]).value.data.strptr())
                                         .offset(row as isize),
                                     (pVals[1].data.astr).as_mut_ptr(),
                                 );
@@ -11068,7 +11095,7 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                                 *((lParse.Nodes[this_node_idx]).value.undef)
                                     .offset(elem as isize) = 0;
                                 strcpy(
-                                    *((lParse.Nodes[this_node_idx]).value.data.strptr)
+                                    *((lParse.Nodes[this_node_idx]).value.data.strptr())
                                         .offset(row as isize),
                                     (pVals[0].data.astr).as_mut_ptr(),
                                 );
@@ -11083,18 +11110,18 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                             if fresh101 == 0 {
                                 break;
                             }
-                            if (lParse.Nodes[theParams[1]]).value.data.lng
-                                == *((lParse.Nodes[theParams[0]]).value.data.lngptr)
+                            if (lParse.Nodes[theParams[1]]).value.data.lng()
+                                == *((lParse.Nodes[theParams[0]]).value.data.lngptr())
                                     .offset(elem as isize)
                             {
-                                *((lParse.Nodes[this_node_idx]).value.data.lngptr)
+                                *((lParse.Nodes[this_node_idx]).value.data.lngptr())
                                     .offset(elem as isize) = 0;
                                 *((lParse.Nodes[this_node_idx]).value.undef)
                                     .offset(elem as isize) = 1;
                             } else {
-                                *((lParse.Nodes[this_node_idx]).value.data.lngptr)
+                                *((lParse.Nodes[this_node_idx]).value.data.lngptr())
                                     .offset(elem as isize) =
-                                    *((lParse.Nodes[theParams[0]]).value.data.lngptr)
+                                    *((lParse.Nodes[theParams[0]]).value.data.lngptr())
                                         .offset(elem as isize);
                                 *((lParse.Nodes[this_node_idx]).value.undef)
                                     .offset(elem as isize) =
@@ -11108,18 +11135,18 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                             if fresh102 == 0 {
                                 break;
                             }
-                            if (lParse.Nodes[theParams[1]]).value.data.dbl
-                                == *((lParse.Nodes[theParams[0]]).value.data.dblptr)
+                            if (lParse.Nodes[theParams[1]]).value.data.dbl()
+                                == *((lParse.Nodes[theParams[0]]).value.data.dblptr())
                                     .offset(elem as isize)
                             {
-                                *((lParse.Nodes[this_node_idx]).value.data.dblptr)
+                                *((lParse.Nodes[this_node_idx]).value.data.dblptr())
                                     .offset(elem as isize) = 0.0;
                                 *((lParse.Nodes[this_node_idx]).value.undef)
                                     .offset(elem as isize) = 1;
                             } else {
-                                *((lParse.Nodes[this_node_idx]).value.data.dblptr)
+                                *((lParse.Nodes[this_node_idx]).value.data.dblptr())
                                     .offset(elem as isize) =
-                                    *((lParse.Nodes[theParams[0]]).value.data.dblptr)
+                                    *((lParse.Nodes[theParams[0]]).value.data.dblptr())
                                         .offset(elem as isize);
                                 *((lParse.Nodes[this_node_idx]).value.undef)
                                     .offset(elem as isize) =
@@ -11140,9 +11167,9 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                         *fresh104 =
                             *((lParse.Nodes[theParams[0]]).value.undef).offset(elem as isize);
                         if *fresh104 == 0 {
-                            *((lParse.Nodes[this_node_idx]).value.data.dblptr)
+                            *((lParse.Nodes[this_node_idx]).value.data.dblptr())
                                 .offset(elem as isize) =
-                                sin(*((lParse.Nodes[theParams[0]]).value.data.dblptr)
+                                sin(*((lParse.Nodes[theParams[0]]).value.data.dblptr())
                                     .offset(elem as isize));
                         }
                     },
@@ -11157,9 +11184,9 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                         *fresh106 =
                             *((lParse.Nodes[theParams[0]]).value.undef).offset(elem as isize);
                         if *fresh106 == 0 {
-                            *((lParse.Nodes[this_node_idx]).value.data.dblptr)
+                            *((lParse.Nodes[this_node_idx]).value.data.dblptr())
                                 .offset(elem as isize) =
-                                cos(*((lParse.Nodes[theParams[0]]).value.data.dblptr)
+                                cos(*((lParse.Nodes[theParams[0]]).value.data.dblptr())
                                     .offset(elem as isize));
                         }
                     },
@@ -11174,9 +11201,9 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                         *fresh108 =
                             *((lParse.Nodes[theParams[0]]).value.undef).offset(elem as isize);
                         if *fresh108 == 0 {
-                            *((lParse.Nodes[this_node_idx]).value.data.dblptr)
+                            *((lParse.Nodes[this_node_idx]).value.data.dblptr())
                                 .offset(elem as isize) =
-                                tan(*((lParse.Nodes[theParams[0]]).value.data.dblptr)
+                                tan(*((lParse.Nodes[theParams[0]]).value.data.dblptr())
                                     .offset(elem as isize));
                         }
                     },
@@ -11191,15 +11218,15 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                         *fresh110 =
                             *((lParse.Nodes[theParams[0]]).value.undef).offset(elem as isize);
                         if *fresh110 == 0 {
-                            dval = *((lParse.Nodes[theParams[0]]).value.data.dblptr)
+                            dval = *((lParse.Nodes[theParams[0]]).value.data.dblptr())
                                 .offset(elem as isize);
                             if dval < -1.0 || dval > 1.0 {
-                                *((lParse.Nodes[this_node_idx]).value.data.dblptr)
+                                *((lParse.Nodes[this_node_idx]).value.data.dblptr())
                                     .offset(elem as isize) = 0.0;
                                 *((lParse.Nodes[this_node_idx]).value.undef)
                                     .offset(elem as isize) = 1;
                             } else {
-                                *((lParse.Nodes[this_node_idx]).value.data.dblptr)
+                                *((lParse.Nodes[this_node_idx]).value.data.dblptr())
                                     .offset(elem as isize) = asin(dval);
                             }
                         }
@@ -11215,15 +11242,15 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                         *fresh112 =
                             *((lParse.Nodes[theParams[0]]).value.undef).offset(elem as isize);
                         if *fresh112 == 0 {
-                            dval = *((lParse.Nodes[theParams[0]]).value.data.dblptr)
+                            dval = *((lParse.Nodes[theParams[0]]).value.data.dblptr())
                                 .offset(elem as isize);
                             if dval < -1.0 || dval > 1.0 {
-                                *((lParse.Nodes[this_node_idx]).value.data.dblptr)
+                                *((lParse.Nodes[this_node_idx]).value.data.dblptr())
                                     .offset(elem as isize) = 0.0;
                                 *((lParse.Nodes[this_node_idx]).value.undef)
                                     .offset(elem as isize) = 1;
                             } else {
-                                *((lParse.Nodes[this_node_idx]).value.data.dblptr)
+                                *((lParse.Nodes[this_node_idx]).value.data.dblptr())
                                     .offset(elem as isize) = acos(dval);
                             }
                         }
@@ -11239,9 +11266,9 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                         *fresh114 =
                             *((lParse.Nodes[theParams[0]]).value.undef).offset(elem as isize);
                         if *fresh114 == 0 {
-                            dval = *((lParse.Nodes[theParams[0]]).value.data.dblptr)
+                            dval = *((lParse.Nodes[theParams[0]]).value.data.dblptr())
                                 .offset(elem as isize);
-                            *((lParse.Nodes[this_node_idx]).value.data.dblptr)
+                            *((lParse.Nodes[this_node_idx]).value.data.dblptr())
                                 .offset(elem as isize) = atan(dval);
                         }
                     },
@@ -11256,9 +11283,9 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                         *fresh116 =
                             *((lParse.Nodes[theParams[0]]).value.undef).offset(elem as isize);
                         if *fresh116 == 0 {
-                            *((lParse.Nodes[this_node_idx]).value.data.dblptr)
+                            *((lParse.Nodes[this_node_idx]).value.data.dblptr())
                                 .offset(elem as isize) = sinh(
-                                *((lParse.Nodes[theParams[0]]).value.data.dblptr)
+                                *((lParse.Nodes[theParams[0]]).value.data.dblptr())
                                     .offset(elem as isize),
                             );
                         }
@@ -11274,9 +11301,9 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                         *fresh118 =
                             *((lParse.Nodes[theParams[0]]).value.undef).offset(elem as isize);
                         if *fresh118 == 0 {
-                            *((lParse.Nodes[this_node_idx]).value.data.dblptr)
+                            *((lParse.Nodes[this_node_idx]).value.data.dblptr())
                                 .offset(elem as isize) = cosh(
-                                *((lParse.Nodes[theParams[0]]).value.data.dblptr)
+                                *((lParse.Nodes[theParams[0]]).value.data.dblptr())
                                     .offset(elem as isize),
                             );
                         }
@@ -11292,9 +11319,9 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                         *fresh120 =
                             *((lParse.Nodes[theParams[0]]).value.undef).offset(elem as isize);
                         if *fresh120 == 0 {
-                            *((lParse.Nodes[this_node_idx]).value.data.dblptr)
+                            *((lParse.Nodes[this_node_idx]).value.data.dblptr())
                                 .offset(elem as isize) = tanh(
-                                *((lParse.Nodes[theParams[0]]).value.data.dblptr)
+                                *((lParse.Nodes[theParams[0]]).value.data.dblptr())
                                     .offset(elem as isize),
                             );
                         }
@@ -11310,9 +11337,9 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                         *fresh122 =
                             *((lParse.Nodes[theParams[0]]).value.undef).offset(elem as isize);
                         if *fresh122 == 0 {
-                            dval = *((lParse.Nodes[theParams[0]]).value.data.dblptr)
+                            dval = *((lParse.Nodes[theParams[0]]).value.data.dblptr())
                                 .offset(elem as isize);
-                            *((lParse.Nodes[this_node_idx]).value.data.dblptr)
+                            *((lParse.Nodes[this_node_idx]).value.data.dblptr())
                                 .offset(elem as isize) = exp(dval);
                         }
                     },
@@ -11327,15 +11354,15 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                         *fresh124 =
                             *((lParse.Nodes[theParams[0]]).value.undef).offset(elem as isize);
                         if *fresh124 == 0 {
-                            dval = *((lParse.Nodes[theParams[0]]).value.data.dblptr)
+                            dval = *((lParse.Nodes[theParams[0]]).value.data.dblptr())
                                 .offset(elem as isize);
                             if dval <= 0.0 {
-                                *((lParse.Nodes[this_node_idx]).value.data.dblptr)
+                                *((lParse.Nodes[this_node_idx]).value.data.dblptr())
                                     .offset(elem as isize) = 0.0;
                                 *((lParse.Nodes[this_node_idx]).value.undef)
                                     .offset(elem as isize) = 1;
                             } else {
-                                *((lParse.Nodes[this_node_idx]).value.data.dblptr)
+                                *((lParse.Nodes[this_node_idx]).value.data.dblptr())
                                     .offset(elem as isize) = log(dval);
                             }
                         }
@@ -11351,15 +11378,15 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                         *fresh126 =
                             *((lParse.Nodes[theParams[0]]).value.undef).offset(elem as isize);
                         if *fresh126 == 0 {
-                            dval = *((lParse.Nodes[theParams[0]]).value.data.dblptr)
+                            dval = *((lParse.Nodes[theParams[0]]).value.data.dblptr())
                                 .offset(elem as isize);
                             if dval <= 0.0 {
-                                *((lParse.Nodes[this_node_idx]).value.data.dblptr)
+                                *((lParse.Nodes[this_node_idx]).value.data.dblptr())
                                     .offset(elem as isize) = 0.0;
                                 *((lParse.Nodes[this_node_idx]).value.undef)
                                     .offset(elem as isize) = 1;
                             } else {
-                                *((lParse.Nodes[this_node_idx]).value.data.dblptr)
+                                *((lParse.Nodes[this_node_idx]).value.data.dblptr())
                                     .offset(elem as isize) = log10(dval);
                             }
                         }
@@ -11375,15 +11402,15 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                         *fresh128 =
                             *((lParse.Nodes[theParams[0]]).value.undef).offset(elem as isize);
                         if *fresh128 == 0 {
-                            dval = *((lParse.Nodes[theParams[0]]).value.data.dblptr)
+                            dval = *((lParse.Nodes[theParams[0]]).value.data.dblptr())
                                 .offset(elem as isize);
                             if dval < 0.0 {
-                                *((lParse.Nodes[this_node_idx]).value.data.dblptr)
+                                *((lParse.Nodes[this_node_idx]).value.data.dblptr())
                                     .offset(elem as isize) = 0.0;
                                 *((lParse.Nodes[this_node_idx]).value.undef)
                                     .offset(elem as isize) = 1;
                             } else {
-                                *((lParse.Nodes[this_node_idx]).value.data.dblptr)
+                                *((lParse.Nodes[this_node_idx]).value.data.dblptr())
                                     .offset(elem as isize) = sqrt(dval);
                             }
                         }
@@ -11399,9 +11426,9 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                         *fresh130 =
                             *((lParse.Nodes[theParams[0]]).value.undef).offset(elem as isize);
                         if *fresh130 == 0 {
-                            *((lParse.Nodes[this_node_idx]).value.data.dblptr)
+                            *((lParse.Nodes[this_node_idx]).value.data.dblptr())
                                 .offset(elem as isize) = ceil(
-                                *((lParse.Nodes[theParams[0]]).value.data.dblptr)
+                                *((lParse.Nodes[theParams[0]]).value.data.dblptr())
                                     .offset(elem as isize),
                             );
                         }
@@ -11417,9 +11444,9 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                         *fresh132 =
                             *((lParse.Nodes[theParams[0]]).value.undef).offset(elem as isize);
                         if *fresh132 == 0 {
-                            *((lParse.Nodes[this_node_idx]).value.data.dblptr)
+                            *((lParse.Nodes[this_node_idx]).value.data.dblptr())
                                 .offset(elem as isize) = floor(
-                                *((lParse.Nodes[theParams[0]]).value.data.dblptr)
+                                *((lParse.Nodes[theParams[0]]).value.data.dblptr())
                                     .offset(elem as isize),
                             );
                         }
@@ -11435,9 +11462,9 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                         *fresh134 =
                             *((lParse.Nodes[theParams[0]]).value.undef).offset(elem as isize);
                         if *fresh134 == 0 {
-                            *((lParse.Nodes[this_node_idx]).value.data.dblptr)
+                            *((lParse.Nodes[this_node_idx]).value.data.dblptr())
                                 .offset(elem as isize) = floor(
-                                *((lParse.Nodes[theParams[0]]).value.data.dblptr)
+                                *((lParse.Nodes[theParams[0]]).value.data.dblptr())
                                     .offset(elem as isize)
                                     + 0.5,
                             );
@@ -11466,16 +11493,22 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                                     break;
                                 }
                                 if vector[i as usize] > 1 {
-                                    pVals[i as usize].data.dbl =
-                                        *((lParse.Nodes[theParams[i as usize]]).value.data.dblptr)
-                                            .offset(elem as isize);
+                                    pVals[i as usize].data.dbl = *((lParse.Nodes
+                                        [theParams[i as usize]])
+                                        .value
+                                        .data
+                                        .dblptr())
+                                    .offset(elem as isize);
                                     pNull[i as usize] =
                                         *((lParse.Nodes[theParams[i as usize]]).value.undef)
                                             .offset(elem as isize);
                                 } else if vector[i as usize] != 0 {
-                                    pVals[i as usize].data.dbl =
-                                        *((lParse.Nodes[theParams[i as usize]]).value.data.dblptr)
-                                            .offset(row as isize);
+                                    pVals[i as usize].data.dbl = *((lParse.Nodes
+                                        [theParams[i as usize]])
+                                        .value
+                                        .data
+                                        .dblptr())
+                                    .offset(row as isize);
                                     pNull[i as usize] =
                                         *((lParse.Nodes[theParams[i as usize]]).value.undef)
                                             .offset(row as isize);
@@ -11490,7 +11523,7 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                                 0
                             };
                             if *fresh138 == 0 {
-                                *((lParse.Nodes[this_node_idx]).value.data.dblptr)
+                                *((lParse.Nodes[this_node_idx]).value.data.dblptr())
                                     .offset(elem as isize) =
                                     atan2(pVals[0].data.dbl, pVals[1].data.dbl);
                             }
@@ -11518,16 +11551,22 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                                     break;
                                 }
                                 if vector[i as usize] > 1 {
-                                    pVals[i as usize].data.dbl =
-                                        *((lParse.Nodes[theParams[i as usize]]).value.data.dblptr)
-                                            .offset(elem as isize);
+                                    pVals[i as usize].data.dbl = *((lParse.Nodes
+                                        [theParams[i as usize]])
+                                        .value
+                                        .data
+                                        .dblptr())
+                                    .offset(elem as isize);
                                     pNull[i as usize] =
                                         *((lParse.Nodes[theParams[i as usize]]).value.undef)
                                             .offset(elem as isize);
                                 } else if vector[i as usize] != 0 {
-                                    pVals[i as usize].data.dbl =
-                                        *((lParse.Nodes[theParams[i as usize]]).value.data.dblptr)
-                                            .offset(row as isize);
+                                    pVals[i as usize].data.dbl = *((lParse.Nodes
+                                        [theParams[i as usize]])
+                                        .value
+                                        .data
+                                        .dblptr())
+                                    .offset(row as isize);
                                     pNull[i as usize] =
                                         *((lParse.Nodes[theParams[i as usize]]).value.undef)
                                             .offset(row as isize);
@@ -11542,7 +11581,7 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                                     || c_int::from(pNull[3]) != 0,
                             ) as c_char;
                             if *fresh142 == 0 {
-                                *((lParse.Nodes[this_node_idx]).value.data.dblptr)
+                                *((lParse.Nodes[this_node_idx]).value.data.dblptr())
                                     .offset(elem as isize) = angsep_calc(
                                     pVals[0].data.dbl,
                                     pVals[1].data.dbl,
@@ -11582,16 +11621,19 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                                         if valInit != 0 {
                                             valInit = 0;
                                             minVal =
-                                                *((lParse.Nodes[theParams[0]]).value.data.lngptr)
+                                                *((lParse.Nodes[theParams[0]]).value.data.lngptr())
                                                     .offset(elem as isize);
                                         } else {
                                             minVal = if minVal
-                                                < *((lParse.Nodes[theParams[0]]).value.data.lngptr)
-                                                    .offset(elem as isize)
+                                                < *((lParse.Nodes[theParams[0]])
+                                                    .value
+                                                    .data
+                                                    .lngptr())
+                                                .offset(elem as isize)
                                             {
                                                 minVal
                                             } else {
-                                                *((lParse.Nodes[theParams[0]]).value.data.lngptr)
+                                                *((lParse.Nodes[theParams[0]]).value.data.lngptr())
                                                     .offset(elem as isize)
                                             };
                                         }
@@ -11599,7 +11641,7 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                                             .offset(row as isize) = 0;
                                     }
                                 }
-                                *((lParse.Nodes[this_node_idx]).value.data.lngptr)
+                                *((lParse.Nodes[this_node_idx]).value.data.lngptr())
                                     .offset(row as isize) = minVal;
                             }
                         } else if (lParse.Nodes[this_node_idx]).ntype
@@ -11630,16 +11672,19 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                                         if valInit != 0 {
                                             valInit = 0;
                                             minVal_0 =
-                                                *((lParse.Nodes[theParams[0]]).value.data.dblptr)
+                                                *((lParse.Nodes[theParams[0]]).value.data.dblptr())
                                                     .offset(elem as isize);
                                         } else {
                                             minVal_0 = if minVal_0
-                                                < *((lParse.Nodes[theParams[0]]).value.data.dblptr)
-                                                    .offset(elem as isize)
+                                                < *((lParse.Nodes[theParams[0]])
+                                                    .value
+                                                    .data
+                                                    .dblptr())
+                                                .offset(elem as isize)
                                             {
                                                 minVal_0
                                             } else {
-                                                *((lParse.Nodes[theParams[0]]).value.data.dblptr)
+                                                *((lParse.Nodes[theParams[0]]).value.data.dblptr())
                                                     .offset(elem as isize)
                                             };
                                         }
@@ -11647,7 +11692,7 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                                             .offset(row as isize) = 0;
                                     }
                                 }
-                                *((lParse.Nodes[this_node_idx]).value.data.dblptr)
+                                *((lParse.Nodes[this_node_idx]).value.data.dblptr())
                                     .offset(row as isize) = minVal_0;
                             }
                         } else if (lParse.Nodes[this_node_idx]).ntype
@@ -11661,7 +11706,7 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                                     break;
                                 }
                                 let mut sptr1_0: *mut c_char =
-                                    *((lParse.Nodes[theParams[0]]).value.data.strptr)
+                                    *((lParse.Nodes[theParams[0]]).value.data.strptr())
                                         .offset(row as isize);
                                 minVal_1 = b'1' as c_char;
                                 while *sptr1_0 != 0 {
@@ -11670,10 +11715,10 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                                     }
                                     sptr1_0 = sptr1_0.offset(1);
                                 }
-                                *(*((lParse.Nodes[this_node_idx]).value.data.strptr)
+                                *(*((lParse.Nodes[this_node_idx]).value.data.strptr())
                                     .offset(row as isize))
                                 .offset(0) = minVal_1;
-                                *(*((lParse.Nodes[this_node_idx]).value.data.strptr)
+                                *(*((lParse.Nodes[this_node_idx]).value.data.strptr())
                                     .offset(row as isize))
                                 .offset(1) = 0;
                             }
@@ -11733,22 +11778,22 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                                     if c_int::from(pNull[0]) != 0 && c_int::from(pNull[1]) != 0 {
                                         *((lParse.Nodes[this_node_idx]).value.undef)
                                             .offset(elem as isize) = 1;
-                                        *((lParse.Nodes[this_node_idx]).value.data.lngptr)
+                                        *((lParse.Nodes[this_node_idx]).value.data.lngptr())
                                             .offset(elem as isize) = 0;
                                     } else if pNull[0] != 0 {
                                         *((lParse.Nodes[this_node_idx]).value.undef)
                                             .offset(elem as isize) = 0;
-                                        *((lParse.Nodes[this_node_idx]).value.data.lngptr)
+                                        *((lParse.Nodes[this_node_idx]).value.data.lngptr())
                                             .offset(elem as isize) = pVals[1].data.lng;
                                     } else if pNull[1] != 0 {
                                         *((lParse.Nodes[this_node_idx]).value.undef)
                                             .offset(elem as isize) = 0;
-                                        *((lParse.Nodes[this_node_idx]).value.data.lngptr)
+                                        *((lParse.Nodes[this_node_idx]).value.data.lngptr())
                                             .offset(elem as isize) = pVals[0].data.lng;
                                     } else {
                                         *((lParse.Nodes[this_node_idx]).value.undef)
                                             .offset(elem as isize) = 0;
-                                        *((lParse.Nodes[this_node_idx]).value.data.lngptr)
+                                        *((lParse.Nodes[this_node_idx]).value.data.lngptr())
                                             .offset(elem as isize) =
                                             if pVals[0].data.lng < pVals[1].data.lng {
                                                 pVals[0].data.lng
@@ -11811,22 +11856,22 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                                     if c_int::from(pNull[0]) != 0 && c_int::from(pNull[1]) != 0 {
                                         *((lParse.Nodes[this_node_idx]).value.undef)
                                             .offset(elem as isize) = 1;
-                                        *((lParse.Nodes[this_node_idx]).value.data.dblptr)
+                                        *((lParse.Nodes[this_node_idx]).value.data.dblptr())
                                             .offset(elem as isize) = 0.0;
                                     } else if pNull[0] != 0 {
                                         *((lParse.Nodes[this_node_idx]).value.undef)
                                             .offset(elem as isize) = 0;
-                                        *((lParse.Nodes[this_node_idx]).value.data.dblptr)
+                                        *((lParse.Nodes[this_node_idx]).value.data.dblptr())
                                             .offset(elem as isize) = pVals[1].data.dbl;
                                     } else if pNull[1] != 0 {
                                         *((lParse.Nodes[this_node_idx]).value.undef)
                                             .offset(elem as isize) = 0;
-                                        *((lParse.Nodes[this_node_idx]).value.data.dblptr)
+                                        *((lParse.Nodes[this_node_idx]).value.data.dblptr())
                                             .offset(elem as isize) = pVals[0].data.dbl;
                                     } else {
                                         *((lParse.Nodes[this_node_idx]).value.undef)
                                             .offset(elem as isize) = 0;
-                                        *((lParse.Nodes[this_node_idx]).value.data.dblptr)
+                                        *((lParse.Nodes[this_node_idx]).value.data.dblptr())
                                             .offset(elem as isize) =
                                             if pVals[0].data.dbl < pVals[1].data.dbl {
                                                 pVals[0].data.dbl
@@ -11868,16 +11913,19 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                                         if valInit != 0 {
                                             valInit = 0;
                                             maxVal =
-                                                *((lParse.Nodes[theParams[0]]).value.data.lngptr)
+                                                *((lParse.Nodes[theParams[0]]).value.data.lngptr())
                                                     .offset(elem as isize);
                                         } else {
                                             maxVal = if maxVal
-                                                > *((lParse.Nodes[theParams[0]]).value.data.lngptr)
-                                                    .offset(elem as isize)
+                                                > *((lParse.Nodes[theParams[0]])
+                                                    .value
+                                                    .data
+                                                    .lngptr())
+                                                .offset(elem as isize)
                                             {
                                                 maxVal
                                             } else {
-                                                *((lParse.Nodes[theParams[0]]).value.data.lngptr)
+                                                *((lParse.Nodes[theParams[0]]).value.data.lngptr())
                                                     .offset(elem as isize)
                                             };
                                         }
@@ -11885,7 +11933,7 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                                             .offset(row as isize) = 0;
                                     }
                                 }
-                                *((lParse.Nodes[this_node_idx]).value.data.lngptr)
+                                *((lParse.Nodes[this_node_idx]).value.data.lngptr())
                                     .offset(row as isize) = maxVal;
                             }
                         } else if (lParse.Nodes[this_node_idx]).ntype
@@ -11916,16 +11964,19 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                                         if valInit != 0 {
                                             valInit = 0;
                                             maxVal_0 =
-                                                *((lParse.Nodes[theParams[0]]).value.data.dblptr)
+                                                *((lParse.Nodes[theParams[0]]).value.data.dblptr())
                                                     .offset(elem as isize);
                                         } else {
                                             maxVal_0 = if maxVal_0
-                                                > *((lParse.Nodes[theParams[0]]).value.data.dblptr)
-                                                    .offset(elem as isize)
+                                                > *((lParse.Nodes[theParams[0]])
+                                                    .value
+                                                    .data
+                                                    .dblptr())
+                                                .offset(elem as isize)
                                             {
                                                 maxVal_0
                                             } else {
-                                                *((lParse.Nodes[theParams[0]]).value.data.dblptr)
+                                                *((lParse.Nodes[theParams[0]]).value.data.dblptr())
                                                     .offset(elem as isize)
                                             };
                                         }
@@ -11933,7 +11984,7 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                                             .offset(row as isize) = 0;
                                     }
                                 }
-                                *((lParse.Nodes[this_node_idx]).value.data.dblptr)
+                                *((lParse.Nodes[this_node_idx]).value.data.dblptr())
                                     .offset(row as isize) = maxVal_0;
                             }
                         } else if (lParse.Nodes[this_node_idx]).ntype
@@ -11947,7 +11998,7 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                                     break;
                                 }
                                 let mut sptr1_1: *mut c_char =
-                                    *((lParse.Nodes[theParams[0]]).value.data.strptr)
+                                    *((lParse.Nodes[theParams[0]]).value.data.strptr())
                                         .offset(row as isize);
                                 maxVal_1 = b'0' as c_char;
                                 while *sptr1_1 != 0 {
@@ -11956,10 +12007,10 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                                     }
                                     sptr1_1 = sptr1_1.offset(1);
                                 }
-                                *(*((lParse.Nodes[this_node_idx]).value.data.strptr)
+                                *(*((lParse.Nodes[this_node_idx]).value.data.strptr())
                                     .offset(row as isize))
                                 .offset(0) = maxVal_1;
-                                *(*((lParse.Nodes[this_node_idx]).value.data.strptr)
+                                *(*((lParse.Nodes[this_node_idx]).value.data.strptr())
                                     .offset(row as isize))
                                 .offset(1) = 0;
                             }
@@ -12019,22 +12070,22 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                                     if c_int::from(pNull[0]) != 0 && c_int::from(pNull[1]) != 0 {
                                         *((lParse.Nodes[this_node_idx]).value.undef)
                                             .offset(elem as isize) = 1;
-                                        *((lParse.Nodes[this_node_idx]).value.data.lngptr)
+                                        *((lParse.Nodes[this_node_idx]).value.data.lngptr())
                                             .offset(elem as isize) = 0;
                                     } else if pNull[0] != 0 {
                                         *((lParse.Nodes[this_node_idx]).value.undef)
                                             .offset(elem as isize) = 0;
-                                        *((lParse.Nodes[this_node_idx]).value.data.lngptr)
+                                        *((lParse.Nodes[this_node_idx]).value.data.lngptr())
                                             .offset(elem as isize) = pVals[1].data.lng;
                                     } else if pNull[1] != 0 {
                                         *((lParse.Nodes[this_node_idx]).value.undef)
                                             .offset(elem as isize) = 0;
-                                        *((lParse.Nodes[this_node_idx]).value.data.lngptr)
+                                        *((lParse.Nodes[this_node_idx]).value.data.lngptr())
                                             .offset(elem as isize) = pVals[0].data.lng;
                                     } else {
                                         *((lParse.Nodes[this_node_idx]).value.undef)
                                             .offset(elem as isize) = 0;
-                                        *((lParse.Nodes[this_node_idx]).value.data.lngptr)
+                                        *((lParse.Nodes[this_node_idx]).value.data.lngptr())
                                             .offset(elem as isize) =
                                             if pVals[0].data.lng > pVals[1].data.lng {
                                                 pVals[0].data.lng
@@ -12097,22 +12148,22 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                                     if c_int::from(pNull[0]) != 0 && c_int::from(pNull[1]) != 0 {
                                         *((lParse.Nodes[this_node_idx]).value.undef)
                                             .offset(elem as isize) = 1;
-                                        *((lParse.Nodes[this_node_idx]).value.data.dblptr)
+                                        *((lParse.Nodes[this_node_idx]).value.data.dblptr())
                                             .offset(elem as isize) = 0.0;
                                     } else if pNull[0] != 0 {
                                         *((lParse.Nodes[this_node_idx]).value.undef)
                                             .offset(elem as isize) = 0;
-                                        *((lParse.Nodes[this_node_idx]).value.data.dblptr)
+                                        *((lParse.Nodes[this_node_idx]).value.data.dblptr())
                                             .offset(elem as isize) = pVals[1].data.dbl;
                                     } else if pNull[1] != 0 {
                                         *((lParse.Nodes[this_node_idx]).value.undef)
                                             .offset(elem as isize) = 0;
-                                        *((lParse.Nodes[this_node_idx]).value.data.dblptr)
+                                        *((lParse.Nodes[this_node_idx]).value.data.dblptr())
                                             .offset(elem as isize) = pVals[0].data.dbl;
                                     } else {
                                         *((lParse.Nodes[this_node_idx]).value.undef)
                                             .offset(elem as isize) = 0;
-                                        *((lParse.Nodes[this_node_idx]).value.data.dblptr)
+                                        *((lParse.Nodes[this_node_idx]).value.data.dblptr())
                                             .offset(elem as isize) =
                                             if pVals[0].data.dbl > pVals[1].data.dbl {
                                                 pVals[0].data.dbl
@@ -12146,16 +12197,22 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                                     break;
                                 }
                                 if vector[i as usize] > 1 {
-                                    pVals[i as usize].data.dbl =
-                                        *((lParse.Nodes[theParams[i as usize]]).value.data.dblptr)
-                                            .offset(elem as isize);
+                                    pVals[i as usize].data.dbl = *((lParse.Nodes
+                                        [theParams[i as usize]])
+                                        .value
+                                        .data
+                                        .dblptr())
+                                    .offset(elem as isize);
                                     pNull[i as usize] =
                                         *((lParse.Nodes[theParams[i as usize]]).value.undef)
                                             .offset(elem as isize);
                                 } else if vector[i as usize] != 0 {
-                                    pVals[i as usize].data.dbl =
-                                        *((lParse.Nodes[theParams[i as usize]]).value.data.dblptr)
-                                            .offset(row as isize);
+                                    pVals[i as usize].data.dbl = *((lParse.Nodes
+                                        [theParams[i as usize]])
+                                        .value
+                                        .data
+                                        .dblptr())
+                                    .offset(row as isize);
                                     pNull[i as usize] =
                                         *((lParse.Nodes[theParams[i as usize]]).value.undef)
                                             .offset(row as isize);
@@ -12169,7 +12226,7 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                                     || c_int::from(pNull[2]) != 0,
                             ) as c_char;
                             if *fresh168 == 0 {
-                                *((lParse.Nodes[this_node_idx]).value.data.logptr)
+                                *((lParse.Nodes[this_node_idx]).value.data.logptr())
                                     .offset(elem as isize) =
                                     bnear(pVals[0].data.dbl, pVals[1].data.dbl, pVals[2].data.dbl);
                             }
@@ -12197,16 +12254,22 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                                     break;
                                 }
                                 if vector[i as usize] > 1 {
-                                    pVals[i as usize].data.dbl =
-                                        *((lParse.Nodes[theParams[i as usize]]).value.data.dblptr)
-                                            .offset(elem as isize);
+                                    pVals[i as usize].data.dbl = *((lParse.Nodes
+                                        [theParams[i as usize]])
+                                        .value
+                                        .data
+                                        .dblptr())
+                                    .offset(elem as isize);
                                     pNull[i as usize] =
                                         *((lParse.Nodes[theParams[i as usize]]).value.undef)
                                             .offset(elem as isize);
                                 } else if vector[i as usize] != 0 {
-                                    pVals[i as usize].data.dbl =
-                                        *((lParse.Nodes[theParams[i as usize]]).value.data.dblptr)
-                                            .offset(row as isize);
+                                    pVals[i as usize].data.dbl = *((lParse.Nodes
+                                        [theParams[i as usize]])
+                                        .value
+                                        .data
+                                        .dblptr())
+                                    .offset(row as isize);
                                     pNull[i as usize] =
                                         *((lParse.Nodes[theParams[i as usize]]).value.undef)
                                             .offset(row as isize);
@@ -12222,7 +12285,7 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                                     || c_int::from(pNull[4]) != 0,
                             ) as c_char;
                             if *fresh172 == 0 {
-                                *((lParse.Nodes[this_node_idx]).value.data.logptr)
+                                *((lParse.Nodes[this_node_idx]).value.data.logptr())
                                     .offset(elem as isize) = circle(
                                     pVals[0].data.dbl,
                                     pVals[1].data.dbl,
@@ -12255,16 +12318,22 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                                     break;
                                 }
                                 if vector[i as usize] > 1 {
-                                    pVals[i as usize].data.dbl =
-                                        *((lParse.Nodes[theParams[i as usize]]).value.data.dblptr)
-                                            .offset(elem as isize);
+                                    pVals[i as usize].data.dbl = *((lParse.Nodes
+                                        [theParams[i as usize]])
+                                        .value
+                                        .data
+                                        .dblptr())
+                                    .offset(elem as isize);
                                     pNull[i as usize] =
                                         *((lParse.Nodes[theParams[i as usize]]).value.undef)
                                             .offset(elem as isize);
                                 } else if vector[i as usize] != 0 {
-                                    pVals[i as usize].data.dbl =
-                                        *((lParse.Nodes[theParams[i as usize]]).value.data.dblptr)
-                                            .offset(row as isize);
+                                    pVals[i as usize].data.dbl = *((lParse.Nodes
+                                        [theParams[i as usize]])
+                                        .value
+                                        .data
+                                        .dblptr())
+                                    .offset(row as isize);
                                     pNull[i as usize] =
                                         *((lParse.Nodes[theParams[i as usize]]).value.undef)
                                             .offset(row as isize);
@@ -12282,7 +12351,7 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                                     || c_int::from(pNull[6]) != 0,
                             ) as c_char;
                             if *fresh176 == 0 {
-                                *((lParse.Nodes[this_node_idx]).value.data.logptr)
+                                *((lParse.Nodes[this_node_idx]).value.data.logptr())
                                     .offset(elem as isize) = saobox(
                                     pVals[0].data.dbl,
                                     pVals[1].data.dbl,
@@ -12317,16 +12386,22 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                                     break;
                                 }
                                 if vector[i as usize] > 1 {
-                                    pVals[i as usize].data.dbl =
-                                        *((lParse.Nodes[theParams[i as usize]]).value.data.dblptr)
-                                            .offset(elem as isize);
+                                    pVals[i as usize].data.dbl = *((lParse.Nodes
+                                        [theParams[i as usize]])
+                                        .value
+                                        .data
+                                        .dblptr())
+                                    .offset(elem as isize);
                                     pNull[i as usize] =
                                         *((lParse.Nodes[theParams[i as usize]]).value.undef)
                                             .offset(elem as isize);
                                 } else if vector[i as usize] != 0 {
-                                    pVals[i as usize].data.dbl =
-                                        *((lParse.Nodes[theParams[i as usize]]).value.data.dblptr)
-                                            .offset(row as isize);
+                                    pVals[i as usize].data.dbl = *((lParse.Nodes
+                                        [theParams[i as usize]])
+                                        .value
+                                        .data
+                                        .dblptr())
+                                    .offset(row as isize);
                                     pNull[i as usize] =
                                         *((lParse.Nodes[theParams[i as usize]]).value.undef)
                                             .offset(row as isize);
@@ -12344,7 +12419,7 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                                     || c_int::from(pNull[6]) != 0,
                             ) as c_char;
                             if *fresh180 == 0 {
-                                *((lParse.Nodes[this_node_idx]).value.data.logptr)
+                                *((lParse.Nodes[this_node_idx]).value.data.logptr())
                                     .offset(elem as isize) = ellipse(
                                     pVals[0].data.dbl,
                                     pVals[1].data.dbl,
@@ -12374,13 +12449,13 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                                 elem -= 1;
                                 if vector[2] > 1 {
                                     pVals[2].data.log =
-                                        *((lParse.Nodes[theParams[2]]).value.data.logptr)
+                                        *((lParse.Nodes[theParams[2]]).value.data.logptr())
                                             .offset(elem as isize);
                                     pNull[2] = *((lParse.Nodes[theParams[2]]).value.undef)
                                         .offset(elem as isize);
                                 } else if vector[2] != 0 {
                                     pVals[2].data.log =
-                                        *((lParse.Nodes[theParams[2]]).value.data.logptr)
+                                        *((lParse.Nodes[theParams[2]]).value.data.logptr())
                                             .offset(row as isize);
                                     pNull[2] = *((lParse.Nodes[theParams[2]]).value.undef)
                                         .offset(row as isize);
@@ -12419,12 +12494,12 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                                 *fresh184 = pNull[2];
                                 if *fresh184 == 0 {
                                     if pVals[2].data.log != 0 {
-                                        *((lParse.Nodes[this_node_idx]).value.data.logptr)
+                                        *((lParse.Nodes[this_node_idx]).value.data.logptr())
                                             .offset(elem as isize) = pVals[0].data.log;
                                         *((lParse.Nodes[this_node_idx]).value.undef)
                                             .offset(elem as isize) = pNull[0];
                                     } else {
-                                        *((lParse.Nodes[this_node_idx]).value.data.logptr)
+                                        *((lParse.Nodes[this_node_idx]).value.data.logptr())
                                             .offset(elem as isize) = pVals[1].data.log;
                                         *((lParse.Nodes[this_node_idx]).value.undef)
                                             .offset(elem as isize) = pNull[1];
@@ -12448,13 +12523,13 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                                 elem -= 1;
                                 if vector[2] > 1 {
                                     pVals[2].data.log =
-                                        *((lParse.Nodes[theParams[2]]).value.data.logptr)
+                                        *((lParse.Nodes[theParams[2]]).value.data.logptr())
                                             .offset(elem as isize);
                                     pNull[2] = *((lParse.Nodes[theParams[2]]).value.undef)
                                         .offset(elem as isize);
                                 } else if vector[2] != 0 {
                                     pVals[2].data.log =
-                                        *((lParse.Nodes[theParams[2]]).value.data.logptr)
+                                        *((lParse.Nodes[theParams[2]]).value.data.logptr())
                                             .offset(row as isize);
                                     pNull[2] = *((lParse.Nodes[theParams[2]]).value.undef)
                                         .offset(row as isize);
@@ -12493,12 +12568,12 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                                 *fresh188 = pNull[2];
                                 if *fresh188 == 0 {
                                     if pVals[2].data.log != 0 {
-                                        *((lParse.Nodes[this_node_idx]).value.data.lngptr)
+                                        *((lParse.Nodes[this_node_idx]).value.data.lngptr())
                                             .offset(elem as isize) = pVals[0].data.lng;
                                         *((lParse.Nodes[this_node_idx]).value.undef)
                                             .offset(elem as isize) = pNull[0];
                                     } else {
-                                        *((lParse.Nodes[this_node_idx]).value.data.lngptr)
+                                        *((lParse.Nodes[this_node_idx]).value.data.lngptr())
                                             .offset(elem as isize) = pVals[1].data.lng;
                                         *((lParse.Nodes[this_node_idx]).value.undef)
                                             .offset(elem as isize) = pNull[1];
@@ -12522,13 +12597,13 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                                 elem -= 1;
                                 if vector[2] > 1 {
                                     pVals[2].data.log =
-                                        *((lParse.Nodes[theParams[2]]).value.data.logptr)
+                                        *((lParse.Nodes[theParams[2]]).value.data.logptr())
                                             .offset(elem as isize);
                                     pNull[2] = *((lParse.Nodes[theParams[2]]).value.undef)
                                         .offset(elem as isize);
                                 } else if vector[2] != 0 {
                                     pVals[2].data.log =
-                                        *((lParse.Nodes[theParams[2]]).value.data.logptr)
+                                        *((lParse.Nodes[theParams[2]]).value.data.logptr())
                                             .offset(row as isize);
                                     pNull[2] = *((lParse.Nodes[theParams[2]]).value.undef)
                                         .offset(row as isize);
@@ -12567,12 +12642,12 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                                 *fresh192 = pNull[2];
                                 if *fresh192 == 0 {
                                     if pVals[2].data.log != 0 {
-                                        *((lParse.Nodes[this_node_idx]).value.data.dblptr)
+                                        *((lParse.Nodes[this_node_idx]).value.data.dblptr())
                                             .offset(elem as isize) = pVals[0].data.dbl;
                                         *((lParse.Nodes[this_node_idx]).value.undef)
                                             .offset(elem as isize) = pNull[0];
                                     } else {
-                                        *((lParse.Nodes[this_node_idx]).value.data.dblptr)
+                                        *((lParse.Nodes[this_node_idx]).value.data.dblptr())
                                             .offset(elem as isize) = pVals[1].data.dbl;
                                         *((lParse.Nodes[this_node_idx]).value.undef)
                                             .offset(elem as isize) = pNull[1];
@@ -12588,7 +12663,7 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                             }
                             if vector[2] != 0 {
                                 pVals[2].data.log =
-                                    *((lParse.Nodes[theParams[2]]).value.data.logptr)
+                                    *((lParse.Nodes[theParams[2]]).value.data.logptr())
                                         .offset(row as isize);
                                 pNull[2] = *((lParse.Nodes[theParams[2]]).value.undef)
                                     .offset(row as isize);
@@ -12603,8 +12678,11 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                                 if vector[i as usize] != 0 {
                                     strcpy(
                                         (pVals[i as usize].data.astr).as_mut_ptr(),
-                                        *((lParse.Nodes[theParams[i as usize]]).value.data.strptr)
-                                            .offset(row as isize),
+                                        *((lParse.Nodes[theParams[i as usize]])
+                                            .value
+                                            .data
+                                            .strptr())
+                                        .offset(row as isize),
                                     );
                                     pNull[i as usize] =
                                         *((lParse.Nodes[theParams[i as usize]]).value.undef)
@@ -12617,7 +12695,7 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                             if *fresh195 == 0 {
                                 if pVals[2].data.log != 0 {
                                     strcpy(
-                                        *((lParse.Nodes[this_node_idx]).value.data.strptr)
+                                        *((lParse.Nodes[this_node_idx]).value.data.strptr())
                                             .offset(row as isize),
                                         (pVals[0].data.astr).as_mut_ptr(),
                                     );
@@ -12625,7 +12703,7 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                                         .offset(row as isize) = pNull[0];
                                 } else {
                                     strcpy(
-                                        *((lParse.Nodes[this_node_idx]).value.data.strptr)
+                                        *((lParse.Nodes[this_node_idx]).value.data.strptr())
                                             .offset(row as isize),
                                         (pVals[1].data.astr).as_mut_ptr(),
                                     );
@@ -12633,7 +12711,7 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                                         .offset(row as isize) = pNull[1];
                                 }
                             } else {
-                                *(*((lParse.Nodes[this_node_idx]).value.data.strptr)
+                                *(*((lParse.Nodes[this_node_idx]).value.data.strptr())
                                     .offset(row as isize))
                                 .offset(0) = 0;
                             }
@@ -12660,9 +12738,9 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                             let mut str: *mut c_char = ptr::null_mut();
                             let mut undef: c_int = 0;
                             if posconst != 0 {
-                                pos = (lParse.Nodes[theParams[1]]).value.data.lng as c_int;
+                                pos = (lParse.Nodes[theParams[1]]).value.data.lng() as c_int;
                             } else {
-                                pos = *((lParse.Nodes[theParams[1]]).value.data.lngptr)
+                                pos = *((lParse.Nodes[theParams[1]]).value.data.lngptr())
                                     .offset(row as isize)
                                     as c_int;
                                 if *((lParse.Nodes[theParams[1]]).value.undef).offset(row as isize)
@@ -12672,12 +12750,13 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                                 }
                             }
                             if strconst != 0 {
-                                str = ((lParse.Nodes[theParams[0]]).value.data.astr).as_mut_ptr();
+                                str = ((lParse.Nodes[theParams[0]]).value.data.astr_mut())
+                                    .as_mut_ptr();
                                 if src_len == 0 {
                                     src_len = strlen(str) as c_int;
                                 }
                             } else {
-                                str = *((lParse.Nodes[theParams[0]]).value.data.strptr)
+                                str = *((lParse.Nodes[theParams[0]]).value.data.strptr())
                                     .offset(row as isize);
                                 if *((lParse.Nodes[theParams[0]]).value.undef).offset(row as isize)
                                     != 0
@@ -12688,7 +12767,7 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                             if lenconst != 0 {
                                 len = dest_len;
                             } else {
-                                len = *((lParse.Nodes[theParams[2]]).value.data.lngptr)
+                                len = *((lParse.Nodes[theParams[2]]).value.data.lngptr())
                                     .offset(row as isize)
                                     as c_int;
                                 if *((lParse.Nodes[theParams[2]]).value.undef).offset(row as isize)
@@ -12697,7 +12776,7 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                                     undef = 1;
                                 }
                             }
-                            *(*((lParse.Nodes[this_node_idx]).value.data.strptr)
+                            *(*((lParse.Nodes[this_node_idx]).value.data.strptr())
                                 .offset(row as isize))
                             .offset(0) = 0;
                             if pos == 0 {
@@ -12706,7 +12785,7 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                             if undef == 0
                                 && cstrmid(
                                     lParse,
-                                    *((lParse.Nodes[this_node_idx]).value.data.strptr)
+                                    *((lParse.Nodes[this_node_idx]).value.data.strptr())
                                         .offset(row as isize),
                                     len,
                                     str,
@@ -12735,9 +12814,10 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                             let mut str2: *mut c_char = ptr::null_mut();
                             let mut undef_0: c_int = 0;
                             if const1 != 0 {
-                                str1 = ((lParse.Nodes[theParams[0]]).value.data.astr).as_mut_ptr();
+                                str1 = ((lParse.Nodes[theParams[0]]).value.data.astr_mut())
+                                    .as_mut_ptr();
                             } else {
-                                str1 = *((lParse.Nodes[theParams[0]]).value.data.strptr)
+                                str1 = *((lParse.Nodes[theParams[0]]).value.data.strptr())
                                     .offset(row as isize);
                                 if *((lParse.Nodes[theParams[0]]).value.undef).offset(row as isize)
                                     != 0
@@ -12746,9 +12826,10 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                                 }
                             }
                             if const2 != 0 {
-                                str2 = ((lParse.Nodes[theParams[1]]).value.data.astr).as_mut_ptr();
+                                str2 = ((lParse.Nodes[theParams[1]]).value.data.astr_mut())
+                                    .as_mut_ptr();
                             } else {
-                                str2 = *((lParse.Nodes[theParams[1]]).value.data.strptr)
+                                str2 = *((lParse.Nodes[theParams[1]]).value.data.strptr())
                                     .offset(row as isize);
                                 if *((lParse.Nodes[theParams[1]]).value.undef).offset(row as isize)
                                     != 0
@@ -12756,16 +12837,16 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                                     undef_0 = 1;
                                 }
                             }
-                            *((lParse.Nodes[this_node_idx]).value.data.lngptr)
+                            *((lParse.Nodes[this_node_idx]).value.data.lngptr())
                                 .offset(row as isize) = 0;
                             if undef_0 == 0 {
                                 let res_0: *mut c_char = strstr(str1, str2);
                                 if res_0.is_null() {
                                     undef_0 = 1;
-                                    *((lParse.Nodes[this_node_idx]).value.data.lngptr)
+                                    *((lParse.Nodes[this_node_idx]).value.data.lngptr())
                                         .offset(row as isize) = 0;
                                 } else {
-                                    *((lParse.Nodes[this_node_idx]).value.data.lngptr)
+                                    *((lParse.Nodes[this_node_idx]).value.data.lngptr())
                                         .offset(row as isize) =
                                         res_0.offset_from(str1) as c_long + 1;
                                 }
@@ -12821,7 +12902,7 @@ fn Do_Deref(lParse: &mut ParseData, this_node_idx: usize) {
             isConst[i as usize] =
                 c_int::from((lParse.Nodes[theDims[i as usize]]).operation == CONST_OP);
             if isConst[i as usize] != 0 {
-                dimVals[i as usize] = (lParse.Nodes[theDims[i as usize]]).value.data.lng;
+                dimVals[i as usize] = (lParse.Nodes[theDims[i as usize]]).value.data.lng();
             } else {
                 allConst = 0;
             }
@@ -12880,32 +12961,32 @@ fn Do_Deref(lParse: &mut ParseData, this_node_idx: usize) {
                         if (lParse.Nodes[this_node_idx]).ntype
                             == fits_parser_yytokentype::DOUBLE as c_int
                         {
-                            *((lParse.Nodes[this_node_idx]).value.data.dblptr)
+                            *((lParse.Nodes[this_node_idx]).value.data.dblptr())
                                 .offset(row as isize) =
-                                *((lParse.Nodes[theVar]).value.data.dblptr).offset(elem as isize);
+                                *((lParse.Nodes[theVar]).value.data.dblptr()).offset(elem as isize);
                         } else if (lParse.Nodes[this_node_idx]).ntype
                             == fits_parser_yytokentype::LONG as c_int
                         {
-                            *((lParse.Nodes[this_node_idx]).value.data.lngptr)
+                            *((lParse.Nodes[this_node_idx]).value.data.lngptr())
                                 .offset(row as isize) =
-                                *((lParse.Nodes[theVar]).value.data.lngptr).offset(elem as isize);
+                                *((lParse.Nodes[theVar]).value.data.lngptr()).offset(elem as isize);
                         } else if (lParse.Nodes[this_node_idx]).ntype
                             == fits_parser_yytokentype::BOOLEAN as c_int
                         {
-                            *((lParse.Nodes[this_node_idx]).value.data.logptr)
+                            *((lParse.Nodes[this_node_idx]).value.data.logptr())
                                 .offset(row as isize) =
-                                *((lParse.Nodes[theVar]).value.data.logptr).offset(elem as isize);
+                                *((lParse.Nodes[theVar]).value.data.logptr()).offset(elem as isize);
                         } else {
                             /* XXX Note, the below expression uses knowledge of
                             the layout of the string format, namely (nelem+1)
                             characters per string, followed by (nelem+1)
                             "undef" values. */
 
-                            *(*((lParse.Nodes[this_node_idx]).value.data.strptr)
+                            *(*((lParse.Nodes[this_node_idx]).value.data.strptr())
                                 .offset(row as isize))
-                            .offset(0) = *(*((lParse.Nodes[theVar]).value.data.strptr).offset(0))
+                            .offset(0) = *(*((lParse.Nodes[theVar]).value.data.strptr()).offset(0))
                                 .offset((elem + row) as isize);
-                            *(*((lParse.Nodes[this_node_idx]).value.data.strptr)
+                            *(*((lParse.Nodes[this_node_idx]).value.data.strptr())
                                 .offset(row as isize))
                             .offset(1) = 0; /* Null terminate */
                         }
@@ -12941,7 +13022,7 @@ fn Do_Deref(lParse: &mut ParseData, this_node_idx: usize) {
                                 *((lParse.Nodes[theVar]).value.undef).offset(row as isize);
                         }
                         memcpy(
-                            (*((lParse.Nodes[this_node_idx]).value.data.strptr).offset(0))
+                            (*((lParse.Nodes[this_node_idx]).value.data.strptr()).offset(0))
                                 .offset(
                                     (row as c_ulong)
                                         .wrapping_mul(::core::mem::size_of::<c_char>() as c_ulong)
@@ -12951,7 +13032,7 @@ fn Do_Deref(lParse: &mut ParseData, this_node_idx: usize) {
                                         ) as isize,
                                 )
                                 .cast::<c_void>(),
-                            (*((lParse.Nodes[theVar]).value.data.strptr).offset(0)).offset(
+                            (*((lParse.Nodes[theVar]).value.data.strptr()).offset(0)).offset(
                                 (elem as c_ulong)
                                     .wrapping_mul(::core::mem::size_of::<c_char>() as c_ulong)
                                     as isize,
@@ -12961,7 +13042,7 @@ fn Do_Deref(lParse: &mut ParseData, this_node_idx: usize) {
                                 .try_into()
                                 .unwrap(),
                         );
-                        *(*((lParse.Nodes[this_node_idx]).value.data.strptr)
+                        *(*((lParse.Nodes[this_node_idx]).value.data.strptr())
                             .offset(row as isize))
                         .offset((lParse.Nodes[this_node_idx]).value.nelem as isize) = 0; /* Null terminate */
                         elem += (lParse.Nodes[theVar]).value.nelem + 1;
@@ -13028,7 +13109,7 @@ fn Do_Deref(lParse: &mut ParseData, this_node_idx: usize) {
                                 break;
                             } else {
                                 dimVals[i as usize] =
-                                    *((lParse.Nodes[theDims[i as usize]]).value.data.lngptr)
+                                    *((lParse.Nodes[theDims[i as usize]]).value.data.lngptr())
                                         .offset(row as isize);
                             }
                         }
@@ -13071,31 +13152,31 @@ fn Do_Deref(lParse: &mut ParseData, this_node_idx: usize) {
                         if (lParse.Nodes[this_node_idx]).ntype
                             == fits_parser_yytokentype::DOUBLE as c_int
                         {
-                            *((lParse.Nodes[this_node_idx]).value.data.dblptr)
+                            *((lParse.Nodes[this_node_idx]).value.data.dblptr())
                                 .offset(row as isize) =
-                                *((lParse.Nodes[theVar]).value.data.dblptr).offset(elem as isize);
+                                *((lParse.Nodes[theVar]).value.data.dblptr()).offset(elem as isize);
                         } else if (lParse.Nodes[this_node_idx]).ntype
                             == fits_parser_yytokentype::LONG as c_int
                         {
-                            *((lParse.Nodes[this_node_idx]).value.data.lngptr)
+                            *((lParse.Nodes[this_node_idx]).value.data.lngptr())
                                 .offset(row as isize) =
-                                *((lParse.Nodes[theVar]).value.data.lngptr).offset(elem as isize);
+                                *((lParse.Nodes[theVar]).value.data.lngptr()).offset(elem as isize);
                         } else if (lParse.Nodes[this_node_idx]).ntype
                             == fits_parser_yytokentype::BOOLEAN as c_int
                         {
-                            *((lParse.Nodes[this_node_idx]).value.data.logptr)
+                            *((lParse.Nodes[this_node_idx]).value.data.logptr())
                                 .offset(row as isize) =
-                                *((lParse.Nodes[theVar]).value.data.logptr).offset(elem as isize);
+                                *((lParse.Nodes[theVar]).value.data.logptr()).offset(elem as isize);
                         } else {
                             /* XXX Note, the below expression uses knowledge of
                             the layout of the string format, namely (nelem+1)
                             characters per string, followed by (nelem+1)
                             "undef" values. */
-                            *(*((lParse.Nodes[this_node_idx]).value.data.strptr)
+                            *(*((lParse.Nodes[this_node_idx]).value.data.strptr())
                                 .offset(row as isize))
-                            .offset(0) = *(*((lParse.Nodes[theVar]).value.data.strptr).offset(0))
+                            .offset(0) = *(*((lParse.Nodes[theVar]).value.data.strptr()).offset(0))
                                 .offset((elem + row) as isize);
-                            *(*((lParse.Nodes[this_node_idx]).value.data.strptr)
+                            *(*((lParse.Nodes[this_node_idx]).value.data.strptr())
                                 .offset(row as isize))
                             .offset(1) = 0; /* Null terminate */
                         }
@@ -13118,7 +13199,7 @@ fn Do_Deref(lParse: &mut ParseData, this_node_idx: usize) {
                         break;
                     } else {
                         dimVals[0] =
-                            *((lParse.Nodes[theDims[0]]).value.data.lngptr).offset(row as isize);
+                            *((lParse.Nodes[theDims[0]]).value.data.lngptr()).offset(row as isize);
                         if dimVals[0] < 1
                             || dimVals[0]
                                 > (lParse.Nodes[theVar]).value.naxes
@@ -13139,7 +13220,7 @@ fn Do_Deref(lParse: &mut ParseData, this_node_idx: usize) {
                                     *((lParse.Nodes[theVar]).value.undef).offset(row as isize);
                             }
                             memcpy(
-                                (*((lParse.Nodes[this_node_idx]).value.data.strptr).offset(0))
+                                (*((lParse.Nodes[this_node_idx]).value.data.strptr()).offset(0))
                                     .offset(
                                         (row as c_ulong)
                                             .wrapping_mul(
@@ -13151,7 +13232,7 @@ fn Do_Deref(lParse: &mut ParseData, this_node_idx: usize) {
                                             ) as isize,
                                     )
                                     .cast::<c_void>(),
-                                (*((lParse.Nodes[theVar]).value.data.strptr).offset(0)).offset(
+                                (*((lParse.Nodes[theVar]).value.data.strptr()).offset(0)).offset(
                                     (elem as c_ulong)
                                         .wrapping_mul(::core::mem::size_of::<c_char>() as c_ulong)
                                         as isize,
@@ -13161,7 +13242,7 @@ fn Do_Deref(lParse: &mut ParseData, this_node_idx: usize) {
                                     .try_into()
                                     .unwrap(),
                             );
-                            *(*((lParse.Nodes[this_node_idx]).value.data.strptr)
+                            *(*((lParse.Nodes[this_node_idx]).value.data.strptr())
                                 .offset(row as isize))
                             .offset((lParse.Nodes[this_node_idx]).value.nelem as isize) = 0; /* Null terminate */
                         } else {
@@ -13240,12 +13321,12 @@ fn Do_GTI(lParse: &mut ParseData, this_node_idx: usize) {
         let theExpr = (lParse.Nodes[this_node_idx]).SubNodes[1];
 
         nGTI = (lParse.Nodes[theTimes]).value.nelem;
-        start = (lParse.Nodes[theTimes]).value.data.dblptr;
-        stop = ((lParse.Nodes[theTimes]).value.data.dblptr).offset(nGTI as isize);
+        start = (lParse.Nodes[theTimes]).value.data.dblptr();
+        stop = ((lParse.Nodes[theTimes]).value.data.dblptr()).offset(nGTI as isize);
         ordered = (lParse.Nodes[theTimes]).ntype;
         if (lParse.Nodes[theExpr]).operation == CONST_OP {
             gti = Search_GTI(
-                (lParse.Nodes[theExpr]).value.data.dbl,
+                (lParse.Nodes[theExpr]).value.data.dbl(),
                 nGTI,
                 start,
                 stop,
@@ -13261,7 +13342,7 @@ fn Do_GTI(lParse: &mut ParseData, this_node_idx: usize) {
             (lParse.Nodes[this_node_idx]).operation = CONST_OP;
         } else {
             Allocate_Ptrs(lParse, this_node_idx);
-            times = (lParse.Nodes[theExpr]).value.data.dblptr;
+            times = (lParse.Nodes[theExpr]).value.data.dblptr();
             if lParse.status == 0 {
                 elem = lParse.nRows * (lParse.Nodes[this_node_idx]).value.nelem;
                 if nGTI != 0 {
@@ -13292,13 +13373,13 @@ fn Do_GTI(lParse: &mut ParseData, this_node_idx: usize) {
                             );
                         }
                         if dorow != 0 {
-                            *((lParse.Nodes[this_node_idx]).value.data.lngptr)
+                            *((lParse.Nodes[this_node_idx]).value.data.lngptr())
                                 .offset(elem as isize) =
                                 if gti >= 0 { gti + 1 } else { -(1) as c_long };
                             *((lParse.Nodes[this_node_idx]).value.undef).offset(elem as isize) =
                                 (if gti >= 0 { 0 } else { 1 }) as c_char;
                         } else {
-                            *((lParse.Nodes[this_node_idx]).value.data.logptr)
+                            *((lParse.Nodes[this_node_idx]).value.data.logptr())
                                 .offset(elem as isize) = if gti >= 0 { 1 } else { 0 };
                         }
                     }
@@ -13318,8 +13399,8 @@ fn Do_GTI(lParse: &mut ParseData, this_node_idx: usize) {
                         if fresh205 == 0 {
                             break;
                         }
-                        *((lParse.Nodes[this_node_idx]).value.data.logptr).offset(elem as isize) =
-                            0;
+                        *((lParse.Nodes[this_node_idx]).value.data.logptr())
+                            .offset(elem as isize) = 0;
                         *((lParse.Nodes[this_node_idx]).value.undef).offset(elem as isize) = 0;
                     }
                 }
@@ -13351,14 +13432,14 @@ fn Do_GTI_Over(lParse: &mut ParseData, this_node_idx: usize) {
         let theStart = (lParse.Nodes[this_node_idx]).SubNodes[1];
 
         nGTI = (lParse.Nodes[theTimes]).value.nelem;
-        gtiStart = (lParse.Nodes[theTimes]).value.data.dblptr;
-        gtiStop = ((lParse.Nodes[theTimes]).value.data.dblptr).offset(nGTI as isize);
+        gtiStart = (lParse.Nodes[theTimes]).value.data.dblptr();
+        gtiStop = ((lParse.Nodes[theTimes]).value.data.dblptr()).offset(nGTI as isize);
         if (lParse.Nodes[theStart]).operation == CONST_OP
             && (lParse.Nodes[theStop]).operation == CONST_OP
         {
             (lParse.Nodes[this_node_idx]).value.data.dbl = GTI_Over(
-                (lParse.Nodes[theStart]).value.data.dbl,
-                (lParse.Nodes[theStop]).value.data.dbl,
+                (lParse.Nodes[theStart]).value.data.dbl(),
+                (lParse.Nodes[theStop]).value.data.dbl(),
                 nGTI,
                 gtiStart,
                 gtiStop,
@@ -13371,16 +13452,16 @@ fn Do_GTI_Over(lParse: &mut ParseData, this_node_idx: usize) {
             let mut uStart: c_double = 0.0;
             let mut uStop: c_double = 0.0;
             if (lParse.Nodes[theStart]).operation == CONST_OP {
-                uStart = (lParse.Nodes[theStart]).value.data.dbl;
+                uStart = (lParse.Nodes[theStart]).value.data.dbl();
             }
             if (lParse.Nodes[theStop]).operation == CONST_OP {
-                uStop = (lParse.Nodes[theStop]).value.data.dbl;
+                uStop = (lParse.Nodes[theStop]).value.data.dbl();
             }
 
             Allocate_Ptrs(lParse, this_node_idx);
 
-            evtStart = (lParse.Nodes[theStart]).value.data.dblptr;
-            evtStop = (lParse.Nodes[theStop]).value.data.dblptr;
+            evtStart = (lParse.Nodes[theStart]).value.data.dblptr();
+            evtStop = (lParse.Nodes[theStop]).value.data.dblptr();
             if lParse.status == 0 {
                 elem = lParse.nRows * (lParse.Nodes[this_node_idx]).value.nelem;
                 if nGTI != 0 {
@@ -13422,8 +13503,8 @@ fn Do_GTI_Over(lParse: &mut ParseData, this_node_idx: usize) {
                         } else {
                             toverlap = uStop - uStart;
                         }
-                        *((lParse.Nodes[this_node_idx]).value.data.dblptr).offset(elem as isize) =
-                            toverlap;
+                        *((lParse.Nodes[this_node_idx]).value.data.dblptr())
+                            .offset(elem as isize) = toverlap;
                     }
                 } else {
                     loop {
@@ -13432,8 +13513,8 @@ fn Do_GTI_Over(lParse: &mut ParseData, this_node_idx: usize) {
                         if fresh208 == 0 {
                             break;
                         }
-                        *((lParse.Nodes[this_node_idx]).value.data.dblptr).offset(elem as isize) =
-                            0.0;
+                        *((lParse.Nodes[this_node_idx]).value.data.dblptr())
+                            .offset(elem as isize) = 0.0;
                         *((lParse.Nodes[this_node_idx]).value.undef).offset(elem as isize) = 0;
                     }
                 }
@@ -13599,19 +13680,23 @@ fn Do_REG(lParse: &mut ParseData, this_node_idx: usize) {
         if Xvector != 0 {
             Xvector = (lParse.Nodes[theX]).value.nelem as c_int;
         } else {
-            Xval = (lParse.Nodes[theX]).value.data.dbl;
+            Xval = (lParse.Nodes[theX]).value.data.dbl();
         }
         Yvector = c_int::from((lParse.Nodes[theY]).operation != CONST_OP);
         if Yvector != 0 {
             Yvector = (lParse.Nodes[theY]).value.nelem as c_int;
         } else {
-            Yval = (lParse.Nodes[theY]).value.data.dbl;
+            Yval = (lParse.Nodes[theY]).value.data.dbl();
         }
         if Xvector == 0 && Yvector == 0 {
             (lParse.Nodes[this_node_idx]).value.data.log = if fits_in_region(
                 Xval,
                 Yval,
-                &mut *(lParse.Nodes[theRegion]).value.data.ptr.cast::<SAORegion>(),
+                &mut *(lParse.Nodes[theRegion])
+                    .value
+                    .data
+                    .ptr()
+                    .cast::<SAORegion>(),
             ) != 0
             {
                 1
@@ -13639,17 +13724,21 @@ fn Do_REG(lParse: &mut ParseData, this_node_idx: usize) {
                         }
                         elem -= 1;
                         if Xvector > 1 {
-                            Xval = *((lParse.Nodes[theX]).value.data.dblptr).offset(elem as isize);
+                            Xval =
+                                *((lParse.Nodes[theX]).value.data.dblptr()).offset(elem as isize);
                             Xnull = *((lParse.Nodes[theX]).value.undef).offset(elem as isize);
                         } else if Xvector != 0 {
-                            Xval = *((lParse.Nodes[theX]).value.data.dblptr).offset(rows as isize);
+                            Xval =
+                                *((lParse.Nodes[theX]).value.data.dblptr()).offset(rows as isize);
                             Xnull = *((lParse.Nodes[theX]).value.undef).offset(rows as isize);
                         }
                         if Yvector > 1 {
-                            Yval = *((lParse.Nodes[theY]).value.data.dblptr).offset(elem as isize);
+                            Yval =
+                                *((lParse.Nodes[theY]).value.data.dblptr()).offset(elem as isize);
                             Ynull = *((lParse.Nodes[theY]).value.undef).offset(elem as isize);
                         } else if Yvector != 0 {
-                            Yval = *((lParse.Nodes[theY]).value.data.dblptr).offset(rows as isize);
+                            Yval =
+                                *((lParse.Nodes[theY]).value.data.dblptr()).offset(rows as isize);
                             Ynull = *((lParse.Nodes[theY]).value.undef).offset(rows as isize);
                         }
                         *((lParse.Nodes[this_node_idx]).value.undef).offset(elem as isize) =
@@ -13661,17 +13750,21 @@ fn Do_REG(lParse: &mut ParseData, this_node_idx: usize) {
                         if *((lParse.Nodes[this_node_idx]).value.undef).offset(elem as isize) != 0 {
                             continue;
                         }
-                        *((lParse.Nodes[this_node_idx]).value.data.logptr).offset(elem as isize) =
-                            if fits_in_region(
-                                Xval,
-                                Yval,
-                                &mut *(lParse.Nodes[theRegion]).value.data.ptr.cast::<SAORegion>(),
-                            ) != 0
-                            {
-                                1
-                            } else {
-                                0
-                            };
+                        *((lParse.Nodes[this_node_idx]).value.data.logptr())
+                            .offset(elem as isize) = if fits_in_region(
+                            Xval,
+                            Yval,
+                            &mut *(lParse.Nodes[theRegion])
+                                .value
+                                .data
+                                .ptr()
+                                .cast::<SAORegion>(),
+                        ) != 0
+                        {
+                            1
+                        } else {
+                            0
+                        };
                     }
                     nelem = (lParse.Nodes[this_node_idx]).value.nelem;
                 }
@@ -13794,16 +13887,16 @@ fn Do_Vector(lParse: &mut ParseData, this_node_idx: usize) {
                         *((this_node).value.undef).offset(idx as isize) = 0;
                         match (this_node).ntype.into() {
                             fits_parser_yytokentype::BOOLEAN => {
-                                *((this_node).value.data.logptr).offset(idx as isize) =
-                                    that_node.value.data.log;
+                                *((this_node).value.data.logptr()).offset(idx as isize) =
+                                    that_node.value.data.log();
                             }
                             fits_parser_yytokentype::LONG => {
-                                *((this_node).value.data.lngptr).offset(idx as isize) =
-                                    that_node.value.data.lng;
+                                *((this_node).value.data.lngptr()).offset(idx as isize) =
+                                    that_node.value.data.lng();
                             }
                             fits_parser_yytokentype::DOUBLE => {
-                                *((this_node).value.data.dblptr).offset(idx as isize) =
-                                    that_node.value.data.dbl;
+                                *((this_node).value.data.dblptr()).offset(idx as isize) =
+                                    that_node.value.data.dbl();
                             }
                             _ => {}
                         }
@@ -13830,19 +13923,19 @@ fn Do_Vector(lParse: &mut ParseData, this_node_idx: usize) {
                                 *(that_node.value.undef).offset(idx as isize);
                             match (this_node).ntype.into() {
                                 fits_parser_yytokentype::BOOLEAN => {
-                                    *((this_node).value.data.logptr)
+                                    *((this_node).value.data.logptr())
                                         .offset((jdx + elem) as isize) =
-                                        *(that_node.value.data.logptr).offset(idx as isize);
+                                        *(that_node.value.data.logptr()).offset(idx as isize);
                                 }
                                 fits_parser_yytokentype::LONG => {
-                                    *((this_node).value.data.lngptr)
+                                    *((this_node).value.data.lngptr())
                                         .offset((jdx + elem) as isize) =
-                                        *(that_node.value.data.lngptr).offset(idx as isize);
+                                        *(that_node.value.data.lngptr()).offset(idx as isize);
                                 }
                                 fits_parser_yytokentype::DOUBLE => {
-                                    *((this_node).value.data.dblptr)
+                                    *((this_node).value.data.dblptr())
                                         .offset((jdx + elem) as isize) =
-                                        *(that_node.value.data.dblptr).offset(idx as isize);
+                                        *(that_node.value.data.dblptr()).offset(idx as isize);
                                 }
                                 _ => {}
                             }
@@ -13901,16 +13994,16 @@ fn Do_Array(lParse: &mut ParseData, this_node_idx: usize) {
                     *(this_node.value.undef).offset(idx as isize) = 0;
                     match this_node.ntype.into() {
                         fits_parser_yytokentype::BOOLEAN => {
-                            *(this_node.value.data.logptr).offset(idx as isize) =
-                                (that_node).value.data.log;
+                            *(this_node.value.data.logptr()).offset(idx as isize) =
+                                (that_node).value.data.log();
                         }
                         fits_parser_yytokentype::LONG => {
-                            *(this_node.value.data.lngptr).offset(idx as isize) =
-                                (that_node).value.data.lng;
+                            *(this_node.value.data.lngptr()).offset(idx as isize) =
+                                (that_node).value.data.lng();
                         }
                         fits_parser_yytokentype::DOUBLE => {
-                            *(this_node.value.data.dblptr).offset(idx as isize) =
-                                (that_node).value.data.dbl;
+                            *(this_node.value.data.dblptr()).offset(idx as isize) =
+                                (that_node).value.data.dbl();
                         }
                         _ => {}
                     }
@@ -13927,16 +14020,16 @@ fn Do_Array(lParse: &mut ParseData, this_node_idx: usize) {
                         *((that_node).value.undef).offset(idx as isize);
                     match this_node.ntype.into() {
                         fits_parser_yytokentype::BOOLEAN => {
-                            *(this_node.value.data.logptr).offset(idx as isize) =
-                                *((that_node).value.data.logptr).offset(idx as isize);
+                            *(this_node.value.data.logptr()).offset(idx as isize) =
+                                *((that_node).value.data.logptr()).offset(idx as isize);
                         }
                         fits_parser_yytokentype::LONG => {
-                            *(this_node.value.data.lngptr).offset(idx as isize) =
-                                *((that_node).value.data.lngptr).offset(idx as isize);
+                            *(this_node.value.data.lngptr()).offset(idx as isize) =
+                                *((that_node).value.data.lngptr()).offset(idx as isize);
                         }
                         fits_parser_yytokentype::DOUBLE => {
-                            *(this_node.value.data.dblptr).offset(idx as isize) =
-                                *((that_node).value.data.dblptr).offset(idx as isize);
+                            *(this_node.value.data.dblptr()).offset(idx as isize) =
+                                *((that_node).value.data.dblptr()).offset(idx as isize);
                         }
                         _ => {}
                     }
@@ -13961,16 +14054,16 @@ fn Do_Array(lParse: &mut ParseData, this_node_idx: usize) {
                             *((that_node).value.undef).offset(row as isize);
                         match this_node.ntype.into() {
                             fits_parser_yytokentype::BOOLEAN => {
-                                *(this_node.value.data.logptr).offset(idx as isize) =
-                                    *((that_node).value.data.logptr).offset(row as isize);
+                                *(this_node.value.data.logptr()).offset(idx as isize) =
+                                    *((that_node).value.data.logptr()).offset(row as isize);
                             }
                             fits_parser_yytokentype::LONG => {
-                                *(this_node.value.data.lngptr).offset(idx as isize) =
-                                    *((that_node).value.data.lngptr).offset(row as isize);
+                                *(this_node.value.data.lngptr()).offset(idx as isize) =
+                                    *((that_node).value.data.lngptr()).offset(row as isize);
                             }
                             fits_parser_yytokentype::DOUBLE => {
-                                *(this_node.value.data.dblptr).offset(idx as isize) =
-                                    *((that_node).value.data.dblptr).offset(row as isize);
+                                *(this_node.value.data.dblptr()).offset(idx as isize) =
+                                    *((that_node).value.data.dblptr()).offset(row as isize);
                             }
                             _ => {}
                         }
@@ -14368,7 +14461,7 @@ mod node_buffer_tests {
         assert_eq!(lparse.status, 0);
         assert!(lparse.node_buffers[idx].is_some());
 
-        let dptr = unsafe { lparse.Nodes[idx].value.data.dblptr };
+        let dptr = unsafe { lparse.Nodes[idx].value.data.dblptr() };
         let undef = lparse.Nodes[idx].value.undef;
         assert!(!dptr.is_null());
         assert!(!undef.is_null());
@@ -14387,7 +14480,7 @@ mod node_buffer_tests {
 
         free_node_data(&mut lparse, idx);
         assert!(lparse.node_buffers[idx].is_none());
-        assert!(unsafe { lparse.Nodes[idx].value.data.ptr }.is_null());
+        assert!(unsafe { lparse.Nodes[idx].value.data.ptr() }.is_null());
     }
 
     /// Exercises the Rust-owned STRING node buffer: Allocate_Ptrs builds the row
@@ -14411,7 +14504,7 @@ mod node_buffer_tests {
         assert_eq!(lparse.status, 0);
         assert!(lparse.node_buffers[idx].is_some());
 
-        let strptr = unsafe { lparse.Nodes[idx].value.data.strptr };
+        let strptr = unsafe { lparse.Nodes[idx].value.data.strptr() };
         let undef = lparse.Nodes[idx].value.undef;
         assert!(!strptr.is_null());
         assert!(!undef.is_null());
@@ -14438,7 +14531,7 @@ mod node_buffer_tests {
 
         free_node_data(&mut lparse, idx);
         assert!(lparse.node_buffers[idx].is_none());
-        assert!(unsafe { lparse.Nodes[idx].value.data.strptr }.is_null());
+        assert!(unsafe { lparse.Nodes[idx].value.data.strptr() }.is_null());
     }
 
     /// BITSTR nodes allocate a strptr buffer but no undef array. Confirms the
@@ -14456,7 +14549,7 @@ mod node_buffer_tests {
         Allocate_Ptrs(&mut lparse, 0);
         assert_eq!(lparse.status, 0);
         assert!(lparse.node_buffers[0].is_some());
-        assert!(!unsafe { lparse.Nodes[0].value.data.strptr }.is_null());
+        assert!(!unsafe { lparse.Nodes[0].value.data.strptr() }.is_null());
         assert!(lparse.Nodes[0].value.undef.is_null()); // BITSTRs don't use undef
         free_node_data(&mut lparse, 0);
         assert!(lparse.node_buffers[0].is_none());
@@ -14476,9 +14569,9 @@ mod node_buffer_tests {
         lparse.Nodes.push(node);
 
         Allocate_Ptrs(&mut lparse, 0);
-        let p1 = unsafe { lparse.Nodes[0].value.data.ptr };
+        let p1 = unsafe { lparse.Nodes[0].value.data.ptr() };
         Allocate_Ptrs(&mut lparse, 0); // old buffer must be dropped here
-        let p2 = unsafe { lparse.Nodes[0].value.data.ptr };
+        let p2 = unsafe { lparse.Nodes[0].value.data.ptr() };
         assert!(!p1.is_null() && !p2.is_null());
         // New buffer is usable.
         unsafe {
@@ -14508,7 +14601,7 @@ mod node_buffer_tests {
         assert!(lparse.node_buffers.is_empty());
 
         free_node_data(&mut lparse, 0);
-        assert!(unsafe { lparse.Nodes[0].value.data.ptr }.is_null());
+        assert!(unsafe { lparse.Nodes[0].value.data.ptr() }.is_null());
     }
 
     /// Dropping ParseData (as ffcprs does via `node_buffers = Vec::new()`) must

--- a/src/eval_y.rs
+++ b/src/eval_y.rs
@@ -4,7 +4,7 @@ use core::slice;
 use core::{cmp, ptr};
 
 use bytemuck::{cast_slice, cast_slice_mut};
-use libc::{calloc, free, malloc, memcpy, time, time_t};
+use libc::{free, malloc, memcpy, time, time_t};
 
 const APPROX: f64 = 1.0e-7;
 
@@ -68,7 +68,9 @@ use crate::c_types::{
     c_char, c_double, c_int, c_long, c_schar, c_short, c_uchar, c_uint, c_ulong, c_void,
 };
 use crate::cfileio::{ffclos_safe, ffexts_safe, ffopen_safe};
-use crate::eval_defs::{CONST_OP, MAXDIMS, MAXSUBS, Node, ParseData, data_union, lval, yyscan_t};
+use crate::eval_defs::{
+    CONST_OP, MAXDIMS, MAXSUBS, Node, NodeBuf, ParseData, data_union, lval, yyscan_t,
+};
 use crate::eval_l::{fits_parser_yyGetVariable, fits_parser_yylex, yyguts_t};
 use crate::eval_tab::fits_parser_yytokentype::BITSTR;
 use crate::eval_tab::{FITS_PARSER_YYSTYPE, fits_parser_yytokentype};
@@ -6666,7 +6668,7 @@ fn New_GTI(
                     &mut lParse.status,
                 );
                 if lParse.status != 0 {
-                    free((lParse.Nodes[that0_idx]).value.data.dblptr.cast::<c_void>());
+                    free_node_data(lParse, that0_idx);
                     return -(1);
                 }
 
@@ -7343,6 +7345,43 @@ fn Evaluate_Node(lParse: &mut ParseData, thisNode: c_int) {
     }
 }
 
+/// Allocate the Rust-owned backing store for a numeric node's result buffer
+/// (`n_bytes`, covering the data array followed by its undef flags), retain it
+/// in `lParse.node_buffers[idx]`, and return a zeroed raw view of its start.
+/// Returns null on allocation failure (matching the previous `calloc`).
+fn alloc_node_data(lParse: &mut ParseData, idx: usize, n_bytes: usize) -> *mut c_void {
+    if lParse.node_buffers.len() <= idx {
+        lParse.node_buffers.resize_with(idx + 1, || None);
+    }
+    match NodeBuf::new(n_bytes) {
+        Some(buf) => {
+            let ptr = buf.as_ptr().cast::<c_void>();
+            lParse.node_buffers[idx] = Some(buf);
+            ptr
+        }
+        None => {
+            lParse.node_buffers[idx] = None;
+            core::ptr::null_mut()
+        }
+    }
+}
+
+/// Release a numeric node's result buffer. If it is Rust-owned (present in
+/// `node_buffers`) the box is dropped; otherwise the legacy malloc'd pointer is
+/// freed with `libc::free`. The node's data pointer is nulled either way, so a
+/// repeated call is a safe no-op. `undef` (a view into the same buffer) is left
+/// to the caller.
+pub(crate) fn free_node_data(lParse: &mut ParseData, idx: usize) {
+    let owned = idx < lParse.node_buffers.len() && lParse.node_buffers[idx].is_some();
+    if owned {
+        lParse.node_buffers[idx] = None; // drops the NodeBuf (frees the buffer)
+    } else {
+        // Legacy malloc'd pointer (e.g. GTI data); free with libc.
+        unsafe { free((lParse.Nodes[idx]).value.data.ptr) };
+    }
+    (lParse.Nodes[idx]).value.data.ptr = core::ptr::null_mut();
+}
+
 fn Allocate_Ptrs(lParse: &mut ParseData, this_node_idx: usize) {
     unsafe {
         let mut elem: c_long = 0;
@@ -7422,41 +7461,42 @@ fn Allocate_Ptrs(lParse: &mut ParseData, this_node_idx: usize) {
                     size = 1;
                 }
             }
-            (lParse.Nodes[this_node_idx]).value.data.ptr = calloc(
-                ((size + 1) as c_ulong).try_into().unwrap(),
-                (elem as c_ulong).try_into().unwrap(),
-            );
-            if ((lParse.Nodes[this_node_idx]).value.data.ptr).is_null() {
+            // Rust-owned buffer of (size + 1) * elem bytes (matching the former
+            // calloc): `elem * size` bytes of data followed by `elem` undef
+            // flags. Owned by lParse.node_buffers; data.ptr/undef are views.
+            let n_bytes = ((size + 1) * elem) as usize;
+            let p = alloc_node_data(lParse, this_node_idx, n_bytes);
+            (lParse.Nodes[this_node_idx]).value.data.ptr = p;
+            if p.is_null() {
                 lParse.status = MEMORY_ALLOCATION;
             } else {
-                (lParse.Nodes[this_node_idx]).value.undef = (lParse.Nodes[this_node_idx])
-                    .value
-                    .data
-                    .ptr
-                    .cast::<c_char>()
-                    .offset((elem * size) as isize);
+                (lParse.Nodes[this_node_idx]).value.undef =
+                    p.cast::<c_char>().offset((elem * size) as isize);
             }
         };
     }
 }
 
-unsafe fn free_node_buffer(node: &mut Node) {
-    if (node.ntype == fits_parser_yytokentype::BITSTR as c_int
-        || node.ntype == fits_parser_yytokentype::STRING as c_int)
+unsafe fn free_node_buffer(lParse: &mut ParseData, idx: usize) {
+    let ntype = lParse.Nodes[idx].ntype;
+    if ntype == fits_parser_yytokentype::BITSTR as c_int
+        || ntype == fits_parser_yytokentype::STRING as c_int
     {
-        if (!node.value.data.strptr.is_null()) {
-            if (!(*node.value.data.strptr).is_null()) {
-                free((*node.value.data.strptr) as *mut c_void);
+        // STRING/BITSTR nodes still use the legacy malloc'd 2-D strptr buffer.
+        let strptr = lParse.Nodes[idx].value.data.strptr;
+        if !strptr.is_null() {
+            if !(*strptr).is_null() {
+                free((*strptr) as *mut c_void);
             }
-            free(node.value.data.strptr as *mut c_void);
-            node.value.data.strptr = ptr::null_mut();
+            free(strptr as *mut c_void);
+            lParse.Nodes[idx].value.data.strptr = ptr::null_mut();
         }
-    } else if (!node.value.data.ptr.is_null()) {
-        free(node.value.data.ptr);
-        node.value.data.ptr = ptr::null_mut();
+    } else {
+        // Numeric nodes: Rust-owned buffer (or legacy malloc for GTI etc.).
+        free_node_data(lParse, idx);
     }
 
-    node.value.undef = ptr::null_mut();
+    lParse.Nodes[idx].value.undef = ptr::null_mut();
 }
 
 fn Do_Unary(lParse: &mut ParseData, this_node_idx: usize) {
@@ -7704,7 +7744,7 @@ fn Do_Unary(lParse: &mut ParseData, this_node_idx: usize) {
         let that_idx = (lParse.Nodes[this_node_idx]).SubNodes[0];
 
         if (lParse.Nodes[that_idx]).operation > 0 {
-            free((lParse.Nodes[that_idx]).value.data.ptr);
+            free_node_data(lParse, that_idx);
         }
     }
 }
@@ -7750,7 +7790,7 @@ fn Do_Offset(lParse: &mut ParseData, this_node_idx: usize) {
             if (lParse.status == 0) {
                 lParse.status = PARSE_SYNTAX_ERR;
             }
-            free_node_buffer(&mut (lParse.Nodes[this_node_idx]));
+            free_node_buffer(lParse, this_node_idx);
             return;
         }
 
@@ -7810,7 +7850,7 @@ fn Do_Offset(lParse: &mut ParseData, this_node_idx: usize) {
                     if (lParse.status == 0) {
                         lParse.status = PARSE_SYNTAX_ERR;
                     }
-                    free_node_buffer(&mut (lParse.Nodes[this_node_idx]));
+                    free_node_buffer(lParse, this_node_idx);
                     return;
                 }
             } else if (rowOffset < 0) {
@@ -7822,7 +7862,7 @@ fn Do_Offset(lParse: &mut ParseData, this_node_idx: usize) {
                     if (lParse.status == 0) {
                         lParse.status = PARSE_SYNTAX_ERR;
                     }
-                    free_node_buffer(&mut (lParse.Nodes[this_node_idx]));
+                    free_node_buffer(lParse, this_node_idx);
                     return;
                 }
             }
@@ -8718,10 +8758,10 @@ fn Do_BinOp_log(lParse: &mut ParseData, this_node_idx: usize) {
             }
         }
         if (lParse.Nodes[that1_idx]).operation > 0 {
-            free((lParse.Nodes[that1_idx]).value.data.ptr);
+            free_node_data(lParse, that1_idx);
         }
         if (lParse.Nodes[that2_idx]).operation > 0 {
-            free((lParse.Nodes[that2_idx]).value.data.ptr);
+            free_node_data(lParse, that2_idx);
         }
     }
 }
@@ -9015,10 +9055,10 @@ fn Do_BinOp_lng(lParse: &mut ParseData, this_node_idx: usize) {
             }
         }
         if (lParse.Nodes[that1_idx]).operation > 0 {
-            free((lParse.Nodes[that1_idx]).value.data.ptr);
+            free_node_data(lParse, that1_idx);
         }
         if (lParse.Nodes[that2_idx]).operation > 0 {
-            free((lParse.Nodes[that2_idx]).value.data.ptr);
+            free_node_data(lParse, that2_idx);
         }
     }
 }
@@ -9314,10 +9354,10 @@ fn Do_BinOp_dbl(lParse: &mut ParseData, this_node_idx: usize) {
             }
         }
         if (lParse.Nodes[that1_idx]).operation > 0 {
-            free((lParse.Nodes[that1_idx]).value.data.ptr);
+            free_node_data(lParse, that1_idx);
         }
         if (lParse.Nodes[that2_idx]).operation > 0 {
-            free((lParse.Nodes[that2_idx]).value.data.ptr);
+            free_node_data(lParse, that2_idx);
         }
     }
 }
@@ -10065,7 +10105,7 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                                 lParse,
                                 cs!(c"AXISELEM(V,n) n value exceeded maximum dimension"),
                             );
-                            free((lParse.Nodes[this_node_idx]).value.data.ptr);
+                            free_node_data(lParse, this_node_idx);
                         } else {
                             ielem = 0;
                             while ielem < elem {
@@ -10633,7 +10673,7 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                                     lParse,
                                     cs!(c"Could not allocate temporary memory in median function"),
                                 );
-                                free((lParse.Nodes[this_node_idx]).value.data.ptr);
+                                free_node_data(lParse, this_node_idx);
                             } else {
                                 irow = 0;
                                 while c_long::from(irow) < row {
@@ -10687,7 +10727,7 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                                     lParse,
                                     cs!(c"Could not allocate temporary memory in median function"),
                                 );
-                                free((lParse.Nodes[this_node_idx]).value.data.ptr);
+                                free_node_data(lParse, this_node_idx);
                             } else {
                                 irow_0 = 0;
                                 while c_long::from(irow_0) < row {
@@ -12745,7 +12785,7 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                 break;
             }
             if (lParse.Nodes[theParams[i as usize]]).operation > 0 {
-                free((lParse.Nodes[theParams[i as usize]]).value.data.ptr);
+                free_node_data(lParse, theParams[i as usize]);
             }
         }
     }
@@ -12873,7 +12913,7 @@ fn Do_Deref(lParse: &mut ParseData, this_node_idx: usize) {
                     }
                 } else {
                     fits_parser_yyerror(lParse, cs!(c"Index out of range"));
-                    free((lParse.Nodes[this_node_idx]).value.data.ptr);
+                    free_node_data(lParse, this_node_idx);
                     (lParse.Nodes[this_node_idx]).value.data.ptr = ptr::null_mut();
                 }
             } else if allConst != 0 && nDims == 1 {
@@ -12885,7 +12925,7 @@ fn Do_Deref(lParse: &mut ParseData, this_node_idx: usize) {
                             [((lParse.Nodes[theVar]).value.naxis - 1) as usize]
                 {
                     fits_parser_yyerror(lParse, cs!(c"Index out of range"));
-                    free((lParse.Nodes[this_node_idx]).value.data.ptr);
+                    free_node_data(lParse, this_node_idx);
                     (lParse.Nodes[this_node_idx]).value.data.ptr = ptr::null_mut();
                 } else if (lParse.Nodes[this_node_idx]).ntype
                     == fits_parser_yytokentype::BITSTR as c_int
@@ -12982,7 +13022,7 @@ fn Do_Deref(lParse: &mut ParseData, this_node_idx: usize) {
                                     lParse,
                                     cs!(c"Null encountered as vector index"),
                                 );
-                                free((lParse.Nodes[this_node_idx]).value.data.ptr);
+                                free_node_data(lParse, this_node_idx);
                                 (lParse.Nodes[this_node_idx]).value.data.ptr = ptr::null_mut();
                                 break;
                             } else {
@@ -13060,7 +13100,7 @@ fn Do_Deref(lParse: &mut ParseData, this_node_idx: usize) {
                         }
                     } else {
                         fits_parser_yyerror(lParse, cs!(c"Index out of range"));
-                        free((lParse.Nodes[this_node_idx]).value.data.ptr);
+                        free_node_data(lParse, this_node_idx);
                         (lParse.Nodes[this_node_idx]).value.data.ptr = ptr::null_mut();
                     }
                     row += 1;
@@ -13072,7 +13112,7 @@ fn Do_Deref(lParse: &mut ParseData, this_node_idx: usize) {
                     /* Index cannot be a constant */
                     if *((lParse.Nodes[theDims[0]]).value.undef).offset(row as isize) != 0 {
                         fits_parser_yyerror(lParse, cs!(c"Null encountered as vector index"));
-                        free((lParse.Nodes[this_node_idx]).value.data.ptr);
+                        free_node_data(lParse, this_node_idx);
                         (lParse.Nodes[this_node_idx]).value.data.ptr = ptr::null_mut();
                         break;
                     } else {
@@ -13084,7 +13124,7 @@ fn Do_Deref(lParse: &mut ParseData, this_node_idx: usize) {
                                     [((lParse.Nodes[theVar]).value.naxis - 1) as usize]
                         {
                             fits_parser_yyerror(lParse, cs!(c"Index out of range"));
-                            free((lParse.Nodes[this_node_idx]).value.data.ptr);
+                            free_node_data(lParse, this_node_idx);
                             (lParse.Nodes[this_node_idx]).value.data.ptr = ptr::null_mut();
                         } else if (lParse.Nodes[this_node_idx]).ntype
                             == fits_parser_yytokentype::BITSTR as c_int
@@ -13173,13 +13213,13 @@ fn Do_Deref(lParse: &mut ParseData, this_node_idx: usize) {
             {
                 free((*((lParse.Nodes[theVar]).value.data.strptr).offset(0)).cast::<c_void>());
             } else {
-                free((lParse.Nodes[theVar]).value.data.ptr);
+                free_node_data(lParse, theVar);
             }
         }
         i = 0;
         while i < nDims {
             if (lParse.Nodes[theDims[i as usize]]).operation > 0 {
-                free((lParse.Nodes[theDims[i as usize]]).value.data.ptr);
+                free_node_data(lParse, theDims[i as usize]);
             }
             i += 1;
         }
@@ -13290,7 +13330,7 @@ fn Do_GTI(lParse: &mut ParseData, this_node_idx: usize) {
             }
         }
         if (lParse.Nodes[theExpr]).operation > 0 {
-            free((lParse.Nodes[theExpr]).value.data.ptr);
+            free_node_data(lParse, theExpr);
         }
     }
 }
@@ -13404,10 +13444,10 @@ fn Do_GTI_Over(lParse: &mut ParseData, this_node_idx: usize) {
             }
         }
         if (lParse.Nodes[theStart]).operation > 0 {
-            free((lParse.Nodes[theStart]).value.data.ptr);
+            free_node_data(lParse, theStart);
         }
         if (lParse.Nodes[theStop]).operation > 0 {
-            free((lParse.Nodes[theStop]).value.data.ptr);
+            free_node_data(lParse, theStop);
         }
     }
 }
@@ -13642,10 +13682,10 @@ fn Do_REG(lParse: &mut ParseData, this_node_idx: usize) {
             }
         }
         if (lParse.Nodes[theX]).operation > 0 {
-            free((lParse.Nodes[theX]).value.data.ptr);
+            free_node_data(lParse, theX);
         }
         if (lParse.Nodes[theY]).operation > 0 {
-            free((lParse.Nodes[theY]).value.data.ptr);
+            free_node_data(lParse, theY);
         }
     }
 }
@@ -14305,4 +14345,52 @@ fn fits_parser_yyerror(lParse: &mut ParseData, s: &[c_char]) {
     msg[79] = 0;
 
     ffpmsg_slice(&msg);
+}
+
+#[cfg(test)]
+mod node_buffer_tests {
+    use super::*;
+
+    /// Exercises the Rust-owned numeric node buffer end to end: Allocate_Ptrs
+    /// builds the backing store, data/undef are written and read back through
+    /// the raw union views, and free_node_data releases it. Runs with no file
+    /// I/O so it executes under Miri, which flags OOB access and allocator
+    /// mismatches (e.g. freeing this Vec-backed buffer with libc::free).
+    #[test]
+    fn numeric_node_buffer_alloc_access_free_roundtrip() {
+        let mut lparse = ParseData::default();
+        lparse.nRows = 4;
+
+        let mut node = Node::default();
+        node.ntype = fits_parser_yytokentype::DOUBLE as c_int;
+        node.value.nelem = 2;
+        node.operation = 1; // non-constant -> heap array
+        lparse.Nodes.push(node);
+        let idx = 0usize;
+
+        Allocate_Ptrs(&mut lparse, idx);
+        assert_eq!(lparse.status, 0);
+        assert!(lparse.node_buffers[idx].is_some());
+
+        let dptr = unsafe { lparse.Nodes[idx].value.data.dblptr };
+        let undef = lparse.Nodes[idx].value.undef;
+        assert!(!dptr.is_null());
+        assert!(!undef.is_null());
+
+        let elem = (lparse.Nodes[idx].value.nelem * lparse.nRows) as usize;
+        unsafe {
+            for i in 0..elem {
+                *dptr.add(i) = i as f64 * 1.5;
+                *undef.add(i) = (i % 2) as c_char;
+            }
+            for i in 0..elem {
+                assert_eq!(*dptr.add(i), i as f64 * 1.5);
+                assert_eq!(*undef.add(i), (i % 2) as c_char);
+            }
+        }
+
+        free_node_data(&mut lparse, idx);
+        assert!(lparse.node_buffers[idx].is_none());
+        assert!(unsafe { lparse.Nodes[idx].value.data.ptr }.is_null());
+    }
 }

--- a/src/eval_y.rs
+++ b/src/eval_y.rs
@@ -69,7 +69,7 @@ use crate::c_types::{
 };
 use crate::cfileio::{ffclos_safe, ffexts_safe, ffopen_safe};
 use crate::eval_defs::{
-    CONST_OP, MAXDIMS, MAXSUBS, Node, NodeBuf, ParseData, data_union, lval, yyscan_t,
+    CONST_OP, MAX_STRLEN, MAXDIMS, MAXSUBS, Node, NodeBuf, ParseData, data_union, lval, yyscan_t,
 };
 use crate::eval_l::{fits_parser_yyGetVariable, fits_parser_yylex, yyguts_t};
 use crate::eval_tab::fits_parser_yytokentype::BITSTR;
@@ -630,11 +630,24 @@ fn New_Const(
             this_node.DoOp = None;
             this_node.nSubNodes = 0;
             this_node.ntype = returnType;
-            memcpy(
-                &mut this_node.value.data as *const _ as *mut c_void,
-                value,
-                (len as c_ulong).try_into().unwrap(),
-            );
+            // Store the constant as a typed value rather than memcpy'ing raw
+            // bytes into the storage (which would depend on its in-memory
+            // layout).
+            if returnType == fits_parser_yytokentype::DOUBLE as c_int {
+                this_node.value.data.dbl = *value.cast::<f64>();
+            } else if returnType == fits_parser_yytokentype::LONG as c_int {
+                this_node.value.data.lng = *value.cast::<c_long>();
+            } else if returnType == fits_parser_yytokentype::BOOLEAN as c_int {
+                this_node.value.data.log = *value.cast::<c_char>();
+            } else {
+                // STRING / BITSTR: copy the bytes into the fixed astr buffer.
+                let n = (len as usize).min(MAX_STRLEN as usize);
+                core::ptr::copy_nonoverlapping(
+                    value.cast::<c_char>(),
+                    this_node.value.data.astr.as_mut_ptr(),
+                    n,
+                );
+            }
             this_node.value.undef = ptr::null_mut();
             this_node.value.nelem = 1;
             this_node.value.naxis = 1;

--- a/src/eval_y.rs
+++ b/src/eval_y.rs
@@ -1189,7 +1189,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
     unsafe {
         let mut current_block: Block;
         let mut yychar: c_int = 0;
-        static mut YYVAL_DEFAULT: FITS_PARSER_YYSTYPE = FITS_PARSER_YYSTYPE { Node: 0 };
+        static mut YYVAL_DEFAULT: FITS_PARSER_YYSTYPE = FITS_PARSER_YYSTYPE::Node(0);
         let mut yylval: FITS_PARSER_YYSTYPE = YYVAL_DEFAULT;
         let mut fits_parser_yynerrs: c_int = 0;
         let mut yystate: yy_state_fast_t = 0;
@@ -1198,13 +1198,13 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
         let mut yyssa: [yy_state_t; 100] = [0; 100];
         let mut yyss: &mut [yy_state_t] = &mut yyssa;
         let mut yyssp: usize = 0;
-        let mut yyvsa: [FITS_PARSER_YYSTYPE; 100] = [FITS_PARSER_YYSTYPE { Node: 0 }; 100];
+        let mut yyvsa: [FITS_PARSER_YYSTYPE; 100] = [FITS_PARSER_YYSTYPE::Node(0); 100];
         let mut yyvs: &mut [FITS_PARSER_YYSTYPE] = &mut yyvsa;
         let mut yyvsp: usize = 0;
         let mut yyn: c_int = 0;
         let mut yyresult: c_int = 0;
         let mut yytoken: yysymbol_kind_t = YYSYMBOL_YYEMPTY;
-        let mut yyval: FITS_PARSER_YYSTYPE = FITS_PARSER_YYSTYPE { Node: 0 };
+        let mut yyval: FITS_PARSER_YYSTYPE = FITS_PARSER_YYSTYPE::Node(0);
         let mut yylen: c_int = 0;
         yychar = fits_parser_yytokentype::FITS_PARSER_YYEMPTY as c_int;
         's_54: loop {
@@ -1496,7 +1496,8 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         }
                         10 => {
                             /* bvector: '{' bexpr  */
-                            yyval.Node = New_Vector(lParse, yyvs[yyvsp].node());
+                            yyval =
+                                FITS_PARSER_YYSTYPE::Node(New_Vector(lParse, yyvs[yyvsp].node()));
                             if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
@@ -1508,11 +1509,17 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             if (lParse.Nodes[yyvs[yyvsp - 2].node() as usize]).nSubNodes
                                 >= 10 as c_int
                             {
-                                yyvs[yyvsp - 2].Node = Close_Vec(lParse, yyvs[yyvsp - 2].node());
+                                yyvs[yyvsp - 2] = FITS_PARSER_YYSTYPE::Node(Close_Vec(
+                                    lParse,
+                                    yyvs[yyvsp - 2].node(),
+                                ));
                                 if yyvs[yyvsp - 2].node() < 0 {
                                     current_block = Block::YyErrLab;
                                 } else {
-                                    yyval.Node = New_Vector(lParse, yyvs[yyvsp - 2].node());
+                                    yyval = FITS_PARSER_YYSTYPE::Node(New_Vector(
+                                        lParse,
+                                        yyvs[yyvsp - 2].node(),
+                                    ));
                                     if yyval.node() < 0 {
                                         current_block = Block::YyErrLab;
                                     } else {
@@ -1520,7 +1527,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     }
                                 }
                             } else {
-                                yyval.Node = yyvs[yyvsp - 2].node();
+                                yyval = FITS_PARSER_YYSTYPE::Node(yyvs[yyvsp - 2].node());
                                 current_block = Block::ReduceJoin10;
                             }
                             match current_block {
@@ -1538,7 +1545,8 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         }
                         12 => {
                             /* vector: '{' expr  */
-                            yyval.Node = New_Vector(lParse, yyvs[yyvsp].node());
+                            yyval =
+                                FITS_PARSER_YYSTYPE::Node(New_Vector(lParse, yyvs[yyvsp].node()));
                             if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
@@ -1556,11 +1564,17 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             if (lParse.Nodes[yyvs[yyvsp - 2].node() as usize]).nSubNodes
                                 >= 10 as c_int
                             {
-                                yyvs[yyvsp - 2].Node = Close_Vec(lParse, yyvs[yyvsp - 2].node());
+                                yyvs[yyvsp - 2] = FITS_PARSER_YYSTYPE::Node(Close_Vec(
+                                    lParse,
+                                    yyvs[yyvsp - 2].node(),
+                                ));
                                 if yyvs[yyvsp - 2].node() < 0 {
                                     current_block = Block::YyErrLab;
                                 } else {
-                                    yyval.Node = New_Vector(lParse, yyvs[yyvsp - 2].node());
+                                    yyval = FITS_PARSER_YYSTYPE::Node(New_Vector(
+                                        lParse,
+                                        yyvs[yyvsp - 2].node(),
+                                    ));
                                     if yyval.node() < 0 {
                                         current_block = Block::YyErrLab;
                                     } else {
@@ -1568,7 +1582,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     }
                                 }
                             } else {
-                                yyval.Node = yyvs[yyvsp - 2].node();
+                                yyval = FITS_PARSER_YYSTYPE::Node(yyvs[yyvsp - 2].node());
                                 current_block = Block::ReduceJoin11;
                             }
                             match current_block {
@@ -1589,11 +1603,17 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             if (lParse.Nodes[yyvs[yyvsp - 2].node() as usize]).nSubNodes
                                 >= MAXSUBS as c_int
                             {
-                                yyvs[yyvsp - 2].Node = Close_Vec(lParse, yyvs[yyvsp - 2].node());
+                                yyvs[yyvsp - 2] = FITS_PARSER_YYSTYPE::Node(Close_Vec(
+                                    lParse,
+                                    yyvs[yyvsp - 2].node(),
+                                ));
                                 if yyvs[yyvsp - 2].node() < 0 {
                                     current_block = Block::YyErrLab;
                                 } else {
-                                    yyval.Node = New_Vector(lParse, yyvs[yyvsp - 2].node());
+                                    yyval = FITS_PARSER_YYSTYPE::Node(New_Vector(
+                                        lParse,
+                                        yyvs[yyvsp - 2].node(),
+                                    ));
                                     if yyval.node() < 0 {
                                         current_block = Block::YyErrLab;
                                     } else {
@@ -1601,7 +1621,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     }
                                 }
                             } else {
-                                yyval.Node = yyvs[yyvsp - 2].node();
+                                yyval = FITS_PARSER_YYSTYPE::Node(yyvs[yyvsp - 2].node());
                                 current_block = Block::ReduceJoin9;
                             }
                             match current_block {
@@ -1624,11 +1644,17 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             if (lParse.Nodes[yyvs[yyvsp - 2].node() as usize]).nSubNodes
                                 >= 10 as c_int
                             {
-                                yyvs[yyvsp - 2].Node = Close_Vec(lParse, yyvs[yyvsp - 2].node());
+                                yyvs[yyvsp - 2] = FITS_PARSER_YYSTYPE::Node(Close_Vec(
+                                    lParse,
+                                    yyvs[yyvsp - 2].node(),
+                                ));
                                 if yyvs[yyvsp - 2].node() < 0 {
                                     current_block = Block::YyErrLab;
                                 } else {
-                                    yyval.Node = New_Vector(lParse, yyvs[yyvsp - 2].node());
+                                    yyval = FITS_PARSER_YYSTYPE::Node(New_Vector(
+                                        lParse,
+                                        yyvs[yyvsp - 2].node(),
+                                    ));
                                     if yyval.node() < 0 {
                                         current_block = Block::YyErrLab;
                                     } else {
@@ -1636,7 +1662,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     }
                                 }
                             } else {
-                                yyval.Node = yyvs[yyvsp - 2].node();
+                                yyval = FITS_PARSER_YYSTYPE::Node(yyvs[yyvsp - 2].node());
                                 current_block = Block::ReduceJoin13;
                             }
                             match current_block {
@@ -1654,7 +1680,10 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         }
                         16 => {
                             /* expr: vector '}'  */
-                            yyval.Node = Close_Vec(lParse, yyvs[yyvsp - 1].node());
+                            yyval = FITS_PARSER_YYSTYPE::Node(Close_Vec(
+                                lParse,
+                                yyvs[yyvsp - 1].node(),
+                            ));
                             if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
@@ -1663,7 +1692,10 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         }
                         17 => {
                             /* bexpr: bvector '}'  */
-                            yyval.Node = Close_Vec(lParse, yyvs[yyvsp - 1].node());
+                            yyval = FITS_PARSER_YYSTYPE::Node(Close_Vec(
+                                lParse,
+                                yyvs[yyvsp - 1].node(),
+                            ));
                             if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
@@ -1672,13 +1704,13 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         }
                         18 => {
                             /* bits: BITSTR  */
-                            yyval.Node = New_Const(
+                            yyval = FITS_PARSER_YYSTYPE::Node(New_Const(
                                 lParse,
                                 fits_parser_yytokentype::BITSTR as c_int,
                                 (yyvs[yyvsp].astr_mut()).as_mut_ptr().cast::<c_void>(),
                                 (astr_len(yyvs[yyvsp].astr())).wrapping_add((1).try_into().unwrap())
                                     as c_long,
-                            );
+                            ));
                             if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
@@ -1689,7 +1721,10 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         }
                         19 => {
                             /* bits: BITCOL  */
-                            yyval.Node = New_Column(lParse, yyvs[yyvsp].lng() as c_int);
+                            yyval = FITS_PARSER_YYSTYPE::Node(New_Column(
+                                lParse,
+                                yyvs[yyvsp].lng() as c_int,
+                            ));
                             if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
@@ -1709,11 +1744,11 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 );
                                 current_block = Block::YyErrLab;
                             } else {
-                                yyval.Node = New_Offset(
+                                yyval = FITS_PARSER_YYSTYPE::Node(New_Offset(
                                     lParse,
                                     yyvs[yyvsp - 3].lng() as c_int,
                                     yyvs[yyvsp - 1].node(),
-                                );
+                                ));
                                 if yyval.node() < 0 {
                                     current_block = Block::YyErrLab;
                                 } else {
@@ -1723,13 +1758,13 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         }
                         21 => {
                             /* bits: bits '&' bits  */
-                            yyval.Node = New_BinOp(
+                            yyval = FITS_PARSER_YYSTYPE::Node(New_BinOp(
                                 lParse,
                                 fits_parser_yytokentype::BITSTR as c_int,
                                 yyvs[yyvsp - 2].node(),
                                 '&' as i32,
                                 yyvs[yyvsp].node(),
-                            );
+                            ));
                             if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
@@ -1749,13 +1784,13 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         }
                         22 => {
                             /* bits: bits '|' bits  */
-                            yyval.Node = New_BinOp(
+                            yyval = FITS_PARSER_YYSTYPE::Node(New_BinOp(
                                 lParse,
                                 fits_parser_yytokentype::BITSTR as c_int,
                                 yyvs[yyvsp - 2].node(),
                                 '|' as i32,
                                 yyvs[yyvsp].node(),
-                            );
+                            ));
                             if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
@@ -1785,13 +1820,13 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 );
                                 current_block = Block::YyErrLab;
                             } else {
-                                yyval.Node = New_BinOp(
+                                yyval = FITS_PARSER_YYSTYPE::Node(New_BinOp(
                                     lParse,
                                     fits_parser_yytokentype::BITSTR as c_int,
                                     yyvs[yyvsp - 2].node(),
                                     '+' as i32,
                                     yyvs[yyvsp].node(),
-                                );
+                                ));
                                 if yyval.node() < 0 {
                                     current_block = Block::YyErrLab;
                                 } else {
@@ -1808,7 +1843,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         }
                         24 => {
                             /* bits: bits '[' expr ']'  */
-                            yyval.Node = New_Deref(
+                            yyval = FITS_PARSER_YYSTYPE::Node(New_Deref(
                                 lParse,
                                 yyvs[yyvsp - 3].node(),
                                 1,
@@ -1817,7 +1852,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 0,
                                 0,
                                 0,
-                            );
+                            ));
                             if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
@@ -1826,7 +1861,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         }
                         25 => {
                             /* bits: bits '[' expr ',' expr ']'  */
-                            yyval.Node = New_Deref(
+                            yyval = FITS_PARSER_YYSTYPE::Node(New_Deref(
                                 lParse,
                                 yyvs[yyvsp - 5].node(),
                                 2,
@@ -1835,7 +1870,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 0,
                                 0,
                                 0,
-                            );
+                            ));
                             if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
@@ -1844,7 +1879,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         }
                         26 => {
                             /* bits: bits '[' expr ',' expr ',' expr ']'  */
-                            yyval.Node = New_Deref(
+                            yyval = FITS_PARSER_YYSTYPE::Node(New_Deref(
                                 lParse,
                                 yyvs[yyvsp - 7].node(),
                                 3 as c_int,
@@ -1853,7 +1888,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 yyvs[yyvsp - 1].node(),
                                 0,
                                 0,
-                            );
+                            ));
                             if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
@@ -1862,7 +1897,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         }
                         27 => {
                             /* bits: bits '[' expr ',' expr ',' expr ',' expr ']'  */
-                            yyval.Node = New_Deref(
+                            yyval = FITS_PARSER_YYSTYPE::Node(New_Deref(
                                 lParse,
                                 yyvs[yyvsp - 9].node(),
                                 4 as c_int,
@@ -1871,7 +1906,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 yyvs[yyvsp - 3].node(),
                                 yyvs[yyvsp - 1].node(),
                                 0,
-                            );
+                            ));
                             if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
@@ -1880,7 +1915,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         }
                         28 => {
                             /* bits: bits '[' expr ',' expr ',' expr ',' expr ',' expr ']'  */
-                            yyval.Node = New_Deref(
+                            yyval = FITS_PARSER_YYSTYPE::Node(New_Deref(
                                 lParse,
                                 yyvs[yyvsp - 11].node(),
                                 5 as c_int,
@@ -1889,7 +1924,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 yyvs[yyvsp - 5].node(),
                                 yyvs[yyvsp - 3].node(),
                                 yyvs[yyvsp - 1].node(),
-                            );
+                            ));
                             if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
@@ -1898,12 +1933,12 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         }
                         29 => {
                             /* bits: NOT bits  */
-                            yyval.Node = New_Unary(
+                            yyval = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                 lParse,
                                 fits_parser_yytokentype::BITSTR as c_int,
                                 fits_parser_yytokentype::NOT as c_int,
                                 yyvs[yyvsp].node(),
-                            );
+                            ));
                             if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
@@ -1912,17 +1947,17 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         }
                         30 => {
                             /* bits: '(' bits ')'  */
-                            yyval.Node = yyvs[yyvsp - 1].node();
+                            yyval = FITS_PARSER_YYSTYPE::Node(yyvs[yyvsp - 1].node());
                             current_block = Block::ReduceDone;
                         }
                         31 => {
                             /* expr: LONG  */
-                            yyval.Node = New_Const(
+                            yyval = FITS_PARSER_YYSTYPE::Node(New_Const(
                                 lParse,
                                 fits_parser_yytokentype::LONG as c_int,
                                 (&mut yyvs[yyvsp].lng() as *mut c_long).cast::<c_void>(),
                                 ::core::mem::size_of::<c_long>() as c_ulong as c_long,
-                            );
+                            ));
                             if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
@@ -1931,12 +1966,12 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         }
                         32 => {
                             /* expr: DOUBLE  */
-                            yyval.Node = New_Const(
+                            yyval = FITS_PARSER_YYSTYPE::Node(New_Const(
                                 lParse,
                                 fits_parser_yytokentype::DOUBLE as c_int,
                                 (&mut yyvs[yyvsp].dbl() as *mut c_double).cast::<c_void>(),
                                 ::core::mem::size_of::<c_double>() as c_ulong as c_long,
-                            );
+                            ));
                             if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
@@ -1945,7 +1980,10 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         }
                         33 => {
                             /* expr: COLUMN  */
-                            yyval.Node = New_Column(lParse, yyvs[yyvsp].lng() as c_int);
+                            yyval = FITS_PARSER_YYSTYPE::Node(New_Column(
+                                lParse,
+                                yyvs[yyvsp].lng() as c_int,
+                            ));
                             if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
@@ -1965,11 +2003,11 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 );
                                 current_block = Block::YyErrLab;
                             } else {
-                                yyval.Node = New_Offset(
+                                yyval = FITS_PARSER_YYSTYPE::Node(New_Offset(
                                     lParse,
                                     yyvs[yyvsp - 3].lng() as c_int,
                                     yyvs[yyvsp - 1].node(),
-                                );
+                                ));
                                 if yyval.node() < 0 {
                                     current_block = Block::YyErrLab;
                                 } else {
@@ -1979,7 +2017,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         }
                         35 => {
                             /* expr: ROWREF  */
-                            yyval.Node = New_Func(
+                            yyval = FITS_PARSER_YYSTYPE::Node(New_Func(
                                 lParse,
                                 fits_parser_yytokentype::LONG as c_int,
                                 ROW_FCT,
@@ -1991,12 +2029,12 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 0,
                                 0,
                                 0,
-                            );
+                            ));
                             current_block = Block::ReduceDone;
                         }
                         36 => {
                             /* expr: NULLREF  */
-                            yyval.Node = New_Func(
+                            yyval = FITS_PARSER_YYSTYPE::Node(New_Func(
                                 lParse,
                                 fits_parser_yytokentype::LONG as c_int,
                                 NULL_FCT,
@@ -2008,7 +2046,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 0,
                                 0,
                                 0,
-                            );
+                            ));
                             current_block = Block::ReduceDone;
                         }
                         37 => {
@@ -2016,29 +2054,29 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             if (lParse.Nodes[yyvs[yyvsp - 2].node() as usize]).ntype
                                 > (lParse.Nodes[yyvs[yyvsp].node() as usize]).ntype
                             {
-                                yyvs[yyvsp].Node = New_Unary(
+                                yyvs[yyvsp] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                     lParse,
                                     ((lParse.Nodes)[yyvs[yyvsp - 2].node() as usize]).ntype,
                                     0,
                                     yyvs[yyvsp].node(),
-                                );
+                                ));
                             } else if ((lParse.Nodes)[yyvs[yyvsp - 2].node() as usize]).ntype
                                 < (lParse.Nodes[yyvs[yyvsp].node() as usize]).ntype
                             {
-                                yyvs[yyvsp - 2].Node = New_Unary(
+                                yyvs[yyvsp - 2] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                     lParse,
                                     (lParse.Nodes[yyvs[yyvsp].node() as usize]).ntype,
                                     0,
                                     yyvs[yyvsp - 2].node(),
-                                );
+                                ));
                             }
-                            yyval.Node = New_BinOp(
+                            yyval = FITS_PARSER_YYSTYPE::Node(New_BinOp(
                                 lParse,
                                 (lParse.Nodes[yyvs[yyvsp - 2].node() as usize]).ntype,
                                 yyvs[yyvsp - 2].node(),
                                 '%' as i32,
                                 yyvs[yyvsp].node(),
-                            );
+                            ));
                             if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
@@ -2050,29 +2088,29 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             if (lParse.Nodes[yyvs[yyvsp - 2].node() as usize]).ntype
                                 > (lParse.Nodes[yyvs[yyvsp].node() as usize]).ntype
                             {
-                                yyvs[yyvsp].Node = New_Unary(
+                                yyvs[yyvsp] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                     lParse,
                                     ((lParse.Nodes)[yyvs[yyvsp - 2].node() as usize]).ntype,
                                     0,
                                     yyvs[yyvsp].node(),
-                                );
+                                ));
                             } else if ((lParse.Nodes)[yyvs[yyvsp - 2].node() as usize]).ntype
                                 < (lParse.Nodes[yyvs[yyvsp].node() as usize]).ntype
                             {
-                                yyvs[yyvsp - 2].Node = New_Unary(
+                                yyvs[yyvsp - 2] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                     lParse,
                                     (lParse.Nodes[yyvs[yyvsp].node() as usize]).ntype,
                                     0,
                                     yyvs[yyvsp - 2].node(),
-                                );
+                                ));
                             }
-                            yyval.Node = New_BinOp(
+                            yyval = FITS_PARSER_YYSTYPE::Node(New_BinOp(
                                 lParse,
                                 (lParse.Nodes[yyvs[yyvsp - 2].node() as usize]).ntype,
                                 yyvs[yyvsp - 2].node(),
                                 '+' as i32,
                                 yyvs[yyvsp].node(),
-                            );
+                            ));
                             if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
@@ -2084,29 +2122,29 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             if (lParse.Nodes[yyvs[yyvsp - 2].node() as usize]).ntype
                                 > (lParse.Nodes[yyvs[yyvsp].node() as usize]).ntype
                             {
-                                yyvs[yyvsp].Node = New_Unary(
+                                yyvs[yyvsp] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                     lParse,
                                     ((lParse.Nodes)[yyvs[yyvsp - 2].node() as usize]).ntype,
                                     0,
                                     yyvs[yyvsp].node(),
-                                );
+                                ));
                             } else if ((lParse.Nodes)[yyvs[yyvsp - 2].node() as usize]).ntype
                                 < (lParse.Nodes[yyvs[yyvsp].node() as usize]).ntype
                             {
-                                yyvs[yyvsp - 2].Node = New_Unary(
+                                yyvs[yyvsp - 2] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                     lParse,
                                     (lParse.Nodes[yyvs[yyvsp].node() as usize]).ntype,
                                     0,
                                     yyvs[yyvsp - 2].node(),
-                                );
+                                ));
                             }
-                            yyval.Node = New_BinOp(
+                            yyval = FITS_PARSER_YYSTYPE::Node(New_BinOp(
                                 lParse,
                                 (lParse.Nodes[yyvs[yyvsp - 2].node() as usize]).ntype,
                                 yyvs[yyvsp - 2].node(),
                                 '-' as i32,
                                 yyvs[yyvsp].node(),
-                            );
+                            ));
                             if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
@@ -2118,29 +2156,29 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             if (lParse.Nodes[yyvs[yyvsp - 2].node() as usize]).ntype
                                 > (lParse.Nodes[yyvs[yyvsp].node() as usize]).ntype
                             {
-                                yyvs[yyvsp].Node = New_Unary(
+                                yyvs[yyvsp] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                     lParse,
                                     ((lParse.Nodes)[yyvs[yyvsp - 2].node() as usize]).ntype,
                                     0,
                                     yyvs[yyvsp].node(),
-                                );
+                                ));
                             } else if ((lParse.Nodes)[yyvs[yyvsp - 2].node() as usize]).ntype
                                 < (lParse.Nodes[yyvs[yyvsp].node() as usize]).ntype
                             {
-                                yyvs[yyvsp - 2].Node = New_Unary(
+                                yyvs[yyvsp - 2] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                     lParse,
                                     (lParse.Nodes[yyvs[yyvsp].node() as usize]).ntype,
                                     0,
                                     yyvs[yyvsp - 2].node(),
-                                );
+                                ));
                             }
-                            yyval.Node = New_BinOp(
+                            yyval = FITS_PARSER_YYSTYPE::Node(New_BinOp(
                                 lParse,
                                 (lParse.Nodes[yyvs[yyvsp - 2].node() as usize]).ntype,
                                 yyvs[yyvsp - 2].node(),
                                 '*' as i32,
                                 yyvs[yyvsp].node(),
-                            );
+                            ));
                             if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
@@ -2152,29 +2190,29 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             if (lParse.Nodes[yyvs[yyvsp - 2].node() as usize]).ntype
                                 > (lParse.Nodes[yyvs[yyvsp].node() as usize]).ntype
                             {
-                                yyvs[yyvsp].Node = New_Unary(
+                                yyvs[yyvsp] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                     lParse,
                                     ((lParse.Nodes)[yyvs[yyvsp - 2].node() as usize]).ntype,
                                     0,
                                     yyvs[yyvsp].node(),
-                                );
+                                ));
                             } else if ((lParse.Nodes)[yyvs[yyvsp - 2].node() as usize]).ntype
                                 < (lParse.Nodes[yyvs[yyvsp].node() as usize]).ntype
                             {
-                                yyvs[yyvsp - 2].Node = New_Unary(
+                                yyvs[yyvsp - 2] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                     lParse,
                                     (lParse.Nodes[yyvs[yyvsp].node() as usize]).ntype,
                                     0,
                                     yyvs[yyvsp - 2].node(),
-                                );
+                                ));
                             }
-                            yyval.Node = New_BinOp(
+                            yyval = FITS_PARSER_YYSTYPE::Node(New_BinOp(
                                 lParse,
                                 (lParse.Nodes[yyvs[yyvsp - 2].node() as usize]).ntype,
                                 yyvs[yyvsp - 2].node(),
                                 '/' as i32,
                                 yyvs[yyvsp].node(),
-                            );
+                            ));
                             if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
@@ -2191,13 +2229,13 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 fits_parser_yyerror(lParse, cs!(c"Bitwise operations with incompatible types; only (bit OP bit) and (int OP int) are allowed"));
                                 current_block = Block::YyErrLab;
                             } else {
-                                yyval.Node = New_BinOp(
+                                yyval = FITS_PARSER_YYSTYPE::Node(New_BinOp(
                                     lParse,
                                     ((lParse.Nodes)[yyvs[yyvsp - 2].node() as usize]).ntype,
                                     yyvs[yyvsp - 2].node(),
                                     '&' as i32,
                                     yyvs[yyvsp].node(),
-                                );
+                                ));
                                 current_block = Block::ReduceDone;
                             }
                         }
@@ -2211,13 +2249,13 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 fits_parser_yyerror(lParse, cs!(c"Bitwise operations with incompatible types; only (bit OP bit) and (int OP int) are allowed"));
                                 current_block = Block::YyErrLab;
                             } else {
-                                yyval.Node = New_BinOp(
+                                yyval = FITS_PARSER_YYSTYPE::Node(New_BinOp(
                                     lParse,
                                     ((lParse.Nodes)[yyvs[yyvsp - 2].node() as usize]).ntype,
                                     yyvs[yyvsp - 2].node(),
                                     '|' as i32,
                                     yyvs[yyvsp].node(),
-                                );
+                                ));
                                 current_block = Block::ReduceDone;
                             }
                         }
@@ -2231,13 +2269,13 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 fits_parser_yyerror(lParse, cs!(c"Bitwise operations with incompatible types; only (bit OP bit) and (int OP int) are allowed"));
                                 current_block = Block::YyErrLab;
                             } else {
-                                yyval.Node = New_BinOp(
+                                yyval = FITS_PARSER_YYSTYPE::Node(New_BinOp(
                                     lParse,
                                     ((lParse.Nodes)[yyvs[yyvsp - 2].node() as usize]).ntype,
                                     yyvs[yyvsp - 2].node(),
                                     '^' as i32,
                                     yyvs[yyvsp].node(),
-                                );
+                                ));
                                 current_block = Block::ReduceDone;
                             }
                         }
@@ -2246,29 +2284,29 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             if (lParse.Nodes[yyvs[yyvsp - 2].node() as usize]).ntype
                                 > (lParse.Nodes[yyvs[yyvsp].node() as usize]).ntype
                             {
-                                yyvs[yyvsp].Node = New_Unary(
+                                yyvs[yyvsp] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                     lParse,
                                     ((lParse.Nodes)[yyvs[yyvsp - 2].node() as usize]).ntype,
                                     0,
                                     yyvs[yyvsp].node(),
-                                );
+                                ));
                             } else if ((lParse.Nodes)[yyvs[yyvsp - 2].node() as usize]).ntype
                                 < (lParse.Nodes[yyvs[yyvsp].node() as usize]).ntype
                             {
-                                yyvs[yyvsp - 2].Node = New_Unary(
+                                yyvs[yyvsp - 2] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                     lParse,
                                     (lParse.Nodes[yyvs[yyvsp].node() as usize]).ntype,
                                     0,
                                     yyvs[yyvsp - 2].node(),
-                                );
+                                ));
                             }
-                            yyval.Node = New_BinOp(
+                            yyval = FITS_PARSER_YYSTYPE::Node(New_BinOp(
                                 lParse,
                                 (lParse.Nodes[yyvs[yyvsp - 2].node() as usize]).ntype,
                                 yyvs[yyvsp - 2].node(),
                                 fits_parser_yytokentype::POWER as c_int,
                                 yyvs[yyvsp].node(),
-                            );
+                            ));
                             if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
@@ -2277,17 +2315,17 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         }
                         46 => {
                             /* expr: '+' expr  */
-                            yyval.Node = yyvs[yyvsp].node();
+                            yyval = FITS_PARSER_YYSTYPE::Node(yyvs[yyvsp].node());
                             current_block = Block::ReduceDone;
                         }
                         47 => {
                             /* expr: '-' expr  */
-                            yyval.Node = New_Unary(
+                            yyval = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                 lParse,
                                 (lParse.Nodes[yyvs[yyvsp].node() as usize]).ntype,
                                 fits_parser_yytokentype::UMINUS as c_int,
                                 yyvs[yyvsp].node(),
-                            );
+                            ));
                             if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
@@ -2296,24 +2334,24 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         }
                         48 => {
                             /* expr: '(' expr ')'  */
-                            yyval.Node = yyvs[yyvsp - 1].node();
+                            yyval = FITS_PARSER_YYSTYPE::Node(yyvs[yyvsp - 1].node());
                             current_block = Block::ReduceDone;
                         }
                         49 => {
                             /* expr: expr '*' bexpr  */
-                            yyvs[yyvsp].Node = New_Unary(
+                            yyvs[yyvsp] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                 lParse,
                                 (lParse.Nodes[yyvs[yyvsp - 2].node() as usize]).ntype,
                                 0,
                                 yyvs[yyvsp].node(),
-                            );
-                            yyval.Node = New_BinOp(
+                            ));
+                            yyval = FITS_PARSER_YYSTYPE::Node(New_BinOp(
                                 lParse,
                                 (lParse.Nodes[yyvs[yyvsp - 2].node() as usize]).ntype,
                                 yyvs[yyvsp - 2].node(),
                                 '*' as i32,
                                 yyvs[yyvsp].node(),
-                            );
+                            ));
                             if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
@@ -2322,19 +2360,19 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         }
                         50 => {
                             /* expr: bexpr '*' expr  */
-                            yyvs[yyvsp - 2].Node = New_Unary(
+                            yyvs[yyvsp - 2] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                 lParse,
                                 (lParse.Nodes[yyvs[yyvsp].node() as usize]).ntype,
                                 0,
                                 yyvs[yyvsp - 2].node(),
-                            );
-                            yyval.Node = New_BinOp(
+                            ));
+                            yyval = FITS_PARSER_YYSTYPE::Node(New_BinOp(
                                 lParse,
                                 (lParse.Nodes[yyvs[yyvsp].node() as usize]).ntype,
                                 yyvs[yyvsp - 2].node(),
                                 '*' as i32,
                                 yyvs[yyvsp].node(),
-                            );
+                            ));
                             if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
@@ -2346,21 +2384,21 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             if (lParse.Nodes[yyvs[yyvsp - 2].node() as usize]).ntype
                                 > (lParse.Nodes[yyvs[yyvsp].node() as usize]).ntype
                             {
-                                yyvs[yyvsp].Node = New_Unary(
+                                yyvs[yyvsp] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                     lParse,
                                     ((lParse.Nodes)[yyvs[yyvsp - 2].node() as usize]).ntype,
                                     0,
                                     yyvs[yyvsp].node(),
-                                );
+                                ));
                             } else if ((lParse.Nodes)[yyvs[yyvsp - 2].node() as usize]).ntype
                                 < (lParse.Nodes[yyvs[yyvsp].node() as usize]).ntype
                             {
-                                yyvs[yyvsp - 2].Node = New_Unary(
+                                yyvs[yyvsp - 2] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                     lParse,
                                     (lParse.Nodes[yyvs[yyvsp].node() as usize]).ntype,
                                     0,
                                     yyvs[yyvsp - 2].node(),
-                                );
+                                ));
                             }
                             if Test_Dims(lParse, yyvs[yyvsp - 2].node(), yyvs[yyvsp].node()) == 0 {
                                 fits_parser_yyerror(
@@ -2369,7 +2407,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 );
                                 current_block = Block::YyErrLab;
                             } else {
-                                yyval.Node = New_Func(
+                                yyval = FITS_PARSER_YYSTYPE::Node(New_Func(
                                     lParse,
                                     0,
                                     IFTHENELSE_FCT,
@@ -2381,7 +2419,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     0,
                                     0,
                                     0,
-                                );
+                                ));
                                 if yyval.node() < 0 {
                                     current_block = Block::YyErrLab;
                                 } else {
@@ -2421,21 +2459,21 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             if (lParse.Nodes[yyvs[yyvsp - 2].node() as usize]).ntype
                                 > (lParse.Nodes[yyvs[yyvsp].node() as usize]).ntype
                             {
-                                yyvs[yyvsp].Node = New_Unary(
+                                yyvs[yyvsp] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                     lParse,
                                     ((lParse.Nodes)[yyvs[yyvsp - 2].node() as usize]).ntype,
                                     0,
                                     yyvs[yyvsp].node(),
-                                );
+                                ));
                             } else if ((lParse.Nodes)[yyvs[yyvsp - 2].node() as usize]).ntype
                                 < (lParse.Nodes[yyvs[yyvsp].node() as usize]).ntype
                             {
-                                yyvs[yyvsp - 2].Node = New_Unary(
+                                yyvs[yyvsp - 2] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                     lParse,
                                     (lParse.Nodes[yyvs[yyvsp].node() as usize]).ntype,
                                     0,
                                     yyvs[yyvsp - 2].node(),
-                                );
+                                ));
                             }
                             if Test_Dims(lParse, yyvs[yyvsp - 2].node(), yyvs[yyvsp].node()) == 0 {
                                 fits_parser_yyerror(
@@ -2444,7 +2482,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 );
                                 current_block = Block::YyErrLab;
                             } else {
-                                yyval.Node = New_Func(
+                                yyval = FITS_PARSER_YYSTYPE::Node(New_Func(
                                     lParse,
                                     0,
                                     IFTHENELSE_FCT,
@@ -2456,7 +2494,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     0,
                                     0,
                                     0,
-                                );
+                                ));
                                 if yyval.node() < 0 {
                                     current_block = Block::YyErrLab;
                                 } else {
@@ -2496,21 +2534,21 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             if (lParse.Nodes[yyvs[yyvsp - 2].node() as usize]).ntype
                                 > (lParse.Nodes[yyvs[yyvsp].node() as usize]).ntype
                             {
-                                yyvs[yyvsp].Node = New_Unary(
+                                yyvs[yyvsp] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                     lParse,
                                     ((lParse.Nodes)[yyvs[yyvsp - 2].node() as usize]).ntype,
                                     0,
                                     yyvs[yyvsp].node(),
-                                );
+                                ));
                             } else if ((lParse.Nodes)[yyvs[yyvsp - 2].node() as usize]).ntype
                                 < (lParse.Nodes[yyvs[yyvsp].node() as usize]).ntype
                             {
-                                yyvs[yyvsp - 2].Node = New_Unary(
+                                yyvs[yyvsp - 2] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                     lParse,
                                     (lParse.Nodes[yyvs[yyvsp].node() as usize]).ntype,
                                     0,
                                     yyvs[yyvsp - 2].node(),
-                                );
+                                ));
                             }
                             if Test_Dims(lParse, yyvs[yyvsp - 2].node(), yyvs[yyvsp].node()) == 0 {
                                 fits_parser_yyerror(
@@ -2519,7 +2557,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 );
                                 current_block = Block::YyErrLab;
                             } else {
-                                yyval.Node = New_Func(
+                                yyval = FITS_PARSER_YYSTYPE::Node(New_Func(
                                     lParse,
                                     0,
                                     IFTHENELSE_FCT,
@@ -2531,7 +2569,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     0,
                                     0,
                                     0,
-                                );
+                                ));
                                 if yyval.node() < 0 {
                                     current_block = Block::YyErrLab;
                                 } else {
@@ -2569,7 +2607,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         54 => {
                             /* expr: FUNCTION ')'  */
                             if astr_eq(yyvs[yyvsp - 1].astr(), c"RANDOM(") {
-                                yyval.Node = New_Func(
+                                yyval = FITS_PARSER_YYSTYPE::Node(New_Func(
                                     lParse,
                                     fits_parser_yytokentype::DOUBLE as c_int,
                                     RND_FCT,
@@ -2581,10 +2619,10 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     0,
                                     0,
                                     0,
-                                );
+                                ));
                                 current_block = Block::ReduceJoin7;
                             } else if astr_eq(yyvs[yyvsp - 1].astr(), c"RANDOMN(") {
-                                yyval.Node = New_Func(
+                                yyval = FITS_PARSER_YYSTYPE::Node(New_Func(
                                     lParse,
                                     fits_parser_yytokentype::DOUBLE as c_int,
                                     GASRND_FCT,
@@ -2596,7 +2634,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     0,
                                     0,
                                     0,
-                                );
+                                ));
                                 current_block = Block::ReduceJoin7;
                             } else {
                                 fits_parser_yyerror(lParse, cs!(c"Function() not supported"));
@@ -2616,7 +2654,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         55 => {
                             /* expr: FUNCTION bexpr ')'  */
                             if astr_eq(yyvs[yyvsp - 2].astr(), c"SUM(") {
-                                yyval.Node = New_Func(
+                                yyval = FITS_PARSER_YYSTYPE::Node(New_Func(
                                     lParse,
                                     fits_parser_yytokentype::LONG as c_int,
                                     SUM_FCT,
@@ -2628,10 +2666,10 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     0,
                                     0,
                                     0,
-                                );
+                                ));
                                 current_block = Block::ReduceJoin5;
                             } else if astr_eq(yyvs[yyvsp - 2].astr(), c"NELEM(") {
-                                yyval.Node = New_Const(
+                                yyval = FITS_PARSER_YYSTYPE::Node(New_Const(
                                     lParse,
                                     fits_parser_yytokentype::LONG as c_int,
                                     (&((lParse.Nodes)[yyvs[yyvsp - 1].node() as usize])
@@ -2640,7 +2678,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         as *const c_long)
                                         .cast::<c_void>(),
                                     ::core::mem::size_of::<c_long>() as c_ulong as c_long,
-                                );
+                                ));
                                 current_block = Block::ReduceJoin5;
                             } else if astr_eq(yyvs[yyvsp - 2].astr(), c"ACCUM(") {
                                 let mut zero: c_long = 0;
@@ -2651,13 +2689,13 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     ::core::mem::size_of::<c_long>() as c_ulong as c_long,
                                 );
 
-                                yyval.Node = New_BinOp(
+                                yyval = FITS_PARSER_YYSTYPE::Node(New_BinOp(
                                     lParse,
                                     fits_parser_yytokentype::LONG as c_int,
                                     yyvs[yyvsp - 1].node(),
                                     fits_parser_yytokentype::ACCUM as c_int,
                                     new_node,
-                                );
+                                ));
                                 current_block = Block::ReduceJoin5;
                             } else {
                                 fits_parser_yyerror(lParse, cs!(c"Function(bool) not supported"));
@@ -2694,25 +2732,25 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     == CONST_OP
                                 {
                                     let mut one: c_long = 1;
-                                    yyval.Node = New_Const(
+                                    yyval = FITS_PARSER_YYSTYPE::Node(New_Const(
                                         lParse,
                                         fits_parser_yytokentype::LONG as c_int,
                                         (&mut one as *mut c_long).cast::<c_void>(),
                                         ::core::mem::size_of::<c_long>() as c_ulong as c_long,
-                                    );
+                                    ));
                                     current_block = Block::ReduceJoin4;
                                 } else {
                                     if ((lParse.Nodes)[yyvs[yyvsp - 1].node() as usize]).ntype
                                         != fits_parser_yytokentype::LONG as c_int
                                     {
-                                        yyvs[yyvsp - 1].Node = New_Unary(
+                                        yyvs[yyvsp - 1] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                             lParse,
                                             fits_parser_yytokentype::LONG as c_int,
                                             0,
                                             yyvs[yyvsp - 1].node(),
-                                        );
+                                        ));
                                     }
-                                    yyval.Node = New_Func(
+                                    yyval = FITS_PARSER_YYSTYPE::Node(New_Func(
                                         lParse,
                                         0,
                                         AXISELEM_FCT,
@@ -2724,7 +2762,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         0,
                                         0,
                                         0,
-                                    );
+                                    ));
                                     if yyval.node() < 0 {
                                         current_block = Block::YyErrLab;
                                     } else {
@@ -2751,12 +2789,12 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     == CONST_OP
                                 {
                                     let mut one_0: c_long = 1;
-                                    yyval.Node = New_Const(
+                                    yyval = FITS_PARSER_YYSTYPE::Node(New_Const(
                                         lParse,
                                         fits_parser_yytokentype::LONG as c_int,
                                         (&mut one_0 as *mut c_long).cast::<c_void>(),
                                         ::core::mem::size_of::<c_long>() as c_ulong as c_long,
-                                    );
+                                    ));
                                     current_block = Block::ReduceJoin4;
                                 } else {
                                     let mut iaxis: c_long = 0;
@@ -2764,12 +2802,12 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     if ((lParse.Nodes)[yyvs[yyvsp - 1].node() as usize]).ntype
                                         != fits_parser_yytokentype::LONG as c_int
                                     {
-                                        yyvs[yyvsp - 1].Node = New_Unary(
+                                        yyvs[yyvsp - 1] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                             lParse,
                                             fits_parser_yytokentype::LONG as c_int,
                                             0,
                                             yyvs[yyvsp - 1].node(),
-                                        );
+                                        ));
                                     }
                                     iaxis = ((lParse.Nodes)[yyvs[yyvsp - 1].node() as usize])
                                         .value
@@ -2788,12 +2826,12 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     } else {
                                         iaxis = 1;
                                     }
-                                    yyval.Node = New_Const(
+                                    yyval = FITS_PARSER_YYSTYPE::Node(New_Const(
                                         lParse,
                                         fits_parser_yytokentype::LONG as c_int,
                                         (&mut iaxis as *mut c_long).cast::<c_void>(),
                                         ::core::mem::size_of::<c_long>() as c_ulong as c_long,
-                                    );
+                                    ));
                                     if yyval.node() < 0 {
                                         current_block = Block::YyErrLab;
                                     } else {
@@ -2801,11 +2839,11 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     }
                                 }
                             } else if astr_eq(yyvs[yyvsp - 4].astr(), c"ARRAY(") {
-                                yyval.Node = New_Array(
+                                yyval = FITS_PARSER_YYSTYPE::Node(New_Array(
                                     lParse,
                                     yyvs[yyvsp - 3].node(),
                                     yyvs[yyvsp - 1].node(),
-                                );
+                                ));
                                 if yyval.node() < 0 {
                                     current_block = Block::YyErrLab;
                                 } else {
@@ -2832,7 +2870,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         57 => {
                             /* expr: FUNCTION sexpr ')'  */
                             if astr_eq(yyvs[yyvsp - 2].astr(), c"NELEM(") {
-                                yyval.Node = New_Const(
+                                yyval = FITS_PARSER_YYSTYPE::Node(New_Const(
                                     lParse,
                                     fits_parser_yytokentype::LONG as c_int,
                                     (&((lParse.Nodes)[yyvs[yyvsp - 1].node() as usize])
@@ -2841,10 +2879,10 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         as *const c_long)
                                         .cast::<c_void>(),
                                     ::core::mem::size_of::<c_long>() as c_ulong as c_long,
-                                );
+                                ));
                                 current_block = Block::ReduceJoin8;
                             } else if astr_eq(yyvs[yyvsp - 2].astr(), c"NVALID(") {
-                                yyval.Node = New_Func(
+                                yyval = FITS_PARSER_YYSTYPE::Node(New_Func(
                                     lParse,
                                     fits_parser_yytokentype::LONG as c_int,
                                     NONNULL_FCT,
@@ -2856,7 +2894,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     0,
                                     0,
                                     0,
-                                );
+                                ));
                                 current_block = Block::ReduceJoin8;
                             } else {
                                 fits_parser_yyerror(lParse, cs!(c"Function(str) not supported"));
@@ -2876,7 +2914,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         58 => {
                             /* expr: FUNCTION bits ')'  */
                             if astr_eq(yyvs[yyvsp - 2].astr(), c"NELEM(") {
-                                yyval.Node = New_Const(
+                                yyval = FITS_PARSER_YYSTYPE::Node(New_Const(
                                     lParse,
                                     fits_parser_yytokentype::LONG as c_int,
                                     (&((lParse.Nodes)[yyvs[yyvsp - 1].node() as usize])
@@ -2885,10 +2923,10 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         as *const c_long)
                                         .cast::<c_void>(),
                                     ::core::mem::size_of::<c_long>() as c_ulong as c_long,
-                                );
+                                ));
                                 current_block = Block::ReduceJoin3;
                             } else if astr_eq(yyvs[yyvsp - 2].astr(), c"NVALID(") {
-                                yyval.Node = New_Const(
+                                yyval = FITS_PARSER_YYSTYPE::Node(New_Const(
                                     lParse,
                                     fits_parser_yytokentype::LONG as c_int,
                                     (&((lParse.Nodes)[yyvs[yyvsp - 1].node() as usize])
@@ -2897,10 +2935,10 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         as *const c_long)
                                         .cast::<c_void>(),
                                     ::core::mem::size_of::<c_long>() as c_ulong as c_long,
-                                );
+                                ));
                                 current_block = Block::ReduceJoin3;
                             } else if astr_eq(yyvs[yyvsp - 2].astr(), c"SUM(") {
-                                yyval.Node = New_Func(
+                                yyval = FITS_PARSER_YYSTYPE::Node(New_Func(
                                     lParse,
                                     fits_parser_yytokentype::LONG as c_int,
                                     SUM_FCT,
@@ -2912,10 +2950,10 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     0,
                                     0,
                                     0,
-                                );
+                                ));
                                 current_block = Block::ReduceJoin3;
                             } else if astr_eq(yyvs[yyvsp - 2].astr(), c"MIN(") {
-                                yyval.Node = New_Func(
+                                yyval = FITS_PARSER_YYSTYPE::Node(New_Func(
                                     lParse,
                                     ((lParse.Nodes)[yyvs[yyvsp - 1].node() as usize]).ntype,
                                     MIN1_FCT,
@@ -2927,7 +2965,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     0,
                                     0,
                                     0,
-                                );
+                                ));
                                 (((lParse.Nodes)[yyval.node() as usize]).value).nelem = 1;
                                 current_block = Block::ReduceJoin3;
                             } else if astr_eq(yyvs[yyvsp - 2].astr(), c"ACCUM(") {
@@ -2939,16 +2977,16 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     ::core::mem::size_of::<c_long>() as c_ulong as c_long,
                                 );
 
-                                yyval.Node = New_BinOp(
+                                yyval = FITS_PARSER_YYSTYPE::Node(New_BinOp(
                                     lParse,
                                     fits_parser_yytokentype::LONG as c_int,
                                     yyvs[yyvsp - 1].node(),
                                     fits_parser_yytokentype::ACCUM as c_int,
                                     new_node,
-                                );
+                                ));
                                 current_block = Block::ReduceJoin3;
                             } else if astr_eq(yyvs[yyvsp - 2].astr(), c"MAX(") {
-                                yyval.Node = New_Func(
+                                yyval = FITS_PARSER_YYSTYPE::Node(New_Func(
                                     lParse,
                                     ((lParse.Nodes)[yyvs[yyvsp - 1].node() as usize]).ntype,
                                     MAX1_FCT,
@@ -2960,7 +2998,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     0,
                                     0,
                                     0,
-                                );
+                                ));
                                 (((lParse.Nodes)[yyval.node() as usize]).value).nelem = 1;
                                 current_block = Block::ReduceJoin3;
                             } else {
@@ -2981,7 +3019,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         59 => {
                             /* expr: FUNCTION expr ')'  */
                             if astr_eq(yyvs[yyvsp - 2].astr(), c"SUM(") {
-                                yyval.Node = New_Func(
+                                yyval = FITS_PARSER_YYSTYPE::Node(New_Func(
                                     lParse,
                                     ((lParse.Nodes)[yyvs[yyvsp - 1].node() as usize]).ntype,
                                     SUM_FCT,
@@ -2993,10 +3031,10 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     0,
                                     0,
                                     0,
-                                );
+                                ));
                                 current_block = Block::ReduceJoin1;
                             } else if astr_eq(yyvs[yyvsp - 2].astr(), c"AVERAGE(") {
-                                yyval.Node = New_Func(
+                                yyval = FITS_PARSER_YYSTYPE::Node(New_Func(
                                     lParse,
                                     fits_parser_yytokentype::DOUBLE as c_int,
                                     AVERAGE_FCT,
@@ -3008,10 +3046,10 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     0,
                                     0,
                                     0,
-                                );
+                                ));
                                 current_block = Block::ReduceJoin1;
                             } else if astr_eq(yyvs[yyvsp - 2].astr(), c"STDDEV(") {
-                                yyval.Node = New_Func(
+                                yyval = FITS_PARSER_YYSTYPE::Node(New_Func(
                                     lParse,
                                     fits_parser_yytokentype::DOUBLE as c_int,
                                     STDDEV_FCT,
@@ -3023,10 +3061,10 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     0,
                                     0,
                                     0,
-                                );
+                                ));
                                 current_block = Block::ReduceJoin1;
                             } else if astr_eq(yyvs[yyvsp - 2].astr(), c"MEDIAN(") {
-                                yyval.Node = New_Func(
+                                yyval = FITS_PARSER_YYSTYPE::Node(New_Func(
                                     lParse,
                                     ((lParse.Nodes)[yyvs[yyvsp - 1].node() as usize]).ntype,
                                     MEDIAN_FCT,
@@ -3038,10 +3076,10 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     0,
                                     0,
                                     0,
-                                );
+                                ));
                                 current_block = Block::ReduceJoin1;
                             } else if astr_eq(yyvs[yyvsp - 2].astr(), c"NELEM(") {
-                                yyval.Node = New_Const(
+                                yyval = FITS_PARSER_YYSTYPE::Node(New_Const(
                                     lParse,
                                     fits_parser_yytokentype::LONG as c_int,
                                     (&((lParse.Nodes)[yyvs[yyvsp - 1].node() as usize])
@@ -3050,10 +3088,10 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         as *const c_long)
                                         .cast::<c_void>(),
                                     ::core::mem::size_of::<c_long>() as c_ulong as c_long,
-                                );
+                                ));
                                 current_block = Block::ReduceJoin1;
                             } else if astr_eq(yyvs[yyvsp - 2].astr(), c"NVALID(") {
-                                yyval.Node = New_Func(
+                                yyval = FITS_PARSER_YYSTYPE::Node(New_Func(
                                     lParse,
                                     fits_parser_yytokentype::LONG as c_int,
                                     NONNULL_FCT,
@@ -3065,7 +3103,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     0,
                                     0,
                                     0,
-                                );
+                                ));
                                 current_block = Block::ReduceJoin1;
                             } else if astr_eq(yyvs[yyvsp - 2].astr(), c"ACCUM(")
                                 && ((lParse.Nodes)[yyvs[yyvsp - 1].node() as usize]).ntype
@@ -3082,13 +3120,13 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     ::core::mem::size_of::<c_long>() as c_ulong as c_long,
                                 );
 
-                                yyval.Node = New_BinOp(
+                                yyval = FITS_PARSER_YYSTYPE::Node(New_BinOp(
                                     lParse,
                                     fits_parser_yytokentype::LONG as c_int,
                                     yyvs[yyvsp - 1].node(),
                                     fits_parser_yytokentype::ACCUM as c_int,
                                     new_node,
-                                );
+                                ));
                                 current_block = Block::ReduceJoin1;
                             } else if astr_eq(yyvs[yyvsp - 2].astr(), c"ACCUM(")
                                 && ((lParse.Nodes)[yyvs[yyvsp - 1].node() as usize]).ntype
@@ -3102,13 +3140,13 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     ::core::mem::size_of::<c_double>() as c_ulong as c_long,
                                 );
 
-                                yyval.Node = New_BinOp(
+                                yyval = FITS_PARSER_YYSTYPE::Node(New_BinOp(
                                     lParse,
                                     fits_parser_yytokentype::DOUBLE as c_int,
                                     yyvs[yyvsp - 1].node(),
                                     fits_parser_yytokentype::ACCUM as c_int,
                                     new_node,
-                                );
+                                ));
                                 current_block = Block::ReduceJoin1;
                             } else if astr_eq(yyvs[yyvsp - 2].astr(), c"SEQDIFF(")
                                 && ((lParse.Nodes)[yyvs[yyvsp - 1].node() as usize]).ntype
@@ -3122,13 +3160,13 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     ::core::mem::size_of::<c_long>() as c_ulong as c_long,
                                 );
 
-                                yyval.Node = New_BinOp(
+                                yyval = FITS_PARSER_YYSTYPE::Node(New_BinOp(
                                     lParse,
                                     fits_parser_yytokentype::LONG as c_int,
                                     yyvs[yyvsp - 1].node(),
                                     fits_parser_yytokentype::DIFF as c_int,
                                     new_node,
-                                );
+                                ));
                                 current_block = Block::ReduceJoin1;
                             } else if astr_eq(yyvs[yyvsp - 2].astr(), c"SEQDIFF(")
                                 && ((lParse.Nodes)[yyvs[yyvsp - 1].node() as usize]).ntype
@@ -3142,16 +3180,16 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     ::core::mem::size_of::<c_double>() as c_ulong as c_long,
                                 );
 
-                                yyval.Node = New_BinOp(
+                                yyval = FITS_PARSER_YYSTYPE::Node(New_BinOp(
                                     lParse,
                                     fits_parser_yytokentype::DOUBLE as c_int,
                                     yyvs[yyvsp - 1].node(),
                                     fits_parser_yytokentype::DIFF as c_int,
                                     new_node,
-                                );
+                                ));
                                 current_block = Block::ReduceJoin1;
                             } else if astr_eq(yyvs[yyvsp - 2].astr(), c"ABS(") {
-                                yyval.Node = New_Func(
+                                yyval = FITS_PARSER_YYSTYPE::Node(New_Func(
                                     lParse,
                                     0,
                                     ABS_FCT,
@@ -3163,10 +3201,10 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     0,
                                     0,
                                     0,
-                                );
+                                ));
                                 current_block = Block::ReduceJoin1;
                             } else if astr_eq(yyvs[yyvsp - 2].astr(), c"MIN(") {
-                                yyval.Node = New_Func(
+                                yyval = FITS_PARSER_YYSTYPE::Node(New_Func(
                                     lParse,
                                     ((lParse.Nodes)[yyvs[yyvsp - 1].node() as usize]).ntype,
                                     MIN1_FCT,
@@ -3178,10 +3216,10 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     0,
                                     0,
                                     0,
-                                );
+                                ));
                                 current_block = Block::ReduceJoin1;
                             } else if astr_eq(yyvs[yyvsp - 2].astr(), c"MAX(") {
-                                yyval.Node = New_Func(
+                                yyval = FITS_PARSER_YYSTYPE::Node(New_Func(
                                     lParse,
                                     ((lParse.Nodes)[yyvs[yyvsp - 1].node() as usize]).ntype,
                                     MAX1_FCT,
@@ -3193,10 +3231,10 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     0,
                                     0,
                                     0,
-                                );
+                                ));
                                 current_block = Block::ReduceJoin1;
                             } else if astr_eq(yyvs[yyvsp - 2].astr(), c"RANDOM(") {
-                                yyval.Node = New_Func(
+                                yyval = FITS_PARSER_YYSTYPE::Node(New_Func(
                                     lParse,
                                     0,
                                     RND_FCT,
@@ -3208,7 +3246,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     0,
                                     0,
                                     0,
-                                );
+                                ));
                                 if yyval.node() < 0 {
                                     current_block = Block::YyErrLab;
                                 } else {
@@ -3217,7 +3255,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     current_block = Block::ReduceJoin1;
                                 }
                             } else if astr_eq(yyvs[yyvsp - 2].astr(), c"RANDOMN(") {
-                                yyval.Node = New_Func(
+                                yyval = FITS_PARSER_YYSTYPE::Node(New_Func(
                                     lParse,
                                     0,
                                     GASRND_FCT,
@@ -3229,7 +3267,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     0,
                                     0,
                                     0,
-                                );
+                                ));
                                 if yyval.node() < 0 {
                                     current_block = Block::YyErrLab;
                                 } else {
@@ -3242,15 +3280,15 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     == CONST_OP
                                 {
                                     let mut one_1: c_long = 1;
-                                    yyval.Node = New_Const(
+                                    yyval = FITS_PARSER_YYSTYPE::Node(New_Const(
                                         lParse,
                                         fits_parser_yytokentype::LONG as c_int,
                                         (&mut one_1 as *mut c_long).cast::<c_void>(),
                                         ::core::mem::size_of::<c_long>() as c_ulong as c_long,
-                                    );
+                                    ));
                                     current_block = Block::ReduceJoin1;
                                 } else {
-                                    yyval.Node = New_Func(
+                                    yyval = FITS_PARSER_YYSTYPE::Node(New_Func(
                                         lParse,
                                         0,
                                         ELEMNUM_FCT,
@@ -3262,7 +3300,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         0,
                                         0,
                                         0,
-                                    );
+                                    ));
                                     if yyval.node() < 0 {
                                         current_block = Block::YyErrLab;
                                     } else {
@@ -3276,12 +3314,12 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     == CONST_OP
                                 {
                                     let mut one_2: c_long = 1;
-                                    yyval.Node = New_Const(
+                                    yyval = FITS_PARSER_YYSTYPE::Node(New_Const(
                                         lParse,
                                         fits_parser_yytokentype::LONG as c_int,
                                         (&mut one_2 as *mut c_long).cast::<c_void>(),
                                         ::core::mem::size_of::<c_long>() as c_ulong as c_long,
-                                    );
+                                    ));
                                     current_block = Block::ReduceJoin1;
                                 } else {
                                     let mut naxis_0: c_long = c_long::from(
@@ -3289,12 +3327,12 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                             .value
                                             .naxis,
                                     );
-                                    yyval.Node = New_Const(
+                                    yyval = FITS_PARSER_YYSTYPE::Node(New_Const(
                                         lParse,
                                         fits_parser_yytokentype::LONG as c_int,
                                         (&mut naxis_0 as *mut c_long).cast::<c_void>(),
                                         ::core::mem::size_of::<c_long>() as c_ulong as c_long,
-                                    );
+                                    ));
                                     if yyval.node() < 0 {
                                         current_block = Block::YyErrLab;
                                     } else {
@@ -3305,15 +3343,15 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 if ((lParse.Nodes)[yyvs[yyvsp - 1].node() as usize]).ntype
                                     != fits_parser_yytokentype::DOUBLE as c_int
                                 {
-                                    yyvs[yyvsp - 1].Node = New_Unary(
+                                    yyvs[yyvsp - 1] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                         lParse,
                                         fits_parser_yytokentype::DOUBLE as c_int,
                                         0,
                                         yyvs[yyvsp - 1].node(),
-                                    );
+                                    ));
                                 }
                                 if astr_eq(yyvs[yyvsp - 2].astr(), c"SIN(") {
-                                    yyval.Node = New_Func(
+                                    yyval = FITS_PARSER_YYSTYPE::Node(New_Func(
                                         lParse,
                                         0,
                                         SIN_FCT,
@@ -3325,10 +3363,10 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         0,
                                         0,
                                         0,
-                                    );
+                                    ));
                                     current_block = Block::ReduceJoin1;
                                 } else if astr_eq(yyvs[yyvsp - 2].astr(), c"COS(") {
-                                    yyval.Node = New_Func(
+                                    yyval = FITS_PARSER_YYSTYPE::Node(New_Func(
                                         lParse,
                                         0,
                                         COS_FCT,
@@ -3340,10 +3378,10 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         0,
                                         0,
                                         0,
-                                    );
+                                    ));
                                     current_block = Block::ReduceJoin1;
                                 } else if astr_eq(yyvs[yyvsp - 2].astr(), c"TAN(") {
-                                    yyval.Node = New_Func(
+                                    yyval = FITS_PARSER_YYSTYPE::Node(New_Func(
                                         lParse,
                                         0,
                                         TAN_FCT,
@@ -3355,12 +3393,12 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         0,
                                         0,
                                         0,
-                                    );
+                                    ));
                                     current_block = Block::ReduceJoin1;
                                 } else if astr_eq(yyvs[yyvsp - 2].astr(), c"ARCSIN(")
                                     || astr_eq(yyvs[yyvsp - 2].astr(), c"ASIN(")
                                 {
-                                    yyval.Node = New_Func(
+                                    yyval = FITS_PARSER_YYSTYPE::Node(New_Func(
                                         lParse,
                                         0,
                                         ASIN_FCT,
@@ -3372,12 +3410,12 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         0,
                                         0,
                                         0,
-                                    );
+                                    ));
                                     current_block = Block::ReduceJoin1;
                                 } else if astr_eq(yyvs[yyvsp - 2].astr(), c"ARCCOS(")
                                     || astr_eq(yyvs[yyvsp - 2].astr(), c"ACOS(")
                                 {
-                                    yyval.Node = New_Func(
+                                    yyval = FITS_PARSER_YYSTYPE::Node(New_Func(
                                         lParse,
                                         0,
                                         ACOS_FCT,
@@ -3389,12 +3427,12 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         0,
                                         0,
                                         0,
-                                    );
+                                    ));
                                     current_block = Block::ReduceJoin1;
                                 } else if astr_eq(yyvs[yyvsp - 2].astr(), c"ARCTAN(")
                                     || astr_eq(yyvs[yyvsp - 2].astr(), c"ATAN(")
                                 {
-                                    yyval.Node = New_Func(
+                                    yyval = FITS_PARSER_YYSTYPE::Node(New_Func(
                                         lParse,
                                         0,
                                         ATAN_FCT,
@@ -3406,10 +3444,10 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         0,
                                         0,
                                         0,
-                                    );
+                                    ));
                                     current_block = Block::ReduceJoin1;
                                 } else if astr_eq(yyvs[yyvsp - 2].astr(), c"SINH(") {
-                                    yyval.Node = New_Func(
+                                    yyval = FITS_PARSER_YYSTYPE::Node(New_Func(
                                         lParse,
                                         0,
                                         SINH_FCT,
@@ -3421,10 +3459,10 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         0,
                                         0,
                                         0,
-                                    );
+                                    ));
                                     current_block = Block::ReduceJoin1;
                                 } else if astr_eq(yyvs[yyvsp - 2].astr(), c"COSH(") {
-                                    yyval.Node = New_Func(
+                                    yyval = FITS_PARSER_YYSTYPE::Node(New_Func(
                                         lParse,
                                         0,
                                         COSH_FCT,
@@ -3436,10 +3474,10 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         0,
                                         0,
                                         0,
-                                    );
+                                    ));
                                     current_block = Block::ReduceJoin1;
                                 } else if astr_eq(yyvs[yyvsp - 2].astr(), c"TANH(") {
-                                    yyval.Node = New_Func(
+                                    yyval = FITS_PARSER_YYSTYPE::Node(New_Func(
                                         lParse,
                                         0,
                                         TANH_FCT,
@@ -3451,10 +3489,10 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         0,
                                         0,
                                         0,
-                                    );
+                                    ));
                                     current_block = Block::ReduceJoin1;
                                 } else if astr_eq(yyvs[yyvsp - 2].astr(), c"EXP(") {
-                                    yyval.Node = New_Func(
+                                    yyval = FITS_PARSER_YYSTYPE::Node(New_Func(
                                         lParse,
                                         0,
                                         EXP_FCT,
@@ -3466,10 +3504,10 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         0,
                                         0,
                                         0,
-                                    );
+                                    ));
                                     current_block = Block::ReduceJoin1;
                                 } else if astr_eq(yyvs[yyvsp - 2].astr(), c"LOG(") {
-                                    yyval.Node = New_Func(
+                                    yyval = FITS_PARSER_YYSTYPE::Node(New_Func(
                                         lParse,
                                         0,
                                         LOG_FCT,
@@ -3481,10 +3519,10 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         0,
                                         0,
                                         0,
-                                    );
+                                    ));
                                     current_block = Block::ReduceJoin1;
                                 } else if astr_eq(yyvs[yyvsp - 2].astr(), c"LOG10(") {
-                                    yyval.Node = New_Func(
+                                    yyval = FITS_PARSER_YYSTYPE::Node(New_Func(
                                         lParse,
                                         0,
                                         LOG10_FCT,
@@ -3496,10 +3534,10 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         0,
                                         0,
                                         0,
-                                    );
+                                    ));
                                     current_block = Block::ReduceJoin1;
                                 } else if astr_eq(yyvs[yyvsp - 2].astr(), c"SQRT(") {
-                                    yyval.Node = New_Func(
+                                    yyval = FITS_PARSER_YYSTYPE::Node(New_Func(
                                         lParse,
                                         0,
                                         SQRT_FCT,
@@ -3511,10 +3549,10 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         0,
                                         0,
                                         0,
-                                    );
+                                    ));
                                     current_block = Block::ReduceJoin1;
                                 } else if astr_eq(yyvs[yyvsp - 2].astr(), c"ROUND(") {
-                                    yyval.Node = New_Func(
+                                    yyval = FITS_PARSER_YYSTYPE::Node(New_Func(
                                         lParse,
                                         0,
                                         ROUND_FCT,
@@ -3526,10 +3564,10 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         0,
                                         0,
                                         0,
-                                    );
+                                    ));
                                     current_block = Block::ReduceJoin1;
                                 } else if astr_eq(yyvs[yyvsp - 2].astr(), c"FLOOR(") {
-                                    yyval.Node = New_Func(
+                                    yyval = FITS_PARSER_YYSTYPE::Node(New_Func(
                                         lParse,
                                         0,
                                         FLOOR_FCT,
@@ -3541,10 +3579,10 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         0,
                                         0,
                                         0,
-                                    );
+                                    ));
                                     current_block = Block::ReduceJoin1;
                                 } else if astr_eq(yyvs[yyvsp - 2].astr(), c"CEIL(") {
-                                    yyval.Node = New_Func(
+                                    yyval = FITS_PARSER_YYSTYPE::Node(New_Func(
                                         lParse,
                                         0,
                                         CEIL_FCT,
@@ -3556,10 +3594,10 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         0,
                                         0,
                                         0,
-                                    );
+                                    ));
                                     current_block = Block::ReduceJoin1;
                                 } else if astr_eq(yyvs[yyvsp - 2].astr(), c"RANDOMP(") {
-                                    yyval.Node = New_Func(
+                                    yyval = FITS_PARSER_YYSTYPE::Node(New_Func(
                                         lParse,
                                         0,
                                         POIRND_FCT,
@@ -3571,7 +3609,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         0,
                                         0,
                                         0,
-                                    );
+                                    ));
                                     ((lParse.Nodes)[yyval.node() as usize]).ntype =
                                         fits_parser_yytokentype::LONG as c_int;
                                     current_block = Block::ReduceJoin1;
@@ -3597,7 +3635,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         60 => {
                             /* expr: IFUNCTION sexpr ',' sexpr ')'  */
                             if astr_eq(yyvs[yyvsp - 4].astr(), c"STRSTR(") {
-                                yyval.Node = New_Func(
+                                yyval = FITS_PARSER_YYSTYPE::Node(New_Func(
                                     lParse,
                                     fits_parser_yytokentype::LONG as c_int,
                                     STRPOS_FCT,
@@ -3609,7 +3647,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     0,
                                     0,
                                     0,
-                                );
+                                ));
                                 if yyval.node() < 0 {
                                     current_block = Block::YyErrLab;
                                 } else {
@@ -3643,24 +3681,24 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     if ((lParse.Nodes)[yyvs[yyvsp - 3].node() as usize]).ntype
                                         > ((lParse.Nodes)[yyvs[yyvsp - 1].node() as usize]).ntype
                                     {
-                                        yyvs[yyvsp - 1].Node = New_Unary(
+                                        yyvs[yyvsp - 1] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                             lParse,
                                             ((lParse.Nodes)[yyvs[yyvsp - 3].node() as usize]).ntype,
                                             0,
                                             yyvs[yyvsp - 1].node(),
-                                        );
+                                        ));
                                     } else if ((lParse.Nodes)[yyvs[yyvsp - 3].node() as usize])
                                         .ntype
                                         < ((lParse.Nodes)[yyvs[yyvsp - 1].node() as usize]).ntype
                                     {
-                                        yyvs[yyvsp - 3].Node = New_Unary(
+                                        yyvs[yyvsp - 3] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                             lParse,
                                             ((lParse.Nodes)[yyvs[yyvsp - 1].node() as usize]).ntype,
                                             0,
                                             yyvs[yyvsp - 3].node(),
-                                        );
+                                        ));
                                     }
-                                    yyval.Node = New_Func(
+                                    yyval = FITS_PARSER_YYSTYPE::Node(New_Func(
                                         lParse,
                                         0,
                                         DEFNULL_FCT,
@@ -3672,7 +3710,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         0,
                                         0,
                                         0,
-                                    );
+                                    ));
                                     if yyval.node() < 0 {
                                         current_block = Block::YyErrLab;
                                     } else {
@@ -3689,27 +3727,27 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 if ((lParse.Nodes)[yyvs[yyvsp - 3].node() as usize]).ntype
                                     != fits_parser_yytokentype::DOUBLE as c_int
                                 {
-                                    yyvs[yyvsp - 3].Node = New_Unary(
+                                    yyvs[yyvsp - 3] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                         lParse,
                                         fits_parser_yytokentype::DOUBLE as c_int,
                                         0,
                                         yyvs[yyvsp - 3].node(),
-                                    );
+                                    ));
                                 }
                                 if ((lParse.Nodes)[yyvs[yyvsp - 1].node() as usize]).ntype
                                     != fits_parser_yytokentype::DOUBLE as c_int
                                 {
-                                    yyvs[yyvsp - 1].Node = New_Unary(
+                                    yyvs[yyvsp - 1] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                         lParse,
                                         fits_parser_yytokentype::DOUBLE as c_int,
                                         0,
                                         yyvs[yyvsp - 1].node(),
-                                    );
+                                    ));
                                 }
                                 if Test_Dims(lParse, yyvs[yyvsp - 3].node(), yyvs[yyvsp - 1].node())
                                     != 0
                                 {
-                                    yyval.Node = New_Func(
+                                    yyval = FITS_PARSER_YYSTYPE::Node(New_Func(
                                         lParse,
                                         0,
                                         ATAN2_FCT,
@@ -3721,7 +3759,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         0,
                                         0,
                                         0,
-                                    );
+                                    ));
                                     if yyval.node() < 0 {
                                         current_block = Block::YyErrLab;
                                     } else {
@@ -3747,26 +3785,26 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 if ((lParse.Nodes)[yyvs[yyvsp - 3].node() as usize]).ntype
                                     > ((lParse.Nodes)[yyvs[yyvsp - 1].node() as usize]).ntype
                                 {
-                                    yyvs[yyvsp - 1].Node = New_Unary(
+                                    yyvs[yyvsp - 1] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                         lParse,
                                         ((lParse.Nodes)[yyvs[yyvsp - 3].node() as usize]).ntype,
                                         0,
                                         yyvs[yyvsp - 1].node(),
-                                    );
+                                    ));
                                 } else if ((lParse.Nodes)[yyvs[yyvsp - 3].node() as usize]).ntype
                                     < ((lParse.Nodes)[yyvs[yyvsp - 1].node() as usize]).ntype
                                 {
-                                    yyvs[yyvsp - 3].Node = New_Unary(
+                                    yyvs[yyvsp - 3] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                         lParse,
                                         ((lParse.Nodes)[yyvs[yyvsp - 1].node() as usize]).ntype,
                                         0,
                                         yyvs[yyvsp - 3].node(),
-                                    );
+                                    ));
                                 }
                                 if Test_Dims(lParse, yyvs[yyvsp - 3].node(), yyvs[yyvsp - 1].node())
                                     != 0
                                 {
-                                    yyval.Node = New_Func(
+                                    yyval = FITS_PARSER_YYSTYPE::Node(New_Func(
                                         lParse,
                                         0,
                                         MIN2_FCT,
@@ -3778,7 +3816,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         0,
                                         0,
                                         0,
-                                    );
+                                    ));
                                     if yyval.node() < 0 {
                                         current_block = Block::YyErrLab;
                                     } else {
@@ -3804,26 +3842,26 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 if ((lParse.Nodes)[yyvs[yyvsp - 3].node() as usize]).ntype
                                     > ((lParse.Nodes)[yyvs[yyvsp - 1].node() as usize]).ntype
                                 {
-                                    yyvs[yyvsp - 1].Node = New_Unary(
+                                    yyvs[yyvsp - 1] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                         lParse,
                                         ((lParse.Nodes)[yyvs[yyvsp - 3].node() as usize]).ntype,
                                         0,
                                         yyvs[yyvsp - 1].node(),
-                                    );
+                                    ));
                                 } else if ((lParse.Nodes)[yyvs[yyvsp - 3].node() as usize]).ntype
                                     < ((lParse.Nodes)[yyvs[yyvsp - 1].node() as usize]).ntype
                                 {
-                                    yyvs[yyvsp - 3].Node = New_Unary(
+                                    yyvs[yyvsp - 3] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                         lParse,
                                         ((lParse.Nodes)[yyvs[yyvsp - 1].node() as usize]).ntype,
                                         0,
                                         yyvs[yyvsp - 3].node(),
-                                    );
+                                    ));
                                 }
                                 if Test_Dims(lParse, yyvs[yyvsp - 3].node(), yyvs[yyvsp - 1].node())
                                     != 0
                                 {
-                                    yyval.Node = New_Func(
+                                    yyval = FITS_PARSER_YYSTYPE::Node(New_Func(
                                         lParse,
                                         0,
                                         MAX2_FCT,
@@ -3835,7 +3873,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         0,
                                         0,
                                         0,
-                                    );
+                                    ));
                                     if yyval.node() < 0 {
                                         current_block = Block::YyErrLab;
                                     } else {
@@ -3874,14 +3912,14 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     if ((lParse.Nodes)[yyvs[yyvsp - 3].node() as usize]).ntype
                                         != ((lParse.Nodes)[yyvs[yyvsp - 1].node() as usize]).ntype
                                     {
-                                        yyvs[yyvsp - 3].Node = New_Unary(
+                                        yyvs[yyvsp - 3] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                             lParse,
                                             ((lParse.Nodes)[yyvs[yyvsp - 1].node() as usize]).ntype,
                                             0,
                                             yyvs[yyvsp - 3].node(),
-                                        );
+                                        ));
                                     }
-                                    yyval.Node = New_Func(
+                                    yyval = FITS_PARSER_YYSTYPE::Node(New_Func(
                                         lParse,
                                         0,
                                         SETNULL_FCT,
@@ -3893,7 +3931,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         0,
                                         0,
                                         0,
-                                    );
+                                    ));
                                     current_block = Block::ReduceJoin2;
                                 }
                             } else if astr_eq(yyvs[yyvsp - 4].astr(), c"AXISELEM(") {
@@ -3914,25 +3952,25 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     == CONST_OP
                                 {
                                     let mut one_3: c_long = 1;
-                                    yyval.Node = New_Const(
+                                    yyval = FITS_PARSER_YYSTYPE::Node(New_Const(
                                         lParse,
                                         fits_parser_yytokentype::LONG as c_int,
                                         (&mut one_3 as *mut c_long).cast::<c_void>(),
                                         ::core::mem::size_of::<c_long>() as c_ulong as c_long,
-                                    );
+                                    ));
                                     current_block = Block::ReduceJoin2;
                                 } else {
                                     if ((lParse.Nodes)[yyvs[yyvsp - 1].node() as usize]).ntype
                                         != fits_parser_yytokentype::LONG as c_int
                                     {
-                                        yyvs[yyvsp - 1].Node = New_Unary(
+                                        yyvs[yyvsp - 1] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                             lParse,
                                             fits_parser_yytokentype::LONG as c_int,
                                             0,
                                             yyvs[yyvsp - 1].node(),
-                                        );
+                                        ));
                                     }
-                                    yyval.Node = New_Func(
+                                    yyval = FITS_PARSER_YYSTYPE::Node(New_Func(
                                         lParse,
                                         0,
                                         AXISELEM_FCT,
@@ -3944,7 +3982,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         0,
                                         0,
                                         0,
-                                    );
+                                    ));
                                     if yyval.node() < 0 {
                                         current_block = Block::YyErrLab;
                                     } else {
@@ -3971,12 +4009,12 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     == CONST_OP
                                 {
                                     let mut one_4: c_long = 1;
-                                    yyval.Node = New_Const(
+                                    yyval = FITS_PARSER_YYSTYPE::Node(New_Const(
                                         lParse,
                                         fits_parser_yytokentype::LONG as c_int,
                                         (&mut one_4 as *mut c_long).cast::<c_void>(),
                                         ::core::mem::size_of::<c_long>() as c_ulong as c_long,
-                                    );
+                                    ));
                                     current_block = Block::ReduceJoin2;
                                 } else {
                                     let mut iaxis_0: c_long = 0;
@@ -3984,12 +4022,12 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     if ((lParse.Nodes)[yyvs[yyvsp - 1].node() as usize]).ntype
                                         != fits_parser_yytokentype::LONG as c_int
                                     {
-                                        yyvs[yyvsp - 1].Node = New_Unary(
+                                        yyvs[yyvsp - 1] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                             lParse,
                                             fits_parser_yytokentype::LONG as c_int,
                                             0,
                                             yyvs[yyvsp - 1].node(),
-                                        );
+                                        ));
                                     }
                                     iaxis_0 = ((lParse.Nodes)[yyvs[yyvsp - 1].node() as usize])
                                         .value
@@ -4008,12 +4046,12 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     } else {
                                         iaxis_0 = 1;
                                     }
-                                    yyval.Node = New_Const(
+                                    yyval = FITS_PARSER_YYSTYPE::Node(New_Const(
                                         lParse,
                                         fits_parser_yytokentype::LONG as c_int,
                                         (&mut iaxis_0 as *mut c_long).cast::<c_void>(),
                                         ::core::mem::size_of::<c_long>() as c_ulong as c_long,
-                                    );
+                                    ));
                                     if yyval.node() < 0 {
                                         current_block = Block::YyErrLab;
                                     } else {
@@ -4021,11 +4059,11 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     }
                                 }
                             } else if astr_eq(yyvs[yyvsp - 4].astr(), c"ARRAY(") {
-                                yyval.Node = New_Array(
+                                yyval = FITS_PARSER_YYSTYPE::Node(New_Array(
                                     lParse,
                                     yyvs[yyvsp - 3].node(),
                                     yyvs[yyvsp - 1].node(),
-                                );
+                                ));
                                 if yyval.node() < 0 {
                                     current_block = Block::YyErrLab;
                                 } else {
@@ -4051,42 +4089,42 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 if ((lParse.Nodes)[yyvs[yyvsp - 7].node() as usize]).ntype
                                     != fits_parser_yytokentype::DOUBLE as c_int
                                 {
-                                    yyvs[yyvsp - 7].Node = New_Unary(
+                                    yyvs[yyvsp - 7] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                         lParse,
                                         fits_parser_yytokentype::DOUBLE as c_int,
                                         0,
                                         yyvs[yyvsp - 7].node(),
-                                    );
+                                    ));
                                 }
                                 if ((lParse.Nodes)[yyvs[yyvsp - 5].node() as usize]).ntype
                                     != fits_parser_yytokentype::DOUBLE as c_int
                                 {
-                                    yyvs[yyvsp - 5].Node = New_Unary(
+                                    yyvs[yyvsp - 5] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                         lParse,
                                         fits_parser_yytokentype::DOUBLE as c_int,
                                         0,
                                         yyvs[yyvsp - 5].node(),
-                                    );
+                                    ));
                                 }
                                 if ((lParse.Nodes)[yyvs[yyvsp - 3].node() as usize]).ntype
                                     != fits_parser_yytokentype::DOUBLE as c_int
                                 {
-                                    yyvs[yyvsp - 3].Node = New_Unary(
+                                    yyvs[yyvsp - 3] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                         lParse,
                                         fits_parser_yytokentype::DOUBLE as c_int,
                                         0,
                                         yyvs[yyvsp - 3].node(),
-                                    );
+                                    ));
                                 }
                                 if ((lParse.Nodes)[yyvs[yyvsp - 1].node() as usize]).ntype
                                     != fits_parser_yytokentype::DOUBLE as c_int
                                 {
-                                    yyvs[yyvsp - 1].Node = New_Unary(
+                                    yyvs[yyvsp - 1] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                         lParse,
                                         fits_parser_yytokentype::DOUBLE as c_int,
                                         0,
                                         yyvs[yyvsp - 1].node(),
-                                    );
+                                    ));
                                 }
                                 if Test_Dims(lParse, yyvs[yyvsp - 7].node(), yyvs[yyvsp - 5].node())
                                     != 0
@@ -4101,7 +4139,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         yyvs[yyvsp - 1].node(),
                                     ) != 0
                                 {
-                                    yyval.Node = New_Func(
+                                    yyval = FITS_PARSER_YYSTYPE::Node(New_Func(
                                         lParse,
                                         0,
                                         ANGSEP_FCT,
@@ -4113,7 +4151,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         0,
                                         0,
                                         0,
-                                    );
+                                    ));
                                     if yyval.node() < 0 {
                                         current_block = Block::YyErrLab;
                                     } else {
@@ -4163,7 +4201,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         }
                         63 => {
                             /* expr: GTIOVERLAP STRING ',' expr ',' expr ')'  */
-                            yyval.Node = New_GTI(
+                            yyval = FITS_PARSER_YYSTYPE::Node(New_GTI(
                                 lParse,
                                 GTIOVER_FCT,
                                 (yyvs[yyvsp - 5].astr_mut()).as_mut_ptr(),
@@ -4171,7 +4209,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 yyvs[yyvsp - 1].node(),
                                 c"*START*".as_ptr() as *mut c_char,
                                 c"*STOP*".as_ptr() as *mut c_char,
-                            );
+                            ));
                             if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
@@ -4180,7 +4218,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         }
                         64 => {
                             /* expr: GTIOVERLAP STRING ',' expr ',' expr ',' STRING ',' STRING ')'  */
-                            yyval.Node = New_GTI(
+                            yyval = FITS_PARSER_YYSTYPE::Node(New_GTI(
                                 lParse,
                                 GTIOVER_FCT,
                                 (yyvs[yyvsp - 9].astr_mut()).as_mut_ptr(),
@@ -4188,7 +4226,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 yyvs[yyvsp - 5].node(),
                                 (yyvs[yyvsp - 3].astr_mut()).as_mut_ptr(),
                                 (yyvs[yyvsp - 1].astr_mut()).as_mut_ptr(),
-                            );
+                            ));
                             if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
@@ -4197,7 +4235,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         }
                         65 => {
                             /* expr: expr '[' expr ']'  */
-                            yyval.Node = New_Deref(
+                            yyval = FITS_PARSER_YYSTYPE::Node(New_Deref(
                                 lParse,
                                 yyvs[yyvsp - 3].node(),
                                 1,
@@ -4206,7 +4244,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 0,
                                 0,
                                 0,
-                            );
+                            ));
                             if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
@@ -4215,7 +4253,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         }
                         66 => {
                             /* expr: expr '[' expr ',' expr ']'  */
-                            yyval.Node = New_Deref(
+                            yyval = FITS_PARSER_YYSTYPE::Node(New_Deref(
                                 lParse,
                                 yyvs[yyvsp - 5].node(),
                                 2,
@@ -4224,7 +4262,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 0,
                                 0,
                                 0,
-                            );
+                            ));
                             if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
@@ -4233,7 +4271,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         }
                         67 => {
                             /* expr: expr '[' expr ',' expr ',' expr ']'  */
-                            yyval.Node = New_Deref(
+                            yyval = FITS_PARSER_YYSTYPE::Node(New_Deref(
                                 lParse,
                                 yyvs[yyvsp - 7].node(),
                                 3 as c_int,
@@ -4242,7 +4280,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 yyvs[yyvsp - 1].node(),
                                 0,
                                 0,
-                            );
+                            ));
                             if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
@@ -4251,7 +4289,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         }
                         68 => {
                             /* expr: expr '[' expr ',' expr ',' expr ',' expr ']'  */
-                            yyval.Node = New_Deref(
+                            yyval = FITS_PARSER_YYSTYPE::Node(New_Deref(
                                 lParse,
                                 yyvs[yyvsp - 9].node(),
                                 4 as c_int,
@@ -4260,7 +4298,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 yyvs[yyvsp - 3].node(),
                                 yyvs[yyvsp - 1].node(),
                                 0,
-                            );
+                            ));
                             if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
@@ -4269,7 +4307,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         }
                         69 => {
                             /* expr: expr '[' expr ',' expr ',' expr ',' expr ',' expr ']'  */
-                            yyval.Node = New_Deref(
+                            yyval = FITS_PARSER_YYSTYPE::Node(New_Deref(
                                 lParse,
                                 yyvs[yyvsp - 11].node(),
                                 5 as c_int,
@@ -4278,7 +4316,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 yyvs[yyvsp - 5].node(),
                                 yyvs[yyvsp - 3].node(),
                                 yyvs[yyvsp - 1].node(),
-                            );
+                            ));
                             if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
@@ -4287,12 +4325,12 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         }
                         70 => {
                             /* expr: INTCAST expr  */
-                            yyval.Node = New_Unary(
+                            yyval = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                 lParse,
                                 fits_parser_yytokentype::LONG as c_int,
                                 fits_parser_yytokentype::INTCAST as c_int,
                                 yyvs[yyvsp].node(),
-                            );
+                            ));
                             if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
@@ -4301,12 +4339,12 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         }
                         71 => {
                             /* expr: INTCAST bexpr  */
-                            yyval.Node = New_Unary(
+                            yyval = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                 lParse,
                                 fits_parser_yytokentype::LONG as c_int,
                                 fits_parser_yytokentype::INTCAST as c_int,
                                 yyvs[yyvsp].node(),
-                            );
+                            ));
                             if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
@@ -4315,12 +4353,12 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         }
                         72 => {
                             /* expr: FLTCAST expr  */
-                            yyval.Node = New_Unary(
+                            yyval = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                 lParse,
                                 fits_parser_yytokentype::DOUBLE as c_int,
                                 fits_parser_yytokentype::FLTCAST as c_int,
                                 yyvs[yyvsp].node(),
-                            );
+                            ));
                             if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
@@ -4329,12 +4367,12 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         }
                         73 => {
                             /* expr: FLTCAST bexpr  */
-                            yyval.Node = New_Unary(
+                            yyval = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                 lParse,
                                 fits_parser_yytokentype::DOUBLE as c_int,
                                 fits_parser_yytokentype::FLTCAST as c_int,
                                 yyvs[yyvsp].node(),
-                            );
+                            ));
                             if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
@@ -4343,12 +4381,12 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         }
                         74 => {
                             /* bexpr: BOOLEAN  */
-                            yyval.Node = New_Const(
+                            yyval = FITS_PARSER_YYSTYPE::Node(New_Const(
                                 lParse,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
                                 (&mut yyvs[yyvsp].log() as *mut c_char).cast::<c_void>(),
                                 ::core::mem::size_of::<c_char>() as c_ulong as c_long,
-                            );
+                            ));
                             if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
@@ -4357,7 +4395,10 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         }
                         75 => {
                             /* bexpr: BCOLUMN  */
-                            yyval.Node = New_Column(lParse, yyvs[yyvsp].lng() as c_int);
+                            yyval = FITS_PARSER_YYSTYPE::Node(New_Column(
+                                lParse,
+                                yyvs[yyvsp].lng() as c_int,
+                            ));
                             if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
@@ -4377,11 +4418,11 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 );
                                 current_block = Block::YyErrLab;
                             } else {
-                                yyval.Node = New_Offset(
+                                yyval = FITS_PARSER_YYSTYPE::Node(New_Offset(
                                     lParse,
                                     yyvs[yyvsp - 3].lng() as c_int,
                                     yyvs[yyvsp - 1].node(),
-                                );
+                                ));
                                 if yyval.node() < 0 {
                                     current_block = Block::YyErrLab;
                                 } else {
@@ -4391,13 +4432,13 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         }
                         77 => {
                             /* bexpr: bits EQ bits  */
-                            yyval.Node = New_BinOp(
+                            yyval = FITS_PARSER_YYSTYPE::Node(New_BinOp(
                                 lParse,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
                                 yyvs[yyvsp - 2].node(),
                                 fits_parser_yytokentype::EQ as c_int,
                                 yyvs[yyvsp].node(),
-                            );
+                            ));
                             if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
@@ -4407,13 +4448,13 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         }
                         78 => {
                             /* bexpr: bits NE bits  */
-                            yyval.Node = New_BinOp(
+                            yyval = FITS_PARSER_YYSTYPE::Node(New_BinOp(
                                 lParse,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
                                 yyvs[yyvsp - 2].node(),
                                 fits_parser_yytokentype::NE as c_int,
                                 yyvs[yyvsp].node(),
-                            );
+                            ));
                             if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
@@ -4423,13 +4464,13 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         }
                         79 => {
                             /* bexpr: bits LT bits  */
-                            yyval.Node = New_BinOp(
+                            yyval = FITS_PARSER_YYSTYPE::Node(New_BinOp(
                                 lParse,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
                                 yyvs[yyvsp - 2].node(),
                                 fits_parser_yytokentype::LT as c_int,
                                 yyvs[yyvsp].node(),
-                            );
+                            ));
                             if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
@@ -4439,13 +4480,13 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         }
                         80 => {
                             /* bexpr: bits LTE bits  */
-                            yyval.Node = New_BinOp(
+                            yyval = FITS_PARSER_YYSTYPE::Node(New_BinOp(
                                 lParse,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
                                 yyvs[yyvsp - 2].node(),
                                 fits_parser_yytokentype::LTE as c_int,
                                 yyvs[yyvsp].node(),
-                            );
+                            ));
                             if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
@@ -4455,13 +4496,13 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         }
                         81 => {
                             /* bexpr: bits GT bits  */
-                            yyval.Node = New_BinOp(
+                            yyval = FITS_PARSER_YYSTYPE::Node(New_BinOp(
                                 lParse,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
                                 yyvs[yyvsp - 2].node(),
                                 fits_parser_yytokentype::GT as c_int,
                                 yyvs[yyvsp].node(),
-                            );
+                            ));
                             if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
@@ -4471,13 +4512,13 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         }
                         82 => {
                             /* bexpr: bits GTE bits  */
-                            yyval.Node = New_BinOp(
+                            yyval = FITS_PARSER_YYSTYPE::Node(New_BinOp(
                                 lParse,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
                                 yyvs[yyvsp - 2].node(),
                                 fits_parser_yytokentype::GTE as c_int,
                                 yyvs[yyvsp].node(),
-                            );
+                            ));
                             if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
@@ -4490,29 +4531,29 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             if (lParse.Nodes[yyvs[yyvsp - 2].node() as usize]).ntype
                                 > (lParse.Nodes[yyvs[yyvsp].node() as usize]).ntype
                             {
-                                yyvs[yyvsp].Node = New_Unary(
+                                yyvs[yyvsp] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                     lParse,
                                     ((lParse.Nodes)[yyvs[yyvsp - 2].node() as usize]).ntype,
                                     0,
                                     yyvs[yyvsp].node(),
-                                );
+                                ));
                             } else if ((lParse.Nodes)[yyvs[yyvsp - 2].node() as usize]).ntype
                                 < (lParse.Nodes[yyvs[yyvsp].node() as usize]).ntype
                             {
-                                yyvs[yyvsp - 2].Node = New_Unary(
+                                yyvs[yyvsp - 2] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                     lParse,
                                     (lParse.Nodes[yyvs[yyvsp].node() as usize]).ntype,
                                     0,
                                     yyvs[yyvsp - 2].node(),
-                                );
+                                ));
                             }
-                            yyval.Node = New_BinOp(
+                            yyval = FITS_PARSER_YYSTYPE::Node(New_BinOp(
                                 lParse,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
                                 yyvs[yyvsp - 2].node(),
                                 fits_parser_yytokentype::GT as c_int,
                                 yyvs[yyvsp].node(),
-                            );
+                            ));
                             if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
@@ -4524,29 +4565,29 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             if (lParse.Nodes[yyvs[yyvsp - 2].node() as usize]).ntype
                                 > (lParse.Nodes[yyvs[yyvsp].node() as usize]).ntype
                             {
-                                yyvs[yyvsp].Node = New_Unary(
+                                yyvs[yyvsp] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                     lParse,
                                     ((lParse.Nodes)[yyvs[yyvsp - 2].node() as usize]).ntype,
                                     0,
                                     yyvs[yyvsp].node(),
-                                );
+                                ));
                             } else if ((lParse.Nodes)[yyvs[yyvsp - 2].node() as usize]).ntype
                                 < (lParse.Nodes[yyvs[yyvsp].node() as usize]).ntype
                             {
-                                yyvs[yyvsp - 2].Node = New_Unary(
+                                yyvs[yyvsp - 2] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                     lParse,
                                     (lParse.Nodes[yyvs[yyvsp].node() as usize]).ntype,
                                     0,
                                     yyvs[yyvsp - 2].node(),
-                                );
+                                ));
                             }
-                            yyval.Node = New_BinOp(
+                            yyval = FITS_PARSER_YYSTYPE::Node(New_BinOp(
                                 lParse,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
                                 yyvs[yyvsp - 2].node(),
                                 fits_parser_yytokentype::LT as c_int,
                                 yyvs[yyvsp].node(),
-                            );
+                            ));
                             if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
@@ -4558,29 +4599,29 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             if (lParse.Nodes[yyvs[yyvsp - 2].node() as usize]).ntype
                                 > (lParse.Nodes[yyvs[yyvsp].node() as usize]).ntype
                             {
-                                yyvs[yyvsp].Node = New_Unary(
+                                yyvs[yyvsp] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                     lParse,
                                     ((lParse.Nodes)[yyvs[yyvsp - 2].node() as usize]).ntype,
                                     0,
                                     yyvs[yyvsp].node(),
-                                );
+                                ));
                             } else if ((lParse.Nodes)[yyvs[yyvsp - 2].node() as usize]).ntype
                                 < (lParse.Nodes[yyvs[yyvsp].node() as usize]).ntype
                             {
-                                yyvs[yyvsp - 2].Node = New_Unary(
+                                yyvs[yyvsp - 2] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                     lParse,
                                     (lParse.Nodes[yyvs[yyvsp].node() as usize]).ntype,
                                     0,
                                     yyvs[yyvsp - 2].node(),
-                                );
+                                ));
                             }
-                            yyval.Node = New_BinOp(
+                            yyval = FITS_PARSER_YYSTYPE::Node(New_BinOp(
                                 lParse,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
                                 yyvs[yyvsp - 2].node(),
                                 fits_parser_yytokentype::GTE as c_int,
                                 yyvs[yyvsp].node(),
-                            );
+                            ));
                             if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
@@ -4592,29 +4633,29 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             if (lParse.Nodes[yyvs[yyvsp - 2].node() as usize]).ntype
                                 > (lParse.Nodes[yyvs[yyvsp].node() as usize]).ntype
                             {
-                                yyvs[yyvsp].Node = New_Unary(
+                                yyvs[yyvsp] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                     lParse,
                                     ((lParse.Nodes)[yyvs[yyvsp - 2].node() as usize]).ntype,
                                     0,
                                     yyvs[yyvsp].node(),
-                                );
+                                ));
                             } else if ((lParse.Nodes)[yyvs[yyvsp - 2].node() as usize]).ntype
                                 < (lParse.Nodes[yyvs[yyvsp].node() as usize]).ntype
                             {
-                                yyvs[yyvsp - 2].Node = New_Unary(
+                                yyvs[yyvsp - 2] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                     lParse,
                                     (lParse.Nodes[yyvs[yyvsp].node() as usize]).ntype,
                                     0,
                                     yyvs[yyvsp - 2].node(),
-                                );
+                                ));
                             }
-                            yyval.Node = New_BinOp(
+                            yyval = FITS_PARSER_YYSTYPE::Node(New_BinOp(
                                 lParse,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
                                 yyvs[yyvsp - 2].node(),
                                 fits_parser_yytokentype::LTE as c_int,
                                 yyvs[yyvsp].node(),
-                            );
+                            ));
                             if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
@@ -4626,29 +4667,29 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             if (lParse.Nodes[yyvs[yyvsp - 2].node() as usize]).ntype
                                 > (lParse.Nodes[yyvs[yyvsp].node() as usize]).ntype
                             {
-                                yyvs[yyvsp].Node = New_Unary(
+                                yyvs[yyvsp] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                     lParse,
                                     ((lParse.Nodes)[yyvs[yyvsp - 2].node() as usize]).ntype,
                                     0,
                                     yyvs[yyvsp].node(),
-                                );
+                                ));
                             } else if ((lParse.Nodes)[yyvs[yyvsp - 2].node() as usize]).ntype
                                 < (lParse.Nodes[yyvs[yyvsp].node() as usize]).ntype
                             {
-                                yyvs[yyvsp - 2].Node = New_Unary(
+                                yyvs[yyvsp - 2] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                     lParse,
                                     (lParse.Nodes[yyvs[yyvsp].node() as usize]).ntype,
                                     0,
                                     yyvs[yyvsp - 2].node(),
-                                );
+                                ));
                             }
-                            yyval.Node = New_BinOp(
+                            yyval = FITS_PARSER_YYSTYPE::Node(New_BinOp(
                                 lParse,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
                                 yyvs[yyvsp - 2].node(),
                                 '~' as i32,
                                 yyvs[yyvsp].node(),
-                            );
+                            ));
                             if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
@@ -4660,29 +4701,29 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             if (lParse.Nodes[yyvs[yyvsp - 2].node() as usize]).ntype
                                 > (lParse.Nodes[yyvs[yyvsp].node() as usize]).ntype
                             {
-                                yyvs[yyvsp].Node = New_Unary(
+                                yyvs[yyvsp] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                     lParse,
                                     ((lParse.Nodes)[yyvs[yyvsp - 2].node() as usize]).ntype,
                                     0,
                                     yyvs[yyvsp].node(),
-                                );
+                                ));
                             } else if ((lParse.Nodes)[yyvs[yyvsp - 2].node() as usize]).ntype
                                 < (lParse.Nodes[yyvs[yyvsp].node() as usize]).ntype
                             {
-                                yyvs[yyvsp - 2].Node = New_Unary(
+                                yyvs[yyvsp - 2] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                     lParse,
                                     (lParse.Nodes[yyvs[yyvsp].node() as usize]).ntype,
                                     0,
                                     yyvs[yyvsp - 2].node(),
-                                );
+                                ));
                             }
-                            yyval.Node = New_BinOp(
+                            yyval = FITS_PARSER_YYSTYPE::Node(New_BinOp(
                                 lParse,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
                                 yyvs[yyvsp - 2].node(),
                                 fits_parser_yytokentype::EQ as c_int,
                                 yyvs[yyvsp].node(),
-                            );
+                            ));
                             if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
@@ -4694,29 +4735,29 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             if (lParse.Nodes[yyvs[yyvsp - 2].node() as usize]).ntype
                                 > (lParse.Nodes[yyvs[yyvsp].node() as usize]).ntype
                             {
-                                yyvs[yyvsp].Node = New_Unary(
+                                yyvs[yyvsp] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                     lParse,
                                     ((lParse.Nodes)[yyvs[yyvsp - 2].node() as usize]).ntype,
                                     0,
                                     yyvs[yyvsp].node(),
-                                );
+                                ));
                             } else if ((lParse.Nodes)[yyvs[yyvsp - 2].node() as usize]).ntype
                                 < (lParse.Nodes[yyvs[yyvsp].node() as usize]).ntype
                             {
-                                yyvs[yyvsp - 2].Node = New_Unary(
+                                yyvs[yyvsp - 2] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                     lParse,
                                     (lParse.Nodes[yyvs[yyvsp].node() as usize]).ntype,
                                     0,
                                     yyvs[yyvsp - 2].node(),
-                                );
+                                ));
                             }
-                            yyval.Node = New_BinOp(
+                            yyval = FITS_PARSER_YYSTYPE::Node(New_BinOp(
                                 lParse,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
                                 yyvs[yyvsp - 2].node(),
                                 fits_parser_yytokentype::NE as c_int,
                                 yyvs[yyvsp].node(),
-                            );
+                            ));
                             if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
@@ -4725,13 +4766,13 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         }
                         90 => {
                             /* bexpr: sexpr EQ sexpr  */
-                            yyval.Node = New_BinOp(
+                            yyval = FITS_PARSER_YYSTYPE::Node(New_BinOp(
                                 lParse,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
                                 yyvs[yyvsp - 2].node(),
                                 fits_parser_yytokentype::EQ as c_int,
                                 yyvs[yyvsp].node(),
-                            );
+                            ));
                             if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
@@ -4741,13 +4782,13 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         }
                         91 => {
                             /* bexpr: sexpr NE sexpr  */
-                            yyval.Node = New_BinOp(
+                            yyval = FITS_PARSER_YYSTYPE::Node(New_BinOp(
                                 lParse,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
                                 yyvs[yyvsp - 2].node(),
                                 fits_parser_yytokentype::NE as c_int,
                                 yyvs[yyvsp].node(),
-                            );
+                            ));
                             if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
@@ -4757,13 +4798,13 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         }
                         92 => {
                             /* bexpr: sexpr GT sexpr  */
-                            yyval.Node = New_BinOp(
+                            yyval = FITS_PARSER_YYSTYPE::Node(New_BinOp(
                                 lParse,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
                                 yyvs[yyvsp - 2].node(),
                                 fits_parser_yytokentype::GT as c_int,
                                 yyvs[yyvsp].node(),
-                            );
+                            ));
                             if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
@@ -4773,13 +4814,13 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         }
                         93 => {
                             /* bexpr: sexpr GTE sexpr  */
-                            yyval.Node = New_BinOp(
+                            yyval = FITS_PARSER_YYSTYPE::Node(New_BinOp(
                                 lParse,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
                                 yyvs[yyvsp - 2].node(),
                                 fits_parser_yytokentype::GTE as c_int,
                                 yyvs[yyvsp].node(),
-                            );
+                            ));
                             if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
@@ -4789,13 +4830,13 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         }
                         94 => {
                             /* bexpr: sexpr LT sexpr  */
-                            yyval.Node = New_BinOp(
+                            yyval = FITS_PARSER_YYSTYPE::Node(New_BinOp(
                                 lParse,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
                                 yyvs[yyvsp - 2].node(),
                                 fits_parser_yytokentype::LT as c_int,
                                 yyvs[yyvsp].node(),
-                            );
+                            ));
                             if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
@@ -4805,13 +4846,13 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         }
                         95 => {
                             /* bexpr: sexpr LTE sexpr  */
-                            yyval.Node = New_BinOp(
+                            yyval = FITS_PARSER_YYSTYPE::Node(New_BinOp(
                                 lParse,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
                                 yyvs[yyvsp - 2].node(),
                                 fits_parser_yytokentype::LTE as c_int,
                                 yyvs[yyvsp].node(),
-                            );
+                            ));
                             if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
@@ -4821,13 +4862,13 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         }
                         96 => {
                             /* bexpr: bexpr AND bexpr  */
-                            yyval.Node = New_BinOp(
+                            yyval = FITS_PARSER_YYSTYPE::Node(New_BinOp(
                                 lParse,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
                                 yyvs[yyvsp - 2].node(),
                                 fits_parser_yytokentype::AND as c_int,
                                 yyvs[yyvsp].node(),
-                            );
+                            ));
                             if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
@@ -4836,13 +4877,13 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         }
                         97 => {
                             /* bexpr: bexpr OR bexpr  */
-                            yyval.Node = New_BinOp(
+                            yyval = FITS_PARSER_YYSTYPE::Node(New_BinOp(
                                 lParse,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
                                 yyvs[yyvsp - 2].node(),
                                 fits_parser_yytokentype::OR as c_int,
                                 yyvs[yyvsp].node(),
-                            );
+                            ));
                             if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
@@ -4851,13 +4892,13 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         }
                         98 => {
                             /* bexpr: bexpr EQ bexpr  */
-                            yyval.Node = New_BinOp(
+                            yyval = FITS_PARSER_YYSTYPE::Node(New_BinOp(
                                 lParse,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
                                 yyvs[yyvsp - 2].node(),
                                 fits_parser_yytokentype::EQ as c_int,
                                 yyvs[yyvsp].node(),
-                            );
+                            ));
                             if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
@@ -4866,13 +4907,13 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         }
                         99 => {
                             /* bexpr: bexpr NE bexpr  */
-                            yyval.Node = New_BinOp(
+                            yyval = FITS_PARSER_YYSTYPE::Node(New_BinOp(
                                 lParse,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
                                 yyvs[yyvsp - 2].node(),
                                 fits_parser_yytokentype::NE as c_int,
                                 yyvs[yyvsp].node(),
-                            );
+                            ));
                             if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
@@ -4884,81 +4925,81 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             if ((lParse.Nodes)[yyvs[yyvsp - 4].node() as usize]).ntype
                                 > (lParse.Nodes[yyvs[yyvsp - 2].node() as usize]).ntype
                             {
-                                yyvs[yyvsp - 2].Node = New_Unary(
+                                yyvs[yyvsp - 2] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                     lParse,
                                     ((lParse.Nodes)[yyvs[yyvsp - 4].node() as usize]).ntype,
                                     0,
                                     yyvs[yyvsp - 2].node(),
-                                );
+                                ));
                             } else if ((lParse.Nodes)[yyvs[yyvsp - 4].node() as usize]).ntype
                                 < (lParse.Nodes[yyvs[yyvsp - 2].node() as usize]).ntype
                             {
-                                yyvs[yyvsp - 4].Node = New_Unary(
+                                yyvs[yyvsp - 4] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                     lParse,
                                     ((lParse.Nodes)[yyvs[yyvsp - 2].node() as usize]).ntype,
                                     0,
                                     yyvs[yyvsp - 4].node(),
-                                );
+                                ));
                             }
                             if ((lParse.Nodes)[yyvs[yyvsp - 4].node() as usize]).ntype
                                 > (lParse.Nodes[yyvs[yyvsp].node() as usize]).ntype
                             {
-                                yyvs[yyvsp].Node = New_Unary(
+                                yyvs[yyvsp] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                     lParse,
                                     ((lParse.Nodes)[yyvs[yyvsp - 4].node() as usize]).ntype,
                                     0,
                                     yyvs[yyvsp].node(),
-                                );
+                                ));
                             } else if ((lParse.Nodes)[yyvs[yyvsp - 4].node() as usize]).ntype
                                 < (lParse.Nodes[yyvs[yyvsp].node() as usize]).ntype
                             {
-                                yyvs[yyvsp - 4].Node = New_Unary(
+                                yyvs[yyvsp - 4] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                     lParse,
                                     (lParse.Nodes[yyvs[yyvsp].node() as usize]).ntype,
                                     0,
                                     yyvs[yyvsp - 4].node(),
-                                );
+                                ));
                             }
                             if (lParse.Nodes[yyvs[yyvsp - 2].node() as usize]).ntype
                                 > (lParse.Nodes[yyvs[yyvsp].node() as usize]).ntype
                             {
-                                yyvs[yyvsp].Node = New_Unary(
+                                yyvs[yyvsp] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                     lParse,
                                     ((lParse.Nodes)[yyvs[yyvsp - 2].node() as usize]).ntype,
                                     0,
                                     yyvs[yyvsp].node(),
-                                );
+                                ));
                             } else if ((lParse.Nodes)[yyvs[yyvsp - 2].node() as usize]).ntype
                                 < (lParse.Nodes[yyvs[yyvsp].node() as usize]).ntype
                             {
-                                yyvs[yyvsp - 2].Node = New_Unary(
+                                yyvs[yyvsp - 2] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                     lParse,
                                     (lParse.Nodes[yyvs[yyvsp].node() as usize]).ntype,
                                     0,
                                     yyvs[yyvsp - 2].node(),
-                                );
+                                ));
                             }
-                            yyvs[yyvsp - 2].Node = New_BinOp(
+                            yyvs[yyvsp - 2] = FITS_PARSER_YYSTYPE::Node(New_BinOp(
                                 lParse,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
                                 yyvs[yyvsp - 2].node(),
                                 fits_parser_yytokentype::LTE as c_int,
                                 yyvs[yyvsp - 4].node(),
-                            );
-                            yyvs[yyvsp].Node = New_BinOp(
+                            ));
+                            yyvs[yyvsp] = FITS_PARSER_YYSTYPE::Node(New_BinOp(
                                 lParse,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
                                 yyvs[yyvsp - 4].node(),
                                 fits_parser_yytokentype::LTE as c_int,
                                 yyvs[yyvsp].node(),
-                            );
-                            yyval.Node = New_BinOp(
+                            ));
+                            yyval = FITS_PARSER_YYSTYPE::Node(New_BinOp(
                                 lParse,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
                                 yyvs[yyvsp - 2].node(),
                                 fits_parser_yytokentype::AND as c_int,
                                 yyvs[yyvsp].node(),
-                            );
+                            ));
                             if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
@@ -4974,7 +5015,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 );
                                 current_block = Block::YyErrLab;
                             } else {
-                                yyval.Node = New_Func(
+                                yyval = FITS_PARSER_YYSTYPE::Node(New_Func(
                                     lParse,
                                     0,
                                     IFTHENELSE_FCT,
@@ -4986,7 +5027,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     0,
                                     0,
                                     0,
-                                );
+                                ));
                                 if yyval.node() < 0 {
                                     current_block = Block::YyErrLab;
                                 } else {
@@ -5020,7 +5061,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         102 => {
                             /* bexpr: BFUNCTION expr ')'  */
                             if astr_eq(yyvs[yyvsp - 2].astr(), c"ISNULL(") {
-                                yyval.Node = New_Func(
+                                yyval = FITS_PARSER_YYSTYPE::Node(New_Func(
                                     lParse,
                                     0,
                                     ISNULL_FCT,
@@ -5032,7 +5073,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     0,
                                     0,
                                     0,
-                                );
+                                ));
                                 if yyval.node() < 0 {
                                     current_block = Block::YyErrLab;
                                 } else {
@@ -5051,7 +5092,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         103 => {
                             /* bexpr: BFUNCTION bexpr ')'  */
                             if astr_eq(yyvs[yyvsp - 2].astr(), c"ISNULL(") {
-                                yyval.Node = New_Func(
+                                yyval = FITS_PARSER_YYSTYPE::Node(New_Func(
                                     lParse,
                                     0,
                                     ISNULL_FCT,
@@ -5063,7 +5104,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     0,
                                     0,
                                     0,
-                                );
+                                ));
                                 if yyval.node() < 0 {
                                     current_block = Block::YyErrLab;
                                 } else {
@@ -5082,7 +5123,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         104 => {
                             /* bexpr: BFUNCTION sexpr ')'  */
                             if astr_eq(yyvs[yyvsp - 2].astr(), c"ISNULL(") {
-                                yyval.Node = New_Func(
+                                yyval = FITS_PARSER_YYSTYPE::Node(New_Func(
                                     lParse,
                                     fits_parser_yytokentype::BOOLEAN as c_int,
                                     ISNULL_FCT,
@@ -5094,7 +5135,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     0,
                                     0,
                                     0,
-                                );
+                                ));
                                 if yyval.node() < 0 {
                                     current_block = Block::YyErrLab;
                                 } else {
@@ -5123,7 +5164,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         yyvs[yyvsp - 1].node(),
                                     ) != 0
                                 {
-                                    yyval.Node = New_Func(
+                                    yyval = FITS_PARSER_YYSTYPE::Node(New_Func(
                                         lParse,
                                         0,
                                         DEFNULL_FCT,
@@ -5135,7 +5176,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         0,
                                         0,
                                         0,
-                                    );
+                                    ));
                                     if yyval.node() < 0 {
                                         current_block = Block::YyErrLab;
                                     } else {
@@ -5161,32 +5202,32 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             if ((lParse.Nodes)[yyvs[yyvsp - 5].node() as usize]).ntype
                                 != fits_parser_yytokentype::DOUBLE as c_int
                             {
-                                yyvs[yyvsp - 5].Node = New_Unary(
+                                yyvs[yyvsp - 5] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                     lParse,
                                     fits_parser_yytokentype::DOUBLE as c_int,
                                     0,
                                     yyvs[yyvsp - 5].node(),
-                                );
+                                ));
                             }
                             if ((lParse.Nodes)[yyvs[yyvsp - 3].node() as usize]).ntype
                                 != fits_parser_yytokentype::DOUBLE as c_int
                             {
-                                yyvs[yyvsp - 3].Node = New_Unary(
+                                yyvs[yyvsp - 3] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                     lParse,
                                     fits_parser_yytokentype::DOUBLE as c_int,
                                     0,
                                     yyvs[yyvsp - 3].node(),
-                                );
+                                ));
                             }
                             if ((lParse.Nodes)[yyvs[yyvsp - 1].node() as usize]).ntype
                                 != fits_parser_yytokentype::DOUBLE as c_int
                             {
-                                yyvs[yyvsp - 1].Node = New_Unary(
+                                yyvs[yyvsp - 1] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                     lParse,
                                     fits_parser_yytokentype::DOUBLE as c_int,
                                     0,
                                     yyvs[yyvsp - 1].node(),
-                                );
+                                ));
                             }
                             if !(Test_Dims(lParse, yyvs[yyvsp - 5].node(), yyvs[yyvsp - 3].node())
                                 != 0
@@ -5202,7 +5243,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 );
                                 current_block = Block::YyErrLab;
                             } else if astr_eq(yyvs[yyvsp - 6].astr(), c"NEAR(") {
-                                yyval.Node = New_Func(
+                                yyval = FITS_PARSER_YYSTYPE::Node(New_Func(
                                     lParse,
                                     fits_parser_yytokentype::BOOLEAN as c_int,
                                     NEAR_FCT,
@@ -5214,7 +5255,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     0,
                                     0,
                                     0,
-                                );
+                                ));
                                 if yyval.node() < 0 {
                                     current_block = Block::YyErrLab;
                                 } else {
@@ -5255,52 +5296,52 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             if ((lParse.Nodes)[yyvs[yyvsp - 9].node() as usize]).ntype
                                 != fits_parser_yytokentype::DOUBLE as c_int
                             {
-                                yyvs[yyvsp - 9].Node = New_Unary(
+                                yyvs[yyvsp - 9] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                     lParse,
                                     fits_parser_yytokentype::DOUBLE as c_int,
                                     0,
                                     yyvs[yyvsp - 9].node(),
-                                );
+                                ));
                             }
                             if ((lParse.Nodes)[yyvs[yyvsp - 7].node() as usize]).ntype
                                 != fits_parser_yytokentype::DOUBLE as c_int
                             {
-                                yyvs[yyvsp - 7].Node = New_Unary(
+                                yyvs[yyvsp - 7] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                     lParse,
                                     fits_parser_yytokentype::DOUBLE as c_int,
                                     0,
                                     yyvs[yyvsp - 7].node(),
-                                );
+                                ));
                             }
                             if ((lParse.Nodes)[yyvs[yyvsp - 5].node() as usize]).ntype
                                 != fits_parser_yytokentype::DOUBLE as c_int
                             {
-                                yyvs[yyvsp - 5].Node = New_Unary(
+                                yyvs[yyvsp - 5] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                     lParse,
                                     fits_parser_yytokentype::DOUBLE as c_int,
                                     0,
                                     yyvs[yyvsp - 5].node(),
-                                );
+                                ));
                             }
                             if ((lParse.Nodes)[yyvs[yyvsp - 3].node() as usize]).ntype
                                 != fits_parser_yytokentype::DOUBLE as c_int
                             {
-                                yyvs[yyvsp - 3].Node = New_Unary(
+                                yyvs[yyvsp - 3] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                     lParse,
                                     fits_parser_yytokentype::DOUBLE as c_int,
                                     0,
                                     yyvs[yyvsp - 3].node(),
-                                );
+                                ));
                             }
                             if ((lParse.Nodes)[yyvs[yyvsp - 1].node() as usize]).ntype
                                 != fits_parser_yytokentype::DOUBLE as c_int
                             {
-                                yyvs[yyvsp - 1].Node = New_Unary(
+                                yyvs[yyvsp - 1] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                     lParse,
                                     fits_parser_yytokentype::DOUBLE as c_int,
                                     0,
                                     yyvs[yyvsp - 1].node(),
-                                );
+                                ));
                             }
                             if !(Test_Dims(lParse, yyvs[yyvsp - 9].node(), yyvs[yyvsp - 7].node())
                                 != 0
@@ -5326,7 +5367,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 );
                                 current_block = Block::YyErrLab;
                             } else if astr_eq(yyvs[yyvsp - 10].astr(), c"CIRCLE(") {
-                                yyval.Node = New_Func(
+                                yyval = FITS_PARSER_YYSTYPE::Node(New_Func(
                                     lParse,
                                     fits_parser_yytokentype::BOOLEAN as c_int,
                                     CIRCLE_FCT,
@@ -5338,7 +5379,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     yyvs[yyvsp - 1].node(),
                                     0,
                                     0,
-                                );
+                                ));
                                 if yyval.node() < 0 {
                                     current_block = Block::YyErrLab;
                                 } else {
@@ -5397,72 +5438,72 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             if ((lParse.Nodes)[yyvs[yyvsp - 13].node() as usize]).ntype
                                 != fits_parser_yytokentype::DOUBLE as c_int
                             {
-                                yyvs[yyvsp - 13].Node = New_Unary(
+                                yyvs[yyvsp - 13] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                     lParse,
                                     fits_parser_yytokentype::DOUBLE as c_int,
                                     0,
                                     yyvs[yyvsp - 13].node(),
-                                );
+                                ));
                             }
                             if ((lParse.Nodes)[yyvs[yyvsp - 11].node() as usize]).ntype
                                 != fits_parser_yytokentype::DOUBLE as c_int
                             {
-                                yyvs[yyvsp - 11].Node = New_Unary(
+                                yyvs[yyvsp - 11] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                     lParse,
                                     fits_parser_yytokentype::DOUBLE as c_int,
                                     0,
                                     yyvs[yyvsp - 11].node(),
-                                );
+                                ));
                             }
                             if ((lParse.Nodes)[yyvs[yyvsp - 9].node() as usize]).ntype
                                 != fits_parser_yytokentype::DOUBLE as c_int
                             {
-                                yyvs[yyvsp - 9].Node = New_Unary(
+                                yyvs[yyvsp - 9] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                     lParse,
                                     fits_parser_yytokentype::DOUBLE as c_int,
                                     0,
                                     yyvs[yyvsp - 9].node(),
-                                );
+                                ));
                             }
                             if ((lParse.Nodes)[yyvs[yyvsp - 7].node() as usize]).ntype
                                 != fits_parser_yytokentype::DOUBLE as c_int
                             {
-                                yyvs[yyvsp - 7].Node = New_Unary(
+                                yyvs[yyvsp - 7] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                     lParse,
                                     fits_parser_yytokentype::DOUBLE as c_int,
                                     0,
                                     yyvs[yyvsp - 7].node(),
-                                );
+                                ));
                             }
                             if ((lParse.Nodes)[yyvs[yyvsp - 5].node() as usize]).ntype
                                 != fits_parser_yytokentype::DOUBLE as c_int
                             {
-                                yyvs[yyvsp - 5].Node = New_Unary(
+                                yyvs[yyvsp - 5] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                     lParse,
                                     fits_parser_yytokentype::DOUBLE as c_int,
                                     0,
                                     yyvs[yyvsp - 5].node(),
-                                );
+                                ));
                             }
                             if ((lParse.Nodes)[yyvs[yyvsp - 3].node() as usize]).ntype
                                 != fits_parser_yytokentype::DOUBLE as c_int
                             {
-                                yyvs[yyvsp - 3].Node = New_Unary(
+                                yyvs[yyvsp - 3] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                     lParse,
                                     fits_parser_yytokentype::DOUBLE as c_int,
                                     0,
                                     yyvs[yyvsp - 3].node(),
-                                );
+                                ));
                             }
                             if ((lParse.Nodes)[yyvs[yyvsp - 1].node() as usize]).ntype
                                 != fits_parser_yytokentype::DOUBLE as c_int
                             {
-                                yyvs[yyvsp - 1].Node = New_Unary(
+                                yyvs[yyvsp - 1] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                     lParse,
                                     fits_parser_yytokentype::DOUBLE as c_int,
                                     0,
                                     yyvs[yyvsp - 1].node(),
-                                );
+                                ));
                             }
                             if !(Test_Dims(
                                 lParse,
@@ -5499,7 +5540,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 current_block = Block::YyErrLab;
                             } else {
                                 if astr_eq(yyvs[yyvsp - 14].astr(), c"BOX(") {
-                                    yyval.Node = New_Func(
+                                    yyval = FITS_PARSER_YYSTYPE::Node(New_Func(
                                         lParse,
                                         fits_parser_yytokentype::BOOLEAN as c_int,
                                         BOX_FCT,
@@ -5511,10 +5552,10 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         yyvs[yyvsp - 5].node(),
                                         yyvs[yyvsp - 3].node(),
                                         yyvs[yyvsp - 1].node(),
-                                    );
+                                    ));
                                     current_block = Block::ReduceJoin12;
                                 } else if astr_eq(yyvs[yyvsp - 14].astr(), c"ELLIPSE(") {
-                                    yyval.Node = New_Func(
+                                    yyval = FITS_PARSER_YYSTYPE::Node(New_Func(
                                         lParse,
                                         fits_parser_yytokentype::BOOLEAN as c_int,
                                         ELPS_FCT,
@@ -5526,7 +5567,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         yyvs[yyvsp - 5].node(),
                                         yyvs[yyvsp - 3].node(),
                                         yyvs[yyvsp - 1].node(),
-                                    );
+                                    ));
                                     current_block = Block::ReduceJoin12;
                                 } else {
                                     fits_parser_yyerror(
@@ -5639,7 +5680,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         109 => {
                             /* bexpr: GTIFILTER ')'  */
                             /* Use defaults for all elements */
-                            yyval.Node = New_GTI(
+                            yyval = FITS_PARSER_YYSTYPE::Node(New_GTI(
                                 lParse,
                                 GTIFILT_FCT,
                                 (b"\0" as *const u8).cast::<c_char>() as *mut c_char,
@@ -5647,7 +5688,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 -99,
                                 c"*START*".as_ptr() as *mut c_char,
                                 c"*STOP*".as_ptr() as *mut c_char,
-                            );
+                            ));
                             if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
@@ -5657,7 +5698,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         110 => {
                             /* bexpr: GTIFILTER STRING ')'  */
                             /* Use defaults for all except filename */
-                            yyval.Node = New_GTI(
+                            yyval = FITS_PARSER_YYSTYPE::Node(New_GTI(
                                 lParse,
                                 GTIFILT_FCT,
                                 (yyvs[yyvsp - 1].astr_mut()).as_mut_ptr(),
@@ -5665,7 +5706,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 -99,
                                 c"*START*".as_ptr() as *mut c_char,
                                 c"*STOP*".as_ptr() as *mut c_char,
-                            );
+                            ));
                             if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
@@ -5674,7 +5715,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         }
                         111 => {
                             /* bexpr: GTIFILTER STRING ',' expr ')'  */
-                            yyval.Node = New_GTI(
+                            yyval = FITS_PARSER_YYSTYPE::Node(New_GTI(
                                 lParse,
                                 GTIFILT_FCT,
                                 (yyvs[yyvsp - 3].astr_mut()).as_mut_ptr(),
@@ -5682,7 +5723,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 -99,
                                 c"*START*".as_ptr() as *mut c_char,
                                 c"*STOP*".as_ptr() as *mut c_char,
-                            );
+                            ));
                             if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
@@ -5691,7 +5732,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         }
                         112 => {
                             /* bexpr: GTIFILTER STRING ',' expr ',' STRING ',' STRING ')'  */
-                            yyval.Node = New_GTI(
+                            yyval = FITS_PARSER_YYSTYPE::Node(New_GTI(
                                 lParse,
                                 GTIFILT_FCT,
                                 (yyvs[yyvsp - 7].astr_mut()).as_mut_ptr(),
@@ -5699,7 +5740,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 -99,
                                 (yyvs[yyvsp - 3].astr_mut()).as_mut_ptr(),
                                 (yyvs[yyvsp - 1].astr_mut()).as_mut_ptr(),
-                            );
+                            ));
                             if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
@@ -5709,7 +5750,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         113 => {
                             /* bexpr: GTIFIND ')'  */
                             /* Use defaults for all elements */
-                            yyval.Node = New_GTI(
+                            yyval = FITS_PARSER_YYSTYPE::Node(New_GTI(
                                 lParse,
                                 GTIFIND_FCT,
                                 (b"\0" as *const u8).cast::<c_char>() as *mut c_char,
@@ -5717,7 +5758,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 -99,
                                 c"*START*".as_ptr() as *mut c_char,
                                 c"*STOP*".as_ptr() as *mut c_char,
-                            );
+                            ));
                             if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
@@ -5726,7 +5767,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         }
                         114 => {
                             /* bexpr: GTIFIND STRING ')'  *//* Use defaults for all except filename */
-                            yyval.Node = New_GTI(
+                            yyval = FITS_PARSER_YYSTYPE::Node(New_GTI(
                                 lParse,
                                 GTIFIND_FCT,
                                 (yyvs[yyvsp - 1].astr_mut()).as_mut_ptr(),
@@ -5734,7 +5775,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 -99,
                                 c"*START*".as_ptr() as *mut c_char,
                                 c"*STOP*".as_ptr() as *mut c_char,
-                            );
+                            ));
                             if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
@@ -5743,7 +5784,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         }
                         115 => {
                             /* bexpr: GTIFIND STRING ',' expr ')'  */
-                            yyval.Node = New_GTI(
+                            yyval = FITS_PARSER_YYSTYPE::Node(New_GTI(
                                 lParse,
                                 GTIFIND_FCT,
                                 (yyvs[yyvsp - 3].astr_mut()).as_mut_ptr(),
@@ -5751,7 +5792,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 -99,
                                 c"*START*".as_ptr() as *mut c_char,
                                 c"*STOP*".as_ptr() as *mut c_char,
-                            );
+                            ));
                             if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
@@ -5760,7 +5801,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         }
                         116 => {
                             /* bexpr: GTIFIND STRING ',' expr ',' STRING ',' STRING ')'  */
-                            yyval.Node = New_GTI(
+                            yyval = FITS_PARSER_YYSTYPE::Node(New_GTI(
                                 lParse,
                                 GTIFIND_FCT,
                                 (yyvs[yyvsp - 7].astr_mut()).as_mut_ptr(),
@@ -5768,7 +5809,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 -99,
                                 (yyvs[yyvsp - 3].astr_mut()).as_mut_ptr(),
                                 (yyvs[yyvsp - 1].astr_mut()).as_mut_ptr(),
-                            );
+                            ));
                             if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
@@ -5778,13 +5819,13 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         117 => {
                             /* bexpr: REGFILTER STRING ')'  *//* Use defaults for all except filename */
                             let mut dummy = [0];
-                            yyval.Node = New_REG(
+                            yyval = FITS_PARSER_YYSTYPE::Node(New_REG(
                                 lParse,
                                 (yyvs[yyvsp - 1].astr_mut()).as_mut_ptr(),
                                 -99,
                                 -99,
                                 dummy.as_mut_ptr(),
-                            );
+                            ));
                             if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
@@ -5794,13 +5835,13 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         118 => {
                             /* bexpr: REGFILTER STRING ',' expr ',' expr ')'  */
                             let mut dummy = [0];
-                            yyval.Node = New_REG(
+                            yyval = FITS_PARSER_YYSTYPE::Node(New_REG(
                                 lParse,
                                 (yyvs[yyvsp - 5].astr_mut()).as_mut_ptr(),
                                 yyvs[yyvsp - 3].node(),
                                 yyvs[yyvsp - 1].node(),
                                 dummy.as_mut_ptr(),
-                            );
+                            ));
                             if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
@@ -5809,13 +5850,13 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         }
                         119 => {
                             /* bexpr: REGFILTER STRING ',' expr ',' expr ',' STRING ')'  */
-                            yyval.Node = New_REG(
+                            yyval = FITS_PARSER_YYSTYPE::Node(New_REG(
                                 lParse,
                                 (yyvs[yyvsp - 7].astr_mut()).as_mut_ptr(),
                                 yyvs[yyvsp - 5].node(),
                                 yyvs[yyvsp - 3].node(),
                                 (yyvs[yyvsp - 1].astr_mut()).as_mut_ptr(),
-                            );
+                            ));
                             if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
@@ -5824,7 +5865,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         }
                         120 => {
                             /* bexpr: bexpr '[' expr ']'  */
-                            yyval.Node = New_Deref(
+                            yyval = FITS_PARSER_YYSTYPE::Node(New_Deref(
                                 lParse,
                                 yyvs[yyvsp - 3].node(),
                                 1,
@@ -5833,7 +5874,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 0,
                                 0,
                                 0,
-                            );
+                            ));
                             if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
@@ -5842,7 +5883,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         }
                         121 => {
                             /* bexpr: bexpr '[' expr ',' expr ']'  */
-                            yyval.Node = New_Deref(
+                            yyval = FITS_PARSER_YYSTYPE::Node(New_Deref(
                                 lParse,
                                 yyvs[yyvsp - 5].node(),
                                 2,
@@ -5851,7 +5892,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 0,
                                 0,
                                 0,
-                            );
+                            ));
                             if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
@@ -5860,7 +5901,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         }
                         122 => {
                             /* bexpr: bexpr '[' expr ',' expr ',' expr ']'  */
-                            yyval.Node = New_Deref(
+                            yyval = FITS_PARSER_YYSTYPE::Node(New_Deref(
                                 lParse,
                                 yyvs[yyvsp - 7].node(),
                                 3 as c_int,
@@ -5869,7 +5910,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 yyvs[yyvsp - 1].node(),
                                 0,
                                 0,
-                            );
+                            ));
                             if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
@@ -5878,7 +5919,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         }
                         123 => {
                             /* bexpr: bexpr '[' expr ',' expr ',' expr ',' expr ']'  */
-                            yyval.Node = New_Deref(
+                            yyval = FITS_PARSER_YYSTYPE::Node(New_Deref(
                                 lParse,
                                 yyvs[yyvsp - 9].node(),
                                 4 as c_int,
@@ -5887,7 +5928,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 yyvs[yyvsp - 3].node(),
                                 yyvs[yyvsp - 1].node(),
                                 0,
-                            );
+                            ));
                             if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
@@ -5896,7 +5937,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         }
                         124 => {
                             /* bexpr: bexpr '[' expr ',' expr ',' expr ',' expr ',' expr ']'  */
-                            yyval.Node = New_Deref(
+                            yyval = FITS_PARSER_YYSTYPE::Node(New_Deref(
                                 lParse,
                                 yyvs[yyvsp - 11].node(),
                                 5 as c_int,
@@ -5905,7 +5946,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 yyvs[yyvsp - 5].node(),
                                 yyvs[yyvsp - 3].node(),
                                 yyvs[yyvsp - 1].node(),
-                            );
+                            ));
                             if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
@@ -5914,12 +5955,12 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         }
                         125 => {
                             /* bexpr: NOT bexpr  */
-                            yyval.Node = New_Unary(
+                            yyval = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                 lParse,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
                                 fits_parser_yytokentype::NOT as c_int,
                                 yyvs[yyvsp].node(),
-                            );
+                            ));
                             if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
@@ -5928,18 +5969,18 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         }
                         126 => {
                             /* bexpr: '(' bexpr ')'  */
-                            yyval.Node = yyvs[yyvsp - 1].node();
+                            yyval = FITS_PARSER_YYSTYPE::Node(yyvs[yyvsp - 1].node());
                             current_block = Block::ReduceDone;
                         }
                         127 => {
                             /* sexpr: STRING  */
-                            yyval.Node = New_Const(
+                            yyval = FITS_PARSER_YYSTYPE::Node(New_Const(
                                 lParse,
                                 fits_parser_yytokentype::STRING as c_int,
                                 (yyvs[yyvsp].astr_mut()).as_mut_ptr().cast::<c_void>(),
                                 (astr_len(yyvs[yyvsp].astr())).wrapping_add((1).try_into().unwrap())
                                     as c_long,
-                            );
+                            ));
                             if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
@@ -5950,7 +5991,10 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         }
                         128 => {
                             /* sexpr: SCOLUMN  */
-                            yyval.Node = New_Column(lParse, yyvs[yyvsp].lng() as c_int);
+                            yyval = FITS_PARSER_YYSTYPE::Node(New_Column(
+                                lParse,
+                                yyvs[yyvsp].lng() as c_int,
+                            ));
                             if yyval.node() < 0 {
                                 current_block = Block::YyErrLab;
                             } else {
@@ -5970,11 +6014,11 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 );
                                 current_block = Block::YyErrLab;
                             } else {
-                                yyval.Node = New_Offset(
+                                yyval = FITS_PARSER_YYSTYPE::Node(New_Offset(
                                     lParse,
                                     yyvs[yyvsp - 3].lng() as c_int,
                                     yyvs[yyvsp - 1].node(),
-                                );
+                                ));
                                 if yyval.node() < 0 {
                                     current_block = Block::YyErrLab;
                                 } else {
@@ -5984,7 +6028,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         }
                         130 => {
                             /* sexpr: SNULLREF  */
-                            yyval.Node = New_Func(
+                            yyval = FITS_PARSER_YYSTYPE::Node(New_Func(
                                 lParse,
                                 fits_parser_yytokentype::STRING as c_int,
                                 NULL_FCT,
@@ -5996,12 +6040,12 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 0,
                                 0,
                                 0,
-                            );
+                            ));
                             current_block = Block::ReduceDone;
                         }
                         131 => {
                             /* sexpr: '(' sexpr ')'  */
-                            yyval.Node = yyvs[yyvsp - 1].node();
+                            yyval = FITS_PARSER_YYSTYPE::Node(yyvs[yyvsp - 1].node());
                             current_block = Block::ReduceDone;
                         }
                         132 => {
@@ -6016,13 +6060,13 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 );
                                 current_block = Block::YyErrLab;
                             } else {
-                                yyval.Node = New_BinOp(
+                                yyval = FITS_PARSER_YYSTYPE::Node(New_BinOp(
                                     lParse,
                                     fits_parser_yytokentype::STRING as c_int,
                                     yyvs[yyvsp - 2].node(),
                                     '+' as i32,
                                     yyvs[yyvsp].node(),
-                                );
+                                ));
                                 if yyval.node() < 0 {
                                     current_block = Block::YyErrLab;
                                 } else {
@@ -6064,7 +6108,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         ((lParse.Nodes)[yyvs[yyvsp].node() as usize]).value.nelem
                                             as c_int;
                                 }
-                                yyval.Node = New_FuncSize(
+                                yyval = FITS_PARSER_YYSTYPE::Node(New_FuncSize(
                                     lParse,
                                     0,
                                     IFTHENELSE_FCT,
@@ -6077,7 +6121,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     0,
                                     0,
                                     outSize,
-                                );
+                                ));
                                 if yyval.node() < 0 {
                                     current_block = Block::YyErrLab;
                                 } else {
@@ -6113,7 +6157,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         .nelem
                                         as c_int;
                                 }
-                                yyval.Node = New_FuncSize(
+                                yyval = FITS_PARSER_YYSTYPE::Node(New_FuncSize(
                                     lParse,
                                     0,
                                     DEFNULL_FCT,
@@ -6126,7 +6170,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     0,
                                     0,
                                     outSize_0,
-                                );
+                                ));
                                 if yyval.node() < 0 {
                                     current_block = Block::YyErrLab;
                                 } else {
@@ -6195,7 +6239,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         );
                                         current_block = Block::YyErrLab;
                                     } else {
-                                        yyval.Node = New_FuncSize(
+                                        yyval = FITS_PARSER_YYSTYPE::Node(New_FuncSize(
                                             lParse,
                                             0,
                                             STRMID_FCT,
@@ -6208,7 +6252,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                             0,
                                             0,
                                             len,
-                                        );
+                                        ));
                                         if yyval.node() < 0 {
                                             current_block = Block::YyErrLab;
                                         } else {
@@ -6529,7 +6573,7 @@ fn New_GTI(
         let mut timeSpan: c_double = 0.0;
         let mut xcol: [c_char; 20] = [0; 20];
         let mut xexpr: [c_char; 20] = [0; 20];
-        let mut colVal: FITS_PARSER_YYSTYPE = FITS_PARSER_YYSTYPE { Node: 0 };
+        let mut colVal: FITS_PARSER_YYSTYPE = FITS_PARSER_YYSTYPE::Node(0);
 
         if (Op as c_uint == GTIFILT_FCT as c_int as c_uint
             || Op as c_uint == GTIFIND_FCT as c_int as c_uint)
@@ -6944,7 +6988,7 @@ fn New_REG(
         };
         let mut cX: *mut c_char = ptr::null_mut();
         let mut cY: *mut c_char = ptr::null_mut();
-        let mut colVal: FITS_PARSER_YYSTYPE = FITS_PARSER_YYSTYPE { Node: 0 };
+        let mut colVal: FITS_PARSER_YYSTYPE = FITS_PARSER_YYSTYPE::Node(0);
         if NodeX == -99 {
             type_0 = fits_parser_yyGetVariable(lParse, cs!(c"X"), &mut colVal);
             if type_0 == fits_parser_yytokentype::COLUMN as c_int {

--- a/src/eval_y.rs
+++ b/src/eval_y.rs
@@ -97,6 +97,12 @@ fn astr_eq(buf: &[c_char], s: &CStr) -> bool {
         && needle.iter().zip(buf.iter()).all(|(&n, &b)| n == b as u8)
 }
 
+/// Safe equivalent of `strlen(astr)` for the fixed `astr` buffer: the number of
+/// bytes before the first NUL, bounded by the buffer length (never reads OOB).
+fn astr_len(buf: &[c_char]) -> usize {
+    buf.iter().position(|&b| b == 0).unwrap_or(buf.len())
+}
+
 pub type yy_state_t = yytype_int16;
 pub type yytype_int16 = c_short;
 pub type yysymbol_kind_t = c_int;
@@ -1620,15 +1626,14 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 lParse,
                                 fits_parser_yytokentype::BITSTR as c_int,
                                 (yyvs[yyvsp].astr).as_mut_ptr().cast::<c_void>(),
-                                (strlen((yyvs[yyvsp].astr).as_mut_ptr()))
-                                    .wrapping_add((1).try_into().unwrap())
+                                (astr_len(&yyvs[yyvsp].astr)).wrapping_add((1).try_into().unwrap())
                                     as c_long,
                             );
                             if yyval.Node < 0 {
                                 current_block = 4830776507462815627;
                             } else {
                                 (((lParse.Nodes)[yyval.Node as usize]).value).nelem =
-                                    strlen((yyvs[yyvsp].astr).as_mut_ptr()) as c_long;
+                                    astr_len(&yyvs[yyvsp].astr) as c_long;
                                 current_block = 17353983478346836848;
                             }
                         }
@@ -5743,15 +5748,14 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 lParse,
                                 fits_parser_yytokentype::STRING as c_int,
                                 (yyvs[yyvsp].astr).as_mut_ptr().cast::<c_void>(),
-                                (strlen((yyvs[yyvsp].astr).as_mut_ptr()))
-                                    .wrapping_add((1).try_into().unwrap())
+                                (astr_len(&yyvs[yyvsp].astr)).wrapping_add((1).try_into().unwrap())
                                     as c_long,
                             );
                             if yyval.Node < 0 {
                                 current_block = 4830776507462815627;
                             } else {
                                 (((lParse.Nodes)[yyval.Node as usize]).value).nelem =
-                                    strlen((yyvs[yyvsp].astr).as_mut_ptr()) as c_long;
+                                    astr_len(&yyvs[yyvsp].astr) as c_long;
                                 current_block = 17353983478346836848;
                             }
                         }

--- a/src/eval_y.rs
+++ b/src/eval_y.rs
@@ -10582,13 +10582,14 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                             let mut dptr: *mut c_long =
                                 (lParse.Nodes[theParams[0]]).value.data.lngptr;
                             let mut uptr: *mut c_char = (lParse.Nodes[theParams[0]]).value.undef;
-                            let mptr: *mut c_long = malloc(
-                                (::core::mem::size_of::<c_long>() as c_ulong)
-                                    .wrapping_mul(nelem as c_ulong)
-                                    .try_into()
-                                    .unwrap(),
-                            )
-                            .cast::<c_long>();
+                            let mut mptr_buf: Vec<c_long> = Vec::new();
+                            let mptr: *mut c_long =
+                                if mptr_buf.try_reserve_exact(nelem as usize).is_ok() {
+                                    mptr_buf.resize(nelem as usize, 0);
+                                    mptr_buf.as_mut_ptr()
+                                } else {
+                                    core::ptr::null_mut()
+                                };
                             let mut irow: c_int = 0;
                             if mptr.is_null() {
                                 fits_parser_yyerror(
@@ -10630,19 +10631,19 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                                     }
                                     irow += 1;
                                 }
-                                free(mptr.cast::<c_void>());
                             }
                         } else {
                             let mut dptr_0: *mut c_double =
                                 (lParse.Nodes[theParams[0]]).value.data.dblptr;
                             let mut uptr_0: *mut c_char = (lParse.Nodes[theParams[0]]).value.undef;
-                            let mptr_0: *mut c_double = malloc(
-                                (::core::mem::size_of::<c_double>() as c_ulong)
-                                    .wrapping_mul(nelem as c_ulong)
-                                    .try_into()
-                                    .unwrap(),
-                            )
-                            .cast::<c_double>();
+                            let mut mptr_0_buf: Vec<c_double> = Vec::new();
+                            let mptr_0: *mut c_double =
+                                if mptr_0_buf.try_reserve_exact(nelem as usize).is_ok() {
+                                    mptr_0_buf.resize(nelem as usize, 0.0);
+                                    mptr_0_buf.as_mut_ptr()
+                                } else {
+                                    core::ptr::null_mut()
+                                };
                             let mut irow_0: c_int = 0;
                             if mptr_0.is_null() {
                                 fits_parser_yyerror(
@@ -10684,7 +10685,6 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                                     }
                                     irow_0 += 1;
                                 }
-                                free(mptr_0.cast::<c_void>());
                             }
                         }
                     }

--- a/src/eval_y.rs
+++ b/src/eval_y.rs
@@ -14235,135 +14235,139 @@ fn padded_bit(s: &[c_char], width: usize, j: usize) -> c_char {
 }
 
 fn bitlgte(bits1: *mut c_char, oper: c_int, bits2: *mut c_char) -> c_char {
-    unsafe {
-        // Confine unsafe to reading the two NUL-terminated bit strings.
-        let l1 = strlen(bits1) as usize;
-        let l2 = strlen(bits2) as usize;
-        let s1 = core::slice::from_raw_parts(bits1, l1);
-        let s2 = core::slice::from_raw_parts(bits2, l2);
-        let length = l1.max(l2);
+    // Confine unsafe to reading the two NUL-terminated bit strings.
+    let (s1, s2) = unsafe {
+        (
+            core::slice::from_raw_parts(bits1, strlen(bits1) as usize),
+            core::slice::from_raw_parts(bits2, strlen(bits2) as usize),
+        )
+    };
+    let length = s1.len().max(s2.len());
 
-        // Interpret both strings as unsigned integers (rightmost char = LSB),
-        // skipping don't-care ('x'/'X') positions, then compare magnitudes.
-        let mut val1: c_int = 0;
-        let mut val2: c_int = 0;
-        let mut nextbit: c_int = 1;
-        for j in (0..length).rev() {
-            let chr1 = padded_bit(s1, length, j);
-            let chr2 = padded_bit(s2, length, j);
-            if chr1 != b'x' as c_char
-                && chr1 != b'X' as c_char
-                && chr2 != b'x' as c_char
-                && chr2 != b'X' as c_char
-            {
-                if chr1 == b'1' as c_char {
-                    val1 += nextbit;
-                }
-                if chr2 == b'1' as c_char {
-                    val2 += nextbit;
-                }
-                nextbit *= 2;
+    // Interpret both strings as unsigned integers (rightmost char = LSB),
+    // skipping don't-care ('x'/'X') positions, then compare magnitudes.
+    let mut val1: c_int = 0;
+    let mut val2: c_int = 0;
+    let mut nextbit: c_int = 1;
+    for j in (0..length).rev() {
+        let chr1 = padded_bit(s1, length, j);
+        let chr2 = padded_bit(s2, length, j);
+        if chr1 != b'x' as c_char
+            && chr1 != b'X' as c_char
+            && chr2 != b'x' as c_char
+            && chr2 != b'X' as c_char
+        {
+            if chr1 == b'1' as c_char {
+                val1 += nextbit;
             }
+            if chr2 == b'1' as c_char {
+                val2 += nextbit;
+            }
+            nextbit *= 2;
         }
-
-        (match oper {
-            282 => val1 < val2,
-            283 => val1 <= val2,
-            281 => val1 > val2,
-            284 => val1 >= val2,
-            _ => false,
-        }) as c_char
     }
+
+    (match oper {
+        282 => val1 < val2,
+        283 => val1 <= val2,
+        281 => val1 > val2,
+        284 => val1 >= val2,
+        _ => false,
+    }) as c_char
 }
 /// Combine two NUL-terminated bit strings bit-by-bit with `op`, left-padding the
 /// shorter operand with '0', and write the NUL-terminated result to `result`
 /// (which must hold at least `max(len1, len2) + 1` bytes). Replaces the C
 /// malloc-a-scratch-stream-and-pointer-walk idiom with bounded slice access.
-///
-/// # Safety
-/// `bitstrm1`/`bitstrm2` must be valid NUL-terminated strings and `result` must
-/// point to a buffer large enough for the longer operand plus a NUL; `result`
-/// must not overlap either operand.
-unsafe fn bit_binop(
+/// `unsafe` is confined to building the slices from the (internally-supplied,
+/// valid) node buffer pointers; the combine loop is bounds-checked.
+fn bit_binop(
     result: *mut c_char,
     bitstrm1: *mut c_char,
     bitstrm2: *mut c_char,
     op: impl Fn(c_char, c_char) -> c_char,
 ) {
-    unsafe {
+    let (s1, s2, out) = unsafe {
         let l1 = strlen(bitstrm1) as usize;
         let l2 = strlen(bitstrm2) as usize;
-        let s1 = core::slice::from_raw_parts(bitstrm1, l1);
-        let s2 = core::slice::from_raw_parts(bitstrm2, l2);
         let n = l1.max(l2);
-        let out = core::slice::from_raw_parts_mut(result, n + 1);
-        for i in 0..n {
-            out[i] = op(padded_bit(s1, n, i), padded_bit(s2, n, i));
-        }
-        out[n] = 0;
+        (
+            core::slice::from_raw_parts(bitstrm1, l1),
+            core::slice::from_raw_parts(bitstrm2, l2),
+            core::slice::from_raw_parts_mut(result, n + 1),
+        )
+    };
+    let n = s1.len().max(s2.len());
+    for i in 0..n {
+        out[i] = op(padded_bit(s1, n, i), padded_bit(s2, n, i));
     }
+    out[n] = 0;
 }
 
 fn bitand(result: *mut c_char, bitstrm1: *mut c_char, bitstrm2: *mut c_char) {
-    unsafe {
-        bit_binop(result, bitstrm1, bitstrm2, |chr1, chr2| {
-            if chr1 == b'x' as c_char || chr2 == b'x' as c_char {
-                b'x' as c_char
-            } else if chr1 == b'1' as c_char && chr2 == b'1' as c_char {
-                b'1' as c_char
-            } else {
-                b'0' as c_char
-            }
-        });
-    }
+    bit_binop(result, bitstrm1, bitstrm2, |chr1, chr2| {
+        if chr1 == b'x' as c_char || chr2 == b'x' as c_char {
+            b'x' as c_char
+        } else if chr1 == b'1' as c_char && chr2 == b'1' as c_char {
+            b'1' as c_char
+        } else {
+            b'0' as c_char
+        }
+    });
 }
 fn bitor(result: *mut c_char, bitstrm1: *mut c_char, bitstrm2: *mut c_char) {
-    unsafe {
-        bit_binop(result, bitstrm1, bitstrm2, |chr1, chr2| {
-            if chr1 == b'1' as c_char || chr2 == b'1' as c_char {
-                b'1' as c_char
-            } else if chr1 == b'0' as c_char || chr2 == b'0' as c_char {
-                b'0' as c_char
-            } else {
-                b'x' as c_char
-            }
-        });
-    }
+    bit_binop(result, bitstrm1, bitstrm2, |chr1, chr2| {
+        if chr1 == b'1' as c_char || chr2 == b'1' as c_char {
+            b'1' as c_char
+        } else if chr1 == b'0' as c_char || chr2 == b'0' as c_char {
+            b'0' as c_char
+        } else {
+            b'x' as c_char
+        }
+    });
 }
 fn bitnot(result: *mut c_char, bits: *mut c_char) {
-    unsafe {
-        // Confine unsafe to building slices from the NUL-terminated bit strings;
-        // the inversion itself is bounded safe indexing.
+    // Confine unsafe to building slices from the NUL-terminated bit strings;
+    // the inversion itself is bounded safe indexing.
+    let (bits, result) = unsafe {
         let length = strlen(bits) as usize;
-        let bits = core::slice::from_raw_parts(bits, length);
-        let result = core::slice::from_raw_parts_mut(result, length + 1);
-        for i in 0..length {
-            let chr = bits[i];
-            result[i] = if chr == b'1' as c_char {
-                b'0' as c_char
-            } else if chr == b'0' as c_char {
-                b'1' as c_char
-            } else {
-                chr
-            };
-        }
-        result[length] = 0;
+        (
+            core::slice::from_raw_parts(bits, length),
+            core::slice::from_raw_parts_mut(result, length + 1),
+        )
+    };
+    let length = bits.len();
+    for i in 0..length {
+        let chr = bits[i];
+        result[i] = if chr == b'1' as c_char {
+            b'0' as c_char
+        } else if chr == b'0' as c_char {
+            b'1' as c_char
+        } else {
+            chr
+        };
     }
+    result[length] = 0;
 }
 
 fn bitcmp(bitstrm1: *mut c_char, bitstrm2: *mut c_char) -> c_char {
-    unsafe {
+    // Confine unsafe to viewing the NUL-terminated bit strings as slices; the
+    // padding/compare below is bounds-checked.
+    let (mut bitstrm1, mut bitstrm2) = unsafe {
+        (
+            core::slice::from_raw_parts_mut(bitstrm1, strlen(bitstrm1) as usize + 1),
+            core::slice::from_raw_parts_mut(bitstrm2, strlen(bitstrm2) as usize + 1),
+        )
+    };
+    {
         let mut i: c_int = 0;
         let mut ldiff: c_int = 0;
         let mut largestStream: c_int = 0;
         let mut chr1: c_char = 0;
         let mut chr2: c_char = 0;
 
-        let mut l1 = strlen(bitstrm1) as c_int;
-        let mut l2 = strlen(bitstrm2) as c_int;
-
-        let mut bitstrm1 = core::slice::from_raw_parts_mut(bitstrm1, l1 as usize + 1);
-        let mut bitstrm2 = core::slice::from_raw_parts_mut(bitstrm2, l2 as usize + 1);
+        let mut l1 = bitstrm1.len() as c_int - 1;
+        let mut l2 = bitstrm2.len() as c_int - 1;
 
         largestStream = cmp::max(l1, l2);
 

--- a/src/eval_y.rs
+++ b/src/eval_y.rs
@@ -86,6 +86,17 @@ use crate::wrappers::strncpy_safe;
 use crate::wrappers::{strcat, strcmp, strcpy, strlen, strstr};
 use crate::{atoi, cs, int_snprintf};
 
+/// Safe equivalent of the cfitsio `FSTRCMP(buf, s) == 0` idiom: returns `true`
+/// when the NUL-terminated contents of the fixed `astr` buffer equal the C
+/// string `s`. Replaces the first-char-shortcut + `strcmp` expansion emitted by
+/// the bison grammar, with bounded (panic-free) comparison.
+fn astr_eq(buf: &[c_char], s: &CStr) -> bool {
+    let needle = s.to_bytes();
+    buf.len() > needle.len()
+        && buf[needle.len()] == 0
+        && needle.iter().zip(buf.iter()).all(|(&n, &b)| n == b as u8)
+}
+
 pub type yy_state_t = yytype_int16;
 pub type yytype_int16 = c_short;
 pub type yysymbol_kind_t = c_int;
@@ -2485,18 +2496,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         }
                         54 => {
                             /* expr: FUNCTION ')'  */
-                            if (if c_int::from(yyvs[yyvsp - 1].astr[0])
-                                < c_int::from((cs!(c"RANDOM("))[0])
-                            {
-                                -(1)
-                            } else if c_int::from(yyvs[yyvsp - 1].astr[0])
-                                > c_int::from((cs!(c"RANDOM("))[0])
-                            {
-                                1
-                            } else {
-                                strcmp((yyvs[yyvsp - 1].astr).as_mut_ptr(), c"RANDOM(".as_ptr())
-                            }) == 0
-                            {
+                            if astr_eq(&yyvs[yyvsp - 1].astr, c"RANDOM(") {
                                 yyval.Node = New_Func(
                                     lParse,
                                     fits_parser_yytokentype::DOUBLE as c_int,
@@ -2511,18 +2511,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     0,
                                 );
                                 current_block = 1297461190301222800;
-                            } else if (if c_int::from(yyvs[yyvsp - 1].astr[0])
-                                < c_int::from((cs!(c"RANDOMN("))[0])
-                            {
-                                -(1)
-                            } else if c_int::from(yyvs[yyvsp - 1].astr[0])
-                                > c_int::from((cs!(c"RANDOMN("))[0])
-                            {
-                                1
-                            } else {
-                                strcmp((yyvs[yyvsp - 1].astr).as_mut_ptr(), c"RANDOMN(".as_ptr())
-                            }) == 0
-                            {
+                            } else if astr_eq(&yyvs[yyvsp - 1].astr, c"RANDOMN(") {
                                 yyval.Node = New_Func(
                                     lParse,
                                     fits_parser_yytokentype::DOUBLE as c_int,
@@ -2554,18 +2543,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         }
                         55 => {
                             /* expr: FUNCTION bexpr ')'  */
-                            if (if c_int::from(yyvs[yyvsp - 2].astr[0])
-                                < c_int::from((cs!(c"SUM("))[0])
-                            {
-                                -(1)
-                            } else if c_int::from(yyvs[yyvsp - 2].astr[0])
-                                > c_int::from((cs!(c"SUM("))[0])
-                            {
-                                1
-                            } else {
-                                strcmp((yyvs[yyvsp - 2].astr).as_mut_ptr(), c"SUM(".as_ptr())
-                            }) == 0
-                            {
+                            if astr_eq(&yyvs[yyvsp - 2].astr, c"SUM(") {
                                 yyval.Node = New_Func(
                                     lParse,
                                     fits_parser_yytokentype::LONG as c_int,
@@ -2580,18 +2558,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     0,
                                 );
                                 current_block = 10848699504537784535;
-                            } else if (if c_int::from(yyvs[yyvsp - 2].astr[0])
-                                < c_int::from((cs!(c"NELEM("))[0])
-                            {
-                                -(1)
-                            } else if c_int::from(yyvs[yyvsp - 2].astr[0])
-                                > c_int::from((cs!(c"NELEM("))[0])
-                            {
-                                1
-                            } else {
-                                strcmp((yyvs[yyvsp - 2].astr).as_mut_ptr(), c"NELEM(".as_ptr())
-                            }) == 0
-                            {
+                            } else if astr_eq(&yyvs[yyvsp - 2].astr, c"NELEM(") {
                                 yyval.Node = New_Const(
                                     lParse,
                                     fits_parser_yytokentype::LONG as c_int,
@@ -2601,18 +2568,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     ::core::mem::size_of::<c_long>() as c_ulong as c_long,
                                 );
                                 current_block = 10848699504537784535;
-                            } else if (if c_int::from(yyvs[yyvsp - 2].astr[0])
-                                < c_int::from((cs!(c"ACCUM("))[0])
-                            {
-                                -(1)
-                            } else if c_int::from(yyvs[yyvsp - 2].astr[0])
-                                > c_int::from((cs!(c"ACCUM("))[0])
-                            {
-                                1
-                            } else {
-                                strcmp((yyvs[yyvsp - 2].astr).as_mut_ptr(), c"ACCUM(".as_ptr())
-                            }) == 0
-                            {
+                            } else if astr_eq(&yyvs[yyvsp - 2].astr, c"ACCUM(") {
                                 let mut zero: c_long = 0;
                                 let new_node = New_Const(
                                     lParse,
@@ -2646,18 +2602,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         }
                         56 => {
                             /* expr: FUNCTION bexpr ',' expr ')'  */
-                            if (if c_int::from(yyvs[yyvsp - 4].astr[0])
-                                < c_int::from((cs!(c"AXISELEM"))[0])
-                            {
-                                -(1)
-                            } else if c_int::from(yyvs[yyvsp - 4].astr[0])
-                                > c_int::from((cs!(c"AXISELEM"))[0])
-                            {
-                                1
-                            } else {
-                                strcmp((yyvs[yyvsp - 4].astr).as_mut_ptr(), c"AXISELEM(".as_ptr())
-                            }) == 0
-                            {
+                            if astr_eq(&yyvs[yyvsp - 4].astr, c"AXISELEM(") {
                                 if ((lParse.Nodes)[yyvs[yyvsp - 1].Node as usize]).operation
                                     != CONST_OP
                                     || ((lParse.Nodes)[yyvs[yyvsp - 1].Node as usize]).value.nelem
@@ -2711,18 +2656,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         current_block = 13755523488868872559;
                                     }
                                 }
-                            } else if (if c_int::from(yyvs[yyvsp - 4].astr[0])
-                                < c_int::from((cs!(c"NAXES("))[0])
-                            {
-                                -(1)
-                            } else if c_int::from(yyvs[yyvsp - 4].astr[0])
-                                > c_int::from((cs!(c"NAXES("))[0])
-                            {
-                                1
-                            } else {
-                                strcmp((yyvs[yyvsp - 4].astr).as_mut_ptr(), c"NAXES(".as_ptr())
-                            }) == 0
-                            {
+                            } else if astr_eq(&yyvs[yyvsp - 4].astr, c"NAXES(") {
                                 if ((lParse.Nodes)[yyvs[yyvsp - 1].Node as usize]).operation
                                     != CONST_OP
                                     || ((lParse.Nodes)[yyvs[yyvsp - 1].Node as usize]).value.nelem
@@ -2785,18 +2719,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         current_block = 13755523488868872559;
                                     }
                                 }
-                            } else if (if c_int::from(yyvs[yyvsp - 4].astr[0])
-                                < c_int::from((cs!(c"ARRAY("))[0])
-                            {
-                                -(1)
-                            } else if c_int::from(yyvs[yyvsp - 4].astr[0])
-                                > c_int::from((cs!(c"ARRAY("))[0])
-                            {
-                                1
-                            } else {
-                                strcmp((yyvs[yyvsp - 4].astr).as_mut_ptr(), c"ARRAY(".as_ptr())
-                            }) == 0
-                            {
+                            } else if astr_eq(&yyvs[yyvsp - 4].astr, c"ARRAY(") {
                                 yyval.Node =
                                     New_Array(lParse, yyvs[yyvsp - 3].Node, yyvs[yyvsp - 1].Node);
                                 if yyval.Node < 0 {
@@ -2824,18 +2747,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         }
                         57 => {
                             /* expr: FUNCTION sexpr ')'  */
-                            if (if c_int::from(yyvs[yyvsp - 2].astr[0])
-                                < c_int::from((cs!(c"NELEM("))[0])
-                            {
-                                -(1)
-                            } else if c_int::from(yyvs[yyvsp - 2].astr[0])
-                                > c_int::from((cs!(c"NELEM("))[0])
-                            {
-                                1
-                            } else {
-                                strcmp((yyvs[yyvsp - 2].astr).as_mut_ptr(), c"NELEM(".as_ptr())
-                            }) == 0
-                            {
+                            if astr_eq(&yyvs[yyvsp - 2].astr, c"NELEM(") {
                                 yyval.Node = New_Const(
                                     lParse,
                                     fits_parser_yytokentype::LONG as c_int,
@@ -2845,18 +2757,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     ::core::mem::size_of::<c_long>() as c_ulong as c_long,
                                 );
                                 current_block = 15752106442776732052;
-                            } else if (if c_int::from(yyvs[yyvsp - 2].astr[0])
-                                < c_int::from((cs!(c"NVALID("))[0])
-                            {
-                                -(1)
-                            } else if c_int::from(yyvs[yyvsp - 2].astr[0])
-                                > c_int::from((cs!(c"NVALID("))[0])
-                            {
-                                1
-                            } else {
-                                strcmp((yyvs[yyvsp - 2].astr).as_mut_ptr(), c"NVALID(".as_ptr())
-                            }) == 0
-                            {
+                            } else if astr_eq(&yyvs[yyvsp - 2].astr, c"NVALID(") {
                                 yyval.Node = New_Func(
                                     lParse,
                                     fits_parser_yytokentype::LONG as c_int,
@@ -2888,18 +2789,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         }
                         58 => {
                             /* expr: FUNCTION bits ')'  */
-                            if (if c_int::from(yyvs[yyvsp - 2].astr[0])
-                                < c_int::from((cs!(c"NELEM("))[0])
-                            {
-                                -(1)
-                            } else if c_int::from(yyvs[yyvsp - 2].astr[0])
-                                > c_int::from((cs!(c"NELEM("))[0])
-                            {
-                                1
-                            } else {
-                                strcmp((yyvs[yyvsp - 2].astr).as_mut_ptr(), c"NELEM(".as_ptr())
-                            }) == 0
-                            {
+                            if astr_eq(&yyvs[yyvsp - 2].astr, c"NELEM(") {
                                 yyval.Node = New_Const(
                                     lParse,
                                     fits_parser_yytokentype::LONG as c_int,
@@ -2909,18 +2799,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     ::core::mem::size_of::<c_long>() as c_ulong as c_long,
                                 );
                                 current_block = 494012601817399562;
-                            } else if (if c_int::from(yyvs[yyvsp - 2].astr[0])
-                                < c_int::from((cs!(c"NVALID("))[0])
-                            {
-                                -(1)
-                            } else if c_int::from(yyvs[yyvsp - 2].astr[0])
-                                > c_int::from((cs!(c"NVALID("))[0])
-                            {
-                                1
-                            } else {
-                                strcmp((yyvs[yyvsp - 2].astr).as_mut_ptr(), c"NVALID(".as_ptr())
-                            }) == 0
-                            {
+                            } else if astr_eq(&yyvs[yyvsp - 2].astr, c"NVALID(") {
                                 yyval.Node = New_Const(
                                     lParse,
                                     fits_parser_yytokentype::LONG as c_int,
@@ -2930,18 +2809,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     ::core::mem::size_of::<c_long>() as c_ulong as c_long,
                                 );
                                 current_block = 494012601817399562;
-                            } else if (if c_int::from(yyvs[yyvsp - 2].astr[0])
-                                < c_int::from((cs!(c"SUM("))[0])
-                            {
-                                -(1)
-                            } else if c_int::from(yyvs[yyvsp - 2].astr[0])
-                                > c_int::from((cs!(c"SUM("))[0])
-                            {
-                                1
-                            } else {
-                                strcmp((yyvs[yyvsp - 2].astr).as_mut_ptr(), c"SUM(".as_ptr())
-                            }) == 0
-                            {
+                            } else if astr_eq(&yyvs[yyvsp - 2].astr, c"SUM(") {
                                 yyval.Node = New_Func(
                                     lParse,
                                     fits_parser_yytokentype::LONG as c_int,
@@ -2956,18 +2824,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     0,
                                 );
                                 current_block = 494012601817399562;
-                            } else if (if c_int::from(yyvs[yyvsp - 2].astr[0])
-                                < c_int::from((cs!(c"MIN("))[0])
-                            {
-                                -(1)
-                            } else if c_int::from(yyvs[yyvsp - 2].astr[0])
-                                > c_int::from((cs!(c"MIN("))[0])
-                            {
-                                1
-                            } else {
-                                strcmp((yyvs[yyvsp - 2].astr).as_mut_ptr(), c"MIN(".as_ptr())
-                            }) == 0
-                            {
+                            } else if astr_eq(&yyvs[yyvsp - 2].astr, c"MIN(") {
                                 yyval.Node = New_Func(
                                     lParse,
                                     ((lParse.Nodes)[yyvs[yyvsp - 1].Node as usize]).ntype,
@@ -2983,18 +2840,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 );
                                 (((lParse.Nodes)[yyval.Node as usize]).value).nelem = 1;
                                 current_block = 494012601817399562;
-                            } else if (if c_int::from(yyvs[yyvsp - 2].astr[0])
-                                < c_int::from((cs!(c"ACCUM("))[0])
-                            {
-                                -(1)
-                            } else if c_int::from(yyvs[yyvsp - 2].astr[0])
-                                > c_int::from((cs!(c"ACCUM("))[0])
-                            {
-                                1
-                            } else {
-                                strcmp((yyvs[yyvsp - 2].astr).as_mut_ptr(), c"ACCUM(".as_ptr())
-                            }) == 0
-                            {
+                            } else if astr_eq(&yyvs[yyvsp - 2].astr, c"ACCUM(") {
                                 let mut zero_0: c_long = 0;
                                 let new_node = New_Const(
                                     lParse,
@@ -3011,18 +2857,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     new_node,
                                 );
                                 current_block = 494012601817399562;
-                            } else if (if c_int::from(yyvs[yyvsp - 2].astr[0])
-                                < c_int::from((cs!(c"MAX("))[0])
-                            {
-                                -(1)
-                            } else if c_int::from(yyvs[yyvsp - 2].astr[0])
-                                > c_int::from((cs!(c"MAX("))[0])
-                            {
-                                1
-                            } else {
-                                strcmp((yyvs[yyvsp - 2].astr).as_mut_ptr(), c"MAX(".as_ptr())
-                            }) == 0
-                            {
+                            } else if astr_eq(&yyvs[yyvsp - 2].astr, c"MAX(") {
                                 yyval.Node = New_Func(
                                     lParse,
                                     ((lParse.Nodes)[yyvs[yyvsp - 1].Node as usize]).ntype,
@@ -3055,18 +2890,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         }
                         59 => {
                             /* expr: FUNCTION expr ')'  */
-                            if (if c_int::from(yyvs[yyvsp - 2].astr[0])
-                                < c_int::from((cs!(c"SUM("))[0])
-                            {
-                                -(1)
-                            } else if c_int::from(yyvs[yyvsp - 2].astr[0])
-                                > c_int::from((cs!(c"SUM("))[0])
-                            {
-                                1
-                            } else {
-                                strcmp((yyvs[yyvsp - 2].astr).as_mut_ptr(), c"SUM(".as_ptr())
-                            }) == 0
-                            {
+                            if astr_eq(&yyvs[yyvsp - 2].astr, c"SUM(") {
                                 yyval.Node = New_Func(
                                     lParse,
                                     ((lParse.Nodes)[yyvs[yyvsp - 1].Node as usize]).ntype,
@@ -3081,18 +2905,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     0,
                                 );
                                 current_block = 7600445499126923600;
-                            } else if (if c_int::from(yyvs[yyvsp - 2].astr[0])
-                                < c_int::from((cs!(c"AVERAGE("))[0])
-                            {
-                                -(1)
-                            } else if c_int::from(yyvs[yyvsp - 2].astr[0])
-                                > c_int::from((cs!(c"AVERAGE("))[0])
-                            {
-                                1
-                            } else {
-                                strcmp((yyvs[yyvsp - 2].astr).as_mut_ptr(), c"AVERAGE(".as_ptr())
-                            }) == 0
-                            {
+                            } else if astr_eq(&yyvs[yyvsp - 2].astr, c"AVERAGE(") {
                                 yyval.Node = New_Func(
                                     lParse,
                                     fits_parser_yytokentype::DOUBLE as c_int,
@@ -3107,18 +2920,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     0,
                                 );
                                 current_block = 7600445499126923600;
-                            } else if (if c_int::from(yyvs[yyvsp - 2].astr[0])
-                                < c_int::from((cs!(c"STDDEV("))[0])
-                            {
-                                -(1)
-                            } else if c_int::from(yyvs[yyvsp - 2].astr[0])
-                                > c_int::from((cs!(c"STDDEV("))[0])
-                            {
-                                1
-                            } else {
-                                strcmp((yyvs[yyvsp - 2].astr).as_mut_ptr(), c"STDDEV(".as_ptr())
-                            }) == 0
-                            {
+                            } else if astr_eq(&yyvs[yyvsp - 2].astr, c"STDDEV(") {
                                 yyval.Node = New_Func(
                                     lParse,
                                     fits_parser_yytokentype::DOUBLE as c_int,
@@ -3133,18 +2935,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     0,
                                 );
                                 current_block = 7600445499126923600;
-                            } else if (if c_int::from(yyvs[yyvsp - 2].astr[0])
-                                < c_int::from((cs!(c"MEDIAN("))[0])
-                            {
-                                -(1)
-                            } else if c_int::from(yyvs[yyvsp - 2].astr[0])
-                                > c_int::from((cs!(c"MEDIAN("))[0])
-                            {
-                                1
-                            } else {
-                                strcmp((yyvs[yyvsp - 2].astr).as_mut_ptr(), c"MEDIAN(".as_ptr())
-                            }) == 0
-                            {
+                            } else if astr_eq(&yyvs[yyvsp - 2].astr, c"MEDIAN(") {
                                 yyval.Node = New_Func(
                                     lParse,
                                     ((lParse.Nodes)[yyvs[yyvsp - 1].Node as usize]).ntype,
@@ -3159,18 +2950,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     0,
                                 );
                                 current_block = 7600445499126923600;
-                            } else if (if c_int::from(yyvs[yyvsp - 2].astr[0])
-                                < c_int::from((cs!(c"NELEM("))[0])
-                            {
-                                -(1)
-                            } else if c_int::from(yyvs[yyvsp - 2].astr[0])
-                                > c_int::from((cs!(c"NELEM("))[0])
-                            {
-                                1
-                            } else {
-                                strcmp((yyvs[yyvsp - 2].astr).as_mut_ptr(), c"NELEM(".as_ptr())
-                            }) == 0
-                            {
+                            } else if astr_eq(&yyvs[yyvsp - 2].astr, c"NELEM(") {
                                 yyval.Node = New_Const(
                                     lParse,
                                     fits_parser_yytokentype::LONG as c_int,
@@ -3180,18 +2960,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     ::core::mem::size_of::<c_long>() as c_ulong as c_long,
                                 );
                                 current_block = 7600445499126923600;
-                            } else if (if c_int::from(yyvs[yyvsp - 2].astr[0])
-                                < c_int::from((cs!(c"NVALID("))[0])
-                            {
-                                -(1)
-                            } else if c_int::from(yyvs[yyvsp - 2].astr[0])
-                                > c_int::from((cs!(c"NVALID("))[0])
-                            {
-                                1
-                            } else {
-                                strcmp((yyvs[yyvsp - 2].astr).as_mut_ptr(), c"NVALID(".as_ptr())
-                            }) == 0
-                            {
+                            } else if astr_eq(&yyvs[yyvsp - 2].astr, c"NVALID(") {
                                 yyval.Node = New_Func(
                                     lParse,
                                     fits_parser_yytokentype::LONG as c_int,
@@ -3206,17 +2975,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     0,
                                 );
                                 current_block = 7600445499126923600;
-                            } else if (if c_int::from(yyvs[yyvsp - 2].astr[0])
-                                < c_int::from((cs!(c"ACCUM("))[0])
-                            {
-                                -(1)
-                            } else if c_int::from(yyvs[yyvsp - 2].astr[0])
-                                > c_int::from((cs!(c"ACCUM("))[0])
-                            {
-                                1
-                            } else {
-                                strcmp((yyvs[yyvsp - 2].astr).as_mut_ptr(), c"ACCUM(".as_ptr())
-                            }) == 0
+                            } else if astr_eq(&yyvs[yyvsp - 2].astr, c"ACCUM(")
                                 && ((lParse.Nodes)[yyvs[yyvsp - 1].Node as usize]).ntype
                                     == fits_parser_yytokentype::LONG as c_int
                             {
@@ -3239,17 +2998,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     new_node,
                                 );
                                 current_block = 7600445499126923600;
-                            } else if (if c_int::from(yyvs[yyvsp - 2].astr[0])
-                                < c_int::from((cs!(c"ACCUM("))[0])
-                            {
-                                -(1)
-                            } else if c_int::from(yyvs[yyvsp - 2].astr[0])
-                                > c_int::from((cs!(c"ACCUM("))[0])
-                            {
-                                1
-                            } else {
-                                strcmp((yyvs[yyvsp - 2].astr).as_mut_ptr(), c"ACCUM(".as_ptr())
-                            }) == 0
+                            } else if astr_eq(&yyvs[yyvsp - 2].astr, c"ACCUM(")
                                 && ((lParse.Nodes)[yyvs[yyvsp - 1].Node as usize]).ntype
                                     == fits_parser_yytokentype::DOUBLE as c_int
                             {
@@ -3269,17 +3018,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     new_node,
                                 );
                                 current_block = 7600445499126923600;
-                            } else if (if c_int::from(yyvs[yyvsp - 2].astr[0])
-                                < c_int::from((cs!(c"SEQDIFF("))[0])
-                            {
-                                -(1)
-                            } else if c_int::from(yyvs[yyvsp - 2].astr[0])
-                                > c_int::from((cs!(c"SEQDIFF("))[0])
-                            {
-                                1
-                            } else {
-                                strcmp((yyvs[yyvsp - 2].astr).as_mut_ptr(), c"SEQDIFF(".as_ptr())
-                            }) == 0
+                            } else if astr_eq(&yyvs[yyvsp - 2].astr, c"SEQDIFF(")
                                 && ((lParse.Nodes)[yyvs[yyvsp - 1].Node as usize]).ntype
                                     == fits_parser_yytokentype::LONG as c_int
                             {
@@ -3299,17 +3038,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     new_node,
                                 );
                                 current_block = 7600445499126923600;
-                            } else if (if c_int::from(yyvs[yyvsp - 2].astr[0])
-                                < c_int::from((cs!(c"SEQDIFF("))[0])
-                            {
-                                -(1)
-                            } else if c_int::from(yyvs[yyvsp - 2].astr[0])
-                                > c_int::from((cs!(c"SEQDIFF("))[0])
-                            {
-                                1
-                            } else {
-                                strcmp((yyvs[yyvsp - 2].astr).as_mut_ptr(), c"SEQDIFF(".as_ptr())
-                            }) == 0
+                            } else if astr_eq(&yyvs[yyvsp - 2].astr, c"SEQDIFF(")
                                 && ((lParse.Nodes)[yyvs[yyvsp - 1].Node as usize]).ntype
                                     == fits_parser_yytokentype::DOUBLE as c_int
                             {
@@ -3329,18 +3058,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     new_node,
                                 );
                                 current_block = 7600445499126923600;
-                            } else if (if c_int::from(yyvs[yyvsp - 2].astr[0])
-                                < c_int::from((cs!(c"ABS("))[0])
-                            {
-                                -(1)
-                            } else if c_int::from(yyvs[yyvsp - 2].astr[0])
-                                > c_int::from((cs!(c"ABS("))[0])
-                            {
-                                1
-                            } else {
-                                strcmp((yyvs[yyvsp - 2].astr).as_mut_ptr(), c"ABS(".as_ptr())
-                            }) == 0
-                            {
+                            } else if astr_eq(&yyvs[yyvsp - 2].astr, c"ABS(") {
                                 yyval.Node = New_Func(
                                     lParse,
                                     0,
@@ -3355,18 +3073,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     0,
                                 );
                                 current_block = 7600445499126923600;
-                            } else if (if c_int::from(yyvs[yyvsp - 2].astr[0])
-                                < c_int::from((cs!(c"MIN("))[0])
-                            {
-                                -(1)
-                            } else if c_int::from(yyvs[yyvsp - 2].astr[0])
-                                > c_int::from((cs!(c"MIN("))[0])
-                            {
-                                1
-                            } else {
-                                strcmp((yyvs[yyvsp - 2].astr).as_mut_ptr(), c"MIN(".as_ptr())
-                            }) == 0
-                            {
+                            } else if astr_eq(&yyvs[yyvsp - 2].astr, c"MIN(") {
                                 yyval.Node = New_Func(
                                     lParse,
                                     ((lParse.Nodes)[yyvs[yyvsp - 1].Node as usize]).ntype,
@@ -3381,18 +3088,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     0,
                                 );
                                 current_block = 7600445499126923600;
-                            } else if (if c_int::from(yyvs[yyvsp - 2].astr[0])
-                                < c_int::from((cs!(c"MAX("))[0])
-                            {
-                                -(1)
-                            } else if c_int::from(yyvs[yyvsp - 2].astr[0])
-                                > c_int::from((cs!(c"MAX("))[0])
-                            {
-                                1
-                            } else {
-                                strcmp((yyvs[yyvsp - 2].astr).as_mut_ptr(), c"MAX(".as_ptr())
-                            }) == 0
-                            {
+                            } else if astr_eq(&yyvs[yyvsp - 2].astr, c"MAX(") {
                                 yyval.Node = New_Func(
                                     lParse,
                                     ((lParse.Nodes)[yyvs[yyvsp - 1].Node as usize]).ntype,
@@ -3407,18 +3103,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     0,
                                 );
                                 current_block = 7600445499126923600;
-                            } else if (if c_int::from(yyvs[yyvsp - 2].astr[0])
-                                < c_int::from((cs!(c"RANDOM("))[0])
-                            {
-                                -(1)
-                            } else if c_int::from(yyvs[yyvsp - 2].astr[0])
-                                > c_int::from((cs!(c"RANDOM("))[0])
-                            {
-                                1
-                            } else {
-                                strcmp((yyvs[yyvsp - 2].astr).as_mut_ptr(), c"RANDOM(".as_ptr())
-                            }) == 0
-                            {
+                            } else if astr_eq(&yyvs[yyvsp - 2].astr, c"RANDOM(") {
                                 yyval.Node = New_Func(
                                     lParse,
                                     0,
@@ -3439,18 +3124,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         fits_parser_yytokentype::DOUBLE as c_int;
                                     current_block = 7600445499126923600;
                                 }
-                            } else if (if c_int::from(yyvs[yyvsp - 2].astr[0])
-                                < c_int::from((cs!(c"RANDOMN("))[0])
-                            {
-                                -(1)
-                            } else if c_int::from(yyvs[yyvsp - 2].astr[0])
-                                > c_int::from((cs!(c"RANDOMN("))[0])
-                            {
-                                1
-                            } else {
-                                strcmp((yyvs[yyvsp - 2].astr).as_mut_ptr(), c"RANDOMN(".as_ptr())
-                            }) == 0
-                            {
+                            } else if astr_eq(&yyvs[yyvsp - 2].astr, c"RANDOMN(") {
                                 yyval.Node = New_Func(
                                     lParse,
                                     0,
@@ -3471,18 +3145,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         fits_parser_yytokentype::DOUBLE as c_int;
                                     current_block = 7600445499126923600;
                                 }
-                            } else if (if c_int::from(yyvs[yyvsp - 2].astr[0])
-                                < c_int::from((cs!(c"ELEMENTNUM"))[0])
-                            {
-                                -(1)
-                            } else if c_int::from(yyvs[yyvsp - 2].astr[0])
-                                > c_int::from((cs!(c"ELEMENTNUM"))[0])
-                            {
-                                1
-                            } else {
-                                strcmp((yyvs[yyvsp - 2].astr).as_mut_ptr(), c"ELEMENTNUM(".as_ptr())
-                            }) == 0
-                            {
+                            } else if astr_eq(&yyvs[yyvsp - 2].astr, c"ELEMENTNUM(") {
                                 if ((lParse.Nodes)[yyvs[yyvsp - 1].Node as usize]).operation
                                     == CONST_OP
                                 {
@@ -3516,18 +3179,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         current_block = 7600445499126923600;
                                     }
                                 }
-                            } else if (if c_int::from(yyvs[yyvsp - 2].astr[0])
-                                < c_int::from((cs!(c"NAXIS("))[0])
-                            {
-                                -(1)
-                            } else if c_int::from(yyvs[yyvsp - 2].astr[0])
-                                > c_int::from((cs!(c"NAXIS("))[0])
-                            {
-                                1
-                            } else {
-                                strcmp((yyvs[yyvsp - 2].astr).as_mut_ptr(), c"NAXIS(".as_ptr())
-                            }) == 0
-                            {
+                            } else if astr_eq(&yyvs[yyvsp - 2].astr, c"NAXIS(") {
                                 if ((lParse.Nodes)[yyvs[yyvsp - 1].Node as usize]).operation
                                     == CONST_OP
                                 {
@@ -3566,18 +3218,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         yyvs[yyvsp - 1].Node,
                                     );
                                 }
-                                if (if c_int::from(yyvs[yyvsp - 2].astr[0])
-                                    < c_int::from((cs!(c"SIN("))[0])
-                                {
-                                    -(1)
-                                } else if c_int::from(yyvs[yyvsp - 2].astr[0])
-                                    > c_int::from((cs!(c"SIN("))[0])
-                                {
-                                    1
-                                } else {
-                                    strcmp((yyvs[yyvsp - 2].astr).as_mut_ptr(), c"SIN(".as_ptr())
-                                }) == 0
-                                {
+                                if astr_eq(&yyvs[yyvsp - 2].astr, c"SIN(") {
                                     yyval.Node = New_Func(
                                         lParse,
                                         0,
@@ -3592,18 +3233,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         0,
                                     );
                                     current_block = 7600445499126923600;
-                                } else if (if c_int::from(yyvs[yyvsp - 2].astr[0])
-                                    < c_int::from((cs!(c"COS("))[0])
-                                {
-                                    -(1)
-                                } else if c_int::from(yyvs[yyvsp - 2].astr[0])
-                                    > c_int::from((cs!(c"COS("))[0])
-                                {
-                                    1
-                                } else {
-                                    strcmp((yyvs[yyvsp - 2].astr).as_mut_ptr(), c"COS(".as_ptr())
-                                }) == 0
-                                {
+                                } else if astr_eq(&yyvs[yyvsp - 2].astr, c"COS(") {
                                     yyval.Node = New_Func(
                                         lParse,
                                         0,
@@ -3618,18 +3248,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         0,
                                     );
                                     current_block = 7600445499126923600;
-                                } else if (if c_int::from(yyvs[yyvsp - 2].astr[0])
-                                    < c_int::from((cs!(c"TAN("))[0])
-                                {
-                                    -(1)
-                                } else if c_int::from(yyvs[yyvsp - 2].astr[0])
-                                    > c_int::from((cs!(c"TAN("))[0])
-                                {
-                                    1
-                                } else {
-                                    strcmp((yyvs[yyvsp - 2].astr).as_mut_ptr(), c"TAN(".as_ptr())
-                                }) == 0
-                                {
+                                } else if astr_eq(&yyvs[yyvsp - 2].astr, c"TAN(") {
                                     yyval.Node = New_Func(
                                         lParse,
                                         0,
@@ -3644,31 +3263,8 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         0,
                                     );
                                     current_block = 7600445499126923600;
-                                } else if (if c_int::from(yyvs[yyvsp - 2].astr[0])
-                                    < c_int::from((cs!(c"ARCSIN"))[0])
-                                {
-                                    -(1)
-                                } else if c_int::from(yyvs[yyvsp - 2].astr[0])
-                                    > c_int::from((cs!(c"ARCSIN"))[0])
-                                {
-                                    1
-                                } else {
-                                    strcmp((yyvs[yyvsp - 2].astr).as_mut_ptr(), c"ARCSIN(".as_ptr())
-                                }) == 0
-                                    || (if c_int::from(yyvs[yyvsp - 2].astr[0])
-                                        < c_int::from((cs!(c"ASIN"))[0])
-                                    {
-                                        -(1)
-                                    } else if c_int::from(yyvs[yyvsp - 2].astr[0])
-                                        > c_int::from((cs!(c"ASIN"))[0])
-                                    {
-                                        1
-                                    } else {
-                                        strcmp(
-                                            (yyvs[yyvsp - 2].astr).as_mut_ptr(),
-                                            c"ASIN(".as_ptr(),
-                                        )
-                                    }) == 0
+                                } else if astr_eq(&yyvs[yyvsp - 2].astr, c"ARCSIN(")
+                                    || astr_eq(&yyvs[yyvsp - 2].astr, c"ASIN(")
                                 {
                                     yyval.Node = New_Func(
                                         lParse,
@@ -3684,31 +3280,8 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         0,
                                     );
                                     current_block = 7600445499126923600;
-                                } else if (if c_int::from(yyvs[yyvsp - 2].astr[0])
-                                    < c_int::from((cs!(c"ARCCOS"))[0])
-                                {
-                                    -(1)
-                                } else if c_int::from(yyvs[yyvsp - 2].astr[0])
-                                    > c_int::from((cs!(c"ARCCOS"))[0])
-                                {
-                                    1
-                                } else {
-                                    strcmp((yyvs[yyvsp - 2].astr).as_mut_ptr(), c"ARCCOS(".as_ptr())
-                                }) == 0
-                                    || (if c_int::from(yyvs[yyvsp - 2].astr[0])
-                                        < c_int::from((cs!(c"ACOS"))[0])
-                                    {
-                                        -(1)
-                                    } else if c_int::from(yyvs[yyvsp - 2].astr[0])
-                                        > c_int::from((cs!(c"ACOS"))[0])
-                                    {
-                                        1
-                                    } else {
-                                        strcmp(
-                                            (yyvs[yyvsp - 2].astr).as_mut_ptr(),
-                                            c"ACOS(".as_ptr(),
-                                        )
-                                    }) == 0
+                                } else if astr_eq(&yyvs[yyvsp - 2].astr, c"ARCCOS(")
+                                    || astr_eq(&yyvs[yyvsp - 2].astr, c"ACOS(")
                                 {
                                     yyval.Node = New_Func(
                                         lParse,
@@ -3724,31 +3297,8 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         0,
                                     );
                                     current_block = 7600445499126923600;
-                                } else if (if c_int::from(yyvs[yyvsp - 2].astr[0])
-                                    < c_int::from((cs!(c"ARCTAN"))[0])
-                                {
-                                    -(1)
-                                } else if c_int::from(yyvs[yyvsp - 2].astr[0])
-                                    > c_int::from((cs!(c"ARCTAN"))[0])
-                                {
-                                    1
-                                } else {
-                                    strcmp((yyvs[yyvsp - 2].astr).as_mut_ptr(), c"ARCTAN(".as_ptr())
-                                }) == 0
-                                    || (if c_int::from(yyvs[yyvsp - 2].astr[0])
-                                        < c_int::from((cs!(c"ATAN"))[0])
-                                    {
-                                        -(1)
-                                    } else if c_int::from(yyvs[yyvsp - 2].astr[0])
-                                        > c_int::from((cs!(c"ATAN"))[0])
-                                    {
-                                        1
-                                    } else {
-                                        strcmp(
-                                            (yyvs[yyvsp - 2].astr).as_mut_ptr(),
-                                            c"ATAN(".as_ptr(),
-                                        )
-                                    }) == 0
+                                } else if astr_eq(&yyvs[yyvsp - 2].astr, c"ARCTAN(")
+                                    || astr_eq(&yyvs[yyvsp - 2].astr, c"ATAN(")
                                 {
                                     yyval.Node = New_Func(
                                         lParse,
@@ -3764,18 +3314,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         0,
                                     );
                                     current_block = 7600445499126923600;
-                                } else if (if c_int::from(yyvs[yyvsp - 2].astr[0])
-                                    < c_int::from((cs!(c"SINH"))[0])
-                                {
-                                    -(1)
-                                } else if c_int::from(yyvs[yyvsp - 2].astr[0])
-                                    > c_int::from((cs!(c"SINH"))[0])
-                                {
-                                    1
-                                } else {
-                                    strcmp((yyvs[yyvsp - 2].astr).as_mut_ptr(), c"SINH(".as_ptr())
-                                }) == 0
-                                {
+                                } else if astr_eq(&yyvs[yyvsp - 2].astr, c"SINH(") {
                                     yyval.Node = New_Func(
                                         lParse,
                                         0,
@@ -3790,18 +3329,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         0,
                                     );
                                     current_block = 7600445499126923600;
-                                } else if (if c_int::from(yyvs[yyvsp - 2].astr[0])
-                                    < c_int::from((cs!(c"COSH"))[0])
-                                {
-                                    -(1)
-                                } else if c_int::from(yyvs[yyvsp - 2].astr[0])
-                                    > c_int::from((cs!(c"COSH"))[0])
-                                {
-                                    1
-                                } else {
-                                    strcmp((yyvs[yyvsp - 2].astr).as_mut_ptr(), c"COSH(".as_ptr())
-                                }) == 0
-                                {
+                                } else if astr_eq(&yyvs[yyvsp - 2].astr, c"COSH(") {
                                     yyval.Node = New_Func(
                                         lParse,
                                         0,
@@ -3816,18 +3344,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         0,
                                     );
                                     current_block = 7600445499126923600;
-                                } else if (if c_int::from(yyvs[yyvsp - 2].astr[0])
-                                    < c_int::from((cs!(c"TANH"))[0])
-                                {
-                                    -(1)
-                                } else if c_int::from(yyvs[yyvsp - 2].astr[0])
-                                    > c_int::from((cs!(c"TANH"))[0])
-                                {
-                                    1
-                                } else {
-                                    strcmp((yyvs[yyvsp - 2].astr).as_mut_ptr(), c"TANH(".as_ptr())
-                                }) == 0
-                                {
+                                } else if astr_eq(&yyvs[yyvsp - 2].astr, c"TANH(") {
                                     yyval.Node = New_Func(
                                         lParse,
                                         0,
@@ -3842,18 +3359,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         0,
                                     );
                                     current_block = 7600445499126923600;
-                                } else if (if c_int::from(yyvs[yyvsp - 2].astr[0])
-                                    < c_int::from((cs!(c"EXP("))[0])
-                                {
-                                    -(1)
-                                } else if c_int::from(yyvs[yyvsp - 2].astr[0])
-                                    > c_int::from((cs!(c"EXP("))[0])
-                                {
-                                    1
-                                } else {
-                                    strcmp((yyvs[yyvsp - 2].astr).as_mut_ptr(), c"EXP(".as_ptr())
-                                }) == 0
-                                {
+                                } else if astr_eq(&yyvs[yyvsp - 2].astr, c"EXP(") {
                                     yyval.Node = New_Func(
                                         lParse,
                                         0,
@@ -3868,18 +3374,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         0,
                                     );
                                     current_block = 7600445499126923600;
-                                } else if (if c_int::from(yyvs[yyvsp - 2].astr[0])
-                                    < c_int::from((cs!(c"LOG("))[0])
-                                {
-                                    -(1)
-                                } else if c_int::from(yyvs[yyvsp - 2].astr[0])
-                                    > c_int::from((cs!(c"LOG("))[0])
-                                {
-                                    1
-                                } else {
-                                    strcmp((yyvs[yyvsp - 2].astr).as_mut_ptr(), c"LOG(".as_ptr())
-                                }) == 0
-                                {
+                                } else if astr_eq(&yyvs[yyvsp - 2].astr, c"LOG(") {
                                     yyval.Node = New_Func(
                                         lParse,
                                         0,
@@ -3894,18 +3389,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         0,
                                     );
                                     current_block = 7600445499126923600;
-                                } else if (if c_int::from(yyvs[yyvsp - 2].astr[0])
-                                    < c_int::from((cs!(c"LOG10"))[0])
-                                {
-                                    -(1)
-                                } else if c_int::from(yyvs[yyvsp - 2].astr[0])
-                                    > c_int::from((cs!(c"LOG10"))[0])
-                                {
-                                    1
-                                } else {
-                                    strcmp((yyvs[yyvsp - 2].astr).as_mut_ptr(), c"LOG10(".as_ptr())
-                                }) == 0
-                                {
+                                } else if astr_eq(&yyvs[yyvsp - 2].astr, c"LOG10(") {
                                     yyval.Node = New_Func(
                                         lParse,
                                         0,
@@ -3920,18 +3404,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         0,
                                     );
                                     current_block = 7600445499126923600;
-                                } else if (if c_int::from(yyvs[yyvsp - 2].astr[0])
-                                    < c_int::from((cs!(c"SQRT"))[0])
-                                {
-                                    -(1)
-                                } else if c_int::from(yyvs[yyvsp - 2].astr[0])
-                                    > c_int::from((cs!(c"SQRT"))[0])
-                                {
-                                    1
-                                } else {
-                                    strcmp((yyvs[yyvsp - 2].astr).as_mut_ptr(), c"SQRT(".as_ptr())
-                                }) == 0
-                                {
+                                } else if astr_eq(&yyvs[yyvsp - 2].astr, c"SQRT(") {
                                     yyval.Node = New_Func(
                                         lParse,
                                         0,
@@ -3946,18 +3419,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         0,
                                     );
                                     current_block = 7600445499126923600;
-                                } else if (if c_int::from(yyvs[yyvsp - 2].astr[0])
-                                    < c_int::from((cs!(c"ROUND"))[0])
-                                {
-                                    -(1)
-                                } else if c_int::from(yyvs[yyvsp - 2].astr[0])
-                                    > c_int::from((cs!(c"ROUND"))[0])
-                                {
-                                    1
-                                } else {
-                                    strcmp((yyvs[yyvsp - 2].astr).as_mut_ptr(), c"ROUND(".as_ptr())
-                                }) == 0
-                                {
+                                } else if astr_eq(&yyvs[yyvsp - 2].astr, c"ROUND(") {
                                     yyval.Node = New_Func(
                                         lParse,
                                         0,
@@ -3972,18 +3434,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         0,
                                     );
                                     current_block = 7600445499126923600;
-                                } else if (if c_int::from(yyvs[yyvsp - 2].astr[0])
-                                    < c_int::from((cs!(c"FLOOR"))[0])
-                                {
-                                    -(1)
-                                } else if c_int::from(yyvs[yyvsp - 2].astr[0])
-                                    > c_int::from((cs!(c"FLOOR"))[0])
-                                {
-                                    1
-                                } else {
-                                    strcmp((yyvs[yyvsp - 2].astr).as_mut_ptr(), c"FLOOR(".as_ptr())
-                                }) == 0
-                                {
+                                } else if astr_eq(&yyvs[yyvsp - 2].astr, c"FLOOR(") {
                                     yyval.Node = New_Func(
                                         lParse,
                                         0,
@@ -3998,18 +3449,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         0,
                                     );
                                     current_block = 7600445499126923600;
-                                } else if (if c_int::from(yyvs[yyvsp - 2].astr[0])
-                                    < c_int::from((cs!(c"CEIL"))[0])
-                                {
-                                    -(1)
-                                } else if c_int::from(yyvs[yyvsp - 2].astr[0])
-                                    > c_int::from((cs!(c"CEIL"))[0])
-                                {
-                                    1
-                                } else {
-                                    strcmp((yyvs[yyvsp - 2].astr).as_mut_ptr(), c"CEIL(".as_ptr())
-                                }) == 0
-                                {
+                                } else if astr_eq(&yyvs[yyvsp - 2].astr, c"CEIL(") {
                                     yyval.Node = New_Func(
                                         lParse,
                                         0,
@@ -4024,21 +3464,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         0,
                                     );
                                     current_block = 7600445499126923600;
-                                } else if (if c_int::from(yyvs[yyvsp - 2].astr[0])
-                                    < c_int::from((cs!(c"RANDOMP"))[0])
-                                {
-                                    -(1)
-                                } else if c_int::from(yyvs[yyvsp - 2].astr[0])
-                                    > c_int::from((cs!(c"RANDOMP"))[0])
-                                {
-                                    1
-                                } else {
-                                    strcmp(
-                                        (yyvs[yyvsp - 2].astr).as_mut_ptr(),
-                                        c"RANDOMP(".as_ptr(),
-                                    )
-                                }) == 0
-                                {
+                                } else if astr_eq(&yyvs[yyvsp - 2].astr, c"RANDOMP(") {
                                     yyval.Node = New_Func(
                                         lParse,
                                         0,
@@ -4076,18 +3502,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         }
                         60 => {
                             /* expr: IFUNCTION sexpr ',' sexpr ')'  */
-                            if (if c_int::from(yyvs[yyvsp - 4].astr[0])
-                                < c_int::from((cs!(c"STRSTR("))[0])
-                            {
-                                -(1)
-                            } else if c_int::from(yyvs[yyvsp - 4].astr[0])
-                                > c_int::from((cs!(c"STRSTR("))[0])
-                            {
-                                1
-                            } else {
-                                strcmp((yyvs[yyvsp - 4].astr).as_mut_ptr(), c"STRSTR(".as_ptr())
-                            }) == 0
-                            {
+                            if astr_eq(&yyvs[yyvsp - 4].astr, c"STRSTR(") {
                                 yyval.Node = New_Func(
                                     lParse,
                                     fits_parser_yytokentype::LONG as c_int,
@@ -4118,18 +3533,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         }
                         61 => {
                             /* expr: FUNCTION expr ',' expr ')'  */
-                            if (if c_int::from(yyvs[yyvsp - 4].astr[0])
-                                < c_int::from((cs!(c"DEFNULL("))[0])
-                            {
-                                -(1)
-                            } else if c_int::from(yyvs[yyvsp - 4].astr[0])
-                                > c_int::from((cs!(c"DEFNULL("))[0])
-                            {
-                                1
-                            } else {
-                                strcmp((yyvs[yyvsp - 4].astr).as_mut_ptr(), c"DEFNULL(".as_ptr())
-                            }) == 0
-                            {
+                            if astr_eq(&yyvs[yyvsp - 4].astr, c"DEFNULL(") {
                                 if ((lParse.Nodes)[yyvs[yyvsp - 3].Node as usize]).value.nelem
                                     >= ((lParse.Nodes)[yyvs[yyvsp - 1].Node as usize]).value.nelem
                                     && Test_Dims(lParse, yyvs[yyvsp - 3].Node, yyvs[yyvsp - 1].Node)
@@ -4179,18 +3583,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     );
                                     current_block = 4830776507462815627;
                                 }
-                            } else if (if c_int::from(yyvs[yyvsp - 4].astr[0])
-                                < c_int::from((cs!(c"ARCTAN2("))[0])
-                            {
-                                -(1)
-                            } else if c_int::from(yyvs[yyvsp - 4].astr[0])
-                                > c_int::from((cs!(c"ARCTAN2("))[0])
-                            {
-                                1
-                            } else {
-                                strcmp((yyvs[yyvsp - 4].astr).as_mut_ptr(), c"ARCTAN2(".as_ptr())
-                            }) == 0
-                            {
+                            } else if astr_eq(&yyvs[yyvsp - 4].astr, c"ARCTAN2(") {
                                 if ((lParse.Nodes)[yyvs[yyvsp - 3].Node as usize]).ntype
                                     != fits_parser_yytokentype::DOUBLE as c_int
                                 {
@@ -4248,18 +3641,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     );
                                     current_block = 4830776507462815627;
                                 }
-                            } else if (if c_int::from(yyvs[yyvsp - 4].astr[0])
-                                < c_int::from((cs!(c"MIN("))[0])
-                            {
-                                -(1)
-                            } else if c_int::from(yyvs[yyvsp - 4].astr[0])
-                                > c_int::from((cs!(c"MIN("))[0])
-                            {
-                                1
-                            } else {
-                                strcmp((yyvs[yyvsp - 4].astr).as_mut_ptr(), c"MIN(".as_ptr())
-                            }) == 0
-                            {
+                            } else if astr_eq(&yyvs[yyvsp - 4].astr, c"MIN(") {
                                 if ((lParse.Nodes)[yyvs[yyvsp - 3].Node as usize]).ntype
                                     > ((lParse.Nodes)[yyvs[yyvsp - 1].Node as usize]).ntype
                                 {
@@ -4316,18 +3698,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     );
                                     current_block = 4830776507462815627;
                                 }
-                            } else if (if c_int::from(yyvs[yyvsp - 4].astr[0])
-                                < c_int::from((cs!(c"MAX("))[0])
-                            {
-                                -(1)
-                            } else if c_int::from(yyvs[yyvsp - 4].astr[0])
-                                > c_int::from((cs!(c"MAX("))[0])
-                            {
-                                1
-                            } else {
-                                strcmp((yyvs[yyvsp - 4].astr).as_mut_ptr(), c"MAX(".as_ptr())
-                            }) == 0
-                            {
+                            } else if astr_eq(&yyvs[yyvsp - 4].astr, c"MAX(") {
                                 if ((lParse.Nodes)[yyvs[yyvsp - 3].Node as usize]).ntype
                                     > ((lParse.Nodes)[yyvs[yyvsp - 1].Node as usize]).ntype
                                 {
@@ -4384,18 +3755,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     );
                                     current_block = 4830776507462815627;
                                 }
-                            } else if (if c_int::from(yyvs[yyvsp - 4].astr[0])
-                                < c_int::from((cs!(c"SETNULL("))[0])
-                            {
-                                -(1)
-                            } else if c_int::from(yyvs[yyvsp - 4].astr[0])
-                                > c_int::from((cs!(c"SETNULL("))[0])
-                            {
-                                1
-                            } else {
-                                strcmp((yyvs[yyvsp - 4].astr).as_mut_ptr(), c"SETNULL(".as_ptr())
-                            }) == 0
-                            {
+                            } else if astr_eq(&yyvs[yyvsp - 4].astr, c"SETNULL(") {
                                 if ((lParse.Nodes)[yyvs[yyvsp - 3].Node as usize]).operation
                                     != CONST_OP
                                     || ((lParse.Nodes)[yyvs[yyvsp - 3].Node as usize]).value.nelem
@@ -4432,18 +3792,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     );
                                     current_block = 9966817879908499150;
                                 }
-                            } else if (if c_int::from(yyvs[yyvsp - 4].astr[0])
-                                < c_int::from((cs!(c"AXISELEM"))[0])
-                            {
-                                -(1)
-                            } else if c_int::from(yyvs[yyvsp - 4].astr[0])
-                                > c_int::from((cs!(c"AXISELEM"))[0])
-                            {
-                                1
-                            } else {
-                                strcmp((yyvs[yyvsp - 4].astr).as_mut_ptr(), c"AXISELEM(".as_ptr())
-                            }) == 0
-                            {
+                            } else if astr_eq(&yyvs[yyvsp - 4].astr, c"AXISELEM(") {
                                 if ((lParse.Nodes)[yyvs[yyvsp - 1].Node as usize]).operation
                                     != CONST_OP
                                     || ((lParse.Nodes)[yyvs[yyvsp - 1].Node as usize]).value.nelem
@@ -4497,18 +3846,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         current_block = 9966817879908499150;
                                     }
                                 }
-                            } else if (if c_int::from(yyvs[yyvsp - 4].astr[0])
-                                < c_int::from((cs!(c"NAXES("))[0])
-                            {
-                                -(1)
-                            } else if c_int::from(yyvs[yyvsp - 4].astr[0])
-                                > c_int::from((cs!(c"NAXES("))[0])
-                            {
-                                1
-                            } else {
-                                strcmp((yyvs[yyvsp - 4].astr).as_mut_ptr(), c"NAXES(".as_ptr())
-                            }) == 0
-                            {
+                            } else if astr_eq(&yyvs[yyvsp - 4].astr, c"NAXES(") {
                                 if ((lParse.Nodes)[yyvs[yyvsp - 1].Node as usize]).operation
                                     != CONST_OP
                                     || ((lParse.Nodes)[yyvs[yyvsp - 1].Node as usize]).value.nelem
@@ -4571,18 +3909,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         current_block = 9966817879908499150;
                                     }
                                 }
-                            } else if (if c_int::from(yyvs[yyvsp - 4].astr[0])
-                                < c_int::from((cs!(c"ARRAY("))[0])
-                            {
-                                -(1)
-                            } else if c_int::from(yyvs[yyvsp - 4].astr[0])
-                                > c_int::from((cs!(c"ARRAY("))[0])
-                            {
-                                1
-                            } else {
-                                strcmp((yyvs[yyvsp - 4].astr).as_mut_ptr(), c"ARRAY(".as_ptr())
-                            }) == 0
-                            {
+                            } else if astr_eq(&yyvs[yyvsp - 4].astr, c"ARRAY(") {
                                 yyval.Node =
                                     New_Array(lParse, yyvs[yyvsp - 3].Node, yyvs[yyvsp - 1].Node);
                                 if yyval.Node < 0 {
@@ -4606,18 +3933,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         }
                         62 => {
                             /* expr: FUNCTION expr ',' expr ',' expr ',' expr ')'  */
-                            if (if c_int::from(yyvs[yyvsp - 8].astr[0])
-                                < c_int::from((cs!(c"ANGSEP("))[0])
-                            {
-                                -(1)
-                            } else if c_int::from(yyvs[yyvsp - 8].astr[0])
-                                > c_int::from((cs!(c"ANGSEP("))[0])
-                            {
-                                1
-                            } else {
-                                strcmp((yyvs[yyvsp - 8].astr).as_mut_ptr(), c"ANGSEP(".as_ptr())
-                            }) == 0
-                            {
+                            if astr_eq(&yyvs[yyvsp - 8].astr, c"ANGSEP(") {
                                 if ((lParse.Nodes)[yyvs[yyvsp - 7].Node as usize]).ntype
                                     != fits_parser_yytokentype::DOUBLE as c_int
                                 {
@@ -5580,18 +4896,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         }
                         102 => {
                             /* bexpr: BFUNCTION expr ')'  */
-                            if (if c_int::from(yyvs[yyvsp - 2].astr[0])
-                                < c_int::from((cs!(c"ISNULL("))[0])
-                            {
-                                -(1)
-                            } else if c_int::from(yyvs[yyvsp - 2].astr[0])
-                                > c_int::from((cs!(c"ISNULL("))[0])
-                            {
-                                1
-                            } else {
-                                strcmp((yyvs[yyvsp - 2].astr).as_mut_ptr(), c"ISNULL(".as_ptr())
-                            }) == 0
-                            {
+                            if astr_eq(&yyvs[yyvsp - 2].astr, c"ISNULL(") {
                                 yyval.Node = New_Func(
                                     lParse,
                                     0,
@@ -5622,18 +4927,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         }
                         103 => {
                             /* bexpr: BFUNCTION bexpr ')'  */
-                            if (if c_int::from(yyvs[yyvsp - 2].astr[0])
-                                < c_int::from((cs!(c"ISNULL("))[0])
-                            {
-                                -(1)
-                            } else if c_int::from(yyvs[yyvsp - 2].astr[0])
-                                > c_int::from((cs!(c"ISNULL("))[0])
-                            {
-                                1
-                            } else {
-                                strcmp((yyvs[yyvsp - 2].astr).as_mut_ptr(), c"ISNULL(".as_ptr())
-                            }) == 0
-                            {
+                            if astr_eq(&yyvs[yyvsp - 2].astr, c"ISNULL(") {
                                 yyval.Node = New_Func(
                                     lParse,
                                     0,
@@ -5664,18 +4958,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         }
                         104 => {
                             /* bexpr: BFUNCTION sexpr ')'  */
-                            if (if c_int::from(yyvs[yyvsp - 2].astr[0])
-                                < c_int::from((cs!(c"ISNULL("))[0])
-                            {
-                                -(1)
-                            } else if c_int::from(yyvs[yyvsp - 2].astr[0])
-                                > c_int::from((cs!(c"ISNULL("))[0])
-                            {
-                                1
-                            } else {
-                                strcmp((yyvs[yyvsp - 2].astr).as_mut_ptr(), c"ISNULL(".as_ptr())
-                            }) == 0
-                            {
+                            if astr_eq(&yyvs[yyvsp - 2].astr, c"ISNULL(") {
                                 yyval.Node = New_Func(
                                     lParse,
                                     fits_parser_yytokentype::BOOLEAN as c_int,
@@ -5704,18 +4987,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         }
                         105 => {
                             /* bexpr: FUNCTION bexpr ',' bexpr ')'  */
-                            if (if c_int::from(yyvs[yyvsp - 4].astr[0])
-                                < c_int::from((cs!(c"DEFNULL("))[0])
-                            {
-                                -(1)
-                            } else if c_int::from(yyvs[yyvsp - 4].astr[0])
-                                > c_int::from((cs!(c"DEFNULL("))[0])
-                            {
-                                1
-                            } else {
-                                strcmp((yyvs[yyvsp - 4].astr).as_mut_ptr(), c"DEFNULL(".as_ptr())
-                            }) == 0
-                            {
+                            if astr_eq(&yyvs[yyvsp - 4].astr, c"DEFNULL(") {
                                 if ((lParse.Nodes)[yyvs[yyvsp - 3].Node as usize]).value.nelem
                                     >= ((lParse.Nodes)[yyvs[yyvsp - 1].Node as usize]).value.nelem
                                     && Test_Dims(lParse, yyvs[yyvsp - 3].Node, yyvs[yyvsp - 1].Node)
@@ -5795,18 +5067,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     cs!(c"Dimensions of NEAR arguments are not compatible"),
                                 );
                                 current_block = 4830776507462815627;
-                            } else if (if c_int::from(yyvs[yyvsp - 6].astr[0])
-                                < c_int::from((cs!(c"NEAR("))[0])
-                            {
-                                -(1)
-                            } else if c_int::from(yyvs[yyvsp - 6].astr[0])
-                                > c_int::from((cs!(c"NEAR("))[0])
-                            {
-                                1
-                            } else {
-                                strcmp((yyvs[yyvsp - 6].astr).as_mut_ptr(), c"NEAR(".as_ptr())
-                            }) == 0
-                            {
+                            } else if astr_eq(&yyvs[yyvsp - 6].astr, c"NEAR(") {
                                 yyval.Node = New_Func(
                                     lParse,
                                     fits_parser_yytokentype::BOOLEAN as c_int,
@@ -5916,18 +5177,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     cs!(c"Dimensions of CIRCLE arguments are not compatible"),
                                 );
                                 current_block = 4830776507462815627;
-                            } else if (if c_int::from(yyvs[yyvsp - 10].astr[0])
-                                < c_int::from((cs!(c"CIRCLE("))[0])
-                            {
-                                -(1)
-                            } else if c_int::from(yyvs[yyvsp - 10].astr[0])
-                                > c_int::from((cs!(c"CIRCLE("))[0])
-                            {
-                                1
-                            } else {
-                                strcmp((yyvs[yyvsp - 10].astr).as_mut_ptr(), c"CIRCLE(".as_ptr())
-                            }) == 0
-                            {
+                            } else if astr_eq(&yyvs[yyvsp - 10].astr, c"CIRCLE(") {
                                 yyval.Node = New_Func(
                                     lParse,
                                     fits_parser_yytokentype::BOOLEAN as c_int,
@@ -6074,18 +5324,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 fits_parser_yyerror(lParse, cs!(c"Dimensions of BOX or ELLIPSE arguments are not compatible"));
                                 current_block = 4830776507462815627;
                             } else {
-                                if (if c_int::from(yyvs[yyvsp - 14].astr[0])
-                                    < c_int::from((cs!(c"BOX("))[0])
-                                {
-                                    -(1)
-                                } else if c_int::from(yyvs[yyvsp - 14].astr[0])
-                                    > c_int::from((cs!(c"BOX("))[0])
-                                {
-                                    1
-                                } else {
-                                    strcmp((yyvs[yyvsp - 14].astr).as_mut_ptr(), c"BOX(".as_ptr())
-                                }) == 0
-                                {
+                                if astr_eq(&yyvs[yyvsp - 14].astr, c"BOX(") {
                                     yyval.Node = New_Func(
                                         lParse,
                                         fits_parser_yytokentype::BOOLEAN as c_int,
@@ -6100,21 +5339,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                         yyvs[yyvsp - 1].Node,
                                     );
                                     current_block = 3023179740610631044;
-                                } else if (if c_int::from(yyvs[yyvsp - 14].astr[0])
-                                    < c_int::from((cs!(c"ELLIPSE"))[0])
-                                {
-                                    -(1)
-                                } else if c_int::from(yyvs[yyvsp - 14].astr[0])
-                                    > c_int::from((cs!(c"ELLIPSE"))[0])
-                                {
-                                    1
-                                } else {
-                                    strcmp(
-                                        (yyvs[yyvsp - 14].astr).as_mut_ptr(),
-                                        c"ELLIPSE(".as_ptr(),
-                                    )
-                                }) == 0
-                                {
+                                } else if astr_eq(&yyvs[yyvsp - 14].astr, c"ELLIPSE(") {
                                     yyval.Node = New_Func(
                                         lParse,
                                         fits_parser_yytokentype::BOOLEAN as c_int,
@@ -6668,18 +5893,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         }
                         134 => {
                             /* sexpr: FUNCTION sexpr ',' sexpr ')'  */
-                            if (if c_int::from(yyvs[yyvsp - 4].astr[0])
-                                < c_int::from((cs!(c"DEFNULL("))[0])
-                            {
-                                -(1)
-                            } else if c_int::from(yyvs[yyvsp - 4].astr[0])
-                                > c_int::from((cs!(c"DEFNULL("))[0])
-                            {
-                                1
-                            } else {
-                                strcmp((yyvs[yyvsp - 4].astr).as_mut_ptr(), c"DEFNULL(".as_ptr())
-                            }) == 0
-                            {
+                            if astr_eq(&yyvs[yyvsp - 4].astr, c"DEFNULL(") {
                                 /* Since the output can be calculated now, as a constant
                                 scalar, we must precalculate the output size, in
                                 order to avoid an overflow. */
@@ -6734,18 +5948,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         }
                         135 => {
                             /* sexpr: FUNCTION sexpr ',' expr ',' expr ')'  */
-                            if (if c_int::from(yyvs[yyvsp - 6].astr[0])
-                                < c_int::from((cs!(c"STRMID("))[0])
-                            {
-                                -(1)
-                            } else if c_int::from(yyvs[yyvsp - 6].astr[0])
-                                > c_int::from((cs!(c"STRMID("))[0])
-                            {
-                                1
-                            } else {
-                                strcmp((yyvs[yyvsp - 6].astr).as_mut_ptr(), c"STRMID(".as_ptr())
-                            }) == 0
-                            {
+                            if astr_eq(&yyvs[yyvsp - 6].astr, c"STRMID(") {
                                 let mut len: c_int = 0;
                                 if ((lParse.Nodes)[yyvs[yyvsp - 3].Node as usize]).ntype
                                     != fits_parser_yytokentype::LONG as c_int

--- a/src/eval_y.rs
+++ b/src/eval_y.rs
@@ -621,40 +621,38 @@ fn New_Const(
     value: *const c_void,
     len: c_long,
 ) -> c_int {
-    unsafe {
-        let mut n: c_int = 0;
-        n = Alloc_Node(lParse);
-        if n >= 0 {
-            let this_node = &mut lParse.Nodes[n as usize];
-            this_node.operation = CONST_OP; /* Flag a constant */
-            this_node.DoOp = None;
-            this_node.nSubNodes = 0;
-            this_node.ntype = returnType;
-            // Store the constant as a typed value rather than memcpy'ing raw
-            // bytes into the storage (which would depend on its in-memory
-            // layout).
-            if returnType == fits_parser_yytokentype::DOUBLE as c_int {
-                this_node.value.data = data_union::Double(*value.cast::<f64>());
-            } else if returnType == fits_parser_yytokentype::LONG as c_int {
-                this_node.value.data = data_union::Long(*value.cast::<c_long>());
-            } else if returnType == fits_parser_yytokentype::BOOLEAN as c_int {
-                this_node.value.data = data_union::Logical(*value.cast::<c_char>());
-            } else {
-                // STRING / BITSTR: copy the bytes into the fixed astr buffer.
-                let n = (len as usize).min(MAX_STRLEN as usize);
-                core::ptr::copy_nonoverlapping(
-                    value.cast::<c_char>(),
-                    this_node.value.data.astr_mut().as_mut_ptr(),
-                    n,
-                );
+    let n = Alloc_Node(lParse);
+    if n >= 0 {
+        let this_node = &mut lParse.Nodes[n as usize];
+        this_node.operation = CONST_OP; /* Flag a constant */
+        this_node.DoOp = None;
+        this_node.nSubNodes = 0;
+        this_node.ntype = returnType;
+        // Store the constant as a typed value rather than memcpy'ing raw bytes
+        // into the storage (which would depend on its in-memory layout). The
+        // only unsafe part is reading the constant from the caller's raw
+        // pointer.
+        this_node.value.data = if returnType == fits_parser_yytokentype::DOUBLE as c_int {
+            data_union::Double(unsafe { *value.cast::<f64>() })
+        } else if returnType == fits_parser_yytokentype::LONG as c_int {
+            data_union::Long(unsafe { *value.cast::<c_long>() })
+        } else if returnType == fits_parser_yytokentype::BOOLEAN as c_int {
+            data_union::Logical(unsafe { *value.cast::<c_char>() })
+        } else {
+            // STRING / BITSTR: copy the bytes into a fixed astr buffer.
+            let nbytes = (len as usize).min(MAX_STRLEN as usize);
+            let mut a = [0 as c_char; MAX_STRLEN as usize];
+            unsafe {
+                core::ptr::copy_nonoverlapping(value.cast::<c_char>(), a.as_mut_ptr(), nbytes);
             }
-            this_node.value.undef = ptr::null_mut();
-            this_node.value.nelem = 1;
-            this_node.value.naxis = 1;
-            this_node.value.naxes[0] = 1;
-        }
-        n
+            data_union::Str(a)
+        };
+        this_node.value.undef = ptr::null_mut();
+        this_node.value.nelem = 1;
+        this_node.value.naxis = 1;
+        this_node.value.naxes[0] = 1;
     }
+    n
 }
 
 fn New_Column(lParse: &mut ParseData, ColNum: c_int) -> c_int {

--- a/src/histo.rs
+++ b/src/histo.rs
@@ -4675,7 +4675,7 @@ fn fits_get_expr_minmax(
         result = &mut lParse.Nodes[lParse.resultNode as usize];
         match Info.datatype {
             TDOUBLE => {
-                let tmp = unsafe { result.value.data.dbl };
+                let tmp = unsafe { result.value.data.dbl() };
                 if let Some(dm) = datamax {
                     *dm = tmp;
                 }
@@ -4684,7 +4684,7 @@ fn fits_get_expr_minmax(
                 }
             }
             TLONG => {
-                let tmp = unsafe { result.value.data.lng as f64 };
+                let tmp = unsafe { result.value.data.lng() as f64 };
                 if let Some(dm) = datamax {
                     *dm = tmp;
                 }
@@ -4693,7 +4693,13 @@ fn fits_get_expr_minmax(
                 }
             }
             TLOGICAL => {
-                let tmp = unsafe { if result.value.data.log == 1 { 1.0 } else { 0.0 } };
+                let tmp = unsafe {
+                    if result.value.data.log() == 1 {
+                        1.0
+                    } else {
+                        0.0
+                    }
+                };
                 if let Some(dm) = datamax {
                     *dm = tmp;
                 }
@@ -4703,7 +4709,7 @@ fn fits_get_expr_minmax(
             }
             TBIT => {
                 let tmp = unsafe {
-                    if result.value.data.astr[0] != 0 {
+                    if result.value.data.astr()[0] != 0 {
                         1.0
                     } else {
                         0.0

--- a/tests/test_gtifilt.rs
+++ b/tests/test_gtifilt.rs
@@ -1,0 +1,119 @@
+//! Integration test for the `gtifilt()` row filter (GTIFILTER expression).
+//!
+//! Builds a FITS file with an events table (a `TIME` column) plus a Good-Time-
+//! Interval extension (`START`/`STOP` columns), then filters the events, keeping
+//! only rows whose `TIME` falls inside one of the intervals. This exercises the
+//! `New_GTI` code path and its per-node result buffer, which otherwise has no
+//! coverage.
+
+use libc::{c_char, c_int, c_long};
+
+use rsfitsio::aliases::rust_api::*;
+use rsfitsio::fitsio::{BINARY_TBL, BYTE_IMG, READONLY, fitsfile};
+
+mod common;
+use common::with_temp_file;
+
+/// NUL-terminated `c_char` buffer from a `str`.
+fn cc(s: &str) -> Vec<c_char> {
+    let mut v: Vec<c_char> = s.bytes().map(|b| b as c_char).collect();
+    v.push(0);
+    v
+}
+
+#[test]
+fn test_gtifilt_basic() {
+    with_temp_file(|filename| {
+        let mut status: c_int = 0;
+        let path = cc(filename);
+
+        // TIME values of the six events.
+        let times: [f64; 6] = [0.5, 1.5, 2.5, 3.5, 4.5, 5.5];
+        // Good-time intervals [1, 2] and [4, 5].
+        let start: [f64; 2] = [1.0, 4.0];
+        let stop: [f64; 2] = [2.0, 5.0];
+
+        // --- Build the file: primary + EVENTS table + GTI extension ---
+        let mut fptr: Option<Box<fitsfile>> = None;
+        fits_create_file(&mut fptr, &path, &mut status);
+        assert_eq!(status, 0, "create_file");
+
+        {
+            let f = fptr.as_deref_mut().unwrap();
+            let naxes: [c_long; 0] = [];
+            fits_create_img(f, BYTE_IMG, 0, &naxes, &mut status);
+            assert_eq!(status, 0, "create null primary");
+        }
+
+        {
+            let f = fptr.as_deref_mut().unwrap();
+            let ttype = [Some(cc("TIME"))];
+            let ttype_ref: Vec<Option<&[c_char]>> = ttype.iter().map(|o| o.as_deref()).collect();
+            let tform_v = [cc("1D")];
+            let tform_ref: Vec<&[c_char]> = tform_v.iter().map(|v| v.as_slice()).collect();
+            fits_create_tbl(
+                f,
+                BINARY_TBL,
+                times.len() as i64,
+                1,
+                &ttype_ref,
+                &tform_ref,
+                None,
+                Some(&cc("EVENTS")),
+                &mut status,
+            );
+            assert_eq!(status, 0, "create EVENTS table");
+            fits_write_col_dbl(f, 1, 1, 1, times.len() as i64, &times, &mut status);
+            assert_eq!(status, 0, "write TIME column");
+        }
+
+        {
+            let f = fptr.as_deref_mut().unwrap();
+            let ttype = [Some(cc("START")), Some(cc("STOP"))];
+            let ttype_ref: Vec<Option<&[c_char]>> = ttype.iter().map(|o| o.as_deref()).collect();
+            let tform_v = [cc("1D"), cc("1D")];
+            let tform_ref: Vec<&[c_char]> = tform_v.iter().map(|v| v.as_slice()).collect();
+            fits_create_tbl(
+                f,
+                BINARY_TBL,
+                start.len() as i64,
+                2,
+                &ttype_ref,
+                &tform_ref,
+                None,
+                Some(&cc("GTI")),
+                &mut status,
+            );
+            assert_eq!(status, 0, "create GTI table");
+            fits_write_col_dbl(f, 1, 1, 1, start.len() as i64, &start, &mut status);
+            fits_write_col_dbl(f, 2, 1, 1, stop.len() as i64, &stop, &mut status);
+            assert_eq!(status, 0, "write START/STOP columns");
+        }
+
+        fits_close_file(fptr.take().unwrap(), &mut status);
+        assert_eq!(status, 0, "close after build");
+
+        // --- Reopen, move to EVENTS, and apply gtifilt() ---
+        let mut rfptr: Option<Box<fitsfile>> = None;
+        fits_open_file(&mut rfptr, &path, READONLY, &mut status);
+        assert_eq!(status, 0, "reopen");
+
+        let f = rfptr.as_deref_mut().unwrap();
+        let mut hdutype = 0;
+        fits_movabs_hdu(f, 2, Some(&mut hdutype), &mut status);
+        assert_eq!(status, 0, "move to EVENTS");
+
+        let expr = cc("gtifilter()");
+        let mut n_good: c_long = -1;
+        let mut row_status: [c_char; 6] = [0; 6];
+        fits_find_rows(f, &expr, 1, 6, &mut n_good, &mut row_status, &mut status);
+        assert_eq!(status, 0, "gtifilt() evaluation (status={status})");
+
+        // TIME 1.5 is in [1, 2] and 4.5 is in [4, 5]; the rest fall outside.
+        assert_eq!(row_status, [0, 1, 0, 0, 1, 0], "matched rows");
+        assert_eq!(n_good, 2, "number of good rows");
+
+        fits_close_file(rfptr.take().unwrap(), &mut status);
+        assert_eq!(status, 0, "close after filter");
+    });
+}

--- a/tests/test_regfilter.rs
+++ b/tests/test_regfilter.rs
@@ -1,0 +1,92 @@
+//! Integration test for the `regfilter()` row filter (REGFILTER expression).
+//!
+//! Builds a FITS table with X/Y spatial columns and a DS9-style region file
+//! (a circle in pixel coordinates), then filters the rows, keeping only those
+//! whose (X, Y) falls inside the region. Exercises the `New_REG` code path and
+//! its region-pointer handling, which otherwise has no coverage.
+
+use libc::{c_char, c_int, c_long};
+
+use rsfitsio::aliases::rust_api::*;
+use rsfitsio::fitsio::{BINARY_TBL, BYTE_IMG, READONLY, fitsfile};
+
+mod common;
+use common::with_temp_file;
+
+fn cc(s: &str) -> Vec<c_char> {
+    let mut v: Vec<c_char> = s.bytes().map(|b| b as c_char).collect();
+    v.push(0);
+    v
+}
+
+#[test]
+fn test_regfilter_circle() {
+    with_temp_file(|filename| {
+        let mut status: c_int = 0;
+        let path = cc(filename);
+
+        // Region file: a circle centred at (100,100) with radius 30 (pixels).
+        let region_path = format!("{filename}.reg");
+        std::fs::write(&region_path, "circle(100,100,30)\n").unwrap();
+
+        // Event X/Y coordinates.
+        let xs: [f64; 4] = [100.0, 120.0, 100.0, 200.0];
+        let ys: [f64; 4] = [100.0, 100.0, 140.0, 200.0];
+
+        // --- Build the file: primary + EVENTS table with X and Y ---
+        let mut fptr: Option<Box<fitsfile>> = None;
+        fits_create_file(&mut fptr, &path, &mut status);
+        assert_eq!(status, 0, "create_file");
+        {
+            let f = fptr.as_deref_mut().unwrap();
+            let naxes: [c_long; 0] = [];
+            fits_create_img(f, BYTE_IMG, 0, &naxes, &mut status);
+            assert_eq!(status, 0, "primary");
+
+            let ttype = [Some(cc("X")), Some(cc("Y"))];
+            let ttype_ref: Vec<Option<&[c_char]>> = ttype.iter().map(|o| o.as_deref()).collect();
+            let tform_v = [cc("1D"), cc("1D")];
+            let tform_ref: Vec<&[c_char]> = tform_v.iter().map(|v| v.as_slice()).collect();
+            fits_create_tbl(
+                f,
+                BINARY_TBL,
+                xs.len() as i64,
+                2,
+                &ttype_ref,
+                &tform_ref,
+                None,
+                Some(&cc("EVENTS")),
+                &mut status,
+            );
+            assert_eq!(status, 0, "create EVENTS");
+            fits_write_col_dbl(f, 1, 1, 1, xs.len() as i64, &xs, &mut status);
+            fits_write_col_dbl(f, 2, 1, 1, ys.len() as i64, &ys, &mut status);
+            assert_eq!(status, 0, "write X/Y");
+        }
+        fits_close_file(fptr.take().unwrap(), &mut status);
+        assert_eq!(status, 0, "close");
+
+        // --- Reopen, move to EVENTS, apply regfilter("<region file>") ---
+        let mut rfptr: Option<Box<fitsfile>> = None;
+        fits_open_file(&mut rfptr, &path, READONLY, &mut status);
+        assert_eq!(status, 0, "reopen");
+        let f = rfptr.as_deref_mut().unwrap();
+        let mut hdutype = 0;
+        fits_movabs_hdu(f, 2, Some(&mut hdutype), &mut status);
+        assert_eq!(status, 0, "move to EVENTS");
+
+        let expr = cc(&format!("regfilter(\"{region_path}\")"));
+        let mut n_good: c_long = -1;
+        let mut row_status: [c_char; 4] = [0; 4];
+        fits_find_rows(f, &expr, 1, 4, &mut n_good, &mut row_status, &mut status);
+        assert_eq!(status, 0, "regfilter evaluation (status={status})");
+
+        // (100,100) centre and (120,100) dist 20 are inside r=30; (100,140)
+        // dist 40 and (200,200) are outside.
+        assert_eq!(row_status, [1, 1, 0, 0], "matched rows");
+        assert_eq!(n_good, 2, "number of good rows");
+
+        fits_close_file(rfptr.take().unwrap(), &mut status);
+        let _ = std::fs::remove_file(&region_path);
+    });
+}


### PR DESCRIPTION
The eval* code has a reasonable test coverage, so I asked Claude to see if it could remove the unsafe usage. This was largely caused by the literal translation from the C code and using `date_union` as a union instead as an enum. 