### PR TITLE
Fix usize underflow when unshuffling GZIP_2 tiles

### DIFF
--- a/src/imcompress.rs
+++ b/src/imcompress.rs
@@ -13084,31 +13084,30 @@ fn fits_shuffle_8bytes(heap: &mut [c_char], length: LONGLONG, status: &mut c_int
 }
 
 /*--------------------------------------------------------------------------*/
-/// unshuffle the bytes in an array of 2-byte integers
-fn fits_unshuffle_2bytes(heap: &mut [c_char], length: LONGLONG, status: &mut c_int) -> c_int {
-    let length = length as usize;
-    let heap = cast_slice_mut(heap);
-
-    let mut p: Vec<u8> = vec![0; length * 2];
-
-    let ptr: usize = 0;
-    let mut heapptr: usize = (2 * length) - 1;
-    let mut cptr: usize = ptr + (2 * length) - 1;
-
-    for ii in 0..length {
-        p[cptr] = heap[heapptr];
-        cptr -= 1;
-        p[cptr] = heap[heapptr - length];
-        /* advance cptr past the second byte too (matches the 4-/8-byte
-        variants); guard the final decrement so the last iteration does not
-        underflow the usize index. */
-        if ii + 1 < length {
-            cptr -= 1;
-        }
-        heapptr -= 1;
+/// Undo the byte shuffling of an array of `length` values of `NBYTES` bytes each.
+///
+/// The shuffled heap holds `NBYTES` planes of `length` bytes: every value's first
+/// byte, then every value's second byte, and so on.  Reassembling the values is
+/// simply the transpose of that layout.
+fn unshuffle_bytes<const NBYTES: usize>(heap: &mut [c_char], length: usize) {
+    if length == 0 {
+        return;
     }
 
-    heap[0..(length * 2)].copy_from_slice(&p[..(length * 2)]);
+    let heap: &mut [u8] = cast_slice_mut(&mut heap[..length * NBYTES]);
+
+    let planes = heap.to_vec();
+    for (byte_index, plane) in planes.chunks_exact(length).enumerate() {
+        for (value, &byte) in heap.chunks_exact_mut(NBYTES).zip(plane) {
+            value[byte_index] = byte;
+        }
+    }
+}
+
+/*--------------------------------------------------------------------------*/
+/// unshuffle the bytes in an array of 2-byte integers
+fn fits_unshuffle_2bytes(heap: &mut [c_char], length: LONGLONG, status: &mut c_int) -> c_int {
+    unshuffle_bytes::<2>(heap, length as usize);
 
     *status
 }
@@ -13116,28 +13115,7 @@ fn fits_unshuffle_2bytes(heap: &mut [c_char], length: LONGLONG, status: &mut c_i
 /*--------------------------------------------------------------------------*/
 /// unshuffle the bytes in an array of 4-byte integers or floats
 fn fits_unshuffle_4bytes(heap: &mut [c_char], length: LONGLONG, status: &mut c_int) -> c_int {
-    let length = length as usize;
-    let heap = cast_slice_mut(heap);
-
-    let mut p: Vec<u8> = vec![0; length * 4];
-
-    let ptr: usize = 0;
-    let mut heapptr: usize = (4 * length) - 1;
-    let mut cptr: usize = ptr + (4 * length) - 1;
-
-    for _ii in 0..length {
-        p[cptr] = heap[heapptr];
-        cptr -= 1;
-        p[cptr] = heap[heapptr - length];
-        cptr -= 1;
-        p[cptr] = heap[heapptr - (2 * length)];
-        cptr -= 1;
-        p[cptr] = heap[heapptr - (3 * length)];
-        cptr -= 1;
-        heapptr -= 1;
-    }
-
-    heap[0..(length * 4)].copy_from_slice(&p[..(length * 4)]);
+    unshuffle_bytes::<4>(heap, length as usize);
 
     *status
 }
@@ -13145,36 +13123,7 @@ fn fits_unshuffle_4bytes(heap: &mut [c_char], length: LONGLONG, status: &mut c_i
 /*--------------------------------------------------------------------------*/
 /// unshuffle the bytes in an array of 8-byte integers or doubles
 fn fits_unshuffle_8bytes(heap: &mut [c_char], length: LONGLONG, status: &mut c_int) -> c_int {
-    let length = length as usize;
-    let heap = cast_slice_mut(heap);
-
-    let mut p: Vec<u8> = vec![0; length * 8];
-
-    let ptr: usize = 0;
-    let mut heapptr: usize = (8 * length) - 1;
-    let mut cptr: usize = ptr + (8 * length) - 1;
-
-    for _ii in 0..length {
-        p[cptr] = heap[heapptr];
-        cptr -= 1;
-        p[cptr] = heap[heapptr - length];
-        cptr -= 1;
-        p[cptr] = heap[heapptr - (2 * length)];
-        cptr -= 1;
-        p[cptr] = heap[heapptr - (3 * length)];
-        cptr -= 1;
-        p[cptr] = heap[heapptr - (4 * length)];
-        cptr -= 1;
-        p[cptr] = heap[heapptr - (5 * length)];
-        cptr -= 1;
-        p[cptr] = heap[heapptr - (6 * length)];
-        cptr -= 1;
-        p[cptr] = heap[heapptr - (7 * length)];
-        cptr -= 1;
-        heapptr -= 1;
-    }
-
-    heap[0..(length * 8)].copy_from_slice(&p[..(length * 8)]);
+    unshuffle_bytes::<8>(heap, length as usize);
 
     *status
 }
@@ -14173,10 +14122,12 @@ mod ricecomp_tests {
 #[cfg(test)]
 mod tests {
     use super::{
-        fits_get_compression_type_safe, fits_get_dither_seed_safe, fits_get_noise_bits_safe,
-        fits_get_quantize_level_safe, fits_get_tile_dim_safer, fits_img_compress_safe,
-        fits_set_compression_type_safe, fits_set_dither_seed_safe, fits_set_noise_bits_safe,
-        fits_set_quantize_level_safe, fits_set_quantize_method_safe, fits_set_tile_dim_safe,
+        c_char, c_int, fits_get_compression_type_safe, fits_get_dither_seed_safe,
+        fits_get_noise_bits_safe, fits_get_quantize_level_safe, fits_get_tile_dim_safer,
+        fits_img_compress_safe, fits_set_compression_type_safe, fits_set_dither_seed_safe,
+        fits_set_noise_bits_safe, fits_set_quantize_level_safe, fits_set_quantize_method_safe,
+        fits_set_tile_dim_safe, fits_shuffle_2bytes, fits_shuffle_4bytes, fits_shuffle_8bytes,
+        fits_unshuffle_2bytes, fits_unshuffle_4bytes, fits_unshuffle_8bytes,
     };
     use crate::c_types::c_long;
     use crate::cfileio::{ffclos_safe, ffinit_safe, ffopen_safe};
@@ -14631,5 +14582,93 @@ mod tests {
                 compress_roundtrip(filename, BYTE_IMG, TBYTE, RICE_1, 32, 32, &original);
             assert_eq!(decompressed, original);
         });
+    }
+
+    // Byte (un)shuffling helpers used by GZIP_2.  See
+    // https://github.com/cruzzil/rsfitsio/issues/89: the unshuffle functions
+    // used to run their destination cursor one step past the start of the
+    // buffer, which panicked on the usize underflow whenever overflow checks
+    // were on.
+
+    /// `length` values of `nbytes` bytes each, with recognisable byte values:
+    /// value `ii` holds the bytes `10 * ii + 1 ..= 10 * ii + nbytes`.
+    fn sample(length: usize, nbytes: usize) -> Vec<c_char> {
+        (0..length)
+            .flat_map(|ii| (1..=nbytes).map(move |b| (10 * ii + b) as u8))
+            .map(|b| b as c_char)
+            .collect()
+    }
+
+    #[test]
+    fn test_shuffle_4bytes_groups_bytes_into_planes() {
+        let mut heap = sample(3, 4);
+        let mut status: c_int = 0;
+        fits_shuffle_4bytes(&mut heap, 3, &mut status);
+
+        // all the first bytes, then all the second bytes, and so on
+        let expected: &[u8] = &[1, 11, 21, 2, 12, 22, 3, 13, 23, 4, 14, 24];
+        assert_eq!(cast_slice::<c_char, u8>(&heap), expected);
+        assert_eq!(status, 0);
+    }
+
+    #[test]
+    fn test_unshuffle_4bytes_restores_the_values() {
+        let shuffled: Vec<c_char> = [1u8, 11, 21, 2, 12, 22, 3, 13, 23, 4, 14, 24]
+            .iter()
+            .map(|&b| b as c_char)
+            .collect();
+        let mut heap = shuffled;
+        let mut status: c_int = 0;
+        fits_unshuffle_4bytes(&mut heap, 3, &mut status);
+
+        assert_eq!(heap, sample(3, 4));
+        assert_eq!(status, 0);
+    }
+
+    /// Unshuffling is the exact inverse of shuffling, for every width and for
+    /// the lengths that used to trip the cursor underflow.
+    #[test]
+    fn test_unshuffle_inverts_shuffle() {
+        for length in 0..8_usize {
+            for nbytes in [2_usize, 4, 8] {
+                let original = sample(length, nbytes);
+                let mut heap = original.clone();
+                let mut status: c_int = 0;
+
+                match nbytes {
+                    2 => {
+                        fits_shuffle_2bytes(&mut heap, length as i64, &mut status);
+                        fits_unshuffle_2bytes(&mut heap, length as i64, &mut status);
+                    }
+                    4 => {
+                        fits_shuffle_4bytes(&mut heap, length as i64, &mut status);
+                        fits_unshuffle_4bytes(&mut heap, length as i64, &mut status);
+                    }
+                    _ => {
+                        fits_shuffle_8bytes(&mut heap, length as i64, &mut status);
+                        fits_unshuffle_8bytes(&mut heap, length as i64, &mut status);
+                    }
+                }
+
+                assert_eq!(heap, original, "length {length}, {nbytes}-byte values");
+                assert_eq!(status, 0);
+            }
+        }
+    }
+
+    /// The heap buffer is usually larger than the shuffled data; nothing past
+    /// `length * nbytes` may be touched.
+    #[test]
+    fn test_unshuffle_leaves_trailing_bytes_alone() {
+        let mut heap = sample(2, 8);
+        heap.extend_from_slice(cast_slice_mut::<u8, c_char>(&mut [0xAA_u8; 5]));
+        let mut status: c_int = 0;
+
+        fits_shuffle_8bytes(&mut heap[..16], 2, &mut status);
+        fits_unshuffle_8bytes(&mut heap, 2, &mut status);
+
+        assert_eq!(heap[..16], sample(2, 8)[..]);
+        assert!(heap[16..].iter().all(|&b| b as u8 == 0xAA));
+        assert_eq!(status, 0);
     }
 }

--- a/tests/test_tile_compress.rs
+++ b/tests/test_tile_compress.rs
@@ -1,0 +1,116 @@
+//! Round-trip tests for tile-compressed images.
+
+mod common;
+
+#[cfg(test)]
+mod tests {
+    use crate::common::with_temp_file;
+    use bytemuck::cast_slice;
+    use libc::c_int;
+    use rsfitsio::aliases::rust_api::*;
+    use rsfitsio::fitsio::{
+        DOUBLE_IMG, FLOAT_IMG, GZIP_2, LONGLONG, READONLY, SHORT_IMG, fitsfile,
+    };
+    use rsfitsio::imcompress::{fits_set_compression_type_safe, fits_set_quantize_level_safe};
+    use std::ffi::CString;
+
+    const NX: LONGLONG = 16;
+    const NY: LONGLONG = 8;
+    const NELEM: usize = (NX * NY) as usize;
+
+    /// Regression test for https://github.com/cruzzil/rsfitsio/issues/89
+    ///
+    /// The GZIP_2 byte unshuffling used on read decremented its destination
+    /// cursor once more than there were bytes to store, which underflowed the
+    /// `usize` index and panicked in any build with overflow checks on.
+    #[test]
+    fn test_gzip2_float_round_trip() {
+        with_temp_file(|filename| {
+            let filename_cstr = CString::new(filename).unwrap();
+            let name = cast_slice(filename_cstr.to_bytes_with_nul());
+            let data: Vec<f32> = (0..NELEM).map(|i| i as f32 * 0.5).collect();
+            let mut status: c_int = 0;
+
+            let mut fptr: Option<Box<fitsfile>> = None;
+            fits_create_diskfile(&mut fptr, name, &mut status);
+            let f = fptr.as_mut().unwrap();
+            fits_set_quantize_level_safe(f, 0.0, &mut status); // lossless floats
+            fits_set_compression_type_safe(f, GZIP_2, &mut status);
+            fits_create_imgll(f, FLOAT_IMG, 2, &[NX, NY], &mut status);
+            fits_write_img_flt(f, 1, 1, NELEM as LONGLONG, &data, &mut status);
+            fits_close_file(fptr.take().unwrap(), &mut status);
+            assert_eq!(status, 0, "Failed to write GZIP_2 float image");
+
+            fits_open_diskfile(&mut fptr, name, READONLY, &mut status);
+            let f = fptr.as_mut().unwrap();
+            fits_movabs_hdu(f, 2, None, &mut status); // the image is in the extension
+            let mut out = vec![0f32; NELEM];
+            fits_read_img_flt(f, 1, 1, NELEM as LONGLONG, 0.0, &mut out, None, &mut status);
+            fits_close_file(fptr.take().unwrap(), &mut status);
+
+            assert_eq!(status, 0, "Failed to read GZIP_2 float image");
+            assert_eq!(out, data, "GZIP_2 float round trip differs");
+        });
+    }
+
+    /// Regression test for https://github.com/cruzzil/rsfitsio/issues/89
+    #[test]
+    fn test_gzip2_double_round_trip() {
+        with_temp_file(|filename| {
+            let filename_cstr = CString::new(filename).unwrap();
+            let name = cast_slice(filename_cstr.to_bytes_with_nul());
+            let data: Vec<f64> = (0..NELEM).map(|i| i as f64 * 0.25).collect();
+            let mut status: c_int = 0;
+
+            let mut fptr: Option<Box<fitsfile>> = None;
+            fits_create_diskfile(&mut fptr, name, &mut status);
+            let f = fptr.as_mut().unwrap();
+            fits_set_quantize_level_safe(f, 0.0, &mut status); // lossless doubles
+            fits_set_compression_type_safe(f, GZIP_2, &mut status);
+            fits_create_imgll(f, DOUBLE_IMG, 2, &[NX, NY], &mut status);
+            fits_write_img_dbl(f, 1, 1, NELEM as LONGLONG, &data, &mut status);
+            fits_close_file(fptr.take().unwrap(), &mut status);
+            assert_eq!(status, 0, "Failed to write GZIP_2 double image");
+
+            fits_open_diskfile(&mut fptr, name, READONLY, &mut status);
+            let f = fptr.as_mut().unwrap();
+            fits_movabs_hdu(f, 2, None, &mut status);
+            let mut out = vec![0f64; NELEM];
+            fits_read_img_dbl(f, 1, 1, NELEM as LONGLONG, 0.0, &mut out, None, &mut status);
+            fits_close_file(fptr.take().unwrap(), &mut status);
+
+            assert_eq!(status, 0, "Failed to read GZIP_2 double image");
+            assert_eq!(out, data, "GZIP_2 double round trip differs");
+        });
+    }
+
+    /// Regression test for https://github.com/cruzzil/rsfitsio/issues/89
+    #[test]
+    fn test_gzip2_short_round_trip() {
+        with_temp_file(|filename| {
+            let filename_cstr = CString::new(filename).unwrap();
+            let name = cast_slice(filename_cstr.to_bytes_with_nul());
+            let data: Vec<i16> = (0..NELEM).map(|i| (i as i16) * 3 - 100).collect();
+            let mut status: c_int = 0;
+
+            let mut fptr: Option<Box<fitsfile>> = None;
+            fits_create_diskfile(&mut fptr, name, &mut status);
+            let f = fptr.as_mut().unwrap();
+            fits_set_compression_type_safe(f, GZIP_2, &mut status);
+            fits_create_imgll(f, SHORT_IMG, 2, &[NX, NY], &mut status);
+            fits_write_img_sht(f, 1, 1, NELEM as LONGLONG, &data, &mut status);
+            fits_close_file(fptr.take().unwrap(), &mut status);
+            assert_eq!(status, 0, "Failed to write GZIP_2 short image");
+
+            fits_open_diskfile(&mut fptr, name, READONLY, &mut status);
+            let f = fptr.as_mut().unwrap();
+            fits_movabs_hdu(f, 2, None, &mut status);
+            let mut out = vec![0i16; NELEM];
+            fits_read_img_sht(f, 1, 1, NELEM as LONGLONG, 0, &mut out, None, &mut status);
+            fits_close_file(fptr.take().unwrap(), &mut status);
+
+            assert_eq!(status, 0, "Failed to read GZIP_2 short image");
+            assert_eq!(out, data, "GZIP_2 short round trip differs");
+        });
+    }
+}


### PR DESCRIPTION
Fixes #89.

## The bug

`fits_unshuffle_4bytes` and `fits_unshuffle_8bytes` decrement their destination cursor once per stored byte *plus* once at the end of each iteration, so the final pass takes the index from `0` to `-1`. As a `usize` that panics in any build with overflow checks on, which means reading back **any** `GZIP_2` tile-compressed image fails under `cargo test`/`cargo run`. `fits_unshuffle_2bytes` had a `if ii + 1 < length` guard bolted on for the same reason. All three also underflowed on `length == 0`, before the loop even started.

## The fix

The shuffled heap is `NBYTES` planes of `length` bytes (all first bytes, then all second bytes, …), so unshuffling is just the transpose: plane `j` becomes byte `j` of each value. The three functions now share one index-safe helper instead of each carrying its own reverse pointer walk.

## Tests

Unit tests in `src/imcompress.rs` (`mod tests`) cover the helpers directly:
- the shuffled layout for a hand-computed 4-byte case, and its exact inverse;
- `unshuffle` inverts `shuffle` for 2/4/8-byte values at lengths 0..8 — this is what caught the `length == 0` case;
- bytes past `length * nbytes` in the heap buffer are left untouched.

`tests/test_tile_compress.rs` adds `GZIP_2` write/read round trips for float, double and short images — the float and double ones reproduce the panic from the issue on `main`.

Verified: `cargo test` (all suites), `cargo clippy --all-targets` (clean), `cargo fmt --check`, and `./testprog_check.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)