### PR TITLE
Transpile fitsverify from CFITSIO

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -28,6 +28,14 @@ jobs:
           cargo llvm-cov run --example iter_a --no-report
           cargo llvm-cov run --example iter_b --no-report
           cargo llvm-cov run --example iter_c --no-report
+          # fitsverify exits with the number of errors + warnings it found, so
+          # a non-zero status here is a normal result, not a failure.
+          cargo llvm-cov run --bin fitsverify --no-report -- testprog.fit || true
+          cargo llvm-cov run --bin fitsverify --no-report -- -l testprog.fit || true
+          cargo llvm-cov run --bin fitsverify --no-report -- -q -e testprog.fit || true
+          cargo llvm-cov run --bin fitsverify --no-report -- -H testprog.fit || true
+          cargo llvm-cov run --bin fitsverify --no-report -- examples/iter_a/iter_a.fit examples/iter_b/iter_b.fit examples/iter_c/iter_c.fit || true
+          cargo llvm-cov run --bin fitsverify --no-report -- -l examples/iter_var/vari.fits || true
           cargo llvm-cov report --lcov --output-path lcov.info
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v7

--- a/src/bin/fitsverify/common.rs
+++ b/src/bin/fitsverify/common.rs
@@ -7,21 +7,21 @@
    which is semantically identical and avoids global mutable state.  The truly
    persistent globals (the flags and counters) live in `flags` below.  */
 
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
+use std::cmp::Ordering;
 use std::fmt::Display;
 use std::io::Write;
-use std::sync::atomic::{AtomicI32, AtomicI64, Ordering};
 
 use rsfitsio::c_types::{c_char, c_int, c_long, c_ulong};
 use rsfitsio::fitsio::{FLEN_KEYWORD, FLEN_VALUE, LONGLONG};
 
-pub const MAXERRORS: c_int = 200;
-pub const MAXWRNS: c_int = 200;
+pub(crate) const MAXERRORS: c_int = 200;
+pub(crate) const MAXWRNS: c_int = 200;
 
 /* static char errmes[256]; */
-pub const ERRMES_LEN: usize = 256;
+pub(crate) const ERRMES_LEN: usize = 256;
 /* static char comm[FLEN_FILENAME+6]; */
-pub const COMM_LEN: usize = rsfitsio::fitsio::FLEN_FILENAME + 6;
+pub(crate) const COMM_LEN: usize = rsfitsio::fitsio::FLEN_FILENAME + 6;
 
 /********************************
 *				*
@@ -30,7 +30,7 @@ pub const COMM_LEN: usize = rsfitsio::fitsio::FLEN_FILENAME + 6;
 ********************************/
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug, Default)]
-pub enum kwdtyp {
+pub(crate) enum kwdtyp {
     STR_KEY, /* string   key */
     LOG_KEY, /* Logical key */
     INT_KEY, /* Integer key */
@@ -43,32 +43,32 @@ pub enum kwdtyp {
 }
 
 /* error number masks of  the keyword test */
-pub const BAD_STR: c_ulong = 0x0001;
-pub const NO_TRAIL_QUOTE: c_ulong = 0x0002;
-pub const BAD_NUM: c_ulong = 0x0004;
-pub const LOWCASE_EXPO: c_ulong = 0x0008;
-pub const NO_TRAIL_PAREN: c_ulong = 0x0010;
-pub const NO_COMMA: c_ulong = 0x0020;
-pub const TOO_MANY_COMMA: c_ulong = 0x0040;
-pub const BAD_REAL: c_ulong = 0x0080;
-pub const BAD_IMG: c_ulong = 0x0100;
-pub const BAD_LOGICAL: c_ulong = 0x0200;
-pub const NO_START_SLASH: c_ulong = 0x0400;
-pub const BAD_COMMENT: c_ulong = 0x0800;
-pub const UNKNOWN_TYPE: c_ulong = 0x1000;
+pub(crate) const BAD_STR: c_ulong = 0x0001;
+pub(crate) const NO_TRAIL_QUOTE: c_ulong = 0x0002;
+pub(crate) const BAD_NUM: c_ulong = 0x0004;
+pub(crate) const LOWCASE_EXPO: c_ulong = 0x0008;
+pub(crate) const NO_TRAIL_PAREN: c_ulong = 0x0010;
+pub(crate) const NO_COMMA: c_ulong = 0x0020;
+pub(crate) const TOO_MANY_COMMA: c_ulong = 0x0040;
+pub(crate) const BAD_REAL: c_ulong = 0x0080;
+pub(crate) const BAD_IMG: c_ulong = 0x0100;
+pub(crate) const BAD_LOGICAL: c_ulong = 0x0200;
+pub(crate) const NO_START_SLASH: c_ulong = 0x0400;
+pub(crate) const BAD_COMMENT: c_ulong = 0x0800;
+pub(crate) const UNKNOWN_TYPE: c_ulong = 0x1000;
 
 /* Number of possible WCS descriptions to check.*/
 /* 1 for the primary + 26 for [A-Z] suffix. */
-pub const NWCSDESCR: usize = 27;
+pub(crate) const NWCSDESCR: usize = 27;
 
 /* keyword structure */
 #[derive(Clone)]
-pub struct FitsKey {
-    pub kname: [c_char; FLEN_KEYWORD], /* fits keyword name */
-    pub ktype: kwdtyp,                 /* fits keyword type */
-    pub kvalue: [c_char; FLEN_VALUE],  /* fits keyword name */
-    pub kindex: c_int,                 /* position at the header */
-    pub goodkey: c_int,                /* good keyword flag (=1 good)*/
+pub(crate) struct FitsKey {
+    pub(crate) kname: [c_char; FLEN_KEYWORD], /* fits keyword name */
+    pub(crate) ktype: kwdtyp,                 /* fits keyword type */
+    pub(crate) kvalue: [c_char; FLEN_VALUE],  /* fits keyword name */
+    pub(crate) kindex: c_int,                 /* position at the header */
+    pub(crate) goodkey: c_int,                /* good keyword flag (=1 good)*/
 }
 
 impl Default for FitsKey {
@@ -88,33 +88,33 @@ impl Default for FitsKey {
 *       Headers  		*
 *				*
 ********************************/
-pub struct FitsHdu {
-    pub hdutype: c_int,                /* hdutype */
-    pub hdunum: c_int,                 /* hdunum  */
-    pub isgroup: c_int,                /* random group flag */
-    pub istilecompressed: c_int,       /* tile compressed image */
-    pub gcount: c_int,                 /* gcount  */
-    pub pcount: LONGLONG,              /* pcount  */
-    pub bitpix: c_int,                 /* pix number */
-    pub naxis: c_int,                  /* number of the axis,used for image array*/
-    pub naxes: Vec<LONGLONG>,          /* dimension of each axis,used for image array*/
-    pub ncols: c_int,                  /* number of the columns, used for image only*/
-    pub extname: [c_char; FLEN_VALUE], /* EXTENSION NAME */
-    pub extver: c_int,                 /* extension version */
-    pub datamax: Vec<Vec<c_char>>,     /* strings for the maximum of the data in a column */
-    pub datamin: Vec<Vec<c_char>>,     /* strings for the minimum of the data in a column */
-    pub tnull: Vec<Vec<c_char>>,       /* number of NULL values */
-    pub nkeys: c_int,                  /* number of keys */
-    pub tkeys: c_int,                  /* total of the keys tested*/
-    pub heap: c_int,                   /* heap */
-    pub kwds: Vec<FitsKey>,            /* keywords list starting from the
+pub(crate) struct FitsHdu {
+    pub(crate) hdutype: c_int,                /* hdutype */
+    pub(crate) hdunum: c_int,                 /* hdunum  */
+    pub(crate) isgroup: c_int,                /* random group flag */
+    pub(crate) istilecompressed: c_int,       /* tile compressed image */
+    pub(crate) gcount: c_int,                 /* gcount  */
+    pub(crate) pcount: LONGLONG,              /* pcount  */
+    pub(crate) bitpix: c_int,                 /* pix number */
+    pub(crate) naxis: c_int,                  /* number of the axis,used for image array*/
+    pub(crate) naxes: Vec<LONGLONG>,          /* dimension of each axis,used for image array*/
+    pub(crate) ncols: c_int,                  /* number of the columns, used for image only*/
+    pub(crate) extname: [c_char; FLEN_VALUE], /* EXTENSION NAME */
+    pub(crate) extver: c_int,                 /* extension version */
+    pub(crate) datamax: Vec<Vec<c_char>>,     /* strings for the maximum of the data in a column */
+    pub(crate) datamin: Vec<Vec<c_char>>,     /* strings for the minimum of the data in a column */
+    pub(crate) tnull: Vec<Vec<c_char>>,       /* number of NULL values */
+    pub(crate) nkeys: c_int,                  /* number of keys */
+    pub(crate) tkeys: c_int,                  /* total of the keys tested*/
+    pub(crate) heap: c_int,                   /* heap */
+    pub(crate) kwds: Vec<FitsKey>,            /* keywords list starting from the
                                        last NAXISn keyword. The array
                                        is sorted in the ascending alphabetical
                                        order of keyword names. The last keyword END
                                        and commentary keywords are  excluded.
                                        The total number of element, tkey, is
                                        nkeys - 4 - naxis - ncomm. */
-    pub use_longstr: c_int, /* flag indicates that the long string
+    pub(crate) use_longstr: c_int, /* flag indicates that the long string
                             convention is used */
 }
 
@@ -145,9 +145,9 @@ impl Default for FitsHdu {
     }
 }
 
-pub struct ColName {
-    pub name: Vec<c_char>, /* column name */
-    pub index: c_int,      /* column index */
+pub(crate) struct ColName {
+    pub(crate) name: Vec<c_char>, /* column name */
+    pub(crate) index: c_int,      /* column index */
 }
 
 /********************************
@@ -156,13 +156,13 @@ pub struct ColName {
 *				*
 ********************************/
 #[derive(Clone)]
-pub struct HduName {
-    pub hdutype: c_int,                /* hdutype */
-    pub hdunum: c_int,                 /* hdunum  */
-    pub extname: [c_char; FLEN_VALUE], /* extension name, used for extension*/
-    pub extver: c_int,                 /* extension version, used for extension */
-    pub errnum: c_int,                 /* number of errors in this hdu */
-    pub wrnno: c_int,                  /* number of warnning in this hdu */
+pub(crate) struct HduName {
+    pub(crate) hdutype: c_int,                /* hdutype */
+    pub(crate) hdunum: c_int,                 /* hdunum  */
+    pub(crate) extname: [c_char; FLEN_VALUE], /* extension name, used for extension*/
+    pub(crate) extver: c_int,                 /* extension version, used for extension */
+    pub(crate) errnum: c_int,                 /* number of errors in this hdu */
+    pub(crate) wrnno: c_int,                  /* number of warnning in this hdu */
 }
 
 impl Default for HduName {
@@ -182,16 +182,21 @@ impl Default for HduName {
  *  The `extern int' globals from fverify.h / ftverify.c.
  *==========================================================================*/
 
+/* These are file statics in the C, i.e. per-process state in a single-threaded
+   program.  Thread-locals give exactly that, and keep the test threads from
+   trampling on each other's counters. */
 macro_rules! int_global {
     ($get:ident, $set:ident, $store:ident, $init:expr) => {
-        static $store: AtomicI32 = AtomicI32::new($init);
-        #[inline]
-        pub fn $get() -> c_int {
-            $store.load(Ordering::Relaxed)
+        thread_local! {
+            static $store: Cell<c_int> = const { Cell::new($init) };
         }
         #[inline]
-        pub fn $set(v: c_int) {
-            $store.store(v, Ordering::Relaxed);
+        pub(crate) fn $get() -> c_int {
+            $store.with(Cell::get)
+        }
+        #[inline]
+        pub(crate) fn $set(v: c_int) {
+            $store.with(|c| c.set(v));
         }
     };
 }
@@ -207,20 +212,22 @@ int_global!(testhierarch, set_testhierarch, TESTHIERARCH, 0);
 int_global!(totalhdu, set_totalhdu, TOTALHDU, 0);
 
 /* long totalerr, totalwrn;  (ftverify.c) */
-static TOTALERR: AtomicI64 = AtomicI64::new(0);
-static TOTALWRN: AtomicI64 = AtomicI64::new(0);
+thread_local! {
+    static TOTALERR: Cell<i64> = const { Cell::new(0) };
+    static TOTALWRN: Cell<i64> = const { Cell::new(0) };
+}
 
-pub fn totalerr() -> i64 {
-    TOTALERR.load(Ordering::Relaxed)
+pub(crate) fn totalerr() -> i64 {
+    TOTALERR.with(Cell::get)
 }
-pub fn totalwrn() -> i64 {
-    TOTALWRN.load(Ordering::Relaxed)
+pub(crate) fn totalwrn() -> i64 {
+    TOTALWRN.with(Cell::get)
 }
-pub fn add_totalerr(v: i64) {
-    TOTALERR.fetch_add(v, Ordering::Relaxed);
+pub(crate) fn add_totalerr(v: i64) {
+    TOTALERR.with(|c| c.set(c.get() + v));
 }
-pub fn add_totalwrn(v: i64) {
-    TOTALWRN.fetch_add(v, Ordering::Relaxed);
+pub(crate) fn add_totalwrn(v: i64) {
+    TOTALWRN.with(|c| c.set(c.get() + v));
 }
 
 /*===========================================================================
@@ -233,7 +240,7 @@ pub fn add_totalwrn(v: i64) {
  *==========================================================================*/
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
-pub enum Out {
+pub(crate) enum Out {
     Null,
     Stdout,
     Stderr,
@@ -245,11 +252,11 @@ thread_local! {
         const { RefCell::new(None) };
 }
 
-pub fn out_set_file(f: std::fs::File) {
+pub(crate) fn out_set_file(f: std::fs::File) {
     OUTFILE.with(|o| *o.borrow_mut() = Some(std::io::BufWriter::new(f)));
 }
 
-pub fn out_close_file() {
+pub(crate) fn out_close_file() {
     OUTFILE.with(|o| {
         if let Some(f) = o.borrow_mut().as_mut() {
             let _ = f.flush();
@@ -259,7 +266,7 @@ pub fn out_close_file() {
 }
 
 /* fwrite() of raw bytes to `out'; a no-op for the NULL stream. */
-pub fn fwrite_out(out: Out, b: &[u8]) {
+pub(crate) fn fwrite_out(out: Out, b: &[u8]) {
     match out {
         Out::Null => {}
         Out::Stdout => {
@@ -280,7 +287,7 @@ pub fn fwrite_out(out: Out, b: &[u8]) {
     }
 }
 
-pub fn fflush_out(out: Out) {
+pub(crate) fn fflush_out(out: Out) {
     match out {
         Out::Stdout => {
             let _ = std::io::stdout().flush();
@@ -309,7 +316,7 @@ pub fn fflush_out(out: Out) {
  *      Rust:  spf!(errmes; "Keyword #", kpos, ", ", CS(&kname), " is duplicated.");
  *==========================================================================*/
 
-pub trait Put {
+pub(crate) trait Put {
     fn put(&self, v: &mut Vec<u8>);
 }
 
@@ -329,7 +336,7 @@ macro_rules! put_via_display {
 put_via_display!(i8, u8, i16, u16, i32, u32, i64, u64, isize, usize);
 
 /* %s of a NUL-terminated c_char buffer */
-pub struct CS<'a>(pub &'a [c_char]);
+pub(crate) struct CS<'a>(pub &'a [c_char]);
 
 impl Put for CS<'_> {
     fn put(&self, v: &mut Vec<u8>) {
@@ -342,8 +349,17 @@ impl Put for CS<'_> {
     }
 }
 
+/* %s of a plain byte slice */
+pub(crate) struct BS<'a>(pub &'a [u8]);
+
+impl Put for BS<'_> {
+    fn put(&self, v: &mut Vec<u8>) {
+        v.extend_from_slice(self.0);
+    }
+}
+
 /* %c */
-pub struct CHR(pub c_char);
+pub(crate) struct CHR(pub c_char);
 
 impl Put for CHR {
     fn put(&self, v: &mut Vec<u8>) {
@@ -353,7 +369,7 @@ impl Put for CHR {
 
 /* %[-]<width>[.<prec>]s of a NUL-terminated c_char buffer.
    `width' < 0 means left justified, as in "%-20s". */
-pub struct CSW<'a>(pub &'a [c_char], pub i32, pub Option<usize>);
+pub(crate) struct CSW<'a>(pub &'a [c_char], pub i32, pub Option<usize>);
 
 impl Put for CSW<'_> {
     fn put(&self, v: &mut Vec<u8>) {
@@ -367,7 +383,7 @@ impl Put for CSW<'_> {
 }
 
 /* %[-]<width>[.<prec>]s of a Rust &str */
-pub struct SW<'a>(pub &'a str, pub i32, pub Option<usize>);
+pub(crate) struct SW<'a>(pub &'a str, pub i32, pub Option<usize>);
 
 impl Put for SW<'_> {
     fn put(&self, v: &mut Vec<u8>) {
@@ -380,7 +396,7 @@ impl Put for SW<'_> {
 }
 
 /* %[-]<width>d */
-pub struct DW<T: Display>(pub T, pub i32);
+pub(crate) struct DW<T: Display>(pub T, pub i32);
 
 impl<T: Display> Put for DW<T> {
     fn put(&self, v: &mut Vec<u8>) {
@@ -432,7 +448,7 @@ macro_rules! pf {
     }};
 }
 
-pub fn set_cstr(dst: &mut [c_char], src: &[u8]) {
+pub(crate) fn set_cstr(dst: &mut [c_char], src: &[u8]) {
     let n = std::cmp::min(src.len(), dst.len() - 1);
     for i in 0..n {
         dst[i] = src[i] as c_char;
@@ -440,7 +456,7 @@ pub fn set_cstr(dst: &mut [c_char], src: &[u8]) {
     dst[n] = 0;
 }
 
-pub fn cat_cstr(dst: &mut [c_char], src: &[u8]) {
+pub(crate) fn cat_cstr(dst: &mut [c_char], src: &[u8]) {
     let l = cstrlen(dst);
     let n = std::cmp::min(src.len(), dst.len() - 1 - l);
     for i in 0..n {
@@ -450,12 +466,12 @@ pub fn cat_cstr(dst: &mut [c_char], src: &[u8]) {
 }
 
 /* strlen() that tolerates an unterminated buffer (returns its length). */
-pub fn cstrlen(s: &[c_char]) -> usize {
+pub(crate) fn cstrlen(s: &[c_char]) -> usize {
     s.iter().position(|&c| c == 0).unwrap_or(s.len())
 }
 
 /* The bytes of a NUL-terminated c_char buffer. */
-pub fn cbytes(s: &[c_char]) -> &[u8] {
+pub(crate) fn cbytes(s: &[c_char]) -> &[u8] {
     let n = cstrlen(s);
     // SAFETY: c_char and u8 have the same size and alignment.
     unsafe { std::slice::from_raw_parts(s.as_ptr().cast::<u8>(), n) }
@@ -474,14 +490,14 @@ pub fn cbytes(s: &[c_char]) -> &[u8] {
  *==========================================================================*/
 
 /* strcpy(); truncates instead of overrunning `dst' the way the C would. */
-pub fn strcpy_c(dst: &mut [c_char], src: &[c_char]) {
+pub(crate) fn strcpy_c(dst: &mut [c_char], src: &[c_char]) {
     let n = std::cmp::min(cstrlen(src), dst.len() - 1);
     dst[..n].copy_from_slice(&src[..n]);
     dst[n] = 0;
 }
 
 /* strncpy(): at most n bytes, NUL-padding a short source. */
-pub fn strncpy_c(dst: &mut [c_char], src: &[c_char], n: usize) {
+pub(crate) fn strncpy_c(dst: &mut [c_char], src: &[c_char], n: usize) {
     let n = std::cmp::min(n, dst.len());
     let mut i = 0;
     while i < n && i < src.len() && src[i] != 0 {
@@ -494,41 +510,53 @@ pub fn strncpy_c(dst: &mut [c_char], src: &[c_char], n: usize) {
     }
 }
 
-/* strcmp() / strncmp() with glibc's unsigned-char comparison, tolerating a
-   buffer that runs to its end without a NUL. */
-pub fn strcmp_c(a: &[c_char], b: &[c_char]) -> c_int {
-    strncmp_c(a, b, usize::MAX)
+/* Slice comparison over the NUL-terminated contents gives exactly strcmp()'s
+   ordering: Rust compares `[u8]` lexicographically, which is glibc's
+   unsigned-char comparison, and a shorter prefix sorts first just as the
+   terminating NUL does. */
+pub(crate) fn ccmp(a: &[c_char], b: &[c_char]) -> Ordering {
+    cbytes(a).cmp(cbytes(b))
 }
 
-pub fn strncmp_c(a: &[c_char], b: &[c_char], n: usize) -> c_int {
-    let mut i = 0usize;
-    while i < n {
-        let ca = if i < a.len() { a[i] as u8 } else { 0 };
-        let cb = if i < b.len() { b[i] as u8 } else { 0 };
-        if ca != cb {
-            return ca as c_int - cb as c_int;
-        }
-        if ca == 0 {
-            return 0;
-        }
-        i += 1;
+/* `while (*p == ' ') p++;` -- the C only skips blanks, not all whitespace. */
+pub(crate) fn skip_spaces(b: &[u8]) -> &[u8] {
+    let n = b.iter().position(|&c| c != b' ').unwrap_or(b.len());
+    &b[n..]
+}
+
+/* The C's trailing-blank strip stops at index 0 (`while (l > 0 && ...)`), so an
+   all-blank field keeps one character rather than becoming empty. */
+pub(crate) fn trim_end_spaces(b: &[u8]) -> &[u8] {
+    let mut end = b.len();
+    while end > 1 && b[end - 1] == b' ' {
+        end -= 1;
     }
-    0
+    &b[..end]
+}
+
+/* strcmp(s, lit) == 0 */
+pub(crate) fn ceq(s: &[c_char], lit: &[u8]) -> bool {
+    cbytes(s) == lit
+}
+
+/* strncmp(s, lit, strlen(lit)) == 0 */
+pub(crate) fn cstarts(s: &[c_char], lit: &[u8]) -> bool {
+    cbytes(s).starts_with(lit)
 }
 
 /* strchr() as an offset; stops at the NUL, as C does. */
-pub fn chr_pos(s: &[c_char], c: u8) -> Option<usize> {
+pub(crate) fn chr_pos(s: &[c_char], c: u8) -> Option<usize> {
     let n = cstrlen(s);
     s[..n].iter().position(|&x| x as u8 == c)
 }
 
 /* strchr() != NULL */
-pub fn chr_in(s: &[c_char], c: u8) -> bool {
+pub(crate) fn chr_in(s: &[c_char], c: u8) -> bool {
     chr_pos(s, c).is_some()
 }
 
 /* A NUL-terminated owned copy (what the C aliases with a `char *'). */
-pub fn cvec(s: &[c_char]) -> Vec<c_char> {
+pub(crate) fn cvec(s: &[c_char]) -> Vec<c_char> {
     let n = cstrlen(s);
     let mut v = Vec::with_capacity(n + 1);
     v.extend_from_slice(&s[..n]);
@@ -542,32 +570,32 @@ pub fn cvec(s: &[c_char]) -> Vec<c_char> {
  *==========================================================================*/
 
 #[inline]
-pub fn isprint_c(c: c_char) -> bool {
+pub(crate) fn isprint_c(c: c_char) -> bool {
     (0x20..=0x7e).contains(&(c as u8))
 }
 
 #[inline]
-pub fn isspace_c(c: c_char) -> bool {
+pub(crate) fn isspace_c(c: c_char) -> bool {
     matches!(c as u8, b' ' | b'\t' | b'\n' | 0x0b | 0x0c | b'\r')
 }
 
 #[inline]
-pub fn isdigit_c(c: c_char) -> bool {
+pub(crate) fn isdigit_c(c: c_char) -> bool {
     (b'0'..=b'9').contains(&(c as u8))
 }
 
 #[inline]
-pub fn isupper_c(c: c_char) -> bool {
+pub(crate) fn isupper_c(c: c_char) -> bool {
     (b'A'..=b'Z').contains(&(c as u8))
 }
 
 #[inline]
-pub fn isascii_c(c: c_char) -> bool {
+pub(crate) fn isascii_c(c: c_char) -> bool {
     (c as u8) < 128
 }
 
 #[inline]
-pub fn toupper_c(c: c_char) -> c_char {
+pub(crate) fn toupper_c(c: c_char) -> c_char {
     if (b'a'..=b'z').contains(&(c as u8)) {
         (c as u8 - 32) as c_char
     } else {
@@ -583,7 +611,7 @@ pub fn toupper_c(c: c_char) -> c_char {
  *==========================================================================*/
 
 /* strtol(s, &end, 10); returns (value, index one past the last char consumed) */
-pub fn strtol_c(s: &[c_char]) -> (c_long, usize) {
+pub(crate) fn strtol_c(s: &[c_char]) -> (c_long, usize) {
     let mut i = 0usize;
     let n = cstrlen(s);
 
@@ -630,12 +658,12 @@ pub fn strtol_c(s: &[c_char]) -> (c_long, usize) {
 }
 
 /* strtoll(s, NULL, 10) */
-pub fn strtoll_c(s: &[c_char]) -> LONGLONG {
+pub(crate) fn strtoll_c(s: &[c_char]) -> LONGLONG {
     strtol_c(s).0 as LONGLONG
 }
 
 /* strtod(s, NULL) / atof(s) */
-pub fn strtod_c(s: &[c_char]) -> f64 {
+pub(crate) fn strtod_c(s: &[c_char]) -> f64 {
     let b = cbytes(s);
     let mut i = 0usize;
     while i < b.len() && (b[i] as char).is_whitespace() {
@@ -771,10 +799,19 @@ mod tests {
         assert_eq!(&e[..5], &[b'a' as c_char, b'b' as c_char, 0, 0, 0]);
         assert_eq!(e[5], b'x' as c_char);
 
-        assert_eq!(strcmp_c(&to_buf::<16>("abc"), &to_buf::<16>("abc")), 0);
-        assert!(strcmp_c(&to_buf::<16>("abc"), &to_buf::<16>("abd")) < 0);
-        assert!(strcmp_c(&to_buf::<16>("abd"), &to_buf::<16>("abc")) > 0);
-        assert_eq!(strncmp_c(&to_buf::<16>("abcZ"), &to_buf::<16>("abcY"), 3), 0);
+        /* ccmp is strcmp's ordering; ceq/cstarts are the == 0 forms */
+        assert_eq!(ccmp(&to_buf::<16>("abc"), &to_buf::<16>("abc")), Ordering::Equal);
+        assert_eq!(ccmp(&to_buf::<16>("abc"), &to_buf::<16>("abd")), Ordering::Less);
+        assert_eq!(ccmp(&to_buf::<16>("abd"), &to_buf::<16>("abc")), Ordering::Greater);
+        /* a shorter string sorts first, as the terminating NUL does in strcmp */
+        assert_eq!(ccmp(&to_buf::<16>("abc"), &to_buf::<16>("abcd")), Ordering::Less);
+
+        assert!(ceq(&to_buf::<16>("NAXIS"), b"NAXIS"));
+        assert!(!ceq(&to_buf::<16>("NAXIS"), b"NAXIS1"));
+        assert!(!ceq(&to_buf::<16>("NAXIS1"), b"NAXIS"));
+        assert!(cstarts(&to_buf::<16>("NAXIS1"), b"NAXIS"));
+        assert!(cstarts(&to_buf::<16>("NAXIS"), b"NAXIS"));
+        assert!(!cstarts(&to_buf::<16>("NAXI"), b"NAXIS"));
 
         /* strchr stops at the NUL, so bytes past it are not found */
         let mut s = to_buf::<16>("abc");
@@ -785,6 +822,14 @@ mod tests {
         assert!(!chr_in(&s, b'q'));
 
         assert_eq!(cvec(&to_buf::<16>("hi")), vec![104, 105, 0]);
+
+        /* the C only skips/strips blanks, and never empties an all-blank field */
+        assert_eq!(skip_spaces(b"  1.5"), b"1.5");
+        assert_eq!(skip_spaces(b"\t1.5"), b"\t1.5");
+        assert_eq!(skip_spaces(b"   "), b"");
+        assert_eq!(trim_end_spaces(b"1.5   "), b"1.5");
+        assert_eq!(trim_end_spaces(b"   "), b" ");
+        assert_eq!(trim_end_spaces(b""), b"");
     }
 
     /* The message builder has to pass bytes through untouched: fitsverify

--- a/src/bin/fitsverify/common.rs
+++ b/src/bin/fitsverify/common.rs
@@ -9,7 +9,6 @@
 
 use std::cell::{Cell, RefCell};
 use std::cmp::Ordering;
-use std::fmt::Display;
 use std::io::Write;
 
 use rsfitsio::c_types::{c_char, c_int, c_long, c_ulong};
@@ -326,6 +325,14 @@ impl Put for &str {
     }
 }
 
+/* so a format!() can be handed straight to spf!/pf! for the conversions that
+   std already does: widths, precisions, zero padding, hex */
+impl Put for String {
+    fn put(&self, v: &mut Vec<u8>) {
+        v.extend_from_slice(self.as_bytes());
+    }
+}
+
 macro_rules! put_via_display {
     ($($t:ty),*) => { $(
         impl Put for $t {
@@ -333,7 +340,9 @@ macro_rules! put_via_display {
         }
     )* };
 }
-put_via_display!(i8, u8, i16, u16, i32, u32, i64, u64, isize, usize);
+/* the integer widths actually passed to spf!/pf!; c_int and c_long are
+   covered by i32/i64 on every target this builds for */
+put_via_display!(i32, i64, usize);
 
 /* %s of a NUL-terminated c_char buffer */
 pub(crate) struct CS<'a>(pub &'a [c_char]);
@@ -382,28 +391,9 @@ impl Put for CSW<'_> {
     }
 }
 
-/* %[-]<width>[.<prec>]s of a Rust &str */
-pub(crate) struct SW<'a>(pub &'a str, pub i32, pub Option<usize>);
-
-impl Put for SW<'_> {
-    fn put(&self, v: &mut Vec<u8>) {
-        let mut b: Vec<u8> = self.0.as_bytes().to_vec();
-        if let Some(p) = self.2 {
-            b.truncate(p);
-        }
-        pad(v, &b, self.1);
-    }
-}
-
-/* %[-]<width>d */
-pub(crate) struct DW<T: Display>(pub T, pub i32);
-
-impl<T: Display> Put for DW<T> {
-    fn put(&self, v: &mut Vec<u8>) {
-        pad(v, self.0.to_string().as_bytes(), self.1);
-    }
-}
-
+/* printf's width/justification for a *byte* string.  Numbers and &str go
+   through format!() instead -- std does this for them -- but format! cannot
+   take arbitrary bytes, so CSW still needs it. */
 fn pad(v: &mut Vec<u8>, b: &[u8], width: i32) {
     let w = width.unsigned_abs() as usize;
     if b.len() >= w {
@@ -565,42 +555,48 @@ pub(crate) fn cvec(s: &[c_char]) -> Vec<c_char> {
 }
 
 /*===========================================================================
- *  <ctype.h>.  These mirror glibc in the "C" locale, where every class is
- *  false for the negative values a signed `char' can hold.
+ *  <ctype.h>.  Rust's u8 methods cover most of these exactly; the two that
+ *  differ are noted.  All take a c_char because the FITS buffers come from
+ *  rsfitsio as [c_char], and glibc in the "C" locale reports false for every
+ *  class on the negative values a signed char can hold -- which `as u8'
+ *  reproduces, and which also makes these independent of whether c_char is
+ *  signed or unsigned on the target.
  *==========================================================================*/
 
+/* isprint(): u8::is_ascii_graphic() is 0x21..=0x7e, i.e. printable *except*
+   the space, which C counts. */
 #[inline]
 pub(crate) fn isprint_c(c: c_char) -> bool {
-    (0x20..=0x7e).contains(&(c as u8))
+    let c = c as u8;
+    c == b' ' || c.is_ascii_graphic()
 }
 
+/* isspace(): u8::is_ascii_whitespace() deliberately omits the vertical tab,
+   which C's isspace() includes. */
 #[inline]
 pub(crate) fn isspace_c(c: c_char) -> bool {
-    matches!(c as u8, b' ' | b'\t' | b'\n' | 0x0b | 0x0c | b'\r')
+    let c = c as u8;
+    c.is_ascii_whitespace() || c == 0x0b
 }
 
 #[inline]
 pub(crate) fn isdigit_c(c: c_char) -> bool {
-    (b'0'..=b'9').contains(&(c as u8))
+    (c as u8).is_ascii_digit()
 }
 
 #[inline]
 pub(crate) fn isupper_c(c: c_char) -> bool {
-    (b'A'..=b'Z').contains(&(c as u8))
+    (c as u8).is_ascii_uppercase()
 }
 
 #[inline]
 pub(crate) fn isascii_c(c: c_char) -> bool {
-    (c as u8) < 128
+    (c as u8).is_ascii()
 }
 
 #[inline]
 pub(crate) fn toupper_c(c: c_char) -> c_char {
-    if (b'a'..=b'z').contains(&(c as u8)) {
-        (c as u8 - 32) as c_char
-    } else {
-        c
-    }
+    (c as u8).to_ascii_uppercase() as c_char
 }
 
 /*===========================================================================
@@ -840,9 +836,10 @@ mod tests {
         spf!(b; "n=", 42, " c=", CHR(0xfeu8 as c_char), "!");
         assert_eq!(cbytes(&b), b"n=42 c=\xfe!");
 
-        /* %-4d / %-20s / %.8s style conversions */
+        /* Widths for numbers and &str come from std's format!; only CSW pads
+           by hand, because format! cannot take arbitrary bytes. */
         let mut w = [0 as c_char; 64];
-        spf!(w; "[", DW(7, -4), "][", DW(7, 4), "]");
+        spf!(w; "[", format!("{:<4}", 7), "][", format!("{:>4}", 7), "]");
         assert_eq!(cbytes(&w), b"[7   ][   7]");
 
         let name = to_buf::<16>("ABCDEFGHIJ");

--- a/src/bin/fitsverify/common.rs
+++ b/src/bin/fitsverify/common.rs
@@ -1,11 +1,27 @@
-use rsfitsio::c_types::{c_char, c_int, c_ulong};
-use rsfitsio::fitsio::{FLEN_FILENAME, FLEN_KEYWORD, FLEN_VALUE, LONGLONG};
+/* Transpiled from cfitsio/utilities/fverify.h, plus the small amount of
+   infrastructure that C gets for free from <stdio.h>/<ctype.h>/<stdlib.h>.
 
-pub(crate) const MAXERRORS: usize = 200;
-pub(crate) const MAXWRNS: usize = 200;
+   The C globals declared here (errmes, comm, prhead, testdata, ...) are file
+   statics / externs in the C.  Buffers that are only ever "printf into it, then
+   immediately consume it" (errmes, comm, temp) become locals at each use site,
+   which is semantically identical and avoids global mutable state.  The truly
+   persistent globals (the flags and counters) live in `flags` below.  */
 
-static ERRMES: [c_char; 256] = [0; 256]; /* error message buffer */
-static COMM: [c_char; FLEN_FILENAME + 6] = [0; FLEN_FILENAME + 6]; /* comment buffer */
+use std::cell::RefCell;
+use std::fmt::Display;
+use std::io::Write;
+use std::sync::atomic::{AtomicI32, AtomicI64, Ordering};
+
+use rsfitsio::c_types::{c_char, c_int, c_long, c_ulong};
+use rsfitsio::fitsio::{FLEN_KEYWORD, FLEN_VALUE, LONGLONG};
+
+pub const MAXERRORS: c_int = 200;
+pub const MAXWRNS: c_int = 200;
+
+/* static char errmes[256]; */
+pub const ERRMES_LEN: usize = 256;
+/* static char comm[FLEN_FILENAME+6]; */
+pub const COMM_LEN: usize = rsfitsio::fitsio::FLEN_FILENAME + 6;
 
 /********************************
 *				*
@@ -13,7 +29,8 @@ static COMM: [c_char; FLEN_FILENAME + 6] = [0; FLEN_FILENAME + 6]; /* comment bu
 *				*
 ********************************/
 
-enum kwdtyp {
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Default)]
+pub enum kwdtyp {
     STR_KEY, /* string   key */
     LOG_KEY, /* Logical key */
     INT_KEY, /* Integer key */
@@ -21,35 +38,49 @@ enum kwdtyp {
     CMI_KEY, /* Complex integer key */
     CMF_KEY, /* Complex float key */
     COM_KEY, /* history, comment, "  ", and end */
+    #[default]
     UNKNOWN, /* Unknown types */
 }
 
 /* error number masks of  the keyword test */
-const BAD_STR: c_ulong = 0x0001;
-const NO_TRAIL_QUOTE: c_ulong = 0x0002;
-const BAD_NUM: c_ulong = 0x0004;
-const LOWCASE_EXPO: c_ulong = 0x0008;
-const NO_TRAIL_PAREN: c_ulong = 0x0010;
-const NO_COMMA: c_ulong = 0x0020;
-const TOO_MANY_COMMA: c_ulong = 0x0040;
-const BAD_REAL: c_ulong = 0x0080;
-const BAD_IMG: c_ulong = 0x0100;
-const BAD_LOGICAL: c_ulong = 0x0200;
-const NO_START_SLASH: c_ulong = 0x0400;
-const BAD_COMMENT: c_ulong = 0x0800;
-const UNKNOWN_TYPE: c_ulong = 0x1000;
+pub const BAD_STR: c_ulong = 0x0001;
+pub const NO_TRAIL_QUOTE: c_ulong = 0x0002;
+pub const BAD_NUM: c_ulong = 0x0004;
+pub const LOWCASE_EXPO: c_ulong = 0x0008;
+pub const NO_TRAIL_PAREN: c_ulong = 0x0010;
+pub const NO_COMMA: c_ulong = 0x0020;
+pub const TOO_MANY_COMMA: c_ulong = 0x0040;
+pub const BAD_REAL: c_ulong = 0x0080;
+pub const BAD_IMG: c_ulong = 0x0100;
+pub const BAD_LOGICAL: c_ulong = 0x0200;
+pub const NO_START_SLASH: c_ulong = 0x0400;
+pub const BAD_COMMENT: c_ulong = 0x0800;
+pub const UNKNOWN_TYPE: c_ulong = 0x1000;
 
 /* Number of possible WCS descriptions to check.*/
 /* 1 for the primary + 26 for [A-Z] suffix. */
-const NWCSDESCR: usize = 27;
+pub const NWCSDESCR: usize = 27;
 
 /* keyword structure */
-struct FitsKey {
-    kname: [char; FLEN_KEYWORD], /* fits keyword name */
-    ktype: kwdtyp,               /* fits keyword type */
-    kvalue: [char; FLEN_VALUE],  /* fits keyword name */
-    kindex: c_int,               /* position at the header */
-    goodkey: c_int,              /* good keyword flag (=1 good)*/
+#[derive(Clone)]
+pub struct FitsKey {
+    pub kname: [c_char; FLEN_KEYWORD], /* fits keyword name */
+    pub ktype: kwdtyp,                 /* fits keyword type */
+    pub kvalue: [c_char; FLEN_VALUE],  /* fits keyword name */
+    pub kindex: c_int,                 /* position at the header */
+    pub goodkey: c_int,                /* good keyword flag (=1 good)*/
+}
+
+impl Default for FitsKey {
+    fn default() -> Self {
+        Self {
+            kname: [0; FLEN_KEYWORD],
+            ktype: kwdtyp::UNKNOWN,
+            kvalue: [0; FLEN_VALUE],
+            kindex: 0,
+            goodkey: 0,
+        }
+    }
 }
 
 /********************************
@@ -57,46 +88,590 @@ struct FitsKey {
 *       Headers  		*
 *				*
 ********************************/
-struct FitsHdu {
-    hdutype: c_int,                /* hdutype */
-    hdunum: c_int,                 /* hdunum  */
-    isgroup: c_int,                /* random group flag */
-    istilecompressed: c_int,       /* tile compressed image */
-    gcount: c_int,                 /* gcount  */
-    pcount: LONGLONG,              /* pcount  */
-    bitpix: c_int,                 /* pix number */
-    naxis: c_int,                  /* number of the axis,used for image array*/
-    naxes: *mut LONGLONG,          /* dimension of each axis,used for image array*/
-    ncols: c_int,                  /* number of the columns, used for image only*/
-    extname: [c_char; FLEN_VALUE], /* EXTENSION NAME */
-    extver: c_int,                 /* extension version */
-    datamax: *mut *mut c_char,     /* strings for the maximum of the data in a column */
-    datamin: *mut *mut c_char,     /* strings for the minimum of the data in a column */
-    tnull: *mut *mut c_char,       /* number of NULL values */
-    nkeys: c_int,                  /* number of keys */
-    tkeys: c_int,                  /* total of the keys tested*/
-    heap: c_int,                   /* heap */
-    kwds: *mut *mut FitsKey,       /* keywords list starting from the
-                                   last NAXISn keyword. The array
-                                   is sorted in the ascending alphabetical
-                                   order of keyword names. The last keyword END
-                                   and commentary keywords are  excluded.
-                                   The total number of element, tkey, is
-                                   nkeys - 4 - naxis - ncomm. */
-    use_longstr: c_int, /* flag indicates that the long string
-                        convention is used */
+pub struct FitsHdu {
+    pub hdutype: c_int,                /* hdutype */
+    pub hdunum: c_int,                 /* hdunum  */
+    pub isgroup: c_int,                /* random group flag */
+    pub istilecompressed: c_int,       /* tile compressed image */
+    pub gcount: c_int,                 /* gcount  */
+    pub pcount: LONGLONG,              /* pcount  */
+    pub bitpix: c_int,                 /* pix number */
+    pub naxis: c_int,                  /* number of the axis,used for image array*/
+    pub naxes: Vec<LONGLONG>,          /* dimension of each axis,used for image array*/
+    pub ncols: c_int,                  /* number of the columns, used for image only*/
+    pub extname: [c_char; FLEN_VALUE], /* EXTENSION NAME */
+    pub extver: c_int,                 /* extension version */
+    pub datamax: Vec<Vec<c_char>>,     /* strings for the maximum of the data in a column */
+    pub datamin: Vec<Vec<c_char>>,     /* strings for the minimum of the data in a column */
+    pub tnull: Vec<Vec<c_char>>,       /* number of NULL values */
+    pub nkeys: c_int,                  /* number of keys */
+    pub tkeys: c_int,                  /* total of the keys tested*/
+    pub heap: c_int,                   /* heap */
+    pub kwds: Vec<FitsKey>,            /* keywords list starting from the
+                                       last NAXISn keyword. The array
+                                       is sorted in the ascending alphabetical
+                                       order of keyword names. The last keyword END
+                                       and commentary keywords are  excluded.
+                                       The total number of element, tkey, is
+                                       nkeys - 4 - naxis - ncomm. */
+    pub use_longstr: c_int, /* flag indicates that the long string
+                            convention is used */
 }
 
-struct ColName {
-    name: *mut c_char, /* column name */
-    index: c_int,      /* column index */
+impl Default for FitsHdu {
+    fn default() -> Self {
+        Self {
+            hdutype: 0,
+            hdunum: 0,
+            isgroup: 0,
+            istilecompressed: 0,
+            gcount: 0,
+            pcount: 0,
+            bitpix: 0,
+            naxis: 0,
+            naxes: Vec::new(),
+            ncols: 0,
+            extname: [0; FLEN_VALUE],
+            extver: 0,
+            datamax: Vec::new(),
+            datamin: Vec::new(),
+            tnull: Vec::new(),
+            nkeys: 0,
+            tkeys: 0,
+            heap: 0,
+            kwds: Vec::new(),
+            use_longstr: 0,
+        }
+    }
 }
 
-struct HduName {
-    hdutype: c_int,                /* hdutype */
-    hdunum: c_int,                 /* hdunum  */
-    extname: [c_char; FLEN_VALUE], /* extension name, used for extension*/
-    extver: c_int,                 /* extension version, used for extension */
-    errnum: c_int,                 /* number of errors in this hdu */
-    wrnno: c_int,                  /* number of warnning in this hdu */
+pub struct ColName {
+    pub name: Vec<c_char>, /* column name */
+    pub index: c_int,      /* column index */
+}
+
+/********************************
+*				*
+*       Files   		*
+*				*
+********************************/
+#[derive(Clone)]
+pub struct HduName {
+    pub hdutype: c_int,                /* hdutype */
+    pub hdunum: c_int,                 /* hdunum  */
+    pub extname: [c_char; FLEN_VALUE], /* extension name, used for extension*/
+    pub extver: c_int,                 /* extension version, used for extension */
+    pub errnum: c_int,                 /* number of errors in this hdu */
+    pub wrnno: c_int,                  /* number of warnning in this hdu */
+}
+
+impl Default for HduName {
+    fn default() -> Self {
+        Self {
+            hdutype: 0,
+            hdunum: 0,
+            extname: [0; FLEN_VALUE],
+            extver: 0,
+            errnum: 0,
+            wrnno: 0,
+        }
+    }
+}
+
+/*===========================================================================
+ *  The `extern int' globals from fverify.h / ftverify.c.
+ *==========================================================================*/
+
+macro_rules! int_global {
+    ($get:ident, $set:ident, $store:ident, $init:expr) => {
+        static $store: AtomicI32 = AtomicI32::new($init);
+        #[inline]
+        pub fn $get() -> c_int {
+            $store.load(Ordering::Relaxed)
+        }
+        #[inline]
+        pub fn $set(v: c_int) {
+            $store.store(v, Ordering::Relaxed);
+        }
+    };
+}
+
+int_global!(err_report, set_err_report, ERR_REPORT, 0);
+int_global!(prhead, set_prhead, PRHEAD, 0);
+int_global!(prstat, set_prstat, PRSTAT, 1);
+int_global!(testdata, set_testdata, TESTDATA, 1);
+int_global!(testcsum, set_testcsum, TESTCSUM, 1);
+int_global!(testfill, set_testfill, TESTFILL, 1);
+int_global!(heasarc_conv, set_heasarc_conv, HEASARC_CONV, 1);
+int_global!(testhierarch, set_testhierarch, TESTHIERARCH, 0);
+int_global!(totalhdu, set_totalhdu, TOTALHDU, 0);
+
+/* long totalerr, totalwrn;  (ftverify.c) */
+static TOTALERR: AtomicI64 = AtomicI64::new(0);
+static TOTALWRN: AtomicI64 = AtomicI64::new(0);
+
+pub fn totalerr() -> i64 {
+    TOTALERR.load(Ordering::Relaxed)
+}
+pub fn totalwrn() -> i64 {
+    TOTALWRN.load(Ordering::Relaxed)
+}
+pub fn add_totalerr(v: i64) {
+    TOTALERR.fetch_add(v, Ordering::Relaxed);
+}
+pub fn add_totalwrn(v: i64) {
+    TOTALWRN.fetch_add(v, Ordering::Relaxed);
+}
+
+/*===========================================================================
+ *  `FILE *out'
+ *
+ *  In the standalone fitsverify the report stream is always stdout, stderr or
+ *  NULL, but ftverify_work() also has a branch that fopen()s a log file, so
+ *  the File variant is carried too.  `Out' stays Copy (like the C FILE*) by
+ *  keeping the actual handle in a thread-local.
+ *==========================================================================*/
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum Out {
+    Null,
+    Stdout,
+    Stderr,
+    File,
+}
+
+thread_local! {
+    static OUTFILE: RefCell<Option<std::io::BufWriter<std::fs::File>>> =
+        const { RefCell::new(None) };
+}
+
+pub fn out_set_file(f: std::fs::File) {
+    OUTFILE.with(|o| *o.borrow_mut() = Some(std::io::BufWriter::new(f)));
+}
+
+pub fn out_close_file() {
+    OUTFILE.with(|o| {
+        if let Some(f) = o.borrow_mut().as_mut() {
+            let _ = f.flush();
+        }
+        *o.borrow_mut() = None;
+    });
+}
+
+/* fwrite() of raw bytes to `out'; a no-op for the NULL stream. */
+pub fn fwrite_out(out: Out, b: &[u8]) {
+    match out {
+        Out::Null => {}
+        Out::Stdout => {
+            let so = std::io::stdout();
+            let mut l = so.lock();
+            let _ = l.write_all(b);
+        }
+        Out::Stderr => {
+            let se = std::io::stderr();
+            let mut l = se.lock();
+            let _ = l.write_all(b);
+        }
+        Out::File => OUTFILE.with(|o| {
+            if let Some(f) = o.borrow_mut().as_mut() {
+                let _ = f.write_all(b);
+            }
+        }),
+    }
+}
+
+pub fn fflush_out(out: Out) {
+    match out {
+        Out::Stdout => {
+            let _ = std::io::stdout().flush();
+        }
+        Out::Stderr => {
+            let _ = std::io::stderr().flush();
+        }
+        Out::File => OUTFILE.with(|o| {
+            if let Some(f) = o.borrow_mut().as_mut() {
+                let _ = f.flush();
+            }
+        }),
+        Out::Null => {}
+    }
+}
+
+/*===========================================================================
+ *  printf-alikes.
+ *
+ *  FITS cards may hold arbitrary bytes and fitsverify prints them back in its
+ *  diagnostics, so every message is built as a byte string rather than going
+ *  through Rust's UTF-8 `String'.  `spf!' is sprintf(), `pf!' is printf(), and
+ *  each argument is one printf conversion:
+ *
+ *      C:     sprintf(errmes, "Keyword #%d, %s is duplicated.", kpos, kname);
+ *      Rust:  spf!(errmes; "Keyword #", kpos, ", ", CS(&kname), " is duplicated.");
+ *==========================================================================*/
+
+pub trait Put {
+    fn put(&self, v: &mut Vec<u8>);
+}
+
+impl Put for &str {
+    fn put(&self, v: &mut Vec<u8>) {
+        v.extend_from_slice(self.as_bytes());
+    }
+}
+
+macro_rules! put_via_display {
+    ($($t:ty),*) => { $(
+        impl Put for $t {
+            fn put(&self, v: &mut Vec<u8>) { v.extend_from_slice(self.to_string().as_bytes()); }
+        }
+    )* };
+}
+put_via_display!(i8, u8, i16, u16, i32, u32, i64, u64, isize, usize);
+
+/* %s of a NUL-terminated c_char buffer */
+pub struct CS<'a>(pub &'a [c_char]);
+
+impl Put for CS<'_> {
+    fn put(&self, v: &mut Vec<u8>) {
+        for &c in self.0 {
+            if c == 0 {
+                break;
+            }
+            v.push(c as u8);
+        }
+    }
+}
+
+/* %c */
+pub struct CHR(pub c_char);
+
+impl Put for CHR {
+    fn put(&self, v: &mut Vec<u8>) {
+        v.push(self.0 as u8);
+    }
+}
+
+/* %[-]<width>[.<prec>]s of a NUL-terminated c_char buffer.
+   `width' < 0 means left justified, as in "%-20s". */
+pub struct CSW<'a>(pub &'a [c_char], pub i32, pub Option<usize>);
+
+impl Put for CSW<'_> {
+    fn put(&self, v: &mut Vec<u8>) {
+        let mut b: Vec<u8> = Vec::new();
+        CS(self.0).put(&mut b);
+        if let Some(p) = self.2 {
+            b.truncate(p);
+        }
+        pad(v, &b, self.1);
+    }
+}
+
+/* %[-]<width>[.<prec>]s of a Rust &str */
+pub struct SW<'a>(pub &'a str, pub i32, pub Option<usize>);
+
+impl Put for SW<'_> {
+    fn put(&self, v: &mut Vec<u8>) {
+        let mut b: Vec<u8> = self.0.as_bytes().to_vec();
+        if let Some(p) = self.2 {
+            b.truncate(p);
+        }
+        pad(v, &b, self.1);
+    }
+}
+
+/* %[-]<width>d */
+pub struct DW<T: Display>(pub T, pub i32);
+
+impl<T: Display> Put for DW<T> {
+    fn put(&self, v: &mut Vec<u8>) {
+        pad(v, self.0.to_string().as_bytes(), self.1);
+    }
+}
+
+fn pad(v: &mut Vec<u8>, b: &[u8], width: i32) {
+    let w = width.unsigned_abs() as usize;
+    if b.len() >= w {
+        v.extend_from_slice(b);
+    } else if width < 0 {
+        v.extend_from_slice(b);
+        v.extend(std::iter::repeat_n(b' ', w - b.len()));
+    } else {
+        v.extend(std::iter::repeat_n(b' ', w - b.len()));
+        v.extend_from_slice(b);
+    }
+}
+
+/* Formats the arguments and stores the result NUL-terminated in `dst'.
+   C's sprintf() would run off the end of these fixed buffers; we truncate. */
+#[macro_export]
+macro_rules! spf {
+    ($dst:expr; $($x:expr),* $(,)?) => {{
+        let mut __v: Vec<u8> = Vec::new();
+        $( $crate::common::Put::put(&$x, &mut __v); )*
+        $crate::common::set_cstr(&mut $dst[..], &__v);
+    }};
+}
+
+/* Formats the arguments and appends them, NUL-terminated, to `dst' (strcat). */
+#[macro_export]
+macro_rules! scat {
+    ($dst:expr; $($x:expr),* $(,)?) => {{
+        let mut __v: Vec<u8> = Vec::new();
+        $( $crate::common::Put::put(&$x, &mut __v); )*
+        $crate::common::cat_cstr(&mut $dst[..], &__v);
+    }};
+}
+
+/* printf() */
+#[macro_export]
+macro_rules! pf {
+    ($out:expr; $($x:expr),* $(,)?) => {{
+        let mut __v: Vec<u8> = Vec::new();
+        $( $crate::common::Put::put(&$x, &mut __v); )*
+        $crate::common::fwrite_out($out, &__v);
+    }};
+}
+
+pub fn set_cstr(dst: &mut [c_char], src: &[u8]) {
+    let n = std::cmp::min(src.len(), dst.len() - 1);
+    for i in 0..n {
+        dst[i] = src[i] as c_char;
+    }
+    dst[n] = 0;
+}
+
+pub fn cat_cstr(dst: &mut [c_char], src: &[u8]) {
+    let l = cstrlen(dst);
+    let n = std::cmp::min(src.len(), dst.len() - 1 - l);
+    for i in 0..n {
+        dst[l + i] = src[i] as c_char;
+    }
+    dst[l + n] = 0;
+}
+
+/* strlen() that tolerates an unterminated buffer (returns its length). */
+pub fn cstrlen(s: &[c_char]) -> usize {
+    s.iter().position(|&c| c == 0).unwrap_or(s.len())
+}
+
+/* The bytes of a NUL-terminated c_char buffer. */
+pub fn cbytes(s: &[c_char]) -> &[u8] {
+    let n = cstrlen(s);
+    // SAFETY: c_char and u8 have the same size and alignment.
+    unsafe { std::slice::from_raw_parts(s.as_ptr().cast::<u8>(), n) }
+}
+
+/*===========================================================================
+ *  <string.h>
+ *
+ *  rsfitsio's wrappers.rs has strcpy_safe/strncpy_safe/strcmp_safe/strchr_safe,
+ *  but they are not drop-in here: strlen_safe/strcpy_safe panic on a buffer
+ *  with no NUL, strncpy_safe panics when the source is shorter than n,
+ *  strchr_safe scans the whole slice rather than stopping at the NUL, and the
+ *  strcmp_safe family subtracts signed c_char rather than glibc's unsigned
+ *  char.  fitsverify is fed deliberately malformed headers, so it needs the
+ *  non-panicking, glibc-shaped variants below.
+ *==========================================================================*/
+
+/* strcpy(); truncates instead of overrunning `dst' the way the C would. */
+pub fn strcpy_c(dst: &mut [c_char], src: &[c_char]) {
+    let n = std::cmp::min(cstrlen(src), dst.len() - 1);
+    dst[..n].copy_from_slice(&src[..n]);
+    dst[n] = 0;
+}
+
+/* strncpy(): at most n bytes, NUL-padding a short source. */
+pub fn strncpy_c(dst: &mut [c_char], src: &[c_char], n: usize) {
+    let n = std::cmp::min(n, dst.len());
+    let mut i = 0;
+    while i < n && i < src.len() && src[i] != 0 {
+        dst[i] = src[i];
+        i += 1;
+    }
+    while i < n {
+        dst[i] = 0;
+        i += 1;
+    }
+}
+
+/* strcmp() / strncmp() with glibc's unsigned-char comparison, tolerating a
+   buffer that runs to its end without a NUL. */
+pub fn strcmp_c(a: &[c_char], b: &[c_char]) -> c_int {
+    strncmp_c(a, b, usize::MAX)
+}
+
+pub fn strncmp_c(a: &[c_char], b: &[c_char], n: usize) -> c_int {
+    let mut i = 0usize;
+    while i < n {
+        let ca = if i < a.len() { a[i] as u8 } else { 0 };
+        let cb = if i < b.len() { b[i] as u8 } else { 0 };
+        if ca != cb {
+            return ca as c_int - cb as c_int;
+        }
+        if ca == 0 {
+            return 0;
+        }
+        i += 1;
+    }
+    0
+}
+
+/* strchr() as an offset; stops at the NUL, as C does. */
+pub fn chr_pos(s: &[c_char], c: u8) -> Option<usize> {
+    let n = cstrlen(s);
+    s[..n].iter().position(|&x| x as u8 == c)
+}
+
+/* strchr() != NULL */
+pub fn chr_in(s: &[c_char], c: u8) -> bool {
+    chr_pos(s, c).is_some()
+}
+
+/* A NUL-terminated owned copy (what the C aliases with a `char *'). */
+pub fn cvec(s: &[c_char]) -> Vec<c_char> {
+    let n = cstrlen(s);
+    let mut v = Vec::with_capacity(n + 1);
+    v.extend_from_slice(&s[..n]);
+    v.push(0);
+    v
+}
+
+/*===========================================================================
+ *  <ctype.h>.  These mirror glibc in the "C" locale, where every class is
+ *  false for the negative values a signed `char' can hold.
+ *==========================================================================*/
+
+#[inline]
+pub fn isprint_c(c: c_char) -> bool {
+    (0x20..=0x7e).contains(&(c as u8))
+}
+
+#[inline]
+pub fn isspace_c(c: c_char) -> bool {
+    matches!(c as u8, b' ' | b'\t' | b'\n' | 0x0b | 0x0c | b'\r')
+}
+
+#[inline]
+pub fn isdigit_c(c: c_char) -> bool {
+    (b'0'..=b'9').contains(&(c as u8))
+}
+
+#[inline]
+pub fn isupper_c(c: c_char) -> bool {
+    (b'A'..=b'Z').contains(&(c as u8))
+}
+
+#[inline]
+pub fn isascii_c(c: c_char) -> bool {
+    (c as u8) < 128
+}
+
+#[inline]
+pub fn toupper_c(c: c_char) -> c_char {
+    if (b'a'..=b'z').contains(&(c as u8)) {
+        (c as u8 - 32) as c_char
+    } else {
+        c
+    }
+}
+
+/*===========================================================================
+ *  <stdlib.h> string conversions.
+ *
+ *  fitsverify tests strtol()'s results against LONG_MAX / LONG_MIN to detect
+ *  malformed values, so the saturating overflow behaviour has to be kept.
+ *==========================================================================*/
+
+/* strtol(s, &end, 10); returns (value, index one past the last char consumed) */
+pub fn strtol_c(s: &[c_char]) -> (c_long, usize) {
+    let mut i = 0usize;
+    let n = cstrlen(s);
+
+    while i < n && isspace_c(s[i]) {
+        i += 1;
+    }
+
+    let mut neg = false;
+    if i < n && (s[i] as u8 == b'+' || s[i] as u8 == b'-') {
+        neg = s[i] as u8 == b'-';
+        i += 1;
+    }
+
+    let start = i;
+    let mut acc: i128 = 0;
+    let mut overflow = false;
+    while i < n && isdigit_c(s[i]) {
+        if !overflow {
+            acc = acc * 10 + (s[i] as u8 - b'0') as i128;
+            if acc > (c_long::MAX as i128) + 1 {
+                overflow = true;
+            }
+        }
+        i += 1;
+    }
+
+    if i == start {
+        /* no digits: strtol() returns 0 and endptr == the original string */
+        return (0, 0);
+    }
+
+    let v = if neg { -acc } else { acc };
+    let v = if overflow || v > c_long::MAX as i128 {
+        c_long::MAX
+    } else if v < c_long::MIN as i128 {
+        c_long::MIN
+    } else {
+        v as c_long
+    };
+    (v, i)
+}
+
+/* strtoll(s, NULL, 10) */
+pub fn strtoll_c(s: &[c_char]) -> LONGLONG {
+    strtol_c(s).0 as LONGLONG
+}
+
+/* strtod(s, NULL) / atof(s) */
+pub fn strtod_c(s: &[c_char]) -> f64 {
+    let b = cbytes(s);
+    let mut i = 0usize;
+    while i < b.len() && (b[i] as char).is_whitespace() {
+        i += 1;
+    }
+    let start = i;
+    if i < b.len() && (b[i] == b'+' || b[i] == b'-') {
+        i += 1;
+    }
+    while i < b.len() && b[i].is_ascii_digit() {
+        i += 1;
+    }
+    if i < b.len() && b[i] == b'.' {
+        i += 1;
+        while i < b.len() && b[i].is_ascii_digit() {
+            i += 1;
+        }
+    }
+    if i < b.len() && (b[i] == b'e' || b[i] == b'E' || b[i] == b'd' || b[i] == b'D') {
+        let save = i;
+        i += 1;
+        if i < b.len() && (b[i] == b'+' || b[i] == b'-') {
+            i += 1;
+        }
+        if i < b.len() && b[i].is_ascii_digit() {
+            while i < b.len() && b[i].is_ascii_digit() {
+                i += 1;
+            }
+        } else {
+            i = save;
+        }
+    }
+    if i == start {
+        return 0.0;
+    }
+    /* FITS allows 'D'/'d' as the exponent marker; Rust's parser wants 'e'. */
+    let mut t = String::from_utf8_lossy(&b[start..i]).into_owned();
+    if t.contains(['d', 'D']) {
+        t = t.replace(['d', 'D'], "e");
+    }
+    t.parse::<f64>().unwrap_or(0.0)
 }

--- a/src/bin/fitsverify/common.rs
+++ b/src/bin/fitsverify/common.rs
@@ -616,7 +616,10 @@ pub fn strtol_c(s: &[c_char]) -> (c_long, usize) {
     }
 
     let v = if neg { -acc } else { acc };
-    let v = if overflow || v > c_long::MAX as i128 {
+    /* C's strtol() saturates towards the sign of the value it was parsing. */
+    let v = if overflow {
+        if neg { c_long::MIN } else { c_long::MAX }
+    } else if v > c_long::MAX as i128 {
         c_long::MAX
     } else if v < c_long::MIN as i128 {
         c_long::MIN
@@ -674,4 +677,143 @@ pub fn strtod_c(s: &[c_char]) -> f64 {
         t = t.replace(['d', 'D'], "e");
     }
     t.parse::<f64>().unwrap_or(0.0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn to_buf<const N: usize>(s: &str) -> [c_char; N] {
+        let mut b = [0 as c_char; N];
+        for (i, &c) in s.as_bytes().iter().enumerate() {
+            b[i] = c as c_char;
+        }
+        b
+    }
+
+    /* strtol() saturates at LONG_MAX/LONG_MIN on overflow, and fitsverify
+       tests its results against those to spot malformed TDISPn widths, so the
+       saturation has to survive the port. */
+    #[test]
+    fn test_strtol_c() {
+        assert_eq!(strtol_c(&to_buf::<32>("123abc")), (123, 3));
+        assert_eq!(strtol_c(&to_buf::<32>("  -45")), (-45, 5));
+        assert_eq!(strtol_c(&to_buf::<32>("+7")), (7, 2));
+        assert_eq!(strtol_c(&to_buf::<32>("0")), (0, 1));
+        /* no conversion: C leaves endptr == nptr and returns 0 */
+        assert_eq!(strtol_c(&to_buf::<32>("")), (0, 0));
+        assert_eq!(strtol_c(&to_buf::<32>("abc")), (0, 0));
+        assert_eq!(strtol_c(&to_buf::<32>("+")), (0, 0));
+        /* overflow saturates rather than wrapping */
+        assert_eq!(strtol_c(&to_buf::<32>("99999999999999999999")).0, c_long::MAX);
+        assert_eq!(strtol_c(&to_buf::<32>("-99999999999999999999")).0, c_long::MIN);
+        /* the endptr is what the PC/CD alt-suffix test keys off */
+        assert_eq!(strtol_c(&to_buf::<32>("12_3")), (12, 2));
+    }
+
+    #[test]
+    fn test_strtod_c() {
+        assert_eq!(strtod_c(&to_buf::<32>("1.5")), 1.5);
+        assert_eq!(strtod_c(&to_buf::<32>("-0.25")), -0.25);
+        assert_eq!(strtod_c(&to_buf::<32>("1.5E2")), 150.0);
+        /* FITS allows 'D' as the exponent marker */
+        assert_eq!(strtod_c(&to_buf::<32>("1.5D2")), 150.0);
+        assert_eq!(strtod_c(&to_buf::<32>("abc")), 0.0);
+        assert_eq!(strtod_c(&to_buf::<32>("")), 0.0);
+        /* a trailing exponent marker with no digits is not consumed */
+        assert_eq!(strtod_c(&to_buf::<32>("2.0E")), 2.0);
+    }
+
+    /* glibc's C locale reports false for every class on the negative values a
+       signed char can hold, and c_char is unsigned on some targets, so these
+       must not depend on the platform's char signedness. */
+    #[test]
+    fn test_ctype_helpers() {
+        assert!(!isprint_c(0x1f as c_char));
+        assert!(isprint_c(0x20 as c_char));
+        assert!(isprint_c(0x7e as c_char));
+        assert!(!isprint_c(0x7f as c_char));
+        assert!(!isprint_c(0x80u8 as c_char));
+        assert!(!isprint_c(0xffu8 as c_char));
+
+        assert!(isascii_c(0x7f as c_char));
+        assert!(!isascii_c(0x80u8 as c_char));
+
+        assert!(isspace_c(b' ' as c_char));
+        assert!(isspace_c(b'\t' as c_char));
+        assert!(!isspace_c(b'x' as c_char));
+        assert!(!isspace_c(0xa0u8 as c_char));
+
+        assert!(isdigit_c(b'0' as c_char));
+        assert!(isdigit_c(b'9' as c_char));
+        assert!(!isdigit_c(b'a' as c_char));
+
+        assert!(isupper_c(b'A' as c_char));
+        assert!(!isupper_c(b'a' as c_char));
+
+        assert_eq!(toupper_c(b'a' as c_char), b'A' as c_char);
+        assert_eq!(toupper_c(b'Z' as c_char), b'Z' as c_char);
+        assert_eq!(toupper_c(b'_' as c_char), b'_' as c_char);
+    }
+
+    #[test]
+    fn test_string_helpers() {
+        let mut d = [0 as c_char; 8];
+        strcpy_c(&mut d, &to_buf::<16>("abc"));
+        assert_eq!(cstrlen(&d), 3);
+        /* strcpy_c truncates where the C would overrun the destination */
+        strcpy_c(&mut d, &to_buf::<32>("abcdefghijkl"));
+        assert_eq!(cstrlen(&d), 7);
+
+        /* strncpy NUL-pads a short source */
+        let mut e = [b'x' as c_char; 8];
+        strncpy_c(&mut e, &to_buf::<16>("ab"), 5);
+        assert_eq!(&e[..5], &[b'a' as c_char, b'b' as c_char, 0, 0, 0]);
+        assert_eq!(e[5], b'x' as c_char);
+
+        assert_eq!(strcmp_c(&to_buf::<16>("abc"), &to_buf::<16>("abc")), 0);
+        assert!(strcmp_c(&to_buf::<16>("abc"), &to_buf::<16>("abd")) < 0);
+        assert!(strcmp_c(&to_buf::<16>("abd"), &to_buf::<16>("abc")) > 0);
+        assert_eq!(strncmp_c(&to_buf::<16>("abcZ"), &to_buf::<16>("abcY"), 3), 0);
+
+        /* strchr stops at the NUL, so bytes past it are not found */
+        let mut s = to_buf::<16>("abc");
+        s[5] = b'z' as c_char;
+        assert_eq!(chr_pos(&s, b'b'), Some(1));
+        assert_eq!(chr_pos(&s, b'z'), None);
+        assert!(chr_in(&s, b'c'));
+        assert!(!chr_in(&s, b'q'));
+
+        assert_eq!(cvec(&to_buf::<16>("hi")), vec![104, 105, 0]);
+    }
+
+    /* The message builder has to pass bytes through untouched: fitsverify
+       echoes malformed cards, which are routinely not valid UTF-8. */
+    #[test]
+    fn test_spf_is_byte_exact() {
+        let mut b = [0 as c_char; 64];
+        spf!(b; "n=", 42, " c=", CHR(0xfeu8 as c_char), "!");
+        assert_eq!(cbytes(&b), b"n=42 c=\xfe!");
+
+        /* %-4d / %-20s / %.8s style conversions */
+        let mut w = [0 as c_char; 64];
+        spf!(w; "[", DW(7, -4), "][", DW(7, 4), "]");
+        assert_eq!(cbytes(&w), b"[7   ][   7]");
+
+        let name = to_buf::<16>("ABCDEFGHIJ");
+        let mut p = [0 as c_char; 64];
+        spf!(p; CSW(&name, 0, Some(8)), "|", CSW(&name, -12, None), "|");
+        assert_eq!(cbytes(&p), b"ABCDEFGH|ABCDEFGHIJ  |");
+
+        /* sprintf into a fixed buffer truncates rather than overrunning it */
+        let mut t = [0 as c_char; 5];
+        spf!(t; "abcdefgh");
+        assert_eq!(cbytes(&t), b"abcd");
+
+        /* strcat */
+        let mut c = [0 as c_char; 16];
+        spf!(c; "ab");
+        scat!(c; "cd", 9);
+        assert_eq!(cbytes(&c), b"abcd9");
+    }
 }

--- a/src/bin/fitsverify/fvrf_data.rs
+++ b/src/bin/fitsverify/fvrf_data.rs
@@ -708,7 +708,7 @@ pub extern "C" fn iterdata(
                     l = 1;
                     while l <= repeat[iu] {
                         let v = unsafe { *data.offset((k * repeat[iu] + l) as isize) } as c_uchar;
-                        spf!(comm; "0x", SW(&format!("{v:02x}"), 0, None), " ");
+                        spf!(comm; "0x", format!("{v:02x}"), " ");
                         scat!(errmes; CS(&comm));
                         l += 1;
                     }

--- a/src/bin/fitsverify/fvrf_data.rs
+++ b/src/bin/fitsverify/fvrf_data.rs
@@ -5,8 +5,7 @@
    iterdata keep the C's pointer arithmetic inside small unsafe blocks.  All
    the other column reads use the typed safe wrappers.  */
 
-use std::cell::RefCell;
-use std::sync::atomic::{AtomicI32, Ordering};
+use std::cell::{Cell, RefCell};
 
 use bytemuck::cast_slice;
 use rsfitsio::aliases::rust_api::{
@@ -16,6 +15,8 @@ use rsfitsio::aliases::rust_api::{
     fits_verify_chksum,
 };
 use rsfitsio::buffers::ffgtbb_safe;
+use std::ffi::CStr;
+
 use rsfitsio::c_types::{c_char, c_int, c_long, c_uchar, c_void};
 use rsfitsio::cs;
 use rsfitsio::fitscore::{ffasfm_safe, ffcdfl_safe};
@@ -68,7 +69,7 @@ struct UserIter {
 *  this routine does not read the image pixels.
 *
 *************************************************************/
-pub fn test_data(
+pub(crate) fn test_data(
     infits: &mut fitsfile, /* input fits file   */
     out: Out,              /* output ascii file */
     hduptr: &mut FitsHdu,  /* fits hdu pointer  */
@@ -603,22 +604,22 @@ thread_local! {
     static REPEAT_V: RefCell<Vec<c_long>> = const { RefCell::new(Vec::new()) };
     static DATATYPE_V: RefCell<Vec<c_int>> = const { RefCell::new(Vec::new()) };
 }
-static IT_NNUM: AtomicI32 = AtomicI32::new(0);
-static IT_NTXT: AtomicI32 = AtomicI32::new(0);
-static IT_NCMP: AtomicI32 = AtomicI32::new(0);
-static IT_NFLOAT: AtomicI32 = AtomicI32::new(0);
-static FIND_BADBIT: AtomicI32 = AtomicI32::new(0);
-static FIND_BADDOT: AtomicI32 = AtomicI32::new(0);
-static FIND_BADSPACE: AtomicI32 = AtomicI32::new(0);
-static FIND_BADCHAR: AtomicI32 = AtomicI32::new(0);
-static FIND_BADLOG: AtomicI32 = AtomicI32::new(0);
+thread_local! { static IT_NNUM: Cell<c_int> = const { Cell::new(0) }; }
+thread_local! { static IT_NTXT: Cell<c_int> = const { Cell::new(0) }; }
+thread_local! { static IT_NCMP: Cell<c_int> = const { Cell::new(0) }; }
+thread_local! { static IT_NFLOAT: Cell<c_int> = const { Cell::new(0) }; }
+thread_local! { static FIND_BADBIT: Cell<c_int> = const { Cell::new(0) }; }
+thread_local! { static FIND_BADDOT: Cell<c_int> = const { Cell::new(0) }; }
+thread_local! { static FIND_BADSPACE: Cell<c_int> = const { Cell::new(0) }; }
+thread_local! { static FIND_BADCHAR: Cell<c_int> = const { Cell::new(0) }; }
+thread_local! { static FIND_BADLOG: Cell<c_int> = const { Cell::new(0) }; }
 
 fn iterdata_reset() {
-    FIND_BADBIT.store(0, Ordering::Relaxed);
-    FIND_BADDOT.store(0, Ordering::Relaxed);
-    FIND_BADSPACE.store(0, Ordering::Relaxed);
-    FIND_BADCHAR.store(0, Ordering::Relaxed);
-    FIND_BADLOG.store(0, Ordering::Relaxed);
+    FIND_BADBIT.with(|c| c.set(0));
+    FIND_BADDOT.with(|c| c.set(0));
+    FIND_BADSPACE.with(|c| c.set(0));
+    FIND_BADCHAR.with(|c| c.set(0));
+    FIND_BADLOG.with(|c| c.set(0));
 }
 
 pub extern "C" fn iterdata(
@@ -646,10 +647,10 @@ pub extern "C" fn iterdata(
 
     if firstn == 1 {
         /* first time for this table, so initialize */
-        IT_NNUM.store(usrpt.nnum, Ordering::Relaxed);
-        IT_NCMP.store(usrpt.ncmp, Ordering::Relaxed);
-        IT_NTXT.store(usrpt.ntxt, Ordering::Relaxed);
-        IT_NFLOAT.store(usrpt.nfloat, Ordering::Relaxed);
+        IT_NNUM.with(|c| c.set(usrpt.nnum));
+        IT_NCMP.with(|c| c.set(usrpt.ncmp));
+        IT_NTXT.with(|c| c.set(usrpt.ntxt));
+        IT_NFLOAT.with(|c| c.set(usrpt.nfloat));
         REPEAT_V.with(|r| {
             let mut r = r.borrow_mut();
             r.clear();
@@ -667,10 +668,10 @@ pub extern "C" fn iterdata(
         iterdata_reset();
     }
 
-    let nnum = IT_NNUM.load(Ordering::Relaxed);
-    let ncmp = IT_NCMP.load(Ordering::Relaxed);
-    let ntxt = IT_NTXT.load(Ordering::Relaxed);
-    let nfloat = IT_NFLOAT.load(Ordering::Relaxed);
+    let nnum = IT_NNUM.with(Cell::get);
+    let ncmp = IT_NCMP.with(Cell::get);
+    let ntxt = IT_NTXT.with(Cell::get);
+    let nfloat = IT_NFLOAT.with(Cell::get);
     let repeat = REPEAT_V.with(|r| r.borrow().clone());
     let datatype = DATATYPE_V.with(|d| d.borrow().clone());
 
@@ -692,10 +693,10 @@ pub extern "C" fn iterdata(
             i += 1;
             continue;
         }
-        FIND_BADBIT.store(0, Ordering::Relaxed);
+        FIND_BADBIT.with(|c| c.set(0));
 
         /* check for the bit jurisfication  */
-        if FIND_BADBIT.load(Ordering::Relaxed) == 0 && usrpt.indatatyp[iu] == TBIT {
+        if FIND_BADBIT.with(Cell::get) == 0 && usrpt.indatatyp[iu] == TBIT {
             k = 0;
             while k < nrows {
                 j = (k + 1) * repeat[iu];
@@ -715,7 +716,7 @@ pub extern "C" fn iterdata(
                     wrterr(usrpt.out, &errmes, 2);
                     spf!(errmes; "             (Other rows may have errors).");
                     print_fmt(usrpt.out, &errmes, 13);
-                    FIND_BADBIT.store(1, Ordering::Relaxed);
+                    FIND_BADBIT.with(|c| c.set(1));
                     break;
                 }
                 k += 1;
@@ -735,32 +736,27 @@ pub extern "C" fn iterdata(
                 i += 1;
                 continue;
             }
-            // SAFETY: for a TSTRING column the iterator's array is a char*[nrows+1].
+            // SAFETY: a TSTRING iterator column's array is a char*[nrows+1];
+            // slot 0 is the null-value string, slots 1..=nrows the row values,
+            // all NUL-terminated and owned by the iterator for this call.
             let cdata: *const *const c_char = cols[iu].array.cast::<*const c_char>();
-            FIND_BADCHAR.store(0, Ordering::Relaxed);
+            let row = |n: c_long| -> &[u8] { unsafe { CStr::from_ptr(*cdata.offset(n as isize)) }.to_bytes() };
+            FIND_BADCHAR.with(|c| c.set(0));
 
             /* test for illegal ASCII text characters > 126  or < 32 */
-            if FIND_BADCHAR.load(Ordering::Relaxed) == 0 {
+            if FIND_BADCHAR.with(Cell::get) == 0 {
                 k = 0;
-                'rows: while k < nrows {
-                    let ucdata = unsafe { *cdata.offset((k + 1) as isize) };
-                    j = 0;
-                    loop {
-                        let c = unsafe { *ucdata.offset(j as isize) } as u8;
-                        if c == 0 {
-                            break;
-                        }
-                        if c > 126 || c < 32 {
-                            spf!(errmes;
-                                "String in row #", (firstn + k) as i64, ", column #",
-                                cols[iu].colnum, " contains non-ASCII text.");
-                            wrterr(usrpt.out, &errmes, 1);
-                            spf!(errmes; "             (Other rows may have errors).");
-                            print_fmt(usrpt.out, &errmes, 13);
-                            FIND_BADCHAR.store(1, Ordering::Relaxed);
-                            break 'rows;
-                        }
-                        j += 1;
+                while k < nrows {
+                    /* NB: the C breaks out of the inner scan only, so the row
+                       loop carries on and every offending row is reported. */
+                    if row(k + 1).iter().any(|&c| !(32..=126).contains(&c)) {
+                        spf!(errmes;
+                            "String in row #", (firstn + k) as i64, ", column #",
+                            cols[iu].colnum, " contains non-ASCII text.");
+                        wrterr(usrpt.out, &errmes, 1);
+                        spf!(errmes; "             (Other rows may have errors).");
+                        print_fmt(usrpt.out, &errmes, 13);
+                        FIND_BADCHAR.with(|c| c.set(1));
                     }
                     k += 1;
                 }
@@ -778,7 +774,7 @@ pub extern "C" fn iterdata(
             /* test for illegal logical column values */
             /* The first element in the array gives the value that is used to
             represent nulls */
-            if FIND_BADLOG.load(Ordering::Relaxed) == 0 {
+            if FIND_BADLOG.with(Cell::get) == 0 {
                 j = 1;
                 while j <= nrows * repeat[iu] {
                     if unsafe { *ldata.offset(j as isize) } > 2 {
@@ -789,7 +785,7 @@ pub extern "C" fn iterdata(
                         wrterr(usrpt.out, &errmes, 1);
                         spf!(errmes; "             (Other rows may have similar errors).");
                         print_fmt(usrpt.out, &errmes, 13);
-                        FIND_BADLOG.store(1, Ordering::Relaxed);
+                        FIND_BADLOG.with(|c| c.set(1));
                         break;
                     }
                     j += 1;
@@ -808,36 +804,31 @@ pub extern "C" fn iterdata(
             continue;
         }
         // SAFETY: TSTRING iterator column, char*[nrows+1] as above.
-        let cdata: *mut *mut c_char = cols[iu].array.cast::<*mut c_char>();
-        FIND_BADDOT.store(0, Ordering::Relaxed);
-        FIND_BADSPACE.store(0, Ordering::Relaxed);
+        // SAFETY: as above -- a TSTRING iterator column.
+        let cdata: *const *const c_char = cols[iu].array.cast::<*const c_char>();
+        let row = |n: c_long| -> &[u8] { unsafe { CStr::from_ptr(*cdata.offset(n as isize)) }.to_bytes() };
+        FIND_BADDOT.with(|c| c.set(0));
+        FIND_BADSPACE.with(|c| c.set(0));
 
         /* test for missing (implicit) decimal point in floating point numbers */
-        if FIND_BADDOT.load(Ordering::Relaxed) == 0 {
+        if FIND_BADDOT.with(Cell::get) == 0 {
             k = 0;
             while k < nrows {
-                let nullstr = unsafe { *cdata };
-                let mut floatvalue = unsafe { *cdata.offset((k + 1) as isize) };
-                if unsafe { cstrcmp(nullstr, floatvalue) } != 0
-                    && unsafe { cstrchr(floatvalue, b'.') }.is_null()
-                {
-                    while unsafe { *floatvalue } as u8 == b' ' {
-                        /* skip leading spaces */
-                        floatvalue = unsafe { floatvalue.add(1) };
-                    }
+                let floatvalue = row(k + 1);
+                if floatvalue != row(0) && !floatvalue.contains(&b'.') {
+                    let floatvalue = skip_spaces(floatvalue); /* skip leading spaces */
 
-                    if unsafe { cstrlen_raw(floatvalue) } != 0 {
+                    if !floatvalue.is_empty() {
                         /* ignore completely blank fields */
 
                         spf!(errmes;
                             "Number in row #", (firstn + k) as i64, ", column #",
                             cols[iu].colnum, " has no decimal point:");
                         wrterr(usrpt.out, &errmes, 1);
-                        let fv = unsafe { raw_to_vec(floatvalue) };
-                        spf!(errmes; CS(&fv));
+                        spf!(errmes; BS(floatvalue));
                         scat!(errmes; "  (Other rows may have similar errors).");
                         print_fmt(usrpt.out, &errmes, 13);
-                        FIND_BADDOT.store(1, Ordering::Relaxed);
+                        FIND_BADDOT.with(|c| c.set(1));
                         break;
                     }
                 }
@@ -845,36 +836,26 @@ pub extern "C" fn iterdata(
             }
         }
 
-        if FIND_BADSPACE.load(Ordering::Relaxed) == 0 {
+        if FIND_BADSPACE.with(Cell::get) == 0 {
             k = 0;
             while k < nrows {
-                let nullstr = unsafe { *cdata };
-                let mut floatvalue = unsafe { *cdata.offset((k + 1) as isize) };
+                let floatvalue = row(k + 1);
 
-                if unsafe { cstrcmp(nullstr, floatvalue) } != 0 {
+                if floatvalue != row(0) {
                     /* not a null value? */
-                    while unsafe { *floatvalue } as u8 == b' ' {
-                        /* skip leading spaces */
-                        floatvalue = unsafe { floatvalue.add(1) };
-                    }
+                    /* The C strips the trailing blanks in place; nothing reads
+                       the row again afterwards, so a trimmed view is equivalent. */
+                    let floatvalue = trim_end_spaces(skip_spaces(floatvalue));
 
-                    l = unsafe { cstrlen_raw(floatvalue) } as c_long - 1;
-                    while l > 0 && unsafe { *floatvalue.offset(l as isize) } as u8 == b' ' {
-                        /* remove trailing spaces */
-                        unsafe { *floatvalue.offset(l as isize) = 0 };
-                        l -= 1;
-                    }
-
-                    if !unsafe { cstrchr(floatvalue, b' ') }.is_null() {
+                    if floatvalue.contains(&b' ') {
                         spf!(errmes;
                             "Number in row #", (firstn + k) as i64, ", column #",
                             cols[iu].colnum, " has embedded space:");
                         wrterr(usrpt.out, &errmes, 1);
-                        let fv = unsafe { raw_to_vec(floatvalue) };
-                        spf!(errmes; CS(&fv));
+                        spf!(errmes; BS(floatvalue));
                         scat!(errmes; "  (Other rows may have similar errors).");
                         print_fmt(usrpt.out, &errmes, 13);
-                        FIND_BADSPACE.store(1, Ordering::Relaxed);
+                        FIND_BADSPACE.with(|c| c.set(1));
                         break;
                     }
                 }
@@ -899,7 +880,7 @@ pub extern "C" fn iterdata(
 *   Test the bytes between the ASCII table column.
 *
 *************************************************************/
-pub fn test_agap(
+fn test_agap(
     infits: &mut fitsfile, /* input fits file   */
     out: Out,              /* output ascii file */
     hduptr: &mut FitsHdu,  /* fits hdu pointer  */
@@ -1031,7 +1012,7 @@ pub fn test_agap(
 *   Test the checksum of the hdu
 *
 *************************************************************/
-pub fn test_checksum(
+fn test_checksum(
     infits: &mut fitsfile, /* input fits file   */
     out: Out,              /* output ascii file */
 ) {
@@ -1063,63 +1044,6 @@ pub fn test_checksum(
             wrtwrn_str(out, "HDU checksum is not in agreement with CHECKSUM.", 0);
         }
     }
-}
-
-/*===========================================================================
- *  raw C-string helpers, only for the iterator's `char **' arrays
- *==========================================================================*/
-
-unsafe fn cstrlen_raw(s: *const c_char) -> usize {
-    let mut n = 0usize;
-    unsafe {
-        while *s.add(n) != 0 {
-            n += 1;
-        }
-    }
-    n
-}
-
-unsafe fn cstrcmp(a: *const c_char, b: *const c_char) -> c_int {
-    let mut i = 0usize;
-    unsafe {
-        loop {
-            let ca = *a.add(i) as u8;
-            let cb = *b.add(i) as u8;
-            if ca != cb {
-                return ca as c_int - cb as c_int;
-            }
-            if ca == 0 {
-                return 0;
-            }
-            i += 1;
-        }
-    }
-}
-
-unsafe fn cstrchr(s: *const c_char, c: u8) -> *const c_char {
-    let mut i = 0usize;
-    unsafe {
-        loop {
-            let v = *s.add(i) as u8;
-            if v == c {
-                return s.add(i);
-            }
-            if v == 0 {
-                return std::ptr::null();
-            }
-            i += 1;
-        }
-    }
-}
-
-unsafe fn raw_to_vec(s: *const c_char) -> Vec<c_char> {
-    let n = unsafe { cstrlen_raw(s) };
-    let mut v = Vec::with_capacity(n + 1);
-    for i in 0..n {
-        v.push(unsafe { *s.add(i) });
-    }
-    v.push(0);
-    v
 }
 
 #[allow(dead_code)]

--- a/src/bin/fitsverify/fvrf_data.rs
+++ b/src/bin/fitsverify/fvrf_data.rs
@@ -1,1 +1,1129 @@
-pub type data = i32;
+/* Transpiled from cfitsio/utilities/fvrf_data.c
+
+   The CFITSIO iterator hands its work function a `void *userPointer' and an
+   array of iteratorCol whose `array' member is a raw buffer, so test_data /
+   iterdata keep the C's pointer arithmetic inside small unsafe blocks.  All
+   the other column reads use the typed safe wrappers.  */
+
+use std::cell::RefCell;
+use std::sync::atomic::{AtomicI32, Ordering};
+
+use bytemuck::cast_slice;
+use rsfitsio::aliases::rust_api::{
+    fits_get_coltype, fits_get_num_rows, fits_get_num_rowsll, fits_get_rowsize,
+    fits_iterate_data, fits_read_col_log, fits_read_col_str, fits_read_descriptll,
+    fits_read_key_lng, fits_read_key_lnglng, fits_read_key_str, fits_read_tblbytes,
+    fits_verify_chksum,
+};
+use rsfitsio::buffers::ffgtbb_safe;
+use rsfitsio::c_types::{c_char, c_int, c_long, c_uchar, c_void};
+use rsfitsio::cs;
+use rsfitsio::fitscore::{ffasfm_safe, ffcdfl_safe};
+use rsfitsio::fitsio::{
+    ASCII_TBL, BINARY_TBL, FLEN_VALUE, LONGLONG, TBIT, TBYTE, TCOMPLEX, TDBLCOMPLEX, TDOUBLE,
+    TFLOAT, TLOGICAL, TLONG, TSHORT, TSTRING, fitsfile, iteratorCol,
+};
+
+use crate::common::*;
+use crate::fvrf_head::parse_vtform;
+use crate::fvrf_misc::*;
+use crate::{scat, spf};
+
+/* flag for input only iterator column (fitsio.h InputCol) */
+const InputCol: c_int = 0;
+
+struct UserIter {
+    nnum: c_int,
+    ncmp: c_int,
+    nfloat: c_int,
+    indatatyp: Vec<c_int>,
+    datamax: Vec<f64>,
+    datamin: Vec<f64>,
+    tnull: Vec<f64>,
+    mask: Vec<c_uchar>, /* for bit X column only */
+    ntxt: c_int,
+    out: Out,
+}
+
+/*************************************************************
+*
+*      test_data
+*
+*   Test the HDU data
+*
+*  This routine reads every row and column of ASCII tables to
+*  verify that the values have the correct format.
+*
+*  This routine checks the following types of columns in binary tables:
+*
+*    Logical L - value must be T, F or zero
+*    Bit    nX - if n != a multiple of 8, then check that fill bits = 0
+*    String  A - must contain ascii text, or zero
+*
+*   It is impossible to write an invalid value to the other types of
+*   columns in binary tables (B, I, J, K, E, D, C and M) so these
+*   columns are not read.
+*
+*  Since it is impossible to write an invalid value in a FITS image,
+*  this routine does not read the image pixels.
+*
+*************************************************************/
+pub fn test_data(
+    infits: &mut fitsfile, /* input fits file   */
+    out: Out,              /* output ascii file */
+    hduptr: &mut FitsHdu,  /* fits hdu pointer  */
+) {
+    let mut iter_col: Vec<iteratorCol> = Vec::new();
+    let ncols: c_int;
+
+    let mut nnum = 0; /* the list of the column  whose data
+                      type is numerical(scalar and complex) */
+    let mut numlist: Vec<c_int>;
+    let mut nfloat = 0; /* the list of the floating point columns in ASCII table */
+    let mut floatlist: Vec<c_int>;
+
+    let ncmp = 0; /* the list of the column  whose data
+                  type is numerical(scalar and complex) */
+    let cmplist: Vec<c_int>;
+    let mut ntxt = 0; /* the list of column  whose data type is
+                      string, logical, bit or complex */
+    let mut txtlist: Vec<c_int>;
+    let niter: c_int; /* total columns read into  the literator function */
+
+    let mut ndesc = 0; /* the list of column which is the descriptor of
+                       the variable length array. */
+    let mut desclist: Vec<c_int>;
+    let mut isVarQFormat: Vec<c_int>; /* Format type for each of the ndesc variable-length
+                                      columns: 0 = type 'P', 1 = type 'Q' */
+
+    let mut rows_per_loop: c_long = 0;
+    let offset: c_long;
+
+    let mut datatype: c_int = 0;
+    let mut repeat: c_long = 0;
+
+    let mut totalrows: c_long = 0;
+    let mut length: LONGLONG = 0;
+    let mut toffset: LONGLONG = 0;
+    let mut maxlen: Vec<c_long>;
+    let mut icol: c_int;
+    let mut cdata: Vec<c_char>;
+    let mut dflag: Vec<c_int>;
+    let lnull: c_char = 2;
+    let mut anynul: c_int = 0;
+
+    let mut rlength: c_long;
+    let mut bytelength: c_long;
+    let mut maxmax: c_long;
+
+    let mut i: usize;
+    let mut j: usize;
+    let mut jl: c_long;
+    let mut k: c_long;
+    let mut status: c_int = 0;
+    let mut errtmp: [c_char; 80] = [0; 80];
+    let mut perbyte: Vec<c_int>;
+    let mut errmes: [c_char; ERRMES_LEN] = [0; ERRMES_LEN];
+
+    let mut naxis2: LONGLONG = 0;
+
+    let mut largeVarLengthWarned = 0;
+    let mut largeVarOffsetWarned = 0;
+
+    if testcsum() != 0 {
+        test_checksum(infits, out);
+    }
+
+    if testfill() != 0 {
+        test_agap(infits, out, hduptr); /* test the bytes between the
+                                        ascii table columns. */
+        if ffcdfl_safe(infits, &mut status) != 0 {
+            wrtferr_str(out, "checking data fill: ", &mut status, 1);
+            status = 0;
+        }
+    }
+
+    if hduptr.hdutype != ASCII_TBL && hduptr.hdutype != BINARY_TBL {
+        return;
+    }
+
+    ncols = hduptr.ncols;
+    if ncols <= 0 {
+        return;
+    }
+
+    fits_read_key_lnglng(infits, cs!(c"NAXIS2"), &mut naxis2, None, &mut status);
+
+    if naxis2 > 2147483647 {
+        wrtout_str(
+            out,
+            "Cannot test data in tables with more than 2**31 (2147483647) rows.",
+        );
+        return;
+    }
+
+    /* separate the numerical, complex, text and
+      the variable length vector columns */
+    numlist = vec![0; ncols as usize];
+    floatlist = vec![0; ncols as usize];
+    cmplist = vec![0; ncols as usize];
+    txtlist = vec![0; ncols as usize];
+    desclist = vec![0; ncols as usize];
+    let _ = &cmplist;
+
+    if hduptr.hdutype == ASCII_TBL {
+        /*read every column of an ASCII table */
+        rows_per_loop = 0;
+        for i in 0..ncols {
+            if fits_get_coltype(infits, i + 1, Some(&mut datatype), None, None, &mut status) != 0 {
+                spf!(errmes; "Column #", i, ": ");
+                wrtferr(out, &errmes, &mut status, 2);
+            }
+            if datatype != TSTRING {
+                numlist[nnum as usize] = i + 1;
+                nnum += 1;
+
+                if datatype > TLONG {
+                    /* floating point number column */
+                    floatlist[nfloat as usize] = i + 1;
+                    nfloat += 1;
+                }
+            } else {
+                txtlist[ntxt as usize] = i + 1;
+                ntxt += 1;
+            }
+        }
+    } else if hduptr.hdutype == BINARY_TBL {
+        /* only check Bit, Logical and String columns in Binary tables */
+        rows_per_loop = 0;
+        for i in 0..ncols {
+            if fits_get_coltype(
+                infits,
+                i + 1,
+                Some(&mut datatype),
+                Some(&mut repeat),
+                None,
+                &mut status,
+            ) != 0
+            {
+                spf!(errmes; "Column #", i, ": ");
+                wrtferr(out, &errmes, &mut status, 2);
+            }
+
+            if datatype < 0 {
+                /* variable length column */
+                desclist[ndesc as usize] = i + 1;
+                ndesc += 1;
+            } else if datatype == TBIT && (repeat % 8) != 0 {
+                /* bit column that does not have a multiple of 8 bits */
+                numlist[nnum as usize] = i + 1;
+                nnum += 1;
+            } else if datatype == TLOGICAL || datatype == TSTRING {
+                txtlist[ntxt as usize] = i + 1;
+                ntxt += 1;
+            }
+            /* ignore all other types of columns (B I J K E D C and M ) */
+        }
+    }
+
+    /*  Use Iterator to read the columns that are not variable length arrays */
+    /* columns from  1 to nnum are scalar numerical columns.
+       columns from  nnum+1 to  nnum+ncmp are complex columns.
+       columns from  nnum+ncmp are text columns */
+    niter = nnum + ncmp + ntxt + nfloat;
+
+    if niter != 0 {
+        iter_col = vec![iteratorCol::default(); niter as usize];
+    }
+
+    /* fits_iter_set_by_num() just fills in these four members */
+    let fptr_raw: *mut fitsfile = infits;
+    for i in 0..nnum as usize {
+        iter_col[i].fptr = fptr_raw;
+        iter_col[i].colnum = numlist[i];
+        iter_col[i].datatype = TDOUBLE;
+        iter_col[i].iotype = InputCol;
+    }
+    for i in 0..ncmp as usize {
+        let j = nnum as usize + i;
+        iter_col[j].fptr = fptr_raw;
+        iter_col[j].colnum = cmplist[i];
+        iter_col[j].datatype = TDBLCOMPLEX;
+        iter_col[j].iotype = InputCol;
+    }
+    for i in 0..ntxt as usize {
+        let j = (nnum + ncmp) as usize + i;
+        iter_col[j].fptr = fptr_raw;
+        iter_col[j].colnum = txtlist[i];
+        iter_col[j].datatype = 0;
+        iter_col[j].iotype = InputCol;
+    }
+    for i in 0..nfloat as usize {
+        let j = (nnum + ncmp + ntxt) as usize + i;
+        iter_col[j].fptr = fptr_raw;
+        iter_col[j].colnum = floatlist[i];
+        iter_col[j].datatype = TSTRING;
+        iter_col[j].iotype = InputCol;
+    }
+
+    offset = 0;
+    let mut usrdata = UserIter {
+        nnum,
+        ncmp,
+        nfloat,
+        indatatyp: Vec::new(),
+        datamax: Vec::new(),
+        datamin: Vec::new(),
+        tnull: Vec::new(),
+        mask: Vec::new(),
+        ntxt,
+        out,
+    };
+    if nnum > 0 || ncmp > 0 {
+        usrdata.datamax = vec![0.0; (nnum + ncmp) as usize];
+        usrdata.datamin = vec![0.0; (nnum + ncmp) as usize];
+    }
+    usrdata.tnull = vec![0.0; ncols as usize];
+
+    /* get the mask for the bit X column
+        for column other than the X, it always 255
+        for Column nX, it will be 000...111, where # of 0 is n%8,
+        # of 1 is 8 - n%8.
+    */
+
+    if nnum > 0 {
+        usrdata.mask = vec![0; nnum as usize];
+        usrdata.indatatyp = vec![0; nnum as usize];
+    }
+    for i in 0..nnum as usize {
+        let jc = iter_col[i].colnum; /* fits_iter_get_colnum() */
+        if fits_get_coltype(
+            infits,
+            jc,
+            Some(&mut datatype),
+            Some(&mut repeat),
+            None,
+            &mut status,
+        ) != 0
+        {
+            spf!(errmes; "Column #", i, ": ");
+            wrtferr(out, &errmes, &mut status, 2);
+        }
+        usrdata.indatatyp[i] = datatype;
+        usrdata.mask[i] = 255;
+        if datatype == TBIT {
+            repeat %= 8;
+            usrdata.mask[i] >>= repeat;
+            if repeat == 0 {
+                usrdata.mask[i] = 0;
+            }
+        }
+    }
+
+    if niter > 0 {
+        iterdata_reset();
+        let up: *mut c_void = (&mut usrdata as *mut UserIter).cast();
+        if fits_iterate_data(
+            niter,
+            &mut iter_col,
+            offset,
+            rows_per_loop,
+            iterdata,
+            up,
+            &mut status,
+        ) != 0
+        {
+            wrtserr_str(out, "When Reading data, ", &mut status, 2);
+        }
+    }
+
+    /* the C free()s iter_col, numlist, floatlist, cmplist, txtlist and the
+       usrdata arrays here; RAII does that. */
+
+    if ndesc != 0 {
+        /* ------------read the variable length vectors -------------------*/
+        usrdata.datamax = vec![0.0; ndesc as usize];
+        usrdata.datamin = vec![0.0; ndesc as usize];
+        usrdata.tnull = vec![0.0; ndesc as usize];
+        maxlen = vec![0; ndesc as usize];
+        dflag = vec![0; ndesc as usize];
+        perbyte = vec![0; ndesc as usize];
+        isVarQFormat = vec![0; ndesc as usize];
+        fits_get_num_rows(infits, &mut totalrows, &mut status);
+        status = 0;
+
+        /* this routine now only reads and test BIT, LOGICAL, and STRING columns */
+        /* There is no point in reading the other columns because the other datatypes */
+        /* have no possible invalid values.  */
+
+        for i in 0..ndesc as usize {
+            icol = desclist[i];
+            parse_vtform(
+                infits,
+                out,
+                hduptr,
+                icol,
+                &mut datatype,
+                &mut maxlen[i],
+                &mut isVarQFormat[i],
+            );
+            dflag[i] = 4;
+            match datatype {
+                d if d == -TBIT => {
+                    dflag[i] = 1;
+                    perbyte[i] = -8;
+                }
+                d if d == -TBYTE => {
+                    perbyte[i] = 1;
+                }
+                d if d == -TLOGICAL => {
+                    dflag[i] = 3;
+                    perbyte[i] = 1;
+                }
+                d if d == -TSTRING => {
+                    dflag[i] = 0;
+                    perbyte[i] = 1;
+                }
+                d if d == -TSHORT => {
+                    perbyte[i] = 2;
+                }
+                d if d == -TLONG => {
+                    perbyte[i] = 4;
+                }
+                d if d == -TFLOAT => {
+                    perbyte[i] = 4;
+                }
+                d if d == -TDOUBLE => {
+                    perbyte[i] = 8;
+                }
+                d if d == -TCOMPLEX => {
+                    dflag[i] = 2;
+                    perbyte[i] = 8;
+                }
+                d if d == -TDBLCOMPLEX => {
+                    dflag[i] = 2;
+                    perbyte[i] = 16;
+                }
+                _ => {}
+            }
+        }
+
+        maxmax = maxlen[0];
+        for i in 1..ndesc as usize {
+            if maxmax < maxlen[i] {
+                maxmax = maxlen[i];
+            }
+        }
+        if maxmax < 0 {
+            maxmax = 100;
+        }
+        cdata = vec![0; (maxmax + 1) as usize];
+
+        jl = 1;
+        while jl <= totalrows {
+            for i in 0..ndesc as usize {
+                icol = desclist[i];
+
+                /* read and check the descriptor length and offset values */
+                if fits_read_descriptll(
+                    infits,
+                    icol,
+                    jl as LONGLONG,
+                    Some(&mut length),
+                    Some(&mut toffset),
+                    &mut status,
+                ) != 0
+                {
+                    spf!(errtmp; "Row #", jl as i64, " Col.#", icol, ": ");
+                    wrtferr(out, &errtmp, &mut status, 2);
+                }
+                if isVarQFormat[i] == 0 {
+                    if largeVarLengthWarned == 0 && length > 2147483647 {
+                        spf!(errmes;
+                            "Var row length exceeds maximum 32-bit signed int.  ");
+                        spf!(errtmp;
+                            "First detected for Row #", jl as i64, " Column #", icol);
+                        scat!(errmes; CS(&errtmp));
+                        wrtwrn(out, &errmes, 0);
+                        largeVarLengthWarned = 1;
+                    }
+                    if largeVarOffsetWarned == 0 && toffset > 2147483647 {
+                        spf!(errmes;
+                            "Heap offset for var length row exceeds maximum 32-bit signed int.  ");
+                        spf!(errtmp;
+                            "First detected for Row #", jl as i64, " Column #", icol);
+                        scat!(errmes; CS(&errtmp));
+                        wrtwrn(out, &errmes, 0);
+                        largeVarOffsetWarned = 1;
+                    }
+                }
+
+                if length > maxlen[i] as LONGLONG && maxlen[i] > -1 {
+                    spf!(errmes;
+                        "Descriptor of Column #", icol, " at Row ", jl as i64, ": ");
+                    spf!(errtmp;
+                        "nelem(", length as i64, ") > maxlen(", maxlen[i] as i64,
+                        ") given by TFORM", icol, ".");
+                    scat!(errmes; CS(&errtmp));
+                    wrterr(out, &errmes, 1);
+                }
+
+                if perbyte[i] < 0 {
+                    bytelength = (length / 8) as c_long;
+                } else {
+                    bytelength = (length * perbyte[i] as LONGLONG) as c_long;
+                }
+
+                if toffset + bytelength as LONGLONG > hduptr.pcount {
+                    spf!(errmes;
+                        "Descriptor of Column #", icol, " at Row ", jl as i64, ": ");
+                    spf!(errtmp;
+                        " offset of first element(", toffset as i64, ") + nelem(",
+                        length as i64, ")");
+                    scat!(errmes; CS(&errtmp));
+                    if perbyte[i] < 0 {
+                        spf!(errtmp;
+                            "/8 >  total heap area  = ", hduptr.pcount as i64, ".");
+                    } else {
+                        spf!(errtmp;
+                            "*", perbyte[i], " >  total heap area  = ", hduptr.pcount as i64,
+                            ".");
+                    }
+                    scat!(errmes; CS(&errtmp));
+                    wrterr(out, &errmes, 2);
+                }
+
+                if length == 0 {
+                    continue;
+                } /* skip the 0 length array */
+
+                /* now check the values in BIT, LOGICAL, and String columns */
+                rlength = length as c_long;
+                if length > maxmax as LONGLONG {
+                    rlength = maxmax;
+                }
+
+                if dflag[i] == 1 { /* read BIT column */
+
+                    /*  NOT YET IMPLEMENTED:  This code should test that the fill bits that
+                    pad out the last byte are all zero. */
+                } else if dflag[i] == 0 {
+                    /* read String column */
+                    anynul = 0;
+                    let mut sbuf: Vec<c_char> = vec![0; (maxmax + 1) as usize];
+                    {
+                        let mut arr: [&mut [c_char]; 1] = [&mut sbuf];
+                        if fits_read_col_str(
+                            infits,
+                            icol,
+                            jl as LONGLONG,
+                            1,
+                            rlength as LONGLONG,
+                            None,
+                            &mut arr,
+                            Some(&mut anynul),
+                            &mut status,
+                        ) != 0
+                        {
+                            spf!(errtmp; "Row #", jl as i64, " Col.#", icol, ": ");
+                            wrtferr(out, &errtmp, &mut status, 2);
+                        } else {
+                            j = 0;
+                            while sbuf[j] != 0 {
+                                if (sbuf[j] as u8) > 126 || (sbuf[j] as u8) < 32 {
+                                    spf!(errmes;
+                                        "String in row #", jl as i64, ", and column #", icol,
+                                        " contains non-ASCII text.");
+                                    wrterr(out, &errmes, 1);
+                                    spf!(errmes;
+                                        "             (This error is reported only once; other rows may have errors).");
+                                    print_fmt(out, &errmes, 13);
+                                    break;
+                                }
+                                j += 1;
+                            }
+                        }
+                    }
+                    cdata = sbuf;
+                } else if dflag[i] == 3 {
+                    /* read Logical column */
+                    anynul = 0;
+                    if fits_read_col_log(
+                        infits,
+                        icol,
+                        jl as LONGLONG,
+                        1,
+                        rlength as LONGLONG,
+                        lnull,
+                        &mut cdata,
+                        Some(&mut anynul),
+                        &mut status,
+                    ) != 0
+                    {
+                        spf!(errtmp; "Row #", jl as i64, " Col.#", icol, ": ");
+                        wrtferr(out, &errtmp, &mut status, 2);
+                    } else {
+                        k = 0;
+                        while k < rlength {
+                            if (cdata[k as usize] as i8) > 2 {
+                                spf!(errmes;
+                                    "Logical value in row #", jl as i64, ", column #", icol,
+                                    " not equal to 'T', 'F', or 0");
+                                wrterr(out, &errmes, 1);
+                                spf!(errmes;
+                                    "             (This error is reported only once; other rows may have errors).");
+                                print_fmt(out, &errmes, 13);
+                                break;
+                            }
+                            k += 1;
+                        }
+                    }
+                }
+            }
+            jl += 1;
+        }
+    }
+
+    /* data_end: */
+    i = 0;
+    while i < ncols as usize {
+        hduptr.datamax[i][12] = 0;
+        hduptr.datamin[i][12] = 0;
+        hduptr.tnull[i][11] = 0;
+        i += 1;
+    }
+}
+
+/***********************************************************************/
+/* iterator work function */
+
+/* The C keeps its per-table state in function statics; the same state lives
+   here so that it survives across the iterator's repeated calls. */
+thread_local! {
+    static REPEAT_V: RefCell<Vec<c_long>> = const { RefCell::new(Vec::new()) };
+    static DATATYPE_V: RefCell<Vec<c_int>> = const { RefCell::new(Vec::new()) };
+}
+static IT_NNUM: AtomicI32 = AtomicI32::new(0);
+static IT_NTXT: AtomicI32 = AtomicI32::new(0);
+static IT_NCMP: AtomicI32 = AtomicI32::new(0);
+static IT_NFLOAT: AtomicI32 = AtomicI32::new(0);
+static FIND_BADBIT: AtomicI32 = AtomicI32::new(0);
+static FIND_BADDOT: AtomicI32 = AtomicI32::new(0);
+static FIND_BADSPACE: AtomicI32 = AtomicI32::new(0);
+static FIND_BADCHAR: AtomicI32 = AtomicI32::new(0);
+static FIND_BADLOG: AtomicI32 = AtomicI32::new(0);
+
+fn iterdata_reset() {
+    FIND_BADBIT.store(0, Ordering::Relaxed);
+    FIND_BADDOT.store(0, Ordering::Relaxed);
+    FIND_BADSPACE.store(0, Ordering::Relaxed);
+    FIND_BADCHAR.store(0, Ordering::Relaxed);
+    FIND_BADLOG.store(0, Ordering::Relaxed);
+}
+
+pub extern "C" fn iterdata(
+    totaln: c_long,
+    _offset: c_long,
+    firstn: c_long,
+    nrows: c_long,
+    narray: c_int,
+    iter_col: *mut iteratorCol,
+    usrdata: *mut c_void,
+) -> c_int {
+    let mut i: c_int;
+    let mut j: c_long;
+    let mut k: c_long;
+    let mut l: c_long;
+    let mut nelem: c_long;
+    let mut errmes: [c_char; ERRMES_LEN] = [0; ERRMES_LEN];
+    let mut comm: [c_char; COMM_LEN] = [0; COMM_LEN];
+
+    // SAFETY: `usrdata` is the &mut UserIter that test_data handed to
+    // fits_iterate_data, and `iter_col` is the narray-long column array the
+    // iterator owns for the duration of this call.
+    let usrpt: &UserIter = unsafe { &*(usrdata as *const UserIter) };
+    let cols: &[iteratorCol] = unsafe { std::slice::from_raw_parts(iter_col, narray as usize) };
+
+    if firstn == 1 {
+        /* first time for this table, so initialize */
+        IT_NNUM.store(usrpt.nnum, Ordering::Relaxed);
+        IT_NCMP.store(usrpt.ncmp, Ordering::Relaxed);
+        IT_NTXT.store(usrpt.ntxt, Ordering::Relaxed);
+        IT_NFLOAT.store(usrpt.nfloat, Ordering::Relaxed);
+        REPEAT_V.with(|r| {
+            let mut r = r.borrow_mut();
+            r.clear();
+            for c in cols.iter() {
+                r.push(c.repeat); /* fits_iter_get_repeat() */
+            }
+        });
+        DATATYPE_V.with(|d| {
+            let mut d = d.borrow_mut();
+            d.clear();
+            for c in cols.iter() {
+                d.push(c.datatype); /* fits_iter_get_datatype() */
+            }
+        });
+        iterdata_reset();
+    }
+
+    let nnum = IT_NNUM.load(Ordering::Relaxed);
+    let ncmp = IT_NCMP.load(Ordering::Relaxed);
+    let ntxt = IT_NTXT.load(Ordering::Relaxed);
+    let nfloat = IT_NFLOAT.load(Ordering::Relaxed);
+    let repeat = REPEAT_V.with(|r| r.borrow().clone());
+    let datatype = DATATYPE_V.with(|d| d.borrow().clone());
+
+    /* columns from  1 to nnum are scalar numerical columns.
+       columns from  nnum+1 to  nnum+ncmp are complex columns. (not used any more)
+       columns from  nnum+ncmp are text columns */
+
+    /* deal with the numerical column */
+    i = 0;
+    while i < nnum + ncmp {
+        let iu = i as usize;
+        // SAFETY: for a numeric column the iterator's array is repeat*nrows+1 doubles.
+        let data: *const f64 = cols[iu].array.cast::<f64>();
+        nelem = nrows * repeat[iu];
+        if i >= nnum {
+            nelem = 2 * nrows * repeat[iu];
+        }
+        if nelem == 0 {
+            i += 1;
+            continue;
+        }
+        FIND_BADBIT.store(0, Ordering::Relaxed);
+
+        /* check for the bit jurisfication  */
+        if FIND_BADBIT.load(Ordering::Relaxed) == 0 && usrpt.indatatyp[iu] == TBIT {
+            k = 0;
+            while k < nrows {
+                j = (k + 1) * repeat[iu];
+                let bdata = unsafe { *data.offset(j as isize) } as c_uchar;
+                if bdata & usrpt.mask[iu] != 0 {
+                    spf!(errmes;
+                        "Row #", (firstn + k) as i64, ", and Column #", cols[iu].colnum,
+                        ": X vector ");
+                    l = 1;
+                    while l <= repeat[iu] {
+                        let v = unsafe { *data.offset((k * repeat[iu] + l) as isize) } as c_uchar;
+                        spf!(comm; "0x", SW(&format!("{v:02x}"), 0, None), " ");
+                        scat!(errmes; CS(&comm));
+                        l += 1;
+                    }
+                    scat!(errmes; "is not left justified.");
+                    wrterr(usrpt.out, &errmes, 2);
+                    spf!(errmes; "             (Other rows may have errors).");
+                    print_fmt(usrpt.out, &errmes, 13);
+                    FIND_BADBIT.store(1, Ordering::Relaxed);
+                    break;
+                }
+                k += 1;
+            }
+        }
+        i += 1;
+    }
+
+    /* deal with character and logical columns */
+    i = nnum + ncmp;
+    while i < nnum + ncmp + ntxt {
+        let iu = i as usize;
+        if datatype[iu] == TSTRING {
+            /* character */
+            nelem = nrows;
+            if nelem == 0 {
+                i += 1;
+                continue;
+            }
+            // SAFETY: for a TSTRING column the iterator's array is a char*[nrows+1].
+            let cdata: *const *const c_char = cols[iu].array.cast::<*const c_char>();
+            FIND_BADCHAR.store(0, Ordering::Relaxed);
+
+            /* test for illegal ASCII text characters > 126  or < 32 */
+            if FIND_BADCHAR.load(Ordering::Relaxed) == 0 {
+                k = 0;
+                'rows: while k < nrows {
+                    let ucdata = unsafe { *cdata.offset((k + 1) as isize) };
+                    j = 0;
+                    loop {
+                        let c = unsafe { *ucdata.offset(j as isize) } as u8;
+                        if c == 0 {
+                            break;
+                        }
+                        if c > 126 || c < 32 {
+                            spf!(errmes;
+                                "String in row #", (firstn + k) as i64, ", column #",
+                                cols[iu].colnum, " contains non-ASCII text.");
+                            wrterr(usrpt.out, &errmes, 1);
+                            spf!(errmes; "             (Other rows may have errors).");
+                            print_fmt(usrpt.out, &errmes, 13);
+                            FIND_BADCHAR.store(1, Ordering::Relaxed);
+                            break 'rows;
+                        }
+                        j += 1;
+                    }
+                    k += 1;
+                }
+            }
+        } else {
+            /* logical value */
+            nelem = nrows * repeat[iu];
+            if nelem == 0 {
+                i += 1;
+                continue;
+            }
+            // SAFETY: for a logical column the array is repeat*nrows+1 bytes.
+            let ldata: *const c_uchar = cols[iu].array.cast::<c_uchar>();
+
+            /* test for illegal logical column values */
+            /* The first element in the array gives the value that is used to
+            represent nulls */
+            if FIND_BADLOG.load(Ordering::Relaxed) == 0 {
+                j = 1;
+                while j <= nrows * repeat[iu] {
+                    if unsafe { *ldata.offset(j as isize) } > 2 {
+                        spf!(errmes;
+                            "Logical value in row #",
+                            ((firstn + j - 2) / repeat[iu] + 1) as i64, ", column #",
+                            cols[iu].colnum, " not equal to 'T', 'F', or 0");
+                        wrterr(usrpt.out, &errmes, 1);
+                        spf!(errmes; "             (Other rows may have similar errors).");
+                        print_fmt(usrpt.out, &errmes, 13);
+                        FIND_BADLOG.store(1, Ordering::Relaxed);
+                        break;
+                    }
+                    j += 1;
+                }
+            }
+        }
+        i += 1;
+    }
+
+    i = nnum + ncmp + ntxt;
+    while i < nnum + ncmp + ntxt + nfloat {
+        let iu = i as usize;
+        nelem = nrows;
+        if nelem == 0 {
+            i += 1;
+            continue;
+        }
+        // SAFETY: TSTRING iterator column, char*[nrows+1] as above.
+        let cdata: *mut *mut c_char = cols[iu].array.cast::<*mut c_char>();
+        FIND_BADDOT.store(0, Ordering::Relaxed);
+        FIND_BADSPACE.store(0, Ordering::Relaxed);
+
+        /* test for missing (implicit) decimal point in floating point numbers */
+        if FIND_BADDOT.load(Ordering::Relaxed) == 0 {
+            k = 0;
+            while k < nrows {
+                let nullstr = unsafe { *cdata };
+                let mut floatvalue = unsafe { *cdata.offset((k + 1) as isize) };
+                if unsafe { cstrcmp(nullstr, floatvalue) } != 0
+                    && unsafe { cstrchr(floatvalue, b'.') }.is_null()
+                {
+                    while unsafe { *floatvalue } as u8 == b' ' {
+                        /* skip leading spaces */
+                        floatvalue = unsafe { floatvalue.add(1) };
+                    }
+
+                    if unsafe { cstrlen_raw(floatvalue) } != 0 {
+                        /* ignore completely blank fields */
+
+                        spf!(errmes;
+                            "Number in row #", (firstn + k) as i64, ", column #",
+                            cols[iu].colnum, " has no decimal point:");
+                        wrterr(usrpt.out, &errmes, 1);
+                        let fv = unsafe { raw_to_vec(floatvalue) };
+                        spf!(errmes; CS(&fv));
+                        scat!(errmes; "  (Other rows may have similar errors).");
+                        print_fmt(usrpt.out, &errmes, 13);
+                        FIND_BADDOT.store(1, Ordering::Relaxed);
+                        break;
+                    }
+                }
+                k += 1;
+            }
+        }
+
+        if FIND_BADSPACE.load(Ordering::Relaxed) == 0 {
+            k = 0;
+            while k < nrows {
+                let nullstr = unsafe { *cdata };
+                let mut floatvalue = unsafe { *cdata.offset((k + 1) as isize) };
+
+                if unsafe { cstrcmp(nullstr, floatvalue) } != 0 {
+                    /* not a null value? */
+                    while unsafe { *floatvalue } as u8 == b' ' {
+                        /* skip leading spaces */
+                        floatvalue = unsafe { floatvalue.add(1) };
+                    }
+
+                    l = unsafe { cstrlen_raw(floatvalue) } as c_long - 1;
+                    while l > 0 && unsafe { *floatvalue.offset(l as isize) } as u8 == b' ' {
+                        /* remove trailing spaces */
+                        unsafe { *floatvalue.offset(l as isize) = 0 };
+                        l -= 1;
+                    }
+
+                    if !unsafe { cstrchr(floatvalue, b' ') }.is_null() {
+                        spf!(errmes;
+                            "Number in row #", (firstn + k) as i64, ", column #",
+                            cols[iu].colnum, " has embedded space:");
+                        wrterr(usrpt.out, &errmes, 1);
+                        let fv = unsafe { raw_to_vec(floatvalue) };
+                        spf!(errmes; CS(&fv));
+                        scat!(errmes; "  (Other rows may have similar errors).");
+                        print_fmt(usrpt.out, &errmes, 13);
+                        FIND_BADSPACE.store(1, Ordering::Relaxed);
+                        break;
+                    }
+                }
+                k += 1;
+            }
+        }
+        i += 1;
+    }
+
+    if firstn + nrows - 1 == totaln {
+        /* the C free()s flag_minmax, datatype and repeat here */
+        REPEAT_V.with(|r| r.borrow_mut().clear());
+        DATATYPE_V.with(|d| d.borrow_mut().clear());
+    }
+    0
+}
+
+/*************************************************************
+*
+*      test_agap
+*
+*   Test the bytes between the ASCII table column.
+*
+*************************************************************/
+pub fn test_agap(
+    infits: &mut fitsfile, /* input fits file   */
+    out: Out,              /* output ascii file */
+    hduptr: &mut FitsHdu,  /* fits hdu pointer  */
+) {
+    let ncols: c_int;
+    let mut nrows: LONGLONG = 0;
+    let mut irows: c_long = 0;
+    let rowlen: LONGLONG;
+    let mut data: Vec<c_uchar>;
+    let mut temp: Vec<c_int>;
+    let mut p: usize;
+    let mut i: LONGLONG;
+    let mut j: LONGLONG;
+    let mut ntodo: c_long;
+    let mut nerr: c_long = 0;
+    let mut status: c_int = 0;
+    let mut keyname: [c_char; 9] = [0; 9];
+    let mut tform: [c_char; FLEN_VALUE] = [0; FLEN_VALUE];
+    let mut comment: [c_char; 256] = [0; 256];
+    let mut typecode: c_int = 0;
+    let mut decimals: c_int = 0;
+    let mut width: c_long = 0;
+    let mut tbcol: c_long = 0;
+    let mut firstrow: c_long = 1;
+    let mut errmes: [c_char; ERRMES_LEN] = [0; ERRMES_LEN];
+    nerr = 0;
+
+    if hduptr.hdutype != ASCII_TBL {
+        return;
+    }
+    ncols = hduptr.ncols;
+    fits_get_num_rowsll(infits, &mut nrows, &mut status);
+    status = 0;
+
+    fits_get_rowsize(infits, &mut irows, &mut status);
+    status = 0;
+    rowlen = hduptr.naxes[0];
+    data = vec![0; (rowlen * irows as LONGLONG) as usize];
+
+    /* Create a template row with data fields filled with 1s.
+       Used below - different ASCII rules apply within data columns
+       vs. between data columns. */
+
+    temp = vec![0; rowlen as usize];
+    for k in 1..=ncols {
+        spf!(keyname; "TFORM", k);
+        let mut cbuf: [c_char; rsfitsio::fitsio::FLEN_COMMENT] =
+            [0; rsfitsio::fitsio::FLEN_COMMENT];
+        fits_read_key_str(infits, &keyname, &mut tform, Some(&mut cbuf), &mut status);
+        let _ = &mut comment;
+        if ffasfm_safe(
+            &tform,
+            Some(&mut typecode),
+            Some(&mut width),
+            Some(&mut decimals),
+            &mut status,
+        ) != 0
+        {
+            wrtferr_str(out, "", &mut status, 1);
+        }
+        spf!(keyname; "TBCOL", k);
+        fits_read_key_lng(infits, &keyname, &mut tbcol, Some(&mut cbuf), &mut status);
+        let mut t = tbcol;
+        while t < tbcol + width {
+            if t >= 1 && (t as LONGLONG) <= rowlen {
+                temp[(t - 1) as usize] = 1;
+            }
+            t += 1;
+        }
+    }
+
+    i = nrows;
+    while i > 0 {
+        if i > irows as LONGLONG {
+            ntodo = irows;
+        } else {
+            ntodo = i as c_long;
+        }
+
+        p = 0;
+        if ffgtbb_safe(
+            infits,
+            firstrow as LONGLONG,
+            1,
+            rowlen * ntodo as LONGLONG,
+            &mut data,
+            &mut status,
+        ) != 0
+        {
+            wrtferr_str(out, "", &mut status, 1);
+        }
+        j = 0;
+        while j < rowlen * ntodo as LONGLONG {
+            let c = data[p];
+            if !isascii_c(c as c_char) {
+                if nerr == 0 {
+                    spf!(errmes; "row ", (j / rowlen + 1) as i64,
+                        " contains non-ASCII characters.");
+                    wrterr(out, &errmes, 1);
+                }
+                nerr += 1;
+            } else if isascii_c(c as c_char) && !isprint_c(c as c_char) {
+                if temp[(j % rowlen) as usize] != 0 {
+                    if nerr == 0 {
+                        spf!(errmes; "row ", (j / rowlen + 1) as i64,
+                            " data contains non-ASCII-text characters.");
+                        wrterr(out, &errmes, 1);
+                    }
+                    nerr += 1;
+                }
+            }
+            p += 1;
+            j += 1;
+        }
+        firstrow += ntodo;
+        i -= ntodo as LONGLONG;
+    }
+    if nerr != 0 {
+        spf!(errmes;
+            "This ASCII table contains ", nerr as i64, " non-ASCII-text characters");
+        wrterr(out, &errmes, 1);
+    }
+}
+
+/*************************************************************
+*
+*      test_checksum
+*
+*   Test the checksum of the hdu
+*
+*************************************************************/
+pub fn test_checksum(
+    infits: &mut fitsfile, /* input fits file   */
+    out: Out,              /* output ascii file */
+) {
+    let mut status: c_int = 0;
+    let mut dataok: c_int = 0;
+    let mut hduok: c_int = 0;
+
+    if fits_verify_chksum(infits, &mut dataok, &mut hduok, &mut status) != 0 {
+        wrtferr_str(out, "verifying checksums: ", &mut status, 2);
+        return;
+    }
+
+    if dataok == -1 {
+        wrtwrn_str(
+            out,
+            "Data checksum is not consistent with  the DATASUM keyword",
+            0,
+        );
+    }
+
+    if hduok == -1 {
+        if dataok == 1 {
+            wrtwrn_str(
+                out,
+                "Invalid CHECKSUM means header has been modified. (DATASUM is OK) ",
+                0,
+            );
+        } else {
+            wrtwrn_str(out, "HDU checksum is not in agreement with CHECKSUM.", 0);
+        }
+    }
+}
+
+/*===========================================================================
+ *  raw C-string helpers, only for the iterator's `char **' arrays
+ *==========================================================================*/
+
+unsafe fn cstrlen_raw(s: *const c_char) -> usize {
+    let mut n = 0usize;
+    unsafe {
+        while *s.add(n) != 0 {
+            n += 1;
+        }
+    }
+    n
+}
+
+unsafe fn cstrcmp(a: *const c_char, b: *const c_char) -> c_int {
+    let mut i = 0usize;
+    unsafe {
+        loop {
+            let ca = *a.add(i) as u8;
+            let cb = *b.add(i) as u8;
+            if ca != cb {
+                return ca as c_int - cb as c_int;
+            }
+            if ca == 0 {
+                return 0;
+            }
+            i += 1;
+        }
+    }
+}
+
+unsafe fn cstrchr(s: *const c_char, c: u8) -> *const c_char {
+    let mut i = 0usize;
+    unsafe {
+        loop {
+            let v = *s.add(i) as u8;
+            if v == c {
+                return s.add(i);
+            }
+            if v == 0 {
+                return std::ptr::null();
+            }
+            i += 1;
+        }
+    }
+}
+
+unsafe fn raw_to_vec(s: *const c_char) -> Vec<c_char> {
+    let n = unsafe { cstrlen_raw(s) };
+    let mut v = Vec::with_capacity(n + 1);
+    for i in 0..n {
+        v.push(unsafe { *s.add(i) });
+    }
+    v.push(0);
+    v
+}
+
+#[allow(dead_code)]
+fn _unused() {
+    let _ = fits_read_tblbytes;
+    let _ = fits_iterate_data;
+}

--- a/src/bin/fitsverify/fvrf_file.rs
+++ b/src/bin/fitsverify/fvrf_file.rs
@@ -162,7 +162,7 @@ fn hdus_summary(out: Out) {
         (h[0].wrnno, h[0].errnum)
     });
     spf!(comm;
-        " 1                          Primary Array    ", DW(w0, -4), "      ", DW(e0, -4), "  ");
+        " 1                          Primary Array    ", format!("{:<4}", w0), "      ", format!("{:<4}", e0), "  ");
     wrtout(out, &comm);
     for i in 2..=totalhdu() {
         let (extname, extver, wrnno, errnum, hdutype) = HDUNAME.with(|h| {
@@ -177,23 +177,23 @@ fn hdus_summary(out: Out) {
         }
         match hdutype {
             IMAGE_HDU => {
-                spf!(comm; " ", DW(i, -5), " ", CSW(&temp, -20, None), " Image Array      ",
-                    DW(wrnno, -4), "      ", DW(errnum, -4), "  ");
+                spf!(comm; " ", format!("{:<5}", i), " ", CSW(&temp, -20, None), " Image Array      ",
+                    format!("{:<4}", wrnno), "      ", format!("{:<4}", errnum), "  ");
                 wrtout(out, &comm);
             }
             ASCII_TBL => {
-                spf!(comm; " ", DW(i, -5), " ", CSW(&temp, -20, None), " ASCII Table      ",
-                    DW(wrnno, -4), "      ", DW(errnum, -4), "  ");
+                spf!(comm; " ", format!("{:<5}", i), " ", CSW(&temp, -20, None), " ASCII Table      ",
+                    format!("{:<4}", wrnno), "      ", format!("{:<4}", errnum), "  ");
                 wrtout(out, &comm);
             }
             BINARY_TBL => {
-                spf!(comm; " ", DW(i, -5), " ", CSW(&temp, -20, None), " Binary Table     ",
-                    DW(wrnno, -4), "      ", DW(errnum, -4), "  ");
+                spf!(comm; " ", format!("{:<5}", i), " ", CSW(&temp, -20, None), " Binary Table     ",
+                    format!("{:<4}", wrnno), "      ", format!("{:<4}", errnum), "  ");
                 wrtout(out, &comm);
             }
             _ => {
-                spf!(comm; " ", DW(i, -5), " ", CSW(&temp, -20, None), " Unknown HDU      ",
-                    DW(wrnno, -4), "      ", DW(errnum, -4), "  ");
+                spf!(comm; " ", format!("{:<5}", i), " ", CSW(&temp, -20, None), " Unknown HDU      ",
+                    format!("{:<4}", wrnno), "      ", format!("{:<4}", errnum), "  ");
                 wrtout(out, &comm);
             }
         }
@@ -201,8 +201,8 @@ fn hdus_summary(out: Out) {
     /* check the end of file */
     num_err_wrn(&mut ierr, &mut iwrn);
     if iwrn != 0 || ierr != 0 {
-        spf!(comm; " End-of-file ", SW("", -30, None), "  ", DW(iwrn, -4), "      ",
-            DW(ierr, -4), "  ");
+        spf!(comm; " End-of-file ", format!("{:<30}", ""), "  ", format!("{:<4}", iwrn), "      ",
+            format!("{:<4}", ierr), "  ");
         wrtout(out, &comm);
     }
     wrtout_str(out, " ");

--- a/src/bin/fitsverify/fvrf_file.rs
+++ b/src/bin/fitsverify/fvrf_file.rs
@@ -3,8 +3,7 @@
    `static HduName **hduname' becomes a thread-local Vec<HduName>; the C's
    malloc/calloc/free bookkeeping is dropped in favour of RAII.  */
 
-use std::cell::RefCell;
-use std::sync::atomic::{AtomicI32, Ordering};
+use std::cell::{Cell, RefCell};
 
 use bytemuck::cast_slice;
 use rsfitsio::aliases::rust_api::{
@@ -23,19 +22,19 @@ use crate::{scat, spf};
 thread_local! {
     static HDUNAME: RefCell<Vec<HduName>> = const { RefCell::new(Vec::new()) };
 }
-static TOTAL_ERR: AtomicI32 = AtomicI32::new(1); /* initialzed to 1 in case fail to open file */
-static TOTAL_WARN: AtomicI32 = AtomicI32::new(0);
+thread_local! { static TOTAL_ERR: Cell<c_int> = const { Cell::new(1) }; } /* initialzed to 1 in case fail to open file */
+thread_local! { static TOTAL_WARN: Cell<c_int> = const { Cell::new(0) }; }
 
-pub fn get_total_warn() -> c_int {
-    TOTAL_WARN.load(Ordering::Relaxed)
+pub(crate) fn get_total_warn() -> c_int {
+    TOTAL_WARN.with(Cell::get)
 }
 
-pub fn get_total_err() -> c_int {
-    TOTAL_ERR.load(Ordering::Relaxed)
+pub(crate) fn get_total_err() -> c_int {
+    TOTAL_ERR.with(Cell::get)
 }
 
 /* Get the total hdu number and allocate the memory for hdu array */
-pub fn init_hduname() {
+fn init_hduname() {
     /* allocate memories for the hdu structure array  */
     HDUNAME.with(|h| {
         let mut h = h.borrow_mut();
@@ -53,7 +52,7 @@ pub fn init_hduname() {
 }
 
 /* set the hduname memeber hdutype, extname, extver */
-pub fn set_hduname(
+pub(crate) fn set_hduname(
     hdunum: c_int,             /* hdu number */
     hdutype: c_int,            /* hdutype */
     extname: Option<&[c_char]>, /* extension name */
@@ -76,7 +75,7 @@ pub fn set_hduname(
 }
 
 /* get the total errors and total warnings in this hdu */
-pub fn set_hduerr(hdunum: c_int /* hdu number */) {
+pub(crate) fn set_hduerr(hdunum: c_int /* hdu number */) {
     let i = (hdunum - 1) as usize;
     let mut errnum = 0;
     let mut wrnno = 0;
@@ -90,14 +89,14 @@ pub fn set_hduerr(hdunum: c_int /* hdu number */) {
 }
 
 /* set the basic information for hduname structure */
-pub fn set_hdubasic(hdunum: c_int, hdutype: c_int) {
+pub(crate) fn set_hdubasic(hdunum: c_int, hdutype: c_int) {
     set_hduname(hdunum, hdutype, None, 0);
     set_hduerr(hdunum);
 }
 
 /* test to see whether the two extension having the same name */
 /* return 1: identical 0: different */
-pub fn test_hduname(
+pub(crate) fn test_hduname(
     hdunum1: c_int, /* index of first hdu */
     hdunum2: c_int, /* index of second hdu */
 ) -> c_int {
@@ -108,7 +107,7 @@ pub fn test_hduname(
         if cstrlen(&p1.extname) == 0 || cstrlen(&p2.extname) == 0 {
             return 0;
         }
-        if strcmp_c(&p1.extname, &p2.extname) == 0
+        if cbytes(&p1.extname) == cbytes(&p2.extname)
             && p1.hdutype == p2.hdutype
             && p2.extver == p1.extver
             && hdunum1 != hdunum2
@@ -120,7 +119,7 @@ pub fn test_hduname(
 }
 
 /* Added the error numbers */
-pub fn total_errors(toterr: &mut c_int, totwrn: &mut c_int) {
+fn total_errors(toterr: &mut c_int, totwrn: &mut c_int) {
     let mut ierr = 0;
     let mut iwrn = 0;
     *toterr = 0;
@@ -146,7 +145,7 @@ pub fn total_errors(toterr: &mut c_int, totwrn: &mut c_int) {
 }
 
 /* print the extname, exttype, extver, errnum and wrnno in a  table */
-pub fn hdus_summary(out: Out) {
+fn hdus_summary(out: Out) {
     let mut ierr = 0;
     let mut iwrn = 0;
     let mut temp: [c_char; FLEN_VALUE] = [0; FLEN_VALUE];
@@ -209,12 +208,12 @@ pub fn hdus_summary(out: Out) {
     wrtout_str(out, " ");
 }
 
-pub fn destroy_hduname() {
+fn destroy_hduname() {
     HDUNAME.with(|h| h.borrow_mut().clear());
 }
 
 /* Routine to test the extra bytes at the end of file */
-pub fn test_end(infits: &mut fitsfile, out: Out) {
+pub(crate) fn test_end(infits: &mut fitsfile, out: Out) {
     let mut status: c_int = 0;
     let mut headstart: LONGLONG = 0;
     let mut datastart: LONGLONG = 0;
@@ -281,7 +280,7 @@ pub fn test_end(infits: &mut fitsfile, out: Out) {
 *      Initialize the fverify report
 *
 *******************************************************************************/
-pub fn init_report(
+pub(crate) fn init_report(
     out: Out,               /* output file */
     _rootnam: &[c_char],    /* input file name */
 ) {
@@ -303,7 +302,7 @@ pub fn init_report(
 *      Close the fverify report
 *
 *******************************************************************************/
-pub fn close_report(out: Out /* output file */) {
+pub(crate) fn close_report(out: Out /* output file */) {
     let mut numerrs: c_int = 0; /* number of the errors         */
     let mut numwrns: c_int = 0; /* number of the warnings       */
     let mut comm: [c_char; COMM_LEN] = [0; COMM_LEN];
@@ -314,8 +313,8 @@ pub fn close_report(out: Out /* output file */) {
     }
     total_errors(&mut numerrs, &mut numwrns);
 
-    TOTAL_WARN.store(numwrns, Ordering::Relaxed);
-    TOTAL_ERR.store(numerrs, Ordering::Relaxed);
+    TOTAL_WARN.with(|c| c.set(numwrns));
+    TOTAL_ERR.with(|c| c.set(numerrs));
 
     /* get the total number of errors and warnnings */
     spf!(comm;

--- a/src/bin/fitsverify/fvrf_file.rs
+++ b/src/bin/fitsverify/fvrf_file.rs
@@ -1,1 +1,333 @@
+/* Transpiled from cfitsio/utilities/fvrf_file.c
 
+   `static HduName **hduname' becomes a thread-local Vec<HduName>; the C's
+   malloc/calloc/free bookkeeping is dropped in favour of RAII.  */
+
+use std::cell::RefCell;
+use std::sync::atomic::{AtomicI32, Ordering};
+
+use bytemuck::cast_slice;
+use rsfitsio::aliases::rust_api::{
+    fits_clear_errmsg, fits_get_hduaddrll, fits_movrel_hdu,
+};
+use rsfitsio::buffers::ffmbyt_safe;
+use rsfitsio::c_types::{c_char, c_int};
+use rsfitsio::cs;
+use rsfitsio::fitsio::{ASCII_TBL, BINARY_TBL, END_OF_FILE, FLEN_VALUE, IMAGE_HDU, LONGLONG, fitsfile};
+
+use crate::common::*;
+use crate::fvrf_misc::*;
+use crate::main_ftverify::update_parfile;
+use crate::{scat, spf};
+
+thread_local! {
+    static HDUNAME: RefCell<Vec<HduName>> = const { RefCell::new(Vec::new()) };
+}
+static TOTAL_ERR: AtomicI32 = AtomicI32::new(1); /* initialzed to 1 in case fail to open file */
+static TOTAL_WARN: AtomicI32 = AtomicI32::new(0);
+
+pub fn get_total_warn() -> c_int {
+    TOTAL_WARN.load(Ordering::Relaxed)
+}
+
+pub fn get_total_err() -> c_int {
+    TOTAL_ERR.load(Ordering::Relaxed)
+}
+
+/* Get the total hdu number and allocate the memory for hdu array */
+pub fn init_hduname() {
+    /* allocate memories for the hdu structure array  */
+    HDUNAME.with(|h| {
+        let mut h = h.borrow_mut();
+        h.clear();
+        for _i in 0..totalhdu() {
+            let mut e = HduName::default();
+            e.hdutype = -1;
+            e.errnum = 0;
+            e.wrnno = 0;
+            e.extname[0] = 0;
+            e.extver = 0;
+            h.push(e);
+        }
+    });
+}
+
+/* set the hduname memeber hdutype, extname, extver */
+pub fn set_hduname(
+    hdunum: c_int,             /* hdu number */
+    hdutype: c_int,            /* hdutype */
+    extname: Option<&[c_char]>, /* extension name */
+    extver: c_int,             /* extension version */
+) {
+    let i = (hdunum - 1) as usize;
+    HDUNAME.with(|h| {
+        let mut h = h.borrow_mut();
+        h[i].hdutype = hdutype;
+        match extname {
+            Some(e) => {
+                let n = std::cmp::min(cstrlen(e), FLEN_VALUE - 1);
+                h[i].extname[..n].copy_from_slice(&e[..n]);
+                h[i].extname[n] = 0;
+            }
+            None => h[i].extname[0] = 0,
+        }
+        h[i].extver = extver;
+    });
+}
+
+/* get the total errors and total warnings in this hdu */
+pub fn set_hduerr(hdunum: c_int /* hdu number */) {
+    let i = (hdunum - 1) as usize;
+    let mut errnum = 0;
+    let mut wrnno = 0;
+    num_err_wrn(&mut errnum, &mut wrnno);
+    HDUNAME.with(|h| {
+        let mut h = h.borrow_mut();
+        h[i].errnum = errnum;
+        h[i].wrnno = wrnno;
+    });
+    reset_err_wrn(); /* reset the error and warning counter */
+}
+
+/* set the basic information for hduname structure */
+pub fn set_hdubasic(hdunum: c_int, hdutype: c_int) {
+    set_hduname(hdunum, hdutype, None, 0);
+    set_hduerr(hdunum);
+}
+
+/* test to see whether the two extension having the same name */
+/* return 1: identical 0: different */
+pub fn test_hduname(
+    hdunum1: c_int, /* index of first hdu */
+    hdunum2: c_int, /* index of second hdu */
+) -> c_int {
+    HDUNAME.with(|h| {
+        let h = h.borrow();
+        let p1 = &h[(hdunum1 - 1) as usize];
+        let p2 = &h[(hdunum2 - 1) as usize];
+        if cstrlen(&p1.extname) == 0 || cstrlen(&p2.extname) == 0 {
+            return 0;
+        }
+        if strcmp_c(&p1.extname, &p2.extname) == 0
+            && p1.hdutype == p2.hdutype
+            && p2.extver == p1.extver
+            && hdunum1 != hdunum2
+        {
+            return 1;
+        }
+        0
+    })
+}
+
+/* Added the error numbers */
+pub fn total_errors(toterr: &mut c_int, totwrn: &mut c_int) {
+    let mut ierr = 0;
+    let mut iwrn = 0;
+    *toterr = 0;
+    *totwrn = 0;
+
+    if totalhdu() == 0 {
+        /* this means the file couldn't be opened */
+        *toterr = 1;
+        return;
+    }
+
+    HDUNAME.with(|h| {
+        let h = h.borrow();
+        for i in 0..totalhdu() as usize {
+            *toterr += h[i].errnum;
+            *totwrn += h[i].wrnno;
+        }
+    });
+    /*check the end of file errors */
+    num_err_wrn(&mut ierr, &mut iwrn);
+    *toterr += ierr;
+    *totwrn += iwrn;
+}
+
+/* print the extname, exttype, extver, errnum and wrnno in a  table */
+pub fn hdus_summary(out: Out) {
+    let mut ierr = 0;
+    let mut iwrn = 0;
+    let mut temp: [c_char; FLEN_VALUE] = [0; FLEN_VALUE];
+    let mut temp1: [c_char; FLEN_VALUE] = [0; FLEN_VALUE];
+    let mut comm: [c_char; COMM_LEN] = [0; COMM_LEN];
+
+    wrtsep_str(out, b'+' as c_char, " Error Summary  ", 60);
+    wrtout_str(out, " ");
+    spf!(comm; " HDU#  Name (version)       Type             Warnings  Errors");
+    wrtout(out, &comm);
+
+    let (w0, e0) = HDUNAME.with(|h| {
+        let h = h.borrow();
+        (h[0].wrnno, h[0].errnum)
+    });
+    spf!(comm;
+        " 1                          Primary Array    ", DW(w0, -4), "      ", DW(e0, -4), "  ");
+    wrtout(out, &comm);
+    for i in 2..=totalhdu() {
+        let (extname, extver, wrnno, errnum, hdutype) = HDUNAME.with(|h| {
+            let h = h.borrow();
+            let p = &h[(i - 1) as usize];
+            (p.extname, p.extver, p.wrnno, p.errnum, p.hdutype)
+        });
+        spf!(temp; CS(&extname));
+        if extver != 0 && extver != -999 {
+            spf!(temp1; " (", extver, ")");
+            scat!(temp; CS(&temp1));
+        }
+        match hdutype {
+            IMAGE_HDU => {
+                spf!(comm; " ", DW(i, -5), " ", CSW(&temp, -20, None), " Image Array      ",
+                    DW(wrnno, -4), "      ", DW(errnum, -4), "  ");
+                wrtout(out, &comm);
+            }
+            ASCII_TBL => {
+                spf!(comm; " ", DW(i, -5), " ", CSW(&temp, -20, None), " ASCII Table      ",
+                    DW(wrnno, -4), "      ", DW(errnum, -4), "  ");
+                wrtout(out, &comm);
+            }
+            BINARY_TBL => {
+                spf!(comm; " ", DW(i, -5), " ", CSW(&temp, -20, None), " Binary Table     ",
+                    DW(wrnno, -4), "      ", DW(errnum, -4), "  ");
+                wrtout(out, &comm);
+            }
+            _ => {
+                spf!(comm; " ", DW(i, -5), " ", CSW(&temp, -20, None), " Unknown HDU      ",
+                    DW(wrnno, -4), "      ", DW(errnum, -4), "  ");
+                wrtout(out, &comm);
+            }
+        }
+    }
+    /* check the end of file */
+    num_err_wrn(&mut ierr, &mut iwrn);
+    if iwrn != 0 || ierr != 0 {
+        spf!(comm; " End-of-file ", SW("", -30, None), "  ", DW(iwrn, -4), "      ",
+            DW(ierr, -4), "  ");
+        wrtout(out, &comm);
+    }
+    wrtout_str(out, " ");
+}
+
+pub fn destroy_hduname() {
+    HDUNAME.with(|h| h.borrow_mut().clear());
+}
+
+/* Routine to test the extra bytes at the end of file */
+pub fn test_end(infits: &mut fitsfile, out: Out) {
+    let mut status: c_int = 0;
+    let mut headstart: LONGLONG = 0;
+    let mut datastart: LONGLONG = 0;
+    let mut dataend: LONGLONG = 0;
+    let mut hdutype: c_int = 0;
+    let mut errmes: [c_char; ERRMES_LEN] = [0; ERRMES_LEN];
+
+    /* check whether there are any HDU left */
+    fits_movrel_hdu(infits, 1, Some(&mut hdutype), &mut status);
+    if status == 0 {
+        wrtout_str(out, "< End-of-File >");
+        spf!(errmes; "There are extraneous HDU(s) beyond the end of last HDU.");
+        wrterr(out, &errmes, 2);
+        wrtout_str(out, " ");
+        return;
+    }
+
+    if status != END_OF_FILE {
+        wrtserr_str(out, "Bad HDU? ", &mut status, 2);
+        return;
+    }
+
+    status = 0;
+    fits_clear_errmsg();
+    if fits_get_hduaddrll(
+        infits,
+        Some(&mut headstart),
+        Some(&mut datastart),
+        Some(&mut dataend),
+        &mut status,
+    ) != 0
+    {
+        wrtferr_str(out, "", &mut status, 1);
+    }
+
+    /* try to move to the last byte of this extension.  */
+    if ffmbyt_safe(infits, dataend - 1, 0, &mut status) != 0 {
+        spf!(errmes;
+            "Error trying to read last byte of the file at byte ", dataend as i64, ".");
+        wrterr(out, &errmes, 2);
+        wrtout_str(out, "< End-of-File >");
+        wrtout_str(out, " ");
+        return;
+    }
+
+    /* try to move to what would be the first byte of the next extension.
+      If successfull, we have a problem... */
+
+    ffmbyt_safe(infits, dataend, 0, &mut status);
+    if status == 0 {
+        wrtout_str(out, "< End-of-File >");
+        spf!(errmes; "File has extra byte(s) after last HDU at byte ", dataend as i64, ".");
+        wrterr(out, &errmes, 2);
+        wrtout_str(out, " ");
+    }
+}
+
+/******************************************************************************
+* Function
+*      init_report
+*
+*
+* DESCRIPTION:
+*      Initialize the fverify report
+*
+*******************************************************************************/
+pub fn init_report(
+    out: Out,               /* output file */
+    _rootnam: &[c_char],    /* input file name */
+) {
+    let mut comm: [c_char; COMM_LEN] = [0; COMM_LEN];
+    spf!(comm; "\n", totalhdu(), " Header-Data Units in this file.");
+    wrtout(out, &comm);
+    wrtout_str(out, " ");
+
+    reset_err_wrn();
+    init_hduname();
+}
+
+/******************************************************************************
+* Function
+*      close_report
+*
+*
+* DESCRIPTION:
+*      Close the fverify report
+*
+*******************************************************************************/
+pub fn close_report(out: Out /* output file */) {
+    let mut numerrs: c_int = 0; /* number of the errors         */
+    let mut numwrns: c_int = 0; /* number of the warnings       */
+    let mut comm: [c_char; COMM_LEN] = [0; COMM_LEN];
+
+    /* print out a summary of all the hdus */
+    if prstat() != 0 {
+        hdus_summary(out);
+    }
+    total_errors(&mut numerrs, &mut numwrns);
+
+    TOTAL_WARN.store(numwrns, Ordering::Relaxed);
+    TOTAL_ERR.store(numerrs, Ordering::Relaxed);
+
+    /* get the total number of errors and warnnings */
+    spf!(comm;
+        "**** Verification found ", numwrns, " warning(s) and ", numerrs, " error(s). ****");
+    wrtout(out, &comm);
+
+    update_parfile(numerrs, numwrns);
+    /* destroy the hdu name */
+    destroy_hduname();
+}
+
+#[allow(dead_code)]
+fn _unused() -> &'static [c_char] {
+    cs!(c"")
+}

--- a/src/bin/fitsverify/fvrf_head.rs
+++ b/src/bin/fitsverify/fvrf_head.rs
@@ -3471,3 +3471,93 @@ fn _unused_api() {
     let _ = NullValue::Int(0);
     let _ = cards_len();
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn kw(s: &str) -> [c_char; FLEN_KEYWORD] {
+        let mut b = [0 as c_char; FLEN_KEYWORD];
+        for (i, &c) in s.as_bytes().iter().enumerate() {
+            b[i] = c as c_char;
+        }
+        b
+    }
+
+    #[test]
+    fn test_key_match_exact() {
+        let strs = [kw("BITPIX"), kw("CRPIX1"), kw("CRPIX2"), kw("CRVAL1"), kw("NAXIS")];
+        let (mut k, mut n) = (0, 0);
+
+        key_match(&strs, 5, cs!(c"NAXIS"), 1, &mut k, &mut n);
+        assert_eq!((k, n), (4, 1));
+
+        key_match(&strs, 5, cs!(c"BITPIX"), 1, &mut k, &mut n);
+        assert_eq!((k, n), (0, 1));
+
+        /* not found: the C's sentinels, which the `for (j = k; j < k+n; j++)'
+           loops rely on to iterate zero times */
+        key_match(&strs, 5, cs!(c"THEAP"), 1, &mut k, &mut n);
+        assert_eq!((k, n), (-99, -999));
+        assert!(k + n < k);
+
+        /* exact matching must not match a longer keyword */
+        key_match(&strs, 5, cs!(c"CRPIX"), 1, &mut k, &mut n);
+        assert_eq!((k, n), (-99, -999));
+    }
+
+    #[test]
+    fn test_key_match_prefix() {
+        let strs = [kw("BITPIX"), kw("CRPIX1"), kw("CRPIX2"), kw("CRVAL1"), kw("NAXIS")];
+        let (mut k, mut n) = (0, 0);
+
+        key_match(&strs, 5, cs!(c"CRPIX"), 0, &mut k, &mut n);
+        assert_eq!((k, n), (1, 2));
+
+        key_match(&strs, 5, cs!(c"CR"), 0, &mut k, &mut n);
+        assert_eq!((k, n), (1, 3));
+
+        key_match(&strs, 5, cs!(c"TC"), 0, &mut k, &mut n);
+        assert_eq!((k, n), (-99, -999));
+    }
+
+    /* The C's backward scan is guarded by `i > 0', so a run of matches that
+       begins at index 0 is only partly reported when bsearch lands above it.
+       Locked in here because the port has to reproduce it. */
+    #[test]
+    fn test_key_match_index_zero_quirk() {
+        let strs = [kw("CRPIX1"), kw("CRPIX2"), kw("NAXIS")];
+        let (mut k, mut n) = (0, 0);
+        key_match(&strs, 3, cs!(c"CRPIX"), 0, &mut k, &mut n);
+        /* bsearch lands on index 1; index 0 is never revisited */
+        assert_eq!((k, n), (1, 1));
+    }
+
+    #[test]
+    fn test_parse_wcskey_suffix() {
+        let (mut axis, mut alt) = (0, 0);
+
+        assert_eq!(parse_wcskey_suffix(&kw("CRPIX1"), cs!(c"CRPIX"), &mut axis, &mut alt), 0);
+        assert_eq!((axis, alt), (1, 0));
+
+        assert_eq!(parse_wcskey_suffix(&kw("CRPIX12"), cs!(c"CRPIX"), &mut axis, &mut alt), 0);
+        assert_eq!((axis, alt), (12, 0));
+
+        /* alternate WCS description: trailing A-Z maps to 1-26 */
+        assert_eq!(parse_wcskey_suffix(&kw("CRPIX1A"), cs!(c"CRPIX"), &mut axis, &mut alt), 0);
+        assert_eq!((axis, alt), (1, 1));
+        assert_eq!(parse_wcskey_suffix(&kw("CRPIX2Z"), cs!(c"CRPIX"), &mut axis, &mut alt), 0);
+        assert_eq!((axis, alt), (2, 26));
+
+        /* more than one trailing char, or a non A-Z one, is rejected */
+        assert_eq!(parse_wcskey_suffix(&kw("CRPIX1AB"), cs!(c"CRPIX"), &mut axis, &mut alt), -1);
+        assert_eq!(parse_wcskey_suffix(&kw("CRPIX1a"), cs!(c"CRPIX"), &mut axis, &mut alt), -1);
+
+        /* name shorter than the root */
+        assert_eq!(parse_wcskey_suffix(&kw("CR"), cs!(c"CRPIX"), &mut axis, &mut alt), -1);
+
+        /* no suffix at all leaves both at 0 */
+        assert_eq!(parse_wcskey_suffix(&kw("CRPIX"), cs!(c"CRPIX"), &mut axis, &mut alt), 0);
+        assert_eq!((axis, alt), (0, 0));
+    }
+}

--- a/src/bin/fitsverify/fvrf_head.rs
+++ b/src/bin/fitsverify/fvrf_head.rs
@@ -5,8 +5,8 @@
    `temp' / `ptemp' were only ever used to hand a pattern to key_match(), so
    the pattern is passed directly instead.  */
 
-use std::cell::RefCell;
-use std::sync::atomic::{AtomicI32, Ordering};
+use std::cell::{Cell, RefCell};
+use std::cmp::Ordering;
 
 use bytemuck::cast_slice;
 use rsfitsio::aliases::rust_api::{
@@ -45,11 +45,11 @@ thread_local! {
 }
 
 /* total number of the keywords */
-static NCARDS: AtomicI32 = AtomicI32::new(0);
-static CURHDU: AtomicI32 = AtomicI32::new(0); /* current HDU index */
-static CURTYPE: AtomicI32 = AtomicI32::new(0); /* current HDU type  */
+thread_local! { static NCARDS: Cell<c_int> = const { Cell::new(0) }; }
+thread_local! { static CURHDU: Cell<c_int> = const { Cell::new(0) }; } /* current HDU index */
+thread_local! { static CURTYPE: Cell<c_int> = const { Cell::new(0) }; } /* current HDU type  */
 /* print_title's `static int oldhdu' */
-static OLDHDU: AtomicI32 = AtomicI32::new(0);
+thread_local! { static OLDHDU: Cell<c_int> = const { Cell::new(0) }; }
 
 fn cards_len() -> usize {
     CARDS.with(|c| c.borrow().len())
@@ -95,7 +95,7 @@ fn tunit_at(i: usize) -> Vec<c_char> {
 /* routine to verify individual fitsfile */
 /* NB: like the C, this strips trailing whitespace in the caller's buffer -- 
    ftverify_work() relies on that when it echoes the name fgets() read. */
-pub fn verify_fits(infile: &mut [c_char], out: Out) -> c_int {
+pub(crate) fn verify_fits(infile: &mut [c_char], out: Out) -> c_int {
     let rootnam: [c_char; FLEN_FILENAME] = [0; FLEN_FILENAME]; /* Input Fits file root name */
     let mut infits: Option<Box<fitsfile>> = None; /* input fits file pointer */
     let mut fitshdu = FitsHdu::default(); /* hdu information */
@@ -182,7 +182,7 @@ pub fn verify_fits(infile: &mut [c_char], out: Out) -> c_int {
                 None,
                 &mut status,
             );
-            if strcmp_c(&xtension, cs!(c"BINTABLE")) == 0 {
+            if ceq(&xtension, b"BINTABLE") {
                 print_title(out, i, BINARY_TBL);
             } else {
                 print_title(out, i, hdutype);
@@ -224,7 +224,7 @@ pub fn verify_fits(infile: &mut [c_char], out: Out) -> c_int {
     status
 }
 
-pub fn leave_early(out: Out) {
+pub(crate) fn leave_early(out: Out) {
     let mut comm: [c_char; COMM_LEN] = [0; COMM_LEN];
     spf!(comm; "**** Abort Verification: Fatal Error. ****");
     wrtout(out, &comm);
@@ -233,7 +233,7 @@ pub fn leave_early(out: Out) {
     crate::main_ftverify::update_parfile(1, 0);
 }
 
-pub fn close_err(out: Out) {
+fn close_err(out: Out) {
     let mut merr = 0;
     let mut mwrn = 0;
     num_err_wrn(&mut merr, &mut mwrn);
@@ -251,7 +251,7 @@ pub fn close_err(out: Out) {
 *
 *
 *************************************************************/
-pub fn init_hdu(
+fn init_hdu(
     infits: &mut fitsfile, /* input fits file   */
     out: Out,              /* output ascii file */
     hdunum: c_int,         /* hdu index 	     */
@@ -278,8 +278,8 @@ pub fn init_hdu(
     hduptr.hdutype = hdutype;
 
     /* curhdu and curtype are shared with print_title */
-    CURHDU.store(hdunum, Ordering::Relaxed); /* set the current hdu number */
-    CURTYPE.store(hdutype, Ordering::Relaxed); /* set the current hdu number */
+    CURHDU.with(|c| c.set(hdunum)); /* set the current hdu number */
+    CURTYPE.with(|c| c.set(hdutype)); /* set the current hdu number */
 
     /* check the null character in the header.(only the first one will
        be recorded */
@@ -311,7 +311,7 @@ pub fn init_hdu(
 
     /* read all the keywords  */
     let ncards = hduptr.nkeys as usize;
-    NCARDS.store(ncards as c_int, Ordering::Relaxed);
+    NCARDS.with(|c| c.set(ncards as c_int));
     CARDS.with(|c| {
         let mut c = c.borrow_mut();
         c.clear();
@@ -330,7 +330,7 @@ pub fn init_hdu(
        make a fake END card, because CFITSIO blocks us from reading
        the real END card */
 
-    if strncmp_c(&card_at(ncards - 1), cs!(c"END     "), 8) != 0 {
+    if !cstarts(&card_at(ncards - 1), b"END     ") {
         let mut c: [c_char; FLEN_CARD] = [0; FLEN_CARD];
         strcpy_c(&mut c, cs!(c"END     "));
         CARDS.with(|cc| cc.borrow_mut()[ncards - 1] = c);
@@ -355,10 +355,10 @@ pub fn init_hdu(
     }
     if hdunum == 1 {
         /* SIMPLE should be logical T */
-        if strcmp_c(&tmpkey.kname, cs!(c"SIMPLE")) != 0 {
+        if !ceq(&tmpkey.kname, b"SIMPLE") {
             wrterr_str(out, "The 1st keyword of a primary array is not SIMPLE.", 1);
         }
-        if check_log(&tmpkey, out) == 0 || strcmp_c(&tmpkey.kvalue, cs!(c"T")) != 0 {
+        if check_log(&tmpkey, out) == 0 || !ceq(&tmpkey.kvalue, b"T") {
             wrtwrn_str(
                 out,
                 "SIMPLE != T indicates file may not conform to the FITS Standard.",
@@ -368,7 +368,7 @@ pub fn init_hdu(
 
         check_fixed_log(&card_at(0), out);
     } else {
-        if strcmp_c(&tmpkey.kname, cs!(c"XTENSION")) != 0 {
+        if !ceq(&tmpkey.kname, b"XTENSION") {
             wrterr_str(out, "The 1st keyword of a extension is not XTENSION.", 1);
         }
         check_str(&tmpkey, out);
@@ -382,13 +382,13 @@ pub fn init_hdu(
             p += 1;
         }
         p += 1; /* skip the  quote */
-        if strncmp_c(&c0[p..], cs!(c"TABLE   "), 8) != 0
-            && strncmp_c(&c0[p..], cs!(c"BINTABLE"), 8) != 0
-            && strncmp_c(&c0[p..], cs!(c"A3DTABLE"), 8) != 0
-            && strncmp_c(&c0[p..], cs!(c"IUEIMAGE"), 8) != 0
-            && strncmp_c(&c0[p..], cs!(c"FOREIGN "), 8) != 0
-            && strncmp_c(&c0[p..], cs!(c"DUMP    "), 8) != 0
-            && strncmp_c(&c0[p..], cs!(c"IMAGE   "), 8) != 0
+        if !cstarts(&c0[p..], b"TABLE   ")
+            && !cstarts(&c0[p..], b"BINTABLE")
+            && !cstarts(&c0[p..], b"A3DTABLE")
+            && !cstarts(&c0[p..], b"IUEIMAGE")
+            && !cstarts(&c0[p..], b"FOREIGN ")
+            && !cstarts(&c0[p..], b"DUMP    ")
+            && !cstarts(&c0[p..], b"IMAGE   ")
         {
             spf!(errmes;
                 "Unregistered XTENSION value \"", CSW(&c0[p..], 0, Some(8)), "\".");
@@ -403,7 +403,7 @@ pub fn init_hdu(
         /* test if this is a tile compressed image, stored in a binary table */
         /* If so then test the extension as binary table rather than an image */
 
-        if strncmp_c(&c0[p..], cs!(c"BINTABLE"), 8) == 0 && hduptr.hdutype == IMAGE_HDU {
+        if cstarts(&c0[p..], b"BINTABLE") && hduptr.hdutype == IMAGE_HDU {
             hduptr.hdutype = BINARY_TBL;
             hduptr.istilecompressed = 1;
         } else {
@@ -538,14 +538,14 @@ pub fn init_hdu(
         }
 
         /* only count the non-commentary keywords */
-        if strcmp_c(&hduptr.kwds[i].kname, cs!(c"CONTINUE")) == 0 {
+        if ceq(&hduptr.kwds[i].kname, b"CONTINUE") {
             hduptr.use_longstr = 1;
         }
-        if strcmp_c(&hduptr.kwds[i].kname, cs!(c"COMMENT")) != 0
-            && strcmp_c(&hduptr.kwds[i].kname, cs!(c"HISTORY")) != 0
-            && (strcmp_c(&hduptr.kwds[i].kname, cs!(c"HIERARCH")) != 0 || testhierarch() != 0)
-            && strcmp_c(&hduptr.kwds[i].kname, cs!(c"CONTINUE")) != 0
-            && strcmp_c(&hduptr.kwds[i].kname, cs!(c"")) != 0
+        if !ceq(&hduptr.kwds[i].kname, b"COMMENT")
+            && !ceq(&hduptr.kwds[i].kname, b"HISTORY")
+            && (!ceq(&hduptr.kwds[i].kname, b"HIERARCH") || testhierarch() != 0)
+            && !ceq(&hduptr.kwds[i].kname, b"CONTINUE")
+            && !ceq(&hduptr.kwds[i].kname, b"")
         {
             i += 1;
         }
@@ -568,7 +568,7 @@ pub fn init_hdu(
 
     /* sort the keyword in the ascending order of kname field*/
     /* glibc's qsort is a stable merge sort here, so use a stable sort. */
-    hduptr.kwds[..numusrkey].sort_by(|a, b| compkey(a, b).cmp(&0));
+    hduptr.kwds[..numusrkey].sort_by(compkey);
 
     /* store addresses of sorted keyword names in a working array */
     TMPKWDS.with(|t| {
@@ -612,7 +612,7 @@ pub fn init_hdu(
 *    This includes many tests of WCS keywords
 *
 *************************************************************/
-pub fn test_hdu(
+fn test_hdu(
     infits: &mut fitsfile, /* input fits file   */
     out: Out,              /* output ascii file */
     hduptr: &mut FitsHdu,
@@ -1104,11 +1104,11 @@ pub fn test_hdu(
                 continue;
             }
 
-            if strcmp_c(&kvalue, cs!(c"ICRS")) != 0
-                && strcmp_c(&kvalue, cs!(c"FK5")) != 0
-                && strcmp_c(&kvalue, cs!(c"FK4")) != 0
-                && strcmp_c(&kvalue, cs!(c"FK4-NO-E")) != 0
-                && strcmp_c(&kvalue, cs!(c"GAPPT")) != 0
+            if !ceq(&kvalue, b"ICRS")
+                && !ceq(&kvalue, b"FK5")
+                && !ceq(&kvalue, b"FK4")
+                && !ceq(&kvalue, b"FK4-NO-E")
+                && !ceq(&kvalue, b"GAPPT")
             {
                 spf!(errmes;
                     "Keyword #", kindex, ", ", CS(&kname), " has non-allowed value: ",
@@ -1140,16 +1140,16 @@ pub fn test_hdu(
                 continue;
             }
 
-            if strcmp_c(&kvalue, cs!(c"TOPOCENT")) != 0
-                && strcmp_c(&kvalue, cs!(c"GEOCENTR")) != 0
-                && strcmp_c(&kvalue, cs!(c"BARYCENT")) != 0
-                && strcmp_c(&kvalue, cs!(c"HELIOCEN")) != 0
-                && strcmp_c(&kvalue, cs!(c"LSRK")) != 0
-                && strcmp_c(&kvalue, cs!(c"LSRD")) != 0
-                && strcmp_c(&kvalue, cs!(c"GALACTOC")) != 0
-                && strcmp_c(&kvalue, cs!(c"LOCALGRP")) != 0
-                && strcmp_c(&kvalue, cs!(c"CMBDIPOL")) != 0
-                && strcmp_c(&kvalue, cs!(c"SOURCE")) != 0
+            if !ceq(&kvalue, b"TOPOCENT")
+                && !ceq(&kvalue, b"GEOCENTR")
+                && !ceq(&kvalue, b"BARYCENT")
+                && !ceq(&kvalue, b"HELIOCEN")
+                && !ceq(&kvalue, b"LSRK")
+                && !ceq(&kvalue, b"LSRD")
+                && !ceq(&kvalue, b"GALACTOC")
+                && !ceq(&kvalue, b"LOCALGRP")
+                && !ceq(&kvalue, b"CMBDIPOL")
+                && !ceq(&kvalue, b"SOURCE")
             {
                 spf!(errmes;
                     "Keyword #", kindex, ", ", CS(&kname), " has non-allowed value: ",
@@ -1177,7 +1177,7 @@ pub fn test_hdu(
 *   Test the primary array header
 *
 *************************************************************/
-pub fn test_prm(
+fn test_prm(
     infits: &mut fitsfile, /* input fits file   */
     out: Out,              /* output ascii file */
     hduptr: &mut FitsHdu,  /* hdu information structure */
@@ -1402,7 +1402,7 @@ pub fn test_prm(
 *   Test the extension header
 *
 *************************************************************/
-pub fn test_ext(
+fn test_ext(
     _infits: &mut fitsfile, /* input fits file   */
     out: Out,               /* output ascii file */
     hduptr: &mut FitsHdu,   /* information about header */
@@ -1511,7 +1511,7 @@ pub fn test_ext(
 *   Test the image extension header
 *
 *************************************************************/
-pub fn test_img_ext(
+fn test_img_ext(
     infits: &mut fitsfile, /* input fits file   */
     out: Out,              /* output ascii file */
     hduptr: &mut FitsHdu,  /* information about header */
@@ -1544,7 +1544,7 @@ pub fn test_img_ext(
 * and image Extension.
 *
 *************************************************************/
-pub fn test_array(
+fn test_array(
     _infits: &mut fitsfile, /* input fits file   */
     out: Out,               /* output ascii file */
     hduptr: &mut FitsHdu,   /* information about header */
@@ -1682,7 +1682,7 @@ pub fn test_array(
 *   tunit.
 *
 *************************************************************/
-pub fn test_tbl(
+fn test_tbl(
     _infits: &mut fitsfile, /* input fits file   */
     out: Out,               /* output ascii file */
     hduptr: &mut FitsHdu,   /* information about header */
@@ -2183,7 +2183,7 @@ pub fn test_tbl(
 *   Test the ascii table extension header
 *
 *************************************************************/
-pub fn test_asc_ext(
+fn test_asc_ext(
     infits: &mut fitsfile, /* input fits file   */
     out: Out,              /* output ascii file */
     hduptr: &mut FitsHdu,  /* information about header */
@@ -2357,7 +2357,7 @@ pub fn test_asc_ext(
 *   Test the binary table extension header
 *
 *************************************************************/
-pub fn test_bin_ext(
+fn test_bin_ext(
     infits: &mut fitsfile, /* input fits file   */
     out: Out,              /* output ascii file */
     hduptr: &mut FitsHdu,  /* information about header */
@@ -2650,7 +2650,7 @@ pub fn test_bin_ext(
 *   Test the general keywords that can be in any header
 *
 *************************************************************/
-pub fn test_header(
+fn test_header(
     _infits: &mut fitsfile, /* input fits file   */
     out: Out,               /* output ascii file */
     hduptr: &mut FitsHdu,   /* information about header  */
@@ -2807,8 +2807,8 @@ pub fn test_header(
 
     /* Check the duplication of the keywords */
     for i in 0..(numusrkey - 1).max(0) as usize {
-        if strcmp_c(&tmpkwds[i], &tmpkwds[i + 1]) == 0
-            && strcmp_c(&hduptr.kwds[i].kname, cs!(c"HIERARCH")) != 0
+        if cbytes(&tmpkwds[i]) == cbytes(&tmpkwds[i + 1])
+            && !ceq(&hduptr.kwds[i].kname, b"HIERARCH")
         {
             spf!(errmes;
                 "Keyword ", CS(&hduptr.kwds[i].kname), " is duplicated in card #",
@@ -2992,7 +2992,7 @@ pub fn test_header(
 *   name is stored in a sorted array.
 *
 *************************************************************/
-pub fn key_match(
+fn key_match(
     strs: &[[c_char; FLEN_KEYWORD]], /* fits keyname  array */
     nstr: c_int,                     /* total number of keys */
     pattern: &[c_char],              /* wanted pattern  */
@@ -3007,7 +3007,7 @@ pub fn key_match(
                       return -999 if not found */
 ) {
     let mut i: c_int;
-    let fnpt: fn(&[c_char], &[c_char]) -> c_int = if exact != 0 { compstre } else { compstrp };
+    let fnpt: fn(&[c_char], &[c_char]) -> Ordering = if exact != 0 { compstre } else { compstrp };
     *mkey = -999;
     *ikey = -99;
 
@@ -3018,14 +3018,13 @@ pub fn key_match(
     let mut found: Option<c_int> = None;
     while l < u {
         let idx = (l + u) / 2;
-        let comparison = fnpt(pattern, &strs[idx as usize]);
-        if comparison < 0 {
-            u = idx;
-        } else if comparison > 0 {
-            l = idx + 1;
-        } else {
-            found = Some(idx);
-            break;
+        match fnpt(pattern, &strs[idx as usize]) {
+            Ordering::Less => u = idx,
+            Ordering::Greater => l = idx + 1,
+            Ordering::Equal => {
+                found = Some(idx);
+                break;
+            }
         }
     }
 
@@ -3034,7 +3033,9 @@ pub fn key_match(
         *ikey = pos;
         i = *ikey - 1;
         let mut p = pos - 1;
-        while i > 0 && fnpt(pattern, &strs[p as usize]) == 0 {
+        /* NB: `i > 0', not `i >= 0' -- the C never revisits index 0, so a run
+           of matches starting there is only partly reported.  Kept as-is. */
+        while i > 0 && fnpt(pattern, &strs[p as usize]) == Ordering::Equal {
             *mkey += 1;
             *ikey = i;
             i -= 1;
@@ -3042,7 +3043,7 @@ pub fn key_match(
         }
         i = *ikey + *mkey;
         let mut p = pos + 1;
-        while i < nstr && fnpt(pattern, &strs[p as usize]) == 0 {
+        while i < nstr && fnpt(pattern, &strs[p as usize]) == Ordering::Equal {
             *mkey += 1;
             i += 1;
             p += 1;
@@ -3057,7 +3058,7 @@ pub fn key_match(
 *   Test the whether the column name is unique.
 *
 *************************************************************/
-pub fn test_colnam(out: Out, hduptr: &FitsHdu) {
+fn test_colnam(out: Out, hduptr: &FitsHdu) {
     let n: c_int;
     let mut errmes: [c_char; ERRMES_LEN] = [0; ERRMES_LEN];
 
@@ -3121,7 +3122,7 @@ pub fn test_colnam(out: Out, hduptr: &FitsHdu) {
     }
 
     /* sort the column name in the ascending order of name field*/
-    cols.sort_by(|a, b| compcol(a, b).cmp(&0));
+    cols.sort_by(compcol);
 
     /* Check the duplication of the column name */
     for i in 0..(n - 1).max(0) as usize {
@@ -3129,7 +3130,7 @@ pub fn test_colnam(out: Out, hduptr: &FitsHdu) {
             continue;
         }
 
-        if strcmp_c(&cols[i].name, &cols[i + 1].name) == 0 {
+        if cbytes(&cols[i].name) == cbytes(&cols[i + 1].name) {
             spf!(errmes;
                 "Columns #", cols[i].index, ", ", CS(&ttype[(cols[i].index - 1) as usize]),
                 " and #", cols[i + 1].index, ", ",
@@ -3147,7 +3148,7 @@ pub fn test_colnam(out: Out, hduptr: &FitsHdu) {
 *   Parse the tform of the variable length vector.
 *
 *************************************************************/
-pub fn parse_vtform(
+pub(crate) fn parse_vtform(
     infits: &mut fitsfile,
     out: Out,
     _hduptr: &FitsHdu,
@@ -3215,7 +3216,7 @@ pub fn parse_vtform(
 *    expected format.
 *
 *************************************************************/
-pub fn parse_wcskey_suffix(
+fn parse_wcskey_suffix(
     fullname: &[c_char],
     rootname: &[c_char],
     axis: &mut c_int,
@@ -3261,16 +3262,16 @@ pub fn parse_wcskey_suffix(
 *  when verbose < 2, called by wrterr and wrtwrn.
 *
 *************************************************************/
-pub fn print_title(out: Out, hdunum: c_int, hdutype: c_int) {
+fn print_title(out: Out, hdunum: c_int, hdutype: c_int) {
     let mut hdutitle: [c_char; 64] = [0; 64];
 
     /* print out the title */
-    CURHDU.store(hdunum, Ordering::Relaxed);
-    CURTYPE.store(hdutype, Ordering::Relaxed);
+    CURHDU.with(|c| c.set(hdunum));
+    CURTYPE.with(|c| c.set(hdutype));
     let curhdu = hdunum;
     let curtype = hdutype;
 
-    if OLDHDU.load(Ordering::Relaxed) == curhdu {
+    if OLDHDU.with(Cell::get) == curhdu {
         return;
     } /* Do not print it twice */
     if curhdu == 1 {
@@ -3285,9 +3286,9 @@ pub fn print_title(out: Out, hdunum: c_int, hdutype: c_int) {
     }
     wrtsep(out, b'=' as c_char, &hdutitle, 60);
     wrtout_str(out, " ");
-    OLDHDU.store(curhdu, Ordering::Relaxed);
+    OLDHDU.with(|c| c.set(curhdu));
     if curhdu == totalhdu() {
-        OLDHDU.store(0, Ordering::Relaxed); /* reset the old hdu at the last hdu */
+        OLDHDU.with(|c| c.set(0)); /* reset the old hdu at the last hdu */
     }
 }
 
@@ -3298,9 +3299,9 @@ pub fn print_title(out: Out, hdunum: c_int, hdutype: c_int) {
 *  Print the header of the HDU.
 *
 *************************************************************/
-pub fn print_header(out: Out) {
+fn print_header(out: Out) {
     let mut htemp: [c_char; 100] = [0; 100];
-    let ncards = NCARDS.load(Ordering::Relaxed);
+    let ncards = NCARDS.with(Cell::get);
     for i in 1..=ncards {
         spf!(htemp; DW(i, 4), " | ", CS(&card_at(i as usize - 1)));
         wrtout(out, &htemp);
@@ -3315,7 +3316,7 @@ pub fn print_header(out: Out) {
 *  Print out the summary of this hdu.
 *
 **************************************************************/
-pub fn print_summary(
+fn print_summary(
     _infits: &mut fitsfile, /* input fits file   */
     out: Out,               /* output ascii file */
     hduptr: &FitsHdu,
@@ -3446,7 +3447,7 @@ fn bitpix_text(bitpix: c_int, temp: &mut [c_char]) {
 *  other temporary  spaces.
 *
 **************************************************************/
-pub fn close_hdu(hduptr: &mut FitsHdu) {
+fn close_hdu(hduptr: &mut FitsHdu) {
     /* The C free()s cards, hduptr->kwds, datamin/datamax/tnull, naxes and
        tmpkwds here; RAII does that for us.  (Note the C's
        `if(hdutype == ASCII_TBL && hdutype == BINARY_TBL)' guard around the
@@ -3559,5 +3560,400 @@ mod tests {
         /* no suffix at all leaves both at 0 */
         assert_eq!(parse_wcskey_suffix(&kw("CRPIX"), cs!(c"CRPIX"), &mut axis, &mut alt), 0);
         assert_eq!((axis, alt), (0, 0));
+    }
+}
+
+/* File-level tests.
+
+   Each fixture is a small hand-built FITS file that exercises one report path.
+   The expected (errors, warnings) pairs were read off the C fitsverify acting
+   as the oracle -- they are not recordings of what this implementation happens
+   to produce.  Every fixture here was also checked byte-for-byte (stdout,
+   stderr and exit status) against the C across all seven flag combinations. */
+#[cfg(test)]
+mod fits_tests {
+    use super::*;
+    use crate::fvrf_file::{get_total_err, get_total_warn};
+
+    fn card(s: &str) -> String {
+        format!("{s:<80.80}")
+    }
+
+    fn block(cards: &[&str]) -> String {
+        let mut h: String = cards.iter().map(|c| card(c)).collect();
+        h.push_str(&card("END"));
+        while h.len() % 2880 != 0 {
+            h.push(' ');
+        }
+        h
+    }
+
+    const PRIM: [&str; 3] = [
+        "SIMPLE  =                    T",
+        "BITPIX  =                    8",
+        "NAXIS   =                    0",
+    ];
+    const IMG: [&str; 5] = [
+        "SIMPLE  =                    T",
+        "BITPIX  =                  -32",
+        "NAXIS   =                    2",
+        "NAXIS1  =                    4",
+        "NAXIS2  =                    4",
+    ];
+    const PRIM_EXT: [&str; 4] = [
+        "SIMPLE  =                    T",
+        "BITPIX  =                    8",
+        "NAXIS   =                    0",
+        "EXTEND  =                    T",
+    ];
+
+    /* a primary header with no data, plus `extra' */
+    fn pw(extra: &[&str]) -> Vec<u8> {
+        let mut c: Vec<&str> = PRIM.to_vec();
+        c.extend_from_slice(extra);
+        block(&c).into_bytes()
+    }
+
+    /* a 4x4 float image, plus `extra' */
+    fn img(extra: &[&str]) -> Vec<u8> {
+        let mut c: Vec<&str> = IMG.to_vec();
+        c.extend_from_slice(extra);
+        let mut v = block(&c).into_bytes();
+        v.extend(std::iter::repeat_n(0u8, 2880));
+        v
+    }
+
+    /* a table extension carrying `data', plus `extra' header cards */
+    fn tbl(kind: &str, nax1: usize, nax2: usize, extra: &[&str], data: &[u8]) -> Vec<u8> {
+        let n1 = format!("NAXIS1  = {nax1:>20}");
+        let n2 = format!("NAXIS2  = {nax2:>20}");
+        let x = format!("XTENSION= '{kind}'");
+        let mut c: Vec<&str> = vec![
+            &x,
+            "BITPIX  =                    8",
+            "NAXIS   =                    2",
+            &n1,
+            &n2,
+            "PCOUNT  =                    0",
+            "GCOUNT  =                    1",
+        ];
+        c.extend_from_slice(extra);
+        let mut v = block(&PRIM_EXT).into_bytes();
+        v.extend(block(&c).into_bytes());
+        let mut d = data.to_vec();
+        d.resize(2880, 0);
+        v.extend(d);
+        v
+    }
+
+    /* Runs verify_fits over `bytes' and returns (errors, warnings).  Out::Null
+       suppresses all reporting, so only the counters are under test.  The
+       fitsverify counters are thread-locals, so these run in parallel safely. */
+    fn counts(bytes: &[u8]) -> (c_int, c_int) {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("t.fits");
+        std::fs::write(&path, bytes).unwrap();
+
+        let mut buf = vec![0 as c_char; FLEN_FILENAME];
+        set_cstr(&mut buf, path.to_str().unwrap().as_bytes());
+        verify_fits(&mut buf, Out::Null);
+        (get_total_err(), get_total_warn())
+    }
+
+    /*--- clean input reports nothing -------------------------------------*/
+
+    #[test]
+    fn test_clean_primary_array() {
+        assert_eq!(counts(&pw(&[])), (0, 0));
+    }
+
+    /*--- warnings --------------------------------------------------------*/
+
+    #[test]
+    fn test_simple_false_warns() {
+        let mut c: Vec<&str> = PRIM.to_vec();
+        c[0] = "SIMPLE  =                    F";
+        assert_eq!(counts(&block(&c).into_bytes()), (0, 1));
+    }
+
+    #[test]
+    fn test_deprecated_keywords_warn() {
+        assert_eq!(counts(&pw(&["EPOCH   =               1950.0"])), (0, 1));
+        assert_eq!(counts(&pw(&["BLOCKED =                    T"])), (0, 1));
+    }
+
+    #[test]
+    fn test_duplicate_keyword_warns() {
+        assert_eq!(
+            counts(&pw(&[
+                "DUPKEY  =                    1",
+                "DUPKEY  =                    2",
+            ])),
+            (0, 1)
+        );
+    }
+
+    #[test]
+    fn test_y2k_date_warns() {
+        assert_eq!(counts(&pw(&["DATE    = '01/02/09'"])), (0, 1));
+        /* a four-digit year is fine */
+        assert_eq!(counts(&pw(&["DATE    = '2009-02-01'"])), (0, 0));
+    }
+
+    #[test]
+    fn test_long_string_convention_needs_longstrn() {
+        assert_eq!(
+            counts(&pw(&["LONGKEY = 'abcdefghij&'", "CONTINUE  'klmnop'"])),
+            (0, 1)
+        );
+        /* declaring the convention silences it */
+        assert_eq!(
+            counts(&pw(&[
+                "LONGSTRN= 'OGIP 1.0'",
+                "LONGKEY = 'abcdefghij&'",
+                "CONTINUE  'klmnop'",
+            ])),
+            (0, 0)
+        );
+    }
+
+    #[test]
+    fn test_null_keyword_value_warns() {
+        assert_eq!(counts(&pw(&["NULLKEY ="])), (0, 1));
+    }
+
+    #[test]
+    fn test_bscale_zero_warns() {
+        assert_eq!(counts(&img(&["BSCALE  =                  0.0"])), (0, 1));
+    }
+
+    /*--- keyword syntax errors -------------------------------------------*/
+
+    #[test]
+    fn test_lower_case_keyword_name_errors() {
+        assert_eq!(counts(&pw(&["lowerkey=                    1"])), (1, 0));
+    }
+
+    #[test]
+    fn test_unterminated_string_errors() {
+        assert_eq!(counts(&pw(&["OBJECT  = 'unterminated"])), (1, 0));
+    }
+
+    #[test]
+    fn test_lower_case_exponent_errors() {
+        assert_eq!(counts(&pw(&["VALUE   =              1.25e+02"])), (1, 0));
+        assert_eq!(counts(&pw(&["VALUE   =              1.25E+02"])), (0, 0));
+    }
+
+    /* The C dereferences a NULL pr_end here and dies with SIGSEGV; this port
+       reports the malformed value instead.  A deliberate divergence. */
+    #[test]
+    fn test_complex_without_comma_is_reported_not_fatal() {
+        let (e, _w) = counts(&pw(&["CPLX    = (1 2)"]));
+        assert!(e > 0, "a complex value with no comma must be reported");
+    }
+
+    /*--- keywords in the wrong kind of HDU -------------------------------*/
+
+    #[test]
+    fn test_xtension_in_primary_errors() {
+        assert_eq!(counts(&pw(&["XTENSION= 'IMAGE   '"])), (2, 0));
+    }
+
+    #[test]
+    fn test_pscal_outside_random_groups_errors() {
+        assert_eq!(counts(&pw(&["PSCAL1  =                  1.0"])), (1, 0));
+    }
+
+    #[test]
+    fn test_blank_with_floating_point_data_errors() {
+        assert_eq!(counts(&img(&["BLANK   =                   -1"])), (1, 0));
+    }
+
+    /*--- WCS -------------------------------------------------------------*/
+
+    #[test]
+    fn test_wcs_cdelt_zero_warns() {
+        assert_eq!(
+            counts(&img(&[
+                "CDELT1  =                  0.0",
+                "CDELT2  =                  1.0",
+            ])),
+            (0, 3)
+        );
+    }
+
+    #[test]
+    fn test_wcs_negative_crder_errors() {
+        assert_eq!(counts(&img(&["CRDER1  =                 -1.0"])), (1, 3));
+    }
+
+    #[test]
+    fn test_wcs_pc_and_cd_are_mutually_exclusive() {
+        assert_eq!(
+            counts(&img(&[
+                "PC1_1   =                  1.0",
+                "CD1_1   =                  1.0",
+            ])),
+            (1, 0)
+        );
+    }
+
+    #[test]
+    fn test_wcs_pc_and_crota2_are_mutually_exclusive() {
+        assert_eq!(
+            counts(&img(&[
+                "PC1_1   =                  1.0",
+                "CROTA2  =                  0.0",
+            ])),
+            (1, 3)
+        );
+    }
+
+    #[test]
+    fn test_wcs_non_allowed_frame_values_warn() {
+        assert_eq!(counts(&img(&["RADESYS = 'BOGUS   '"])), (0, 1));
+        assert_eq!(counts(&img(&["SPECSYS = 'NOPE    '"])), (0, 1));
+    }
+
+    /*--- tables ----------------------------------------------------------*/
+
+    #[test]
+    fn test_tdim_not_allowed_in_ascii_table() {
+        assert_eq!(
+            counts(&tbl(
+                "TABLE   ",
+                4,
+                1,
+                &[
+                    "TFIELDS =                    1",
+                    "TBCOL1  =                    1",
+                    "TFORM1  = 'I4      '",
+                    "TTYPE1  = 'C1      '",
+                    "TDIM1   = '(4)     '",
+                ],
+                b"1234",
+            )),
+            (2, 0)
+        );
+    }
+
+    #[test]
+    fn test_tbcol_not_allowed_in_binary_table() {
+        assert_eq!(
+            counts(&tbl(
+                "BINTABLE",
+                4,
+                1,
+                &[
+                    "TFIELDS =                    1",
+                    "TFORM1  = '4A      '",
+                    "TTYPE1  = 'C1      '",
+                    "TBCOL1  =                    1",
+                ],
+                b"abcd",
+            )),
+            (1, 0)
+        );
+    }
+
+    #[test]
+    fn test_missing_column_name_warns() {
+        assert_eq!(
+            counts(&tbl(
+                "BINTABLE",
+                4,
+                1,
+                &["TFIELDS =                    1", "TFORM1  = '4A      '"],
+                b"abcd",
+            )),
+            (0, 1)
+        );
+    }
+
+    #[test]
+    fn test_illegal_character_in_column_name_warns() {
+        assert_eq!(
+            counts(&tbl(
+                "BINTABLE",
+                4,
+                1,
+                &[
+                    "TFIELDS =                    1",
+                    "TFORM1  = '4A      '",
+                    "TTYPE1  = 'a b     '",
+                ],
+                b"abcd",
+            )),
+            (0, 1)
+        );
+    }
+
+    #[test]
+    fn test_duplicate_column_names_warn() {
+        /* the comparison is case insensitive */
+        assert_eq!(
+            counts(&tbl(
+                "BINTABLE",
+                4,
+                1,
+                &[
+                    "TFIELDS =                    2",
+                    "TFORM1  = '2A      '",
+                    "TFORM2  = '2A      '",
+                    "TTYPE1  = 'SAME    '",
+                    "TTYPE2  = 'same    '",
+                ],
+                b"abcd",
+            )),
+            (0, 1)
+        );
+    }
+
+    #[test]
+    fn test_tform_leading_space_errors() {
+        assert_eq!(
+            counts(&tbl(
+                "BINTABLE",
+                4,
+                1,
+                &[
+                    "TFIELDS =                    1",
+                    "TFORM1  = ' 4A     '",
+                    "TTYPE1  = 'C1      '",
+                ],
+                b"abcd",
+            )),
+            (1, 0)
+        );
+    }
+
+    /* Every offending row is reported, not just the first: the C's `break'
+       leaves the inner character scan only, and the row loop carries on. */
+    #[test]
+    fn test_non_ascii_reported_for_every_bad_row() {
+        assert_eq!(
+            counts(&tbl(
+                "BINTABLE",
+                4,
+                3,
+                &[
+                    "TFIELDS =                    1",
+                    "TFORM1  = '4A      '",
+                    "TTYPE1  = 'TXT     '",
+                ],
+                b"a\xffbcabcd\xfeefg", /* rows 1 and 3 are bad, row 2 is clean */
+            )),
+            (2, 0)
+        );
+    }
+
+    /*--- file structure --------------------------------------------------*/
+
+    #[test]
+    fn test_extraneous_bytes_after_last_hdu_error() {
+        let mut v = pw(&[]);
+        v.extend_from_slice(b"junkjunk");
+        assert_eq!(counts(&v), (1, 0));
     }
 }

--- a/src/bin/fitsverify/fvrf_head.rs
+++ b/src/bin/fitsverify/fvrf_head.rs
@@ -2771,7 +2771,7 @@ fn test_header(
             if (0..=10).contains(&yy) {
                 spf!(errmes;
                     "Keyword #", kindex, ", ", CS(&kname), " ", CS(&kvalue),
-                    " intends to mean year 20", SW(&format!("{yy:02}"), -2, None), "?");
+                    " intends to mean year 20", format!("{yy:02}"), "?");
                 wrtwrn(out, &errmes, 0);
             }
         }
@@ -3303,7 +3303,7 @@ fn print_header(out: Out) {
     let mut htemp: [c_char; 100] = [0; 100];
     let ncards = NCARDS.with(Cell::get);
     for i in 1..=ncards {
-        spf!(htemp; DW(i, 4), " | ", CS(&card_at(i as usize - 1)));
+        spf!(htemp; format!("{:>4}", i), " | ", CS(&card_at(i as usize - 1)));
         wrtout(out, &htemp);
     }
     wrtout_str(out, " ");
@@ -3361,7 +3361,7 @@ fn print_summary(
                 spf!(extnv; CS(&tt));
             }
             spf!(comm;
-                " ", DW(i + 1, 3), " ", CSW(&extnv, -20, Some(20)), " ",
+                " ", format!("{:>3}", i + 1), " ", CSW(&extnv, -20, Some(20)), " ",
                 CSW(&tf, -10, Some(10)));
             wrtout(out, &comm);
         }

--- a/src/bin/fitsverify/fvrf_head.rs
+++ b/src/bin/fitsverify/fvrf_head.rs
@@ -1,1 +1,3473 @@
+/* Transpiled from cfitsio/utilities/fvrf_head.c
 
+   The `char **' working arrays (cards, tmpkwds, ttype, tform, tunit) are
+   file-statics in the C; here they are thread-locals holding owned copies.
+   `temp' / `ptemp' were only ever used to hand a pattern to key_match(), so
+   the pattern is passed directly instead.  */
+
+use std::cell::RefCell;
+use std::sync::atomic::{AtomicI32, Ordering};
+
+use bytemuck::cast_slice;
+use rsfitsio::aliases::rust_api::{
+    fits_close_file, fits_decode_tdim, fits_get_coltype, fits_get_hdrspace, fits_get_num_cols,
+    fits_get_num_hdus, fits_movabs_hdu, fits_null_check, fits_open_diskfile, fits_read_key,
+    fits_read_record, fits_str2time,
+};
+use rsfitsio::c_types::{c_char, c_double, c_int, c_long};
+use rsfitsio::cs;
+use rsfitsio::fitscore::ffchfl_safe;
+use rsfitsio::fitsio::{
+    ASCII_TBL, BINARY_TBL, BYTE_IMG, DOUBLE_IMG, FLEN_CARD, FLEN_FILENAME, FLEN_KEYWORD,
+    FLEN_VALUE, FLOAT_IMG, IMAGE_HDU, LONGLONG, LONGLONG_IMG, LONG_IMG, READONLY, SHORT_IMG,
+    ULONG_IMG, USHORT_IMG, fitsfile,
+};
+use rsfitsio::{KeywordDatatypeMut, NullValue};
+
+use crate::common::*;
+use crate::fvrf_data::test_data;
+use crate::fvrf_file::*;
+use crate::fvrf_key::*;
+use crate::fvrf_misc::*;
+use crate::{scat, spf};
+
+thread_local! {
+    /* array to store the keywords  */
+    static CARDS: RefCell<Vec<[c_char; FLEN_CARD]>> = const { RefCell::new(Vec::new()) };
+    /* String array holding the keyword name.  It is sorted in alphabetical
+       ascending order and does not include the keywords before the first
+       non-reserved keyword and END keyword. */
+    static TMPKWDS: RefCell<Vec<[c_char; FLEN_KEYWORD]>> = const { RefCell::new(Vec::new()) };
+
+    static TTYPE: RefCell<Vec<Vec<c_char>>> = const { RefCell::new(Vec::new()) };
+    static TFORM: RefCell<Vec<Vec<c_char>>> = const { RefCell::new(Vec::new()) };
+    static TUNIT: RefCell<Vec<Vec<c_char>>> = const { RefCell::new(Vec::new()) };
+}
+
+/* total number of the keywords */
+static NCARDS: AtomicI32 = AtomicI32::new(0);
+static CURHDU: AtomicI32 = AtomicI32::new(0); /* current HDU index */
+static CURTYPE: AtomicI32 = AtomicI32::new(0); /* current HDU type  */
+/* print_title's `static int oldhdu' */
+static OLDHDU: AtomicI32 = AtomicI32::new(0);
+
+fn cards_len() -> usize {
+    CARDS.with(|c| c.borrow().len())
+}
+
+fn card_at(i: usize) -> [c_char; FLEN_CARD] {
+    CARDS.with(|c| c.borrow()[i])
+}
+
+fn tmpkwds_get() -> Vec<[c_char; FLEN_KEYWORD]> {
+    TMPKWDS.with(|t| t.borrow().clone())
+}
+
+fn tform_at(i: usize) -> Vec<c_char> {
+    TFORM.with(|t| {
+        let t = t.borrow();
+        t.get(i).cloned().unwrap_or_else(|| vec![0])
+    })
+}
+
+fn ttype_at(i: usize) -> Vec<c_char> {
+    TTYPE.with(|t| {
+        let t = t.borrow();
+        t.get(i).cloned().unwrap_or_else(|| vec![0])
+    })
+}
+
+fn tunit_at(i: usize) -> Vec<c_char> {
+    TUNIT.with(|t| {
+        let t = t.borrow();
+        t.get(i).cloned().unwrap_or_else(|| vec![0])
+    })
+}
+
+/******************************************************************************
+* Function
+*      verify_fits
+*
+* DESCRIPTION:
+*      Verify individual fits file.
+*
+*******************************************************************************/
+/* routine to verify individual fitsfile */
+/* NB: like the C, this strips trailing whitespace in the caller's buffer -- 
+   ftverify_work() relies on that when it echoes the name fgets() read. */
+pub fn verify_fits(infile: &mut [c_char], out: Out) -> c_int {
+    let rootnam: [c_char; FLEN_FILENAME] = [0; FLEN_FILENAME]; /* Input Fits file root name */
+    let mut infits: Option<Box<fitsfile>> = None; /* input fits file pointer */
+    let mut fitshdu = FitsHdu::default(); /* hdu information */
+    let mut hdutype: c_int;
+    let mut status: c_int = 0;
+    let mut i: c_int;
+    let len: usize;
+    let mut p: usize;
+    let pfile: usize;
+    let mut xtension: [c_char; FLEN_VALUE] = [0; FLEN_VALUE];
+    let mut comm: [c_char; COMM_LEN] = [0; COMM_LEN];
+
+    /* take out the leading and trailing space and skip the empty line*/
+    p = 0;
+    while isspace_c(infile[p]) {
+        p += 1;
+    }
+    len = cstrlen(&infile[p..]);
+    pfile = p;
+    if len > 0 {
+        let mut q = p + len - 1;
+        let mut ii = len as isize - 1;
+        while ii >= 0 && isspace_c(infile[q]) {
+            infile[q] = 0;
+            if q == 0 {
+                break;
+            }
+            q -= 1;
+            ii -= 1;
+        }
+    }
+    if cstrlen(&infile[pfile..]) == 0 {
+        return status;
+    }
+
+    /* #ifndef WEBTOOL */
+    wrtout_str(out, " ");
+    spf!(comm; "File: ", CS(&infile[pfile..]));
+    wrtout(out, &comm);
+
+    set_totalhdu(0);
+
+    /* #else  (STANDALONE) */
+    if fits_open_diskfile(&mut infits, &infile[pfile..], READONLY, &mut status) != 0 {
+        wrtserr_str(out, "", &mut status, 2);
+        leave_early(out);
+        status = 1;
+        return status;
+    }
+
+    let mut infits = infits.unwrap();
+
+    /* get the total hdus */
+    let mut nhdu: c_int = 0;
+    if fits_get_num_hdus(&mut infits, &mut nhdu, &mut status) != 0 {
+        set_totalhdu(nhdu);
+        wrtserr_str(out, "", &mut status, 2);
+        leave_early(out);
+        status = 1;
+        return status;
+    }
+    set_totalhdu(nhdu);
+
+    /* initialize the report */
+    init_report(out, &rootnam);
+    /*------------------  Hdu Loop --------------------------------*/
+    i = 1;
+    while i <= totalhdu() {
+        /* move to the right hdu and do the CFITSIO test */
+        hdutype = -1;
+        if fits_movabs_hdu(&mut infits, i, Some(&mut hdutype), &mut status) != 0 {
+            print_title(out, i, hdutype);
+            wrtferr_str(out, "", &mut status, 2);
+            set_hdubasic(i, hdutype);
+            break;
+        }
+
+        if i != 1 && hdutype == IMAGE_HDU {
+            /* test if this is a tile compressed image in a binary table */
+            fits_read_key(
+                &mut infits,
+                KeywordDatatypeMut::TSTRING(&mut xtension),
+                cs!(c"XTENSION"),
+                None,
+                &mut status,
+            );
+            if strcmp_c(&xtension, cs!(c"BINTABLE")) == 0 {
+                print_title(out, i, BINARY_TBL);
+            } else {
+                print_title(out, i, hdutype);
+            }
+        } else {
+            print_title(out, i, hdutype);
+        }
+
+        init_hdu(&mut infits, out, i, hdutype, &mut fitshdu); /* initialize fitshdu  */
+
+        test_hdu(&mut infits, out, &mut fitshdu); /* test hdu header */
+
+        if testdata() != 0 {
+            test_data(&mut infits, out, &mut fitshdu);
+        }
+
+        close_err(out); /* end of error report */
+
+        if prhead() != 0 {
+            print_header(out);
+        }
+        if prstat() != 0 {
+            print_summary(&mut infits, out, &fitshdu);
+        }
+        close_hdu(&mut fitshdu); /* clear the fitshdu  */
+
+        i += 1;
+    }
+    /* test the end of file  */
+    test_end(&mut infits, out);
+
+    /*------------------ Closing  --------------------------------*/
+    /* closing the report*/
+    close_report(out);
+
+    /* close the input fitsfile  */
+    fits_close_file(infits, &mut status);
+
+    status
+}
+
+pub fn leave_early(out: Out) {
+    let mut comm: [c_char; COMM_LEN] = [0; COMM_LEN];
+    spf!(comm; "**** Abort Verification: Fatal Error. ****");
+    wrtout(out, &comm);
+
+    /* write the total number of errors and warnings to parfile*/
+    crate::main_ftverify::update_parfile(1, 0);
+}
+
+pub fn close_err(out: Out) {
+    let mut merr = 0;
+    let mut mwrn = 0;
+    num_err_wrn(&mut merr, &mut mwrn);
+    if merr != 0 || mwrn != 0 {
+        wrtout_str(out, " ");
+    }
+}
+
+/*************************************************************
+*
+*      init_hdu
+*
+*   Initialize the FitsHdu, HduName and ttype, tform, tunit if
+* the hdu is a table.
+*
+*
+*************************************************************/
+pub fn init_hdu(
+    infits: &mut fitsfile, /* input fits file   */
+    out: Out,              /* output ascii file */
+    hdunum: c_int,         /* hdu index 	     */
+    hdutype: c_int,        /* hdutype	     */
+    hduptr: &mut FitsHdu,
+) {
+    let mut morekeys: c_int;
+    let mut i: usize;
+    let mut j: usize;
+    let k: usize;
+    let m: usize;
+    let n: usize;
+    let mut status: c_int = 0;
+    let mut p: usize;
+    let numusrkey: usize;
+    let mut lv: LONGLONG;
+    let mut lu: LONGLONG = 0;
+    let mut errmes: [c_char; ERRMES_LEN] = [0; ERRMES_LEN];
+    let mut comm: [c_char; COMM_LEN] = [0; COMM_LEN];
+
+    let mut tmpkey = FitsKey::default();
+
+    hduptr.hdunum = hdunum;
+    hduptr.hdutype = hdutype;
+
+    /* curhdu and curtype are shared with print_title */
+    CURHDU.store(hdunum, Ordering::Relaxed); /* set the current hdu number */
+    CURTYPE.store(hdutype, Ordering::Relaxed); /* set the current hdu number */
+
+    /* check the null character in the header.(only the first one will
+       be recorded */
+    let lvi = fits_null_check(infits, &mut status) as LONGLONG;
+    if lvi > 0 {
+        let mm = (lvi - 1) / 80 + 1;
+        let nn = lvi - (mm - 1) * 80;
+        spf!(errmes; "Byte #", nn as i64, " in Card#", mm as i64, " is a null(\\0).");
+        wrterr(out, &errmes, 1);
+        status = 0;
+    } else if status != 0 {
+        wrtserr_str(out, "", &mut status, 1);
+        status = 0;
+    }
+
+    /* get the total number of keywords */
+    hduptr.nkeys = 0;
+    morekeys = 0;
+    if fits_get_hdrspace(
+        infits,
+        Some(&mut hduptr.nkeys),
+        Some(&mut morekeys),
+        &mut status,
+    ) != 0
+    {
+        wrtferr_str(out, "", &mut status, 1);
+    }
+    hduptr.nkeys += 1; /* include END keyword */
+
+    /* read all the keywords  */
+    let ncards = hduptr.nkeys as usize;
+    NCARDS.store(ncards as c_int, Ordering::Relaxed);
+    CARDS.with(|c| {
+        let mut c = c.borrow_mut();
+        c.clear();
+        c.resize(ncards, [0; FLEN_CARD]);
+    });
+
+    for i in 1..=ncards {
+        let mut card: [c_char; FLEN_CARD] = [0; FLEN_CARD];
+        if fits_read_record(infits, i as c_int, Some(&mut card), &mut status) != 0 {
+            wrtferr_str(out, "", &mut status, 1);
+        }
+        CARDS.with(|c| c.borrow_mut()[i - 1] = card);
+    }
+
+    /* if there were blank cards prior to the END card, then
+       make a fake END card, because CFITSIO blocks us from reading
+       the real END card */
+
+    if strncmp_c(&card_at(ncards - 1), cs!(c"END     "), 8) != 0 {
+        let mut c: [c_char; FLEN_CARD] = [0; FLEN_CARD];
+        strcpy_c(&mut c, cs!(c"END     "));
+        CARDS.with(|cc| cc.borrow_mut()[ncards - 1] = c);
+    }
+
+    /* Parse the XTENSION/SIMPLEX  keyword */
+    let mut card0 = card_at(0);
+    fits_parse_card(
+        out,
+        1,
+        &mut card0,
+        &mut tmpkey.kname,
+        &mut tmpkey.ktype,
+        &mut tmpkey.kvalue,
+        &mut comm,
+    );
+    if tmpkey.kvalue[0] as u8 == b' ' {
+        spf!(errmes;
+            "Keyword #1, ", CS(&tmpkey.kname), " \"", CS(&tmpkey.kvalue),
+            "\" should not have leading space.");
+        wrterr(out, &errmes, 1);
+    }
+    if hdunum == 1 {
+        /* SIMPLE should be logical T */
+        if strcmp_c(&tmpkey.kname, cs!(c"SIMPLE")) != 0 {
+            wrterr_str(out, "The 1st keyword of a primary array is not SIMPLE.", 1);
+        }
+        if check_log(&tmpkey, out) == 0 || strcmp_c(&tmpkey.kvalue, cs!(c"T")) != 0 {
+            wrtwrn_str(
+                out,
+                "SIMPLE != T indicates file may not conform to the FITS Standard.",
+                0,
+            );
+        }
+
+        check_fixed_log(&card_at(0), out);
+    } else {
+        if strcmp_c(&tmpkey.kname, cs!(c"XTENSION")) != 0 {
+            wrterr_str(out, "The 1st keyword of a extension is not XTENSION.", 1);
+        }
+        check_str(&tmpkey, out);
+
+        check_fixed_str(&card_at(0), out);
+
+        /* Get the original string */
+        let c0 = card_at(0);
+        p = 10;
+        while c0[p] as u8 == b' ' {
+            p += 1;
+        }
+        p += 1; /* skip the  quote */
+        if strncmp_c(&c0[p..], cs!(c"TABLE   "), 8) != 0
+            && strncmp_c(&c0[p..], cs!(c"BINTABLE"), 8) != 0
+            && strncmp_c(&c0[p..], cs!(c"A3DTABLE"), 8) != 0
+            && strncmp_c(&c0[p..], cs!(c"IUEIMAGE"), 8) != 0
+            && strncmp_c(&c0[p..], cs!(c"FOREIGN "), 8) != 0
+            && strncmp_c(&c0[p..], cs!(c"DUMP    "), 8) != 0
+            && strncmp_c(&c0[p..], cs!(c"IMAGE   "), 8) != 0
+        {
+            spf!(errmes;
+                "Unregistered XTENSION value \"", CSW(&c0[p..], 0, Some(8)), "\".");
+            wrterr(out, &errmes, 1);
+        } else if c0[p + 8] as u8 != b'\'' {
+            spf!(errmes;
+                "Extra '", CHR(c0[p + 8]), "' follows the XTENSION value \"",
+                CSW(&c0[p..], 0, Some(8)), "\".");
+            wrterr(out, &errmes, 1);
+        }
+
+        /* test if this is a tile compressed image, stored in a binary table */
+        /* If so then test the extension as binary table rather than an image */
+
+        if strncmp_c(&c0[p..], cs!(c"BINTABLE"), 8) == 0 && hduptr.hdutype == IMAGE_HDU {
+            hduptr.hdutype = BINARY_TBL;
+            hduptr.istilecompressed = 1;
+        } else {
+            hduptr.istilecompressed = 0;
+        }
+    }
+
+    /* read the BITPIX keywords */
+    if fits_read_key(
+        infits,
+        KeywordDatatypeMut::TINT(&mut hduptr.bitpix),
+        cs!(c"BITPIX"),
+        None,
+        &mut status,
+    ) != 0
+    {
+        wrtferr_str(out, "", &mut status, 2);
+    }
+    check_fixed_int(&card_at(1), out);
+
+    /* Read and Parse the NAXIS */
+    hduptr.naxis = 0;
+    if fits_read_key(
+        infits,
+        KeywordDatatypeMut::TINT(&mut hduptr.naxis),
+        cs!(c"NAXIS"),
+        None,
+        &mut status,
+    ) != 0
+    {
+        wrtferr_str(out, "", &mut status, 2);
+    }
+    check_fixed_int(&card_at(2), out);
+
+    hduptr.naxes = if hduptr.naxis != 0 {
+        vec![-1; hduptr.naxis as usize]
+    } else {
+        Vec::new()
+    };
+
+    /* Parse the keywords NAXISn */
+    j = 3;
+    while j < 3 + hduptr.naxis as usize {
+        let mut cardj = card_at(j);
+        fits_parse_card(
+            out,
+            1 + j as c_int,
+            &mut cardj,
+            &mut tmpkey.kname,
+            &mut tmpkey.ktype,
+            &mut tmpkey.kvalue,
+            &mut comm,
+        );
+        p = 5;
+        if !isdigit_c(tmpkey.kname[p]) {
+            j += 1;
+            continue;
+        }
+        if check_int(&tmpkey, out) != 0 {
+            lu = strtoll_c(&tmpkey.kvalue);
+        }
+        lv = strtol_c(&tmpkey.kname[p..]).0 as LONGLONG;
+        if lv > hduptr.naxis as LONGLONG && lv <= 0 {
+            spf!(errmes;
+                "Keyword #", tmpkey.kindex, ", ", CS(&tmpkey.kname),
+                " is not allowed (with n > NAXIS = ", hduptr.naxis, ").");
+            wrterr(out, &errmes, 1);
+        } else if lv >= 1 && (lv as usize) <= hduptr.naxes.len() {
+            if hduptr.naxes[(lv - 1) as usize] == -1 {
+                hduptr.naxes[(lv - 1) as usize] = lu;
+            } else {
+                spf!(errmes;
+                    "Keyword #", tmpkey.kindex, ", ", CS(&tmpkey.kname), " is duplicated.");
+                wrterr(out, &errmes, 1);
+            }
+        }
+
+        check_fixed_int(&card_at(j), out);
+        j += 1;
+    }
+
+    /* check all the NAXISn are there */
+    for j in 0..hduptr.naxis as usize {
+        if hduptr.naxes[j] == -1 {
+            spf!(errmes; "Keyword NAXIS", j + 1, " is not present or is out of order.");
+            wrterr(out, &errmes, 2);
+        }
+    }
+
+    /* get the column number */
+    hduptr.ncols = 1;
+    if hduptr.hdutype == ASCII_TBL || hduptr.hdutype == BINARY_TBL {
+        /* get the total number of columns  */
+        if fits_get_num_cols(infits, &mut hduptr.ncols, &mut status) != 0 {
+            wrtferr_str(out, "", &mut status, 2);
+        }
+    }
+
+    /* parse the keywords after NAXISn and prepare the array for
+       sorting. We only check the keywords after the NAXISn */
+    n = (hduptr.nkeys - 4 - hduptr.naxis).max(0) as usize; /* excluding the SIMPLE/XTENSION,
+                                                           BITPIX, NAXIS, NAXISn
+                                                           and END */
+    hduptr.kwds = vec![FitsKey::default(); n];
+    k = 3 + hduptr.naxis as usize; /* index of first keyword following NAXISn. */
+    m = (hduptr.nkeys - 1) as usize; /* last key  */
+    i = 0;
+    hduptr.use_longstr = 0;
+    j = k;
+    while j < m {
+        let mut cardj = card_at(j);
+        hduptr.kwds[i].kindex = j as c_int + 1; /* record number */
+        hduptr.kwds[i].goodkey = 1;
+        let (mut kn, mut kt, mut kv) = (
+            hduptr.kwds[i].kname,
+            hduptr.kwds[i].ktype,
+            hduptr.kwds[i].kvalue,
+        );
+        if fits_parse_card(out, 1 + j as c_int, &mut cardj, &mut kn, &mut kt, &mut kv, &mut comm)
+            != 0
+        {
+            hduptr.kwds[i].goodkey = 0;
+        }
+        hduptr.kwds[i].kname = kn;
+        hduptr.kwds[i].ktype = kt;
+        hduptr.kwds[i].kvalue = kv;
+
+        if hduptr.kwds[i].ktype == kwdtyp::UNKNOWN && hduptr.kwds[i].kvalue[0] == 0 {
+            spf!(errmes;
+                "Keyword #", j + 1, ", ", CS(&hduptr.kwds[i].kname), " has a null value.");
+            wrtwrn(out, &errmes, 0);
+        }
+
+        /* only count the non-commentary keywords */
+        if strcmp_c(&hduptr.kwds[i].kname, cs!(c"CONTINUE")) == 0 {
+            hduptr.use_longstr = 1;
+        }
+        if strcmp_c(&hduptr.kwds[i].kname, cs!(c"COMMENT")) != 0
+            && strcmp_c(&hduptr.kwds[i].kname, cs!(c"HISTORY")) != 0
+            && (strcmp_c(&hduptr.kwds[i].kname, cs!(c"HIERARCH")) != 0 || testhierarch() != 0)
+            && strcmp_c(&hduptr.kwds[i].kname, cs!(c"CONTINUE")) != 0
+            && strcmp_c(&hduptr.kwds[i].kname, cs!(c"")) != 0
+        {
+            i += 1;
+        }
+        j += 1;
+    }
+    numusrkey = i;
+    hduptr.tkeys = i as c_int;
+
+    /* parse the END key */
+    let mut cardend = card_at(hduptr.nkeys as usize - 1);
+    fits_parse_card(
+        out,
+        m as c_int + 1,
+        &mut cardend,
+        &mut tmpkey.kname,
+        &mut tmpkey.ktype,
+        &mut tmpkey.kvalue,
+        &mut comm,
+    );
+
+    /* sort the keyword in the ascending order of kname field*/
+    /* glibc's qsort is a stable merge sort here, so use a stable sort. */
+    hduptr.kwds[..numusrkey].sort_by(|a, b| compkey(a, b).cmp(&0));
+
+    /* store addresses of sorted keyword names in a working array */
+    TMPKWDS.with(|t| {
+        let mut t = t.borrow_mut();
+        t.clear();
+        for i in 0..numusrkey {
+            t.push(hduptr.kwds[i].kname);
+        }
+    });
+
+    /* Initialize  the PCOUNT, GCOUNT and heap values */
+    hduptr.pcount = -99;
+    hduptr.gcount = -99;
+    hduptr.heap = -99;
+
+    /* set the random group flag (will be determined later) */
+    hduptr.isgroup = 0;
+
+    /* allocate memory for datamax and datamin (will determined later)*/
+    hduptr.datamax = Vec::new();
+    hduptr.datamin = Vec::new();
+    hduptr.tnull = Vec::new();
+    if hduptr.ncols > 0 {
+        for _ in 0..hduptr.ncols {
+            hduptr.datamax.push(vec![0; 13]);
+            hduptr.datamin.push(vec![0; 13]);
+            hduptr.tnull.push(vec![0; 12]);
+        }
+    }
+
+    /* initialize  the extension  name and version */
+    hduptr.extname[0] = 0;
+    hduptr.extver = -999;
+}
+
+/*************************************************************
+*
+*      test_hdu
+*
+*   Test the  HDU header
+*    This includes many tests of WCS keywords
+*
+*************************************************************/
+pub fn test_hdu(
+    infits: &mut fitsfile, /* input fits file   */
+    out: Out,              /* output ascii file */
+    hduptr: &mut FitsHdu,
+) {
+    let mut status: c_int = 0;
+    let numusrkey: c_int;
+    let hdunum: c_int;
+    let mut pname: [Option<[c_char; FLEN_KEYWORD]>; NWCSDESCR] = [None; NWCSDESCR];
+    let mut p: usize;
+    let mut j: c_int;
+    let mut k: c_int = 0;
+    let mut m: c_int;
+    let mut n: c_int = 0;
+    let mut wcsaxesmax: c_int = 0;
+    let mut taxes: c_int;
+    let mut iaxis: c_int = 0;
+    let mut ialt: c_int = 0;
+    let mut wcsaxesExists: c_int = 0;
+    let mut wcsaxesvalue: c_int = 0;
+    let mut wcsaxespos: [c_int; NWCSDESCR] = [0; NWCSDESCR];
+    let mut wcskeypos: [c_int; NWCSDESCR] = [0; NWCSDESCR];
+    let mut crota2_exists: c_int = 0;
+    let mut matrix_exists: [c_int; 2] = [0, 0];
+    let mut dvalue: c_double;
+    let mut primary_naxis: c_int = 0;
+    let mut errmes: [c_char; ERRMES_LEN] = [0; ERRMES_LEN];
+
+    /* floating WCS keywords  */
+    let cfltkeys: [&std::ffi::CStr; 7] = [
+        c"CRPIX", c"CRVAL", c"CDELT", c"CROTA", c"CRDER", c"CSYER", c"PV",
+    ];
+    let ncfltkeys = 7;
+    let mut keynum: [c_int; 7] = [0; 7];
+    let mut nmax: c_int = 0;
+
+    /* floating non-indexed WCS keywords  */
+    let cfltnkeys: [&std::ffi::CStr; 11] = [
+        c"RESTFRQ", c"RESTFREQ", c"RESTWAV", c"OBSGEO-X", c"OBSGEO-Y", c"OBSGEO-Z", c"VELOSYS",
+        c"ZSOURCE", c"VELANGL", c"LONPOLE", c"LATPOLE",
+    ];
+    let ncfltnkeys = 11;
+
+    /* floating WCS keywords w/ underscore  */
+    let cflt_keys: [&std::ffi::CStr; 2] = [c"PC", c"CD"];
+    let ncflt_keys = 2;
+
+    /* string WCS keywords  */
+    let cstrkeys: [&std::ffi::CStr; 4] = [c"CTYPE", c"CUNIT", c"PS", c"CNAME"];
+    let ncstrkeys = 4;
+
+    /* string RADESYS keywords with list of allowed values  */
+    let rastrkeys: [&std::ffi::CStr; 2] = [c"RADESYS", c"RADECSYS"];
+    let nrastrkeys = 2;
+
+    /* string spectral ref frame keywords with list of allowed values  */
+    let specstrkeys: [&std::ffi::CStr; 3] = [c"SPECSYS", c"SSYSOBS", c"SSYSSRC"];
+    let nspecstrkeys = 3;
+
+    for i in 0..NWCSDESCR {
+        wcsaxespos[i] = -1;
+        wcskeypos[i] = 1000000000;
+        pname[i] = None;
+    }
+
+    numusrkey = hduptr.tkeys;
+    let tmpkwds = tmpkwds_get();
+
+    /* find the extension  name and version */
+    key_match(&tmpkwds, numusrkey, cs!(c"EXTNAME"), 1, &mut k, &mut n);
+    if k > -1 && hduptr.kwds[k as usize].ktype == kwdtyp::STR_KEY {
+        strcpy_c(&mut hduptr.extname, &hduptr.kwds[k as usize].kvalue.clone());
+    }
+
+    key_match(&tmpkwds, numusrkey, cs!(c"EXTVER"), 1, &mut k, &mut n);
+    if k > -1 && hduptr.kwds[k as usize].ktype == kwdtyp::INT_KEY {
+        hduptr.extver = strtol_c(&hduptr.kwds[k as usize].kvalue).0 as c_int;
+    }
+
+    /* set the HduName structure */
+    hdunum = hduptr.hdunum;
+    let extname = hduptr.extname;
+    set_hduname(hdunum, hduptr.hdutype, Some(&extname), hduptr.extver);
+
+    if hduptr.hdunum == 1 {
+        test_prm(infits, out, hduptr);
+        primary_naxis = hduptr.naxis;
+    } else {
+        /* test the keywords specific to the hdutype*/
+        match hduptr.hdutype {
+            IMAGE_HDU => test_img_ext(infits, out, hduptr),
+            ASCII_TBL => test_asc_ext(infits, out, hduptr),
+            BINARY_TBL => test_bin_ext(infits, out, hduptr),
+            _ => {}
+        }
+    }
+    /* test the general keywords */
+    test_header(infits, out, hduptr);
+
+    /* Check INHERIT keyword; must not be used if primary contains data */
+    key_match(&tmpkwds, numusrkey, cs!(c"INHERIT"), 1, &mut k, &mut n);
+    if k > -1 {
+        if primary_naxis != 0 {
+            spf!(errmes;
+                "Keyword #", hduptr.kwds[k as usize].kindex, ", ",
+                CS(&hduptr.kwds[k as usize].kname),
+                " cannot be used if the primary array contains data (NAXIS != 0).");
+            wrtwrn(out, &errmes, 0);
+        }
+        check_log(&hduptr.kwds[k as usize], out);
+    }
+
+    /* test if CROTA2 exists; if so, then PCi_j must not exist */
+    key_match(&tmpkwds, numusrkey, cs!(c"CROTA2"), 1, &mut k, &mut n);
+    if n == 1 {
+        crota2_exists = hduptr.kwds[k as usize].kindex;
+    }
+
+    /* first find the primary WCSAXES value, if it exists */
+    key_match(&tmpkwds, numusrkey, cs!(c"WCSAXES"), 1, &mut k, &mut n);
+    if k >= 0 {
+        j = k;
+        if check_int(&hduptr.kwds[j as usize], out) != 0 {
+            wcsaxesvalue = strtol_c(&hduptr.kwds[j as usize].kvalue).0 as c_int;
+            nmax = wcsaxesvalue;
+            if wcsaxesvalue > wcsaxesmax {
+                wcsaxesmax = wcsaxesvalue;
+            }
+            wcsaxesExists = 1;
+
+            /* store index of the wcsaxes keyword */
+            /*  (it must appear before other WCS keywords) */
+            if hduptr.kwds[j as usize].kindex > wcsaxespos[0] {
+                wcsaxespos[0] = hduptr.kwds[j as usize].kindex;
+            }
+        }
+    }
+
+    /* Check and find max value of the WCSAXESa keywords */
+    /* Use the max value when checking the range of the indexed WCS keywords. */
+    /* This is a less rigorous test than if one were to test the range of the */
+    /* keywords for each of the alternate WCS systems (A - Z) against the */
+    /* corresponding WCSAXESa keyword.  */
+
+    key_match(&tmpkwds, numusrkey, cs!(c"WCSAXES"), 0, &mut k, &mut n);
+
+    j = k;
+    while j < n + k {
+        if check_int(&hduptr.kwds[j as usize], out) != 0 {
+            taxes = strtol_c(&hduptr.kwds[j as usize].kvalue).0 as c_int;
+            if taxes > wcsaxesmax {
+                wcsaxesmax = taxes;
+            }
+            wcsaxesExists = 1;
+
+            /*  Removed this check on 6/28/2012.  See discussion on FITSBITS related
+                to this requirement.  */
+
+            parse_wcskey_suffix(
+                &hduptr.kwds[j as usize].kname,
+                cs!(c"WCSAXES"),
+                &mut iaxis,
+                &mut ialt,
+            );
+            wcsaxespos[ialt as usize] = hduptr.kwds[j as usize].kindex;
+        }
+        j += 1;
+    }
+
+    /* test datatype of reserved indexed floating point WCS keywords */
+    for i in 0..ncfltkeys {
+        let temp: &[c_char] = cast_slice(cfltkeys[i].to_bytes_with_nul());
+        key_match(&tmpkwds, numusrkey, temp, 0, &mut k, &mut n);
+        if k < 0 {
+            continue;
+        }
+
+        j = k;
+        while j < k + n {
+            let kindex = hduptr.kwds[j as usize].kindex;
+            let kname = hduptr.kwds[j as usize].kname;
+            let kvalue = hduptr.kwds[j as usize].kvalue;
+
+            p = cstrlen(temp);
+            if !isdigit_c(kname[p]) {
+                j += 1;
+                continue;
+            }
+
+            if check_flt(&hduptr.kwds[j as usize], out) == 0 {
+                j += 1;
+                continue;
+            }
+
+            if i == 2 {
+                /* test that CDELTi != 0 */
+                dvalue = strtod_c(&kvalue);
+                if dvalue == 0. {
+                    spf!(errmes;
+                        "Keyword #", kindex, ", ", CS(&kname), ": must have non-zero value.");
+                    wrterr(out, &errmes, 1);
+                }
+            }
+
+            if i == 4 || i == 5 {
+                /* test that CRDERi and CSYSERi are non-negative */
+                dvalue = strtod_c(&kvalue);
+                if dvalue < 0. {
+                    spf!(errmes;
+                        "Keyword #", kindex, ", ", CS(&kname),
+                        ": must have non-negative value: ", CS(&kvalue));
+                    wrterr(out, &errmes, 1);
+                }
+            }
+
+            parse_wcskey_suffix(&kname, temp, &mut iaxis, &mut ialt);
+            if wcsaxesExists != 0 {
+                /* WCSAXES keyword exists */
+
+                if iaxis < 1 || iaxis > wcsaxesmax {
+                    spf!(errmes;
+                        "Keyword #", kindex, ", ", CS(&kname), ": index ", iaxis,
+                        " is not in range 1-", wcsaxesmax, " (WCSAXES).");
+                    wrterr(out, &errmes, 1);
+                }
+            } else if iaxis < 1 || iaxis > hduptr.naxis {
+                spf!(errmes;
+                    "Keyword #", kindex, ", ", CS(&kname), ": index ", iaxis,
+                    " is not in range 1-", hduptr.naxis, " (NAXIS).");
+                wrtwrn(out, &errmes, 0);
+            }
+
+            /* count the number of each keyword */
+            if ialt == 0 {
+                /* only test the primary set of WCS keywords */
+                keynum[i] += 1;
+                if iaxis > nmax {
+                    nmax = iaxis;
+                }
+            }
+
+            /* store lowest index of any wcs keyword */
+            if kindex < wcskeypos[ialt as usize] {
+                wcskeypos[ialt as usize] = kindex;
+                pname[ialt as usize] = Some(kname);
+            }
+            j += 1;
+        }
+    }
+
+    if wcsaxesvalue == 0 {
+        /* limit value of nmax to the legal maximum */
+        if nmax > hduptr.naxis {
+            nmax = hduptr.naxis;
+        }
+    } else if nmax > wcsaxesvalue {
+        nmax = wcsaxesvalue;
+    }
+
+    if keynum[0] < nmax {
+        /* test number of CRPIXi keywords */
+        spf!(errmes; "Some CRPIXi keywords appear to be missing; expected ", nmax, ".");
+        wrtwrn(out, &errmes, 0);
+    }
+    if keynum[1] < nmax {
+        /* test number of CRVALi keywords */
+        spf!(errmes; "Some CRVALi keywords appear to be missing; expected ", nmax, ".");
+        wrtwrn(out, &errmes, 0);
+    }
+
+    /* test datatype of reserved non-indexed floating point WCS keywords */
+    for i in 0..ncfltnkeys {
+        let temp: &[c_char] = cast_slice(cfltnkeys[i].to_bytes_with_nul());
+        key_match(&tmpkwds, numusrkey, temp, 0, &mut k, &mut n);
+
+        if k < 0 {
+            continue;
+        }
+
+        j = k;
+        while j < k + n {
+            if check_flt(&hduptr.kwds[j as usize], out) == 0 {
+                j += 1;
+                continue;
+            }
+            j += 1;
+        }
+    }
+
+    /* test datatype of reserved indexed floating point WCS keywords with "_" */
+    for i in 0..ncflt_keys {
+        let temp: &[c_char] = cast_slice(cflt_keys[i].to_bytes_with_nul());
+        key_match(&tmpkwds, numusrkey, temp, 0, &mut k, &mut n);
+        if k < 0 {
+            continue;
+        }
+
+        j = k;
+        while j < k + n {
+            let kindex = hduptr.kwds[j as usize].kindex;
+            let kname = hduptr.kwds[j as usize].kname;
+
+            p = cstrlen(temp);
+            if !isdigit_c(kname[p]) {
+                j += 1;
+                continue;
+            }
+
+            /* 2 digits must be separated by a '_' */
+            let p2 = match kname[p..].iter().position(|&c| c as u8 == b'_') {
+                Some(o) => p + o,
+                None => {
+                    j += 1;
+                    continue;
+                }
+            };
+
+            if check_flt(&hduptr.kwds[j as usize], out) == 0 {
+                j += 1;
+                continue;
+            }
+
+            /* test the first digit (strtol stops at the '_' anyway, so the C's
+               temporary NUL there is not needed) */
+            m = strtol_c(&kname[p..]).0 as c_int;
+
+            if wcsaxesExists != 0 {
+                /* WCSAXES keyword exists */
+
+                if m < 1 || m > wcsaxesmax {
+                    spf!(errmes;
+                        "Keyword #", kindex, ", ", CS(&kname), ": 1st index ", m,
+                        " is not in range 1-", wcsaxesmax, " (WCSAXES).");
+                    wrterr(out, &errmes, 1);
+                }
+            } else if m < 1 || m > hduptr.naxis {
+                spf!(errmes;
+                    "Keyword #", kindex, ", ", CS(&kname), ": 1st index ", m,
+                    " is not in range 1-", hduptr.naxis, " (NAXIS).");
+                wrtwrn(out, &errmes, 0);
+            }
+
+            /* test the second digit */
+            let pp = p2 + 1;
+            let (mv, endoff) = strtol_c(&kname[pp..]);
+            m = mv as c_int;
+            let p2 = pp + endoff;
+
+            if wcsaxesExists != 0 {
+                /* WCSAXES keyword exists */
+
+                if m < 1 || m > wcsaxesmax {
+                    spf!(errmes;
+                        "Keyword #", kindex, ", ", CS(&kname), ": 2nd index ", m,
+                        " is not in range 1-", wcsaxesmax, " (WCSAXES).");
+                    wrterr(out, &errmes, 1);
+                }
+            } else if m < 1 || m > hduptr.naxis {
+                spf!(errmes;
+                    "Keyword #", kindex, ", ", CS(&kname), ": 2nd index ", m,
+                    " is not in range 1-", hduptr.naxis, " (NAXIS).");
+                wrtwrn(out, &errmes, 0);
+            }
+
+            ialt = 0;
+            if kname[p2] == 0 {
+                /* no alternate suffix on the PC or CD name */
+                matrix_exists[i] = kindex;
+            } else if cstrlen(&kname[p2..]) == 1 {
+                let c = kname[p2] as u8;
+                if c.is_ascii_uppercase() {
+                    ialt = c as c_int - 64;
+                }
+            }
+
+            /* store lowest index of any wcs keyword */
+            if kindex < wcskeypos[ialt as usize] {
+                wcskeypos[ialt as usize] = kindex;
+                pname[ialt as usize] = Some(kname);
+            }
+            j += 1;
+        }
+    }
+
+    if matrix_exists[0] > 0 && matrix_exists[1] > 0 {
+        spf!(errmes;
+            "Keywords PCi_j (#", matrix_exists[0], ") and CDi_j (#", matrix_exists[1],
+            ") are mutually exclusive.");
+        wrterr(out, &errmes, 1);
+    }
+
+    if matrix_exists[0] > 0 && crota2_exists > 0 {
+        spf!(errmes;
+            "Keywords PCi_j (#", matrix_exists[0], ") and CROTA2 (#", crota2_exists,
+            ") are mutually exclusive.");
+        wrterr(out, &errmes, 1);
+    }
+
+    /* test datatype of reserved indexed string WCS keywords */
+    for i in 0..ncstrkeys {
+        let temp: &[c_char] = cast_slice(cstrkeys[i].to_bytes_with_nul());
+        keynum[i] = 0;
+        key_match(&tmpkwds, numusrkey, temp, 0, &mut k, &mut n);
+
+        if k < 0 {
+            continue;
+        }
+
+        j = k;
+        while j < k + n {
+            let kindex = hduptr.kwds[j as usize].kindex;
+            let kname = hduptr.kwds[j as usize].kname;
+
+            p = cstrlen(temp);
+            if !isdigit_c(kname[p]) {
+                j += 1;
+                continue;
+            }
+
+            if check_str(&hduptr.kwds[j as usize], out) == 0 {
+                j += 1;
+                continue;
+            }
+
+            parse_wcskey_suffix(&kname, temp, &mut iaxis, &mut ialt);
+
+            if wcsaxesExists != 0 {
+                /* WCSAXES keyword exists */
+
+                if iaxis < 1 || iaxis > wcsaxesmax {
+                    spf!(errmes;
+                        "Keyword #", kindex, ", ", CS(&kname), ": index ", iaxis,
+                        " is not in range 1-", wcsaxesmax, " (WCSAXES).");
+                    wrterr(out, &errmes, 1);
+                }
+            } else if iaxis < 1 || iaxis > hduptr.naxis {
+                spf!(errmes;
+                    "Keyword #", kindex, ", ", CS(&kname), ": index ", iaxis,
+                    " is not in range 1-", hduptr.naxis, " (NAXIS).");
+                wrtwrn(out, &errmes, 0);
+            }
+
+            if ialt == 0 {
+                /* only test the primary set of WCS keywords */
+                keynum[i] += 1;
+            }
+
+            /* store lowest index of any wcs keyword */
+            if kindex < wcskeypos[ialt as usize] {
+                wcskeypos[ialt as usize] = kindex;
+                pname[ialt as usize] = Some(kname);
+            }
+            j += 1;
+        }
+    }
+
+    if keynum[0] < nmax {
+        spf!(errmes; "Some CTYPEi keywords appear to be missing; expected ", nmax, ".");
+        wrtwrn(out, &errmes, 0);
+    }
+
+    for i in 0..NWCSDESCR {
+        if wcskeypos[i] < wcsaxespos[i] {
+            let nm = pname[i].unwrap_or([0; FLEN_KEYWORD]);
+            spf!(errmes;
+                "WCSAXES keyword #", wcsaxespos[i], " appears after other WCS keyword ",
+                CS(&nm), " #", wcskeypos[i]);
+            wrterr(out, &errmes, 1);
+        }
+    }
+
+    /* test datatype and value of reserved RADECSYS WCS keywords */
+    for i in 0..nrastrkeys {
+        let temp: &[c_char] = cast_slice(rastrkeys[i].to_bytes_with_nul());
+        keynum[i] = 0;
+        key_match(&tmpkwds, numusrkey, temp, 0, &mut k, &mut n);
+
+        if k < 0 {
+            continue;
+        }
+
+        j = k;
+        while j < k + n {
+            let kindex = hduptr.kwds[j as usize].kindex;
+            let kname = hduptr.kwds[j as usize].kname;
+            let kvalue = hduptr.kwds[j as usize].kvalue;
+
+            if check_str(&hduptr.kwds[j as usize], out) == 0 {
+                j += 1;
+                continue;
+            }
+
+            if strcmp_c(&kvalue, cs!(c"ICRS")) != 0
+                && strcmp_c(&kvalue, cs!(c"FK5")) != 0
+                && strcmp_c(&kvalue, cs!(c"FK4")) != 0
+                && strcmp_c(&kvalue, cs!(c"FK4-NO-E")) != 0
+                && strcmp_c(&kvalue, cs!(c"GAPPT")) != 0
+            {
+                spf!(errmes;
+                    "Keyword #", kindex, ", ", CS(&kname), " has non-allowed value: ",
+                    CS(&kvalue));
+                wrtwrn(out, &errmes, 0);
+            }
+            j += 1;
+        }
+    }
+
+    /* test datatype and value of reserved spectral ref frame WCS keywords */
+    for i in 0..nspecstrkeys {
+        let temp: &[c_char] = cast_slice(specstrkeys[i].to_bytes_with_nul());
+        keynum[i] = 0;
+        key_match(&tmpkwds, numusrkey, temp, 0, &mut k, &mut n);
+
+        if k < 0 {
+            continue;
+        }
+
+        j = k;
+        while j < k + n {
+            let kindex = hduptr.kwds[j as usize].kindex;
+            let kname = hduptr.kwds[j as usize].kname;
+            let kvalue = hduptr.kwds[j as usize].kvalue;
+
+            if check_str(&hduptr.kwds[j as usize], out) == 0 {
+                j += 1;
+                continue;
+            }
+
+            if strcmp_c(&kvalue, cs!(c"TOPOCENT")) != 0
+                && strcmp_c(&kvalue, cs!(c"GEOCENTR")) != 0
+                && strcmp_c(&kvalue, cs!(c"BARYCENT")) != 0
+                && strcmp_c(&kvalue, cs!(c"HELIOCEN")) != 0
+                && strcmp_c(&kvalue, cs!(c"LSRK")) != 0
+                && strcmp_c(&kvalue, cs!(c"LSRD")) != 0
+                && strcmp_c(&kvalue, cs!(c"GALACTOC")) != 0
+                && strcmp_c(&kvalue, cs!(c"LOCALGRP")) != 0
+                && strcmp_c(&kvalue, cs!(c"CMBDIPOL")) != 0
+                && strcmp_c(&kvalue, cs!(c"SOURCE")) != 0
+            {
+                spf!(errmes;
+                    "Keyword #", kindex, ", ", CS(&kname), " has non-allowed value: ",
+                    CS(&kvalue));
+                wrtwrn(out, &errmes, 0);
+            }
+            j += 1;
+        }
+    }
+
+    /* test the fill area */
+    if testfill() != 0 && ffchfl_safe(infits, &mut status) != 0 {
+        wrterr_str(
+            out,
+            "The header fill area is not totally filled with blanks.",
+            1,
+        );
+    }
+}
+
+/*************************************************************
+*
+*      test_prm
+*
+*   Test the primary array header
+*
+*************************************************************/
+pub fn test_prm(
+    infits: &mut fitsfile, /* input fits file   */
+    out: Out,              /* output ascii file */
+    hduptr: &mut FitsHdu,  /* hdu information structure */
+) {
+    let mut i: c_int;
+    let mut j: c_int;
+    let mut k: c_int = 0;
+    let mut n: c_int = 0;
+    let mut p: usize;
+    let mut errmes: [c_char; ERRMES_LEN] = [0; ERRMES_LEN];
+
+    let exlkey: [&std::ffi::CStr; 2] = [c"XTENSION", c"INHERIT"];
+    let nexlkey = 1;
+
+    let numusrkey = hduptr.tkeys;
+    let tmpkwds = tmpkwds_get();
+
+    /* The SIMPLE, BITPIX, NAXIS, and NAXISn keywords  have been
+       checked in CFITSIO */
+
+    /* excluded keywords cannot be used. */
+    for i in 0..nexlkey {
+        let temp: &[c_char] = cast_slice(exlkey[i].to_bytes_with_nul());
+        key_match(&tmpkwds, numusrkey, temp, 1, &mut k, &mut n);
+        if n > 0 {
+            spf!(errmes;
+                "Keyword #", hduptr.kwds[k as usize].kindex, ", ", CS(temp),
+                " is not allowed in a primary array.");
+            wrterr(out, &errmes, 1);
+        }
+    }
+
+    /* Check if Random Groups file */
+    key_match(&tmpkwds, numusrkey, cs!(c"GROUPS"), 1, &mut k, &mut n);
+    if k > -1 {
+        let kindex = hduptr.kwds[k as usize].kindex;
+        if hduptr.kwds[k as usize].kvalue[0] as u8 == b'T'
+            && hduptr.naxis > 0
+            && hduptr.naxes[0] == 0
+        {
+            hduptr.isgroup = 1;
+
+            check_fixed_log(&card_at(kindex as usize - 1), out);
+        }
+    }
+
+    /* check the position of the EXTEND  */
+
+    /*  the EXTEND keyword is no longer required if the file contains extensions */
+
+    if hduptr.isgroup == 0 {
+        key_match(&tmpkwds, numusrkey, cs!(c"EXTEND"), 1, &mut k, &mut n);
+        if k > 0 {
+            if check_log(&hduptr.kwds[k as usize], out) != 0
+                && hduptr.kwds[k as usize].kvalue[0] as u8 != b'T'
+                && totalhdu() > 1
+            {
+                spf!(errmes; "There are extensions but EXTEND = F.");
+                wrterr(out, &errmes, 1);
+            }
+        }
+    }
+
+    /* Check PCOUNT and GCOUNT  keyword */
+    key_match(&tmpkwds, numusrkey, cs!(c"PCOUNT"), 1, &mut k, &mut n);
+    if k > -1 {
+        let kindex = hduptr.kwds[k as usize].kindex;
+        let kname = hduptr.kwds[k as usize].kname;
+        /* Primary array cannot have PCOUNT */
+        if hduptr.isgroup == 0 {
+            spf!(errmes;
+                " Keyword #", kindex, ", ", CS(&kname), " is not allowed in a primary array.");
+            wrterr(out, &errmes, 1);
+        } else {
+            if check_int(&hduptr.kwds[k as usize], out) != 0 {
+                hduptr.pcount = strtod_c(&hduptr.kwds[k as usize].kvalue) as LONGLONG;
+            }
+
+            check_fixed_int(&card_at(kindex as usize - 1), out);
+        }
+    }
+
+    key_match(&tmpkwds, numusrkey, cs!(c"GCOUNT"), 1, &mut k, &mut n);
+    if k > -1 {
+        let kindex = hduptr.kwds[k as usize].kindex;
+        let kname = hduptr.kwds[k as usize].kname;
+        /* Primary array cannot have GCOUNT */
+        if hduptr.isgroup == 0 {
+            spf!(errmes;
+                " Keyword #", kindex, ", ", CS(&kname), " is not allowed in a primary array.");
+            wrterr(out, &errmes, 1);
+        } else {
+            if check_int(&hduptr.kwds[k as usize], out) != 0 {
+                hduptr.gcount = strtol_c(&hduptr.kwds[k as usize].kvalue).0 as c_int;
+            }
+
+            check_fixed_int(&card_at(kindex as usize - 1), out);
+        }
+    }
+
+    key_match(&tmpkwds, numusrkey, cs!(c"BLOCKED"), 1, &mut k, &mut n);
+    if k > -1 {
+        spf!(errmes;
+            "Keyword #", hduptr.kwds[k as usize].kindex, ", ",
+            CS(&hduptr.kwds[k as usize].kname), " is deprecated.");
+        wrtwrn(out, &errmes, 0);
+        check_log(&hduptr.kwds[k as usize], out);
+    }
+
+    /*  Check PSCALn keywords (only in Random Groups) */
+    key_match(&tmpkwds, numusrkey, cs!(c"PSCAL"), 0, &mut k, &mut n);
+    j = k;
+    while j < k + n {
+        let kindex = hduptr.kwds[j as usize].kindex;
+        let kname = hduptr.kwds[j as usize].kname;
+        p = 5;
+        if !isdigit_c(kname[p]) {
+            j += 1;
+            continue;
+        }
+
+        if hduptr.isgroup == 0 {
+            spf!(errmes; "Keyword #", kindex, ", ", CS(&kname), " ");
+            scat!(errmes; "is only allowed in Random Groups structures.");
+            wrterr(out, &errmes, 1);
+            j += 1;
+            continue;
+        }
+
+        if check_flt(&hduptr.kwds[j as usize], out) != 0
+            && strtod_c(&hduptr.kwds[j as usize].kvalue) == 0.0
+        {
+            spf!(errmes; "Keyword #", kindex, ", ", CS(&kname), ": ");
+            scat!(errmes; "The scaling factor is zero.");
+            wrtwrn(out, &errmes, 0);
+        }
+
+        i = strtol_c(&kname[p..]).0 as c_int - 1;
+        if i < 0 || i >= hduptr.gcount {
+            spf!(errmes;
+                "Keyword #", kindex, ", ", CS(&kname), ": invalid index ", i + 1,
+                " (> GCOUNT = ", hduptr.gcount, ").");
+            wrterr(out, &errmes, 1);
+            j += 1;
+            continue;
+        }
+        j += 1;
+    }
+
+    /*  Check PZEROn keywords (only in Random Groups) */
+    key_match(&tmpkwds, numusrkey, cs!(c"PZERO"), 0, &mut k, &mut n);
+    j = k;
+    while j < k + n {
+        let kindex = hduptr.kwds[j as usize].kindex;
+        let kname = hduptr.kwds[j as usize].kname;
+        p = 5;
+        if !isdigit_c(kname[p]) {
+            j += 1;
+            continue;
+        }
+
+        if hduptr.isgroup == 0 {
+            spf!(errmes; "Keyword #", kindex, ", ", CS(&kname), " ");
+            scat!(errmes; "is only allowed in Random Groups structures.");
+            wrterr(out, &errmes, 1);
+            j += 1;
+            continue;
+        }
+
+        check_flt(&hduptr.kwds[j as usize], out);
+        i = strtol_c(&kname[p..]).0 as c_int - 1;
+        if i < 0 || i >= hduptr.gcount {
+            spf!(errmes;
+                "Keyword #", kindex, ", ", CS(&kname), ": invalid index ", i + 1,
+                " (> GCOUNT = ", hduptr.gcount, ").");
+            wrterr(out, &errmes, 1);
+            j += 1;
+            continue;
+        }
+        j += 1;
+    }
+
+    /*  Check PTYPEn keywords (only in Random Groups) */
+    key_match(&tmpkwds, numusrkey, cs!(c"PTYPE"), 0, &mut k, &mut n);
+    j = k;
+    while j < k + n {
+        let kindex = hduptr.kwds[j as usize].kindex;
+        let kname = hduptr.kwds[j as usize].kname;
+        p = 5;
+        if !isdigit_c(kname[p]) {
+            j += 1;
+            continue;
+        }
+
+        if hduptr.isgroup == 0 {
+            spf!(errmes; "Keyword #", kindex, ", ", CS(&kname), " ");
+            scat!(errmes; "is only allowed in Random Groups structures.");
+            wrterr(out, &errmes, 1);
+            j += 1;
+            continue;
+        }
+
+        check_str(&hduptr.kwds[j as usize], out);
+        i = strtol_c(&kname[p..]).0 as c_int - 1;
+        if i < 0 || i >= hduptr.gcount {
+            spf!(errmes;
+                "Keyword #", kindex, ", ", CS(&kname), ": invalid index ", i + 1,
+                " (> GCOUNT = ", hduptr.gcount, ").");
+            wrterr(out, &errmes, 1);
+            j += 1;
+            continue;
+        }
+        j += 1;
+    }
+    test_array(infits, out, hduptr);
+}
+
+/*************************************************************
+*
+*      test_ext
+*
+*   Test the extension header
+*
+*************************************************************/
+pub fn test_ext(
+    _infits: &mut fitsfile, /* input fits file   */
+    out: Out,               /* output ascii file */
+    hduptr: &mut FitsHdu,   /* information about header */
+) {
+    let mut i: c_int;
+    let mut j: c_int;
+    let mut k: c_int = 0;
+    let mut n: c_int = 0;
+    let mut p: usize;
+    let exlkey: [&std::ffi::CStr; 3] = [c"SIMPLE", c"EXTEND", c"BLOCKED"];
+    let nexlkey = 3;
+    let exlnkey: [&std::ffi::CStr; 4] = [c"PTYPE", c"PSCAL", c"PZERO", c"GROUPS"];
+    let nexlnkey = 4;
+    let hdunum: c_int;
+    let mut errmes: [c_char; ERRMES_LEN] = [0; ERRMES_LEN];
+    let mut comm: [c_char; COMM_LEN] = [0; COMM_LEN];
+
+    let numusrkey = hduptr.tkeys;
+    let tmpkwds = tmpkwds_get();
+    hdunum = hduptr.hdunum;
+
+    /* check the duplicate extensions */
+    i = hdunum - 1;
+    while i > 0 {
+        if test_hduname(hdunum, i) != 0 {
+            spf!(comm; "The HDU ", hdunum, " and ", i, " have identical type/name/version");
+            wrtwrn(out, &comm, 0);
+        }
+        i -= 1;
+    }
+
+    /* check the position of the PCOUNT  */
+    key_match(&tmpkwds, numusrkey, cs!(c"PCOUNT"), 1, &mut k, &mut n);
+    if k < 0 {
+        spf!(errmes; "cannot find the PCOUNT keyword.");
+        wrterr(out, &errmes, 1);
+    } else {
+        let kindex = hduptr.kwds[k as usize].kindex;
+        if check_int(&hduptr.kwds[k as usize], out) != 0 {
+            hduptr.pcount = strtod_c(&hduptr.kwds[k as usize].kvalue) as LONGLONG;
+        }
+        if kindex != 4 + hduptr.naxis {
+            spf!(errmes; "PCOUNT is not in record ", hduptr.naxis + 4, " of the header.");
+            wrterr(out, &errmes, 1);
+        }
+
+        check_fixed_int(&card_at(kindex as usize - 1), out);
+    }
+
+    /* check the position of the GCOUNT */
+    key_match(&tmpkwds, numusrkey, cs!(c"GCOUNT"), 1, &mut k, &mut n);
+    if k < 0 {
+        spf!(errmes; "cannot find the GCOUNT keyword.");
+        wrterr(out, &errmes, 1);
+    } else {
+        let kindex = hduptr.kwds[k as usize].kindex;
+        if check_int(&hduptr.kwds[k as usize], out) != 0 {
+            hduptr.gcount = strtol_c(&hduptr.kwds[k as usize].kvalue).0 as c_int;
+        }
+        if kindex != 5 + hduptr.naxis {
+            spf!(errmes; "GCOUNT is not in record ", hduptr.naxis + 5, " of the header.");
+            wrterr(out, &errmes, 1);
+        }
+
+        check_fixed_int(&card_at(kindex as usize - 1), out);
+    }
+
+    for i in 0..nexlkey {
+        let temp: &[c_char] = cast_slice(exlkey[i].to_bytes_with_nul());
+        key_match(&tmpkwds, numusrkey, temp, 1, &mut k, &mut n);
+        if k > -1 {
+            spf!(errmes;
+                "Keyword #", hduptr.kwds[k as usize].kindex, ", ",
+                CS(&hduptr.kwds[k as usize].kname), " is not allowed in extensions.");
+            wrterr(out, &errmes, 1);
+        }
+    }
+
+    for i in 0..nexlnkey {
+        let temp: &[c_char] = cast_slice(exlnkey[i].to_bytes_with_nul());
+        key_match(&tmpkwds, numusrkey, temp, 0, &mut k, &mut n);
+        if k > -1 {
+            j = k;
+            while j < k + n {
+                let kname = hduptr.kwds[j as usize].kname;
+                p = 5;
+                if !isdigit_c(kname[p]) {
+                    j += 1;
+                    continue;
+                }
+
+                spf!(errmes;
+                    "Keyword #", hduptr.kwds[j as usize].kindex, ", ", CS(&kname),
+                    " is only allowed in Random Groups structures.");
+                wrterr(out, &errmes, 1);
+                j += 1;
+            }
+        }
+    }
+}
+
+/*************************************************************
+*
+*      test_img_ext
+*
+*   Test the image extension header
+*
+*************************************************************/
+pub fn test_img_ext(
+    infits: &mut fitsfile, /* input fits file   */
+    out: Out,              /* output ascii file */
+    hduptr: &mut FitsHdu,  /* information about header */
+) {
+    let mut errmes: [c_char; ERRMES_LEN] = [0; ERRMES_LEN];
+
+    test_ext(infits, out, hduptr);
+
+    /* The XTENSION, BITPIX, NAXIS, and NAXISn keywords  have been
+       checked in CFITSIO */
+
+    if hduptr.pcount != 0 && hduptr.pcount != -99 {
+        spf!(errmes; "Illegal pcount value ", hduptr.pcount as i64, " for image ext.");
+        wrterr(out, &errmes, 1);
+    }
+
+    if hduptr.gcount != 1 && hduptr.gcount != -99 {
+        spf!(errmes; "Illegal gcount value ", hduptr.gcount, " for image ext.");
+        wrterr(out, &errmes, 1);
+    }
+
+    test_array(infits, out, hduptr);
+}
+
+/*************************************************************
+*
+*      test_array
+*
+*   Test the keywords which are used by both the primary array
+* and image Extension.
+*
+*************************************************************/
+pub fn test_array(
+    _infits: &mut fitsfile, /* input fits file   */
+    out: Out,               /* output ascii file */
+    hduptr: &mut FitsHdu,   /* information about header */
+) {
+    let mut p: usize;
+    let mut j: c_int;
+    let mut k: c_int = 0;
+    let mut n: c_int = 0;
+    let mut errmes: [c_char; ERRMES_LEN] = [0; ERRMES_LEN];
+
+    /* excluded non-indexed keywords  */
+    let exlkeys: [&std::ffi::CStr; 2] = [c"TFIELDS", c"THEAP"];
+    let nexlkeys = 2;
+
+    /* excluded indexed keywords */
+    let exlnkeys: [&std::ffi::CStr; 15] = [
+        c"TBCOL", c"TFORM", c"TSCAL", c"TZERO", c"TNULL", c"TTYPE", c"TUNIT", c"TDISP", c"TDIM",
+        c"TCTYP", c"TCUNI", c"TCRVL", c"TCDLT", c"TCRPX", c"TCROT",
+    ];
+    let nexlnkeys = 15;
+
+    /* non-indexed floating keywords  (excluding BSCALE) */
+    let fltkeys: [&std::ffi::CStr; 3] = [c"BZERO", c"DATAMAX", c"DATAMIN"];
+    let nfltkeys = 3;
+
+    /* non-indexed string keywords */
+    let strkeys: [&std::ffi::CStr; 1] = [c"BUNIT"];
+    let nstrkeys = 1;
+
+    let numusrkey = hduptr.tkeys;
+    let tmpkwds = tmpkwds_get();
+
+    /*  Check BLANK, BSCALE keywords */
+    key_match(&tmpkwds, numusrkey, cs!(c"BLANK"), 1, &mut k, &mut n);
+    if k >= 0 {
+        check_int(&hduptr.kwds[k as usize], out);
+        if hduptr.bitpix < 0 {
+            spf!(errmes;
+                "Keyword #", hduptr.kwds[k as usize].kindex, ", ",
+                CS(&hduptr.kwds[k as usize].kname),
+                " must not be used with floating point data (BITPIX = ", hduptr.bitpix, ").");
+            wrterr(out, &errmes, 2);
+        }
+    }
+
+    key_match(&tmpkwds, numusrkey, cs!(c"BSCALE"), 1, &mut k, &mut n);
+    if k >= 0
+        && check_flt(&hduptr.kwds[k as usize], out) != 0
+        && strtod_c(&hduptr.kwds[k as usize].kvalue) == 0.0
+    {
+        spf!(errmes;
+            "Keyword #", hduptr.kwds[k as usize].kindex, ", ",
+            CS(&hduptr.kwds[k as usize].kname), ": The scaling factor is 0.");
+        wrtwrn(out, &errmes, 0);
+    }
+
+    /* search for excluded, non-indexed keywords */
+    for i in 0..nexlkeys {
+        let temp: &[c_char] = cast_slice(exlkeys[i].to_bytes_with_nul());
+        key_match(&tmpkwds, numusrkey, temp, 1, &mut k, &mut n);
+        if k < 0 {
+            continue;
+        }
+        j = k;
+        while j < k + n {
+            spf!(errmes;
+                "Keyword #", hduptr.kwds[j as usize].kindex, ", ",
+                CS(&hduptr.kwds[j as usize].kname), " is not allowed in the array HDU.");
+            wrterr(out, &errmes, 1);
+            j += 1;
+        }
+    }
+
+    /* search for excluded, indexed keywords */
+    for i in 0..nexlnkeys {
+        let temp: &[c_char] = cast_slice(exlnkeys[i].to_bytes_with_nul());
+        key_match(&tmpkwds, numusrkey, temp, 0, &mut k, &mut n);
+        if k < 0 {
+            continue;
+        }
+        j = k;
+        while j < k + n {
+            let kname = hduptr.kwds[j as usize].kname;
+            p = cstrlen(temp);
+            if !isdigit_c(kname[p]) {
+                j += 1;
+                continue;
+            }
+
+            spf!(errmes;
+                "Keyword #", hduptr.kwds[j as usize].kindex, ", ", CS(&kname),
+                " is not allowed in the array HDU.");
+            wrterr(out, &errmes, 1);
+            j += 1;
+        }
+    }
+
+    /* test datatype of reserved non-indexed floating point keywords */
+    for i in 0..nfltkeys {
+        let temp: &[c_char] = cast_slice(fltkeys[i].to_bytes_with_nul());
+        key_match(&tmpkwds, numusrkey, temp, 1, &mut k, &mut n);
+        if k < 0 {
+            continue;
+        }
+        j = k;
+        while j < k + n {
+            if check_flt(&hduptr.kwds[j as usize], out) == 0 {
+                j += 1;
+                continue;
+            }
+            j += 1;
+        }
+    }
+
+    /* test datatype of reserved non-indexed string keywords */
+    for i in 0..nstrkeys {
+        let temp: &[c_char] = cast_slice(strkeys[i].to_bytes_with_nul());
+        key_match(&tmpkwds, numusrkey, temp, 1, &mut k, &mut n);
+        if k < 0 {
+            continue;
+        }
+        j = k;
+        while j < k + n {
+            check_str(&hduptr.kwds[j as usize], out);
+            j += 1;
+        }
+    }
+}
+
+/*************************************************************
+*
+*      test_tbl
+*
+*   Test the table extension header and fill the tform, ttype,
+*   tunit.
+*
+*************************************************************/
+pub fn test_tbl(
+    _infits: &mut fitsfile, /* input fits file   */
+    out: Out,               /* output ascii file */
+    hduptr: &mut FitsHdu,   /* information about header */
+) {
+    let mut p: usize;
+    let mut m: c_int;
+    let mut n: c_int = 0;
+    let mut i: c_int;
+    let mut j: c_int;
+    let mut k: c_int = 0;
+    let mut w: c_long;
+    let mut d: c_long;
+    let mut e: c_long;
+    let mut lm: c_long;
+    let mcol: c_int;
+    let mut errmes: [c_char; ERRMES_LEN] = [0; ERRMES_LEN];
+
+    /* excluded, non-index keywords (allowed in tile-compressed images) */
+    let exlkey: [&std::ffi::CStr; 6] = [
+        c"BSCALE", c"BZERO", c"BUNIT", c"BLANK", c"DATAMAX", c"DATAMIN",
+    ];
+    let nexlkey = 6;
+
+    /* floating WCS keywords  */
+    let cfltkeys: [&std::ffi::CStr; 4] = [c"TCRVL", c"TCDLT", c"TCRPX", c"TCROT"];
+    let ncfltkeys = 4;
+
+    /* string WCS keywords  */
+    let cstrkeys: [&std::ffi::CStr; 2] = [c"TCTYP", c"TCUNI"];
+    let ncstrkeys = 2;
+
+    let numusrkey = hduptr.tkeys;
+    mcol = hduptr.ncols;
+    let tmpkwds = tmpkwds_get();
+
+    'otherkey: {
+        if mcol <= 0 {
+            break 'otherkey;
+        }
+        /* set the ttype, ttform, tunit for tables */
+        TTYPE.with(|t| {
+            let mut t = t.borrow_mut();
+            t.clear();
+            t.resize(mcol as usize, vec![0]);
+        });
+        TFORM.with(|t| {
+            let mut t = t.borrow_mut();
+            t.clear();
+            t.resize(mcol as usize, vec![0]);
+        });
+        TUNIT.with(|t| {
+            let mut t = t.borrow_mut();
+            t.clear();
+            t.resize(mcol as usize, vec![0]);
+        });
+
+        key_match(&tmpkwds, numusrkey, cs!(c"TFIELDS"), 1, &mut k, &mut n);
+        if k >= 0 {
+            check_fixed_int(&card_at(hduptr.kwds[k as usize].kindex as usize - 1), out);
+        }
+
+        key_match(&tmpkwds, numusrkey, cs!(c"TTYPE"), 0, &mut k, &mut n);
+        j = k;
+        while j < k + n {
+            let kindex = hduptr.kwds[j as usize].kindex;
+            let kname = hduptr.kwds[j as usize].kname;
+            let kvalue = hduptr.kwds[j as usize].kvalue;
+            p = 5;
+            if !isdigit_c(kname[p]) {
+                j += 1;
+                continue;
+            }
+
+            check_str(&hduptr.kwds[j as usize], out);
+            i = strtol_c(&kname[p..]).0 as c_int - 1;
+            if i >= 0 && i < mcol {
+                TTYPE.with(|t| t.borrow_mut()[i as usize] = cvec(&kvalue));
+            } else {
+                spf!(errmes;
+                    "Keyword #", kindex, ", ", CS(&kname), ": invalid index ", i + 1,
+                    " (> TFIELD = ", mcol, ").");
+                wrterr(out, &errmes, 2);
+            }
+            j += 1;
+        }
+
+        key_match(&tmpkwds, numusrkey, cs!(c"TFORM"), 0, &mut k, &mut n);
+        j = k;
+        while j < k + n {
+            let kindex = hduptr.kwds[j as usize].kindex;
+            let kname = hduptr.kwds[j as usize].kname;
+            let kvalue = hduptr.kwds[j as usize].kvalue;
+            p = 5;
+            if !isdigit_c(kname[p]) {
+                j += 1;
+                continue;
+            }
+
+            check_str(&hduptr.kwds[j as usize], out);
+
+            /*  TFORMn keyword no longer required to be padded to at least 8 characters
+                    check_fixed_str(cards[pkey->kindex - 1], out);
+            */
+
+            if kvalue[0] as u8 == b' ' {
+                spf!(errmes;
+                    "Keyword #", kindex, ", ", CS(&kname), ": TFORM=\"", CS(&kvalue), "\" ");
+                scat!(errmes; "should not have leading space.");
+                wrterr(out, &errmes, 1);
+            }
+
+            i = strtol_c(&kname[p..]).0 as c_int - 1;
+            if i >= 0 && i < mcol {
+                TFORM.with(|t| t.borrow_mut()[i as usize] = cvec(&kvalue));
+            } else {
+                spf!(errmes;
+                    "Keyword #", kindex, ", ", CS(&kname), ": invalid index ", i + 1,
+                    " (> TFIELD = ", mcol, ").");
+                wrterr(out, &errmes, 2);
+            }
+
+            p = 0;
+            while kvalue[p] as u8 != b' ' && kvalue[p] != 0 {
+                let c = kvalue[p] as u8;
+                if !c.is_ascii_digit()
+                    && !isupper_c(kvalue[p])
+                    && c != b'.'
+                    && c != b')'
+                    && c != b'('
+                {
+                    spf!(errmes;
+                        "Keyword #", kindex, ", ", CS(&kname), ": The value ", CS(&kvalue),
+                        " has character ", CHR(kvalue[p]),
+                        " which is not uppercase letter.");
+                    wrterr(out, &errmes, 1);
+                }
+
+                p += 1;
+            }
+            j += 1;
+        }
+
+        key_match(&tmpkwds, numusrkey, cs!(c"TUNIT"), 0, &mut k, &mut n);
+        j = k;
+        while j < k + n {
+            let kindex = hduptr.kwds[j as usize].kindex;
+            let kname = hduptr.kwds[j as usize].kname;
+            let kvalue = hduptr.kwds[j as usize].kvalue;
+            p = 5;
+            if !isdigit_c(kname[p]) {
+                j += 1;
+                continue;
+            }
+
+            check_str(&hduptr.kwds[j as usize], out);
+            i = strtol_c(&kname[p..]).0 as c_int - 1;
+            if i >= 0 && i < mcol {
+                TUNIT.with(|t| t.borrow_mut()[i as usize] = cvec(&kvalue));
+            } else {
+                spf!(errmes;
+                    "Keyword #", kindex, ", ", CS(&kname), ": invalid index ", i + 1,
+                    " (> TFIELD = ", mcol, ").");
+                wrterr(out, &errmes, 1);
+            }
+            j += 1;
+        }
+
+        /*  Check TDISPn keywords */
+        key_match(&tmpkwds, numusrkey, cs!(c"TDISP"), 0, &mut k, &mut n);
+        j = k;
+        while j < k + n {
+            let kindex = hduptr.kwds[j as usize].kindex;
+            let kname = hduptr.kwds[j as usize].kname;
+            let kvalue = hduptr.kwds[j as usize].kvalue;
+            p = 5;
+            if !isdigit_c(kname[p]) {
+                j += 1;
+                continue;
+            }
+
+            if kvalue[0] == 0 {
+                j += 1;
+                continue;
+            } /* ignore blank string */
+            check_str(&hduptr.kwds[j as usize], out);
+            if kvalue[0] as u8 == b' ' {
+                spf!(errmes;
+                    "Keyword #", kindex, ", ", CS(&kname), ": TDISP=\"", CS(&kvalue), "\" ");
+                scat!(errmes; "should not have leading space.");
+                wrterr(out, &errmes, 1);
+            }
+
+            i = strtol_c(&kname[p..]).0 as c_int - 1;
+            if i < 0 || i >= mcol {
+                spf!(errmes;
+                    "Keyword #", kindex, ", ", CS(&kname), ": invalid index ", i + 1,
+                    " (> TFIELD = ", mcol, ").");
+                wrterr(out, &errmes, 1);
+                j += 1;
+                continue;
+            }
+            let tf = tform_at(i as usize);
+            p = 0;
+            match kvalue[p] as u8 {
+                b'A' => {
+                    p += 1;
+                    w = strtol_c(&kvalue[p..]).0;
+                    if w == 0 || w == c_long::MAX || w == c_long::MIN {
+                        spf!(errmes;
+                            "Keyword #", kindex, ", ", CS(&kname), ": invalid format \"",
+                            CS(&kvalue), "\".");
+                        wrterr(out, &errmes, 1);
+                    }
+                    if !chr_in(&tf, b'A') {
+                        spf!(errmes;
+                            "Keyword #", kindex, ", ", CS(&kname), ":  Format \"", CS(&kvalue),
+                            "\" cannot be used for TFORM \"", CS(&tf), "\".");
+                        wrterr(out, &errmes, 1);
+                    }
+                }
+                b'L' => {
+                    p += 1;
+                    w = strtol_c(&kvalue[p..]).0;
+                    if w == 0 || w == c_long::MAX || w == c_long::MIN {
+                        spf!(errmes;
+                            "Keyword #", kindex, ", ", CS(&kname), ": invalid format \"",
+                            CS(&kvalue), "\".");
+                        wrterr(out, &errmes, 1);
+                    }
+                    if !chr_in(&tf, b'L') {
+                        spf!(errmes;
+                            "Keyword #", kindex, ", ", CS(&kname), ":  Format ", CS(&kvalue),
+                            " cannot be used for TFORM \"", CS(&tf), "\".");
+                        wrterr(out, &errmes, 1);
+                    }
+                }
+                b'I' | b'B' | b'O' | b'Z' => {
+                    p += 1;
+                    w = strtol_c(&kvalue[p..]).0;
+                    if let Some(q) = chr_pos(&kvalue[p..], b'.') {
+                        p += q;
+                        p += 1;
+                        lm = strtol_c(&kvalue[p..]).0;
+                    } else {
+                        lm = -1; /* no minimum digit field */
+                    }
+                    if w == 0
+                        || w == c_long::MAX
+                        || w == c_long::MIN
+                        || lm == c_long::MAX
+                        || lm == c_long::MIN
+                        || w < lm
+                    {
+                        spf!(errmes;
+                            "Keyword #", kindex, ", ", CS(&kname), ": invalid format \"",
+                            CS(&kvalue), "\".");
+                        wrterr(out, &errmes, 1);
+                    }
+                    if !chr_in(&tf, b'I')
+                        && !chr_in(&tf, b'J')
+                        && !chr_in(&tf, b'K')
+                        && !chr_in(&tf, b'B')
+                        && !chr_in(&tf, b'X')
+                    {
+                        spf!(errmes;
+                            "Keyword #", kindex, ", ", CS(&kname), ":  Format \"", CS(&kvalue),
+                            "\" cannot be used for TFORM \"", CS(&tf), "\".");
+                        wrterr(out, &errmes, 1);
+                    }
+                }
+                b'F' => {
+                    p += 1;
+                    d = -1;
+                    w = strtol_c(&kvalue[p..]).0;
+                    if let Some(q) = chr_pos(&kvalue[p..], b'.') {
+                        p += q;
+                        p += 1;
+                        d = strtol_c(&kvalue[p..]).0;
+                    }
+                    if w == 0
+                        || w == c_long::MAX
+                        || w == c_long::MIN
+                        || d == -1
+                        || d == c_long::MAX
+                        || d == c_long::MIN
+                        || w < d + 1
+                    {
+                        spf!(errmes;
+                            "Keyword #", kindex, ", ", CS(&kname), ": invalid format \"",
+                            CS(&kvalue), "\".");
+                        wrterr(out, &errmes, 1);
+                    }
+                    if !chr_in(&tf, b'E')
+                        && !chr_in(&tf, b'F')
+                        && !chr_in(&tf, b'C')
+                        && !chr_in(&tf, b'D')
+                        && !chr_in(&tf, b'M')
+                        && !chr_in(&tf, b'I')
+                        && !chr_in(&tf, b'J')
+                        && !chr_in(&tf, b'K')
+                        && !chr_in(&tf, b'B')
+                        && !chr_in(&tf, b'X')
+                    {
+                        spf!(errmes;
+                            "Keyword #", kindex, ", ", CS(&kname), ":  Format \"", CS(&kvalue),
+                            "\" cannot be used for TFORM \"", CS(&tf), "\".");
+                        wrterr(out, &errmes, 1);
+                    }
+                }
+                b'E' | b'D' => {
+                    p += 1;
+                    d = 0;
+                    if kvalue[p] as u8 == b'N' || kvalue[p] as u8 == b'S' {
+                        p += 1;
+                    }
+                    w = strtol_c(&kvalue[p..]).0;
+                    if let Some(q) = chr_pos(&kvalue[p..], b'.') {
+                        p += q;
+                        p += 1;
+                        d = strtol_c(&kvalue[p..]).0;
+                    }
+                    if let Some(q) = chr_pos(&kvalue[p..], b'E') {
+                        p += q;
+                        p += 1;
+                        e = strtol_c(&kvalue[p..]).0;
+                    } else {
+                        e = 2;
+                    }
+                    if w == 0
+                        || w == c_long::MAX
+                        || w == c_long::MIN
+                        || d == 0
+                        || d == c_long::MAX
+                        || d == c_long::MIN
+                        || e == 0
+                        || e == c_long::MAX
+                        || e == c_long::MIN
+                        || w < d + e + 3
+                    {
+                        spf!(errmes;
+                            "Keyword #", kindex, ", ", CS(&kname), ": invalid format \"",
+                            CS(&kvalue), "\".");
+                        wrterr(out, &errmes, 1);
+                    }
+                    if !chr_in(&tf, b'E')
+                        && !chr_in(&tf, b'F')
+                        && !chr_in(&tf, b'C')
+                        && !chr_in(&tf, b'D')
+                        && !chr_in(&tf, b'M')
+                        && !chr_in(&tf, b'I')
+                        && !chr_in(&tf, b'J')
+                        && !chr_in(&tf, b'K')
+                        && !chr_in(&tf, b'B')
+                        && !chr_in(&tf, b'X')
+                    {
+                        spf!(errmes;
+                            "Keyword #", kindex, ", ", CS(&kname), ":  Format \"", CS(&kvalue),
+                            "\" cannot be used for TFORM \"", CS(&tf), "\".");
+                        wrterr(out, &errmes, 1);
+                    }
+                }
+                b'G' => {
+                    p += 1;
+                    d = 0;
+                    w = strtol_c(&kvalue[p..]).0;
+                    if let Some(q) = chr_pos(&kvalue[p..], b'.') {
+                        p += q;
+                        p += 1;
+                        d = strtol_c(&kvalue[p..]).0;
+                    }
+                    if let Some(q) = chr_pos(&kvalue[p..], b'E') {
+                        p += q;
+                        p += 1;
+                        e = strtol_c(&kvalue[p..]).0;
+                    } else {
+                        e = 2;
+                    }
+                    if w == 0
+                        || w == c_long::MAX
+                        || w == c_long::MIN
+                        || d == 0
+                        || d == c_long::MAX
+                        || d == c_long::MIN
+                        || e == 0
+                        || e == c_long::MAX
+                        || e == c_long::MIN
+                    {
+                        spf!(errmes;
+                            "Keyword #", kindex, ", ", CS(&kname), ": invalid format \"",
+                            CS(&kvalue), "\".");
+                        wrterr(out, &errmes, 1);
+                    }
+                }
+                _ => {
+                    spf!(errmes;
+                        "Keyword #", kindex, ", ", CS(&kname), ": invalid format \"",
+                        CS(&kvalue), "\".");
+                    wrterr(out, &errmes, 1);
+                }
+            }
+            j += 1;
+        }
+    }
+
+    /* OTHERKEY: */
+    if hduptr.istilecompressed == 0 {
+        /* tile compressed images can have these keywords */
+        for i in 0..nexlkey {
+            let temp: &[c_char] = cast_slice(exlkey[i].to_bytes_with_nul());
+            key_match(&tmpkwds, numusrkey, temp, 1, &mut k, &mut n);
+            if k > -1 {
+                spf!(errmes;
+                    "Keyword #", hduptr.kwds[k as usize].kindex, ", ",
+                    CS(&hduptr.kwds[k as usize].kname),
+                    " is not allowed in the Bin/ASCII table.");
+                wrterr(out, &errmes, 1);
+            }
+        }
+
+        /* these WCS keywords are all allowed (changed July 2010) */
+    }
+
+    /* test datatype of reserved indexed floating point WCS keywords */
+    for i in 0..ncfltkeys {
+        let temp: &[c_char] = cast_slice(cfltkeys[i].to_bytes_with_nul());
+        key_match(&tmpkwds, numusrkey, temp, 0, &mut k, &mut n);
+        if k < 0 {
+            continue;
+        }
+
+        j = k;
+        while j < k + n {
+            let kindex = hduptr.kwds[j as usize].kindex;
+            let kname = hduptr.kwds[j as usize].kname;
+
+            p = cstrlen(temp);
+            if !isdigit_c(kname[p]) {
+                j += 1;
+                continue;
+            }
+
+            if check_flt(&hduptr.kwds[j as usize], out) == 0 {
+                j += 1;
+                continue;
+            }
+
+            m = strtol_c(&kname[p..]).0 as c_int;
+            if m < 1 || m > mcol {
+                spf!(errmes;
+                    "Keyword #", kindex, ", ", CS(&kname), ": index ", m,
+                    " is not in range 1-", mcol, " (TFIELD).");
+                wrterr(out, &errmes, 1);
+            }
+            j += 1;
+        }
+    }
+
+    /* test datatype of reserved indexed string WCS keywords */
+    for i in 0..ncstrkeys {
+        let temp: &[c_char] = cast_slice(cstrkeys[i].to_bytes_with_nul());
+        key_match(&tmpkwds, numusrkey, temp, 0, &mut k, &mut n);
+        if k < 0 {
+            continue;
+        }
+
+        j = k;
+        while j < k + n {
+            let kindex = hduptr.kwds[j as usize].kindex;
+            let kname = hduptr.kwds[j as usize].kname;
+
+            p = cstrlen(temp);
+            if !isdigit_c(kname[p]) {
+                j += 1;
+                continue;
+            }
+
+            if check_str(&hduptr.kwds[j as usize], out) == 0 {
+                j += 1;
+                continue;
+            }
+
+            m = strtol_c(&kname[p..]).0 as c_int;
+            if m < 1 || m > mcol {
+                spf!(errmes;
+                    "Keyword #", kindex, ", ", CS(&kname), ": index ", m,
+                    " is not in range 1-", mcol, " (TFIELD).");
+                wrterr(out, &errmes, 1);
+            }
+            j += 1;
+        }
+    }
+}
+
+/*************************************************************
+*
+*      test_asc_ext
+*
+*   Test the ascii table extension header
+*
+*************************************************************/
+pub fn test_asc_ext(
+    infits: &mut fitsfile, /* input fits file   */
+    out: Out,              /* output ascii file */
+    hduptr: &mut FitsHdu,  /* information about header */
+) {
+    let mut p: usize;
+    let mut i: c_int;
+    let mut j: c_int;
+    let mut k: c_int = 0;
+    let mut n: c_int = 0;
+    let mcol: c_int;
+    let mut errmes: [c_char; ERRMES_LEN] = [0; ERRMES_LEN];
+
+    let numusrkey = hduptr.tkeys;
+    mcol = hduptr.ncols;
+
+    /* The XTENSION, BITPIX, NAXIS, NAXISn, TFIELDS, PCOUNT, GCOUNT, TFORMn,
+       TBCOLn, TTYPEn keywords  have been checked in CFITSIO */
+
+    /* General extension */
+    test_ext(infits, out, hduptr);
+
+    /* general table */
+    test_tbl(infits, out, hduptr);
+
+    let tmpkwds = tmpkwds_get();
+
+    /* Check TBCOLn */
+    key_match(&tmpkwds, numusrkey, cs!(c"TBCOL"), 0, &mut k, &mut n);
+    j = k;
+    while j < k + n {
+        let kindex = hduptr.kwds[j as usize].kindex;
+        let kname = hduptr.kwds[j as usize].kname;
+        p = 5;
+        if !isdigit_c(kname[p]) {
+            j += 1;
+            continue;
+        }
+
+        check_int(&hduptr.kwds[j as usize], out);
+
+        i = strtol_c(&kname[p..]).0 as c_int;
+        if i < 0 || i > mcol {
+            spf!(errmes;
+                "Keyword #", kindex, ", ", CS(&kname), ": invalid index ", i,
+                " (> TFIELD = ", mcol, ").");
+            wrterr(out, &errmes, 1);
+        } else {
+            check_fixed_int(&card_at(kindex as usize - 1), out);
+        }
+        j += 1;
+    }
+
+    /*  Check TNULLn, TSCALn, and TZEORn keywords */
+    key_match(&tmpkwds, numusrkey, cs!(c"TNULL"), 0, &mut k, &mut n);
+    j = k;
+    while j < k + n {
+        let kindex = hduptr.kwds[j as usize].kindex;
+        let kname = hduptr.kwds[j as usize].kname;
+        p = 5;
+        if !isdigit_c(kname[p]) {
+            j += 1;
+            continue;
+        }
+        i = strtol_c(&kname[p..]).0 as c_int - 1;
+        if i < 0 || i >= mcol {
+            spf!(errmes;
+                "Keyword #", kindex, ", ", CS(&kname), ": invalid index ", i + 1,
+                " (> TFIELD = ", mcol, ").");
+            wrterr(out, &errmes, 1);
+        }
+        check_str(&hduptr.kwds[j as usize], out);
+        j += 1;
+    }
+
+    key_match(&tmpkwds, numusrkey, cs!(c"TSCAL"), 0, &mut k, &mut n);
+    j = k;
+    while j < k + n {
+        let kindex = hduptr.kwds[j as usize].kindex;
+        let kname = hduptr.kwds[j as usize].kname;
+        p = 5;
+        if !isdigit_c(kname[p]) {
+            j += 1;
+            continue;
+        }
+        i = strtol_c(&kname[p..]).0 as c_int - 1;
+        if check_flt(&hduptr.kwds[j as usize], out) != 0
+            && strtod_c(&hduptr.kwds[j as usize].kvalue) == 0.0
+        {
+            spf!(errmes; "Keyword #", kindex, ", ", CS(&kname), ": Scaling factor is zero.");
+            wrtwrn(out, &errmes, 0);
+        }
+        if i < 0 || i >= mcol {
+            spf!(errmes;
+                "Keyword #", kindex, ", ", CS(&kname), ": invalid index ", i + 1,
+                " (> TFIELD = ", mcol, ").");
+            wrterr(out, &errmes, 1);
+            j += 1;
+            continue;
+        }
+        if chr_in(&tform_at(i as usize), b'A') {
+            spf!(errmes;
+                "Keyword #", kindex, ", ", CS(&kname),
+                " may not be used for the A-format fields.");
+            wrterr(out, &errmes, 1);
+        }
+        j += 1;
+    }
+
+    key_match(&tmpkwds, numusrkey, cs!(c"TZERO"), 0, &mut k, &mut n);
+    j = k;
+    while j < k + n {
+        let kindex = hduptr.kwds[j as usize].kindex;
+        let kname = hduptr.kwds[j as usize].kname;
+        p = 5;
+        if !isdigit_c(kname[p]) {
+            j += 1;
+            continue;
+        }
+        check_flt(&hduptr.kwds[j as usize], out);
+        i = strtol_c(&kname[p..]).0 as c_int - 1;
+        if i < 0 || i >= mcol {
+            spf!(errmes;
+                "Keyword #", kindex, ", ", CS(&kname), ": invalid index ", i + 1,
+                " (> TFIELD = ", mcol, ").");
+            wrterr(out, &errmes, 1);
+            j += 1;
+            continue;
+        }
+        if chr_in(&tform_at(i as usize), b'A') {
+            spf!(errmes;
+                "Keyword #", kindex, ", ", CS(&kname),
+                " may not be used for the A-format fields.");
+            wrterr(out, &errmes, 1);
+        }
+        j += 1;
+    }
+
+    key_match(&tmpkwds, numusrkey, cs!(c"TDIM"), 0, &mut k, &mut n);
+    j = k;
+    while j < k + n {
+        let kname = hduptr.kwds[j as usize].kname;
+        p = 4;
+        if !isdigit_c(kname[p]) {
+            j += 1;
+            continue;
+        }
+
+        spf!(errmes;
+            "Keyword #", hduptr.kwds[j as usize].kindex, ", ", CS(&kname),
+            " is not allowed in the ASCII table.");
+        wrterr(out, &errmes, 1);
+        j += 1;
+    }
+
+    key_match(&tmpkwds, numusrkey, cs!(c"THEAP"), 1, &mut k, &mut n);
+    if k > -1 {
+        spf!(errmes;
+            "Keyword #", hduptr.kwds[k as usize].kindex, ", ",
+            CS(&hduptr.kwds[k as usize].kname), " is not allowed in the ASCII table.");
+        wrterr(out, &errmes, 1);
+    }
+
+    /* check whether the column name is unique  */
+    test_colnam(out, hduptr);
+}
+
+/*************************************************************
+*
+*      test_bin_ext
+*
+*   Test the binary table extension header
+*
+*************************************************************/
+pub fn test_bin_ext(
+    infits: &mut fitsfile, /* input fits file   */
+    out: Out,              /* output ascii file */
+    hduptr: &mut FitsHdu,  /* information about header */
+) {
+    let mut i: c_int;
+    let mut j: c_int;
+    let mut k: c_int = 0;
+    let mut n: c_int = 0;
+    let mut l: c_long;
+    let mut status: c_int = 0;
+    let mut p: usize;
+
+    let mut ntdim: c_int = 0;
+    let mut tdim: [c_long; 10] = [0; 10];
+    let mut repeat: c_int;
+    let mut width: c_int;
+    let mcol: c_int;
+    let mut vla: c_int;
+    let mut datatype: c_int = 0;
+    let mut errmes: [c_char; ERRMES_LEN] = [0; ERRMES_LEN];
+
+    /* The indexed keywords excluded from ascii table */
+    let exlkeys: [&std::ffi::CStr; 1] = [c"TBCOL"];
+    let nexlkeys = 1;
+
+    let numusrkey = hduptr.tkeys;
+    mcol = hduptr.ncols;
+
+    /* General extension */
+    test_ext(infits, out, hduptr);
+
+    /* General table */
+    test_tbl(infits, out, hduptr);
+
+    let tmpkwds = tmpkwds_get();
+
+    /* The XTENSION, BITPIX, NAXIS, NAXISn, TFIELDS, PCOUNT, GCOUNT, TFORMn,
+       TTYPEn keywords  have been checked in CFITSIO */
+
+    /*  Check TNULLn keywords */
+    key_match(&tmpkwds, numusrkey, cs!(c"TNULL"), 0, &mut k, &mut n);
+    j = k;
+    while j < k + n {
+        let kindex = hduptr.kwds[j as usize].kindex;
+        let kname = hduptr.kwds[j as usize].kname;
+        let kvalue = hduptr.kwds[j as usize].kvalue;
+        p = 5;
+        if !isdigit_c(kname[p]) {
+            j += 1;
+            continue;
+        }
+        check_int(&hduptr.kwds[j as usize], out);
+        i = strtol_c(&kname[p..]).0 as c_int - 1;
+        if i < 0 || i >= mcol {
+            spf!(errmes;
+                "Keyword #", kindex, ", ", CS(&kname), ": invalid index ", i + 1,
+                " (> TFIELD = ", mcol, ").");
+            wrterr(out, &errmes, 1);
+            j += 1;
+            continue;
+        }
+        let tf = tform_at(i as usize);
+        if !chr_in(&tf, b'B') && !chr_in(&tf, b'I') && !chr_in(&tf, b'J') && !chr_in(&tf, b'K') {
+            spf!(errmes;
+                "Keyword #", kindex, ", ", CS(&kname),
+                " is used for the column with format \"", CS(&tf), " \".");
+            wrterr(out, &errmes, 2);
+        }
+        l = strtol_c(&kvalue).0;
+        if chr_in(&tf, b'B') && (l < 0 || l > 255) {
+            spf!(errmes; "Keyword #", kindex, ", ", CS(&kname), ": The value ", l as i64);
+            scat!(errmes; " is not in the range of datatype B.");
+            wrtwrn(out, &errmes, 0);
+        }
+        l = strtol_c(&kvalue).0;
+        if chr_in(&tf, b'I') && (l < -32768 || l > 32767) {
+            spf!(errmes; "Keyword #", kindex, ", ", CS(&kname), ": The value ", l as i64);
+            scat!(errmes; " is not in the range of datatype I ");
+            wrtwrn(out, &errmes, 0);
+        }
+        j += 1;
+    }
+
+    /*  Check TSCALn keywords */
+    key_match(&tmpkwds, numusrkey, cs!(c"TSCAL"), 0, &mut k, &mut n);
+    j = k;
+    while j < k + n {
+        let kindex = hduptr.kwds[j as usize].kindex;
+        let kname = hduptr.kwds[j as usize].kname;
+        p = 5;
+        if !isdigit_c(kname[p]) {
+            j += 1;
+            continue;
+        }
+        if check_flt(&hduptr.kwds[j as usize], out) != 0
+            && strtod_c(&hduptr.kwds[j as usize].kvalue) == 0.0
+        {
+            spf!(errmes; "Keyword #", kindex, ", ", CS(&kname), ":");
+            scat!(errmes; "The scaling factor is zero.");
+            wrtwrn(out, &errmes, 0);
+        }
+        i = strtol_c(&kname[p..]).0 as c_int - 1;
+        if i < 0 || i >= mcol {
+            spf!(errmes;
+                "Keyword #", kindex, ", ", CS(&kname), ": invalid index ", i + 1,
+                " (> TFIELD = ", mcol, ").");
+            wrterr(out, &errmes, 1);
+            j += 1;
+            continue;
+        }
+        let tf = tform_at(i as usize);
+        if chr_in(&tf, b'A') || chr_in(&tf, b'L') || chr_in(&tf, b'X') {
+            spf!(errmes;
+                "Keyword #", kindex, ", ", CS(&kname), " is used in A, L, or X column. ");
+            wrterr(out, &errmes, 1);
+        }
+        j += 1;
+    }
+
+    /*  Check TZEROn keywords */
+    key_match(&tmpkwds, numusrkey, cs!(c"TZERO"), 0, &mut k, &mut n);
+    j = k;
+    while j < k + n {
+        let kindex = hduptr.kwds[j as usize].kindex;
+        let kname = hduptr.kwds[j as usize].kname;
+        p = 5;
+        if !isdigit_c(kname[p]) {
+            j += 1;
+            continue;
+        }
+        check_flt(&hduptr.kwds[j as usize], out);
+        i = strtol_c(&kname[p..]).0 as c_int - 1;
+        if i < 0 || i >= mcol {
+            spf!(errmes;
+                "Keyword #", kindex, ", ", CS(&kname), ": invalid index ", i + 1,
+                " (> TFIELD = ", mcol, ").");
+            wrterr(out, &errmes, 1);
+            j += 1;
+            continue;
+        }
+        let tf = tform_at(i as usize);
+        if chr_in(&tf, b'A') && chr_in(&tf, b'L') && chr_in(&tf, b'X') {
+            spf!(errmes;
+                "Keyword #", kindex, ", ", CS(&kname), " is used in A, L, or X column. ");
+            wrterr(out, &errmes, 1);
+        }
+        j += 1;
+    }
+
+    /* Check THEAP keyword */
+    /* The C indexes naxes[0] and naxes[1] unconditionally; a corrupt header
+       with NAXIS < 2 makes that an out-of-bounds read, so missing axes read
+       as 0 here rather than as whatever happened to be on the stack. */
+    let naxes0 = hduptr.naxes.first().copied().unwrap_or(0);
+    let naxes1 = hduptr.naxes.get(1).copied().unwrap_or(0);
+    hduptr.heap = (naxes0 * naxes1) as c_int;
+    key_match(&tmpkwds, numusrkey, cs!(c"THEAP"), 1, &mut k, &mut n);
+    if k > -1 {
+        if check_int(&hduptr.kwds[k as usize], out) != 0 {
+            hduptr.heap = strtol_c(&hduptr.kwds[k as usize].kvalue).0 as c_int;
+        }
+        if hduptr.pcount == 0 {
+            spf!(errmes;
+                "Pcount is zero, but keyword THEAP is present at record #",
+                hduptr.kwds[k as usize].kindex, "). ");
+            wrterr(out, &errmes, 1);
+        }
+    }
+
+    /* if PCOUNT != 0, test that there is at least 1 variable length array column */
+    vla = 0;
+    if hduptr.pcount != 0 {
+        for i in 0..mcol {
+            if fits_get_coltype(infits, i + 1, Some(&mut datatype), None, None, &mut status) != 0 {
+                spf!(errmes; "Column #", i, ": ");
+                wrtferr(out, &errmes, &mut status, 2);
+            }
+            if datatype < 0 {
+                vla = 1;
+                break;
+            }
+        }
+
+        if vla == 0 {
+            spf!(errmes;
+                "PCOUNT = ", hduptr.pcount as i64,
+                ", but there are no variable-length array columns.");
+            wrtwrn(out, &errmes, 0);
+        }
+    }
+
+    /* Check TDIMn  keywords */
+    key_match(&tmpkwds, numusrkey, cs!(c"TDIM"), 0, &mut k, &mut n);
+    j = k;
+    while j < k + n {
+        let kindex = hduptr.kwds[j as usize].kindex;
+        let kname = hduptr.kwds[j as usize].kname;
+        let kvalue = hduptr.kwds[j as usize].kvalue;
+        p = 4;
+        if !isdigit_c(kname[p]) {
+            j += 1;
+            continue;
+        }
+        check_str(&hduptr.kwds[j as usize], out);
+        if kvalue[0] as u8 == b' ' {
+            spf!(errmes;
+                "Keyword #", kindex, ", ", CS(&kname), ": TDIM=\"", CS(&kvalue), "\" ");
+            scat!(errmes; "should not have leading space.");
+            wrterr(out, &errmes, 1);
+            j += 1;
+            continue;
+        }
+        i = strtol_c(&kname[p..]).0 as c_int - 1;
+        if i < 0 || i >= mcol {
+            spf!(errmes;
+                "Keyword #", kindex, ", ", CS(&kname), ": invalid index ", i + 1,
+                " (> TFIELD = ", mcol, ").");
+            wrterr(out, &errmes, 1);
+            j += 1;
+            continue;
+        }
+        if fits_decode_tdim(
+            infits,
+            &kvalue,
+            i + 1,
+            10,
+            &mut ntdim,
+            &mut tdim,
+            &mut status,
+        ) != 0
+        {
+            spf!(errmes; "Keyword #", kindex, ", ", CS(&kname), ": ");
+            wrtferr(out, &errmes, &mut status, 1);
+        }
+        j += 1;
+    }
+
+    /* check the local convension "rAw"*/
+    for i in 0..hduptr.ncols {
+        let tf = tform_at(i as usize);
+        let ap = match chr_pos(&tf, b'A') {
+            Some(o) => o,
+            None => continue,
+        };
+        repeat = strtol_c(&tf).0 as c_int;
+        let p = ap + 1;
+        if !isdigit_c(tf[p]) {
+            continue;
+        }
+        width = strtol_c(&tf[p..]).0 as c_int;
+        if width != 0 && repeat % width != 0 {
+            spf!(errmes;
+                "TFORM ", CS(&tf), " of column ", i + 1, ": repeat ", repeat,
+                " is not the multiple of the width ", width);
+            wrtwrn(out, &errmes, 0);
+        }
+    }
+
+    for i in 0..nexlkeys {
+        let temp: &[c_char] = cast_slice(exlkeys[i].to_bytes_with_nul());
+        key_match(&tmpkwds, numusrkey, temp, 0, &mut k, &mut n);
+        if k < 0 {
+            continue;
+        }
+        j = k;
+        while j < k + n {
+            let kname = hduptr.kwds[j as usize].kname;
+            p = cstrlen(temp);
+            if !isdigit_c(kname[p]) {
+                j += 1;
+                continue;
+            }
+
+            spf!(errmes;
+                "Keyword #", hduptr.kwds[j as usize].kindex, ", ", CS(&kname),
+                " is not allowed in the Binary table.");
+            wrterr(out, &errmes, 1);
+            j += 1;
+        }
+    }
+
+    /* check whether the column name is unique */
+    test_colnam(out, hduptr);
+}
+
+/*************************************************************
+*
+*      test_header
+*
+*   Test the general keywords that can be in any header
+*
+*************************************************************/
+pub fn test_header(
+    _infits: &mut fitsfile, /* input fits file   */
+    out: Out,               /* output ascii file */
+    hduptr: &mut FitsHdu,   /* information about header  */
+) {
+    /* common mandatory  keywords */
+    let mandkey: [&std::ffi::CStr; 5] = [c"SIMPLE", c"BITPIX", c"NAXIS", c"XTENSION", c"END"];
+    let nmandkey = 5;
+
+    /* string keywords */
+    let strkey: [&std::ffi::CStr; 9] = [
+        c"EXTNAME", c"ORIGIN", c"AUTHOR", c"CREATOR", c"REFERENC", c"TELESCOP", c"INSTRUME",
+        c"OBSERVER", c"OBJECT",
+    ];
+    let nstrkey = 9;
+
+    /* int keywords  */
+    let intkey: [&std::ffi::CStr; 2] = [c"EXTVER", c"EXTLEVEL"];
+    let nintkey = 2;
+
+    /* floating keywords  */
+    let fltkey: [&std::ffi::CStr; 3] = [c"EQUINOX", c"MJD-OBS", c"MJD-AVG"];
+    let nfltkey = 3;
+
+    let mut j: c_int;
+    let mut k: c_int = 0;
+    let mut n: c_int = 0;
+    let mut lv: c_long;
+    let mut stat: rsfitsio::c_types::c_ulong = 0;
+    let mut vtemp: [c_char; 72] = [0; 72];
+    let mut status: c_int = 0;
+    let mut yr: c_int = 0;
+    let mut mn: c_int = 0;
+    let mut dy: c_int = 0;
+    let mut hr: c_int = 0;
+    let mut min: c_int = 0; /* time */
+    let mut sec: c_double = 0.0;
+    let mut yy: c_int;
+    let mut ktype = kwdtyp::UNKNOWN;
+    let mut errmes: [c_char; ERRMES_LEN] = [0; ERRMES_LEN];
+
+    let numusrkey = hduptr.tkeys;
+    let tmpkwds = tmpkwds_get();
+
+    /* Check the mandatory keywords */
+    for i in 0..nmandkey {
+        let pp: &[c_char] = cast_slice(mandkey[i].to_bytes_with_nul());
+        key_match(&tmpkwds, numusrkey, pp, 1, &mut k, &mut n);
+        if k > -1 {
+            j = k;
+            while j < k + n {
+                spf!(errmes;
+                    "Keyword #", hduptr.kwds[j as usize].kindex, ", ",
+                    CS(&hduptr.kwds[j as usize].kname), " is duplicated or out of order.");
+                wrterr(out, &errmes, 1);
+                j += 1;
+            }
+        }
+    }
+
+    /* check the NAXIS index keyword */
+    key_match(&tmpkwds, numusrkey, cs!(c"NAXIS"), 0, &mut k, &mut n);
+    j = k;
+    while j < k + n {
+        let kindex = hduptr.kwds[j as usize].kindex;
+        let kname = hduptr.kwds[j as usize].kname;
+        lv = strtol_c(&kname[5..]).0;
+        if lv > 0 {
+            if kindex as c_long != 3 + lv {
+                spf!(errmes;
+                    "Keyword #", kindex, ", ", CS(&kname), " is duplicated or out of order.");
+                wrterr(out, &errmes, 1);
+            }
+            if lv > hduptr.naxis as c_long {
+                spf!(errmes;
+                    "Keyword #", kindex, ", ", CS(&kname), " is not allowed (with n > NAXIS =",
+                    hduptr.naxis, ").");
+                wrterr(out, &errmes, 1);
+            }
+        }
+        j += 1;
+    }
+
+    /* Check the deprecated keywords */
+    key_match(&tmpkwds, numusrkey, cs!(c"EPOCH"), 1, &mut k, &mut n);
+    if k > -1 {
+        spf!(errmes;
+            "Keyword #", hduptr.kwds[k as usize].kindex, ", ",
+            CS(&hduptr.kwds[k as usize].kname), " is deprecated. Use EQUINOX instead.");
+        wrtwrn(out, &errmes, 0);
+        check_flt(&hduptr.kwds[k as usize], out);
+    }
+
+    /* Check the DATExxxx keyword */
+    key_match(&tmpkwds, numusrkey, cs!(c"DATE"), 0, &mut k, &mut n);
+    j = k;
+    while j < n + k {
+        let kindex = hduptr.kwds[j as usize].kindex;
+        let kname = hduptr.kwds[j as usize].kname;
+        let kvalue = hduptr.kwds[j as usize].kvalue;
+        check_str(&hduptr.kwds[j as usize], out);
+        if fits_str2time(
+            Some(&kvalue),
+            Some(&mut yr),
+            Some(&mut mn),
+            Some(&mut dy),
+            Some(&mut hr),
+            Some(&mut min),
+            Some(&mut sec),
+            &mut status,
+        ) != 0
+        {
+            spf!(errmes; "Keyword #", kindex, ", ", CS(&kname), ": ");
+            wrtserr(out, &errmes, &mut status, 1);
+        }
+        if let Some(o) = chr_pos(&kvalue, b'/') {
+            let pt = o + 4;
+            yy = strtol_c(&kvalue[pt..]).0 as c_int;
+            if (0..=10).contains(&yy) {
+                spf!(errmes;
+                    "Keyword #", kindex, ", ", CS(&kname), " ", CS(&kvalue),
+                    " intends to mean year 20", SW(&format!("{yy:02}"), -2, None), "?");
+                wrtwrn(out, &errmes, 0);
+            }
+        }
+        j += 1;
+    }
+
+    /* Check the reserved string keywords */
+    for i in 0..nstrkey {
+        let temp: &[c_char] = cast_slice(strkey[i].to_bytes_with_nul());
+        key_match(&tmpkwds, numusrkey, temp, 1, &mut k, &mut n);
+        if k > -1 {
+            check_str(&hduptr.kwds[k as usize], out);
+        }
+    }
+
+    /* Check the reserved int keywords */
+    for i in 0..nintkey {
+        let temp: &[c_char] = cast_slice(intkey[i].to_bytes_with_nul());
+        key_match(&tmpkwds, numusrkey, temp, 1, &mut k, &mut n);
+        if k > -1 {
+            check_int(&hduptr.kwds[k as usize], out);
+        }
+    }
+
+    /* Check  reserved floating  keywords */
+    for i in 0..nfltkey {
+        let temp: &[c_char] = cast_slice(fltkey[i].to_bytes_with_nul());
+        key_match(&tmpkwds, numusrkey, temp, 1, &mut k, &mut n);
+        if k > -1 {
+            check_flt(&hduptr.kwds[k as usize], out);
+        }
+    }
+
+    /* Check the duplication of the keywords */
+    for i in 0..(numusrkey - 1).max(0) as usize {
+        if strcmp_c(&tmpkwds[i], &tmpkwds[i + 1]) == 0
+            && strcmp_c(&hduptr.kwds[i].kname, cs!(c"HIERARCH")) != 0
+        {
+            spf!(errmes;
+                "Keyword ", CS(&hduptr.kwds[i].kname), " is duplicated in card #",
+                hduptr.kwds[i].kindex, " and card #", hduptr.kwds[i + 1].kindex, ".");
+            wrtwrn(out, &errmes, 0);
+        }
+    }
+
+    /* check the long string convention */
+    if hduptr.use_longstr == 1 {
+        key_match(&tmpkwds, numusrkey, cs!(c"LONGSTRN"), 1, &mut k, &mut n);
+        if k <= -1 {
+            spf!(errmes;
+                "The OGIP long string keyword convention is used without the recommended LONGSTRN keyword. ");
+            wrtwrn(out, &errmes, 1);
+        }
+    }
+
+    /* Check the HIERARCH keywords */
+    if testhierarch() != 0 {
+        key_match(&tmpkwds, numusrkey, cs!(c"HIERARCH"), 1, &mut k, &mut n);
+        j = k;
+        while j < n + k {
+            let i = (hduptr.kwds[j as usize].kindex - 1) as usize; /* index number of the keyword */
+            let cardi = card_at(i);
+
+            /* Must have a space character following "HIERARCH" */
+            if cardi[8] as u8 != b' ' {
+                spf!(errmes;
+                    "Keyword #", i + 1,
+                    ": does not have a space character in byte 9:               ",
+                    CSW(&cardi, 66, None));
+                wrterr(out, &errmes, 1);
+            }
+
+            /* Whether the characters in HIERARCH token names are valid */
+            let mut pt = 0usize;
+            while cardi[pt] != 0 {
+                if cardi[pt] as u8 == b'=' {
+                    /* look for the required "=" sign */
+                    break;
+                }
+
+                let c = cardi[pt] as u8;
+                if !c.is_ascii_uppercase()
+                    && !c.is_ascii_digit()
+                    && c != b'-'
+                    && c != b'_'
+                    && c != b' '
+                {
+                    spf!(errmes;
+                        "Keyword #", i + 1, ": token contains illegal char \"", CHR(cardi[pt]),
+                        "\" (only A-Z,0-9,-,_): ", CSW(&cardi, 66, None));
+                    wrterr(out, &errmes, 1);
+                    break;
+                }
+
+                pt += 1;
+            }
+
+            if cardi[pt] == 0 {
+                /* the "=" is not present on the card */
+                spf!(errmes;
+                    "Keyword #", i + 1,
+                    ": does not contain the \"=\" value indicator char:      ",
+                    CSW(&cardi, 66, None));
+                wrterr(out, &errmes, 1);
+            } else if cardi[pt] as u8 == b'=' {
+                /* now check that the keyword has a legal value */
+                pt += 1;
+                while isspace_c(cardi[pt]) && cardi[pt] != 0 {
+                    pt += 1;
+                }
+                match cardi[pt] as u8 {
+                    b'\'' => get_str(&cardi, &mut pt, &mut vtemp, &mut stat), /* string */
+                    b'T' | b'F' => get_log(&cardi, &mut pt, &mut vtemp, &mut stat), /*logical */
+                    /* number */
+                    b'+' | b'-' | b'.' | b'0'..=b'9' => {
+                        get_num(&cardi, &mut pt, &mut vtemp, &mut ktype, &mut stat)
+                    }
+                    b'(' => get_cmp(&cardi, &mut pt, &mut vtemp, &mut ktype, &mut stat), /* complex */
+                    b'/' => {} /* comment */
+                    _ => get_unknown(&cardi, &mut pt, &mut vtemp, &mut ktype, &mut stat),
+                }
+
+                pr_kval_err(out, i as c_int + 1, cs!(c"HIERARCH"), &vtemp, stat);
+                stat = 0; /* reset error status for next time */
+            } /* end of keyword value test */
+            j += 1;
+        } /* end of test of individual HIERARCH keywords */
+
+        /* now test for any duplicate HIERARCH keywords */
+        j = k;
+        while j < n + k - 1 {
+            /* loop over all the HIERARCH keywords except the last */
+
+            let i = (hduptr.kwds[j as usize].kindex - 1) as usize;
+            let cardi = card_at(i);
+            if chr_pos(&cardi, b'=').is_some() {
+                let mut jj = j + 1;
+                while jj < n + k {
+                    /* loop over any other HIERARCH keywords */
+                    let ii = (hduptr.kwds[jj as usize].kindex - 1) as usize;
+                    let cardii = card_at(ii);
+                    if chr_pos(&cardi, b'=').is_some() {
+                        /* compare names char by char, ignoring extra spaces */
+                        let mut p1 = 8usize; /*start at the end of the HIERARCH name */
+                        let mut p2 = 8usize;
+
+                        while cardi[p1] == cardii[p2] {
+                            /* chars are the same in both */
+                            if cardi[p1] as u8 == b' ' {
+                                /* this is a space char */
+
+                                /* skip over non-significant spaces in both name,
+                                then continue testing next chars */
+                                while cardi[p1] as u8 == b' ' {
+                                    p1 += 1;
+                                }
+                                while cardii[p2] as u8 == b' ' {
+                                    p2 += 1;
+                                }
+                            } else if cardi[p1] as u8 == b'=' {
+                                /* found '=' in both keywords */
+                                spf!(errmes;
+                                    "HIERARCH keyword name is duplicated in cards #", i + 1,
+                                    " and card #", ii + 1, ":   ", CSW(&cardi, 66, None));
+                                wrtwrn(out, &errmes, 0);
+                                p1 += 1; /* do this to prevent duplicate warning message, below */
+                                break;
+                            } else {
+                                p1 += 1;
+                                p2 += 1;
+                            }
+                        } /* end of identical chars test */
+
+                        /* chars are not identical */
+                        /* test for special case where one is a '=' and other
+                        non-significant spaces followed by '=' */
+                        /* first, skip over spaces in either name */
+                        while cardi[p1] as u8 == b' ' {
+                            p1 += 1;
+                        }
+                        while cardii[p2] as u8 == b' ' {
+                            p2 += 1;
+                        }
+
+                        if cardi[p1] as u8 == b'=' && cardii[p2] as u8 == b'=' {
+                            /* if we got here, then the names are the same except for
+                            non-significant spacing differences */
+                            spf!(errmes;
+                                "HIERARCH keyword name is duplicated in cards #", i + 1,
+                                " and card #", ii + 1, ":   ", CSW(&cardi, 66, None));
+                            wrtwrn(out, &errmes, 0);
+                            break;
+                        } else {
+                            /* these HIERARCH keywords do not have idential tokens */
+                            break;
+                        }
+                    } /* end of if second HIERARCH keyword has a '=' */
+                    #[allow(unreachable_code)]
+                    {
+                        jj += 1;
+                    }
+                } /* end of loop over other HIERARCH keywords */
+            } /* end of if first HIERARCH keyword has a '=' */
+            j += 1;
+        } /* end of loop over all HIERARCH keywords */
+    }
+
+    /*  disabled this routine because it doesn't perform an useful tests
+        test_img_wcs(infits, out, hduptr);
+    */
+}
+
+/*************************************************************
+*
+*      key_match
+*
+*   find the keywords whose name match the pattern. The keywords
+*   name is stored in a sorted array.
+*
+*************************************************************/
+pub fn key_match(
+    strs: &[[c_char; FLEN_KEYWORD]], /* fits keyname  array */
+    nstr: c_int,                     /* total number of keys */
+    pattern: &[c_char],              /* wanted pattern  */
+    exact: c_int,                    /* exact matching or pattern matching
+                                     exact = 1: exact matching.
+                                     exact = 0: pattern matching.
+                                     Any keywords with "patten"* is included
+                                     */
+    ikey: &mut c_int, /* The element number of first key
+                      Return -99 if not found */
+    mkey: &mut c_int, /* total number of key matched
+                      return -999 if not found */
+) {
+    let mut i: c_int;
+    let fnpt: fn(&[c_char], &[c_char]) -> c_int = if exact != 0 { compstre } else { compstrp };
+    *mkey = -999;
+    *ikey = -99;
+
+    /* bsearch(): glibc's binary search, so that the element it lands on for a
+       run of equal keys matches the C exactly. */
+    let mut l: c_int = 0;
+    let mut u: c_int = nstr;
+    let mut found: Option<c_int> = None;
+    while l < u {
+        let idx = (l + u) / 2;
+        let comparison = fnpt(pattern, &strs[idx as usize]);
+        if comparison < 0 {
+            u = idx;
+        } else if comparison > 0 {
+            l = idx + 1;
+        } else {
+            found = Some(idx);
+            break;
+        }
+    }
+
+    if let Some(pos) = found {
+        *mkey = 1;
+        *ikey = pos;
+        i = *ikey - 1;
+        let mut p = pos - 1;
+        while i > 0 && fnpt(pattern, &strs[p as usize]) == 0 {
+            *mkey += 1;
+            *ikey = i;
+            i -= 1;
+            p -= 1;
+        }
+        i = *ikey + *mkey;
+        let mut p = pos + 1;
+        while i < nstr && fnpt(pattern, &strs[p as usize]) == 0 {
+            *mkey += 1;
+            i += 1;
+            p += 1;
+        }
+    }
+}
+
+/*************************************************************
+*
+*      test_colnam
+*
+*   Test the whether the column name is unique.
+*
+*************************************************************/
+pub fn test_colnam(out: Out, hduptr: &FitsHdu) {
+    let n: c_int;
+    let mut errmes: [c_char; ERRMES_LEN] = [0; ERRMES_LEN];
+
+    n = hduptr.ncols;
+
+    if n <= 0 {
+        return;
+    }
+    /* make a local working copy of ttype */
+    let ttype: Vec<Vec<c_char>> = (0..n as usize).map(ttype_at).collect();
+    let mut ttypecopy: Vec<Vec<c_char>> = Vec::with_capacity(n as usize);
+    for i in 0..n as usize {
+        let mut b: Vec<c_char> = vec![0; FLEN_VALUE];
+        strcpy_c(&mut b, &ttype[i]);
+        ttypecopy.push(b);
+    }
+
+    /* check whether there are any other non ASCII-text characters
+      (FITS standard R14). Also "uppercase" the working copies. */
+    for i in 0..n as usize {
+        if cstrlen(&ttype[i]) == 0 {
+            spf!(errmes;
+                "Column #", i + 1, " has no name (No TTYPE", i + 1, " keyword).");
+            wrtwrn(out, &errmes, 0);
+            continue;
+        }
+
+        /*      disable this check (it was only a warning) */
+
+        let mut p = 0usize;
+        while ttype[i][p] != 0 {
+            let c = ttype[i][p] as u8;
+            if !c.is_ascii_lowercase()
+                && !c.is_ascii_uppercase()
+                && !c.is_ascii_digit()
+                && c != b'_'
+            {
+                if c == b'&' {
+                    spf!(errmes;
+                        "Column #", i + 1, ": Reserved column name keyword (TTYPE", i + 1,
+                        ") may use an illegal CONTINUE ('", CHR(ttype[i][p]), "')");
+                    wrtwrn(out, &errmes, 0);
+                } else {
+                    spf!(errmes;
+                        "Column #", i + 1, ": Name \"", CS(&ttype[i]), "\" contains character '",
+                        CHR(ttype[i][p]), "' other than letters, digits, and \"_\".");
+                    wrtwrn(out, &errmes, 0);
+                }
+            }
+            ttypecopy[i][p] = toupper_c(ttype[i][p]);
+            p += 1;
+        }
+    }
+
+    let mut cols: Vec<ColName> = Vec::with_capacity(n as usize);
+    for i in 0..n as usize {
+        cols.push(ColName {
+            name: ttypecopy[i].clone(),
+            index: i as c_int + 1,
+        });
+    }
+
+    /* sort the column name in the ascending order of name field*/
+    cols.sort_by(|a, b| compcol(a, b).cmp(&0));
+
+    /* Check the duplication of the column name */
+    for i in 0..(n - 1).max(0) as usize {
+        if cstrlen(&cols[i].name) == 0 {
+            continue;
+        }
+
+        if strcmp_c(&cols[i].name, &cols[i + 1].name) == 0 {
+            spf!(errmes;
+                "Columns #", cols[i].index, ", ", CS(&ttype[(cols[i].index - 1) as usize]),
+                " and #", cols[i + 1].index, ", ",
+                CS(&ttype[(cols[i + 1].index - 1) as usize]),
+                " are not unique (case insensitive).");
+            wrtwrn(out, &errmes, 0);
+        }
+    }
+}
+
+/*************************************************************
+*
+*     parse_vtform
+*
+*   Parse the tform of the variable length vector.
+*
+*************************************************************/
+pub fn parse_vtform(
+    infits: &mut fitsfile,
+    out: Out,
+    _hduptr: &FitsHdu,
+    colnum: c_int,        /* column number */
+    datacode: &mut c_int, /* data code */
+    maxlen: &mut c_long,  /* maximum length of the vector */
+    isQFormat: &mut c_int, /* true if var col is 'Q' format */
+) {
+    let mut i: c_int = 0;
+    let mut status: c_int = 0;
+    let mut p: usize;
+    let mut errmes: [c_char; ERRMES_LEN] = [0; ERRMES_LEN];
+
+    *maxlen = -1;
+    let temp = tform_at((colnum - 1) as usize);
+    p = 0;
+
+    if isdigit_c(temp[p]) {
+        i = strtol_c(&temp).0 as c_int; /* sscanf(ptemp, "%d", &i) */
+    }
+    if i > 1 {
+        spf!(errmes;
+            "Illegal repeat value for value ", CS(&temp), " of TFORM", colnum, ".");
+        wrterr(out, &errmes, 1);
+    }
+    while isdigit_c(temp[p]) {
+        p += 1;
+    }
+
+    if temp[p] as u8 != b'P' && temp[p] as u8 != b'Q' {
+        spf!(errmes;
+            "TFORM", colnum, " is not for the variable length array: ", CS(&temp), ".");
+        wrterr(out, &errmes, 1);
+    }
+    *isQFormat = if temp[p] as u8 == b'Q' { 1 } else { 0 };
+
+    fits_get_coltype(infits, colnum, Some(datacode), None, None, &mut status);
+    status = 0;
+    let _ = status;
+    p += 2;
+    if p >= temp.len() || temp[p] as u8 != b'(' {
+        return;
+    }
+    p += 1;
+    if !isdigit_c(temp[p]) {
+        spf!(errmes; "Bad value of TFORM", colnum, ": ", CS(&temp), ".");
+        wrterr(out, &errmes, 1);
+    }
+    *maxlen = strtol_c(&temp[p..]).0; /* sscanf(p,"%ld",maxlen) */
+    while isdigit_c(temp[p]) {
+        p += 1;
+    }
+    if temp[p] as u8 != b')' {
+        spf!(errmes; "Bad value of TFORM", colnum, ": ", CS(&temp), ".");
+        wrterr(out, &errmes, 1);
+    }
+}
+
+/*************************************************************
+*
+*     parse_wcskey_suffix
+*
+*   Retrieve the axis number and alternative coordinate suffix
+*    from WCS keywords.  Return -1 if keyword does not match the
+*    expected format.
+*
+*************************************************************/
+pub fn parse_wcskey_suffix(
+    fullname: &[c_char],
+    rootname: &[c_char],
+    axis: &mut c_int,
+    alt: &mut c_int,
+) -> c_int {
+    let mut status: c_int = 0;
+    let testAxis: c_int;
+
+    *axis = 0;
+    *alt = 0;
+    if cstrlen(fullname) < cstrlen(rootname) {
+        status = -1;
+    } else {
+        let suffix = cstrlen(rootname);
+        if cstrlen(&fullname[suffix..]) != 0 {
+            let (v, end) = strtol_c(&fullname[suffix..]);
+            testAxis = v as c_int;
+            let testAlt = suffix + end;
+            if testAxis != 0 {
+                *axis = testAxis;
+            }
+            if cstrlen(&fullname[testAlt..]) == 1 {
+                let c = fullname[testAlt] as u8;
+                if c.is_ascii_uppercase() {
+                    *alt = c as c_int - 64;
+                } else {
+                    status = -1;
+                }
+            } else if cstrlen(&fullname[testAlt..]) > 1 {
+                status = -1;
+            }
+        }
+    }
+
+    status
+}
+
+/*************************************************************
+*
+*      print_title
+*
+*  Print the title of the HDU.
+*  when verbose < 2, called by wrterr and wrtwrn.
+*
+*************************************************************/
+pub fn print_title(out: Out, hdunum: c_int, hdutype: c_int) {
+    let mut hdutitle: [c_char; 64] = [0; 64];
+
+    /* print out the title */
+    CURHDU.store(hdunum, Ordering::Relaxed);
+    CURTYPE.store(hdutype, Ordering::Relaxed);
+    let curhdu = hdunum;
+    let curtype = hdutype;
+
+    if OLDHDU.load(Ordering::Relaxed) == curhdu {
+        return;
+    } /* Do not print it twice */
+    if curhdu == 1 {
+        spf!(hdutitle; " HDU ", curhdu, ": Primary Array ");
+    } else {
+        match curtype {
+            IMAGE_HDU => spf!(hdutitle; " HDU ", curhdu, ": Image Exten. "),
+            ASCII_TBL => spf!(hdutitle; " HDU ", curhdu, ": ASCII Table "),
+            BINARY_TBL => spf!(hdutitle; " HDU ", curhdu, ": BINARY Table "),
+            _ => spf!(hdutitle; " HDU ", curhdu, ": Unknown Ext. "),
+        }
+    }
+    wrtsep(out, b'=' as c_char, &hdutitle, 60);
+    wrtout_str(out, " ");
+    OLDHDU.store(curhdu, Ordering::Relaxed);
+    if curhdu == totalhdu() {
+        OLDHDU.store(0, Ordering::Relaxed); /* reset the old hdu at the last hdu */
+    }
+}
+
+/*************************************************************
+*
+*      print_header
+*
+*  Print the header of the HDU.
+*
+*************************************************************/
+pub fn print_header(out: Out) {
+    let mut htemp: [c_char; 100] = [0; 100];
+    let ncards = NCARDS.load(Ordering::Relaxed);
+    for i in 1..=ncards {
+        spf!(htemp; DW(i, 4), " | ", CS(&card_at(i as usize - 1)));
+        wrtout(out, &htemp);
+    }
+    wrtout_str(out, " ");
+}
+
+/*************************************************************
+*
+*      print_summary
+*
+*  Print out the summary of this hdu.
+*
+**************************************************************/
+pub fn print_summary(
+    _infits: &mut fitsfile, /* input fits file   */
+    out: Out,               /* output ascii file */
+    hduptr: &FitsHdu,
+) {
+    let mut extver: [c_char; 10] = [0; 10];
+    let mut extnv: [c_char; 2 * FLEN_VALUE + 4] = [0; 2 * FLEN_VALUE + 4];
+    let mut npix: c_long;
+    let hdutype: c_int;
+    let mut temp: [c_char; 80] = [0; 80];
+    let mut comm: [c_char; COMM_LEN] = [0; COMM_LEN];
+
+    /* get the error number and wrn number */
+    set_hduerr(hduptr.hdunum);
+
+    hdutype = hduptr.hdutype;
+    spf!(comm; " ", hduptr.nkeys, " header keywords");
+    wrtout(out, &comm);
+    wrtout_str(out, " ");
+    if hdutype == ASCII_TBL || hdutype == BINARY_TBL {
+        spf!(extnv; CS(&hduptr.extname));
+        if hduptr.extver != -999 {
+            spf!(extver; "(", hduptr.extver, ")");
+            scat!(extnv; CS(&extver));
+        }
+
+        spf!(comm;
+            " ", CS(&extnv), "  (", hduptr.ncols, " columns x ",
+            hduptr.naxes.get(1).copied().unwrap_or(0) as i64, " rows)");
+        wrtout(out, &comm);
+        if hduptr.ncols != 0 {
+            wrtout_str(out, " ");
+            spf!(comm; " Col# Name (Units)       Format");
+            wrtout(out, &comm);
+        }
+        for i in 0..hduptr.ncols as usize {
+            let tt = ttype_at(i);
+            let tu = tunit_at(i);
+            let tf = tform_at(i);
+            if cstrlen(&tu) != 0 {
+                spf!(extnv; CS(&tt), " (", CS(&tu), ")");
+            } else {
+                spf!(extnv; CS(&tt));
+            }
+            spf!(comm;
+                " ", DW(i + 1, 3), " ", CSW(&extnv, -20, Some(20)), " ",
+                CSW(&tf, -10, Some(10)));
+            wrtout(out, &comm);
+        }
+    } else if hdutype == IMAGE_HDU && hduptr.isgroup != 0 {
+        spf!(comm; " ", hduptr.gcount, " Random Groups, ");
+
+        bitpix_text(hduptr.bitpix, &mut temp);
+        scat!(comm; CS(&temp));
+
+        spf!(temp; " ", hduptr.naxis, " axes ");
+        scat!(comm; CS(&temp));
+
+        spf!(temp; "(", hduptr.naxes[0] as i64);
+        scat!(comm; CS(&temp));
+
+        npix = hduptr.naxes[0] as c_long;
+        for i in 1..hduptr.naxis as usize {
+            npix *= hduptr.naxes[i] as c_long;
+            spf!(temp; " x ", hduptr.naxes[i] as i64);
+            scat!(comm; CS(&temp));
+        }
+        let _ = npix;
+        scat!(comm; "), ");
+        wrtout(out, &comm);
+    } else if hdutype == IMAGE_HDU {
+        if hduptr.naxis > 0 {
+            if hduptr.hdunum == 1 {
+                extnv[0] = 0;
+            } else {
+                spf!(extnv; CS(&hduptr.extname));
+                if hduptr.extver != -999 {
+                    spf!(extver; " (", hduptr.extver, ")");
+                    scat!(extnv; CS(&extver));
+                }
+            }
+            spf!(comm; CS(&extnv));
+
+            bitpix_text(hduptr.bitpix, &mut temp);
+            scat!(comm; CS(&temp));
+
+            spf!(temp; " ", hduptr.naxis, " axes ");
+            scat!(comm; CS(&temp));
+
+            spf!(temp; "(", hduptr.naxes[0] as i64);
+            scat!(comm; CS(&temp));
+
+            npix = hduptr.naxes[0] as c_long;
+            for i in 1..hduptr.naxis as usize {
+                npix *= hduptr.naxes[i] as c_long;
+                spf!(temp; " x ", hduptr.naxes[i] as i64);
+                scat!(comm; CS(&temp));
+            }
+            let _ = npix;
+            scat!(comm; "), ");
+            wrtout(out, &comm);
+        } else {
+            spf!(comm; " Null data array; NAXIS = 0 ");
+            wrtout(out, &comm);
+        }
+    }
+    wrtout_str(out, " ");
+}
+
+fn bitpix_text(bitpix: c_int, temp: &mut [c_char]) {
+    match bitpix {
+        BYTE_IMG => spf!(temp; " 8-bit integer pixels, "),
+        SHORT_IMG => spf!(temp; " 16-bit integer pixels, "),
+        USHORT_IMG => spf!(temp; " 16-bit unsigned integer pixels, "),
+        LONG_IMG => spf!(temp; " 32-bit integer pixels, "),
+        LONGLONG_IMG => spf!(temp; " 64-bit long integer pixels, "),
+        ULONG_IMG => spf!(temp; " 32-bit unsigned integer pixels, "),
+        FLOAT_IMG => spf!(temp; " 32-bit floating point pixels, "),
+        DOUBLE_IMG => spf!(temp; " 64-bit double precision pixels, "),
+        _ => spf!(temp; " unknown datatype, "),
+    }
+}
+
+/*************************************************************
+*
+*      close_hdu
+*
+*  Free the memory allocated to the FitsHdu structure and
+*  other temporary  spaces.
+*
+**************************************************************/
+pub fn close_hdu(hduptr: &mut FitsHdu) {
+    /* The C free()s cards, hduptr->kwds, datamin/datamax/tnull, naxes and
+       tmpkwds here; RAII does that for us.  (Note the C's
+       `if(hdutype == ASCII_TBL && hdutype == BINARY_TBL)' guard around the
+       ttype/tform/tunit frees can never be true, so those are leaked there
+       and simply left in place here.) */
+    hduptr.kwds.clear();
+    hduptr.datamin.clear();
+    hduptr.datamax.clear();
+    hduptr.tnull.clear();
+    hduptr.naxes.clear();
+    CARDS.with(|c| c.borrow_mut().clear());
+    TMPKWDS.with(|t| t.borrow_mut().clear());
+}
+
+/*===========================================================================
+ *  local helpers
+ *==========================================================================*/
+
+
+#[allow(dead_code)]
+fn _unused_api() {
+    let _ = NullValue::Int(0);
+    let _ = cards_len();
+}

--- a/src/bin/fitsverify/fvrf_key.rs
+++ b/src/bin/fitsverify/fvrf_key.rs
@@ -859,3 +859,209 @@ pub fn check_fixed_str(card: &[c_char], out: Out) -> c_int {
     1
 }
 
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::fvrf_misc::reset_err_wrn;
+
+    /* An 80-column card image, NUL-terminated as CFITSIO hands it over. */
+    fn card(s: &str) -> [c_char; FLEN_CARD] {
+        let mut b = [0 as c_char; FLEN_CARD];
+        for i in 0..80 {
+            b[i] = b' ' as c_char;
+        }
+        for (i, &c) in s.as_bytes().iter().enumerate() {
+            b[i] = c as c_char;
+        }
+        b[80] = 0;
+        b
+    }
+
+    fn parse(s: &str) -> (c_int, kwdtyp, String, String) {
+        reset_err_wrn();
+        let mut c = card(s);
+        let mut kname = [0 as c_char; FLEN_KEYWORD];
+        let mut ktype = kwdtyp::UNKNOWN;
+        let mut kvalue = [0 as c_char; FLEN_VALUE];
+        let mut kcomm = [0 as c_char; COMM_LEN];
+        /* Out::Null suppresses reporting so only the parse result is under test */
+        let r = fits_parse_card(
+            Out::Null, 1, &mut c, &mut kname, &mut ktype, &mut kvalue, &mut kcomm,
+        );
+        (
+            r,
+            ktype,
+            String::from_utf8_lossy(cbytes(&kname)).into_owned(),
+            String::from_utf8_lossy(cbytes(&kvalue)).into_owned(),
+        )
+    }
+
+    #[test]
+    fn test_parse_card_logical() {
+        let (r, t, n, v) = parse("SIMPLE  =                    T / conforms to FITS standard");
+        assert_eq!(r, 0);
+        assert_eq!(t, kwdtyp::LOG_KEY);
+        assert_eq!(n, "SIMPLE");
+        assert_eq!(v, "T");
+    }
+
+    #[test]
+    fn test_parse_card_integer() {
+        let (r, t, n, v) = parse("BITPIX  =                   16 / bits per data value");
+        assert_eq!(r, 0);
+        assert_eq!(t, kwdtyp::INT_KEY);
+        assert_eq!(n, "BITPIX");
+        assert_eq!(v, "16");
+
+        let (_, t, _, v) = parse("TZERO1  =                -32768");
+        assert_eq!(t, kwdtyp::INT_KEY);
+        assert_eq!(v, "-32768");
+    }
+
+    #[test]
+    fn test_parse_card_float() {
+        let (r, t, _, v) = parse("BSCALE  =                  1.5");
+        assert_eq!(r, 0);
+        assert_eq!(t, kwdtyp::FLT_KEY);
+        assert_eq!(v, "1.5");
+
+        /* upper-case exponent is legal */
+        let (r, t, _, v) = parse("CRVAL1  =              1.25E+02");
+        assert_eq!(r, 0);
+        assert_eq!(t, kwdtyp::FLT_KEY);
+        assert_eq!(v, "1.25E+02");
+
+        /* a lower-case exponent is flagged, so the card parse fails */
+        let (r, t, _, _) = parse("CRVAL1  =              1.25e+02");
+        assert_eq!(r, 1);
+        assert_eq!(t, kwdtyp::FLT_KEY);
+    }
+
+    #[test]
+    fn test_parse_card_string() {
+        /* get_str strips the quotes and the trailing blanks inside them */
+        let (r, t, n, v) = parse("EXTNAME = 'FOO     '           / name of this HDU");
+        assert_eq!(r, 0);
+        assert_eq!(t, kwdtyp::STR_KEY);
+        assert_eq!(n, "EXTNAME");
+        assert_eq!(v, "FOO");
+
+        /* '' is the escape for an embedded quote */
+        let (r, t, _, v) = parse("OBJECT  = 'a''b'");
+        assert_eq!(r, 0);
+        assert_eq!(t, kwdtyp::STR_KEY);
+        assert_eq!(v, "a''b");
+
+        /* missing closing quote is an error */
+        let (r, _, _, _) = parse("OBJECT  = 'unterminated");
+        assert_eq!(r, 1);
+    }
+
+    #[test]
+    fn test_parse_card_commentary() {
+        let (r, t, n, _) = parse("COMMENT   some free text");
+        assert_eq!(r, 0);
+        assert_eq!(t, kwdtyp::COM_KEY);
+        assert_eq!(n, "COMMENT");
+
+        let (r, t, n, _) = parse("HISTORY   processed");
+        assert_eq!((r, t), (0, kwdtyp::COM_KEY));
+        assert_eq!(n, "HISTORY");
+
+        /* no value indicator in columns 9-10 makes it commentary */
+        let (r, t, _, _) = parse("FOO       bar");
+        assert_eq!((r, t), (0, kwdtyp::COM_KEY));
+
+        let (r, t, n, _) = parse("END");
+        assert_eq!((r, t), (0, kwdtyp::COM_KEY));
+        assert_eq!(n, "END");
+    }
+
+    #[test]
+    fn test_parse_card_end_must_be_blank_filled() {
+        let mut c = card("END");
+        c[40] = b'X' as c_char;
+        reset_err_wrn();
+        let mut kname = [0 as c_char; FLEN_KEYWORD];
+        let mut ktype = kwdtyp::UNKNOWN;
+        let mut kvalue = [0 as c_char; FLEN_VALUE];
+        let mut kcomm = [0 as c_char; COMM_LEN];
+        let r = fits_parse_card(
+            Out::Null, 1, &mut c, &mut kname, &mut ktype, &mut kvalue, &mut kcomm,
+        );
+        assert_eq!(r, 1);
+    }
+
+    /* Fixed-format checks: the value has to end in column 30 for integers and
+       sit in column 30 for logicals. */
+    #[test]
+    fn test_check_fixed_int() {
+        reset_err_wrn();
+        let good = card(&format!("BITPIX  ={}16", " ".repeat(19)));
+        assert_eq!(check_fixed_int(&good, Out::Null), 1);
+
+        let bad = card("BITPIX  = 16");
+        assert_eq!(check_fixed_int(&bad, Out::Null), 0);
+
+        let signed = card(&format!("TZERO1  ={}-8", " ".repeat(19)));
+        assert_eq!(check_fixed_int(&signed, Out::Null), 1);
+    }
+
+    #[test]
+    fn test_check_fixed_log() {
+        reset_err_wrn();
+        let good = card(&format!("SIMPLE  ={}T", " ".repeat(20)));
+        assert_eq!(check_fixed_log(&good, Out::Null), 1);
+
+        /* right column, wrong value */
+        let notlog = card(&format!("SIMPLE  ={}X", " ".repeat(20)));
+        assert_eq!(check_fixed_log(&notlog, Out::Null), 0);
+
+        /* right value, wrong column */
+        let shifted = card("SIMPLE  = T");
+        assert_eq!(check_fixed_log(&shifted, Out::Null), 0);
+    }
+
+    #[test]
+    fn test_check_fixed_str() {
+        reset_err_wrn();
+        let good = card("XTENSION= 'IMAGE   '");
+        assert_eq!(check_fixed_str(&good, Out::Null), 1);
+
+        /* closing quote before column 20 */
+        let short = card("XTENSION= 'IM'");
+        assert_eq!(check_fixed_str(&short, Out::Null), 0);
+
+        /* does not start in column 11 */
+        let late = card("XTENSION=  'IMAGE  '");
+        assert_eq!(check_fixed_str(&late, Out::Null), 0);
+    }
+
+    /* The check_* helpers gate on the parsed keyword type. */
+    #[test]
+    fn test_check_type_helpers() {
+        reset_err_wrn();
+        let mut k = FitsKey { ktype: kwdtyp::INT_KEY, kindex: 1, ..Default::default() };
+        strcpy_c(&mut k.kname, cs!(c"NAXIS"));
+        strcpy_c(&mut k.kvalue, cs!(c"2"));
+        assert_eq!(check_int(&k, Out::Null), 1);
+        assert_eq!(check_flt(&k, Out::Null), 1); /* an integer is a valid float */
+        assert_eq!(check_str(&k, Out::Null), 0);
+        assert_eq!(check_log(&k, Out::Null), 0);
+
+        k.ktype = kwdtyp::STR_KEY;
+        assert_eq!(check_str(&k, Out::Null), 1);
+        assert_eq!(check_int(&k, Out::Null), 0);
+
+        k.ktype = kwdtyp::LOG_KEY;
+        assert_eq!(check_log(&k, Out::Null), 1);
+
+        k.ktype = kwdtyp::CMI_KEY;
+        assert_eq!(check_cmi(&k, Out::Null), 1);
+        assert_eq!(check_cmf(&k, Out::Null), 1);
+        k.ktype = kwdtyp::CMF_KEY;
+        assert_eq!(check_cmi(&k, Out::Null), 0);
+        assert_eq!(check_cmf(&k, Out::Null), 1);
+    }
+}

--- a/src/bin/fitsverify/fvrf_key.rs
+++ b/src/bin/fitsverify/fvrf_key.rs
@@ -6,8 +6,6 @@
 
 use rsfitsio::c_types::{c_char, c_int, c_ulong};
 use rsfitsio::fitsio::{FLEN_CARD, FLEN_COMMENT, FLEN_KEYWORD, FLEN_VALUE};
-use bytemuck::cast_slice;
-use rsfitsio::cs;
 
 use crate::common::*;
 use crate::fvrf_misc::*;
@@ -16,7 +14,7 @@ use crate::{scat, spf};
 /* Ref: Defininition of the Flexible Image Transport System(FITS),
     Sec. 5.1 and 5.2.
 */
-pub fn fits_parse_card(
+pub(crate) fn fits_parse_card(
     out: Out,                          /* output file pointer */
     kpos: c_int,                       /* keyposition starting from 1 */
     card: &mut [c_char],               /* key card */
@@ -93,11 +91,11 @@ pub fn fits_parse_card(
     }
 
     /* COMMENT, HISTORY, HIERARCH and "" keywords */
-    if strcmp_c(kname, cs!(c"COMMENT")) == 0
-        || strcmp_c(kname, cs!(c"HISTORY")) == 0
-        || strcmp_c(kname, cs!(c"HIERARCH")) == 0
-        || strcmp_c(kname, cs!(c"CONTINUE")) == 0
-        || strcmp_c(kname, cs!(c"")) == 0
+    if ceq(kname, b"COMMENT")
+        || ceq(kname, b"HISTORY")
+        || ceq(kname, b"HIERARCH")
+        || ceq(kname, b"CONTINUE")
+        || ceq(kname, b"")
     {
         *ktype = kwdtyp::COM_KEY;
 
@@ -122,7 +120,7 @@ pub fn fits_parse_card(
     }
 
     /* End Keyword: 9-80 shall be filled with ASCII blanks \x20 */
-    if strcmp_c(kname, cs!(c"END")) == 0 {
+    if ceq(kname, b"END") {
         *ktype = kwdtyp::COM_KEY;
         if card[3] == 0 {
             return 0;
@@ -143,7 +141,7 @@ pub fn fits_parse_card(
     p = 8;
     strncpy_c(&mut vind, &card[p..], 2);
     vind[2] = 0;
-    if strcmp_c(&vind, cs!(c"= ")) != 0 && strcmp_c(&vind, cs!(c"=")) != 0 {
+    if !ceq(&vind, b"= ") && !ceq(&vind, b"=") {
         /* no value indicator, so this is a commentary keyword */
         *ktype = kwdtyp::COM_KEY;
         strcpy_c(kcomm, &card[p..]);
@@ -235,7 +233,7 @@ pub fn fits_parse_card(
 }
 
 /* parse And test the string keys */
-pub fn get_str(
+pub(crate) fn get_str(
     card: &[c_char],      /* card string from character 11*/
     pt: &mut usize,       /* cursor into card */
     kvalue: &mut [c_char], /* key value string */
@@ -291,7 +289,7 @@ pub fn get_str(
 }
 
 /* parse and test the logical keys */
-pub fn get_log(
+pub(crate) fn get_log(
     card: &[c_char],       /* card string */
     pt: &mut usize,        /* cursor into card */
     kvalue: &mut [c_char], /* key value string */
@@ -313,7 +311,7 @@ pub fn get_log(
 }
 
 /* parse and test the numerical keys */
-pub fn get_num(
+pub(crate) fn get_num(
     card: &[c_char],       /* card string */
     pt: &mut usize,        /* cursor into card */
     kvalue: &mut [c_char], /* comment string */
@@ -382,7 +380,7 @@ pub fn get_num(
 }
 
 /* parse and test the complex keys */
-pub fn get_cmp(
+pub(crate) fn get_cmp(
     incard: &[c_char],     /* card string */
     pt: &mut usize,        /* cursor into card */
     kvalue: &mut [c_char], /* comment string */
@@ -489,7 +487,7 @@ pub fn get_cmp(
 }
 
 /* parse and test the comment keys */
-pub fn get_comm(
+fn get_comm(
     card: &[c_char],      /* card string */
     pt: &mut usize,       /* cursor into card */
     kcomm: &mut [c_char], /* comment string */
@@ -517,7 +515,7 @@ pub fn get_comm(
 }
 
 /* parsing the unknown keyword */
-pub fn get_unknown(
+pub(crate) fn get_unknown(
     card: &[c_char],       /* card string */
     pt: &mut usize,        /* cursor into card */
     kvalue: &mut [c_char], /* comment string */
@@ -544,7 +542,7 @@ pub fn get_unknown(
 }
 
 /* routine to print out the error of keyword value/comment */
-pub fn pr_kval_err(
+pub(crate) fn pr_kval_err(
     out: Out,          /* output  FILE */
     kpos: c_int,       /* keyposition starting from 1 */
     kname: &[c_char],  /* keyword name */
@@ -637,7 +635,7 @@ pub fn pr_kval_err(
     }
 }
 
-pub fn check_str(pkey: &FitsKey, out: Out) -> c_int {
+pub(crate) fn check_str(pkey: &FitsKey, out: Out) -> c_int {
     let mut errmes: [c_char; ERRMES_LEN] = [0; ERRMES_LEN];
 
     if pkey.ktype == kwdtyp::UNKNOWN && pkey.kvalue[0] == 0 {
@@ -656,7 +654,7 @@ pub fn check_str(pkey: &FitsKey, out: Out) -> c_int {
     1
 }
 
-pub fn check_int(pkey: &FitsKey, out: Out) -> c_int {
+pub(crate) fn check_int(pkey: &FitsKey, out: Out) -> c_int {
     let mut errmes: [c_char; ERRMES_LEN] = [0; ERRMES_LEN];
 
     if pkey.ktype == kwdtyp::UNKNOWN && pkey.kvalue[0] == 0 {
@@ -678,7 +676,7 @@ pub fn check_int(pkey: &FitsKey, out: Out) -> c_int {
     1
 }
 
-pub fn check_flt(pkey: &FitsKey, out: Out) -> c_int {
+pub(crate) fn check_flt(pkey: &FitsKey, out: Out) -> c_int {
     let mut errmes: [c_char; ERRMES_LEN] = [0; ERRMES_LEN];
 
     if pkey.ktype == kwdtyp::UNKNOWN && pkey.kvalue[0] == 0 {
@@ -700,7 +698,7 @@ pub fn check_flt(pkey: &FitsKey, out: Out) -> c_int {
     1
 }
 
-pub fn check_cmi(pkey: &FitsKey, out: Out) -> c_int {
+fn check_cmi(pkey: &FitsKey, out: Out) -> c_int {
     let mut errmes: [c_char; ERRMES_LEN] = [0; ERRMES_LEN];
 
     if pkey.ktype != kwdtyp::CMI_KEY {
@@ -716,7 +714,7 @@ pub fn check_cmi(pkey: &FitsKey, out: Out) -> c_int {
     1
 }
 
-pub fn check_cmf(pkey: &FitsKey, out: Out) -> c_int {
+fn check_cmf(pkey: &FitsKey, out: Out) -> c_int {
     let mut errmes: [c_char; ERRMES_LEN] = [0; ERRMES_LEN];
 
     if pkey.ktype != kwdtyp::CMI_KEY && pkey.ktype != kwdtyp::CMF_KEY {
@@ -732,7 +730,7 @@ pub fn check_cmf(pkey: &FitsKey, out: Out) -> c_int {
     1
 }
 
-pub fn check_log(pkey: &FitsKey, out: Out) -> c_int {
+pub(crate) fn check_log(pkey: &FitsKey, out: Out) -> c_int {
     let mut errmes: [c_char; ERRMES_LEN] = [0; ERRMES_LEN];
 
     if pkey.ktype != kwdtyp::LOG_KEY {
@@ -748,7 +746,7 @@ pub fn check_log(pkey: &FitsKey, out: Out) -> c_int {
     1
 }
 
-pub fn check_fixed_int(card: &[c_char], out: Out) -> c_int {
+pub(crate) fn check_fixed_int(card: &[c_char], out: Out) -> c_int {
     let mut cptr: usize;
     let mut errmes: [c_char; ERRMES_LEN] = [0; ERRMES_LEN];
 
@@ -783,7 +781,7 @@ pub fn check_fixed_int(card: &[c_char], out: Out) -> c_int {
     1
 }
 
-pub fn check_fixed_log(card: &[c_char], out: Out) -> c_int {
+pub(crate) fn check_fixed_log(card: &[c_char], out: Out) -> c_int {
     let mut cptr: usize;
     let mut errmes: [c_char; ERRMES_LEN] = [0; ERRMES_LEN];
 
@@ -815,7 +813,7 @@ pub fn check_fixed_log(card: &[c_char], out: Out) -> c_int {
     1
 }
 
-pub fn check_fixed_str(card: &[c_char], out: Out) -> c_int {
+pub(crate) fn check_fixed_str(card: &[c_char], out: Out) -> c_int {
     let mut cptr: usize;
     let mut errmes: [c_char; ERRMES_LEN] = [0; ERRMES_LEN];
 
@@ -1043,8 +1041,8 @@ mod tests {
     fn test_check_type_helpers() {
         reset_err_wrn();
         let mut k = FitsKey { ktype: kwdtyp::INT_KEY, kindex: 1, ..Default::default() };
-        strcpy_c(&mut k.kname, cs!(c"NAXIS"));
-        strcpy_c(&mut k.kvalue, cs!(c"2"));
+        set_cstr(&mut k.kname, b"NAXIS");
+        set_cstr(&mut k.kvalue, b"2");
         assert_eq!(check_int(&k, Out::Null), 1);
         assert_eq!(check_flt(&k, Out::Null), 1); /* an integer is a valid float */
         assert_eq!(check_str(&k, Out::Null), 0);

--- a/src/bin/fitsverify/fvrf_key.rs
+++ b/src/bin/fitsverify/fvrf_key.rs
@@ -1,1 +1,861 @@
+/* Transpiled from cfitsio/utilities/fvrf_key.c
+
+   The C walks the card with `char *' cursors; here every cursor is an index
+   into the card slice, and the `char **pt' in/out cursor parameters become
+   `pt: &mut usize'.  */
+
+use rsfitsio::c_types::{c_char, c_int, c_ulong};
+use rsfitsio::fitsio::{FLEN_CARD, FLEN_COMMENT, FLEN_KEYWORD, FLEN_VALUE};
+use bytemuck::cast_slice;
+use rsfitsio::cs;
+
+use crate::common::*;
+use crate::fvrf_misc::*;
+use crate::{scat, spf};
+
+/* Ref: Defininition of the Flexible Image Transport System(FITS),
+    Sec. 5.1 and 5.2.
+*/
+pub fn fits_parse_card(
+    out: Out,                          /* output file pointer */
+    kpos: c_int,                       /* keyposition starting from 1 */
+    card: &mut [c_char],               /* key card */
+    kname: &mut [c_char; FLEN_KEYWORD], /* key name */
+    ktype: &mut kwdtyp,                /* key type */
+    kvalue: &mut [c_char; FLEN_VALUE], /* key value */
+    kcomm: &mut [c_char],              /* comment */
+) -> c_int {
+    let mut vind: [c_char; 3] = [0; 3];
+    let mut p: usize;
+    let mut i: isize;
+    let mut temp1: [c_char; FLEN_CARD] = [0; FLEN_CARD];
+    let mut stat: c_ulong = 0;
+    let mut errmes: [c_char; ERRMES_LEN] = [0; ERRMES_LEN];
+
+    kname[0] = 0;
+    kvalue[0] = 0;
+    kcomm[0] = 0;
+    *ktype = kwdtyp::UNKNOWN;
+
+    if cstrlen(card) > FLEN_CARD - 1 {
+        strncpy_c(&mut temp1, card, 20);
+        temp1[21] = 0;
+        spf!(errmes; "card ", CS(card), " is > 80.");
+        wrterr(out, &errmes, 1);
+        return 1;
+    }
+    card[FLEN_CARD - 1] = 0;
+
+    /* get the kname */
+    strncpy_c(kname, card, 8);
+    kname[8] = 0;
+
+    /* take out the trailing space */
+    i = 7;
+    p = 7;
+    while i >= 0 && isspace_c(kname[p]) {
+        kname[p] = 0;
+        if p == 0 {
+            i -= 1;
+            break;
+        }
+        p -= 1;
+        i -= 1;
+    }
+
+    /* Whether the keyword name is left justified */
+    i = 0;
+    p = 0;
+    while isspace_c(kname[p]) && kname[p] != 0 {
+        p += 1;
+        i += 1;
+    }
+    if i < 8 && i > 0 {
+        spf!(errmes; "Keyword #", kpos, ": Name ", CS(kname), " is not left justified.");
+        wrterr(out, &errmes, 1);
+    }
+    /* Whether the characters in keyword name are valid */
+    while kname[p] != 0 {
+        let c = kname[p] as u8;
+        if !(b'A'..=b'Z').contains(&c)
+            && !(b'0'..=b'9').contains(&c)
+            && c != b'-'
+            && c != b'_'
+        {
+            spf!(errmes;
+                "Keyword #", kpos, ": Name \"", CS(kname), "\" contains char \"", CHR(kname[p]),
+                "\" which is not upper case letter, digit, \"-\", or \"_\".");
+            wrterr(out, &errmes, 1);
+            break;
+        }
+        p += 1;
+        i += 1;
+    }
+
+    /* COMMENT, HISTORY, HIERARCH and "" keywords */
+    if strcmp_c(kname, cs!(c"COMMENT")) == 0
+        || strcmp_c(kname, cs!(c"HISTORY")) == 0
+        || strcmp_c(kname, cs!(c"HIERARCH")) == 0
+        || strcmp_c(kname, cs!(c"CONTINUE")) == 0
+        || strcmp_c(kname, cs!(c"")) == 0
+    {
+        *ktype = kwdtyp::COM_KEY;
+
+        p = 8;
+        strcpy_c(kcomm, &card[p..]);
+        kcomm[FLEN_COMMENT - 1] = 0;
+        while card[p] != 0 {
+            if !isprint_c(card[p]) {
+                spf!(errmes;
+                    "Keyword #", kpos, ", ", CS(kname), ": String contains non-text characters.");
+                wrterr(out, &errmes, 1);
+                return 1;
+            }
+            p += 1;
+        }
+        p = 0;
+        while !isspace_c(kname[p]) && kname[p] != 0 {
+            p += 1;
+        }
+        kname[p] = 0;
+        return 0;
+    }
+
+    /* End Keyword: 9-80 shall be filled with ASCII blanks \x20 */
+    if strcmp_c(kname, cs!(c"END")) == 0 {
+        *ktype = kwdtyp::COM_KEY;
+        if card[3] == 0 {
+            return 0;
+        }
+        p = 8;
+        while card[p] != 0 {
+            if card[p] as u8 != 0x20 {
+                wrterr_str(out, "END keyword contains non-blank characters.", 1);
+                return 1;
+            }
+            p += 1;
+        }
+        kname[3] = 0;
+        return 0;
+    }
+
+    /* check for value indicator */
+    p = 8;
+    strncpy_c(&mut vind, &card[p..], 2);
+    vind[2] = 0;
+    if strcmp_c(&vind, cs!(c"= ")) != 0 && strcmp_c(&vind, cs!(c"=")) != 0 {
+        /* no value indicator, so this is a commentary keyword */
+        *ktype = kwdtyp::COM_KEY;
+        strcpy_c(kcomm, &card[p..]);
+        kcomm[FLEN_COMMENT - 1] = 0;
+        while card[p] != 0 {
+            if !isprint_c(card[p]) {
+                spf!(errmes;
+                    "Keyword #", kpos, ", ", CS(kname), ": String contains non-text characters.");
+                wrterr(out, &errmes, 1);
+                return 1;
+            }
+            p += 1;
+        }
+        p = 0;
+        while !isspace_c(kname[p]) && kname[p] != 0 {
+            p += 1;
+        }
+        kname[p] = 0;
+        return 0;
+    }
+
+    p = 10;
+    while isspace_c(card[p]) && card[p] != 0 {
+        p += 1;
+    }
+    match card[p] as u8 {
+        b'\'' => {
+            /* string */
+            get_str(card, &mut p, kvalue, &mut stat);
+            *ktype = kwdtyp::STR_KEY;
+            if card[p] != 0 {
+                get_comm(card, &mut p, kcomm, &mut stat);
+            }
+        }
+        b'T' | b'F' => {
+            /*logical */
+            get_log(card, &mut p, kvalue, &mut stat);
+            *ktype = kwdtyp::LOG_KEY;
+            if card[p] != 0 {
+                get_comm(card, &mut p, kcomm, &mut stat);
+            }
+        }
+        /* number */
+        b'+' | b'-' | b'.' | b'0'..=b'9' => {
+            get_num(card, &mut p, kvalue, ktype, &mut stat);
+            if card[p] != 0 {
+                get_comm(card, &mut p, kcomm, &mut stat);
+            }
+        }
+        b'(' => {
+            /* complex number */
+            get_cmp(card, &mut p, kvalue, ktype, &mut stat);
+            if card[p] != 0 {
+                get_comm(card, &mut p, kcomm, &mut stat);
+            }
+        }
+        b'/' => {
+            /* comment */
+            if card[p] != 0 {
+                get_comm(card, &mut p, kcomm, &mut stat);
+            }
+            *ktype = kwdtyp::UNKNOWN;
+        }
+        _ => {
+            get_unknown(card, &mut p, kvalue, ktype, &mut stat);
+            if card[p] != 0 {
+                get_comm(card, &mut p, kcomm, &mut stat);
+            }
+        }
+    }
+    /* take out the trailing blanks for non-string keys */
+    if *ktype != kwdtyp::STR_KEY {
+        i = cstrlen(kvalue) as isize;
+        let mut q = i - 1;
+        while q >= 0 && isspace_c(kvalue[q as usize]) && i > 0 {
+            kvalue[q as usize] = 0;
+            q -= 1;
+            i -= 1;
+        }
+        if i == 0 && q >= 0 && isspace_c(kvalue[q as usize]) {
+            kvalue[q as usize] = 0;
+        }
+    }
+    pr_kval_err(out, kpos, kname, kvalue, stat);
+    if stat != 0 {
+        return 1;
+    }
+    0
+}
+
+/* parse And test the string keys */
+pub fn get_str(
+    card: &[c_char],      /* card string from character 11*/
+    pt: &mut usize,       /* cursor into card */
+    kvalue: &mut [c_char], /* key value string */
+    stat: &mut c_ulong,   /* error number */
+) {
+    let mut pi: usize;
+    let mut prev: u8; /* previous char */
+    let mut nchar: isize;
+    let mut p: usize;
+
+    p = *pt;
+    pi = p;
+    p += 1;
+    prev = b'a';
+    while card[p] != 0 {
+        if !isprint_c(card[p]) {
+            *stat |= BAD_STR;
+        }
+        if prev == b'\'' && card[p] as u8 != b'\'' {
+            break;
+        }
+        if prev == b'\'' && card[p] as u8 == b'\'' {
+            /* skip the '' */
+            p += 1;
+            prev = b'a';
+        } else {
+            prev = card[p] as u8;
+            p += 1;
+        }
+    }
+    p -= 1;
+    if card[p] as u8 != b'\'' {
+        *stat |= NO_TRAIL_QUOTE;
+    }
+    pi += 1;
+    nchar = p as isize - pi as isize; /* excluding the ' */
+    if nchar < 0 {
+        nchar = 0;
+    }
+    let nchar = std::cmp::min(nchar as usize, kvalue.len() - 1);
+    strncpy_c(kvalue, &card[pi..], nchar);
+    kvalue[nchar] = 0;
+    let mut q = nchar as isize - 1;
+    while q >= 0 && isspace_c(kvalue[q as usize]) {
+        kvalue[q as usize] = 0;
+        q -= 1;
+    } /* delete the trailing space */
+    p += 1; /* skip the  ' */
+    while isspace_c(card[p]) && card[p] != 0 {
+        p += 1;
+    }
+    *pt = p;
+}
+
+/* parse and test the logical keys */
+pub fn get_log(
+    card: &[c_char],       /* card string */
+    pt: &mut usize,        /* cursor into card */
+    kvalue: &mut [c_char], /* key value string */
+    stat: &mut c_ulong,    /* error number */
+) {
+    let mut p: usize;
+
+    p = *pt;
+    kvalue[0] = card[p];
+    kvalue[1] = 0;
+    p += 1;
+    while isspace_c(card[p]) {
+        p += 1;
+    }
+    if card[p] as u8 != b'/' && card[p] != 0 {
+        *stat |= BAD_LOGICAL;
+    }
+    *pt = p;
+}
+
+/* parse and test the numerical keys */
+pub fn get_num(
+    card: &[c_char],       /* card string */
+    pt: &mut usize,        /* cursor into card */
+    kvalue: &mut [c_char], /* comment string */
+    ktype: &mut kwdtyp,
+    stat: &mut c_ulong, /* error number */
+) {
+    let pi: usize;
+    let mut set_deci = 0;
+    let mut set_expo = 0;
+    let nchar: usize;
+    let mut p: usize;
+
+    p = *pt;
+    pi = p;
+    *ktype = kwdtyp::INT_KEY;
+
+    if card[p] as u8 != b'+' && card[p] as u8 != b'-' && !isdigit_c(card[p]) && card[p] as u8 != b'.'
+    {
+        *stat |= BAD_NUM;
+        return;
+    }
+    if card[p] as u8 == b'.' {
+        *ktype = kwdtyp::FLT_KEY;
+        set_deci = 1;
+    }
+
+    p += 1;
+    while !isspace_c(card[p]) && card[p] != 0 && card[p] as u8 != b'/' {
+        if card[p] as u8 == b'.' && set_deci == 0 {
+            set_deci = 1;
+            *ktype = kwdtyp::FLT_KEY;
+            p += 1;
+            continue;
+        }
+        if (card[p] as u8 == b'd' || card[p] as u8 == b'e') && set_expo == 0 {
+            set_expo = 1;
+            *ktype = kwdtyp::FLT_KEY;
+            p += 1;
+            if card[p] as u8 == b'+' || card[p] as u8 == b'-' {
+                p += 1;
+            }
+            *stat |= LOWCASE_EXPO;
+            continue;
+        }
+        if (card[p] as u8 == b'D' || card[p] as u8 == b'E') && set_expo == 0 {
+            set_expo = 1;
+            *ktype = kwdtyp::FLT_KEY;
+            p += 1;
+            if card[p] as u8 == b'+' || card[p] as u8 == b'-' {
+                p += 1;
+            }
+            continue;
+        }
+        if !isdigit_c(card[p]) {
+            *stat |= BAD_NUM;
+        }
+        p += 1;
+    }
+    nchar = std::cmp::min(p - pi, kvalue.len() - 1);
+    strncpy_c(kvalue, &card[pi..], nchar);
+    kvalue[nchar] = 0;
+    while isspace_c(card[p]) && card[p] != 0 {
+        p += 1;
+    }
+    *pt = p;
+}
+
+/* parse and test the complex keys */
+pub fn get_cmp(
+    incard: &[c_char],     /* card string */
+    pt: &mut usize,        /* cursor into card */
+    kvalue: &mut [c_char], /* comment string */
+    ktype: &mut kwdtyp,
+    stat: &mut c_ulong, /* error number */
+) {
+    let mut p: usize;
+    let mut pr_beg: usize;
+    /* pr_end / pi_beg are left unset by the C when there is no ',' in the
+       value; it then dereferences a NULL pr_end.  Here they stay None and the
+       terminating writes are skipped. */
+    let mut pr_end: Option<usize> = None;
+    let mut pi_beg: Option<usize> = None;
+    let mut pi_end: usize = 0;
+    let nchar: usize;
+    let mut set_comm = 0;
+    let mut set_paren = 0;
+
+    let mut tr: c_ulong = 0;
+    let mut ti: c_ulong = 0;
+    let mut rtype = kwdtyp::UNKNOWN;
+    let mut itype = kwdtyp::UNKNOWN;
+    let mut temp: [c_char; FLEN_CARD] = [0; FLEN_CARD];
+    let mut card: [c_char; FLEN_CARD] = [0; FLEN_CARD];
+
+    strcpy_c(&mut card, &incard[*pt..]); /* save the original */
+    card[FLEN_CARD - 1] = 0;
+
+    *ktype = kwdtyp::CMI_KEY; /* default: integer complex */
+    p = 1;
+    pr_beg = p;
+
+    temp[0] = 0;
+    while card[p] != 0 && card[p] as u8 != b'/' {
+        if card[p] as u8 == b')' {
+            set_paren = 1;
+            pi_end = p;
+            p += 1;
+            break;
+        }
+        if set_comm == 0 && card[p] as u8 == b',' {
+            set_comm = 1;
+            pr_end = Some(p);
+            pi_beg = Some(p + 1);
+        } else if card[p] as u8 == b',' {
+            *stat |= TOO_MANY_COMMA;
+        }
+        p += 1;
+    }
+    if set_comm == 0 {
+        *stat |= NO_COMMA;
+    }
+    if set_paren == 0 {
+        *stat |= NO_TRAIL_PAREN;
+        pi_end = p;
+        if pi_end > 0 {
+            pi_end -= 1;
+            while pi_end > 0 && isspace_c(card[pi_end]) {
+                pi_end -= 1;
+            }
+            pi_end += 1;
+        }
+    }
+
+    nchar = std::cmp::min(pi_end, kvalue.len() - 1);
+    strncpy_c(kvalue, &card, nchar);
+    kvalue[nchar] = 0;
+    while isspace_c(card[p]) && card[p] != 0 {
+        p += 1;
+    }
+    *pt += p;
+
+    /* analyse the real and imagine part */
+    if let Some(e) = pr_end {
+        card[e] = 0;
+    }
+    card[pi_end] = 0;
+    while isspace_c(card[pr_beg]) && card[pr_beg] != 0 {
+        pr_beg += 1;
+    }
+    if let Some(mut b) = pi_beg {
+        while isspace_c(card[b]) && card[b] != 0 {
+            b += 1;
+        }
+        pi_beg = Some(b);
+    }
+    temp[0] = 0;
+    let mut pp = pr_beg;
+    get_num(&card, &mut pp, &mut temp, &mut rtype, &mut tr);
+    if tr != 0 {
+        *stat |= BAD_REAL;
+    }
+    temp[0] = 0;
+    if let Some(b) = pi_beg {
+        let mut pp = b;
+        get_num(&card, &mut pp, &mut temp, &mut itype, &mut ti);
+    }
+    if ti != 0 {
+        *stat |= BAD_IMG;
+    }
+    if rtype == kwdtyp::FLT_KEY || itype == kwdtyp::FLT_KEY {
+        *ktype = kwdtyp::CMF_KEY;
+    }
+}
+
+/* parse and test the comment keys */
+pub fn get_comm(
+    card: &[c_char],      /* card string */
+    pt: &mut usize,       /* cursor into card */
+    kcomm: &mut [c_char], /* comment string */
+    stat: &mut c_ulong,   /* error number */
+) {
+    let pi: usize;
+    let nchar: usize;
+    let mut p: usize;
+
+    p = *pt;
+    pi = p;
+    if card[p] as u8 != b'/' {
+        *stat |= NO_START_SLASH;
+    }
+    p += 1;
+    while card[p] != 0 {
+        if !isprint_c(card[p]) {
+            *stat |= BAD_COMMENT;
+        }
+        p += 1;
+    }
+    nchar = std::cmp::min(p - pi, kcomm.len() - 1);
+    strncpy_c(kcomm, &card[pi..], nchar);
+    kcomm[nchar] = 0;
+}
+
+/* parsing the unknown keyword */
+pub fn get_unknown(
+    card: &[c_char],       /* card string */
+    pt: &mut usize,        /* cursor into card */
+    kvalue: &mut [c_char], /* comment string */
+    ktype: &mut kwdtyp,
+    stat: &mut c_ulong, /* error number */
+) {
+    let mut p: usize;
+    let mut p1: usize;
+    let mut temp: [c_char; FLEN_CARD] = [0; FLEN_CARD];
+
+    p = *pt;
+    strcpy_c(&mut temp, &card[*pt..]);
+    p1 = 0;
+    while card[p] != 0 && card[p] as u8 != b'/' {
+        p += 1;
+        p1 += 1;
+    }
+    temp[p1] = 0;
+    *pt = p;
+
+    strcpy_c(kvalue, &temp);
+    *ktype = kwdtyp::UNKNOWN;
+    *stat |= UNKNOWN_TYPE;
+}
+
+/* routine to print out the error of keyword value/comment */
+pub fn pr_kval_err(
+    out: Out,          /* output  FILE */
+    kpos: c_int,       /* keyposition starting from 1 */
+    kname: &[c_char],  /* keyword name */
+    kval: &[c_char],   /* keyword value */
+    errnum: c_ulong,   /* error number */
+) {
+    let mut errmes: [c_char; ERRMES_LEN] = [0; ERRMES_LEN];
+
+    if errnum == 0 {
+        return;
+    }
+    if errnum & BAD_STR != 0 {
+        spf!(errmes;
+            "Keyword #", kpos, ", ", CS(kname), ": String \"", CS(kval),
+            "\"  contains non-text characters.");
+        wrterr(out, &errmes, 1);
+    }
+    if errnum & NO_TRAIL_QUOTE != 0 {
+        spf!(errmes;
+            "Keyword #", kpos, ", ", CS(kname),
+            ": The closing \"'\" is missing in the string.");
+        wrterr(out, &errmes, 1);
+    }
+    if errnum & BAD_LOGICAL != 0 {
+        spf!(errmes;
+            "Keyword #", kpos, ", ", CS(kname), ": Bad logical value \"", CS(kval), "\".");
+        wrterr(out, &errmes, 1);
+    }
+    if errnum & BAD_NUM != 0 {
+        spf!(errmes;
+            "Keyword #", kpos, ", ", CS(kname), ": Bad numerical value \"", CS(kval), "\".");
+        wrterr(out, &errmes, 1);
+    }
+    if errnum & LOWCASE_EXPO != 0 {
+        spf!(errmes;
+            "Keyword #", kpos, ", ", CS(kname),
+            ": lower-case exponent d or e is illegal in value ", CS(kval), ".");
+        wrterr(out, &errmes, 1);
+    }
+    if errnum & NO_TRAIL_PAREN != 0 {
+        spf!(errmes;
+            "Keyword #", kpos, ", ", CS(kname), ": Complex value \"", CS(kval),
+            "\" misses closing \")\".");
+        wrterr(out, &errmes, 1);
+    }
+    if errnum & NO_COMMA != 0 {
+        spf!(errmes;
+            "keyword #", kpos, ", ", CS(kname), " : Complex value \"", CS(kval),
+            "\" misses \",\".");
+        wrterr(out, &errmes, 1);
+    }
+    if errnum & TOO_MANY_COMMA != 0 {
+        spf!(errmes;
+            "Keyword #", kpos, ", ", CS(kname),
+            ": Too many \",\" are in the complex value \"", CS(kval), "\".");
+        wrterr(out, &errmes, 1);
+    }
+    if errnum & BAD_REAL != 0 {
+        spf!(errmes;
+            "Keyword #", kpos, ", ", CS(kname), ": Real part of complex value \"", CS(kval),
+            "\" is  bad.");
+        wrterr(out, &errmes, 1);
+    }
+    if errnum & BAD_IMG != 0 {
+        spf!(errmes;
+            "Keyword #", kpos, ", ", CS(kname), ": Imagine part of complex value \"", CS(kval),
+            "\" is bad.");
+        wrterr(out, &errmes, 1);
+    }
+    if errnum & NO_START_SLASH != 0 {
+        spf!(errmes;
+            "Keyword #", kpos, ", ", CS(kname),
+            ": Value and Comment not separated by a \"/\".");
+        wrterr(out, &errmes, 1);
+    }
+    if errnum & BAD_COMMENT != 0 {
+        spf!(errmes;
+            "Keyword #", kpos, ", ", CS(kname), ": Comment contains non-text characters.");
+        wrterr(out, &errmes, 1);
+    }
+
+    if errnum & UNKNOWN_TYPE != 0 {
+        if kval[0] != 0 {
+            /* don't report null keywords as an error */
+            spf!(errmes;
+                "Keyword #", kpos, ", ", CS(kname), ": Type of value \"", CS(kval),
+                "\" is unknown.");
+            wrterr(out, &errmes, 1);
+        }
+    }
+}
+
+pub fn check_str(pkey: &FitsKey, out: Out) -> c_int {
+    let mut errmes: [c_char; ERRMES_LEN] = [0; ERRMES_LEN];
+
+    if pkey.ktype == kwdtyp::UNKNOWN && pkey.kvalue[0] == 0 {
+        spf!(errmes;
+            "Keyword #", pkey.kindex, ", ", CS(&pkey.kname),
+            " has a null value; expected a string.");
+        wrterr(out, &errmes, 1);
+        return 0;
+    } else if pkey.ktype != kwdtyp::STR_KEY {
+        spf!(errmes;
+            "Keyword #", pkey.kindex, ", ", CS(&pkey.kname), ": \"", CS(&pkey.kvalue),
+            "\" is not a string.");
+        wrterr(out, &errmes, 1);
+        return 0;
+    }
+    1
+}
+
+pub fn check_int(pkey: &FitsKey, out: Out) -> c_int {
+    let mut errmes: [c_char; ERRMES_LEN] = [0; ERRMES_LEN];
+
+    if pkey.ktype == kwdtyp::UNKNOWN && pkey.kvalue[0] == 0 {
+        spf!(errmes;
+            "Keyword #", pkey.kindex, ", ", CS(&pkey.kname),
+            " has a null value; expected an integer.");
+        wrterr(out, &errmes, 1);
+        return 0;
+    } else if pkey.ktype != kwdtyp::INT_KEY {
+        spf!(errmes;
+            "Keyword #", pkey.kindex, ", ", CS(&pkey.kname), ": value = ", CS(&pkey.kvalue),
+            " is not an integer.");
+        if pkey.ktype == kwdtyp::STR_KEY {
+            scat!(errmes; " The value is entered as a string. ");
+        }
+        wrterr(out, &errmes, 1);
+        return 0;
+    }
+    1
+}
+
+pub fn check_flt(pkey: &FitsKey, out: Out) -> c_int {
+    let mut errmes: [c_char; ERRMES_LEN] = [0; ERRMES_LEN];
+
+    if pkey.ktype == kwdtyp::UNKNOWN && pkey.kvalue[0] == 0 {
+        spf!(errmes;
+            "Keyword #", pkey.kindex, ", ", CS(&pkey.kname),
+            " has a null value; expected a float.");
+        wrterr(out, &errmes, 1);
+        return 0;
+    } else if pkey.ktype != kwdtyp::INT_KEY && pkey.ktype != kwdtyp::FLT_KEY {
+        spf!(errmes;
+            "Keyword #", pkey.kindex, ", ", CS(&pkey.kname), ": value = ", CS(&pkey.kvalue),
+            " is not a floating point number.");
+        if pkey.ktype == kwdtyp::STR_KEY {
+            scat!(errmes; " The value is entered as a string. ");
+        }
+        wrterr(out, &errmes, 1);
+        return 0;
+    }
+    1
+}
+
+pub fn check_cmi(pkey: &FitsKey, out: Out) -> c_int {
+    let mut errmes: [c_char; ERRMES_LEN] = [0; ERRMES_LEN];
+
+    if pkey.ktype != kwdtyp::CMI_KEY {
+        spf!(errmes;
+            "Keyword #", pkey.kindex, ", ", CS(&pkey.kname), ": value = ", CS(&pkey.kvalue),
+            " is not a integer complex number.");
+        if pkey.ktype == kwdtyp::STR_KEY {
+            scat!(errmes; " The value is entered as a string. ");
+        }
+        wrterr(out, &errmes, 1);
+        return 0;
+    }
+    1
+}
+
+pub fn check_cmf(pkey: &FitsKey, out: Out) -> c_int {
+    let mut errmes: [c_char; ERRMES_LEN] = [0; ERRMES_LEN];
+
+    if pkey.ktype != kwdtyp::CMI_KEY && pkey.ktype != kwdtyp::CMF_KEY {
+        spf!(errmes;
+            "Keyword #", pkey.kindex, ", ", CS(&pkey.kname), ": value = ", CS(&pkey.kvalue),
+            " is not a floating point complex number.");
+        if pkey.ktype == kwdtyp::STR_KEY {
+            scat!(errmes; " The value is entered as a string. ");
+        }
+        wrterr(out, &errmes, 1);
+        return 0;
+    }
+    1
+}
+
+pub fn check_log(pkey: &FitsKey, out: Out) -> c_int {
+    let mut errmes: [c_char; ERRMES_LEN] = [0; ERRMES_LEN];
+
+    if pkey.ktype != kwdtyp::LOG_KEY {
+        spf!(errmes;
+            "Keyword #", pkey.kindex, ", ", CS(&pkey.kname), ": value = ", CS(&pkey.kvalue),
+            " is not a logical constant.");
+        if pkey.ktype == kwdtyp::STR_KEY {
+            scat!(errmes; " The value is entered as a string. ");
+        }
+        wrterr(out, &errmes, 1);
+        return 0;
+    }
+    1
+}
+
+pub fn check_fixed_int(card: &[c_char], out: Out) -> c_int {
+    let mut cptr: usize;
+    let mut errmes: [c_char; ERRMES_LEN] = [0; ERRMES_LEN];
+
+    /* fixed format integer must be right justified in columns 11-30 */
+
+    cptr = 10;
+
+    while card[cptr] as u8 == b' ' {
+        cptr += 1;
+    } /* skip leading spaces */
+
+    if card[cptr] as u8 == b'-' {
+        cptr += 1; /* skip leading minus sign */
+    } else if card[cptr] as u8 == b'+' {
+        cptr += 1; /* skip leading plus sign */
+    }
+
+    while isdigit_c(card[cptr]) {
+        cptr += 1;
+    } /* skip digits */
+
+    /* should be pointing to column 31 of the card */
+
+    if cptr != 30 {
+        spf!(errmes; CSW(card, 0, Some(8)), " mandatory keyword is not in integer fixed format:");
+        wrterr(out, &errmes, 1);
+        print_fmt(out, card, 13);
+        print_fmt_str(out, "          -------------------^", 13);
+
+        return 0;
+    }
+    1
+}
+
+pub fn check_fixed_log(card: &[c_char], out: Out) -> c_int {
+    let mut cptr: usize;
+    let mut errmes: [c_char; ERRMES_LEN] = [0; ERRMES_LEN];
+
+    /* fixed format logical must have T or F in column 30 */
+
+    cptr = 10;
+
+    while card[cptr] as u8 == b' ' {
+        cptr += 1;
+    } /* skip leading spaces */
+
+    if card[cptr] as u8 != b'T' && card[cptr] as u8 != b'F' {
+        spf!(errmes;
+            CSW(card, 0, Some(8)), " mandatory keyword does not have T or F logical value.");
+        wrterr(out, &errmes, 1);
+        return 0;
+    }
+
+    /* should be pointing to column 31 of the card */
+
+    if cptr != 29 {
+        spf!(errmes; CSW(card, 0, Some(8)), " mandatory keyword is not in logical fixed format:");
+        wrterr(out, &errmes, 1);
+        print_fmt(out, card, 13);
+        print_fmt_str(out, "          -------------------^", 13);
+
+        return 0;
+    }
+    1
+}
+
+pub fn check_fixed_str(card: &[c_char], out: Out) -> c_int {
+    let mut cptr: usize;
+    let mut errmes: [c_char; ERRMES_LEN] = [0; ERRMES_LEN];
+
+    /* fixed format string must have quotes in columns 11 and >= 20 */
+    /* This only applys to the XTENSION and TFORMn keywords. */
+
+    cptr = 10;
+
+    if card[cptr] as u8 != b'\'' {
+        spf!(errmes;
+            CSW(card, 0, Some(8)), " mandatory string keyword does not start in col 11.");
+        wrterr(out, &errmes, 1);
+        print_fmt(out, card, 13);
+        print_fmt_str(out, "          ^--------^", 13);
+        return 0;
+    }
+
+    cptr += 1;
+
+    while card[cptr] as u8 != b'\'' {
+        if card[cptr] == 0 {
+            spf!(errmes;
+                CSW(card, 0, Some(8)),
+                " mandatory string keyword missing closing quote character:");
+            wrterr(out, &errmes, 1);
+            print_fmt(out, card, 13);
+            return 0;
+        }
+        cptr += 1;
+    }
+
+    if cptr < 19 {
+        spf!(errmes; CSW(card, 0, Some(8)), " mandatory string keyword ends before column 20.");
+        wrterr(out, &errmes, 1);
+        print_fmt(out, card, 13);
+        print_fmt_str(out, "          ^--------^", 13);
+
+        return 0;
+    }
+
+    1
+}
 

--- a/src/bin/fitsverify/fvrf_misc.rs
+++ b/src/bin/fitsverify/fvrf_misc.rs
@@ -1,1 +1,411 @@
+/******************************************************************************
+* Function
+*      wrtout: print messages in the streams of stdout and out.
+*      wrterr: print erro messages  in the streams of stderr and out.
+*      wrtferr: print cfitsio erro messages in the streams of stderr and out.
+*      wrtwrn: print warning messages in the streams of stdout and out.
+*      wrtsep: print seperators.
+*      num_err_wrn: Return the number of errors and  warnings.
+*
+*******************************************************************************/
+/* Transpiled from cfitsio/utilities/fvrf_misc.c */
+
+use std::sync::atomic::{AtomicI32, Ordering};
+
+use rsfitsio::aliases::rust_api::{fits_clear_errmsg, fits_get_errstatus, fits_read_errmsg};
+use rsfitsio::c_types::{c_char, c_int};
+use rsfitsio::fitsio::FLEN_ERRMSG;
+use rsfitsio::wrappers::{strcat_safe, strlen_safe};
+
+use crate::common::*;
+use crate::fvrf_file::close_report;
+use crate::{pf, scat, spf};
+
+static NWRNS: AtomicI32 = AtomicI32::new(0);
+static NERRS: AtomicI32 = AtomicI32::new(0);
+/* static char temp[512]; -- a scratch buffer, made local at each use site */
+const TEMP_LEN: usize = 512;
+
+pub fn num_err_wrn(num_err: &mut c_int, num_wrn: &mut c_int) {
+    *num_wrn = NWRNS.load(Ordering::Relaxed);
+    *num_err = NERRS.load(Ordering::Relaxed);
+}
+
+pub fn reset_err_wrn() {
+    NWRNS.store(0, Ordering::Relaxed);
+    NERRS.store(0, Ordering::Relaxed);
+}
+
+pub fn wrtout(out: Out, mess: &[c_char]) -> c_int {
+    if out != Out::Null {
+        pf!(out; CS(mess), "\n");
+    }
+    if out == Out::Stdout {
+        fflush_out(Out::Stdout);
+    }
+    0
+}
+
+/* wrtout() for a plain Rust literal */
+pub fn wrtout_str(out: Out, mess: &str) -> c_int {
+    if out != Out::Null {
+        pf!(out; mess, "\n");
+    }
+    if out == Out::Stdout {
+        fflush_out(Out::Stdout);
+    }
+    0
+}
+
+pub fn wrtwrn(out: Out, mess: &[c_char], isheasarc: c_int) -> c_int {
+    if err_report() != 0 {
+        return 0;
+    } /* Don't print the warnings */
+    if heasarc_conv() == 0 && isheasarc != 0 {
+        return 0;
+    } /* heasarc warnings  but with
+      heasarc convention turns off */
+    let nwrns = NWRNS.fetch_add(1, Ordering::Relaxed) + 1;
+
+    let mut temp: [c_char; TEMP_LEN] = [0; TEMP_LEN];
+    spf!(temp; "*** Warning: ", CS(mess));
+    if isheasarc != 0 {
+        scat!(temp; " (HEASARC Convention)");
+    }
+    print_fmt(out, &temp, 13);
+    /*    if(nwrns > MAXWRNS ) {
+         fprintf(stderr,"??? Too many Warnings! I give up...\n");
+
+    }  */
+    nwrns
+}
+
+pub fn wrtwrn_str(out: Out, mess: &str, isheasarc: c_int) -> c_int {
+    let mut b: [c_char; TEMP_LEN] = [0; TEMP_LEN];
+    spf!(b; mess);
+    wrtwrn(out, &b, isheasarc)
+}
+
+pub fn wrterr(out: Out, mess: &[c_char], severity: c_int) -> c_int {
+    if severity < err_report() {
+        fits_clear_errmsg();
+        return 0;
+    }
+    let nerrs = NERRS.fetch_add(1, Ordering::Relaxed) + 1;
+
+    let mut temp: [c_char; TEMP_LEN] = [0; TEMP_LEN];
+    spf!(temp; "*** Error:   ", CS(mess));
+    if out != Out::Null {
+        if out != Out::Stdout && out != Out::Stderr {
+            print_fmt(out, &temp, 13);
+        }
+        /*
+           if ERR2OUT is defined, then error messages will be sent to the
+           stdout stream rather than to stderr
+        */
+        /* #ifdef ERR2OUT ... #else */
+        print_fmt(Out::Stderr, &temp, 13);
+    }
+
+    if nerrs > MAXERRORS {
+        pf!(Out::Stderr; "??? Too many Errors! I give up...\n");
+        close_report(out);
+        fflush_out(Out::Stdout);
+        fflush_out(Out::Stderr);
+        std::process::exit(1);
+    }
+    fits_clear_errmsg();
+    nerrs
+}
+
+pub fn wrterr_str(out: Out, mess: &str, severity: c_int) -> c_int {
+    let mut b: [c_char; TEMP_LEN] = [0; TEMP_LEN];
+    spf!(b; mess);
+    wrterr(out, &b, severity)
+}
+
+/* construct an error message: mess + cfitsio error */
+pub fn wrtferr(out: Out, mess: &[c_char], status: &mut c_int, severity: c_int) -> c_int {
+    let mut ttemp: [c_char; 255] = [0; 255];
+
+    if severity < err_report() {
+        fits_clear_errmsg();
+        return 0;
+    }
+    let nerrs = NERRS.fetch_add(1, Ordering::Relaxed) + 1;
+
+    let mut temp: [c_char; TEMP_LEN] = [0; TEMP_LEN];
+    spf!(temp; "*** Error:   ", CS(mess));
+    fits_get_errstatus(*status, &mut ttemp);
+    strcat_safe(&mut temp, &ttemp);
+    if out != Out::Null {
+        if out != Out::Stdout && out != Out::Stderr {
+            print_fmt(out, &temp, 13);
+        }
+        /* #ifdef ERR2OUT ... #else */
+        print_fmt(Out::Stderr, &temp, 13);
+    }
+
+    *status = 0;
+    fits_clear_errmsg();
+    if nerrs > MAXERRORS {
+        pf!(Out::Stderr; "??? Too many Errors! I give up...\n");
+        close_report(out);
+        fflush_out(Out::Stdout);
+        fflush_out(Out::Stderr);
+        std::process::exit(1);
+    }
+    nerrs
+}
+
+pub fn wrtferr_str(out: Out, mess: &str, status: &mut c_int, severity: c_int) -> c_int {
+    let mut b: [c_char; TEMP_LEN] = [0; TEMP_LEN];
+    spf!(b; mess);
+    wrtferr(out, &b, status, severity)
+}
+
+/* dump the cfitsio stack */
+pub fn wrtserr(out: Out, mess: &[c_char], status: &mut c_int, severity: c_int) -> c_int {
+    /* char* errfmt = "             %.67s\n"; */
+    let mut i;
+    /* C declares tmp[20][80] but then prints tmp[nstack] with nstack possibly
+       == 20; one extra row keeps that in bounds. */
+    let mut tmp: [[c_char; FLEN_ERRMSG]; 21] = [[0; FLEN_ERRMSG]; 21];
+    let mut nstack = 0usize;
+
+    if severity < err_report() {
+        fits_clear_errmsg();
+        return 0;
+    }
+    let nerrs = NERRS.fetch_add(1, Ordering::Relaxed) + 1;
+
+    let mut temp: [c_char; TEMP_LEN] = [0; TEMP_LEN];
+    spf!(temp; "*** Error:   ", CS(mess), "(from CFITSIO error stack:)");
+    while nstack < 20 {
+        tmp[nstack][0] = 0;
+        let r = fits_read_errmsg(&mut tmp[nstack]);
+        if r == 0 && tmp[nstack][0] == 0 {
+            break;
+        }
+        nstack += 1;
+    }
+
+    if out != Out::Null {
+        if out != Out::Stdout && out != Out::Stderr {
+            print_fmt(out, &temp, 13);
+            i = 0;
+            while i <= nstack {
+                pf!(out; "             ", CSW(&tmp[i], 0, Some(67)), "\n");
+                i += 1;
+            }
+        }
+
+        /* #ifdef ERR2OUT ... #else */
+        print_fmt(Out::Stderr, &temp, 13);
+        i = 0;
+        while i <= nstack {
+            pf!(Out::Stderr; "             ", CSW(&tmp[i], 0, Some(67)), "\n");
+            i += 1;
+        }
+    }
+
+    *status = 0;
+    fits_clear_errmsg();
+    if nerrs > MAXERRORS {
+        pf!(Out::Stderr; "??? Too many Errors! I give up...\n");
+        close_report(out);
+        fflush_out(Out::Stdout);
+        fflush_out(Out::Stderr);
+        std::process::exit(1);
+    }
+    nerrs
+}
+
+pub fn wrtserr_str(out: Out, mess: &str, status: &mut c_int, severity: c_int) -> c_int {
+    let mut b: [c_char; TEMP_LEN] = [0; TEMP_LEN];
+    spf!(b; mess);
+    wrtserr(out, &b, status, severity)
+}
+
+/* Print output of messages in a 80 character record.
+    Continue lines are aligned. */
+pub fn print_fmt(out: Out, temp: &[c_char], nprompt: c_int) {
+    let mut j: usize;
+    let clen: usize;
+    let mut tmp: [c_char; 81] = [0; 81];
+    /* The C builds a `static char cont_fmt[80]' of `nprompt' blanks followed by
+       "%.67s\n" the first time it sees a new nprompt.  Every call site in
+       fitsverify passes nprompt = 13, so the prompt is simply re-emitted here. */
+
+    if out == Out::Null {
+        return;
+    }
+
+    let slen = cstrlen(temp);
+    let mut i: isize = slen as isize - 80;
+    if i <= 0 {
+        pf!(out; CSW(temp, 0, Some(80)), "\n");
+    } else {
+        let mut p = 0usize;
+        clen = (80 - nprompt) as usize;
+        strncpy_c(&mut tmp, &temp[p..], 80);
+        tmp[80] = 0;
+        if isprint_c(temp[p + 79]) && isprint_c(temp[p + 80]) && temp[p + 80] != 0 {
+            j = 79;
+            while temp[p + j] as u8 != b' ' && j > 0 {
+                j -= 1;
+            }
+            p += j;
+            while temp[p] as u8 == b' ' {
+                p += 1;
+            }
+            tmp[j] = 0;
+        } else if temp[p + 80] as u8 == b' ' {
+            j = 80;
+            while temp[p + j] as u8 == b' ' {
+                j += 1;
+            }
+            p += j;
+        } else {
+            p += 80;
+        }
+        pf!(out; CSW(&tmp, 0, Some(80)), "\n");
+        while temp[p] != 0 && i > 0 {
+            strncpy_c(&mut tmp, &temp[p..], clen);
+            tmp[clen] = 0;
+            i = cstrlen(&temp[p..]) as isize - clen as isize;
+            if i > 0
+                && isprint_c(temp[p + clen - 1])
+                && isprint_c(temp[p + clen])
+                && temp[p + clen] != 0
+            {
+                j = clen;
+                while temp[p + j] as u8 != b' ' && j > 0 {
+                    j -= 1;
+                }
+                p += j;
+                while temp[p] as u8 == b' ' {
+                    p += 1;
+                }
+                tmp[j] = 0;
+            } else if i > 0 && temp[p + clen] as u8 == b' ' {
+                j = clen;
+                while temp[p + j] as u8 == b' ' {
+                    j += 1;
+                }
+                p += j;
+            } else if i > 0 {
+                p += clen;
+            }
+            /* fprintf(out, cont_fmt, tmp) */
+            let mut v: Vec<u8> = Vec::new();
+            v.extend(std::iter::repeat_n(b' ', nprompt as usize));
+            CSW(&tmp, 0, Some(67)).put(&mut v);
+            v.push(b'\n');
+            fwrite_out(out, &v);
+        }
+    }
+    if out == Out::Stdout {
+        fflush_out(Out::Stdout);
+    }
+}
+
+pub fn print_fmt_str(out: Out, s: &str, nprompt: c_int) {
+    let mut b: [c_char; TEMP_LEN] = [0; TEMP_LEN];
+    spf!(b; s);
+    print_fmt(out, &b, nprompt);
+}
+
+/* print a line of char fill with string title in the middle */
+pub fn wrtsep(out: Out, fill: c_char, title: &[c_char], nchar: c_int) {
+    let ntitle: usize;
+    let line: &mut Vec<c_char>;
+    let mut p: usize;
+    let first_end: usize;
+    let mut i;
+    let mut nchar = nchar;
+
+    ntitle = strlen_safe(title);
+    if ntitle as c_int > nchar {
+        nchar = ntitle as c_int;
+    }
+    if nchar <= 0 {
+        return;
+    }
+    let nchar = nchar as usize;
+    let mut linebuf: Vec<c_char> = vec![0; nchar + 1];
+    line = &mut linebuf;
+    p = 0;
+    if ntitle < 1 {
+        i = 0;
+        while i < nchar {
+            line[p] = fill;
+            p += 1;
+            i += 1;
+        }
+        line[p] = 0;
+    } else {
+        first_end = (nchar - ntitle) / 2;
+        i = 0;
+        while i < first_end {
+            line[p] = fill;
+            p += 1;
+            i += 1;
+        }
+        line[p] = 0;
+        strcat_safe(line, title);
+        p += ntitle;
+        i = first_end + ntitle;
+        while i < nchar {
+            line[p] = fill;
+            p += 1;
+            i += 1;
+        }
+        line[p] = 0;
+    }
+    if out != Out::Null {
+        pf!(out; CS(line), "\n");
+    }
+    if out == Out::Stdout {
+        fflush_out(out);
+    }
+}
+
+pub fn wrtsep_str(out: Out, fill: c_char, title: &str, nchar: c_int) {
+    let mut b: [c_char; TEMP_LEN] = [0; TEMP_LEN];
+    spf!(b; title);
+    wrtsep(out, fill, &b, nchar);
+}
+
+/* comparison function for the FitsKey structure array */
+pub fn compkey(key1: &FitsKey, key2: &FitsKey) -> c_int {
+    strncmp_c(&key1.kname, &key2.kname, FLEN_KEYWORD_C)
+}
+
+const FLEN_KEYWORD_C: usize = rsfitsio::fitsio::FLEN_KEYWORD;
+
+/* comparison function for the colname structure array */
+pub fn compcol(col1: &ColName, col2: &ColName) -> c_int {
+    strcmp_c(&col1.name, &col2.name)
+}
+
+/* comparison function for the string pattern maching*/
+pub fn compstrp(str1: &[c_char], str2: &[c_char]) -> c_int {
+    let mut p = 0usize;
+    let mut q = 0usize;
+    while str2[q] == str1[p] && str2[q] != 0 {
+        p += 1;
+        q += 1;
+        if str1[p] == 0 {
+            return 0; /* str2 is longer than str1, but
+                      matched */
+        }
+    }
+    (str1[p] as u8) as c_int - (str2[q] as u8) as c_int
+}
+
+/* comparison function for the string exact maching*/
+pub fn compstre(str1: &[c_char], str2: &[c_char]) -> c_int {
+    strcmp_c(str1, str2)
+}
 

--- a/src/bin/fitsverify/fvrf_misc.rs
+++ b/src/bin/fitsverify/fvrf_misc.rs
@@ -10,7 +10,8 @@
 *******************************************************************************/
 /* Transpiled from cfitsio/utilities/fvrf_misc.c */
 
-use std::sync::atomic::{AtomicI32, Ordering};
+use std::cell::Cell;
+use std::cmp::Ordering;
 
 use rsfitsio::aliases::rust_api::{fits_clear_errmsg, fits_get_errstatus, fits_read_errmsg};
 use rsfitsio::c_types::{c_char, c_int};
@@ -21,22 +22,22 @@ use crate::common::*;
 use crate::fvrf_file::close_report;
 use crate::{pf, scat, spf};
 
-static NWRNS: AtomicI32 = AtomicI32::new(0);
-static NERRS: AtomicI32 = AtomicI32::new(0);
+thread_local! { static NWRNS: Cell<c_int> = const { Cell::new(0) }; }
+thread_local! { static NERRS: Cell<c_int> = const { Cell::new(0) }; }
 /* static char temp[512]; -- a scratch buffer, made local at each use site */
 const TEMP_LEN: usize = 512;
 
-pub fn num_err_wrn(num_err: &mut c_int, num_wrn: &mut c_int) {
-    *num_wrn = NWRNS.load(Ordering::Relaxed);
-    *num_err = NERRS.load(Ordering::Relaxed);
+pub(crate) fn num_err_wrn(num_err: &mut c_int, num_wrn: &mut c_int) {
+    *num_wrn = NWRNS.with(Cell::get);
+    *num_err = NERRS.with(Cell::get);
 }
 
-pub fn reset_err_wrn() {
-    NWRNS.store(0, Ordering::Relaxed);
-    NERRS.store(0, Ordering::Relaxed);
+pub(crate) fn reset_err_wrn() {
+    NWRNS.with(|c| c.set(0));
+    NERRS.with(|c| c.set(0));
 }
 
-pub fn wrtout(out: Out, mess: &[c_char]) -> c_int {
+pub(crate) fn wrtout(out: Out, mess: &[c_char]) -> c_int {
     if out != Out::Null {
         pf!(out; CS(mess), "\n");
     }
@@ -47,7 +48,7 @@ pub fn wrtout(out: Out, mess: &[c_char]) -> c_int {
 }
 
 /* wrtout() for a plain Rust literal */
-pub fn wrtout_str(out: Out, mess: &str) -> c_int {
+pub(crate) fn wrtout_str(out: Out, mess: &str) -> c_int {
     if out != Out::Null {
         pf!(out; mess, "\n");
     }
@@ -57,7 +58,7 @@ pub fn wrtout_str(out: Out, mess: &str) -> c_int {
     0
 }
 
-pub fn wrtwrn(out: Out, mess: &[c_char], isheasarc: c_int) -> c_int {
+pub(crate) fn wrtwrn(out: Out, mess: &[c_char], isheasarc: c_int) -> c_int {
     if err_report() != 0 {
         return 0;
     } /* Don't print the warnings */
@@ -65,7 +66,7 @@ pub fn wrtwrn(out: Out, mess: &[c_char], isheasarc: c_int) -> c_int {
         return 0;
     } /* heasarc warnings  but with
       heasarc convention turns off */
-    let nwrns = NWRNS.fetch_add(1, Ordering::Relaxed) + 1;
+    let nwrns = NWRNS.with(|c| { let v = c.get(); c.set(v + 1); v }) + 1;
 
     let mut temp: [c_char; TEMP_LEN] = [0; TEMP_LEN];
     spf!(temp; "*** Warning: ", CS(mess));
@@ -80,18 +81,18 @@ pub fn wrtwrn(out: Out, mess: &[c_char], isheasarc: c_int) -> c_int {
     nwrns
 }
 
-pub fn wrtwrn_str(out: Out, mess: &str, isheasarc: c_int) -> c_int {
+pub(crate) fn wrtwrn_str(out: Out, mess: &str, isheasarc: c_int) -> c_int {
     let mut b: [c_char; TEMP_LEN] = [0; TEMP_LEN];
     spf!(b; mess);
     wrtwrn(out, &b, isheasarc)
 }
 
-pub fn wrterr(out: Out, mess: &[c_char], severity: c_int) -> c_int {
+pub(crate) fn wrterr(out: Out, mess: &[c_char], severity: c_int) -> c_int {
     if severity < err_report() {
         fits_clear_errmsg();
         return 0;
     }
-    let nerrs = NERRS.fetch_add(1, Ordering::Relaxed) + 1;
+    let nerrs = NERRS.with(|c| { let v = c.get(); c.set(v + 1); v }) + 1;
 
     let mut temp: [c_char; TEMP_LEN] = [0; TEMP_LEN];
     spf!(temp; "*** Error:   ", CS(mess));
@@ -118,21 +119,21 @@ pub fn wrterr(out: Out, mess: &[c_char], severity: c_int) -> c_int {
     nerrs
 }
 
-pub fn wrterr_str(out: Out, mess: &str, severity: c_int) -> c_int {
+pub(crate) fn wrterr_str(out: Out, mess: &str, severity: c_int) -> c_int {
     let mut b: [c_char; TEMP_LEN] = [0; TEMP_LEN];
     spf!(b; mess);
     wrterr(out, &b, severity)
 }
 
 /* construct an error message: mess + cfitsio error */
-pub fn wrtferr(out: Out, mess: &[c_char], status: &mut c_int, severity: c_int) -> c_int {
+pub(crate) fn wrtferr(out: Out, mess: &[c_char], status: &mut c_int, severity: c_int) -> c_int {
     let mut ttemp: [c_char; 255] = [0; 255];
 
     if severity < err_report() {
         fits_clear_errmsg();
         return 0;
     }
-    let nerrs = NERRS.fetch_add(1, Ordering::Relaxed) + 1;
+    let nerrs = NERRS.with(|c| { let v = c.get(); c.set(v + 1); v }) + 1;
 
     let mut temp: [c_char; TEMP_LEN] = [0; TEMP_LEN];
     spf!(temp; "*** Error:   ", CS(mess));
@@ -158,14 +159,14 @@ pub fn wrtferr(out: Out, mess: &[c_char], status: &mut c_int, severity: c_int) -
     nerrs
 }
 
-pub fn wrtferr_str(out: Out, mess: &str, status: &mut c_int, severity: c_int) -> c_int {
+pub(crate) fn wrtferr_str(out: Out, mess: &str, status: &mut c_int, severity: c_int) -> c_int {
     let mut b: [c_char; TEMP_LEN] = [0; TEMP_LEN];
     spf!(b; mess);
     wrtferr(out, &b, status, severity)
 }
 
 /* dump the cfitsio stack */
-pub fn wrtserr(out: Out, mess: &[c_char], status: &mut c_int, severity: c_int) -> c_int {
+pub(crate) fn wrtserr(out: Out, mess: &[c_char], status: &mut c_int, severity: c_int) -> c_int {
     /* char* errfmt = "             %.67s\n"; */
     let mut i;
     /* C declares tmp[20][80] but then prints tmp[nstack] with nstack possibly
@@ -177,7 +178,7 @@ pub fn wrtserr(out: Out, mess: &[c_char], status: &mut c_int, severity: c_int) -
         fits_clear_errmsg();
         return 0;
     }
-    let nerrs = NERRS.fetch_add(1, Ordering::Relaxed) + 1;
+    let nerrs = NERRS.with(|c| { let v = c.get(); c.set(v + 1); v }) + 1;
 
     let mut temp: [c_char; TEMP_LEN] = [0; TEMP_LEN];
     spf!(temp; "*** Error:   ", CS(mess), "(from CFITSIO error stack:)");
@@ -221,7 +222,7 @@ pub fn wrtserr(out: Out, mess: &[c_char], status: &mut c_int, severity: c_int) -
     nerrs
 }
 
-pub fn wrtserr_str(out: Out, mess: &str, status: &mut c_int, severity: c_int) -> c_int {
+pub(crate) fn wrtserr_str(out: Out, mess: &str, status: &mut c_int, severity: c_int) -> c_int {
     let mut b: [c_char; TEMP_LEN] = [0; TEMP_LEN];
     spf!(b; mess);
     wrtserr(out, &b, status, severity)
@@ -229,7 +230,7 @@ pub fn wrtserr_str(out: Out, mess: &str, status: &mut c_int, severity: c_int) ->
 
 /* Print output of messages in a 80 character record.
     Continue lines are aligned. */
-pub fn print_fmt(out: Out, temp: &[c_char], nprompt: c_int) {
+pub(crate) fn print_fmt(out: Out, temp: &[c_char], nprompt: c_int) {
     let mut j: usize;
     let clen: usize;
     let mut tmp: [c_char; 81] = [0; 81];
@@ -310,14 +311,14 @@ pub fn print_fmt(out: Out, temp: &[c_char], nprompt: c_int) {
     }
 }
 
-pub fn print_fmt_str(out: Out, s: &str, nprompt: c_int) {
+pub(crate) fn print_fmt_str(out: Out, s: &str, nprompt: c_int) {
     let mut b: [c_char; TEMP_LEN] = [0; TEMP_LEN];
     spf!(b; s);
     print_fmt(out, &b, nprompt);
 }
 
 /* print a line of char fill with string title in the middle */
-pub fn wrtsep(out: Out, fill: c_char, title: &[c_char], nchar: c_int) {
+pub(crate) fn wrtsep(out: Out, fill: c_char, title: &[c_char], nchar: c_int) {
     let ntitle: usize;
     let line: &mut Vec<c_char>;
     let mut p: usize;
@@ -371,51 +372,48 @@ pub fn wrtsep(out: Out, fill: c_char, title: &[c_char], nchar: c_int) {
     }
 }
 
-pub fn wrtsep_str(out: Out, fill: c_char, title: &str, nchar: c_int) {
+pub(crate) fn wrtsep_str(out: Out, fill: c_char, title: &str, nchar: c_int) {
     let mut b: [c_char; TEMP_LEN] = [0; TEMP_LEN];
     spf!(b; title);
     wrtsep(out, fill, &b, nchar);
 }
 
 /* comparison function for the FitsKey structure array */
-pub fn compkey(key1: &FitsKey, key2: &FitsKey) -> c_int {
-    strncmp_c(&key1.kname, &key2.kname, FLEN_KEYWORD_C)
+pub(crate) fn compkey(key1: &FitsKey, key2: &FitsKey) -> Ordering {
+    ccmp(&key1.kname, &key2.kname)
 }
-
-const FLEN_KEYWORD_C: usize = rsfitsio::fitsio::FLEN_KEYWORD;
 
 /* comparison function for the colname structure array */
-pub fn compcol(col1: &ColName, col2: &ColName) -> c_int {
-    strcmp_c(&col1.name, &col2.name)
+pub(crate) fn compcol(col1: &ColName, col2: &ColName) -> Ordering {
+    ccmp(&col1.name, &col2.name)
 }
 
-/* comparison function for the string pattern maching*/
-pub fn compstrp(str1: &[c_char], str2: &[c_char]) -> c_int {
-    let mut p = 0usize;
-    let mut q = 0usize;
-    while str2[q] == str1[p] && str2[q] != 0 {
-        p += 1;
-        q += 1;
-        if str1[p] == 0 {
-            return 0; /* str2 is longer than str1, but
-                      matched */
-        }
+/* comparison function for the string pattern maching.
+   Equal when the pattern is a prefix of the candidate -- this is what lets
+   key_match() find every CRPIXn from the pattern "CRPIX". */
+pub(crate) fn compstrp(pattern: &[c_char], candidate: &[c_char]) -> Ordering {
+    let p = cbytes(pattern);
+    let q = cbytes(candidate);
+    if q.starts_with(p) {
+        Ordering::Equal
+    } else {
+        p.cmp(q)
     }
-    (str1[p] as u8) as c_int - (str2[q] as u8) as c_int
 }
 
 /* comparison function for the string exact maching*/
-pub fn compstre(str1: &[c_char], str2: &[c_char]) -> c_int {
-    strcmp_c(str1, str2)
+pub(crate) fn compstre(str1: &[c_char], str2: &[c_char]) -> Ordering {
+    ccmp(str1, str2)
 }
 
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rsfitsio::fitsio::FLEN_KEYWORD;
 
-    fn kw(s: &str) -> [c_char; FLEN_KEYWORD_C] {
-        let mut b = [0 as c_char; FLEN_KEYWORD_C];
+    fn kw(s: &str) -> [c_char; FLEN_KEYWORD] {
+        let mut b = [0 as c_char; FLEN_KEYWORD];
         for (i, &c) in s.as_bytes().iter().enumerate() {
             b[i] = c as c_char;
         }
@@ -426,33 +424,33 @@ mod tests {
        it reports equal when the pattern is a prefix of the array element. */
     #[test]
     fn test_compstrp() {
-        assert_eq!(compstrp(&kw("CRPIX"), &kw("CRPIX1")), 0);
-        assert_eq!(compstrp(&kw("CRPIX"), &kw("CRPIX")), 0);
-        assert_eq!(compstrp(&kw("CRPIX"), &kw("CRPIX12A")), 0);
-        /* element shorter than the pattern sorts before it: 'I' - '\0' */
-        assert_eq!(compstrp(&kw("CRPIX"), &kw("CRP")), b'I' as c_int);
+        assert_eq!(compstrp(&kw("CRPIX"), &kw("CRPIX1")), Ordering::Equal);
+        assert_eq!(compstrp(&kw("CRPIX"), &kw("CRPIX")), Ordering::Equal);
+        assert_eq!(compstrp(&kw("CRPIX"), &kw("CRPIX12A")), Ordering::Equal);
+        /* candidate shorter than the pattern is not a match, and sorts before it */
+        assert_eq!(compstrp(&kw("CRPIX"), &kw("CRP")), Ordering::Greater);
         /* ordinary ordering either side */
-        assert!(compstrp(&kw("CRPIX"), &kw("CS")) < 0);
-        assert!(compstrp(&kw("CRPIX"), &kw("BITPIX")) > 0);
+        assert_eq!(compstrp(&kw("CRPIX"), &kw("CS")), Ordering::Less);
+        assert_eq!(compstrp(&kw("CRPIX"), &kw("BITPIX")), Ordering::Greater);
     }
 
     #[test]
     fn test_compstre() {
-        assert_eq!(compstre(&kw("NAXIS"), &kw("NAXIS")), 0);
+        assert_eq!(compstre(&kw("NAXIS"), &kw("NAXIS")), Ordering::Equal);
         /* exact matching, so a longer element is not equal */
-        assert!(compstre(&kw("NAXIS"), &kw("NAXIS1")) < 0);
-        assert!(compstre(&kw("NAXIS1"), &kw("NAXIS")) > 0);
+        assert_eq!(compstre(&kw("NAXIS"), &kw("NAXIS1")), Ordering::Less);
+        assert_eq!(compstre(&kw("NAXIS1"), &kw("NAXIS")), Ordering::Greater);
     }
 
     #[test]
     fn test_compkey_and_compcol() {
         let a = FitsKey { kname: kw("AAA"), ..Default::default() };
         let b = FitsKey { kname: kw("AAB"), ..Default::default() };
-        assert!(compkey(&a, &b) < 0);
-        assert_eq!(compkey(&a, &a.clone()), 0);
+        assert_eq!(compkey(&a, &b), Ordering::Less);
+        assert_eq!(compkey(&a, &a.clone()), Ordering::Equal);
 
         let c1 = ColName { name: cvec(&kw("ALPHA")), index: 1 };
         let c2 = ColName { name: cvec(&kw("BETA")), index: 2 };
-        assert!(compcol(&c1, &c2) < 0);
+        assert_eq!(compcol(&c1, &c2), Ordering::Less);
     }
 }

--- a/src/bin/fitsverify/fvrf_misc.rs
+++ b/src/bin/fitsverify/fvrf_misc.rs
@@ -409,3 +409,50 @@ pub fn compstre(str1: &[c_char], str2: &[c_char]) -> c_int {
     strcmp_c(str1, str2)
 }
 
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn kw(s: &str) -> [c_char; FLEN_KEYWORD_C] {
+        let mut b = [0 as c_char; FLEN_KEYWORD_C];
+        for (i, &c) in s.as_bytes().iter().enumerate() {
+            b[i] = c as c_char;
+        }
+        b
+    }
+
+    /* compstrp is the prefix comparator bsearch() uses for indexed keywords:
+       it reports equal when the pattern is a prefix of the array element. */
+    #[test]
+    fn test_compstrp() {
+        assert_eq!(compstrp(&kw("CRPIX"), &kw("CRPIX1")), 0);
+        assert_eq!(compstrp(&kw("CRPIX"), &kw("CRPIX")), 0);
+        assert_eq!(compstrp(&kw("CRPIX"), &kw("CRPIX12A")), 0);
+        /* element shorter than the pattern sorts before it: 'I' - '\0' */
+        assert_eq!(compstrp(&kw("CRPIX"), &kw("CRP")), b'I' as c_int);
+        /* ordinary ordering either side */
+        assert!(compstrp(&kw("CRPIX"), &kw("CS")) < 0);
+        assert!(compstrp(&kw("CRPIX"), &kw("BITPIX")) > 0);
+    }
+
+    #[test]
+    fn test_compstre() {
+        assert_eq!(compstre(&kw("NAXIS"), &kw("NAXIS")), 0);
+        /* exact matching, so a longer element is not equal */
+        assert!(compstre(&kw("NAXIS"), &kw("NAXIS1")) < 0);
+        assert!(compstre(&kw("NAXIS1"), &kw("NAXIS")) > 0);
+    }
+
+    #[test]
+    fn test_compkey_and_compcol() {
+        let a = FitsKey { kname: kw("AAA"), ..Default::default() };
+        let b = FitsKey { kname: kw("AAB"), ..Default::default() };
+        assert!(compkey(&a, &b) < 0);
+        assert_eq!(compkey(&a, &a.clone()), 0);
+
+        let c1 = ColName { name: cvec(&kw("ALPHA")), index: 1 };
+        let c2 = ColName { name: cvec(&kw("BETA")), index: 2 };
+        assert!(compcol(&c1, &c2) < 0);
+    }
+}

--- a/src/bin/fitsverify/main.rs
+++ b/src/bin/fitsverify/main.rs
@@ -36,13 +36,11 @@ use crate::common::*;
 /*---------------------------------------------------------------------------*/
 /*  ftverify.c                                                               */
 /*---------------------------------------------------------------------------*/
-pub mod main_ftverify {
+pub(crate) mod main_ftverify {
     use std::io::BufRead;
 
-    use bytemuck::cast_slice;
     use rsfitsio::aliases::rust_api::fits_get_version;
     use rsfitsio::c_types::{c_char, c_int};
-    use rsfitsio::cs;
     use rsfitsio::fitsio::{FILE_NOT_CREATED, FILE_NOT_OPENED, FLEN_FILENAME};
 
     use crate::common::*;
@@ -53,13 +51,13 @@ pub mod main_ftverify {
 
     const MAXMSG: usize = 256;
 
-    pub const PIL_LINESIZE: usize = 1024;
+    const PIL_LINESIZE: usize = 1024;
 
     /*---------------------------------------------------------------------------*/
     /* call work function to verify that infile conforms to the FITS
            standard and write report to the output file */
     #[allow(clippy::too_many_arguments)]
-    pub fn ftverify_work(
+    pub(crate) fn ftverify_work(
         infile: &[c_char],  /* I - Input file name (Fits) */
         outfile: &[c_char], /* I - Output file name (ASCII) */
         _prehead: c_int,
@@ -116,8 +114,8 @@ pub mod main_ftverify {
         /* test if writing output log to a disk file */
         if prstat != 0
             && cstrlen(op) != 0
-            && strcmp_c(op, cs!(c"STDOUT")) != 0
-            && strcmp_c(op, cs!(c"STDERR")) != 0
+            && !ceq(op, b"STDOUT")
+            && !ceq(op, b"STDERR")
             && std::fs::File::open(cstr_to_os(op)).is_ok()
         {
             spf!(msg; "Clobber is not set. Cannot overwrite the file", CS(op));
@@ -127,9 +125,9 @@ pub mod main_ftverify {
             return status;
         }
 
-        if prstat != 0 && (cstrlen(op) == 0 || strcmp_c(op, cs!(c"STDOUT")) == 0) {
+        if prstat != 0 && (cstrlen(op) == 0 || ceq(op, b"STDOUT")) {
             outfptr = Out::Stdout;
-        } else if prstat != 0 && (cstrlen(op) == 0 || strcmp_c(op, cs!(c"STDERR")) == 0) {
+        } else if prstat != 0 && (cstrlen(op) == 0 || ceq(op, b"STDERR")) {
             outfptr = Out::Stderr;
         } else if prstat == 0 {
             outfptr = Out::Null;
@@ -280,7 +278,7 @@ pub mod main_ftverify {
     *      Update the numerrs and numwrns parameters in the parfile.
     *
     *******************************************************************************/
-    pub fn update_parfile(nerr: c_int, nwrn: c_int) {
+    pub(crate) fn update_parfile(nerr: c_int, nwrn: c_int) {
         let mut status: c_int;
         let mut parname: [c_char; 32] = [0; 32];
 
@@ -308,40 +306,40 @@ pub mod main_ftverify {
       only needed when ftverify is built in the HEADAS environment.
     --------------------------------------------------------------------*/
 
-    pub fn PILGetFname(_parname: &[c_char], _filename: &mut [c_char]) -> c_int {
+    fn PILGetFname(_parname: &[c_char], _filename: &mut [c_char]) -> c_int {
         0
     }
 
-    pub fn PILGetString(_parname: &[c_char], _stringname: &mut [c_char]) -> c_int {
+    fn PILGetString(_parname: &[c_char], _stringname: &mut [c_char]) -> c_int {
         0
     }
 
-    pub fn PILGetBool(_parname: &[c_char], _intvalue: &mut c_int) -> c_int {
+    fn PILGetBool(_parname: &[c_char], _intvalue: &mut c_int) -> c_int {
         0
     }
 
-    pub fn PILPutInt(_parname: &[c_char], _intvalue: c_int) -> c_int {
+    fn PILPutInt(_parname: &[c_char], _intvalue: c_int) -> c_int {
         0
     }
 
-    pub fn set_toolname(_taskname: &[c_char]) {}
+    fn set_toolname(_taskname: &[c_char]) {}
 
-    pub fn set_toolversion(_taskname: &[c_char]) {}
+    fn set_toolversion(_taskname: &[c_char]) {}
 
-    pub fn get_toolname(taskname: &mut [c_char]) {
+    fn get_toolname(taskname: &mut [c_char]) {
         spf!(taskname; "fitsverify");
     }
 
-    pub fn get_toolversion(taskvers: &mut [c_char]) {
+    fn get_toolversion(taskvers: &mut [c_char]) {
         spf!(taskvers; "4.22");
     }
 
-    pub fn headas_clobberfile(_filename: &[c_char]) {}
+    fn headas_clobberfile(_filename: &[c_char]) {}
 
-    pub fn HD_ERROR_THROW(_msg: &[c_char], _status: c_int) {}
+    fn HD_ERROR_THROW(_msg: &[c_char], _status: c_int) {}
 
     /* An OS path from a NUL-terminated c_char buffer. */
-    pub fn cstr_to_os(s: &[c_char]) -> std::ffi::OsString {
+    fn cstr_to_os(s: &[c_char]) -> std::ffi::OsString {
         #[cfg(unix)]
         {
             use std::os::unix::ffi::OsStringExt;
@@ -359,7 +357,7 @@ use main_ftverify::ftverify_work;
 /*---------------------------------------------------------------------------*/
 /*  fitsverify.c                                                             */
 /*---------------------------------------------------------------------------*/
-pub fn main() -> ExitCode {
+pub(crate) fn main() -> ExitCode {
     let mut status: c_int_alias = 0;
     let mut invalid = 0;
     let mut file1 = 0usize;
@@ -374,7 +372,7 @@ pub fn main() -> ExitCode {
         .collect();
     let argc = argv.len();
 
-    if argc == 2 && strcmp_c(&argv[1], cs!(c"-h")) == 0 {
+    if argc == 2 && ceq(&argv[1], b"-h") {
         print!(
             "{}",
             "fitsverify -- Verify that the input files conform to the FITS Standard.\n\
@@ -493,19 +491,19 @@ pub fn main() -> ExitCode {
 
     /* check for flags on the command line */
     for ii in 1..argc {
-        if argv[ii][0] as u8 != b'-' || strcmp_c(&argv[ii], cs!(c"-")) == 0 {
+        if argv[ii][0] as u8 != b'-' || ceq(&argv[ii], b"-") {
             file1 = ii;
             break;
         }
 
-        if strcmp_c(&argv[ii], cs!(c"-l")) == 0 {
+        if ceq(&argv[ii], b"-l") {
             set_prhead(1);
-        } else if strcmp_c(&argv[ii], cs!(c"-H")) == 0 {
+        } else if ceq(&argv[ii], b"-H") {
             set_testhierarch(1);
-        } else if strcmp_c(&argv[ii], cs!(c"-e")) == 0 {
+        } else if ceq(&argv[ii], b"-e") {
             errormode[0] = b'e' as c_char;
             errormode[1] = 0;
-        } else if strcmp_c(&argv[ii], cs!(c"-q")) == 0 {
+        } else if ceq(&argv[ii], b"-q") {
             set_prstat(0);
         } else {
             invalid = 1;

--- a/src/bin/fitsverify/main.rs
+++ b/src/bin/fitsverify/main.rs
@@ -1,9 +1,21 @@
-#![allow(deprecated)]
-// The C-derived declarations in common.rs cover the whole of fitsverify; the
-// port is still incomplete, so many are not referenced yet.
+/* Transpiled from cfitsio/utilities/ftverify.c and fitsverify.c.
+
+   ftverify.c #includes fitsverify.c for the STANDALONE build, so both live
+   here: `main_ftverify' holds ftverify_work()/update_parfile() and the PIL
+   stubs, and main() below is fitsverify.c's main().  */
+
+// kwdtyp, FitsHdu and friends keep their fitsverify C spellings.
+#![allow(non_camel_case_types, non_snake_case, non_upper_case_globals)]
+#![allow(clippy::upper_case_acronyms)]
+// Several C-derived declarations are only referenced from one arm of a
+// platform/feature branch, or exist purely to mirror the C's shape.
 #![allow(dead_code)]
-// kwdtyp, data and the *_KEY variants keep their fitsverify C spellings.
-#![allow(non_camel_case_types, clippy::upper_case_acronyms)]
+// The C has dead stores that a faithful transpile keeps: C-style declarations
+// initialised and then immediately reassigned (`int status = 0; ... status =
+// f();`), loop counters it bumps but never reads again, and fvrf_key.c's
+// `temp1` buffer, which is filled and then unused. Keeping them preserves the
+// line-by-line correspondence with the original.
+#![allow(unused_assignments, unused_variables)]
 
 use std::process::ExitCode;
 
@@ -14,6 +26,561 @@ mod fvrf_head;
 mod fvrf_key;
 mod fvrf_misc;
 
+use bytemuck::cast_slice;
+use rsfitsio::c_types::c_char;
+use rsfitsio::cs;
+use rsfitsio::fitsio::FLEN_FILENAME;
+
+use crate::common::*;
+
+/*---------------------------------------------------------------------------*/
+/*  ftverify.c                                                               */
+/*---------------------------------------------------------------------------*/
+pub mod main_ftverify {
+    use std::io::BufRead;
+
+    use bytemuck::cast_slice;
+    use rsfitsio::aliases::rust_api::fits_get_version;
+    use rsfitsio::c_types::{c_char, c_int};
+    use rsfitsio::cs;
+    use rsfitsio::fitsio::{FILE_NOT_CREATED, FILE_NOT_OPENED, FLEN_FILENAME};
+
+    use crate::common::*;
+    use crate::fvrf_file::{get_total_err, get_total_warn};
+    use crate::fvrf_head::{leave_early, verify_fits};
+    use crate::fvrf_misc::*;
+    use crate::{pf, spf};
+
+    const MAXMSG: usize = 256;
+
+    pub const PIL_LINESIZE: usize = 1024;
+
+    /*---------------------------------------------------------------------------*/
+    /* call work function to verify that infile conforms to the FITS
+           standard and write report to the output file */
+    #[allow(clippy::too_many_arguments)]
+    pub fn ftverify_work(
+        infile: &[c_char],  /* I - Input file name (Fits) */
+        outfile: &[c_char], /* I - Output file name (ASCII) */
+        _prehead: c_int,
+        prstat: c_int,
+        errreport: &[c_char],
+        _testdata: c_int,
+        _testcsum: c_int,
+        _testfill: c_int,
+        heasarc_conv: c_int,
+        testhierarch: c_int,
+    ) -> c_int {
+        let mut outfptr: Out = Out::Null;
+        let mut list: Option<std::io::BufReader<std::fs::File>> = None;
+        let mut status: c_int = 0;
+        let mut vfstatus: c_int;
+        let mut filestatus: c_int;
+        let mut p: usize;
+        let mut task: [c_char; 80] = [0; 80];
+        let mut tversion: [c_char; 80] = [0; 80];
+        let mut fversion: f32 = 0.0;
+        let mut i: c_int;
+        let mut nerrs: c_int;
+        let mut nwarns: c_int;
+        let mut msg: [c_char; MAXMSG] = [0; MAXMSG];
+        let mut comm: [c_char; COMM_LEN] = [0; COMM_LEN];
+        let mut infile: Vec<c_char> = infile.to_vec();
+        infile.resize(FLEN_FILENAME.max(infile.len()), 0);
+
+        /* determine 'Severe error", "Error", or "Warning" report level */
+        if errreport[0] as u8 == b's' || errreport[0] as u8 == b'S' {
+            set_err_report(2);
+        }
+        if errreport[0] as u8 == b'e' || errreport[0] as u8 == b'E' {
+            set_err_report(1);
+        }
+
+        p = 0;
+        if infile[p] as u8 == b'@' {
+            p += 1;
+            match std::fs::File::open(cstr_to_os(&infile[p..])) {
+                Ok(f) => list = Some(std::io::BufReader::new(f)),
+                Err(_) => {
+                    pf!(Out::Stderr; "Cannot open the list file: ", CS(&infile[p..]), ".");
+                    leave_early(Out::Null);
+                    return FILE_NOT_OPENED;
+                }
+            }
+        }
+
+        /* headas_clobberfile(outfile) -- delete existing file if clobber=YES */
+        headas_clobberfile(outfile);
+        let op = outfile;
+
+        /* test if writing output log to a disk file */
+        if prstat != 0
+            && cstrlen(op) != 0
+            && strcmp_c(op, cs!(c"STDOUT")) != 0
+            && strcmp_c(op, cs!(c"STDERR")) != 0
+            && std::fs::File::open(cstr_to_os(op)).is_ok()
+        {
+            spf!(msg; "Clobber is not set. Cannot overwrite the file", CS(op));
+            status = FILE_NOT_CREATED;
+            HD_ERROR_THROW(&msg, status);
+            leave_early(Out::Null);
+            return status;
+        }
+
+        if prstat != 0 && (cstrlen(op) == 0 || strcmp_c(op, cs!(c"STDOUT")) == 0) {
+            outfptr = Out::Stdout;
+        } else if prstat != 0 && (cstrlen(op) == 0 || strcmp_c(op, cs!(c"STDERR")) == 0) {
+            outfptr = Out::Stderr;
+        } else if prstat == 0 {
+            outfptr = Out::Null;
+        } else {
+            match std::fs::File::create(cstr_to_os(op)) {
+                Ok(f) => {
+                    out_set_file(f);
+                    outfptr = Out::File;
+                }
+                Err(_) => {
+                    pf!(Out::Stderr;
+                        "Error open output file ", CS(outfile), ". Using stdout instead.");
+                    outfptr = Out::Stdout;
+                }
+            }
+        }
+
+        wrtout_str(outfptr, " ");
+        fits_get_version(&mut fversion);
+        get_toolname(&mut task);
+        get_toolversion(&mut tversion);
+        let fversion_int = ((fversion as f64 * 10000.0) + 0.5) as c_int;
+        let fversion_major = fversion_int / 10000;
+        let fversion_minor = (fversion_int % 10000) / 100;
+        let fversion_patch = fversion_int % 100;
+        spf!(comm;
+            CS(&task), " ", CS(&tversion), " (CFITSIO V", fversion_major, ".", fversion_minor,
+            ".", fversion_patch, ")");
+        wrtsep(outfptr, b' ' as c_char, &comm, 60);
+        i = 0;
+        while comm[i as usize] != 0 {
+            comm[i as usize] = b'-' as c_char;
+            i += 1;
+        }
+        wrtsep(outfptr, b' ' as c_char, &comm, 60);
+        wrtout_str(outfptr, " ");
+        match err_report() {
+            2 => {
+                spf!(comm;
+                    "Caution: Only checking for the most severe FITS format errors.");
+                wrtout(outfptr, &comm);
+            }
+            1 => {}
+            _ => {}
+        }
+
+        if heasarc_conv != 0 {
+            spf!(comm; "HEASARC conventions are being checked.");
+            wrtout(outfptr, &comm);
+        }
+
+        if testhierarch != 0 {
+            spf!(comm; "ESO HIERARCH keywords are being checked.");
+            wrtout(outfptr, &comm);
+        }
+
+        /* process each file */
+        match list.as_mut() {
+            None => {
+                vfstatus = verify_fits(&mut infile, outfptr);
+
+                if outfptr == Out::Null {
+                    /* print one-line file summary */
+
+                    /* verify_fits returns a non-zero status for catastrophic
+                     * file I/O problems (an abort), and in this case total_err
+                     * is not updated via close_report(), so we need to set
+                     * nerrs accordingly for the one-line file summary. */
+                    nerrs = if vfstatus != 0 { 1 } else { get_total_err() };
+
+                    nwarns = get_total_warn();
+
+                    filestatus = if (nerrs + nwarns) > 0 { 1 } else { 0 };
+                    if filestatus != 0 {
+                        if err_report() != 0 {
+                            pf!(Out::Stdout;
+                                "verification FAILED: ", CSW(&infile, -20, None), ", ", nerrs,
+                                " errors\n");
+                        } else {
+                            pf!(Out::Stdout;
+                                "verification FAILED: ", CSW(&infile, -20, None), ", ", nwarns,
+                                " warnings and ", nerrs, " errors\n");
+                        }
+                    } else {
+                        pf!(Out::Stdout;
+                            "verification OK: ", CSW(&infile, -20, None), "\n");
+                    }
+                }
+            }
+            Some(list) => {
+                let mut line = String::new();
+                loop {
+                    line.clear();
+                    /* fgets(infile, FLEN_FILENAME, list) */
+                    let n = match list.read_line(&mut line) {
+                        Ok(0) | Err(_) => break,
+                        Ok(n) => n,
+                    };
+                    let _ = n;
+                    infile.iter_mut().for_each(|c| *c = 0);
+                    set_cstr(&mut infile, line.as_bytes());
+
+                    vfstatus = verify_fits(&mut infile, outfptr);
+
+                    if outfptr == Out::Null {
+                        /* print one-line file summary */
+                        nerrs = if vfstatus != 0 { 1 } else { get_total_err() };
+
+                        nwarns = get_total_warn();
+
+                        filestatus = if (nerrs + nwarns) > 0 { 1 } else { 0 };
+                        if filestatus != 0 {
+                            if err_report() != 0 {
+                                pf!(Out::Stdout;
+                                    "verification FAILED: ", CSW(&infile, -20, None), ", ",
+                                    nerrs, " errors\n");
+                            } else {
+                                pf!(Out::Stdout;
+                                    "verification FAILED: ", CSW(&infile, -20, None), ", ",
+                                    nwarns, " warnings and ", nerrs, " errors\n");
+                            }
+                        } else {
+                            pf!(Out::Stdout;
+                                "verification OK: ", CSW(&infile, -20, None), "\n");
+                        }
+                    }
+
+                    for _i in 1..3 {
+                        wrtout_str(outfptr, " ");
+                    }
+                }
+            }
+        }
+
+        /* close the output file  */
+        if outfptr != Out::Stdout && outfptr != Out::Null {
+            out_close_file();
+        }
+
+        status
+    }
+
+    /******************************************************************************
+    * Function
+    *      update_parfile
+    *
+    * DESCRIPTION:
+    *      Update the numerrs and numwrns parameters in the parfile.
+    *
+    *******************************************************************************/
+    pub fn update_parfile(nerr: c_int, nwrn: c_int) {
+        let mut status: c_int;
+        let mut parname: [c_char; 32] = [0; 32];
+
+        add_totalerr(nerr as i64);
+        add_totalwrn(nwrn as i64);
+        /* write the total accumulated total warnings and errors to the
+           parfile */
+        spf!(parname; "numwrns");
+        status = PILPutInt(&parname, totalwrn() as c_int);
+        if status != 0 {
+            pf!(Out::Stderr; "Error to update the numwrns keyword.\n");
+            status = 0;
+        }
+        spf!(parname; "numerrs");
+        status = PILPutInt(&parname, totalerr() as c_int);
+        if status != 0 {
+            pf!(Out::Stderr; "Error to update the numerrs keyword.\n");
+            status = 0;
+        }
+        let _ = status;
+    }
+
+    /*------------------------------------------------------------------
+      The following are all dummy stub routines for functions that are
+      only needed when ftverify is built in the HEADAS environment.
+    --------------------------------------------------------------------*/
+
+    pub fn PILGetFname(_parname: &[c_char], _filename: &mut [c_char]) -> c_int {
+        0
+    }
+
+    pub fn PILGetString(_parname: &[c_char], _stringname: &mut [c_char]) -> c_int {
+        0
+    }
+
+    pub fn PILGetBool(_parname: &[c_char], _intvalue: &mut c_int) -> c_int {
+        0
+    }
+
+    pub fn PILPutInt(_parname: &[c_char], _intvalue: c_int) -> c_int {
+        0
+    }
+
+    pub fn set_toolname(_taskname: &[c_char]) {}
+
+    pub fn set_toolversion(_taskname: &[c_char]) {}
+
+    pub fn get_toolname(taskname: &mut [c_char]) {
+        spf!(taskname; "fitsverify");
+    }
+
+    pub fn get_toolversion(taskvers: &mut [c_char]) {
+        spf!(taskvers; "4.22");
+    }
+
+    pub fn headas_clobberfile(_filename: &[c_char]) {}
+
+    pub fn HD_ERROR_THROW(_msg: &[c_char], _status: c_int) {}
+
+    /* An OS path from a NUL-terminated c_char buffer. */
+    pub fn cstr_to_os(s: &[c_char]) -> std::ffi::OsString {
+        #[cfg(unix)]
+        {
+            use std::os::unix::ffi::OsStringExt;
+            std::ffi::OsString::from_vec(cbytes(s).to_vec())
+        }
+        #[cfg(not(unix))]
+        {
+            std::ffi::OsString::from(String::from_utf8_lossy(cbytes(s)).into_owned())
+        }
+    }
+}
+
+use main_ftverify::ftverify_work;
+
+/*---------------------------------------------------------------------------*/
+/*  fitsverify.c                                                             */
+/*---------------------------------------------------------------------------*/
 pub fn main() -> ExitCode {
-    ExitCode::from(0)
+    let mut status: c_int_alias = 0;
+    let mut invalid = 0;
+    let mut file1 = 0usize;
+    let mut errormode: [c_char; 2] = [b'w' as c_char, 0];
+
+    let argv: Vec<Vec<c_char>> = std::env::args_os()
+        .map(|a| {
+            let mut v: Vec<c_char> = os_bytes(&a).iter().map(|&b| b as c_char).collect();
+            v.push(0);
+            v
+        })
+        .collect();
+    let argc = argv.len();
+
+    if argc == 2 && strcmp_c(&argv[1], cs!(c"-h")) == 0 {
+        print!(
+            "{}",
+            "fitsverify -- Verify that the input files conform to the FITS Standard.\n\
+             \n\
+             USAGE:   fitsverify filename ...  - verify one or more FITS files\n\
+             \x20                                   (may use wildcard characters)\n\
+             \x20  or    fitsverify @filelist.txt - verify a list of FITS files\n"
+        );
+        println!("      ");
+        println!("   Optional flags:");
+        println!("          -H  test ESO HIERARCH keywords");
+        println!("          -l  list all header keywords");
+        println!("          -q  quiet; print one-line pass/fail summary per file");
+        println!("          -e  only test for error conditions (ignore warnings)");
+        println!(" ");
+        println!("   fitsverify exits with a status equal to the number of errors + warnings.");
+        println!("        ");
+        println!("EXAMPLES:");
+        println!("     fitsverify -l m101.fits    - produce a detailed verificaton report of");
+        println!("                                  a single file, including a keyword listing");
+        println!("     fitsverify -q *.fits *.fit - verify all files with .fits or .fit");
+        println!("                                  extensions, writing a 1-line pass/fail");
+        println!("                                  message for each file");
+        println!(" ");
+        println!("DESCRIPTION:");
+        println!("    ");
+        println!("    This task reads one or more input FITS files and verifies that the");
+        println!("    files conform to the specifications of the FITS Standard, Definition");
+        println!("    of the Flexible Image Transport System (FITS), Version 3.0, available");
+        println!("    online  at http://fits.gsfc.nasa.gov/.  The input filename template may");
+        println!("    contain wildcard characters, in which case all matching files will be ");
+        println!("    tested.  Alternatively, the name of an ASCII text file containing a list");
+        println!(
+            "    of file names, one per line, may be entered preceded by an '@' character."
+        );
+        println!("    The following error or warning conditions will be reported:");
+        println!("    ");
+        println!("    ERROR CONDITIONS");
+        println!("    ");
+        println!("     - Mandatory keyword not present or out of order");
+        println!("     - Mandatory keyword has wrong datatype or illegal value");
+        println!("     - END header keyword is not present");
+        println!("     - Sum of table column widths is inconsistent with NAXIS1 value");
+        println!("     - BLANK keyword present in image with floating-point datatype");
+        println!("     - TNULLn keyword present for floating-point binary table column");
+        println!("     - Bit column has non-zero fill bits or is not left adjusted ");
+        println!("     - ASCII TABLE column contains illegal value inconsistent with TFORMn");
+        println!("     - Address to a variable length array not within the data heap ");
+        println!("     - Extraneous bytes in the FITS file following the last HDU    ");
+        println!("     - Mandatory keyword values not expressed in fixed format");
+        println!("     - Mandatory keyword duplicated elsewhere in the header");
+        println!("     - Header contains illegal ASCII character (not ASCII 32 - 126)");
+        println!("     - Keyword name contains illegal character");
+        println!("     - Keyword value field has illegal format");
+        println!("     - Value and comment fields not separated by a slash character");
+        println!("     - END keyword not filled with blanks in columns 9 - 80");
+        println!("     - Reserved keyword with wrong datatype or illegal value");
+        println!("     - XTENSION keyword in the primary array");
+        println!("     - Column related keyword (TFIELDS, TTYPEn,TFORMn, etc.) in an image");
+        println!("     - SIMPLE, EXTEND, or BLOCKED keyword in any extension");
+        println!("     - BSCALE, BZERO, BUNIT, BLANK, DATAMAX, DATAMIN keywords in a table");
+        println!("     - Table WCS keywords (TCTYPn, TCRPXn, TCRVLn, etc.) in an image");
+        println!("     - TDIMn or THEAP keyword in an ASCII table ");
+        println!("     - TBCOLn keyword in a Binary table");
+        println!("     - THEAP keyword in a binary table that has PCOUNT = 0 ");
+        println!("     - XTENSION, TFORMn, TDISPn or TDIMn value contains leading space(s)");
+        println!("     - WCSAXES keyword appears after other WCS keywords");
+        println!("     - Index of any WCS keyword (CRPIXn, CRVALn, etc.) greater than ");
+        println!("       value of WCSAXES");
+        println!("     - Index of any table column descriptor keyword (TTYPEn, TFORMn,");
+        println!("       etc.) greater than value of TFIELDS");
+        println!("     - TSCALn or TZEROn present for an ASCII, logical, or Bit column");
+        println!("     - TDISPn value is inconsistent with the column datatype ");
+        println!("     - Length of a variable length array greater than the maximum ");
+        println!("       length as given by the TFORMn keyword");
+        println!(
+            "     - ASCII table floating-point column value does not have decimal point(*)"
+        );
+        println!("     - ASCII table numeric column value has embedded space character");
+        println!("     - Logical column contains illegal value not equal to 'T', 'F', or 0");
+        println!("     - Character string column contains non-ASCII text character");
+        println!("     - Header fill bytes not all blanks");
+        println!("     - Data fill bytes not all blanks in ASCII tables or all zeros ");
+        println!("       in any other type of HDU ");
+        println!("     - Gaps between defined ASCII table columns contain characters with");
+        println!("       ASCII value > 127");
+        println!("    ");
+        println!("    WARNING CONDITIONS");
+        println!("    ");
+        println!("     - SIMPLE = F");
+        println!("     - Presence of deprecated keywords BLOCKED or EPOCH");
+        println!("     - 2 HDUs have identical EXTNAME, EXTVER, and EXTLEVEL values");
+        println!("     - BSCALE or TSCALn value = 0.");
+        println!("     - BLANK OR TNULLn value exceeds the legal range");
+        println!("     - TFORMn has 'rAw' format and r is not a multiple of w");
+        println!("     - DATE = 'dd/mm/yy' and yy is less than 10 (Y2K problem?)");
+        println!("     - Index of any WCS keyword (CRPIXn, CRVALn, etc.) greater than");
+        println!("       value of NAXIS, if the WCSAXES keyword is not present");
+        println!("     - Duplicated keyword (except COMMENT, HISTORY, blank, etc.)");
+        println!("     - Column name (TTYPEn) does not exist or contains characters ");
+        println!("       other than letter, digit and underscore");
+        println!("     - Calculated checksum inconsistent with CHECKSUM or DATASUM keyword");
+        println!("        ");
+        println!("    This is the stand alone version of the FTOOLS 'fverify' program.  It is");
+        println!("    maintained by the HEASARC at NASA/GSFC.  Any comments about this program");
+        println!(
+            "    should be submitted to http://heasarc.gsfc.nasa.gov/cgi-bin/ftoolshelp"
+        );
+
+        return ExitCode::from(0);
+    }
+
+    set_prhead(0); /* don't print header by default */
+    set_prstat(1); /* print HDU summary by default */
+    set_testhierarch(0); /* do not test ESO HIERARCH keywords by default */
+
+    /* check for flags on the command line */
+    for ii in 1..argc {
+        if argv[ii][0] as u8 != b'-' || strcmp_c(&argv[ii], cs!(c"-")) == 0 {
+            file1 = ii;
+            break;
+        }
+
+        if strcmp_c(&argv[ii], cs!(c"-l")) == 0 {
+            set_prhead(1);
+        } else if strcmp_c(&argv[ii], cs!(c"-H")) == 0 {
+            set_testhierarch(1);
+        } else if strcmp_c(&argv[ii], cs!(c"-e")) == 0 {
+            errormode[0] = b'e' as c_char;
+            errormode[1] = 0;
+        } else if strcmp_c(&argv[ii], cs!(c"-q")) == 0 {
+            set_prstat(0);
+        } else {
+            invalid = 1;
+        }
+    }
+
+    if invalid != 0 || argc == 1 || file1 == 0 {
+        /*  invalid input, so print brief help message */
+
+        println!();
+        println!("fitsverify - test if the input file(s) conform to the FITS format.");
+        println!();
+        println!("Usage:  fitsverify filename ...   or   fitsverify @filelist.txt");
+        println!();
+        println!("  where 'filename' is a filename template (with optional wildcards), and");
+        println!("        'filelist.txt' is an ASCII text file with a list of");
+        println!("         FITS file names, one per line.");
+        println!();
+        println!("   Optional flags:");
+        println!("          -H  test ESO HIERARCH keywords");
+        println!("          -l  list all header keywords");
+        println!("          -q  quiet; print one-line pass/fail summary per file");
+        println!("          -e  only test for error conditions; don't issue warnings");
+        println!();
+        println!("Help:   fitsverify -h");
+        return ExitCode::from(0);
+    }
+
+    /*
+         call work function to verify that infile conforms to the FITS
+         standard and write report to the output file.
+    */
+    for ii in file1..argc {
+        status = ftverify_work(
+            &argv[ii],       /* name of file to verify */
+            cs!(c"STDOUT"),  /* write report to this stream */
+            prhead(),        /* print listing of header keywords? */
+            prstat(),        /* print detailed summary report */
+            &errormode,      /* report errors only, or errors and warnings */
+            1,               /* test the data  */
+            1,               /* test checksum, if checksum keywords are present */
+            1,               /* test data fill areas (should contain all zeros */
+            0,               /* do not test for conformance with HEASARC convensions */
+            /*    that are not required by the FITS Standard */
+            testhierarch(), /* test format of ESO HIERARCH keywords? */
+        );
+
+        if status != 0 {
+            return ExitCode::from(status as u8);
+        }
+    }
+
+    if (totalerr() + totalwrn()) > 255 {
+        ExitCode::from(255)
+    } else {
+        ExitCode::from((totalerr() + totalwrn()) as u8)
+    }
+}
+
+type c_int_alias = rsfitsio::c_types::c_int;
+
+fn os_bytes(s: &std::ffi::OsStr) -> Vec<u8> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::ffi::OsStrExt;
+        s.as_bytes().to_vec()
+    }
+    #[cfg(not(unix))]
+    {
+        s.to_string_lossy().into_owned().into_bytes()
+    }
+}
+
+
+#[allow(dead_code)]
+fn _unused() -> usize {
+    FLEN_FILENAME
 }

--- a/src/cfileio.rs
+++ b/src/cfileio.rs
@@ -7515,7 +7515,7 @@ pub fn ffimport_file_safe(
     }
     lines[0] = 0;
 
-    let aFile = File::options().read(true).open(slice_to_str!(filename));
+    let aFile = File::options().read(true).open(slice_to_str!(filename).as_ref() as &str);
 
     if aFile.is_err() {
         int_snprintf!(

--- a/src/fitscore.rs
+++ b/src/fitscore.rs
@@ -462,12 +462,52 @@ pub fn ffgerr_safe(
     strcpy_safe(errtext, cast_slice(t.to_bytes_with_nul()));
 }
 
-#[derive(Debug, Clone)]
+/// The most a single stack entry can hold.  `push_message` splits at this
+/// size and `ffgmsg` copies at most `FLEN_ERRMSG - 1`, so the two agree by
+/// construction rather than by convention.
+const ERRMSG_CHUNK: usize = FLEN_ERRMSG - 1;
+
+/// One entry in the error stack.
+///
+/// Fixed-size, mirroring the C's `static char errbuff[errmsgsiz][81]`: the
+/// whole stack is then `ERRMSGSIZ * ~82` bytes of static storage and `ffpmsg`
+/// does not reach for the allocator, which matters because it is called while
+/// handling failures.
+///
+/// The length is explicit rather than NUL-terminated.  The stack stores raw
+/// bytes -- the C's ffpmsg() keeps whatever it is handed, and FITS diagnostics
+/// routinely echo card bytes that are not valid UTF-8 -- and a malformed card
+/// can contain an embedded NUL, which terminating would silently truncate.
+#[derive(Debug, Clone, Copy)]
 struct ErrorMessage {
-    /// Raw bytes: the C's ffpmsg() stores whatever it is handed, and FITS
-    /// diagnostics routinely echo card bytes that are not valid UTF-8.
-    content: Vec<u8>,
+    content: [u8; ERRMSG_CHUNK],
+    len: u8,
     is_marker: bool,
+}
+
+impl ErrorMessage {
+    fn new(chunk: &[u8]) -> Self {
+        debug_assert!(chunk.len() <= ERRMSG_CHUNK);
+        let mut content = [0u8; ERRMSG_CHUNK];
+        content[..chunk.len()].copy_from_slice(chunk);
+        Self {
+            content,
+            len: chunk.len() as u8,
+            is_marker: false,
+        }
+    }
+
+    fn marker() -> Self {
+        Self {
+            content: [0; ERRMSG_CHUNK],
+            len: 0,
+            is_marker: true,
+        }
+    }
+
+    fn bytes(&self) -> &[u8] {
+        &self.content[..self.len as usize]
+    }
 }
 
 struct ErrorStack {
@@ -485,18 +525,15 @@ impl ErrorStack {
         let mut remaining = message;
 
         while !remaining.is_empty() {
-            let chunk_size = core::cmp::min(80, remaining.len());
-            let chunk = &remaining[..chunk_size];
+            let chunk_size = core::cmp::min(ERRMSG_CHUNK, remaining.len());
+            let (chunk, rest) = remaining.split_at(chunk_size);
 
             if self.messages.len() >= ERRMSGSIZ {
                 self.messages.pop_front();
             }
 
-            self.messages.push_back(ErrorMessage {
-                content: chunk.to_vec(),
-                is_marker: false,
-            });
-            remaining = &remaining[chunk_size..];
+            self.messages.push_back(ErrorMessage::new(chunk));
+            remaining = rest;
         }
     }
 
@@ -505,16 +542,13 @@ impl ErrorStack {
             self.messages.pop_front();
         }
 
-        self.messages.push_back(ErrorMessage {
-            content: Vec::new(),
-            is_marker: true,
-        });
+        self.messages.push_back(ErrorMessage::marker());
     }
 
-    fn pop_message(&mut self) -> Option<Vec<u8>> {
+    fn pop_message(&mut self) -> Option<ErrorMessage> {
         while let Some(msg) = self.messages.pop_front() {
             if !msg.is_marker {
-                return Some(msg.content);
+                return Some(msg);
             }
         }
         None
@@ -612,7 +646,7 @@ pub fn ffgmsg_safe(err_message: &mut [c_char; FLEN_ERRMSG]) -> c_int {
 
     if let Some(message) = stack.pop_message() {
         // Copy message to buffer
-        let message_bytes = &message[..];
+        let message_bytes = message.bytes();
         let copy_len = core::cmp::min(message_bytes.len(), FLEN_ERRMSG - 1);
 
         for (i, &byte) in message_bytes.iter().take(copy_len).enumerate() {
@@ -688,7 +722,7 @@ pub fn ffxmsg_safer(action: c_int, errmsg: Option<&mut [c_char; FLEN_ERRMSG]>) {
             if let Some(err_message) = errmsg {
                 if let Some(message) = stack.pop_message() {
                     // Copy message to buffer
-                    let message_bytes = &message[..];
+                    let message_bytes = message.bytes();
                     let copy_len = core::cmp::min(message_bytes.len(), FLEN_ERRMSG - 1);
 
                     for (i, &byte) in message_bytes.iter().take(copy_len).enumerate() {
@@ -737,7 +771,7 @@ pub(crate) fn ffxmsg(action: c_int, errmsg: *mut c_char) {
             if let Some(message) = stack.pop_message() {
                 // Safely copy to the provided buffer
                 if !errmsg.is_null() {
-                    let message_bytes = &message[..];
+                    let message_bytes = message.bytes();
                     let copy_len = core::cmp::min(message_bytes.len(), FLEN_ERRMSG - 1);
 
                     unsafe {
@@ -12507,6 +12541,67 @@ mod tests {
 
         let card_str = CStr::from_bytes_until_nul(cast_slice(&card)).unwrap();
         assert_eq!(card_str.to_bytes_with_nul(), expected.to_bytes_with_nul());
+    }
+
+    /* The error stack's storage invariants.  These use a local ErrorStack, so
+       they do not need the global TEST_LOCK. */
+
+    #[test]
+    fn test_stored_entry_always_fits_the_reader_buffer() {
+        /* ffgmsg copies at most FLEN_ERRMSG - 1 bytes, so keeping the chunk
+           size at or below that means no stored entry can ever be truncated on
+           the way out. */
+        assert!(ERRMSG_CHUNK <= FLEN_ERRMSG - 1);
+    }
+
+    #[test]
+    fn test_error_stack_chunks_long_messages() {
+        let mut st = ErrorStack::new();
+        let msg: Vec<u8> = (0..190u32).map(|i| b'a' + (i % 26) as u8).collect();
+        st.push_message(&msg);
+
+        let mut out: Vec<Vec<u8>> = Vec::new();
+        while let Some(m) = st.pop_message() {
+            out.push(m.bytes().to_vec());
+        }
+
+        assert_eq!(out.len(), 3);
+        assert_eq!(out[0].len(), ERRMSG_CHUNK);
+        assert_eq!(out[1].len(), ERRMSG_CHUNK);
+        assert_eq!(out[2].len(), 190 - 2 * ERRMSG_CHUNK);
+        /* split, not lost or reordered */
+        assert_eq!(out.concat(), msg);
+    }
+
+    #[test]
+    fn test_error_stack_keeps_raw_bytes() {
+        /* FITS diagnostics echo card bytes, which are frequently not valid
+           UTF-8; and an embedded NUL must not shorten the stored entry, which
+           is why the length is explicit rather than NUL-terminated. */
+        let mut st = ErrorStack::new();
+        let msg = b"card \xff\xfe with a NUL \x00 in it";
+        st.push_message(msg);
+
+        let m = st.pop_message().unwrap();
+        assert_eq!(m.bytes(), msg);
+        assert_eq!(m.len as usize, msg.len());
+    }
+
+    #[test]
+    fn test_error_stack_evicts_oldest_when_full() {
+        let mut st = ErrorStack::new();
+        for i in 0..(ERRMSGSIZ + 5) {
+            st.push_message(&[b'a' + i as u8]);
+        }
+
+        let mut got: Vec<u8> = Vec::new();
+        while let Some(m) = st.pop_message() {
+            got.push(m.bytes()[0]);
+        }
+
+        assert_eq!(got.len(), ERRMSGSIZ);
+        /* the first five were dropped, so the oldest survivor is the sixth */
+        assert_eq!(got[0], b'a' + 5);
     }
 
     #[test]

--- a/src/fitscore.rs
+++ b/src/fitscore.rs
@@ -464,7 +464,9 @@ pub fn ffgerr_safe(
 
 #[derive(Debug, Clone)]
 struct ErrorMessage {
-    content: String,
+    /// Raw bytes: the C's ffpmsg() stores whatever it is handed, and FITS
+    /// diagnostics routinely echo card bytes that are not valid UTF-8.
+    content: Vec<u8>,
     is_marker: bool,
 }
 
@@ -479,7 +481,7 @@ impl ErrorStack {
         }
     }
 
-    fn push_message(&mut self, message: &str) {
+    fn push_message(&mut self, message: &[u8]) {
         let mut remaining = message;
 
         while !remaining.is_empty() {
@@ -491,7 +493,7 @@ impl ErrorStack {
             }
 
             self.messages.push_back(ErrorMessage {
-                content: chunk.to_string(),
+                content: chunk.to_vec(),
                 is_marker: false,
             });
             remaining = &remaining[chunk_size..];
@@ -504,12 +506,12 @@ impl ErrorStack {
         }
 
         self.messages.push_back(ErrorMessage {
-            content: String::new(),
+            content: Vec::new(),
             is_marker: true,
         });
     }
 
-    fn pop_message(&mut self) -> Option<String> {
+    fn pop_message(&mut self) -> Option<Vec<u8>> {
         while let Some(msg) = self.messages.pop_front() {
             if !msg.is_marker {
                 return Some(msg.content);
@@ -545,35 +547,30 @@ pub unsafe extern "C" fn ffpmsg(err_message: *const c_char) {
 /*--------------------------------------------------------------------------*/
 /// put message on to error stack
 pub fn ffpmsg_safe(err_message: &[c_char]) {
-    // Convert c_char slice to string and use the new safe implementation
-    if let Ok(c_str) = CStr::from_bytes_until_nul(cast_slice(err_message))
-        && let Ok(message) = c_str.to_str()
-    {
-        let mut stack = ERROR_STACK.lock().unwrap();
-        stack.push_message(message);
-    }
+    let mut stack = ERROR_STACK.lock().unwrap();
+    stack.push_message(cstr_bytes(err_message));
 }
 
 pub fn ffpmsg_cstr(err_message: &CStr) {
-    if let Ok(message) = err_message.to_str() {
-        let mut stack = ERROR_STACK.lock().unwrap();
-        stack.push_message(message);
-    }
+    let mut stack = ERROR_STACK.lock().unwrap();
+    stack.push_message(err_message.to_bytes());
 }
 
 pub(crate) fn ffpmsg_slice(err_message: &[c_char]) {
-    // Convert c_char slice to string
-    if let Ok(c_str) = CStr::from_bytes_until_nul(cast_slice(err_message))
-        && let Ok(message) = c_str.to_str()
-    {
-        let mut stack = ERROR_STACK.lock().unwrap();
-        stack.push_message(message);
-    }
+    let mut stack = ERROR_STACK.lock().unwrap();
+    stack.push_message(cstr_bytes(err_message));
+}
+
+/// The bytes of `s` up to its first NUL, or all of `s` if it has none.
+fn cstr_bytes(s: &[c_char]) -> &[u8] {
+    let b: &[u8] = cast_slice(s);
+    let n = b.iter().position(|&c| c == 0).unwrap_or(b.len());
+    &b[..n]
 }
 
 pub(crate) fn ffpmsg_str(err_message: &str) {
     let mut stack = ERROR_STACK.lock().unwrap();
-    stack.push_message(err_message);
+    stack.push_message(err_message.as_bytes());
 }
 
 /*--------------------------------------------------------------------------*/
@@ -615,7 +612,7 @@ pub fn ffgmsg_safe(err_message: &mut [c_char; FLEN_ERRMSG]) -> c_int {
 
     if let Some(message) = stack.pop_message() {
         // Copy message to buffer
-        let message_bytes = message.as_bytes();
+        let message_bytes = &message[..];
         let copy_len = core::cmp::min(message_bytes.len(), FLEN_ERRMSG - 1);
 
         for (i, &byte) in message_bytes.iter().take(copy_len).enumerate() {
@@ -691,7 +688,7 @@ pub fn ffxmsg_safer(action: c_int, errmsg: Option<&mut [c_char; FLEN_ERRMSG]>) {
             if let Some(err_message) = errmsg {
                 if let Some(message) = stack.pop_message() {
                     // Copy message to buffer
-                    let message_bytes = message.as_bytes();
+                    let message_bytes = &message[..];
                     let copy_len = core::cmp::min(message_bytes.len(), FLEN_ERRMSG - 1);
 
                     for (i, &byte) in message_bytes.iter().take(copy_len).enumerate() {
@@ -740,7 +737,7 @@ pub(crate) fn ffxmsg(action: c_int, errmsg: *mut c_char) {
             if let Some(message) = stack.pop_message() {
                 // Safely copy to the provided buffer
                 if !errmsg.is_null() {
-                    let message_bytes = message.as_bytes();
+                    let message_bytes = &message[..];
                     let copy_len = core::cmp::min(message_bytes.len(), FLEN_ERRMSG - 1);
 
                     unsafe {
@@ -762,9 +759,7 @@ pub(crate) fn ffxmsg(action: c_int, errmsg: *mut c_char) {
             if !errmsg.is_null() {
                 // Convert raw pointer to safe string
                 let c_str = unsafe { CStr::from_ptr(errmsg) };
-                if let Ok(message) = c_str.to_str() {
-                    stack.push_message(message);
-                }
+                stack.push_message(c_str.to_bytes());
             }
         }
         PUT_MARK => {
@@ -11912,11 +11907,10 @@ pub(crate) fn ffc2ii(
     }
 
     let cval: &[u8] = cast_slice(cval);
-    let tmp_str = CStr::from_bytes_until_nul(cval)
-        .unwrap()
-        .to_str()
-        .unwrap()
-        .trim();
+    // A malformed card can leave arbitrary/unterminated bytes here; treat those
+    // as an unparseable value (BAD_C2I) rather than panicking.
+    let tmp_str = slice_to_str!(cval);
+    let tmp_str = tmp_str.trim();
     let tmp = atoi::<c_long>(tmp_str);
 
     match tmp {
@@ -11962,11 +11956,10 @@ pub(crate) fn ffc2jj(
     }
 
     let cval: &[u8] = cast_slice(cval);
-    let tmp_str = CStr::from_bytes_until_nul(cval)
-        .unwrap()
-        .to_str()
-        .unwrap()
-        .trim();
+    // A malformed card can leave arbitrary/unterminated bytes here; treat those
+    // as an unparseable value (BAD_C2I) rather than panicking.
+    let tmp_str = slice_to_str!(cval);
+    let tmp_str = tmp_str.trim();
     let tmp = atoi::<LONGLONG>(tmp_str);
 
     match tmp {

--- a/src/getcolb.rs
+++ b/src/getcolb.rs
@@ -5,7 +5,6 @@
 /*  Astrophysic Science Archive Research Center (HEASARC) at the NASA      */
 /*  Goddard Space Flight Center.                                           */
 
-use core::ffi::CStr;
 use core::slice;
 use core::{cmp, mem};
 

--- a/src/getcold.rs
+++ b/src/getcold.rs
@@ -5,7 +5,6 @@
 /*  Astrophysic Science Archive Research Center (HEASARC) at the NASA      */
 /*  Goddard Space Flight Center.                                           */
 
-use core::ffi::CStr;
 use core::slice;
 use core::{cmp, mem};
 

--- a/src/getcole.rs
+++ b/src/getcole.rs
@@ -5,7 +5,6 @@
 /*  Astrophysic Science Archive Research Center (HEASARC) at the NASA      */
 /*  Goddard Space Flight Center.                                           */
 
-use core::ffi::CStr;
 use core::slice;
 use core::{cmp, mem};
 

--- a/src/getcoli.rs
+++ b/src/getcoli.rs
@@ -5,7 +5,6 @@
 /*  Astrophysic Science Archive Research Center (HEASARC) at the NASA      */
 /*  Goddard Space Flight Center.                                           */
 
-use core::ffi::CStr;
 use core::slice;
 use core::{cmp, mem};
 

--- a/src/getcolj.rs
+++ b/src/getcolj.rs
@@ -5,7 +5,6 @@
 /*  Astrophysic Science Archive Research Center (HEASARC) at the NASA      */
 /*  Goddard Space Flight Center.                                           */
 
-use core::ffi::CStr;
 use core::slice;
 use core::{cmp, mem};
 

--- a/src/getcolk.rs
+++ b/src/getcolk.rs
@@ -5,7 +5,6 @@
 /*  Astrophysic Science Archive Research Center (HEASARC) at the NASA      */
 /*  Goddard Space Flight Center.                                           */
 
-use core::ffi::CStr;
 use core::slice;
 use core::{cmp, mem};
 

--- a/src/getcolsb.rs
+++ b/src/getcolsb.rs
@@ -5,7 +5,6 @@
 /*  Astrophysic Science Archive Research Center (HEASARC) at the NASA      */
 /*  Goddard Space Flight Center.                                           */
 
-use core::ffi::CStr;
 use core::slice;
 use core::{cmp, mem};
 

--- a/src/getcolui.rs
+++ b/src/getcolui.rs
@@ -5,7 +5,6 @@
 /*  Astrophysic Science Archive Research Center (HEASARC) at the NASA      */
 /*  Goddard Space Flight Center.                                           */
 
-use core::ffi::CStr;
 use core::slice;
 use core::{cmp, mem};
 

--- a/src/getcoluj.rs
+++ b/src/getcoluj.rs
@@ -5,7 +5,6 @@
 /*  Astrophysic Science Archive Research Center (HEASARC) at the NASA      */
 /*  Goddard Space Flight Center.                                           */
 
-use core::ffi::CStr;
 use core::slice;
 use core::{cmp, mem};
 

--- a/src/getcoluk.rs
+++ b/src/getcoluk.rs
@@ -5,7 +5,6 @@
 /*  Astrophysic Science Archive Research Center (HEASARC) at the NASA      */
 /*  Goddard Space Flight Center.                                           */
 
-use core::ffi::CStr;
 use core::slice;
 use core::{cmp, mem};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -204,10 +204,14 @@ macro_rules! int_snprintf {
 #[macro_export]
 macro_rules! slice_to_str {
     ($e:expr) => {
-        CStr::from_bytes_until_nul(cast_slice($e))
-            .unwrap()
-            .to_str()
-            .unwrap()
+        // FITS buffers can hold arbitrary bytes and may reach here without a
+        // terminator (a malformed header is exactly what fitsverify reports
+        // on), so fall back rather than panicking, as the C's printf would.
+        {
+            let __b: &[u8] = cast_slice($e);
+            let __n = __b.iter().position(|&c| c == 0).unwrap_or(__b.len());
+            ::std::string::String::from_utf8_lossy(&__b[..__n])
+        }
     };
 }
 

--- a/src/putcol.rs
+++ b/src/putcol.rs
@@ -3692,7 +3692,10 @@ pub fn ffiter_safe(
                         /* are there any nulls in the data? */
                         if anynul != 0 {
                             if cols[jj].datatype == TSTRING {
-                                stringptr = &mut cols[jj].array.cast::<c_char>();
+                                /* cols[jj].array is the `char **' block; the null
+                                value goes into the string it points at, not over
+                                the pointer array itself. */
+                                stringptr = cols[jj].array.cast::<*mut c_char>();
                                 if let ColNullValue::StringNull(ptr) = col[jj].null {
                                     memcpy(
                                         (*stringptr).cast::<c_void>(),

--- a/src/putcolb.rs
+++ b/src/putcolb.rs
@@ -5,7 +5,6 @@
 /*  Astrophysic Science Archive Research Center (HEASARC) at the NASA      */
 /*  Goddard Space Flight Center.                                           */
 
-use core::ffi::CStr;
 use core::slice;
 use core::{cmp, mem};
 

--- a/src/putcold.rs
+++ b/src/putcold.rs
@@ -5,7 +5,6 @@
 /*  Astrophysic Science Archive Research Center (HEASARC) at the NASA      */
 /*  Goddard Space Flight Center.                                           */
 
-use core::ffi::CStr;
 use core::slice;
 use core::{cmp, mem};
 

--- a/src/putcole.rs
+++ b/src/putcole.rs
@@ -5,7 +5,6 @@
 /*  Astrophysic Science Archive Research Center (HEASARC) at the NASA      */
 /*  Goddard Space Flight Center.                                           */
 
-use core::ffi::CStr;
 use core::slice;
 use core::{cmp, mem};
 

--- a/src/putcoli.rs
+++ b/src/putcoli.rs
@@ -5,7 +5,6 @@
 /*  Astrophysic Science Archive Research Center (HEASARC) at the NASA      */
 /*  Goddard Space Flight Center.                                           */
 
-use core::ffi::CStr;
 use core::slice;
 use core::{cmp, mem};
 

--- a/src/putcolj.rs
+++ b/src/putcolj.rs
@@ -5,7 +5,6 @@
 /*  Astrophysic Science Archive Research Center (HEASARC) at the NASA      */
 /*  Goddard Space Flight Center.                                           */
 
-use core::ffi::CStr;
 use core::slice;
 use core::{cmp, mem};
 

--- a/src/putcolk.rs
+++ b/src/putcolk.rs
@@ -5,7 +5,6 @@
 /*  Astrophysic Science Archive Research Center (HEASARC) at the NASA      */
 /*  Goddard Space Flight Center.                                           */
 
-use core::ffi::CStr;
 use core::slice;
 use core::{cmp, mem};
 

--- a/src/putcolsb.rs
+++ b/src/putcolsb.rs
@@ -5,7 +5,6 @@
 /*  Astrophysic Science Archive Research Center (HEASARC) at the NASA      */
 /*  Goddard Space Flight Center.                                           */
 
-use core::ffi::CStr;
 use core::slice;
 use core::{cmp, mem};
 

--- a/src/putcolu.rs
+++ b/src/putcolu.rs
@@ -6,7 +6,6 @@
 /*  Goddard Space Flight Center.                                           */
 
 use core::cmp;
-use core::ffi::CStr;
 
 use crate::c_types::*;
 

--- a/src/putcolui.rs
+++ b/src/putcolui.rs
@@ -5,7 +5,6 @@
 /*  Astrophysic Science Archive Research Center (HEASARC) at the NASA      */
 /*  Goddard Space Flight Center.                                           */
 
-use core::ffi::CStr;
 use core::slice;
 use core::{cmp, mem};
 

--- a/src/putcoluj.rs
+++ b/src/putcoluj.rs
@@ -5,7 +5,6 @@
 /*  Astrophysic Science Archive Research Center (HEASARC) at the NASA      */
 /*  Goddard Space Flight Center.                                           */
 
-use core::ffi::CStr;
 use core::slice;
 use core::{cmp, mem};
 

--- a/src/putcoluk.rs
+++ b/src/putcoluk.rs
@@ -5,7 +5,6 @@
 /*  Astrophysic Science Archive Research Center (HEASARC) at the NASA      */
 /*  Goddard Space Flight Center.                                           */
 
-use core::ffi::CStr;
 use core::slice;
 use core::{cmp, mem};
 


### PR DESCRIPTION
Line-by-line port of `cfitsio/utilities/{fitsverify,ftverify,fvrf_key,fvrf_file,fvrf_data,fvrf_head,fvrf_misc}.c` and `fverify.h` into the `fitsverify` binary, keeping the original names, structure and comments per `TRANSPILING.md`.

## Approach

- Safe Rust API throughout. The only raw pointers are in `test_data`/`iterdata`, where the CFITSIO iterator's contract (a `void *userPointer`, and an `iteratorCol` whose `array` is an untyped buffer) leaves no alternative; those are confined to small `// SAFETY:`-commented blocks.
- The C's file statics (`cards`, `tmpkwds`, `ttype`/`tform`/`tunit`, `hduname`) become thread-locals holding owned data; `malloc`/`free` bookkeeping is replaced by RAII.
- The scratch buffers (`errmes`, `comm`, `temp`) become locals at each use site — the C only ever prints into them and immediately consumes them.
- Messages are built as byte strings rather than through Rust's `String`. fitsverify's whole job is to echo malformed cards, which are frequently not valid UTF-8, and a lossy conversion would not match the C's output.

## Verification

The C binary is used as an oracle — identical stdout, stderr **and** exit status:

| Corpus | Result |
|---|---|
| cfitsio test corpus, 21 files x 7 flag combinations | 147/147 |
| CLI edge cases (`-h`, no args, bad flags, missing/non-FITS files, `@filelist`, multi-file) | 15/15 |
| ~5000 mutation-fuzzed variants (byte flips, keyword/value corruption, truncation, appended junk, non-ASCII injection) | no port-level differences remain |

`cargo test` (2284 tests) and `testprog_check.sh` both still pass.

The remaining fuzz differences are all (a) the `(CFITSIO Vx.y.z)` banner — this crate reports 4.6.4, the C links 4.7.0; (b) C unsoundness deliberately not reproduced (below); or (c) pre-existing rsfitsio-vs-cfitsio differences in which diagnostics reach the CFITSIO error stack for corrupt files.

## Deliberate divergences, where the C is unsound

- `init_hdu`'s `FitsKey tmpkey` is never initialised, so the C prints an uninitialised `kindex` (e.g. `Keyword #143153431`); here it is `0`.
- `get_cmp` dereferences a NULL `pr_end` when a complex value has no comma — the C segfaults; guarded here.
- `test_bin_ext` indexes `naxes[0]`/`naxes[1]` regardless of `NAXIS`; missing axes read as `0` rather than off the end of the array.
- `test_agap` writes `temp[tbcol-1 ..]` unbounded, and `wrtserr` reads `tmp[20]` out of bounds; both are bounds-checked here.
- Where the data runs past EOF on a truncated file, the C scans stale buffer contents; this returns zeros.

## Library fixes this port depended on

- **`ffiter`**: the `TSTRING` null-value `memcpy` wrote over the `char *` array itself instead of the string it points at, corrupting the row pointers — `stringptr = &mut cols[jj].array.cast()` took the address of a temporary. This made any iterator read of a string column return a NULL row pointer.
- **Error stack**: it stored `String`, so `ffpmsg` silently *dropped* any message that was not valid UTF-8 (i.e. exactly the card echoes fitsverify needs), and chunking at byte 80 could panic mid-codepoint. It now stores raw bytes, as the C does.
- **`ffc2ii`/`ffc2jj` and `slice_to_str!`** panicked on unterminated or non-UTF-8 buffers instead of reporting a bad value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MB7Lkb94EbHMgxjZKKRGNj