### PR TITLE
Fix a leak and thin assertions in the ported unit tests

### DIFF
--- a/src/drvrsmem.rs
+++ b/src/drvrsmem.rs
@@ -2328,10 +2328,9 @@ mod tests {
         fits_write_imghdr(f.as_deref_mut().unwrap(), BYTE_IMG, 1, &naxes, &mut status);
         assert_eq!(status, 0, "ffphps failed");
         smem_shutdown();
-        // C deliberately leaks the open fitsfile here (cleanup deletes the
-        // segment underneath it); we do the same by forgetting the handle so we
-        // don't attempt to close a segment that has been torn down.
-        std::mem::forget(f.take());
+        // Not fits_close_file: it would flush into the now-detached segment.
+        // Dropping the handle frees it without touching the segment.
+        drop(f.take());
     }
 
     #[test]
@@ -2352,7 +2351,7 @@ mod tests {
         unsafe {
             shared_set_debug(0);
         }
-        std::mem::forget(f.take());
+        drop(f.take());
     }
 
     #[test]

--- a/src/getcold.rs
+++ b/src/getcold.rs
@@ -3086,6 +3086,11 @@ mod tests {
             assert_eq!(result[1], 2.0); // (3,1) -> index 2.
             assert_eq!(result[2], 4.0); // (5,1) -> index 4.
             assert_eq!(result[3], 12.0); // (1,3) -> index 12.
+            assert_eq!(result[4], 14.0); // (3,3) -> index 14.
+            assert_eq!(result[5], 16.0); // (5,3) -> index 16.
+            assert_eq!(result[6], 24.0); // (1,5) -> index 24.
+            assert_eq!(result[7], 26.0); // (3,5) -> index 26.
+            assert_eq!(result[8], 28.0); // (5,5) -> index 28.
             fits_close_file(f.take().unwrap(), &mut status);
         });
     }

--- a/src/getcole.rs
+++ b/src/getcole.rs
@@ -3023,6 +3023,11 @@ mod tests {
             assert_eq!(result[1], 2.0); // (3,1) -> index 2.
             assert_eq!(result[2], 4.0); // (5,1) -> index 4.
             assert_eq!(result[3], 12.0); // (1,3) -> index 12.
+            assert_eq!(result[4], 14.0); // (3,3) -> index 14.
+            assert_eq!(result[5], 16.0); // (5,3) -> index 16.
+            assert_eq!(result[6], 24.0); // (1,5) -> index 24.
+            assert_eq!(result[7], 26.0); // (3,5) -> index 26.
+            assert_eq!(result[8], 28.0); // (5,5) -> index 28.
             fits_close_file(f.take().unwrap(), &mut status);
         });
     }


### PR DESCRIPTION
Ports the applicable parts of heasarc/cfitsio#176.

- `test_cleanup_locked_segment` / `test_cleanup_with_debug` (`src/drvrsmem.rs`) forgot the `fitsfile` rather than dropping it, to avoid flushing into a segment `smem_shutdown` has already detached. Dropping does not close the file, so it avoids the flush without leaking.
- `test_read_subsection_with_increment` (`src/getcold.rs`, `src/getcole.rs`) only checked 4 of the 9 pixels the increment selects. The buffer was already sized correctly, so this is coverage only; the 5 new assertions pass.

The other two defects in that PR do not apply here: the ported `ffpextn` test already sizes its data array to the full image, and `SAORegion` is a plain Rust struct that is dropped rather than leaked.

`cargo test` is green; the `shared_mem` tests behave identically before and after (the two changed ones pass, the pre-existing failures elsewhere in that feature are unaffected).