### PR TITLE
Transpile the last cfileio image-section routines, and un-skip the tests whose blockers were already gone

### DIFF
--- a/src/bin/fitsverify/common.rs
+++ b/src/bin/fitsverify/common.rs
@@ -1,11 +1,11 @@
 /* Transpiled from cfitsio/utilities/fverify.h, plus the small amount of
-   infrastructure that C gets for free from <stdio.h>/<ctype.h>/<stdlib.h>.
+infrastructure that C gets for free from <stdio.h>/<ctype.h>/<stdlib.h>.
 
-   The C globals declared here (errmes, comm, prhead, testdata, ...) are file
-   statics / externs in the C.  Buffers that are only ever "printf into it, then
-   immediately consume it" (errmes, comm, temp) become locals at each use site,
-   which is semantically identical and avoids global mutable state.  The truly
-   persistent globals (the flags and counters) live in `flags` below.  */
+The C globals declared here (errmes, comm, prhead, testdata, ...) are file
+statics / externs in the C.  Buffers that are only ever "printf into it, then
+immediately consume it" (errmes, comm, temp) become locals at each use site,
+which is semantically identical and avoids global mutable state.  The truly
+persistent globals (the flags and counters) live in `flags` below.  */
 
 use std::cell::{Cell, RefCell};
 use std::cmp::Ordering;
@@ -107,14 +107,14 @@ pub(crate) struct FitsHdu {
     pub(crate) tkeys: c_int,                  /* total of the keys tested*/
     pub(crate) heap: c_int,                   /* heap */
     pub(crate) kwds: Vec<FitsKey>,            /* keywords list starting from the
-                                       last NAXISn keyword. The array
-                                       is sorted in the ascending alphabetical
-                                       order of keyword names. The last keyword END
-                                       and commentary keywords are  excluded.
-                                       The total number of element, tkey, is
-                                       nkeys - 4 - naxis - ncomm. */
+                                              last NAXISn keyword. The array
+                                              is sorted in the ascending alphabetical
+                                              order of keyword names. The last keyword END
+                                              and commentary keywords are  excluded.
+                                              The total number of element, tkey, is
+                                              nkeys - 4 - naxis - ncomm. */
     pub(crate) use_longstr: c_int, /* flag indicates that the long string
-                            convention is used */
+                                   convention is used */
 }
 
 impl Default for FitsHdu {
@@ -182,8 +182,8 @@ impl Default for HduName {
  *==========================================================================*/
 
 /* These are file statics in the C, i.e. per-process state in a single-threaded
-   program.  Thread-locals give exactly that, and keep the test threads from
-   trampling on each other's counters. */
+program.  Thread-locals give exactly that, and keep the test threads from
+trampling on each other's counters. */
 macro_rules! int_global {
     ($get:ident, $set:ident, $store:ident, $init:expr) => {
         thread_local! {
@@ -326,7 +326,7 @@ impl Put for &str {
 }
 
 /* so a format!() can be handed straight to spf!/pf! for the conversions that
-   std already does: widths, precisions, zero padding, hex */
+std already does: widths, precisions, zero padding, hex */
 impl Put for String {
     fn put(&self, v: &mut Vec<u8>) {
         v.extend_from_slice(self.as_bytes());
@@ -341,7 +341,7 @@ macro_rules! put_via_display {
     )* };
 }
 /* the integer widths actually passed to spf!/pf!; c_int and c_long are
-   covered by i32/i64 on every target this builds for */
+covered by i32/i64 on every target this builds for */
 put_via_display!(i32, i64, usize);
 
 /* %s of a NUL-terminated c_char buffer */
@@ -377,7 +377,7 @@ impl Put for CHR {
 }
 
 /* %[-]<width>[.<prec>]s of a NUL-terminated c_char buffer.
-   `width' < 0 means left justified, as in "%-20s". */
+`width' < 0 means left justified, as in "%-20s". */
 pub(crate) struct CSW<'a>(pub &'a [c_char], pub i32, pub Option<usize>);
 
 impl Put for CSW<'_> {
@@ -392,8 +392,8 @@ impl Put for CSW<'_> {
 }
 
 /* printf's width/justification for a *byte* string.  Numbers and &str go
-   through format!() instead -- std does this for them -- but format! cannot
-   take arbitrary bytes, so CSW still needs it. */
+through format!() instead -- std does this for them -- but format! cannot
+take arbitrary bytes, so CSW still needs it. */
 fn pad(v: &mut Vec<u8>, b: &[u8], width: i32) {
     let w = width.unsigned_abs() as usize;
     if b.len() >= w {
@@ -408,7 +408,7 @@ fn pad(v: &mut Vec<u8>, b: &[u8], width: i32) {
 }
 
 /* Formats the arguments and stores the result NUL-terminated in `dst'.
-   C's sprintf() would run off the end of these fixed buffers; we truncate. */
+C's sprintf() would run off the end of these fixed buffers; we truncate. */
 #[macro_export]
 macro_rules! spf {
     ($dst:expr; $($x:expr),* $(,)?) => {{
@@ -501,9 +501,9 @@ pub(crate) fn strncpy_c(dst: &mut [c_char], src: &[c_char], n: usize) {
 }
 
 /* Slice comparison over the NUL-terminated contents gives exactly strcmp()'s
-   ordering: Rust compares `[u8]` lexicographically, which is glibc's
-   unsigned-char comparison, and a shorter prefix sorts first just as the
-   terminating NUL does. */
+ordering: Rust compares `[u8]` lexicographically, which is glibc's
+unsigned-char comparison, and a shorter prefix sorts first just as the
+terminating NUL does. */
 pub(crate) fn ccmp(a: &[c_char], b: &[c_char]) -> Ordering {
     cbytes(a).cmp(cbytes(b))
 }
@@ -515,7 +515,7 @@ pub(crate) fn skip_spaces(b: &[u8]) -> &[u8] {
 }
 
 /* The C's trailing-blank strip stops at index 0 (`while (l > 0 && ...)`), so an
-   all-blank field keeps one character rather than becoming empty. */
+all-blank field keeps one character rather than becoming empty. */
 pub(crate) fn trim_end_spaces(b: &[u8]) -> &[u8] {
     let mut end = b.len();
     while end > 1 && b[end - 1] == b' ' {
@@ -564,7 +564,7 @@ pub(crate) fn cvec(s: &[c_char]) -> Vec<c_char> {
  *==========================================================================*/
 
 /* isprint(): u8::is_ascii_graphic() is 0x21..=0x7e, i.e. printable *except*
-   the space, which C counts. */
+the space, which C counts. */
 #[inline]
 pub(crate) fn isprint_c(c: c_char) -> bool {
     let c = c as u8;
@@ -572,7 +572,7 @@ pub(crate) fn isprint_c(c: c_char) -> bool {
 }
 
 /* isspace(): u8::is_ascii_whitespace() deliberately omits the vertical tab,
-   which C's isspace() includes. */
+which C's isspace() includes. */
 #[inline]
 pub(crate) fn isspace_c(c: c_char) -> bool {
     let c = c as u8;
@@ -716,8 +716,8 @@ mod tests {
     }
 
     /* strtol() saturates at LONG_MAX/LONG_MIN on overflow, and fitsverify
-       tests its results against those to spot malformed TDISPn widths, so the
-       saturation has to survive the port. */
+    tests its results against those to spot malformed TDISPn widths, so the
+    saturation has to survive the port. */
     #[test]
     fn test_strtol_c() {
         assert_eq!(strtol_c(&to_buf::<32>("123abc")), (123, 3));
@@ -729,8 +729,14 @@ mod tests {
         assert_eq!(strtol_c(&to_buf::<32>("abc")), (0, 0));
         assert_eq!(strtol_c(&to_buf::<32>("+")), (0, 0));
         /* overflow saturates rather than wrapping */
-        assert_eq!(strtol_c(&to_buf::<32>("99999999999999999999")).0, c_long::MAX);
-        assert_eq!(strtol_c(&to_buf::<32>("-99999999999999999999")).0, c_long::MIN);
+        assert_eq!(
+            strtol_c(&to_buf::<32>("99999999999999999999")).0,
+            c_long::MAX
+        );
+        assert_eq!(
+            strtol_c(&to_buf::<32>("-99999999999999999999")).0,
+            c_long::MIN
+        );
         /* the endptr is what the PC/CD alt-suffix test keys off */
         assert_eq!(strtol_c(&to_buf::<32>("12_3")), (12, 2));
     }
@@ -749,8 +755,8 @@ mod tests {
     }
 
     /* glibc's C locale reports false for every class on the negative values a
-       signed char can hold, and c_char is unsigned on some targets, so these
-       must not depend on the platform's char signedness. */
+    signed char can hold, and c_char is unsigned on some targets, so these
+    must not depend on the platform's char signedness. */
     #[test]
     fn test_ctype_helpers() {
         assert!(!isprint_c(0x1f as c_char));
@@ -796,11 +802,23 @@ mod tests {
         assert_eq!(e[5], b'x' as c_char);
 
         /* ccmp is strcmp's ordering; ceq/cstarts are the == 0 forms */
-        assert_eq!(ccmp(&to_buf::<16>("abc"), &to_buf::<16>("abc")), Ordering::Equal);
-        assert_eq!(ccmp(&to_buf::<16>("abc"), &to_buf::<16>("abd")), Ordering::Less);
-        assert_eq!(ccmp(&to_buf::<16>("abd"), &to_buf::<16>("abc")), Ordering::Greater);
+        assert_eq!(
+            ccmp(&to_buf::<16>("abc"), &to_buf::<16>("abc")),
+            Ordering::Equal
+        );
+        assert_eq!(
+            ccmp(&to_buf::<16>("abc"), &to_buf::<16>("abd")),
+            Ordering::Less
+        );
+        assert_eq!(
+            ccmp(&to_buf::<16>("abd"), &to_buf::<16>("abc")),
+            Ordering::Greater
+        );
         /* a shorter string sorts first, as the terminating NUL does in strcmp */
-        assert_eq!(ccmp(&to_buf::<16>("abc"), &to_buf::<16>("abcd")), Ordering::Less);
+        assert_eq!(
+            ccmp(&to_buf::<16>("abc"), &to_buf::<16>("abcd")),
+            Ordering::Less
+        );
 
         assert!(ceq(&to_buf::<16>("NAXIS"), b"NAXIS"));
         assert!(!ceq(&to_buf::<16>("NAXIS"), b"NAXIS1"));
@@ -829,7 +847,7 @@ mod tests {
     }
 
     /* The message builder has to pass bytes through untouched: fitsverify
-       echoes malformed cards, which are routinely not valid UTF-8. */
+    echoes malformed cards, which are routinely not valid UTF-8. */
     #[test]
     fn test_spf_is_byte_exact() {
         let mut b = [0 as c_char; 64];
@@ -837,7 +855,7 @@ mod tests {
         assert_eq!(cbytes(&b), b"n=42 c=\xfe!");
 
         /* Widths for numbers and &str come from std's format!; only CSW pads
-           by hand, because format! cannot take arbitrary bytes. */
+        by hand, because format! cannot take arbitrary bytes. */
         let mut w = [0 as c_char; 64];
         spf!(w; "[", format!("{:<4}", 7), "][", format!("{:>4}", 7), "]");
         assert_eq!(cbytes(&w), b"[7   ][   7]");

--- a/src/bin/fitsverify/fvrf_data.rs
+++ b/src/bin/fitsverify/fvrf_data.rs
@@ -1,18 +1,17 @@
 /* Transpiled from cfitsio/utilities/fvrf_data.c
 
-   The CFITSIO iterator hands its work function a `void *userPointer' and an
-   array of iteratorCol whose `array' member is a raw buffer, so test_data /
-   iterdata keep the C's pointer arithmetic inside small unsafe blocks.  All
-   the other column reads use the typed safe wrappers.  */
+The CFITSIO iterator hands its work function a `void *userPointer' and an
+array of iteratorCol whose `array' member is a raw buffer, so test_data /
+iterdata keep the C's pointer arithmetic inside small unsafe blocks.  All
+the other column reads use the typed safe wrappers.  */
 
 use std::cell::{Cell, RefCell};
 
 use bytemuck::cast_slice;
 use rsfitsio::aliases::rust_api::{
-    fits_get_coltype, fits_get_num_rows, fits_get_num_rowsll, fits_get_rowsize,
-    fits_iterate_data, fits_read_col_log, fits_read_col_str, fits_read_descriptll,
-    fits_read_key_lng, fits_read_key_lnglng, fits_read_key_str, fits_read_tblbytes,
-    fits_verify_chksum,
+    fits_get_coltype, fits_get_num_rows, fits_get_num_rowsll, fits_get_rowsize, fits_iterate_data,
+    fits_read_col_log, fits_read_col_str, fits_read_descriptll, fits_read_key_lng,
+    fits_read_key_lnglng, fits_read_key_str, fits_read_tblbytes, fits_verify_chksum,
 };
 use rsfitsio::buffers::ffgtbb_safe;
 use std::ffi::CStr;
@@ -78,24 +77,24 @@ pub(crate) fn test_data(
     let ncols: c_int;
 
     let mut nnum = 0; /* the list of the column  whose data
-                      type is numerical(scalar and complex) */
+    type is numerical(scalar and complex) */
     let mut numlist: Vec<c_int>;
     let mut nfloat = 0; /* the list of the floating point columns in ASCII table */
     let mut floatlist: Vec<c_int>;
 
     let ncmp = 0; /* the list of the column  whose data
-                  type is numerical(scalar and complex) */
+    type is numerical(scalar and complex) */
     let cmplist: Vec<c_int>;
     let mut ntxt = 0; /* the list of column  whose data type is
-                      string, logical, bit or complex */
+    string, logical, bit or complex */
     let mut txtlist: Vec<c_int>;
     let niter: c_int; /* total columns read into  the literator function */
 
     let mut ndesc = 0; /* the list of column which is the descriptor of
-                       the variable length array. */
+    the variable length array. */
     let mut desclist: Vec<c_int>;
     let mut isVarQFormat: Vec<c_int>; /* Format type for each of the ndesc variable-length
-                                      columns: 0 = type 'P', 1 = type 'Q' */
+    columns: 0 = type 'P', 1 = type 'Q' */
 
     let mut rows_per_loop: c_long = 0;
     let offset: c_long;
@@ -137,7 +136,7 @@ pub(crate) fn test_data(
 
     if testfill() != 0 {
         test_agap(infits, out, hduptr); /* test the bytes between the
-                                        ascii table columns. */
+        ascii table columns. */
         if ffcdfl_safe(infits, &mut status) != 0 {
             wrtferr_str(out, "checking data fill: ", &mut status, 1);
             status = 0;
@@ -164,7 +163,7 @@ pub(crate) fn test_data(
     }
 
     /* separate the numerical, complex, text and
-      the variable length vector columns */
+    the variable length vector columns */
     numlist = vec![0; ncols as usize];
     floatlist = vec![0; ncols as usize];
     cmplist = vec![0; ncols as usize];
@@ -229,8 +228,8 @@ pub(crate) fn test_data(
 
     /*  Use Iterator to read the columns that are not variable length arrays */
     /* columns from  1 to nnum are scalar numerical columns.
-       columns from  nnum+1 to  nnum+ncmp are complex columns.
-       columns from  nnum+ncmp are text columns */
+    columns from  nnum+1 to  nnum+ncmp are complex columns.
+    columns from  nnum+ncmp are text columns */
     niter = nnum + ncmp + ntxt + nfloat;
 
     if niter != 0 {
@@ -339,7 +338,7 @@ pub(crate) fn test_data(
     }
 
     /* the C free()s iter_col, numlist, floatlist, cmplist, txtlist and the
-       usrdata arrays here; RAII does that. */
+    usrdata arrays here; RAII does that. */
 
     if ndesc != 0 {
         /* ------------read the variable length vectors -------------------*/
@@ -599,7 +598,7 @@ pub(crate) fn test_data(
 /* iterator work function */
 
 /* The C keeps its per-table state in function statics; the same state lives
-   here so that it survives across the iterator's repeated calls. */
+here so that it survives across the iterator's repeated calls. */
 thread_local! {
     static REPEAT_V: RefCell<Vec<c_long>> = const { RefCell::new(Vec::new()) };
     static DATATYPE_V: RefCell<Vec<c_int>> = const { RefCell::new(Vec::new()) };
@@ -676,8 +675,8 @@ pub extern "C" fn iterdata(
     let datatype = DATATYPE_V.with(|d| d.borrow().clone());
 
     /* columns from  1 to nnum are scalar numerical columns.
-       columns from  nnum+1 to  nnum+ncmp are complex columns. (not used any more)
-       columns from  nnum+ncmp are text columns */
+    columns from  nnum+1 to  nnum+ncmp are complex columns. (not used any more)
+    columns from  nnum+ncmp are text columns */
 
     /* deal with the numerical column */
     i = 0;
@@ -740,7 +739,9 @@ pub extern "C" fn iterdata(
             // slot 0 is the null-value string, slots 1..=nrows the row values,
             // all NUL-terminated and owned by the iterator for this call.
             let cdata: *const *const c_char = cols[iu].array.cast::<*const c_char>();
-            let row = |n: c_long| -> &[u8] { unsafe { CStr::from_ptr(*cdata.offset(n as isize)) }.to_bytes() };
+            let row = |n: c_long| -> &[u8] {
+                unsafe { CStr::from_ptr(*cdata.offset(n as isize)) }.to_bytes()
+            };
             FIND_BADCHAR.with(|c| c.set(0));
 
             /* test for illegal ASCII text characters > 126  or < 32 */
@@ -748,7 +749,7 @@ pub extern "C" fn iterdata(
                 k = 0;
                 while k < nrows {
                     /* NB: the C breaks out of the inner scan only, so the row
-                       loop carries on and every offending row is reported. */
+                    loop carries on and every offending row is reported. */
                     if row(k + 1).iter().any(|&c| !(32..=126).contains(&c)) {
                         spf!(errmes;
                             "String in row #", (firstn + k) as i64, ", column #",
@@ -806,7 +807,9 @@ pub extern "C" fn iterdata(
         // SAFETY: TSTRING iterator column, char*[nrows+1] as above.
         // SAFETY: as above -- a TSTRING iterator column.
         let cdata: *const *const c_char = cols[iu].array.cast::<*const c_char>();
-        let row = |n: c_long| -> &[u8] { unsafe { CStr::from_ptr(*cdata.offset(n as isize)) }.to_bytes() };
+        let row = |n: c_long| -> &[u8] {
+            unsafe { CStr::from_ptr(*cdata.offset(n as isize)) }.to_bytes()
+        };
         FIND_BADDOT.with(|c| c.set(0));
         FIND_BADSPACE.with(|c| c.set(0));
 
@@ -844,7 +847,7 @@ pub extern "C" fn iterdata(
                 if floatvalue != row(0) {
                     /* not a null value? */
                     /* The C strips the trailing blanks in place; nothing reads
-                       the row again afterwards, so a trimmed view is equivalent. */
+                    the row again afterwards, so a trimmed view is equivalent. */
                     let floatvalue = trim_end_spaces(skip_spaces(floatvalue));
 
                     if floatvalue.contains(&b' ') {
@@ -921,8 +924,8 @@ fn test_agap(
     data = vec![0; (rowlen * irows as LONGLONG) as usize];
 
     /* Create a template row with data fields filled with 1s.
-       Used below - different ASCII rules apply within data columns
-       vs. between data columns. */
+    Used below - different ASCII rules apply within data columns
+    vs. between data columns. */
 
     temp = vec![0; rowlen as usize];
     for k in 1..=ncols {

--- a/src/bin/fitsverify/fvrf_file.rs
+++ b/src/bin/fitsverify/fvrf_file.rs
@@ -1,18 +1,18 @@
 /* Transpiled from cfitsio/utilities/fvrf_file.c
 
-   `static HduName **hduname' becomes a thread-local Vec<HduName>; the C's
-   malloc/calloc/free bookkeeping is dropped in favour of RAII.  */
+`static HduName **hduname' becomes a thread-local Vec<HduName>; the C's
+malloc/calloc/free bookkeeping is dropped in favour of RAII.  */
 
 use std::cell::{Cell, RefCell};
 
 use bytemuck::cast_slice;
-use rsfitsio::aliases::rust_api::{
-    fits_clear_errmsg, fits_get_hduaddrll, fits_movrel_hdu,
-};
+use rsfitsio::aliases::rust_api::{fits_clear_errmsg, fits_get_hduaddrll, fits_movrel_hdu};
 use rsfitsio::buffers::ffmbyt_safe;
 use rsfitsio::c_types::{c_char, c_int};
 use rsfitsio::cs;
-use rsfitsio::fitsio::{ASCII_TBL, BINARY_TBL, END_OF_FILE, FLEN_VALUE, IMAGE_HDU, LONGLONG, fitsfile};
+use rsfitsio::fitsio::{
+    ASCII_TBL, BINARY_TBL, END_OF_FILE, FLEN_VALUE, IMAGE_HDU, LONGLONG, fitsfile,
+};
 
 use crate::common::*;
 use crate::fvrf_misc::*;
@@ -53,10 +53,10 @@ fn init_hduname() {
 
 /* set the hduname memeber hdutype, extname, extver */
 pub(crate) fn set_hduname(
-    hdunum: c_int,             /* hdu number */
-    hdutype: c_int,            /* hdutype */
+    hdunum: c_int,              /* hdu number */
+    hdutype: c_int,             /* hdutype */
     extname: Option<&[c_char]>, /* extension name */
-    extver: c_int,             /* extension version */
+    extver: c_int,              /* extension version */
 ) {
     let i = (hdunum - 1) as usize;
     HDUNAME.with(|h| {
@@ -260,7 +260,7 @@ pub(crate) fn test_end(infits: &mut fitsfile, out: Out) {
     }
 
     /* try to move to what would be the first byte of the next extension.
-      If successfull, we have a problem... */
+    If successfull, we have a problem... */
 
     ffmbyt_safe(infits, dataend, 0, &mut status);
     if status == 0 {
@@ -281,8 +281,8 @@ pub(crate) fn test_end(infits: &mut fitsfile, out: Out) {
 *
 *******************************************************************************/
 pub(crate) fn init_report(
-    out: Out,               /* output file */
-    _rootnam: &[c_char],    /* input file name */
+    out: Out,            /* output file */
+    _rootnam: &[c_char], /* input file name */
 ) {
     let mut comm: [c_char; COMM_LEN] = [0; COMM_LEN];
     spf!(comm; "\n", totalhdu(), " Header-Data Units in this file.");

--- a/src/bin/fitsverify/fvrf_head.rs
+++ b/src/bin/fitsverify/fvrf_head.rs
@@ -1,9 +1,9 @@
 /* Transpiled from cfitsio/utilities/fvrf_head.c
 
-   The `char **' working arrays (cards, tmpkwds, ttype, tform, tunit) are
-   file-statics in the C; here they are thread-locals holding owned copies.
-   `temp' / `ptemp' were only ever used to hand a pattern to key_match(), so
-   the pattern is passed directly instead.  */
+The `char **' working arrays (cards, tmpkwds, ttype, tform, tunit) are
+file-statics in the C; here they are thread-locals holding owned copies.
+`temp' / `ptemp' were only ever used to hand a pattern to key_match(), so
+the pattern is passed directly instead.  */
 
 use std::cell::{Cell, RefCell};
 use std::cmp::Ordering;
@@ -19,7 +19,7 @@ use rsfitsio::cs;
 use rsfitsio::fitscore::ffchfl_safe;
 use rsfitsio::fitsio::{
     ASCII_TBL, BINARY_TBL, BYTE_IMG, DOUBLE_IMG, FLEN_CARD, FLEN_FILENAME, FLEN_KEYWORD,
-    FLEN_VALUE, FLOAT_IMG, IMAGE_HDU, LONGLONG, LONGLONG_IMG, LONG_IMG, READONLY, SHORT_IMG,
+    FLEN_VALUE, FLOAT_IMG, IMAGE_HDU, LONG_IMG, LONGLONG, LONGLONG_IMG, READONLY, SHORT_IMG,
     ULONG_IMG, USHORT_IMG, fitsfile,
 };
 use rsfitsio::{KeywordDatatypeMut, NullValue};
@@ -93,8 +93,8 @@ fn tunit_at(i: usize) -> Vec<c_char> {
 *
 *******************************************************************************/
 /* routine to verify individual fitsfile */
-/* NB: like the C, this strips trailing whitespace in the caller's buffer -- 
-   ftverify_work() relies on that when it echoes the name fgets() read. */
+/* NB: like the C, this strips trailing whitespace in the caller's buffer --
+ftverify_work() relies on that when it echoes the name fgets() read. */
 pub(crate) fn verify_fits(infile: &mut [c_char], out: Out) -> c_int {
     let rootnam: [c_char; FLEN_FILENAME] = [0; FLEN_FILENAME]; /* Input Fits file root name */
     let mut infits: Option<Box<fitsfile>> = None; /* input fits file pointer */
@@ -282,7 +282,7 @@ fn init_hdu(
     CURTYPE.with(|c| c.set(hdutype)); /* set the current hdu number */
 
     /* check the null character in the header.(only the first one will
-       be recorded */
+    be recorded */
     let lvi = fits_null_check(infits, &mut status) as LONGLONG;
     if lvi > 0 {
         let mm = (lvi - 1) / 80 + 1;
@@ -327,8 +327,8 @@ fn init_hdu(
     }
 
     /* if there were blank cards prior to the END card, then
-       make a fake END card, because CFITSIO blocks us from reading
-       the real END card */
+    make a fake END card, because CFITSIO blocks us from reading
+    the real END card */
 
     if !cstarts(&card_at(ncards - 1), b"END     ") {
         let mut c: [c_char; FLEN_CARD] = [0; FLEN_CARD];
@@ -503,10 +503,10 @@ fn init_hdu(
     }
 
     /* parse the keywords after NAXISn and prepare the array for
-       sorting. We only check the keywords after the NAXISn */
+    sorting. We only check the keywords after the NAXISn */
     n = (hduptr.nkeys - 4 - hduptr.naxis).max(0) as usize; /* excluding the SIMPLE/XTENSION,
-                                                           BITPIX, NAXIS, NAXISn
-                                                           and END */
+    BITPIX, NAXIS, NAXISn
+    and END */
     hduptr.kwds = vec![FitsKey::default(); n];
     k = 3 + hduptr.naxis as usize; /* index of first keyword following NAXISn. */
     m = (hduptr.nkeys - 1) as usize; /* last key  */
@@ -522,8 +522,15 @@ fn init_hdu(
             hduptr.kwds[i].ktype,
             hduptr.kwds[i].kvalue,
         );
-        if fits_parse_card(out, 1 + j as c_int, &mut cardj, &mut kn, &mut kt, &mut kv, &mut comm)
-            != 0
+        if fits_parse_card(
+            out,
+            1 + j as c_int,
+            &mut cardj,
+            &mut kn,
+            &mut kt,
+            &mut kv,
+            &mut comm,
+        ) != 0
         {
             hduptr.kwds[i].goodkey = 0;
         }
@@ -650,8 +657,17 @@ fn test_hdu(
 
     /* floating non-indexed WCS keywords  */
     let cfltnkeys: [&std::ffi::CStr; 11] = [
-        c"RESTFRQ", c"RESTFREQ", c"RESTWAV", c"OBSGEO-X", c"OBSGEO-Y", c"OBSGEO-Z", c"VELOSYS",
-        c"ZSOURCE", c"VELANGL", c"LONPOLE", c"LATPOLE",
+        c"RESTFRQ",
+        c"RESTFREQ",
+        c"RESTWAV",
+        c"OBSGEO-X",
+        c"OBSGEO-Y",
+        c"OBSGEO-Z",
+        c"VELOSYS",
+        c"ZSOURCE",
+        c"VELANGL",
+        c"LONPOLE",
+        c"LATPOLE",
     ];
     let ncfltnkeys = 11;
 
@@ -768,7 +784,7 @@ fn test_hdu(
             wcsaxesExists = 1;
 
             /*  Removed this check on 6/28/2012.  See discussion on FITSBITS related
-                to this requirement.  */
+            to this requirement.  */
 
             parse_wcskey_suffix(
                 &hduptr.kwds[j as usize].kname,
@@ -935,7 +951,7 @@ fn test_hdu(
             }
 
             /* test the first digit (strtol stops at the '_' anyway, so the C's
-               temporary NUL there is not needed) */
+            temporary NUL there is not needed) */
             m = strtol_c(&kname[p..]).0 as c_int;
 
             if wcsaxesExists != 0 {
@@ -1196,7 +1212,7 @@ fn test_prm(
     let tmpkwds = tmpkwds_get();
 
     /* The SIMPLE, BITPIX, NAXIS, and NAXISn keywords  have been
-       checked in CFITSIO */
+    checked in CFITSIO */
 
     /* excluded keywords cannot be used. */
     for i in 0..nexlkey {
@@ -1521,7 +1537,7 @@ fn test_img_ext(
     test_ext(infits, out, hduptr);
 
     /* The XTENSION, BITPIX, NAXIS, and NAXISn keywords  have been
-       checked in CFITSIO */
+    checked in CFITSIO */
 
     if hduptr.pcount != 0 && hduptr.pcount != -99 {
         spf!(errmes; "Illegal pcount value ", hduptr.pcount as i64, " for image ext.");
@@ -2200,7 +2216,7 @@ fn test_asc_ext(
     mcol = hduptr.ncols;
 
     /* The XTENSION, BITPIX, NAXIS, NAXISn, TFIELDS, PCOUNT, GCOUNT, TFORMn,
-       TBCOLn, TTYPEn keywords  have been checked in CFITSIO */
+    TBCOLn, TTYPEn keywords  have been checked in CFITSIO */
 
     /* General extension */
     test_ext(infits, out, hduptr);
@@ -2395,7 +2411,7 @@ fn test_bin_ext(
     let tmpkwds = tmpkwds_get();
 
     /* The XTENSION, BITPIX, NAXIS, NAXISn, TFIELDS, PCOUNT, GCOUNT, TFORMn,
-       TTYPEn keywords  have been checked in CFITSIO */
+    TTYPEn keywords  have been checked in CFITSIO */
 
     /*  Check TNULLn keywords */
     key_match(&tmpkwds, numusrkey, cs!(c"TNULL"), 0, &mut k, &mut n);
@@ -2509,8 +2525,8 @@ fn test_bin_ext(
 
     /* Check THEAP keyword */
     /* The C indexes naxes[0] and naxes[1] unconditionally; a corrupt header
-       with NAXIS < 2 makes that an out-of-bounds read, so missing axes read
-       as 0 here rather than as whatever happened to be on the stack. */
+    with NAXIS < 2 makes that an out-of-bounds read, so missing axes read
+    as 0 here rather than as whatever happened to be on the stack. */
     let naxes0 = hduptr.naxes.first().copied().unwrap_or(0);
     let naxes1 = hduptr.naxes.get(1).copied().unwrap_or(0);
     hduptr.heap = (naxes0 * naxes1) as c_int;
@@ -2661,8 +2677,15 @@ fn test_header(
 
     /* string keywords */
     let strkey: [&std::ffi::CStr; 9] = [
-        c"EXTNAME", c"ORIGIN", c"AUTHOR", c"CREATOR", c"REFERENC", c"TELESCOP", c"INSTRUME",
-        c"OBSERVER", c"OBJECT",
+        c"EXTNAME",
+        c"ORIGIN",
+        c"AUTHOR",
+        c"CREATOR",
+        c"REFERENC",
+        c"TELESCOP",
+        c"INSTRUME",
+        c"OBSERVER",
+        c"OBJECT",
     ];
     let nstrkey = 9;
 
@@ -3012,7 +3035,7 @@ fn key_match(
     *ikey = -99;
 
     /* bsearch(): glibc's binary search, so that the element it lands on for a
-       run of equal keys matches the C exactly. */
+    run of equal keys matches the C exactly. */
     let mut l: c_int = 0;
     let mut u: c_int = nstr;
     let mut found: Option<c_int> = None;
@@ -3034,7 +3057,7 @@ fn key_match(
         i = *ikey - 1;
         let mut p = pos - 1;
         /* NB: `i > 0', not `i >= 0' -- the C never revisits index 0, so a run
-           of matches starting there is only partly reported.  Kept as-is. */
+        of matches starting there is only partly reported.  Kept as-is. */
         while i > 0 && fnpt(pattern, &strs[p as usize]) == Ordering::Equal {
             *mkey += 1;
             *ikey = i;
@@ -3077,7 +3100,7 @@ fn test_colnam(out: Out, hduptr: &FitsHdu) {
     }
 
     /* check whether there are any other non ASCII-text characters
-      (FITS standard R14). Also "uppercase" the working copies. */
+    (FITS standard R14). Also "uppercase" the working copies. */
     for i in 0..n as usize {
         if cstrlen(&ttype[i]) == 0 {
             spf!(errmes;
@@ -3152,9 +3175,9 @@ pub(crate) fn parse_vtform(
     infits: &mut fitsfile,
     out: Out,
     _hduptr: &FitsHdu,
-    colnum: c_int,        /* column number */
-    datacode: &mut c_int, /* data code */
-    maxlen: &mut c_long,  /* maximum length of the vector */
+    colnum: c_int,         /* column number */
+    datacode: &mut c_int,  /* data code */
+    maxlen: &mut c_long,   /* maximum length of the vector */
     isQFormat: &mut c_int, /* true if var col is 'Q' format */
 ) {
     let mut i: c_int = 0;
@@ -3449,10 +3472,10 @@ fn bitpix_text(bitpix: c_int, temp: &mut [c_char]) {
 **************************************************************/
 fn close_hdu(hduptr: &mut FitsHdu) {
     /* The C free()s cards, hduptr->kwds, datamin/datamax/tnull, naxes and
-       tmpkwds here; RAII does that for us.  (Note the C's
-       `if(hdutype == ASCII_TBL && hdutype == BINARY_TBL)' guard around the
-       ttype/tform/tunit frees can never be true, so those are leaked there
-       and simply left in place here.) */
+    tmpkwds here; RAII does that for us.  (Note the C's
+    `if(hdutype == ASCII_TBL && hdutype == BINARY_TBL)' guard around the
+    ttype/tform/tunit frees can never be true, so those are leaked there
+    and simply left in place here.) */
     hduptr.kwds.clear();
     hduptr.datamin.clear();
     hduptr.datamax.clear();
@@ -3465,7 +3488,6 @@ fn close_hdu(hduptr: &mut FitsHdu) {
 /*===========================================================================
  *  local helpers
  *==========================================================================*/
-
 
 #[allow(dead_code)]
 fn _unused_api() {
@@ -3487,7 +3509,13 @@ mod tests {
 
     #[test]
     fn test_key_match_exact() {
-        let strs = [kw("BITPIX"), kw("CRPIX1"), kw("CRPIX2"), kw("CRVAL1"), kw("NAXIS")];
+        let strs = [
+            kw("BITPIX"),
+            kw("CRPIX1"),
+            kw("CRPIX2"),
+            kw("CRVAL1"),
+            kw("NAXIS"),
+        ];
         let (mut k, mut n) = (0, 0);
 
         key_match(&strs, 5, cs!(c"NAXIS"), 1, &mut k, &mut n);
@@ -3497,7 +3525,7 @@ mod tests {
         assert_eq!((k, n), (0, 1));
 
         /* not found: the C's sentinels, which the `for (j = k; j < k+n; j++)'
-           loops rely on to iterate zero times */
+        loops rely on to iterate zero times */
         key_match(&strs, 5, cs!(c"THEAP"), 1, &mut k, &mut n);
         assert_eq!((k, n), (-99, -999));
         assert!(k + n < k);
@@ -3509,7 +3537,13 @@ mod tests {
 
     #[test]
     fn test_key_match_prefix() {
-        let strs = [kw("BITPIX"), kw("CRPIX1"), kw("CRPIX2"), kw("CRVAL1"), kw("NAXIS")];
+        let strs = [
+            kw("BITPIX"),
+            kw("CRPIX1"),
+            kw("CRPIX2"),
+            kw("CRVAL1"),
+            kw("NAXIS"),
+        ];
         let (mut k, mut n) = (0, 0);
 
         key_match(&strs, 5, cs!(c"CRPIX"), 0, &mut k, &mut n);
@@ -3523,8 +3557,8 @@ mod tests {
     }
 
     /* The C's backward scan is guarded by `i > 0', so a run of matches that
-       begins at index 0 is only partly reported when bsearch lands above it.
-       Locked in here because the port has to reproduce it. */
+    begins at index 0 is only partly reported when bsearch lands above it.
+    Locked in here because the port has to reproduce it. */
     #[test]
     fn test_key_match_index_zero_quirk() {
         let strs = [kw("CRPIX1"), kw("CRPIX2"), kw("NAXIS")];
@@ -3538,38 +3572,62 @@ mod tests {
     fn test_parse_wcskey_suffix() {
         let (mut axis, mut alt) = (0, 0);
 
-        assert_eq!(parse_wcskey_suffix(&kw("CRPIX1"), cs!(c"CRPIX"), &mut axis, &mut alt), 0);
+        assert_eq!(
+            parse_wcskey_suffix(&kw("CRPIX1"), cs!(c"CRPIX"), &mut axis, &mut alt),
+            0
+        );
         assert_eq!((axis, alt), (1, 0));
 
-        assert_eq!(parse_wcskey_suffix(&kw("CRPIX12"), cs!(c"CRPIX"), &mut axis, &mut alt), 0);
+        assert_eq!(
+            parse_wcskey_suffix(&kw("CRPIX12"), cs!(c"CRPIX"), &mut axis, &mut alt),
+            0
+        );
         assert_eq!((axis, alt), (12, 0));
 
         /* alternate WCS description: trailing A-Z maps to 1-26 */
-        assert_eq!(parse_wcskey_suffix(&kw("CRPIX1A"), cs!(c"CRPIX"), &mut axis, &mut alt), 0);
+        assert_eq!(
+            parse_wcskey_suffix(&kw("CRPIX1A"), cs!(c"CRPIX"), &mut axis, &mut alt),
+            0
+        );
         assert_eq!((axis, alt), (1, 1));
-        assert_eq!(parse_wcskey_suffix(&kw("CRPIX2Z"), cs!(c"CRPIX"), &mut axis, &mut alt), 0);
+        assert_eq!(
+            parse_wcskey_suffix(&kw("CRPIX2Z"), cs!(c"CRPIX"), &mut axis, &mut alt),
+            0
+        );
         assert_eq!((axis, alt), (2, 26));
 
         /* more than one trailing char, or a non A-Z one, is rejected */
-        assert_eq!(parse_wcskey_suffix(&kw("CRPIX1AB"), cs!(c"CRPIX"), &mut axis, &mut alt), -1);
-        assert_eq!(parse_wcskey_suffix(&kw("CRPIX1a"), cs!(c"CRPIX"), &mut axis, &mut alt), -1);
+        assert_eq!(
+            parse_wcskey_suffix(&kw("CRPIX1AB"), cs!(c"CRPIX"), &mut axis, &mut alt),
+            -1
+        );
+        assert_eq!(
+            parse_wcskey_suffix(&kw("CRPIX1a"), cs!(c"CRPIX"), &mut axis, &mut alt),
+            -1
+        );
 
         /* name shorter than the root */
-        assert_eq!(parse_wcskey_suffix(&kw("CR"), cs!(c"CRPIX"), &mut axis, &mut alt), -1);
+        assert_eq!(
+            parse_wcskey_suffix(&kw("CR"), cs!(c"CRPIX"), &mut axis, &mut alt),
+            -1
+        );
 
         /* no suffix at all leaves both at 0 */
-        assert_eq!(parse_wcskey_suffix(&kw("CRPIX"), cs!(c"CRPIX"), &mut axis, &mut alt), 0);
+        assert_eq!(
+            parse_wcskey_suffix(&kw("CRPIX"), cs!(c"CRPIX"), &mut axis, &mut alt),
+            0
+        );
         assert_eq!((axis, alt), (0, 0));
     }
 }
 
 /* File-level tests.
 
-   Each fixture is a small hand-built FITS file that exercises one report path.
-   The expected (errors, warnings) pairs were read off the C fitsverify acting
-   as the oracle -- they are not recordings of what this implementation happens
-   to produce.  Every fixture here was also checked byte-for-byte (stdout,
-   stderr and exit status) against the C across all seven flag combinations. */
+Each fixture is a small hand-built FITS file that exercises one report path.
+The expected (errors, warnings) pairs were read off the C fitsverify acting
+as the oracle -- they are not recordings of what this implementation happens
+to produce.  Every fixture here was also checked byte-for-byte (stdout,
+stderr and exit status) against the C across all seven flag combinations. */
 #[cfg(test)]
 mod fits_tests {
     use super::*;
@@ -3647,8 +3705,8 @@ mod fits_tests {
     }
 
     /* Runs verify_fits over `bytes' and returns (errors, warnings).  Out::Null
-       suppresses all reporting, so only the counters are under test.  The
-       fitsverify counters are thread-locals, so these run in parallel safely. */
+    suppresses all reporting, so only the counters are under test.  The
+    fitsverify counters are thread-locals, so these run in parallel safely. */
     fn counts(bytes: &[u8]) -> (c_int, c_int) {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("t.fits");
@@ -3746,7 +3804,7 @@ mod fits_tests {
     }
 
     /* The C dereferences a NULL pr_end here and dies with SIGSEGV; this port
-       reports the malformed value instead.  A deliberate divergence. */
+    reports the malformed value instead.  A deliberate divergence. */
     #[test]
     fn test_complex_without_comma_is_reported_not_fatal() {
         let (e, _w) = counts(&pw(&["CPLX    = (1 2)"]));
@@ -3929,7 +3987,7 @@ mod fits_tests {
     }
 
     /* Every offending row is reported, not just the first: the C's `break'
-       leaves the inner character scan only, and the row loop carries on. */
+    leaves the inner character scan only, and the row loop carries on. */
     #[test]
     fn test_non_ascii_reported_for_every_bad_row() {
         assert_eq!(

--- a/src/bin/fitsverify/fvrf_key.rs
+++ b/src/bin/fitsverify/fvrf_key.rs
@@ -1,8 +1,8 @@
 /* Transpiled from cfitsio/utilities/fvrf_key.c
 
-   The C walks the card with `char *' cursors; here every cursor is an index
-   into the card slice, and the `char **pt' in/out cursor parameters become
-   `pt: &mut usize'.  */
+The C walks the card with `char *' cursors; here every cursor is an index
+into the card slice, and the `char **pt' in/out cursor parameters become
+`pt: &mut usize'.  */
 
 use rsfitsio::c_types::{c_char, c_int, c_ulong};
 use rsfitsio::fitsio::{FLEN_CARD, FLEN_COMMENT, FLEN_KEYWORD, FLEN_VALUE};
@@ -15,13 +15,13 @@ use crate::{scat, spf};
     Sec. 5.1 and 5.2.
 */
 pub(crate) fn fits_parse_card(
-    out: Out,                          /* output file pointer */
-    kpos: c_int,                       /* keyposition starting from 1 */
-    card: &mut [c_char],               /* key card */
+    out: Out,                           /* output file pointer */
+    kpos: c_int,                        /* keyposition starting from 1 */
+    card: &mut [c_char],                /* key card */
     kname: &mut [c_char; FLEN_KEYWORD], /* key name */
-    ktype: &mut kwdtyp,                /* key type */
-    kvalue: &mut [c_char; FLEN_VALUE], /* key value */
-    kcomm: &mut [c_char],              /* comment */
+    ktype: &mut kwdtyp,                 /* key type */
+    kvalue: &mut [c_char; FLEN_VALUE],  /* key value */
+    kcomm: &mut [c_char],               /* comment */
 ) -> c_int {
     let mut vind: [c_char; 3] = [0; 3];
     let mut p: usize;
@@ -75,11 +75,7 @@ pub(crate) fn fits_parse_card(
     /* Whether the characters in keyword name are valid */
     while kname[p] != 0 {
         let c = kname[p] as u8;
-        if !(b'A'..=b'Z').contains(&c)
-            && !(b'0'..=b'9').contains(&c)
-            && c != b'-'
-            && c != b'_'
-        {
+        if !(b'A'..=b'Z').contains(&c) && !(b'0'..=b'9').contains(&c) && c != b'-' && c != b'_' {
             spf!(errmes;
                 "Keyword #", kpos, ": Name \"", CS(kname), "\" contains char \"", CHR(kname[p]),
                 "\" which is not upper case letter, digit, \"-\", or \"_\".");
@@ -234,10 +230,10 @@ pub(crate) fn fits_parse_card(
 
 /* parse And test the string keys */
 pub(crate) fn get_str(
-    card: &[c_char],      /* card string from character 11*/
-    pt: &mut usize,       /* cursor into card */
+    card: &[c_char],       /* card string from character 11*/
+    pt: &mut usize,        /* cursor into card */
     kvalue: &mut [c_char], /* key value string */
-    stat: &mut c_ulong,   /* error number */
+    stat: &mut c_ulong,    /* error number */
 ) {
     let mut pi: usize;
     let mut prev: u8; /* previous char */
@@ -328,7 +324,10 @@ pub(crate) fn get_num(
     pi = p;
     *ktype = kwdtyp::INT_KEY;
 
-    if card[p] as u8 != b'+' && card[p] as u8 != b'-' && !isdigit_c(card[p]) && card[p] as u8 != b'.'
+    if card[p] as u8 != b'+'
+        && card[p] as u8 != b'-'
+        && !isdigit_c(card[p])
+        && card[p] as u8 != b'.'
     {
         *stat |= BAD_NUM;
         return;
@@ -390,8 +389,8 @@ pub(crate) fn get_cmp(
     let mut p: usize;
     let mut pr_beg: usize;
     /* pr_end / pi_beg are left unset by the C when there is no ',' in the
-       value; it then dereferences a NULL pr_end.  Here they stay None and the
-       terminating writes are skipped. */
+    value; it then dereferences a NULL pr_end.  Here they stay None and the
+    terminating writes are skipped. */
     let mut pr_end: Option<usize> = None;
     let mut pi_beg: Option<usize> = None;
     let mut pi_end: usize = 0;
@@ -543,11 +542,11 @@ pub(crate) fn get_unknown(
 
 /* routine to print out the error of keyword value/comment */
 pub(crate) fn pr_kval_err(
-    out: Out,          /* output  FILE */
-    kpos: c_int,       /* keyposition starting from 1 */
-    kname: &[c_char],  /* keyword name */
-    kval: &[c_char],   /* keyword value */
-    errnum: c_ulong,   /* error number */
+    out: Out,         /* output  FILE */
+    kpos: c_int,      /* keyposition starting from 1 */
+    kname: &[c_char], /* keyword name */
+    kval: &[c_char],  /* keyword value */
+    errnum: c_ulong,  /* error number */
 ) {
     let mut errmes: [c_char; ERRMES_LEN] = [0; ERRMES_LEN];
 
@@ -857,7 +856,6 @@ pub(crate) fn check_fixed_str(card: &[c_char], out: Out) -> c_int {
     1
 }
 
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -885,7 +883,13 @@ mod tests {
         let mut kcomm = [0 as c_char; COMM_LEN];
         /* Out::Null suppresses reporting so only the parse result is under test */
         let r = fits_parse_card(
-            Out::Null, 1, &mut c, &mut kname, &mut ktype, &mut kvalue, &mut kcomm,
+            Out::Null,
+            1,
+            &mut c,
+            &mut kname,
+            &mut ktype,
+            &mut kvalue,
+            &mut kcomm,
         );
         (
             r,
@@ -986,13 +990,19 @@ mod tests {
         let mut kvalue = [0 as c_char; FLEN_VALUE];
         let mut kcomm = [0 as c_char; COMM_LEN];
         let r = fits_parse_card(
-            Out::Null, 1, &mut c, &mut kname, &mut ktype, &mut kvalue, &mut kcomm,
+            Out::Null,
+            1,
+            &mut c,
+            &mut kname,
+            &mut ktype,
+            &mut kvalue,
+            &mut kcomm,
         );
         assert_eq!(r, 1);
     }
 
     /* Fixed-format checks: the value has to end in column 30 for integers and
-       sit in column 30 for logicals. */
+    sit in column 30 for logicals. */
     #[test]
     fn test_check_fixed_int() {
         reset_err_wrn();
@@ -1040,7 +1050,11 @@ mod tests {
     #[test]
     fn test_check_type_helpers() {
         reset_err_wrn();
-        let mut k = FitsKey { ktype: kwdtyp::INT_KEY, kindex: 1, ..Default::default() };
+        let mut k = FitsKey {
+            ktype: kwdtyp::INT_KEY,
+            kindex: 1,
+            ..Default::default()
+        };
         set_cstr(&mut k.kname, b"NAXIS");
         set_cstr(&mut k.kvalue, b"2");
         assert_eq!(check_int(&k, Out::Null), 1);

--- a/src/bin/fitsverify/fvrf_misc.rs
+++ b/src/bin/fitsverify/fvrf_misc.rs
@@ -65,8 +65,12 @@ pub(crate) fn wrtwrn(out: Out, mess: &[c_char], isheasarc: c_int) -> c_int {
     if heasarc_conv() == 0 && isheasarc != 0 {
         return 0;
     } /* heasarc warnings  but with
-      heasarc convention turns off */
-    let nwrns = NWRNS.with(|c| { let v = c.get(); c.set(v + 1); v }) + 1;
+    heasarc convention turns off */
+    let nwrns = NWRNS.with(|c| {
+        let v = c.get();
+        c.set(v + 1);
+        v
+    }) + 1;
 
     let mut temp: [c_char; TEMP_LEN] = [0; TEMP_LEN];
     spf!(temp; "*** Warning: ", CS(mess));
@@ -92,7 +96,11 @@ pub(crate) fn wrterr(out: Out, mess: &[c_char], severity: c_int) -> c_int {
         fits_clear_errmsg();
         return 0;
     }
-    let nerrs = NERRS.with(|c| { let v = c.get(); c.set(v + 1); v }) + 1;
+    let nerrs = NERRS.with(|c| {
+        let v = c.get();
+        c.set(v + 1);
+        v
+    }) + 1;
 
     let mut temp: [c_char; TEMP_LEN] = [0; TEMP_LEN];
     spf!(temp; "*** Error:   ", CS(mess));
@@ -133,7 +141,11 @@ pub(crate) fn wrtferr(out: Out, mess: &[c_char], status: &mut c_int, severity: c
         fits_clear_errmsg();
         return 0;
     }
-    let nerrs = NERRS.with(|c| { let v = c.get(); c.set(v + 1); v }) + 1;
+    let nerrs = NERRS.with(|c| {
+        let v = c.get();
+        c.set(v + 1);
+        v
+    }) + 1;
 
     let mut temp: [c_char; TEMP_LEN] = [0; TEMP_LEN];
     spf!(temp; "*** Error:   ", CS(mess));
@@ -170,7 +182,7 @@ pub(crate) fn wrtserr(out: Out, mess: &[c_char], status: &mut c_int, severity: c
     /* char* errfmt = "             %.67s\n"; */
     let mut i;
     /* C declares tmp[20][80] but then prints tmp[nstack] with nstack possibly
-       == 20; one extra row keeps that in bounds. */
+    == 20; one extra row keeps that in bounds. */
     let mut tmp: [[c_char; FLEN_ERRMSG]; 21] = [[0; FLEN_ERRMSG]; 21];
     let mut nstack = 0usize;
 
@@ -178,7 +190,11 @@ pub(crate) fn wrtserr(out: Out, mess: &[c_char], status: &mut c_int, severity: c
         fits_clear_errmsg();
         return 0;
     }
-    let nerrs = NERRS.with(|c| { let v = c.get(); c.set(v + 1); v }) + 1;
+    let nerrs = NERRS.with(|c| {
+        let v = c.get();
+        c.set(v + 1);
+        v
+    }) + 1;
 
     let mut temp: [c_char; TEMP_LEN] = [0; TEMP_LEN];
     spf!(temp; "*** Error:   ", CS(mess), "(from CFITSIO error stack:)");
@@ -229,14 +245,14 @@ pub(crate) fn wrtserr_str(out: Out, mess: &str, status: &mut c_int, severity: c_
 }
 
 /* Print output of messages in a 80 character record.
-    Continue lines are aligned. */
+Continue lines are aligned. */
 pub(crate) fn print_fmt(out: Out, temp: &[c_char], nprompt: c_int) {
     let mut j: usize;
     let clen: usize;
     let mut tmp: [c_char; 81] = [0; 81];
     /* The C builds a `static char cont_fmt[80]' of `nprompt' blanks followed by
-       "%.67s\n" the first time it sees a new nprompt.  Every call site in
-       fitsverify passes nprompt = 13, so the prompt is simply re-emitted here. */
+    "%.67s\n" the first time it sees a new nprompt.  Every call site in
+    fitsverify passes nprompt = 13, so the prompt is simply re-emitted here. */
 
     if out == Out::Null {
         return;
@@ -389,8 +405,8 @@ pub(crate) fn compcol(col1: &ColName, col2: &ColName) -> Ordering {
 }
 
 /* comparison function for the string pattern maching.
-   Equal when the pattern is a prefix of the candidate -- this is what lets
-   key_match() find every CRPIXn from the pattern "CRPIX". */
+Equal when the pattern is a prefix of the candidate -- this is what lets
+key_match() find every CRPIXn from the pattern "CRPIX". */
 pub(crate) fn compstrp(pattern: &[c_char], candidate: &[c_char]) -> Ordering {
     let p = cbytes(pattern);
     let q = cbytes(candidate);
@@ -406,7 +422,6 @@ pub(crate) fn compstre(str1: &[c_char], str2: &[c_char]) -> Ordering {
     ccmp(str1, str2)
 }
 
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -421,7 +436,7 @@ mod tests {
     }
 
     /* compstrp is the prefix comparator bsearch() uses for indexed keywords:
-       it reports equal when the pattern is a prefix of the array element. */
+    it reports equal when the pattern is a prefix of the array element. */
     #[test]
     fn test_compstrp() {
         assert_eq!(compstrp(&kw("CRPIX"), &kw("CRPIX1")), Ordering::Equal);
@@ -444,13 +459,25 @@ mod tests {
 
     #[test]
     fn test_compkey_and_compcol() {
-        let a = FitsKey { kname: kw("AAA"), ..Default::default() };
-        let b = FitsKey { kname: kw("AAB"), ..Default::default() };
+        let a = FitsKey {
+            kname: kw("AAA"),
+            ..Default::default()
+        };
+        let b = FitsKey {
+            kname: kw("AAB"),
+            ..Default::default()
+        };
         assert_eq!(compkey(&a, &b), Ordering::Less);
         assert_eq!(compkey(&a, &a.clone()), Ordering::Equal);
 
-        let c1 = ColName { name: cvec(&kw("ALPHA")), index: 1 };
-        let c2 = ColName { name: cvec(&kw("BETA")), index: 2 };
+        let c1 = ColName {
+            name: cvec(&kw("ALPHA")),
+            index: 1,
+        };
+        let c2 = ColName {
+            name: cvec(&kw("BETA")),
+            index: 2,
+        };
         assert_eq!(compcol(&c1, &c2), Ordering::Less);
     }
 }

--- a/src/bin/fitsverify/main.rs
+++ b/src/bin/fitsverify/main.rs
@@ -1,8 +1,8 @@
 /* Transpiled from cfitsio/utilities/ftverify.c and fitsverify.c.
 
-   ftverify.c #includes fitsverify.c for the STANDALONE build, so both live
-   here: `main_ftverify' holds ftverify_work()/update_parfile() and the PIL
-   stubs, and main() below is fitsverify.c's main().  */
+ftverify.c #includes fitsverify.c for the STANDALONE build, so both live
+here: `main_ftverify' holds ftverify_work()/update_parfile() and the PIL
+stubs, and main() below is fitsverify.c's main().  */
 
 // kwdtyp, FitsHdu and friends keep their fitsverify C spellings.
 #![allow(non_camel_case_types, non_snake_case, non_upper_case_globals)]
@@ -55,7 +55,7 @@ pub(crate) mod main_ftverify {
 
     /*---------------------------------------------------------------------------*/
     /* call work function to verify that infile conforms to the FITS
-           standard and write report to the output file */
+    standard and write report to the output file */
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn ftverify_work(
         infile: &[c_char],  /* I - Input file name (Fits) */
@@ -271,13 +271,13 @@ pub(crate) mod main_ftverify {
     }
 
     /******************************************************************************
-    * Function
-    *      update_parfile
-    *
-    * DESCRIPTION:
-    *      Update the numerrs and numwrns parameters in the parfile.
-    *
-    *******************************************************************************/
+     * Function
+     *      update_parfile
+     *
+     * DESCRIPTION:
+     *      Update the numerrs and numwrns parameters in the parfile.
+     *
+     *******************************************************************************/
     pub(crate) fn update_parfile(nerr: c_int, nwrn: c_int) {
         let mut status: c_int;
         let mut parname: [c_char; 32] = [0; 32];
@@ -285,7 +285,7 @@ pub(crate) mod main_ftverify {
         add_totalerr(nerr as i64);
         add_totalwrn(nwrn as i64);
         /* write the total accumulated total warnings and errors to the
-           parfile */
+        parfile */
         spf!(parname; "numwrns");
         status = PILPutInt(&parname, totalwrn() as c_int);
         if status != 0 {
@@ -405,9 +405,7 @@ pub(crate) fn main() -> ExitCode {
         println!("    online  at http://fits.gsfc.nasa.gov/.  The input filename template may");
         println!("    contain wildcard characters, in which case all matching files will be ");
         println!("    tested.  Alternatively, the name of an ASCII text file containing a list");
-        println!(
-            "    of file names, one per line, may be entered preceded by an '@' character."
-        );
+        println!("    of file names, one per line, may be entered preceded by an '@' character.");
         println!("    The following error or warning conditions will be reported:");
         println!("    ");
         println!("    ERROR CONDITIONS");
@@ -448,9 +446,7 @@ pub(crate) fn main() -> ExitCode {
         println!("     - TDISPn value is inconsistent with the column datatype ");
         println!("     - Length of a variable length array greater than the maximum ");
         println!("       length as given by the TFORMn keyword");
-        println!(
-            "     - ASCII table floating-point column value does not have decimal point(*)"
-        );
+        println!("     - ASCII table floating-point column value does not have decimal point(*)");
         println!("     - ASCII table numeric column value has embedded space character");
         println!("     - Logical column contains illegal value not equal to 'T', 'F', or 0");
         println!("     - Character string column contains non-ASCII text character");
@@ -478,9 +474,7 @@ pub(crate) fn main() -> ExitCode {
         println!("        ");
         println!("    This is the stand alone version of the FTOOLS 'fverify' program.  It is");
         println!("    maintained by the HEASARC at NASA/GSFC.  Any comments about this program");
-        println!(
-            "    should be submitted to http://heasarc.gsfc.nasa.gov/cgi-bin/ftoolshelp"
-        );
+        println!("    should be submitted to http://heasarc.gsfc.nasa.gov/cgi-bin/ftoolshelp");
 
         return ExitCode::from(0);
     }
@@ -538,15 +532,15 @@ pub(crate) fn main() -> ExitCode {
     */
     for ii in file1..argc {
         status = ftverify_work(
-            &argv[ii],       /* name of file to verify */
-            cs!(c"STDOUT"),  /* write report to this stream */
-            prhead(),        /* print listing of header keywords? */
-            prstat(),        /* print detailed summary report */
-            &errormode,      /* report errors only, or errors and warnings */
-            1,               /* test the data  */
-            1,               /* test checksum, if checksum keywords are present */
-            1,               /* test data fill areas (should contain all zeros */
-            0,               /* do not test for conformance with HEASARC convensions */
+            &argv[ii],      /* name of file to verify */
+            cs!(c"STDOUT"), /* write report to this stream */
+            prhead(),       /* print listing of header keywords? */
+            prstat(),       /* print detailed summary report */
+            &errormode,     /* report errors only, or errors and warnings */
+            1,              /* test the data  */
+            1,              /* test checksum, if checksum keywords are present */
+            1,              /* test data fill areas (should contain all zeros */
+            0,              /* do not test for conformance with HEASARC convensions */
             /*    that are not required by the FITS Standard */
             testhierarch(), /* test format of ESO HIERARCH keywords? */
         );
@@ -576,7 +570,6 @@ fn os_bytes(s: &std::ffi::OsStr) -> Vec<u8> {
         s.to_string_lossy().into_owned().into_bytes()
     }
 }
-
 
 #[allow(dead_code)]
 fn _unused() -> usize {

--- a/src/cfileio.rs
+++ b/src/cfileio.rs
@@ -11294,21 +11294,65 @@ mod tests {
     // ffexist tests (ffexist_safer is todo!())
     // ------------------------------------------------------------------
 
+    /// Mirrors test_ffexist_exists in ~/code/cfitsio/tests/test_cfileio.c
     #[test]
-    #[ignore = "ffexist_safer is todo!() in src/cfileio.rs"]
-    fn test_ffexist_exists() {}
+    fn test_ffexist_exists() {
+        with_temp_file(|filename| {
+            let mut status: c_int = 0;
+            let name = to_buf(filename);
+            let naxes: [c_long; 1] = [10];
 
-    #[test]
-    #[ignore = "ffexist_safer is todo!() in src/cfileio.rs"]
-    fn test_ffexist_not_exists() {}
+            /* Create a test file */
+            let mut f: Option<Box<fitsfile>> = None;
+            fits_create_file(&mut f, &name, &mut status);
+            fits_write_imghdr(f.as_deref_mut().unwrap(), BYTE_IMG, 1, &naxes, &mut status);
+            fits_close_file(f.take().unwrap(), &mut status);
+            assert_eq!(status, 0, "setup failed");
 
-    #[test]
-    #[ignore = "ffexist_safer is todo!() in src/cfileio.rs"]
-    fn test_ffexist_non_disk() {}
+            /* Test that it exists */
+            let mut exists: c_int = -99;
+            fits_file_exists(&name, &mut exists, &mut status);
+            assert_eq!(status, 0);
+            assert_eq!(exists, 1);
+        });
+    }
 
+    /// Mirrors test_ffexist_not_exists in ~/code/cfitsio/tests/test_cfileio.c
     #[test]
-    #[ignore = "ffexist_safer is todo!() in src/cfileio.rs"]
-    fn test_ffexist_stdin() {}
+    fn test_ffexist_not_exists() {
+        let mut status: c_int = 0;
+        let mut exists: c_int = -99;
+
+        fits_file_exists(
+            &str_to_c_array("this_file_does_not_exist_12345.fits"),
+            &mut exists,
+            &mut status,
+        );
+        assert_eq!(status, 0);
+        assert_eq!(exists, 0);
+    }
+
+    /// Mirrors test_ffexist_non_disk in ~/code/cfitsio/tests/test_cfileio.c
+    #[test]
+    fn test_ffexist_non_disk() {
+        let mut status: c_int = 0;
+        let mut exists: c_int = -99;
+
+        fits_file_exists(&str_to_c_array("mem://test"), &mut exists, &mut status);
+        assert_eq!(status, 0);
+        assert_eq!(exists, -1);
+    }
+
+    /// Mirrors test_ffexist_stdin in ~/code/cfitsio/tests/test_cfileio.c
+    #[test]
+    fn test_ffexist_stdin() {
+        let mut status: c_int = 0;
+        let mut exists: c_int = -99;
+
+        fits_file_exists(&str_to_c_array("-"), &mut exists, &mut status);
+        assert_eq!(status, 0);
+        assert_eq!(exists, -1);
+    }
 
     // ------------------------------------------------------------------
     // ffrtnm (fits_parse_rootname) tests
@@ -11502,17 +11546,10 @@ mod tests {
     // ffextn (fits_parse_extnum) tests - ffextn_safer is todo!()
     // ------------------------------------------------------------------
 
-    #[test]
-    #[ignore = "ffextn_safer is todo!() in src/cfileio.rs"]
-    fn test_ffextn_number() {}
-
-    #[test]
-    #[ignore = "ffextn_safer is todo!() in src/cfileio.rs"]
-    fn test_ffextn_none() {}
-
-    #[test]
-    #[ignore = "ffextn_safer is todo!() in src/cfileio.rs"]
-    fn test_ffextn_binspec() {}
+    /* The three ffextn cases the C's test_cfileio.c covers -- an explicit
+    extension number, no extension specifier, and a binning specification --
+    are already covered, with an extra case each, by test_ffextn_extension_number,
+    test_ffextn_no_extension and test_ffextn_binning_returns_one above. */
 
     // ------------------------------------------------------------------
     // Open function variants
@@ -12743,16 +12780,106 @@ mod tests {
     }
 
     // ------------------------------------------------------------------
-    // Memory buffer operations - ffimem_safer is todo!()
+    // Memory buffer operations
     // ------------------------------------------------------------------
 
+    /// Mirrors test_ffimem in ~/code/cfitsio/tests/test_cfileio.c
+    ///
+    /// `buffer` and `bufsize` are handed to the mem driver by address and it
+    /// keeps those addresses for the life of the file, so both locals have to
+    /// stay put until the file is closed -- as in the C.
     #[test]
-    #[ignore = "ffimem_safer is todo!() in src/cfileio.rs"]
-    fn test_ffimem() {}
+    fn test_ffimem() {
+        let mut status: c_int = 0;
+        let naxes: [c_long; 1] = [5];
+        let mut buffer: *mut c_void = core::ptr::null_mut();
+        let mut bufsize: usize = 0;
+        let data: [u8; 5] = [10, 20, 30, 40, 50];
 
+        /* Create file in memory with realloc capability. */
+        let mut f: Option<Box<fitsfile>> = None;
+        fits_create_memfile(
+            &mut f,
+            &mut buffer,
+            &mut bufsize,
+            2880,
+            Some(libc::realloc),
+            &mut status,
+        );
+        assert_eq!(status, 0, "ffimem failed");
+        fits_write_imghdr(f.as_deref_mut().unwrap(), BYTE_IMG, 1, &naxes, &mut status);
+        fits_write_img_byt(f.as_deref_mut().unwrap(), 1, 1, 5, &data, &mut status);
+        fits_close_file(f.take().unwrap(), &mut status);
+        assert_eq!(status, 0);
+
+        /* Buffer should now contain valid FITS data. */
+        assert!(!buffer.is_null());
+        assert!(bufsize >= 2880, "bufsize = {bufsize}");
+        // SAFETY: the driver filled `buffer` with at least `bufsize` bytes.
+        let head = unsafe { core::slice::from_raw_parts(buffer.cast::<u8>(), 6) };
+        assert_eq!(head, b"SIMPLE");
+
+        // SAFETY: allocated by the driver through the libc realloc we passed.
+        unsafe { libc::free(buffer) };
+    }
+
+    /// Mirrors test_ffomem in ~/code/cfitsio/tests/test_cfileio.c
     #[test]
-    #[ignore = "ffimem_safer is todo!() in src/cfileio.rs (needed to build memory buffer for ffomem)"]
-    fn test_ffomem() {}
+    fn test_ffomem() {
+        let mut status: c_int = 0;
+        let naxes: [c_long; 1] = [5];
+        let mut buffer: *mut c_void = core::ptr::null_mut();
+        let mut bufsize: usize = 0;
+        let data: [u8; 5] = [10, 20, 30, 40, 50];
+
+        /* First create a FITS file in memory. */
+        let mut f: Option<Box<fitsfile>> = None;
+        fits_create_memfile(
+            &mut f,
+            &mut buffer,
+            &mut bufsize,
+            2880,
+            Some(libc::realloc),
+            &mut status,
+        );
+        fits_write_imghdr(f.as_deref_mut().unwrap(), BYTE_IMG, 1, &naxes, &mut status);
+        fits_write_img_byt(f.as_deref_mut().unwrap(), 1, 1, 5, &data, &mut status);
+        fits_close_file(f.take().unwrap(), &mut status);
+        assert_eq!(status, 0, "setup failed");
+
+        /* Now open the same buffer for reading. */
+        let mut f2: Option<Box<fitsfile>> = None;
+        let mut result = [0u8; 5];
+        let mut anynull: c_int = 0;
+        fits_open_memfile(
+            &mut f2,
+            &str_to_c_array("mem://"),
+            READONLY,
+            (&raw const buffer).cast::<*const c_void>(),
+            &mut bufsize,
+            0,
+            libc::realloc,
+            &mut status,
+        );
+        assert_eq!(status, 0, "ffomem failed");
+        fits_read_img_byt(
+            f2.as_deref_mut().unwrap(),
+            1,
+            1,
+            5,
+            0,
+            &mut result,
+            Some(&mut anynull),
+            &mut status,
+        );
+        assert_eq!(status, 0);
+        assert_eq!(result, [10, 20, 30, 40, 50]);
+        fits_close_file(f2.take().unwrap(), &mut status);
+        assert_eq!(status, 0);
+
+        // SAFETY: allocated by the driver through the libc realloc we passed.
+        unsafe { libc::free(buffer) };
+    }
 
     // ------------------------------------------------------------------
     // Misc
@@ -12851,7 +12978,7 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "ffihtps_safe / ffchtps_safe are todo!() in src/cfileio.rs"]
+    #[ignore = "ffihtps_safe / ffchtps_safe are still todo!() in src/cfileio.rs"]
     fn test_ffihtps() {}
 
     #[test]
@@ -13379,10 +13506,85 @@ mod tests {
         });
     }
 
-    // fits_copy_cell2image - fits_copy_cell2image_safe is todo!()
+    /// Mirrors test_fits_copy_cell2image in ~/code/cfitsio/tests/test_cfileio.c
     #[test]
-    #[ignore = "fits_copy_cell2image_safe is todo!() in src/cfileio.rs"]
-    fn test_fits_copy_cell2image() {}
+    fn test_fits_copy_cell2image() {
+        with_temp_file(|inname| {
+            with_temp_file(|outname| {
+                let mut status: c_int = 0;
+                let iname = to_buf(inname);
+                let oname = to_buf(outname);
+
+                /* Create binary table with a 5x5 image cell. */
+                let mut f1: Option<Box<fitsfile>> = None;
+                fits_create_file(&mut f1, &iname, &mut status);
+                fits_write_imghdr(f1.as_deref_mut().unwrap(), BYTE_IMG, 0, &[], &mut status);
+                make_table(
+                    f1.as_deref_mut().unwrap(),
+                    3,
+                    &["IMAGE"],
+                    &["25J"],
+                    Some("IMAGES"),
+                    &mut status,
+                );
+
+                /* Add TDIM to define the 5x5 shape. */
+                fits_write_key_str(
+                    f1.as_deref_mut().unwrap(),
+                    &cc("TDIM1"),
+                    &cc("(5,5)"),
+                    None,
+                    &mut status,
+                );
+
+                /* Write test data to the first row. */
+                let data: Vec<c_int> = (0..25).map(|i| i * 100).collect();
+                fits_write_col_int(f1.as_deref_mut().unwrap(), 1, 1, 1, 25, &data, &mut status);
+                fits_close_file(f1.take().unwrap(), &mut status);
+                assert_eq!(status, 0, "setup failed");
+
+                /* Reopen and copy the cell to a new image file. */
+                let ext_name = path_with_ext(inname, "[IMAGES]");
+                ffopen_safe(&mut f1, &ext_name, READONLY, &mut status);
+                let mut f2: Option<Box<fitsfile>> = None;
+                fits_create_file(&mut f2, &oname, &mut status);
+                assert_eq!(status, 0, "reopen failed");
+
+                fits_copy_cell2image_safe(
+                    f1.as_deref_mut().unwrap(),
+                    f2.as_deref_mut().unwrap(),
+                    &cc("IMAGE"),
+                    1,
+                    &mut status,
+                );
+                assert_eq!(status, 0, "fits_copy_cell2image failed");
+
+                /* Verify the output image. */
+                let g = f2.as_deref_mut().unwrap();
+                let mut naxis: c_int = 0;
+                let mut bitpix: c_int = 0;
+                let mut naxes_out = [0 as c_long; 2];
+                fits_get_img_dim(g, &mut naxis, &mut status);
+                assert_eq!(naxis, 2);
+                fits_get_img_size(g, 2, &mut naxes_out, &mut status);
+                assert_eq!(naxes_out, [5, 5]);
+                fits_get_img_equivtype(g, &mut bitpix, &mut status);
+                assert_eq!(bitpix, LONG_IMG);
+                assert_eq!(status, 0);
+
+                /* the C stops at the header; check the pixels came across too */
+                let mut got = [0 as c_int; 25];
+                let mut anynul: c_int = 0;
+                fits_read_img_int(g, 1, 1, 25, 0, &mut got, Some(&mut anynul), &mut status);
+                assert_eq!(status, 0);
+                assert_eq!(got.to_vec(), data);
+
+                fits_close_file(f1.take().unwrap(), &mut status);
+                fits_close_file(f2.take().unwrap(), &mut status);
+                assert_eq!(status, 0);
+            });
+        });
+    }
 
     // ------------------------------------------------------------------
     // Table functions

--- a/src/cfileio.rs
+++ b/src/cfileio.rs
@@ -11,7 +11,7 @@ use std::fs::File;
 use std::io::{Read, Seek, Write};
 use std::sync::{Mutex, OnceLock};
 
-use crate::c_types::{FILE, c_char, c_int, c_long, c_void};
+use crate::c_types::{FILE, c_char, c_int, c_long, c_short, c_void};
 use crate::drvrnet::{fits_dwnld_prog_bar, fits_net_timeout};
 use crate::grparser::fits_execute_template;
 use crate::helpers::boxed::box_try_new;
@@ -38,22 +38,30 @@ use crate::drvrmem::{
 };
 use crate::fitscore::{ffcrhd_safe, ffgisz_safe, ffpmsg_cstr, ffxmsg_safer};
 
+use crate::KeywordDatatypeMut;
 #[cfg(all(feature = "shared_mem", not(target_os = "windows")))]
 use crate::drvrsmem::{
     smem_close, smem_create, smem_flush, smem_getoptions, smem_getversion, smem_init, smem_open,
     smem_read, smem_remove, smem_seek, smem_setoptions, smem_shutdown, smem_size, smem_write,
 };
-use crate::editcol::ffdcol_safe;
-use crate::edithdu::ffcopy_safe;
-use crate::eval_f::{ffcalc_safe, ffffrw_safer, fffrow_safe, fits_pixel_filter_safer};
+use crate::editcol::{ffdcol_safe, fficol_safe};
+use crate::edithdu::{ffcopy_safe, ffcphd_safe};
+use crate::eval_f::{ffcalc_safe, ffffrw_safer, fffrow_safe, ffsrow_safe, fits_pixel_filter_safer};
 use crate::fitscore::{
-    ALLOCATIONS, ffchdu, ffcmsg_safe, ffgcnn_safe, ffgcno_safe, ffgcprll, ffgerr_safe, ffghdn_safe,
-    ffghdt_safe, ffgidm_safe, ffgmsg_safe, ffgncl_safe, ffgnrw_safe, ffkeyn_safe, ffmahd_safe,
-    ffmnhd_safe, ffmrhd_safe, ffpmsg_slice, ffpmsg_str, ffrdef_safe, ffrhdu_safe, ffupch_safe,
+    ALLOCATIONS, ffchdu, ffcmrk_safe, ffcmsg_safe, ffgcnn_safe, ffgcno_safe, ffgcprll, ffgerr_safe,
+    ffghadll_safe, ffghdn_safe, ffghdt_safe, ffgidm_safe, ffgidt_safe, ffgiprll_safe, ffgkcl_safe,
+    ffgmsg_safe, ffgncl_safe, ffgnrw_safe, ffgtclll_safe, ffkeyn_safe, ffmahd_safe, ffmnhd_safe,
+    ffmrhd_safe, ffpmrk_safe, ffpmsg_slice, ffpmsg_str, ffrdef_safe, ffrhdu_safe, ffupch_safe,
     fits_strcasecmp, fits_strncasecmp, fits_translate_keywords_safe,
 };
+use crate::getcolb::ffgsvb_safe;
+use crate::getcold::ffgsvd_safe;
+use crate::getcole::ffgsve_safe;
+use crate::getcoli::ffgsvi_safe;
+use crate::getcolj::ffgsvjj_safe;
+use crate::getcolk::ffgsvk_safe;
 use crate::getkey::{
-    ffgcrd_safe, ffghsp_safe, ffgkyl_safe, ffgrec_safe, ffgtdmll_safer, ffmaky_safe,
+    ffgcrd_safe, ffghsp_safe, ffgky_safe, ffgkyl_safe, ffgrec_safe, ffgtdmll_safer, ffmaky_safe,
 };
 use crate::group::{fits_clean_url, fits_get_cwd, fits_path2url};
 use crate::histo::{ffbinse, ffhist2e};
@@ -61,10 +69,18 @@ use crate::imcompress::{
     fits_set_compression_type_safe, fits_set_hcomp_scale_safe, fits_set_hcomp_smooth_safe,
     fits_set_quantize_level_safe, fits_set_quantize_method_safe, fits_set_tile_dim_safe,
 };
-use crate::modkey::{ffdkey_safe, ffmkys_safe, ffmnam_safe};
+use crate::modkey::{ffdkey_safe, ffmkyd_safe, ffmkyj_safe, ffmkys_safe, ffmnam_safe};
+use crate::putcol::ffpcl_safe;
+use crate::putcolb::ffpprb_safe;
+use crate::putcold::ffppnd_safe;
+use crate::putcole::ffppne_safe;
+use crate::putcoli::ffppri_safe;
+use crate::putcolj::ffpprjj_safe;
+use crate::putcolk::ffpprk_safe;
 use crate::putkey::ffcrimll_safe;
-use crate::putkey::{ffphis_safe, ffprec_safe};
+use crate::putkey::{ffcrim_safe, ffphis_safe, ffprec_safe, ffptdmll_safe};
 use crate::relibc::header::stdio::{sscanf_d, sscanf_ld};
+use crate::scalnull::ffpscl_safe;
 use crate::wrappers::*;
 use crate::zcompress::uncompress2mem_from_mem;
 use crate::{FFLOCK, FFUNLOCK};
@@ -3644,19 +3660,336 @@ pub unsafe extern "C" fn fits_copy_image2cell(
 }
 
 /*--------------------------------------------------------------------------*/
-/// Copy an image to a table cell (safe version)
+/// Copy an image extension into a table cell at a given row and
+/// column.  The table must have already been created.  If the "colname"
+/// column exists, it will be used, otherwise a new column will be created
+/// in the table.
+///
+/// The "copykeyflag" parameter controls which keywords to copy from the
+/// input image to the output table header (with any appropriate translation).
+///
+/// copykeyflag = 0  -- no keywords will be copied
+/// copykeyflag = 1  -- essentially all keywords will be copied
+/// copykeyflag = 2  -- copy only the WCS related keywords
+///
+/// This routine was written by Craig Markwardt, GSFC
 pub fn fits_copy_image2cell_safe(
-    _fptr: &mut fitsfile,   /* I - pointer to input image extension */
-    _newptr: &mut fitsfile, /* I - pointer to output table */
-    _colname: &[c_char],    /* I - name of column containing the image */
-    rownum: c_long,         /* I - number of the row containing the image */
-    _copykeyflag: c_int,    /* I - controls which keywords to copy */
-    _status: &mut c_int,    /* IO - error status */
+    fptr: &mut fitsfile,   /* I - pointer to input image extension */
+    newptr: &mut fitsfile, /* I - pointer to output table */
+    colname: &[c_char],    /* I - name of column containing the image */
+    rownum: c_long,        /* I - number of the row containing the image */
+    copykeyflag: c_int,    /* I - controls which keywords to copy */
+    status: &mut c_int,    /* IO - error status */
 ) -> c_int {
-    todo!(
-        "fits_copy_image2cell_safe: Copy image to table cell row {}",
-        rownum
+    let mut buffer: [u8; 30000] = [0; 30000];
+    let mut hdutype: c_int = 0;
+    let mut colnum: c_int = 0;
+    let typecode: c_int;
+    let mut bitpix: c_int = 0;
+    let mut naxis: c_int = 0;
+    let mut ncols: c_int = 0;
+    let tformchar: c_char;
+    let mut tform: [c_char; 20] = [0; 20];
+    let imgstart: LONGLONG;
+    let mut naxes: [LONGLONG; 9] = [0; 9];
+    let mut nbytes: LONGLONG;
+    let mut repeat: LONGLONG;
+    let mut ntodo: LONGLONG;
+    let mut firstbyte: LONGLONG;
+
+    let npat: c_int;
+
+    let mut naxis1: c_int = 0;
+    let mut naxes1: [LONGLONG; 9] = [0, 0, 0, 0, 0, 0, 0, 0, 0];
+    let mut repeat1: LONGLONG = 0;
+    let mut width1: LONGLONG = 0;
+    let mut typecode1: c_int = 0;
+    let dummy: [u8; 1] = [0];
+
+    let mut headstart: LONGLONG = 0;
+    let mut datastart: LONGLONG = 0;
+    let mut dataend: LONGLONG = 0;
+
+    /* Image-to-table keyword translation table  */
+    /*                        INPUT      OUTPUT  */
+    /*                       01234567   01234567 */
+    let mut patterns: [[&CStr; 2]; 43] = [
+        [c"BSCALE", c"TSCALn"], /* Standard FITS keywords */
+        [c"BZERO", c"TZEROn"],
+        [c"BUNIT", c"TUNITn"],
+        [c"BLANK", c"TNULLn"],
+        [c"DATAMIN", c"TDMINn"],
+        [c"DATAMAX", c"TDMAXn"],
+        [c"CTYPEi", c"iCTYPn"], /* Coordinate labels */
+        [c"CTYPEia", c"iCTYna"],
+        [c"CUNITi", c"iCUNIn"], /* Coordinate units */
+        [c"CUNITia", c"iCUNna"],
+        [c"CRVALi", c"iCRVLn"], /* WCS keywords */
+        [c"CRVALia", c"iCRVna"],
+        [c"CDELTi", c"iCDLTn"],
+        [c"CDELTia", c"iCDEna"],
+        [c"CRPIXj", c"jCRPXn"],
+        [c"CRPIXja", c"jCRPna"],
+        [c"PCi_ja", c"ijPCna"],
+        [c"CDi_ja", c"ijCDna"],
+        [c"PVi_ma", c"iVn_ma"],
+        [c"PSi_ma", c"iSn_ma"],
+        [c"WCSAXESa", c"WCAXna"],
+        [c"WCSNAMEa", c"WCSNna"],
+        [c"CRDERia", c"iCRDna"],
+        [c"CSYERia", c"iCSYna"],
+        [c"CROTAi", c"iCROTn"],
+        [c"LONPOLEa", c"LONPna"],
+        [c"LATPOLEa", c"LATPna"],
+        [c"EQUINOXa", c"EQUIna"],
+        [c"MJD-OBS", c"MJDOBn"],
+        [c"MJD-AVG", c"MJDAn"],
+        [c"RADESYSa", c"RADEna"],
+        [c"CNAMEia", c"iCNAna"],
+        [c"DATE-AVG", c"DAVGn"],
+        [c"NAXISi", c"-"], /* Remove structural keywords*/
+        [c"PCOUNT", c"-"],
+        [c"GCOUNT", c"-"],
+        [c"EXTEND", c"-"],
+        [c"EXTNAME", c"-"],
+        [c"EXTVER", c"-"],
+        [c"EXTLEVEL", c"-"],
+        [c"CHECKSUM", c"-"],
+        [c"DATASUM", c"-"],
+        [c"*", c"+"], /* copy all other keywords */
+    ];
+
+    if *status > 0 {
+        return *status;
+    }
+
+    /* The C returns NULL_INPUT_PTR here if fptr or newptr is NULL; a &mut
+    reference can never be null, so that check is unreachable and omitted. */
+
+    if ffghdt_safe(fptr, &mut hdutype, status) > 0 {
+        ffpmsg_str("could not get input HDU type");
+        return *status;
+    }
+
+    if hdutype != IMAGE_HDU {
+        ffpmsg_str("The input extension is not an image.");
+        ffpmsg_str(" Cannot open the image.");
+        *status = NOT_IMAGE;
+        return *status;
+    }
+
+    if ffghdt_safe(newptr, &mut hdutype, status) > 0 {
+        ffpmsg_str("could not get output HDU type");
+        return *status;
+    }
+
+    if hdutype != BINARY_TBL {
+        ffpmsg_str("The output extension is not a table.");
+        *status = NOT_BTABLE;
+        return *status;
+    }
+
+    if ffgiprll_safe(
+        fptr,
+        9,
+        Some(&mut bitpix),
+        Some(&mut naxis),
+        Some(&mut naxes),
+        status,
+    ) > 0
+    {
+        ffpmsg_str("Could not read image parameters.");
+        return *status;
+    }
+
+    /* Determine total number of pixels in the image */
+    repeat = 1;
+    for ii in 0..(naxis as usize) {
+        repeat *= naxes[ii];
+    }
+
+    /* Determine the TFORM value for the table cell */
+    if bitpix == BYTE_IMG {
+        typecode = TBYTE;
+        tformchar = bb(b'B');
+        nbytes = repeat;
+    } else if bitpix == SHORT_IMG {
+        typecode = TSHORT;
+        tformchar = bb(b'I');
+        nbytes = repeat * 2;
+    } else if bitpix == LONG_IMG {
+        typecode = TLONG;
+        tformchar = bb(b'J');
+        nbytes = repeat * 4;
+    } else if bitpix == FLOAT_IMG {
+        typecode = TFLOAT;
+        tformchar = bb(b'E');
+        nbytes = repeat * 4;
+    } else if bitpix == DOUBLE_IMG {
+        typecode = TDOUBLE;
+        tformchar = bb(b'D');
+        nbytes = repeat * 8;
+    } else if bitpix == LONGLONG_IMG {
+        typecode = TLONGLONG;
+        tformchar = bb(b'K');
+        nbytes = repeat * 8;
+    } else {
+        ffpmsg_str("Error: the image has an invalid datatype.");
+        *status = BAD_BITPIX;
+        return *status;
+    }
+
+    /* get column number */
+    ffpmrk_safe();
+    ffgcno_safe(newptr, CASEINSEN as c_int, colname, &mut colnum, status);
+    ffcmrk_safe();
+
+    /* Column does not exist; create it */
+    if *status != 0 {
+        *status = 0;
+        int_snprintf!(
+            &mut tform,
+            20,
+            "{:.0}{}",
+            repeat as f64,
+            tformchar as u8 as char
+        );
+        ffgncl_safe(newptr, &mut ncols, status);
+        colnum = ncols + 1;
+        fficol_safe(newptr, colnum, colname, &tform, status);
+        ffptdmll_safe(newptr, colnum, naxis, &naxes, status);
+
+        if *status != 0 {
+            ffpmsg_str("Could not insert new column into output table.");
+            return *status;
+        }
+    } else {
+        ffgtdmll_safer(newptr, colnum, 9, &mut naxis1, &mut naxes1, status);
+        if *status > 0 || naxis != naxis1 {
+            ffpmsg_str("Input image dimensions and output table cell dimensions do not match.");
+            *status = BAD_DIMEN;
+            return *status;
+        }
+        for ii in 0..(naxis as usize) {
+            if naxes[ii] != naxes1[ii] {
+                ffpmsg_str("Input image dimensions and output table cell dimensions do not match.");
+                *status = BAD_DIMEN;
+                return *status;
+            }
+        }
+
+        ffgtclll_safe(
+            newptr,
+            colnum,
+            Some(&mut typecode1),
+            Some(&mut repeat1),
+            Some(&mut width1),
+            status,
+        );
+        if *status > 0 || typecode1 != typecode || repeat1 != repeat {
+            ffpmsg_str("Input image data type does not match output table cell type.");
+            *status = BAD_TFORM;
+            return *status;
+        }
+    }
+
+    /* copy keywords from input image to output table, if required */
+
+    if copykeyflag != 0 {
+        npat = patterns.len() as c_int;
+
+        if copykeyflag == 2 {
+            /* copy only the WCS-related keywords */
+            patterns[(npat - 1) as usize][1] = c"-";
+        }
+
+        /* The 3rd parameter value = 5 means skip the first 4 keywords in the image */
+        fits_translate_keywords_safe(fptr, newptr, 5, &patterns, npat, colnum, 0, 0, status);
+    }
+
+    /* Here is all the code to compute offsets:
+     *     * byte offset from start of row to column (dest table)
+     *     * byte offset from start of file to image data (source image)
+     */
+
+    /* Force the writing of the row of the table by writing the last byte of
+    the array, which grows the table, and/or shifts following extensions */
+    ffpcl_safe(
+        newptr,
+        TBYTE,
+        colnum,
+        rownum as LONGLONG,
+        repeat,
+        1,
+        &dummy,
+        status,
     );
+
+    /* byte offset within the row to the start of the image column */
+    {
+        let colptr = newptr.Fptr.get_tableptr_as_slice(); /* point to first column */
+        /* offset to correct column structure */
+        firstbyte = colptr[(colnum - 1) as usize].tbcol + 1;
+    }
+
+    /* get starting address of input image to be read */
+    ffghadll_safe(
+        fptr,
+        Some(&mut headstart),
+        Some(&mut datastart),
+        Some(&mut dataend),
+        status,
+    );
+    imgstart = datastart;
+
+    /* The C formats a "HISTORY  Table column ... copied from image" card here,
+    and below it a second HISTORY line holding the input file name and HDU
+    number, but both ffprec() calls that would write them are commented out in
+    the C (writing HISTORY is left up to the caller).  Neither string is used
+    for anything else, so both are omitted here, as in fits_copy_cell2image. */
+
+    /* the use of ffread routine, below, requires that any 'dirty' */
+    /* buffers in memory be flushed back to the file first */
+
+    ffflsh_safe(fptr, false, status);
+
+    /* move to the first byte of the input image */
+    ffmbyt_safe(fptr, imgstart, TRUE as c_int, status);
+
+    ntodo = cmp::min(30000, nbytes);
+    ffgbyt(fptr, ntodo, &mut buffer, status); /* read input image */
+    ffptbb_safe(
+        newptr,
+        rownum as LONGLONG,
+        firstbyte,
+        ntodo,
+        &buffer,
+        status,
+    ); /* write to table */
+
+    nbytes -= ntodo;
+    firstbyte += ntodo;
+
+    /* read any additional bytes with low-level ffread routine, for speed */
+    while nbytes != 0 && *status <= 0 {
+        ntodo = cmp::min(30000, nbytes);
+        ffread(&fptr.Fptr, ntodo as c_long, &mut buffer, status);
+        ffptbb_safe(
+            newptr,
+            rownum as LONGLONG,
+            firstbyte,
+            ntodo,
+            &buffer,
+            status,
+        );
+        nbytes -= ntodo;
+        firstbyte += ntodo;
+    }
+
+    /* Re-scan the header so that CFITSIO knows about all the new keywords */
+    ffrdef_safe(newptr, status);
+
+    *status
 }
 
 /*--------------------------------------------------------------------------*/
@@ -3687,13 +4020,107 @@ pub unsafe extern "C" fn fits_select_image_section(
 /// Any HDUs preceding or following the image are also copied to the
 /// output file.
 pub fn fits_select_image_section_safe(
-    _fptr: &mut Option<Box<fitsfile>>, /* IO - pointer to input image; on output it  */
+    fptr: &mut Option<Box<fitsfile>>, /* IO - pointer to input image; on output it  */
     /*      points to the new subimage */
-    _outfile: &[c_char], /* I - name for output file        */
-    _expr: &[c_char],    /* I - Image section expression    */
-    _status: &mut c_int,
+    outfile: &[c_char], /* I - name for output file        */
+    expr: &[c_char],    /* I - Image section expression    */
+    status: &mut c_int,
 ) -> c_int {
-    todo!();
+    let mut newptr: Option<Box<fitsfile>> = None;
+    let mut ii: c_int;
+    let mut hdunum: c_int = 0;
+
+    /* create new empty file to hold the image section */
+    if ffinit_safe(&mut newptr, outfile, status) > 0 {
+        ffpmsg_str("failed to create output file for image section:");
+        ffpmsg_slice(outfile);
+        return *status;
+    }
+
+    ffghdn_safe(fptr.as_deref_mut().unwrap(), &mut hdunum); /* current HDU number in input file */
+
+    /* copy all preceding extensions to the output file, if 'only_one' flag not set */
+    if fptr.as_deref().unwrap().Fptr.only_one == 0 {
+        for ii in 1..hdunum {
+            ffmahd_safe(fptr.as_deref_mut().unwrap(), ii, None, status);
+            if ffcopy_safe(
+                fptr.as_deref_mut().unwrap(),
+                newptr.as_deref_mut().unwrap(),
+                0,
+                status,
+            ) > 0
+            {
+                ffclos_safe(newptr.take().unwrap(), status);
+                return *status;
+            }
+        }
+
+        /* move back to the original HDU position */
+        ffmahd_safe(fptr.as_deref_mut().unwrap(), hdunum, None, status);
+    }
+
+    if fits_copy_image_section_safer(
+        fptr.as_deref_mut().unwrap(),
+        newptr.as_deref_mut().unwrap(),
+        expr,
+        status,
+    ) > 0
+    {
+        ffclos_safe(newptr.take().unwrap(), status);
+        return *status;
+    }
+
+    /* copy any remaining HDUs to the output file, if 'only_one' flag not set */
+
+    if fptr.as_deref().unwrap().Fptr.only_one == 0 {
+        /* C: for (ii = hdunum + 1; 1; ii++); `ii` is read after the loop, so
+        the increment stays at the bottom to preserve the C's exit value */
+        ii = hdunum + 1;
+        loop {
+            if ffmahd_safe(fptr.as_deref_mut().unwrap(), ii, None, status) > 0 {
+                break;
+            }
+
+            ffcopy_safe(
+                fptr.as_deref_mut().unwrap(),
+                newptr.as_deref_mut().unwrap(),
+                0,
+                status,
+            );
+            ii += 1;
+        }
+
+        if *status == END_OF_FILE {
+            *status = 0; /* got the expected EOF error; reset = 0  */
+        } else if *status > 0 {
+            ffclos_safe(newptr.take().unwrap(), status);
+            return *status;
+        }
+    } else {
+        ii = hdunum + 1; /* this value of ii is required below */
+    }
+
+    /* close the original file and return ptr to the new image */
+    ffclos_safe(fptr.take().unwrap(), status);
+
+    *fptr = newptr; /* reset the pointer to the new table */
+
+    /* move back to the image subsection */
+    if ii - 1 != hdunum {
+        ffmahd_safe(fptr.as_deref_mut().unwrap(), hdunum, None, status);
+    } else {
+        /* may have to reset BSCALE and BZERO pixel scaling, */
+        /* since the keywords were previously turned off */
+
+        if ffrdef_safe(fptr.as_deref_mut().unwrap(), status) > 0 {
+            /* the C closes *fptr here and returns with it left dangling;
+            ffclos_safe consumes the Box, so *fptr is left None instead */
+            ffclos_safe(fptr.take().unwrap(), status);
+            return *status;
+        }
+    }
+
+    *status
 }
 
 /*--------------------------------------------------------------------------*/
@@ -3719,12 +4146,479 @@ pub unsafe extern "C" fn fits_copy_image_section(
 /*--------------------------------------------------------------------------*/
 /// copies an image section from the input file to a new output HDU
 pub fn fits_copy_image_section_safer(
-    _fptr: &mut fitsfile,   /* I - pointer to input image */
-    _newptr: &mut fitsfile, /* I - pointer to output image */
-    _expr: &[c_char],       /* I - Image section expression    */
-    _status: &mut c_int,
+    fptr: &mut fitsfile,   /* I - pointer to input image */
+    newptr: &mut fitsfile, /* I - pointer to output image */
+    expr: &[c_char],       /* I - Image section expression    */
+    status: &mut c_int,
 ) -> c_int {
-    todo!();
+    let mut bitpix: c_int = 0;
+    let mut naxis: c_int = 0;
+    let mut numkeys: c_int = 0;
+    let mut naxes: [c_long; 9] = [1, 1, 1, 1, 1, 1, 1, 1, 1];
+    let mut smin: c_long = 0;
+    let mut smax: c_long = 0;
+    let mut sinc: c_long = 0;
+    let mut fpixels: [c_long; 9] = [1, 1, 1, 1, 1, 1, 1, 1, 1];
+    let mut lpixels: [c_long; 9] = [1, 1, 1, 1, 1, 1, 1, 1, 1];
+    let mut incs: [c_long; 9] = [1, 1, 1, 1, 1, 1, 1, 1, 1];
+    let mut keyname: [c_char; FLEN_KEYWORD] = [0; FLEN_KEYWORD];
+    let mut card: [c_char; FLEN_CARD] = [0; FLEN_CARD];
+    let mut tstatus: c_int;
+    let mut anynull: c_int = 0;
+    let minrow: c_long;
+    let maxrow: c_long;
+    let minslice: c_long;
+    let maxslice: c_long;
+    let mincube: c_long;
+    let maxcube: c_long;
+    let mut firstpix: c_long;
+    let ncubeiter: c_long;
+    let nsliceiter: c_long;
+    let nrowiter: c_long;
+    let mut klen: usize;
+    let mut outnaxes: [c_long; 9] = [0; 9];
+    let outsize: c_long;
+    let buffsize: c_long;
+    let mut crpix: f64 = 0.0;
+    let mut cdelt: f64 = 0.0;
+
+    if *status > 0 {
+        return *status;
+    }
+
+    /* get the size of the input image */
+    ffgidt_safe(fptr, &mut bitpix, status);
+    ffgidm_safe(fptr, &mut naxis, status);
+    /* DEVIATION (upstream bug): the C passes `naxis` -- up to 99, whatever the
+    file's NAXIS says -- as the length of the 9-element `naxes` array, so an
+    image with NAXIS >= 10 overflows that stack array here, before the
+    `naxis > 4` check below ever runs.  Clamp to the array length instead: for
+    every naxis the C accepts (1..=4) this is identical, and the oversized
+    cases now reach the BAD_NAXIS error the C already intends to return. */
+    if ffgisz_safe(
+        fptr,
+        cmp::min(naxis, naxes.len() as c_int),
+        &mut naxes,
+        status,
+    ) > 0
+    {
+        return *status;
+    }
+
+    if !(1..=4).contains(&naxis) {
+        ffpmsg_str("Input image either had NAXIS = 0 (NULL image) or has > 4 dimensions");
+        *status = BAD_NAXIS;
+        return *status;
+    }
+
+    /* create output image with same size and type as the input image */
+    /*  Will update the size later */
+    ffcrim_safe(newptr, bitpix, naxis, &naxes, status);
+
+    /* copy all other non-structural keywords from the input to output file */
+    ffghsp_safe(fptr, Some(&mut numkeys), None, status);
+
+    for nkey in 4..=numkeys {
+        /* skip the first few keywords */
+        ffgrec_safe(fptr, nkey, Some(&mut card), status);
+
+        if ffgkcl_safe(&card) > TYP_CMPRS_KEY {
+            /* write the record to the output file */
+            ffprec_safe(newptr, &card, status);
+        }
+    }
+
+    if *status > 0 {
+        ffpmsg_str("error copying header from input image to output image");
+        return *status;
+    }
+
+    /* parse the section specifier to get min, max, and inc for each axis */
+    /* and the size of each output image axis */
+
+    /* the C walks a `char *cptr` along `expr`; track the offset instead */
+    let mut cptr: usize = 0;
+    for ii in 0..(naxis as usize) {
+        if fits_get_section_range_safe(expr, &mut cptr, &mut smin, &mut smax, &mut sinc, status) > 0
+        {
+            ffpmsg_str("error parsing the following image section specifier:");
+            ffpmsg_slice(expr);
+            return *status;
+        }
+
+        if smax == 0 {
+            smax = naxes[ii]; /* use whole axis  by default */
+        } else if smin == 0 {
+            smin = naxes[ii]; /* use inverted whole axis */
+        }
+
+        if smin > naxes[ii] || smax > naxes[ii] {
+            ffpmsg_str("image section exceeds dimensions of input image:");
+            ffpmsg_slice(expr);
+            *status = BAD_NAXIS;
+            return *status;
+        }
+
+        fpixels[ii] = smin;
+        lpixels[ii] = smax;
+        incs[ii] = sinc;
+
+        let lllength: LONGLONG = ((smax - smin).abs() / sinc) as LONGLONG + 1;
+        if lllength > c_long::MAX as LONGLONG {
+            ffpmsg_str("image range exceeds LONG_MAX limit");
+            ffpmsg_slice(expr);
+            *status = NUM_OVERFLOW;
+            return *status;
+        }
+        outnaxes[ii] = lllength as c_long;
+
+        /* modify the NAXISn keyword */
+        ffkeyn_safe(cs!(c"NAXIS"), ii as c_int + 1, &mut keyname, status);
+        ffmkyj_safe(newptr, &keyname, outnaxes[ii] as LONGLONG, None, status);
+
+        /* modify the WCS keywords if necessary */
+
+        if fpixels[ii] != 1 || incs[ii] != 1 {
+            for kk in -1..26 {
+                /* modify any alternate WCS keywords */
+
+                /* read the CRPIXn keyword if it exists in the input file */
+                ffkeyn_safe(cs!(c"CRPIX"), ii as c_int + 1, &mut keyname, status);
+
+                if kk != -1 {
+                    klen = strlen_safe(&keyname);
+                    keyname[klen] = bb(b'A') + kk as c_char;
+                    keyname[klen + 1] = 0;
+                }
+
+                tstatus = 0;
+                if ffgky_safe(
+                    fptr,
+                    KeywordDatatypeMut::TDOUBLE(&mut crpix),
+                    &keyname,
+                    None,
+                    &mut tstatus,
+                ) == 0
+                {
+                    /* calculate the new CRPIXn value */
+                    if fpixels[ii] <= lpixels[ii] {
+                        crpix = (crpix - (fpixels[ii] as f64)) / incs[ii] as f64 + 1.0;
+                        /*  crpix = (crpix - (fpixels[ii] - 1.0) - .5) / incs[ii] + 0.5; */
+                    } else {
+                        crpix = (fpixels[ii] as f64 - crpix) / incs[ii] as f64 + 1.0;
+                        /* crpix = (fpixels[ii] - (crpix - 1.0) - .5) / incs[ii] + 0.5; */
+                    }
+
+                    /* modify the value in the output file */
+                    ffmkyd_safe(newptr, &keyname, crpix, 15, None, status);
+
+                    if incs[ii] != 1 || fpixels[ii] > lpixels[ii] {
+                        /* read the CDELTn keyword if it exists in the input file */
+                        ffkeyn_safe(cs!(c"CDELT"), ii as c_int + 1, &mut keyname, status);
+
+                        if kk != -1 {
+                            klen = strlen_safe(&keyname);
+                            keyname[klen] = bb(b'A') + kk as c_char;
+                            keyname[klen + 1] = 0;
+                        }
+
+                        tstatus = 0;
+                        if ffgky_safe(
+                            fptr,
+                            KeywordDatatypeMut::TDOUBLE(&mut cdelt),
+                            &keyname,
+                            None,
+                            &mut tstatus,
+                        ) == 0
+                        {
+                            /* calculate the new CDELTn value */
+                            if fpixels[ii] <= lpixels[ii] {
+                                cdelt *= incs[ii] as f64;
+                            } else {
+                                cdelt *= -(incs[ii] as f64);
+                            }
+
+                            /* modify the value in the output file */
+                            ffmkyd_safe(newptr, &keyname, cdelt, 15, None, status);
+                        }
+
+                        /* modify the CDi_j keywords if they exist in the input file */
+
+                        ffkeyn_safe(cs!(c"CD1_"), ii as c_int + 1, &mut keyname, status);
+
+                        if kk != -1 {
+                            klen = strlen_safe(&keyname);
+                            keyname[klen] = bb(b'A') + kk as c_char;
+                            keyname[klen + 1] = 0;
+                        }
+
+                        for jj in 0..9 {
+                            /* look for up to 9 dimensions */
+                            keyname[2] = bb(b'1') + jj as c_char;
+
+                            tstatus = 0;
+                            if ffgky_safe(
+                                fptr,
+                                KeywordDatatypeMut::TDOUBLE(&mut cdelt),
+                                &keyname,
+                                None,
+                                &mut tstatus,
+                            ) == 0
+                            {
+                                /* calculate the new CDi_j value */
+                                if fpixels[ii] <= lpixels[ii] {
+                                    cdelt *= incs[ii] as f64;
+                                } else {
+                                    cdelt *= -(incs[ii] as f64);
+                                }
+
+                                /* modify the value in the output file */
+                                ffmkyd_safe(newptr, &keyname, cdelt, 15, None, status);
+                            }
+                        }
+                    } /* end of if (incs[ii]... loop */
+                } /* end of fits_read_key loop */
+            } /* end of for (kk  loop */
+        }
+    } /* end of main NAXIS loop */
+
+    if ffrdef_safe(newptr, status) > 0 {
+        /* force the header to be scanned */
+        return *status;
+    }
+
+    /* turn off any scaling of the pixel values */
+    ffpscl_safe(fptr, 1.0, 0.0, status);
+    ffpscl_safe(newptr, 1.0, 0.0, status);
+
+    /* to reduce memory foot print, just read/write image 1 row at a time */
+
+    outsize = outnaxes[0];
+    buffsize = (bitpix.abs() / 8) as c_long * outsize;
+
+    /* allocate memory for the image row.  The C mallocs `buffsize` bytes as a
+    double* and casts that pointer to the pixel type in use, so allocate f64
+    units here (the widest pixel type, and the alignment the C pointer had)
+    and reinterpret them per bitpix below. */
+    let mut buffer: Vec<f64> = Vec::new();
+    let nbuffelem = (buffsize as usize).div_ceil(mem::size_of::<f64>());
+    if buffer.try_reserve_exact(nbuffelem).is_err() {
+        ffpmsg_str("fits_copy_image_section: no memory for image section");
+        *status = MEMORY_ALLOCATION;
+        return *status;
+    }
+    buffer.resize(nbuffelem, 0.0);
+
+    /* read the image section then write it to the output file */
+
+    minrow = fpixels[1];
+    maxrow = lpixels[1];
+    nrowiter = (maxrow - minrow).abs() / incs[1] + 1;
+
+    minslice = fpixels[2];
+    maxslice = lpixels[2];
+    nsliceiter = (maxslice - minslice).abs() / incs[2] + 1;
+
+    mincube = fpixels[3];
+    maxcube = lpixels[3];
+    ncubeiter = (maxcube - mincube).abs() / incs[3] + 1;
+
+    firstpix = 1;
+    for kiter in 0..ncubeiter {
+        if mincube > maxcube {
+            fpixels[3] = mincube - (kiter * incs[3]);
+        } else {
+            fpixels[3] = mincube + (kiter * incs[3]);
+        }
+
+        lpixels[3] = fpixels[3];
+
+        for jiter in 0..nsliceiter {
+            if minslice > maxslice {
+                fpixels[2] = minslice - (jiter * incs[2]);
+            } else {
+                fpixels[2] = minslice + (jiter * incs[2]);
+            }
+
+            lpixels[2] = fpixels[2];
+
+            for iiter in 0..nrowiter {
+                if minrow > maxrow {
+                    fpixels[1] = minrow - (iiter * incs[1]);
+                } else {
+                    fpixels[1] = minrow + (iiter * incs[1]);
+                }
+
+                lpixels[1] = fpixels[1];
+
+                if bitpix == 8 {
+                    let buff: &mut [u8] = &mut cast_slice_mut(&mut buffer)[..outsize as usize];
+
+                    ffgsvb_safe(
+                        fptr,
+                        1,
+                        naxis,
+                        &naxes,
+                        &fpixels,
+                        &lpixels,
+                        &incs,
+                        0,
+                        buff,
+                        Some(&mut anynull),
+                        status,
+                    );
+
+                    ffpprb_safe(
+                        newptr,
+                        1,
+                        firstpix as LONGLONG,
+                        outsize as LONGLONG,
+                        buff,
+                        status,
+                    );
+                } else if bitpix == 16 {
+                    let buff: &mut [c_short] = &mut cast_slice_mut(&mut buffer)[..outsize as usize];
+
+                    ffgsvi_safe(
+                        fptr,
+                        1,
+                        naxis,
+                        &naxes,
+                        &fpixels,
+                        &lpixels,
+                        &incs,
+                        0,
+                        buff,
+                        Some(&mut anynull),
+                        status,
+                    );
+
+                    ffppri_safe(
+                        newptr,
+                        1,
+                        firstpix as LONGLONG,
+                        outsize as LONGLONG,
+                        buff,
+                        status,
+                    );
+                } else if bitpix == 32 {
+                    let buff: &mut [c_int] = &mut cast_slice_mut(&mut buffer)[..outsize as usize];
+
+                    ffgsvk_safe(
+                        fptr,
+                        1,
+                        naxis,
+                        &naxes,
+                        &fpixels,
+                        &lpixels,
+                        &incs,
+                        0,
+                        buff,
+                        Some(&mut anynull),
+                        status,
+                    );
+
+                    ffpprk_safe(
+                        newptr,
+                        1,
+                        firstpix as LONGLONG,
+                        outsize as LONGLONG,
+                        buff,
+                        status,
+                    );
+                } else if bitpix == -32 {
+                    let buff: &mut [f32] = &mut cast_slice_mut(&mut buffer)[..outsize as usize];
+
+                    ffgsve_safe(
+                        fptr,
+                        1,
+                        naxis,
+                        &naxes,
+                        &fpixels,
+                        &lpixels,
+                        &incs,
+                        FLOATNULLVALUE,
+                        buff,
+                        Some(&mut anynull),
+                        status,
+                    );
+
+                    ffppne_safe(
+                        newptr,
+                        1,
+                        firstpix as LONGLONG,
+                        outsize as LONGLONG,
+                        buff,
+                        FLOATNULLVALUE,
+                        status,
+                    );
+                } else if bitpix == -64 {
+                    let buff: &mut [f64] = &mut buffer[..outsize as usize];
+
+                    ffgsvd_safe(
+                        fptr,
+                        1,
+                        naxis,
+                        &naxes,
+                        &fpixels,
+                        &lpixels,
+                        &incs,
+                        DOUBLENULLVALUE,
+                        buff,
+                        Some(&mut anynull),
+                        status,
+                    );
+
+                    ffppnd_safe(
+                        newptr,
+                        1,
+                        firstpix as LONGLONG,
+                        outsize as LONGLONG,
+                        buff,
+                        DOUBLENULLVALUE,
+                        status,
+                    );
+                } else if bitpix == 64 {
+                    let buff: &mut [LONGLONG] =
+                        &mut cast_slice_mut(&mut buffer)[..outsize as usize];
+
+                    ffgsvjj_safe(
+                        fptr,
+                        1,
+                        naxis,
+                        &naxes,
+                        &fpixels,
+                        &lpixels,
+                        &incs,
+                        0,
+                        buff,
+                        Some(&mut anynull),
+                        status,
+                    );
+
+                    ffpprjj_safe(
+                        newptr,
+                        1,
+                        firstpix as LONGLONG,
+                        outsize as LONGLONG,
+                        buff,
+                        status,
+                    );
+                }
+
+                firstpix += outsize;
+            }
+        }
+    }
+
+    /* the C frees `buffer` here; the Vec is dropped on return instead */
+
+    if *status > 0 {
+        ffpmsg_str("fits_copy_image_section: error copying image section");
+        return *status;
+    }
+
+    *status
 }
 
 /*--------------------------------------------------------------------------*/
@@ -3894,13 +4788,161 @@ pub fn fits_get_section_range_safe(
 
 /*--------------------------------------------------------------------------*/
 pub(crate) fn ffselect_table(
-    _fptr: &mut Option<Box<fitsfile>>, /* IO - pointer to input table; on output it  */
+    fptr: &mut Option<Box<fitsfile>>, /* IO - pointer to input table; on output it  */
     /*      points to the new selected rows table */
-    _outfile: &[c_char; FLEN_FILENAME], /* I - name for output file */
-    _rowfilter: &[c_char; FLEN_FILENAME], /* I - Boolean expression    */
-    _status: &mut c_int,
+    outfile: &[c_char; FLEN_FILENAME], /* I - name for output file */
+    expr: &[c_char; FLEN_FILENAME],    /* I - Boolean expression    */
+    status: &mut c_int,
 ) -> c_int {
-    todo!()
+    let mut newptr: Option<Box<fitsfile>> = None;
+    let mut ii: c_int;
+    let mut hdunum: c_int = 0;
+
+    if outfile[0] != 0 {
+        /* create new empty file in to hold the selected rows */
+        if ffinit_safe(&mut newptr, outfile, status) > 0 {
+            ffpmsg_str("failed to create file for selected rows from input table");
+            ffpmsg_slice(outfile);
+            return *status;
+        }
+
+        ffghdn_safe(fptr.as_deref_mut().unwrap(), &mut hdunum); /* current HDU number in input file */
+
+        /* copy all preceding extensions to the output file, if the 'only_one' flag is not set */
+        if fptr.as_deref().unwrap().Fptr.only_one == 0 {
+            for ii in 1..hdunum {
+                ffmahd_safe(fptr.as_deref_mut().unwrap(), ii, None, status);
+                if ffcopy_safe(
+                    fptr.as_deref_mut().unwrap(),
+                    newptr.as_deref_mut().unwrap(),
+                    0,
+                    status,
+                ) > 0
+                {
+                    ffclos_safe(newptr.take().unwrap(), status);
+                    return *status;
+                }
+            }
+        } else {
+            /* just copy the primary array */
+            ffmahd_safe(fptr.as_deref_mut().unwrap(), 1, None, status);
+            if ffcopy_safe(
+                fptr.as_deref_mut().unwrap(),
+                newptr.as_deref_mut().unwrap(),
+                0,
+                status,
+            ) > 0
+            {
+                ffclos_safe(newptr.take().unwrap(), status);
+                return *status;
+            }
+        }
+
+        ffmahd_safe(fptr.as_deref_mut().unwrap(), hdunum, None, status);
+
+        /* copy all the header keywords from the input to output file */
+        if ffcphd_safe(
+            fptr.as_deref_mut().unwrap(),
+            newptr.as_deref_mut().unwrap(),
+            status,
+        ) > 0
+        {
+            ffclos_safe(newptr.take().unwrap(), status);
+            return *status;
+        }
+
+        /* set number of rows = 0 */
+        ffmkyj_safe(
+            newptr.as_deref_mut().unwrap(),
+            cs!(c"NAXIS2"),
+            0,
+            None,
+            status,
+        );
+        {
+            let n = newptr.as_deref_mut().unwrap();
+            n.Fptr.numrows = 0;
+            n.Fptr.origrows = 0;
+        }
+
+        if ffrdef_safe(newptr.as_deref_mut().unwrap(), status) > 0 {
+            /* force the header to be scanned */
+            ffclos_safe(newptr.take().unwrap(), status);
+            return *status;
+        }
+    }
+    /* else the C sets `newptr = *fptr` and deletes rows in place in the table;
+    here `newptr` simply stays None and the same-file case is handled below */
+
+    /* copy rows which satisfy the selection expression to the output table */
+    /* or delete the nonqualifying rows if *fptr = newptr.   */
+    let selstatus = match newptr.as_deref_mut() {
+        Some(out) => ffsrow_safe(fptr.as_deref_mut().unwrap(), out, expr, status),
+        None => {
+            /* The C passes the same fitsfile* to fits_select_rows as both the
+            input and the output, which makes ffsrow delete the non-qualifying
+            rows in place (it branches on infptr == outfptr).  Safe Rust cannot
+            hand out two `&mut fitsfile` to one file, so bridge through a raw
+            pointer here.
+            TODO (idiomatic pass): give ffsrow_safe an `Option<&mut fitsfile>`
+            output parameter, where None means "same file as infptr", and drop
+            this unsafe block; two live `&mut` to one object is exactly the
+            aliasing that `&mut`'s noalias guarantee forbids. */
+            let f: *mut fitsfile = fptr.as_deref_mut().unwrap();
+            // SAFETY: reproduces the C's deliberate aliasing of infptr/outfptr.
+            unsafe { ffsrow_safe(&mut *f, &mut *f, expr, status) }
+        }
+    };
+
+    if selstatus > 0 {
+        if outfile[0] != 0 {
+            ffclos_safe(newptr.take().unwrap(), status);
+        }
+
+        return *status;
+    }
+
+    if outfile[0] != 0 {
+        /* copy any remaining HDUs to the output copy */
+
+        if fptr.as_deref().unwrap().Fptr.only_one == 0 {
+            /* C: for (ii = hdunum + 1; 1; ii++); the increment stays at the
+            bottom, as in the C, although `ii` is not read after the loop */
+            ii = hdunum + 1;
+            loop {
+                if ffmahd_safe(fptr.as_deref_mut().unwrap(), ii, None, status) > 0 {
+                    break;
+                }
+
+                ffcopy_safe(
+                    fptr.as_deref_mut().unwrap(),
+                    newptr.as_deref_mut().unwrap(),
+                    0,
+                    status,
+                );
+                ii += 1;
+            }
+
+            if *status == END_OF_FILE {
+                *status = 0; /* got the expected EOF error; reset = 0  */
+            } else if *status > 0 {
+                ffclos_safe(newptr.take().unwrap(), status);
+                return *status;
+            }
+        } else {
+            hdunum = 2;
+        }
+
+        /* close the original file and return ptr to the new image */
+        ffclos_safe(fptr.take().unwrap(), status);
+
+        *fptr = newptr; /* reset the pointer to the new table */
+
+        /* move back to the selected table HDU */
+        ffmahd_safe(fptr.as_deref_mut().unwrap(), hdunum, None, status);
+    }
+
+    *status
 }
 
 /*--------------------------------------------------------------------------*/
@@ -7759,14 +8801,108 @@ pub unsafe extern "C" fn fits_get_token2(
 /// software. It is not used by any CFITSIO routine.
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn fits_split_names(
-    list: *const c_char, /* I   - input list of names */
+    list: *mut c_char, /* IO  - list of names; the name returned is terminated */
+                       /*       in place by overwriting its delimiter with a NUL */
 ) -> *mut c_char {
     unsafe { fits_split_names_safer(list) }
 }
 
-/// We probably can't create a safe wrapper around fits_split_names
-pub unsafe fn fits_split_names_safer(_list: *const c_char) -> *mut c_char {
-    todo!()
+/// The C API cannot be given a safe signature: the returned pointer aliases
+/// the caller's buffer, and the cursor kept between calls aliases it too, so
+/// no `&mut [c_char]` borrow can span the sequence of calls.  What is done
+/// here instead is to measure the buffer once, on the call that supplies it,
+/// and drive the whole scan as bounds-checked indexing into a slice; the only
+/// unsafe operations left are taking that measurement and rebuilding the slice
+/// on each continuation call.
+///
+/// Callers keep the C's obligations: the buffer passed as `list` must stay
+/// alive, in place and unshortened until they stop asking for further names.
+pub unsafe fn fits_split_names_safer(list: *mut c_char) -> *mut c_char {
+    let mut depth: c_int = 0;
+
+    /* C: `static char *ptr;` -- file-scope state carried between calls, which
+    here has to carry the buffer's extent as well so the scan can be bounds
+    checked.  The routine is documented above as not thread-safe; a
+    thread_local gives each thread its own cursor, which keeps the crate's
+    parallel tests honest. */
+    #[derive(Clone, Copy)]
+    struct SplitCursor {
+        base: *mut c_char, /* the caller's buffer */
+        len: usize,        /* its length, including the terminating NUL */
+        pos: usize,        /* offset of the next character to examine */
+    }
+
+    thread_local! {
+        static CURSOR: core::cell::Cell<SplitCursor> = const {
+            core::cell::Cell::new(SplitCursor {
+                base: core::ptr::null_mut(),
+                len: 0,
+                pos: 0,
+            })
+        };
+    }
+
+    let mut cursor = CURSOR.get();
+
+    if !list.is_null() {
+        /* reset ptr if a string is given */
+        // SAFETY: the C's contract for a non-NULL `list` is a writable,
+        // NUL-terminated string.  Measure it once, here, so that every step
+        // below is an index into a slice of known length.
+        let len = unsafe { CStr::from_ptr(list) }.to_bytes_with_nul().len();
+        cursor = SplitCursor {
+            base: list,
+            len,
+            pos: 0,
+        };
+    }
+
+    if cursor.base.is_null() {
+        /* DEVIATION: the C dereferences its NULL static if the first call does
+        not supply a string; report "no names" rather than crash */
+        return core::ptr::null_mut();
+    }
+
+    // SAFETY: `base` and `len` describe the buffer as measured on the call
+    // that supplied it, which the caller undertakes to keep alive and in place
+    // for as long as it keeps asking for further names -- the same obligation
+    // the C's `static char *ptr` imposes.  `pos` never leaves `0..len`: it only
+    // advances while the character under it is neither NUL nor a delimiter,
+    // and `buf[len - 1]` is the terminating NUL.
+    let buf: &mut [c_char] = unsafe { slice::from_raw_parts_mut(cursor.base, cursor.len) };
+
+    while buf[cursor.pos] == bb(b' ') {
+        cursor.pos += 1; /* skip leading white space */
+    }
+
+    if buf[cursor.pos] == 0 {
+        CURSOR.set(cursor);
+        return core::ptr::null_mut(); /* no remaining file names */
+    }
+
+    let start = cursor.pos;
+
+    while buf[cursor.pos] != 0 {
+        if buf[cursor.pos] == bb(b'[') || buf[cursor.pos] == bb(b'(') || buf[cursor.pos] == bb(b'{')
+        {
+            depth += 1;
+        } else if buf[cursor.pos] == bb(b'}')
+            || buf[cursor.pos] == bb(b')')
+            || buf[cursor.pos] == bb(b']')
+        {
+            depth -= 1;
+        } else if depth == 0 && (buf[cursor.pos] == bb(b',') || buf[cursor.pos] == bb(b' ')) {
+            buf[cursor.pos] = 0; /* terminate the filename here */
+            cursor.pos += 1; /* save offset of start of next filename */
+            break;
+        }
+        cursor.pos += 1;
+    }
+
+    CURSOR.set(cursor);
+
+    /* the returned pointer is into the caller's own buffer, as in the C */
+    &mut buf[start] as *mut c_char
 }
 
 /*--------------------------------------------------------------------------*/
@@ -10498,40 +11634,702 @@ mod tests {
     // `mod tests` (they exercise the now-private fits_get_section_range_safe).
 
     // ------------------------------------------------------------------
-    // fits_copy_image_section tests - fits_copy_image_section_safer is todo!()
+    // fits_copy_image_section tests
+    // ------------------------------------------------------------------
+
+    /// Create a file holding a single image of the given type and shape, whose
+    /// pixels are the 1-based linear index (1, 2, 3, ... in FITS order).
+    fn make_img(name: &[c_char], bitpix: c_int, naxes: &[c_long], status: &mut c_int) {
+        let mut f: Option<Box<fitsfile>> = None;
+        fits_create_file(&mut f, name, status);
+        fits_create_img(
+            f.as_deref_mut().unwrap(),
+            bitpix,
+            naxes.len() as c_int,
+            naxes,
+            status,
+        );
+        let n: c_long = naxes.iter().product();
+        let data: Vec<f64> = (1..=n).map(|i| i as f64).collect();
+        fits_write_img_dbl(
+            f.as_deref_mut().unwrap(),
+            1,
+            1,
+            n as LONGLONG,
+            &data,
+            status,
+        );
+        fits_close_file(f.take().unwrap(), status);
+        assert_eq!(*status, 0, "make_img setup failed");
+    }
+
+    /// Copy `expr` out of the image in `inname` into a new file `outname`,
+    /// returning the (still open) output file.
+    fn copy_section(
+        inname: &[c_char],
+        outname: &[c_char],
+        expr: &str,
+        status: &mut c_int,
+    ) -> Option<Box<fitsfile>> {
+        let mut fin: Option<Box<fitsfile>> = None;
+        let mut fout: Option<Box<fitsfile>> = None;
+        fits_open_file(&mut fin, inname, READONLY, status);
+        fits_create_file(&mut fout, outname, status);
+        assert_eq!(*status, 0, "copy_section setup failed");
+
+        let e = str_to_c_array(expr);
+        fits_copy_image_section_safer(
+            fin.as_deref_mut().unwrap(),
+            fout.as_deref_mut().unwrap(),
+            &e,
+            status,
+        );
+        fits_close_file(fin.take().unwrap(), status);
+        fout
+    }
+
+    /// The NAXISn values of the image in `f`.
+    fn img_size(f: &mut fitsfile, naxis: usize, status: &mut c_int) -> Vec<c_long> {
+        let mut naxes = vec![0 as c_long; naxis];
+        fits_get_img_size(f, naxis as c_int, &mut naxes, status);
+        naxes
+    }
+
+    #[test]
+    fn test_copy_image_section() {
+        with_temp_file(|inname| {
+            with_temp_file(|outname| {
+                let mut status: c_int = 0;
+                let iname = to_buf(inname);
+                let oname = to_buf(outname);
+                make_img(&iname, BYTE_IMG, &[8, 6], &mut status);
+
+                let mut fout = copy_section(&iname, &oname, "2:5,3:4", &mut status);
+                assert_eq!(status, 0);
+
+                let f = fout.as_deref_mut().unwrap();
+                assert_eq!(img_size(f, 2, &mut status), vec![4, 2]);
+
+                let mut got = [0u8; 8];
+                let mut anynul: c_int = 0;
+                fits_read_img_byt(f, 1, 1, 8, 0, &mut got, Some(&mut anynul), &mut status);
+                assert_eq!(status, 0);
+                assert_eq!(got, [18, 19, 20, 21, 26, 27, 28, 29]);
+
+                fits_close_file(fout.take().unwrap(), &mut status);
+                assert_eq!(status, 0);
+            });
+        });
+    }
+
+    #[test]
+    fn test_copy_image_section_stride() {
+        with_temp_file(|inname| {
+            with_temp_file(|outname| {
+                let mut status: c_int = 0;
+                let iname = to_buf(inname);
+                let oname = to_buf(outname);
+                make_img(&iname, LONG_IMG, &[8, 6], &mut status);
+
+                let mut fout = copy_section(&iname, &oname, "1:8:2,1:6:3", &mut status);
+                assert_eq!(status, 0);
+
+                let f = fout.as_deref_mut().unwrap();
+                assert_eq!(img_size(f, 2, &mut status), vec![4, 2]);
+
+                let mut got = [0 as c_int; 8];
+                let mut anynul: c_int = 0;
+                fits_read_img_int(f, 1, 1, 8, 0, &mut got, Some(&mut anynul), &mut status);
+                assert_eq!(status, 0);
+                assert_eq!(got, [1, 3, 5, 7, 25, 27, 29, 31]);
+
+                fits_close_file(fout.take().unwrap(), &mut status);
+            });
+        });
+    }
+
+    #[test]
+    fn test_copy_image_section_short() {
+        with_temp_file(|inname| {
+            with_temp_file(|outname| {
+                let mut status: c_int = 0;
+                let iname = to_buf(inname);
+                let oname = to_buf(outname);
+                make_img(&iname, SHORT_IMG, &[6, 4], &mut status);
+
+                let mut fout = copy_section(&iname, &oname, "2:4,2:3", &mut status);
+                assert_eq!(status, 0);
+
+                let f = fout.as_deref_mut().unwrap();
+                assert_eq!(img_size(f, 2, &mut status), vec![3, 2]);
+
+                let mut got = [0 as c_short; 6];
+                let mut anynul: c_int = 0;
+                fits_read_img_sht(f, 1, 1, 6, 0, &mut got, Some(&mut anynul), &mut status);
+                assert_eq!(status, 0);
+                assert_eq!(got, [8, 9, 10, 14, 15, 16]);
+
+                fits_close_file(fout.take().unwrap(), &mut status);
+            });
+        });
+    }
+
+    #[test]
+    fn test_copy_image_section_int() {
+        with_temp_file(|inname| {
+            with_temp_file(|outname| {
+                let mut status: c_int = 0;
+                let iname = to_buf(inname);
+                let oname = to_buf(outname);
+                make_img(&iname, LONG_IMG, &[6, 4], &mut status);
+
+                let mut fout = copy_section(&iname, &oname, "2:4,2:3", &mut status);
+                assert_eq!(status, 0);
+
+                let f = fout.as_deref_mut().unwrap();
+                assert_eq!(img_size(f, 2, &mut status), vec![3, 2]);
+
+                let mut got = [0 as c_int; 6];
+                let mut anynul: c_int = 0;
+                fits_read_img_int(f, 1, 1, 6, 0, &mut got, Some(&mut anynul), &mut status);
+                assert_eq!(status, 0);
+                assert_eq!(got, [8, 9, 10, 14, 15, 16]);
+
+                fits_close_file(fout.take().unwrap(), &mut status);
+            });
+        });
+    }
+
+    #[test]
+    fn test_copy_image_section_float() {
+        with_temp_file(|inname| {
+            with_temp_file(|outname| {
+                let mut status: c_int = 0;
+                let iname = to_buf(inname);
+                let oname = to_buf(outname);
+                make_img(&iname, FLOAT_IMG, &[6, 4], &mut status);
+
+                let mut fout = copy_section(&iname, &oname, "2:4,2:3", &mut status);
+                assert_eq!(status, 0);
+
+                let f = fout.as_deref_mut().unwrap();
+                assert_eq!(img_size(f, 2, &mut status), vec![3, 2]);
+
+                let mut got = [0.0f32; 6];
+                let mut anynul: c_int = 0;
+                fits_read_img_flt(f, 1, 1, 6, 0.0, &mut got, Some(&mut anynul), &mut status);
+                assert_eq!(status, 0);
+                assert_eq!(got, [8.0, 9.0, 10.0, 14.0, 15.0, 16.0]);
+
+                fits_close_file(fout.take().unwrap(), &mut status);
+            });
+        });
+    }
+
+    #[test]
+    fn test_copy_image_section_double() {
+        with_temp_file(|inname| {
+            with_temp_file(|outname| {
+                let mut status: c_int = 0;
+                let iname = to_buf(inname);
+                let oname = to_buf(outname);
+                make_img(&iname, DOUBLE_IMG, &[6, 4], &mut status);
+
+                let mut fout = copy_section(&iname, &oname, "2:4,2:3", &mut status);
+                assert_eq!(status, 0);
+
+                let f = fout.as_deref_mut().unwrap();
+                assert_eq!(img_size(f, 2, &mut status), vec![3, 2]);
+
+                let mut got = [0.0f64; 6];
+                let mut anynul: c_int = 0;
+                fits_read_img_dbl(f, 1, 1, 6, 0.0, &mut got, Some(&mut anynul), &mut status);
+                assert_eq!(status, 0);
+                assert_eq!(got, [8.0, 9.0, 10.0, 14.0, 15.0, 16.0]);
+
+                fits_close_file(fout.take().unwrap(), &mut status);
+            });
+        });
+    }
+
+    #[test]
+    fn test_copy_image_section_longlong() {
+        with_temp_file(|inname| {
+            with_temp_file(|outname| {
+                let mut status: c_int = 0;
+                let iname = to_buf(inname);
+                let oname = to_buf(outname);
+                make_img(&iname, LONGLONG_IMG, &[6, 4], &mut status);
+
+                let mut fout = copy_section(&iname, &oname, "2:4,2:3", &mut status);
+                assert_eq!(status, 0);
+
+                let f = fout.as_deref_mut().unwrap();
+                assert_eq!(img_size(f, 2, &mut status), vec![3, 2]);
+
+                let mut got = [0 as LONGLONG; 6];
+                let mut anynul: c_int = 0;
+                fits_read_img_lnglng(f, 1, 1, 6, 0, &mut got, Some(&mut anynul), &mut status);
+                assert_eq!(status, 0);
+                assert_eq!(got, [8, 9, 10, 14, 15, 16]);
+
+                fits_close_file(fout.take().unwrap(), &mut status);
+            });
+        });
+    }
+
+    #[test]
+    fn test_copy_image_section_3d() {
+        with_temp_file(|inname| {
+            with_temp_file(|outname| {
+                let mut status: c_int = 0;
+                let iname = to_buf(inname);
+                let oname = to_buf(outname);
+                make_img(&iname, LONG_IMG, &[4, 3, 2], &mut status);
+
+                /* take the second plane only */
+                let mut fout = copy_section(&iname, &oname, "1:4,1:3,2:2", &mut status);
+                assert_eq!(status, 0);
+
+                let f = fout.as_deref_mut().unwrap();
+                assert_eq!(img_size(f, 3, &mut status), vec![4, 3, 1]);
+
+                let mut got = [0 as c_int; 12];
+                let mut anynul: c_int = 0;
+                fits_read_img_int(f, 1, 1, 12, 0, &mut got, Some(&mut anynul), &mut status);
+                assert_eq!(status, 0);
+                assert_eq!(got, [13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24]);
+
+                fits_close_file(fout.take().unwrap(), &mut status);
+            });
+        });
+    }
+
+    #[test]
+    fn test_copy_image_section_whole_axis() {
+        with_temp_file(|inname| {
+            with_temp_file(|outname| {
+                let mut status: c_int = 0;
+                let iname = to_buf(inname);
+                let oname = to_buf(outname);
+                make_img(&iname, LONG_IMG, &[4, 3], &mut status);
+
+                /* '*' means the whole axis */
+                let mut fout = copy_section(&iname, &oname, "*,2:2", &mut status);
+                assert_eq!(status, 0);
+
+                let f = fout.as_deref_mut().unwrap();
+                assert_eq!(img_size(f, 2, &mut status), vec![4, 1]);
+
+                let mut got = [0 as c_int; 4];
+                let mut anynul: c_int = 0;
+                fits_read_img_int(f, 1, 1, 4, 0, &mut got, Some(&mut anynul), &mut status);
+                assert_eq!(status, 0);
+                assert_eq!(got, [5, 6, 7, 8]);
+
+                fits_close_file(fout.take().unwrap(), &mut status);
+            });
+        });
+    }
+
+    #[test]
+    fn test_copy_image_section_too_many_axes() {
+        /* NAXIS >= 10 overflows the C's 9-element `naxes` array before it gets
+        to the naxis > 4 check; here it must simply report BAD_NAXIS */
+        with_temp_file(|inname| {
+            with_temp_file(|outname| {
+                let mut status: c_int = 0;
+                let iname = to_buf(inname);
+                let oname = to_buf(outname);
+                make_img(
+                    &iname,
+                    BYTE_IMG,
+                    &[2, 1, 1, 1, 1, 1, 1, 1, 1, 1],
+                    &mut status,
+                );
+
+                let mut fout = copy_section(&iname, &oname, "1:2", &mut status);
+                assert_eq!(status, BAD_NAXIS);
+
+                status = 0;
+                fits_close_file(fout.take().unwrap(), &mut status);
+            });
+        });
+    }
+
+    #[test]
+    fn test_copy_image_section_exceeds_input() {
+        with_temp_file(|inname| {
+            with_temp_file(|outname| {
+                let mut status: c_int = 0;
+                let iname = to_buf(inname);
+                let oname = to_buf(outname);
+                make_img(&iname, LONG_IMG, &[4, 3], &mut status);
+
+                let mut fout = copy_section(&iname, &oname, "1:9,1:3", &mut status);
+                assert_eq!(status, BAD_NAXIS);
+
+                status = 0;
+                fits_close_file(fout.take().unwrap(), &mut status);
+            });
+        });
+    }
+
+    // ------------------------------------------------------------------
+    // fits_select_image_section tests
     // ------------------------------------------------------------------
 
     #[test]
-    #[ignore = "fits_copy_image_section_safer is todo!() in src/cfileio.rs"]
-    fn test_copy_image_section() {}
+    fn test_select_image_section() {
+        with_temp_file(|inname| {
+            with_temp_file(|outname| {
+                let mut status: c_int = 0;
+                let iname = to_buf(inname);
+                let oname = to_buf(outname);
+                make_img(&iname, LONG_IMG, &[8, 6], &mut status);
+
+                let mut f: Option<Box<fitsfile>> = None;
+                fits_open_file(&mut f, &iname, READONLY, &mut status);
+                assert_eq!(status, 0, "setup");
+
+                let expr = str_to_c_array("2:5,3:4");
+                fits_select_image_section_safe(&mut f, &to_buf(outname), &expr, &mut status);
+                assert_eq!(status, 0);
+
+                /* on success *fptr points at the new subimage, not the input */
+                let g = f.as_deref_mut().unwrap();
+                assert_eq!(img_size(g, 2, &mut status), vec![4, 2]);
+
+                let mut got = [0 as c_int; 8];
+                let mut anynul: c_int = 0;
+                fits_read_img_int(g, 1, 1, 8, 0, &mut got, Some(&mut anynul), &mut status);
+                assert_eq!(status, 0);
+                assert_eq!(got, [18, 19, 20, 21, 26, 27, 28, 29]);
+
+                fits_close_file(f.take().unwrap(), &mut status);
+                assert_eq!(status, 0);
+                let _ = oname;
+            });
+        });
+    }
+
+    // ------------------------------------------------------------------
+    // fits_copy_image2cell tests
+    // ------------------------------------------------------------------
 
     #[test]
-    #[ignore = "fits_copy_image_section_safer is todo!() in src/cfileio.rs"]
-    fn test_copy_image_section_stride() {}
+    fn test_copy_image2cell_new_column() {
+        with_temp_file(|inname| {
+            with_temp_file(|outname| {
+                let mut status: c_int = 0;
+                let iname = to_buf(inname);
+                let oname = to_buf(outname);
+                make_img(&iname, LONG_IMG, &[4, 3], &mut status);
+
+                /* an output file holding a one-row table with one dummy column */
+                let mut fout: Option<Box<fitsfile>> = None;
+                fits_create_file(&mut fout, &oname, &mut status);
+                let ttype = [Some(str_to_c_array("DUMMY"))];
+                let ttype_ref: Vec<Option<&[c_char]>> =
+                    ttype.iter().map(|o| o.as_deref()).collect();
+                let tform = [str_to_c_array("1J")];
+                let tform_ref: Vec<&[c_char]> = tform.iter().map(|v| v.as_slice()).collect();
+                fits_create_tbl(
+                    fout.as_deref_mut().unwrap(),
+                    BINARY_TBL,
+                    1,
+                    1,
+                    &ttype_ref,
+                    &tform_ref,
+                    None,
+                    None,
+                    &mut status,
+                );
+                assert_eq!(status, 0, "table setup");
+
+                let mut fin: Option<Box<fitsfile>> = None;
+                fits_open_file(&mut fin, &iname, READONLY, &mut status);
+                assert_eq!(status, 0, "setup");
+
+                let colname = str_to_c_array("IMGCOL");
+                fits_copy_image2cell_safe(
+                    fin.as_deref_mut().unwrap(),
+                    fout.as_deref_mut().unwrap(),
+                    &colname,
+                    1,
+                    1,
+                    &mut status,
+                );
+                assert_eq!(status, 0);
+
+                let f = fout.as_deref_mut().unwrap();
+
+                /* the image landed in a newly created second column ... */
+                let mut colnum: c_int = 0;
+                fits_get_colnum(f, CASEINSEN as c_int, &colname, &mut colnum, &mut status);
+                assert_eq!(status, 0);
+                assert_eq!(colnum, 2);
+
+                /* ... with the image's dimensions recorded in TDIM ... */
+                let mut naxis: c_int = 0;
+                let mut naxes = [0 as LONGLONG; 9];
+                fits_read_tdimll(f, colnum, 9, &mut naxis, &mut naxes, &mut status);
+                assert_eq!(status, 0);
+                assert_eq!(naxis, 2);
+                assert_eq!(&naxes[..2], &[4, 3]);
+
+                /* ... and the pixels intact */
+                let mut got = [0 as c_int; 12];
+                let mut anynul: c_int = 0;
+                fits_read_col_int(
+                    f,
+                    colnum,
+                    1,
+                    1,
+                    12,
+                    0,
+                    &mut got,
+                    Some(&mut anynul),
+                    &mut status,
+                );
+                assert_eq!(status, 0);
+                assert_eq!(got, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]);
+
+                fits_close_file(fin.take().unwrap(), &mut status);
+                fits_close_file(fout.take().unwrap(), &mut status);
+                assert_eq!(status, 0);
+            });
+        });
+    }
 
     #[test]
-    #[ignore = "fits_copy_image_section_safer is todo!() in src/cfileio.rs"]
-    fn test_copy_image_section_short() {}
+    fn test_copy_image2cell_rejects_non_table_output() {
+        with_temp_file(|inname| {
+            with_temp_file(|outname| {
+                let mut status: c_int = 0;
+                let iname = to_buf(inname);
+                let oname = to_buf(outname);
+                make_img(&iname, LONG_IMG, &[4, 3], &mut status);
+                make_img(&oname, LONG_IMG, &[2, 2], &mut status);
+
+                let mut fin: Option<Box<fitsfile>> = None;
+                let mut fout: Option<Box<fitsfile>> = None;
+                fits_open_file(&mut fin, &iname, READONLY, &mut status);
+                fits_open_file(&mut fout, &oname, READWRITE, &mut status);
+                assert_eq!(status, 0, "setup");
+
+                let colname = str_to_c_array("IMGCOL");
+                fits_copy_image2cell_safe(
+                    fin.as_deref_mut().unwrap(),
+                    fout.as_deref_mut().unwrap(),
+                    &colname,
+                    1,
+                    1,
+                    &mut status,
+                );
+                assert_eq!(status, NOT_BTABLE);
+
+                status = 0;
+                fits_close_file(fin.take().unwrap(), &mut status);
+                fits_close_file(fout.take().unwrap(), &mut status);
+            });
+        });
+    }
+
+    // ------------------------------------------------------------------
+    // ffselect_table tests
+    // ------------------------------------------------------------------
+
+    /// Create a file with a one-column table holding `data` in the 2nd HDU.
+    fn make_value_table(name: &[c_char], data: &[c_long], status: &mut c_int) {
+        let mut f: Option<Box<fitsfile>> = None;
+        fits_create_file(&mut f, name, status);
+        fits_write_imghdr(f.as_deref_mut().unwrap(), BYTE_IMG, 0, &[], status);
+        let ttype = [Some(str_to_c_array("VALUE"))];
+        let ttype_ref: Vec<Option<&[c_char]>> = ttype.iter().map(|o| o.as_deref()).collect();
+        let tform = [str_to_c_array("1J")];
+        let tform_ref: Vec<&[c_char]> = tform.iter().map(|v| v.as_slice()).collect();
+        fits_create_tbl(
+            f.as_deref_mut().unwrap(),
+            BINARY_TBL,
+            data.len() as LONGLONG,
+            1,
+            &ttype_ref,
+            &tform_ref,
+            None,
+            None,
+            status,
+        );
+        fits_write_col_lng(
+            f.as_deref_mut().unwrap(),
+            1,
+            1,
+            1,
+            data.len() as LONGLONG,
+            data,
+            status,
+        );
+        fits_close_file(f.take().unwrap(), status);
+        assert_eq!(*status, 0, "make_value_table setup failed");
+    }
+
+    fn read_values(f: &mut fitsfile, n: usize, status: &mut c_int) -> Vec<c_long> {
+        let mut got = vec![0 as c_long; n];
+        let mut anynul: c_int = 0;
+        fits_read_col_lng(
+            f,
+            1,
+            1,
+            1,
+            n as LONGLONG,
+            0,
+            &mut got,
+            Some(&mut anynul),
+            status,
+        );
+        got
+    }
 
     #[test]
-    #[ignore = "fits_copy_image_section_safer is todo!() in src/cfileio.rs"]
-    fn test_copy_image_section_int() {}
+    fn test_ffselect_table_to_new_file() {
+        with_temp_file(|inname| {
+            with_temp_file(|outname| {
+                let mut status: c_int = 0;
+                let iname = to_buf(inname);
+                make_value_table(&iname, &[10, 25, 30, 45, 50], &mut status);
+
+                let mut f: Option<Box<fitsfile>> = None;
+                fits_open_file(&mut f, &iname, READONLY, &mut status);
+                fits_movabs_hdu(f.as_deref_mut().unwrap(), 2, None, &mut status);
+                assert_eq!(status, 0, "setup");
+
+                let mut expr = [0 as c_char; FLEN_FILENAME];
+                for (i, &b) in b"VALUE > 20".iter().enumerate() {
+                    expr[i] = b as c_char;
+                }
+
+                ffselect_table(&mut f, &to_buf(outname), &expr, &mut status);
+                assert_eq!(status, 0);
+
+                /* *fptr now points at the selected-rows copy */
+                let g = f.as_deref_mut().unwrap();
+                let mut nrows: LONGLONG = 0;
+                fits_get_num_rowsll(g, &mut nrows, &mut status);
+                assert_eq!(nrows, 4);
+                assert_eq!(read_values(g, 4, &mut status), vec![25, 30, 45, 50]);
+                assert_eq!(status, 0);
+
+                fits_close_file(f.take().unwrap(), &mut status);
+                assert_eq!(status, 0);
+            });
+        });
+    }
 
     #[test]
-    #[ignore = "fits_copy_image_section_safer is todo!() in src/cfileio.rs"]
-    fn test_copy_image_section_float() {}
+    fn test_ffselect_table_in_place() {
+        with_temp_file(|inname| {
+            let mut status: c_int = 0;
+            let iname = to_buf(inname);
+            make_value_table(&iname, &[10, 25, 30, 45, 50], &mut status);
+
+            let mut f: Option<Box<fitsfile>> = None;
+            fits_open_file(&mut f, &iname, READWRITE, &mut status);
+            fits_movabs_hdu(f.as_deref_mut().unwrap(), 2, None, &mut status);
+            assert_eq!(status, 0, "setup");
+
+            /* an empty outfile name means "delete the non-qualifying rows in
+            place", the branch where the C aliases infptr and outfptr */
+            let outfile = [0 as c_char; FLEN_FILENAME];
+            let mut expr = [0 as c_char; FLEN_FILENAME];
+            for (i, &b) in b"VALUE > 20".iter().enumerate() {
+                expr[i] = b as c_char;
+            }
+
+            ffselect_table(&mut f, &outfile, &expr, &mut status);
+            assert_eq!(status, 0);
+
+            let g = f.as_deref_mut().unwrap();
+            let mut nrows: LONGLONG = 0;
+            fits_get_num_rowsll(g, &mut nrows, &mut status);
+            assert_eq!(nrows, 4);
+            assert_eq!(read_values(g, 4, &mut status), vec![25, 30, 45, 50]);
+            assert_eq!(status, 0);
+
+            fits_close_file(f.take().unwrap(), &mut status);
+            assert_eq!(status, 0);
+        });
+    }
+
+    // ------------------------------------------------------------------
+    // fits_split_names tests
+    // ------------------------------------------------------------------
+
+    /// Drive fits_split_names to exhaustion over a writable copy of `list`.
+    fn split_names(list: &str) -> Vec<String> {
+        let mut buf = str_to_c_array(list);
+        let mut out: Vec<String> = Vec::new();
+        unsafe {
+            let mut p = fits_split_names_safer(buf.as_mut_ptr());
+            while !p.is_null() {
+                out.push(c_array_to_string(p));
+                p = fits_split_names_safer(core::ptr::null_mut());
+            }
+        }
+        out
+    }
 
     #[test]
-    #[ignore = "fits_copy_image_section_safer is todo!() in src/cfileio.rs"]
-    fn test_copy_image_section_double() {}
+    fn test_split_names_doc_example() {
+        assert_eq!(
+            split_names("myfile[1][bin (x,y)=4], file2.fits  file3.fits"),
+            vec!["myfile[1][bin (x,y)=4]", "file2.fits", "file3.fits"]
+        );
+    }
 
     #[test]
-    #[ignore = "fits_copy_image_section_safer is todo!() in src/cfileio.rs"]
-    fn test_copy_image_section_longlong() {}
+    fn test_split_names_single() {
+        assert_eq!(split_names("onefile.fits"), vec!["onefile.fits"]);
+    }
 
     #[test]
-    #[ignore = "fits_copy_image_section_safer is todo!() in src/cfileio.rs"]
-    fn test_copy_image_section_3d() {}
+    fn test_split_names_leading_and_repeated_delimiters() {
+        /* Leading blanks are skipped, but -- unlike strtok, which the doc
+        comment compares this to -- consecutive delimiters are NOT merged: each
+        one yields an empty token.  Verified against the C. */
+        assert_eq!(
+            split_names("   a.fits ,, b.fits"),
+            vec!["a.fits", "", "", "b.fits"]
+        );
+    }
+
+    #[test]
+    fn test_split_names_empty() {
+        assert!(split_names("").is_empty());
+        assert!(split_names("     ").is_empty());
+    }
+
+    #[test]
+    fn test_split_names_null_first_call() {
+        /* DEVIATION: the C dereferences its uninitialised static and crashes
+        if the first call passes NULL; this port reports "no names".  Run it on
+        a fresh thread so the thread-local cursor is guaranteed unseeded even
+        under `--test-threads=1`. */
+        let got = std::thread::spawn(|| unsafe {
+            fits_split_names_safer(core::ptr::null_mut()).is_null()
+        })
+        .join()
+        .unwrap();
+        assert!(got);
+    }
+
+    #[test]
+    fn test_split_names_nested_brackets() {
+        /* commas and spaces inside [], () and {} do not split */
+        assert_eq!(
+            split_names("f1.fits[col a, b]{x, y},f2.fits"),
+            vec!["f1.fits[col a, b]{x, y}", "f2.fits"]
+        );
+    }
 
     // ------------------------------------------------------------------
     // URL type tests

--- a/src/cfileio.rs
+++ b/src/cfileio.rs
@@ -8557,7 +8557,9 @@ pub fn ffimport_file_safe(
     }
     lines[0] = 0;
 
-    let aFile = File::options().read(true).open(slice_to_str!(filename).as_ref() as &str);
+    let aFile = File::options()
+        .read(true)
+        .open(slice_to_str!(filename).as_ref() as &str);
 
     if aFile.is_err() {
         int_snprintf!(

--- a/src/fitscore.rs
+++ b/src/fitscore.rs
@@ -5681,9 +5681,7 @@ pub fn ffrhdu_safe(
     if strcmp_safe(&name, cs!(c"SIMPLE")) == 0 {
         /* this is the primary array */
 
-        unsafe {
-            ffpinit(fptr, status); /* initialize the primary array */
-        }
+        ffpinit(fptr, status); /* initialize the primary array */
 
         if let Some(hdutype) = hdutype.as_deref_mut() {
             *hdutype = 0;
@@ -5705,9 +5703,7 @@ pub fn ffrhdu_safe(
         }
 
         if strcmp_safe(&xname[xtension..], cs!(c"TABLE")) == 0 {
-            unsafe {
-                ffainit(fptr, status); /* initialize the ASCII table */
-            }
+            ffainit(fptr, status); /* initialize the ASCII table */
             if let Some(hdutype) = hdutype.as_deref_mut() {
                 *hdutype = 1;
             };
@@ -5715,17 +5711,13 @@ pub fn ffrhdu_safe(
             || strcmp_safe(&xname[xtension..], cs!(c"A3DTABLE")) == 0
             || strcmp_safe(&xname[xtension..], cs!(c"3DTABLE")) == 0
         {
-            unsafe {
-                ffbinit(fptr, status); /* initialize the binary table */
-            }
+            ffbinit(fptr, status); /* initialize the binary table */
             if let Some(hdutype) = hdutype.as_deref_mut() {
                 *hdutype = 2;
             };
         } else {
             tstatus = 0;
-            unsafe {
-                ffpinit(fptr, &mut tstatus); /* probably an IMAGE extension */
-            }
+            ffpinit(fptr, &mut tstatus); /* probably an IMAGE extension */
 
             if tstatus == UNKNOWN_EXT
                 && let Some(hdutype) = hdutype.as_deref_mut()
@@ -5783,7 +5775,7 @@ pub fn ffrhdu_safe(
 /*--------------------------------------------------------------------------*/
 /// initialize the parameters defining the structure of the primary array
 /// or an Image extension
-pub(crate) unsafe fn ffpinit(
+pub(crate) fn ffpinit(
     fptr: &mut fitsfile, /* I - FITS file pointer */
     status: &mut c_int,  /* IO - error status     */
 ) -> c_int {
@@ -6061,7 +6053,7 @@ pub(crate) unsafe fn ffpinit(
 
 /*--------------------------------------------------------------------------*/
 /// initialize the parameters defining the structure of an ASCII table
-pub(crate) unsafe fn ffainit(
+pub(crate) fn ffainit(
     fptr: &mut fitsfile, /* I - FITS file pointer */
     status: &mut c_int,  /* IO - error status     */
 ) -> c_int {
@@ -6334,7 +6326,7 @@ pub(crate) unsafe fn ffainit(
 
 /*--------------------------------------------------------------------------*/
 /// initialize the parameters defining the structure of a binary table
-pub(crate) unsafe fn ffbinit(
+pub(crate) fn ffbinit(
     fptr: &mut fitsfile, /* I - FITS file pointer */
     status: &mut c_int,  /* IO - error status     */
 ) -> c_int {
@@ -12556,13 +12548,13 @@ mod tests {
     }
 
     /* The error stack's storage invariants.  These use a local ErrorStack, so
-       they do not need the global TEST_LOCK. */
+    they do not need the global TEST_LOCK. */
 
     #[test]
     fn test_stored_entry_always_fits_the_reader_buffer() {
         /* ffgmsg copies at most FLEN_ERRMSG - 1 bytes, so keeping the chunk
-           size at or below that means no stored entry can ever be truncated on
-           the way out. */
+        size at or below that means no stored entry can ever be truncated on
+        the way out. */
         assert!(ERRMSG_CHUNK <= FLEN_ERRMSG - 1);
     }
 
@@ -12588,8 +12580,8 @@ mod tests {
     #[test]
     fn test_error_stack_keeps_raw_bytes() {
         /* FITS diagnostics echo card bytes, which are frequently not valid
-           UTF-8; and an embedded NUL must not shorten the stored entry, which
-           is why the length is explicit rather than NUL-terminated. */
+        UTF-8; and an embedded NUL must not shorten the stored entry, which
+        is why the length is explicit rather than NUL-terminated. */
         let mut st = ErrorStack::new();
         let msg = b"card \xff\xfe with a NUL \x00 in it";
         st.push_message(msg);

--- a/src/getkey.rs
+++ b/src/getkey.rs
@@ -6146,8 +6146,8 @@ mod tests {
     use crate::edithdu::ffitab_safe;
     use crate::helpers::testhelpers::{to_buf, with_temp_file};
     use crate::putkey::{
-        ffcrtb_safe, ffdt2s_safe, ffgsdt_safe, ffphps_safe, ffpknjj_safe, ffpkys_safe, ffs2dt_safe,
-        ffs2tm_safe, ffverifydate_safe,
+        ffcrtb_safe, ffdt2s_safe, ffgsdt_safe, ffphps_safe, ffphpsll_safe, ffpknjj_safe,
+        ffpkys_safe, ffs2dt_safe, ffs2tm_safe, fftm2s_safe, ffverifydate_safe,
     };
 
     /* Ported from test_getkey.c - keyword reading functions. */
@@ -6197,7 +6197,48 @@ mod tests {
         });
     }
 
-    /* test_ffgknjj_large_values: skipped - ffphpsll_safe is still todo!() */
+    #[test]
+    fn test_ffgknjj_large_values() {
+        /* Test ffgknjj with values stored as LONGLONG (but small enough for file). */
+        with_temp_file(|filename| {
+            let mut status = 0;
+            let name = to_buf(filename);
+            let naxes: [LONGLONG; 2] = [100, 200];
+
+            let mut fptr: Option<Box<fitsfile>> = None;
+            ffinit_safe(&mut fptr, &name, &mut status);
+            assert_eq!(status, 0, "ffinit failed");
+            ffphpsll_safe(
+                fptr.as_deref_mut().unwrap(),
+                LONGLONG_IMG,
+                2,
+                &naxes,
+                &mut status,
+            );
+            assert_eq!(status, 0, "ffphpsll failed");
+            ffclos_safe(fptr.take().unwrap(), &mut status);
+            assert_eq!(status, 0, "ffclos failed");
+
+            ffopen_safe(&mut fptr, &name, READONLY, &mut status);
+            assert_eq!(status, 0, "ffopen failed");
+            let mut values: [LONGLONG; 2] = [0; 2];
+            let mut nfound: c_int = -1;
+            ffgknjj_safe(
+                fptr.as_deref_mut().unwrap(),
+                cs!(c"NAXIS"),
+                1,
+                2,
+                &mut values,
+                &mut nfound,
+                &mut status,
+            );
+            assert_eq!(status, 0, "ffgknjj failed");
+            assert_eq!(nfound, 2);
+            assert_eq!(values[0], 100);
+            assert_eq!(values[1], 200);
+            ffclos_safe(fptr.take().unwrap(), &mut status);
+        });
+    }
 
     #[test]
     fn test_ffgtdmll_basic() {
@@ -6523,7 +6564,22 @@ mod tests {
         assert_eq!(day, 31);
     }
 
-    /* test_fftm2s: skipped - fftm2s_safe is still todo!() */
+    #[test]
+    fn test_fftm2s() {
+        /* Test fftm2s - convert date/time to string. */
+        let mut status = 0;
+        let mut datestr = [0 as c_char; 32];
+
+        fftm2s_safe(2024, 6, 15, 10, 30, 45.5, 3, &mut datestr, &mut status);
+        assert_eq!(status, 0);
+        assert_eq!(
+            &CStr::from_bytes_until_nul(cast_slice(&datestr))
+                .unwrap()
+                .to_str()
+                .unwrap()[..19],
+            "2024-06-15T10:30:45"
+        );
+    }
 
     #[test]
     fn test_ffs2tm() {

--- a/src/imcompress.rs
+++ b/src/imcompress.rs
@@ -1348,7 +1348,7 @@ pub fn fits_img_compress_safe(
     }
 
     /* Read each image tile, compress, and write to a table row. */
-    unsafe { imcomp_compress_image(infptr, outfptr, status) };
+    imcomp_compress_image(infptr, outfptr, status);
 
     /* force another rescan of the output file keywords, to */
     /* update PCOUNT and TFORMn = '1PB(iii)' keyword values. */
@@ -2030,335 +2030,333 @@ fn imcomp_calc_max_elem(comptype: c_int, nx: c_int, zbitpix: c_int, blocksize: c
 ///   possible to quantize the floating point pixels, then it losslessly
 ///   compresses them with gzip
 /// - writes the compressed byte stream to the output FITS file
-unsafe fn imcomp_compress_image(
+fn imcomp_compress_image(
     infptr: &mut fitsfile,
     outfptr: &mut fitsfile,
     status: &mut c_int,
 ) -> c_int {
-    unsafe {
-        let mut tiledata: Vec<f64> = Vec::new();
-        let mut anynul: c_int = 0;
-        let mut gotnulls = false;
-        let mut datatype: c_int = 0;
-        let mut row: c_long = 0;
-        let mut naxis: c_int = 0;
-        let dummy: f64 = 0.0;
-        let dblnull: f64 = DOUBLENULLVALUE;
-        let fltnull: f32 = FLOATNULLVALUE;
-        let mut maxtilelen: usize = 0;
-        let mut tilelen: c_long = 0;
-        let incre: [c_long; 6] = [1; 6];
-        let mut naxes: [c_long; MAX_COMPRESS_DIM] = [0; MAX_COMPRESS_DIM];
-        let mut fpixel: [c_long; MAX_COMPRESS_DIM] = [0; MAX_COMPRESS_DIM];
-        let mut lpixel: [c_long; MAX_COMPRESS_DIM] = [0; MAX_COMPRESS_DIM];
-        let mut tile: [c_long; MAX_COMPRESS_DIM] = [0; MAX_COMPRESS_DIM];
-        let mut tilesize: [c_long; MAX_COMPRESS_DIM] = [0; MAX_COMPRESS_DIM];
+    let mut tiledata: Vec<f64> = Vec::new();
+    let mut anynul: c_int = 0;
+    let mut gotnulls = false;
+    let mut datatype: c_int = 0;
+    let mut row: c_long = 0;
+    let mut naxis: c_int = 0;
+    let dummy: f64 = 0.0;
+    let dblnull: f64 = DOUBLENULLVALUE;
+    let fltnull: f32 = FLOATNULLVALUE;
+    let mut maxtilelen: usize = 0;
+    let mut tilelen: c_long = 0;
+    let incre: [c_long; 6] = [1; 6];
+    let mut naxes: [c_long; MAX_COMPRESS_DIM] = [0; MAX_COMPRESS_DIM];
+    let mut fpixel: [c_long; MAX_COMPRESS_DIM] = [0; MAX_COMPRESS_DIM];
+    let mut lpixel: [c_long; MAX_COMPRESS_DIM] = [0; MAX_COMPRESS_DIM];
+    let mut tile: [c_long; MAX_COMPRESS_DIM] = [0; MAX_COMPRESS_DIM];
+    let mut tilesize: [c_long; MAX_COMPRESS_DIM] = [0; MAX_COMPRESS_DIM];
 
-        let mut trowsize: c_long = 0;
-        let mut ntrows: c_long = 0;
-        let mut card: [c_char; FLEN_CARD] = [0; FLEN_CARD];
+    let mut trowsize: c_long = 0;
+    let mut ntrows: c_long = 0;
+    let mut card: [c_char; FLEN_CARD] = [0; FLEN_CARD];
 
-        if *status > 0 {
-            return *status;
-        }
+    if *status > 0 {
+        return *status;
+    }
 
-        maxtilelen = (outfptr.Fptr).maxtilelen as usize;
+    maxtilelen = (outfptr.Fptr).maxtilelen as usize;
 
-        /*
-        Allocate buffer to hold 1 tile of data; size depends on which compression
-        algorithm is used:
+    /*
+    Allocate buffer to hold 1 tile of data; size depends on which compression
+    algorithm is used:
 
-        Rice and GZIP will compress byte, short, or int arrays without conversion.
-        PLIO requires 4-byte int values, so byte and short arrays must be
-        converted to int. HCompress internally converts byte or short values to
-        ints, and converts int values to 8-byte longlong integers.
-        */
+    Rice and GZIP will compress byte, short, or int arrays without conversion.
+    PLIO requires 4-byte int values, so byte and short arrays must be
+    converted to int. HCompress internally converts byte or short values to
+    ints, and converts int values to 8-byte longlong integers.
+    */
 
-        let mut allocation_size = 0;
+    let mut allocation_size = 0;
 
-        if (outfptr.Fptr).zbitpix == FLOAT_IMG {
-            datatype = TFLOAT;
+    if (outfptr.Fptr).zbitpix == FLOAT_IMG {
+        datatype = TFLOAT;
 
-            if (outfptr.Fptr).compress_type == HCOMPRESS_1 {
-                /* need twice as much scratch space (8 bytes per pixel) */
-                allocation_size = maxtilelen * 2 * mem::size_of::<f32>();
-            } else {
-                allocation_size = maxtilelen * mem::size_of::<f32>();
-            }
-        } else if (outfptr.Fptr).zbitpix == DOUBLE_IMG {
-            datatype = TDOUBLE;
-            allocation_size = maxtilelen * mem::size_of::<f64>();
-        } else if (outfptr.Fptr).zbitpix == SHORT_IMG {
-            datatype = TSHORT;
-            if (outfptr.Fptr).compress_type == RICE_1
-                || (outfptr.Fptr).compress_type == GZIP_1
-                || (outfptr.Fptr).compress_type == GZIP_2
-                || (outfptr.Fptr).compress_type == BZIP2_1
-                || (outfptr.Fptr).compress_type == NOCOMPRESS
-            {
-                /* only need  buffer of I*2 pixels for gzip, bzip2, and Rice */
-
-                allocation_size = maxtilelen * mem::size_of::<c_short>();
-            } else {
-                /*  need  buffer of I*4 pixels for Hcompress and PLIO */
-                allocation_size = maxtilelen * mem::size_of::<c_int>();
-            }
-        } else if (outfptr.Fptr).zbitpix == BYTE_IMG {
-            datatype = TBYTE;
-            if (outfptr.Fptr).compress_type == RICE_1
-                || (outfptr.Fptr).compress_type == BZIP2_1
-                || (outfptr.Fptr).compress_type == GZIP_1
-                || (outfptr.Fptr).compress_type == GZIP_2
-            {
-                /* only need  buffer of I*1 pixels for gzip, bzip2, and Rice */
-
-                allocation_size = maxtilelen;
-            } else {
-                /*  need  buffer of I*4 pixels for Hcompress and PLIO */
-                allocation_size = maxtilelen * mem::size_of::<c_int>();
-            }
-        } else if (outfptr.Fptr).zbitpix == LONG_IMG {
-            datatype = TINT;
-            if (outfptr.Fptr).compress_type == HCOMPRESS_1 {
-                /* need twice as much scratch space (8 bytes per pixel) */
-                allocation_size = maxtilelen * 2 * mem::size_of::<c_int>();
-            } else {
-                /* only need  buffer of I*4 pixels for gzip, bzip2,  Rice, and PLIO */
-                allocation_size = maxtilelen * mem::size_of::<c_int>();
-            }
+        if (outfptr.Fptr).compress_type == HCOMPRESS_1 {
+            /* need twice as much scratch space (8 bytes per pixel) */
+            allocation_size = maxtilelen * 2 * mem::size_of::<f32>();
         } else {
-            ffpmsg_str("Bad image datatype. (imcomp_compress_image)");
-            *status = MEMORY_ALLOCATION;
-            return *status;
+            allocation_size = maxtilelen * mem::size_of::<f32>();
         }
+    } else if (outfptr.Fptr).zbitpix == DOUBLE_IMG {
+        datatype = TDOUBLE;
+        allocation_size = maxtilelen * mem::size_of::<f64>();
+    } else if (outfptr.Fptr).zbitpix == SHORT_IMG {
+        datatype = TSHORT;
+        if (outfptr.Fptr).compress_type == RICE_1
+            || (outfptr.Fptr).compress_type == GZIP_1
+            || (outfptr.Fptr).compress_type == GZIP_2
+            || (outfptr.Fptr).compress_type == BZIP2_1
+            || (outfptr.Fptr).compress_type == NOCOMPRESS
+        {
+            /* only need  buffer of I*2 pixels for gzip, bzip2, and Rice */
 
-        if tiledata.try_reserve_exact(allocation_size).is_err() {
-            ffpmsg_str("Out of memory. (imcomp_compress_image)");
-            *status = MEMORY_ALLOCATION;
-            return *status;
+            allocation_size = maxtilelen * mem::size_of::<c_short>();
         } else {
-            tiledata.resize(allocation_size, 0.0);
+            /*  need  buffer of I*4 pixels for Hcompress and PLIO */
+            allocation_size = maxtilelen * mem::size_of::<c_int>();
         }
+    } else if (outfptr.Fptr).zbitpix == BYTE_IMG {
+        datatype = TBYTE;
+        if (outfptr.Fptr).compress_type == RICE_1
+            || (outfptr.Fptr).compress_type == BZIP2_1
+            || (outfptr.Fptr).compress_type == GZIP_1
+            || (outfptr.Fptr).compress_type == GZIP_2
+        {
+            /* only need  buffer of I*1 pixels for gzip, bzip2, and Rice */
 
-        /*  calculate size of tile in each dimension */
-        naxis = (outfptr.Fptr).zndim;
-        for ii in 0..MAX_COMPRESS_DIM {
-            if ii < naxis as usize {
-                naxes[ii] = (outfptr.Fptr).znaxis[ii];
-                tilesize[ii] = (outfptr.Fptr).tilesize[ii];
-            } else {
-                naxes[ii] = 1;
-                tilesize[ii] = 1;
-            }
+            allocation_size = maxtilelen;
+        } else {
+            /*  need  buffer of I*4 pixels for Hcompress and PLIO */
+            allocation_size = maxtilelen * mem::size_of::<c_int>();
         }
-        row = 1;
+    } else if (outfptr.Fptr).zbitpix == LONG_IMG {
+        datatype = TINT;
+        if (outfptr.Fptr).compress_type == HCOMPRESS_1 {
+            /* need twice as much scratch space (8 bytes per pixel) */
+            allocation_size = maxtilelen * 2 * mem::size_of::<c_int>();
+        } else {
+            /* only need  buffer of I*4 pixels for gzip, bzip2,  Rice, and PLIO */
+            allocation_size = maxtilelen * mem::size_of::<c_int>();
+        }
+    } else {
+        ffpmsg_str("Bad image datatype. (imcomp_compress_image)");
+        *status = MEMORY_ALLOCATION;
+        return *status;
+    }
 
-        /* set up big loop over up to 6 dimensions */
-        for i5 in (1..=naxes[5]).step_by(tilesize[5] as usize) {
-            fpixel[5] = i5;
-            lpixel[5] = cmp::min(i5 + tilesize[5] - 1, naxes[5]);
-            tile[5] = lpixel[5] - fpixel[5] + 1;
-            for i4 in (1..=naxes[4]).step_by(tilesize[4] as usize) {
-                fpixel[4] = i4;
-                lpixel[4] = cmp::min(i4 + tilesize[4] - 1, naxes[4]);
-                tile[4] = lpixel[4] - fpixel[4] + 1;
-                for i3 in (1..=naxes[3]).step_by(tilesize[3] as usize) {
-                    fpixel[3] = i3;
-                    lpixel[3] = cmp::min(i3 + tilesize[3] - 1, naxes[3]);
-                    tile[3] = lpixel[3] - fpixel[3] + 1;
-                    for i2 in (1..=naxes[2]).step_by(tilesize[2] as usize) {
-                        fpixel[2] = i2;
-                        lpixel[2] = cmp::min(i2 + tilesize[2] - 1, naxes[2]);
-                        tile[2] = lpixel[2] - fpixel[2] + 1;
-                        for i1 in (1..=naxes[1]).step_by(tilesize[1] as usize) {
-                            fpixel[1] = i1;
-                            lpixel[1] = cmp::min(i1 + tilesize[1] - 1, naxes[1]);
-                            tile[1] = lpixel[1] - fpixel[1] + 1;
-                            for i0 in (1..=naxes[0]).step_by(tilesize[0] as usize) {
-                                fpixel[0] = i0;
-                                lpixel[0] = cmp::min(i0 + tilesize[0] - 1, naxes[0]);
-                                tile[0] = lpixel[0] - fpixel[0] + 1;
+    if tiledata.try_reserve_exact(allocation_size).is_err() {
+        ffpmsg_str("Out of memory. (imcomp_compress_image)");
+        *status = MEMORY_ALLOCATION;
+        return *status;
+    } else {
+        tiledata.resize(allocation_size, 0.0);
+    }
 
-                                /* number of pixels in this tile */
-                                tilelen = tile[0];
-                                for ii in 1..(naxis as usize) {
-                                    tilelen *= tile[ii];
-                                }
+    /*  calculate size of tile in each dimension */
+    naxis = (outfptr.Fptr).zndim;
+    for ii in 0..MAX_COMPRESS_DIM {
+        if ii < naxis as usize {
+            naxes[ii] = (outfptr.Fptr).znaxis[ii];
+            tilesize[ii] = (outfptr.Fptr).tilesize[ii];
+        } else {
+            naxes[ii] = 1;
+            tilesize[ii] = 1;
+        }
+    }
+    row = 1;
 
-                                /* read next tile of data from image */
-                                anynul = 0;
-                                if datatype == TFLOAT {
-                                    ffgsve_safe(
-                                        infptr,
-                                        1,
-                                        naxis,
-                                        &naxes,
-                                        &fpixel,
-                                        &lpixel,
-                                        &incre,
-                                        FLOATNULLVALUE,
-                                        cast_slice_mut(&mut tiledata),
-                                        Some(&mut anynul),
-                                        status,
-                                    );
-                                } else if datatype == TDOUBLE {
-                                    ffgsvd_safe(
-                                        infptr,
-                                        1,
-                                        naxis,
-                                        &naxes,
-                                        &fpixel,
-                                        &lpixel,
-                                        &incre,
-                                        DOUBLENULLVALUE,
-                                        cast_slice_mut(&mut tiledata),
-                                        Some(&mut anynul),
-                                        status,
-                                    );
-                                } else if datatype == TINT {
-                                    ffgsvk_safe(
-                                        infptr,
-                                        1,
-                                        naxis,
-                                        &naxes,
-                                        &fpixel,
-                                        &lpixel,
-                                        &incre,
-                                        0,
-                                        cast_slice_mut(&mut tiledata),
-                                        Some(&mut anynul),
-                                        status,
-                                    );
-                                } else if datatype == TSHORT {
-                                    ffgsvi_safe(
-                                        infptr,
-                                        1,
-                                        naxis,
-                                        &naxes,
-                                        &fpixel,
-                                        &lpixel,
-                                        &incre,
-                                        0,
-                                        cast_slice_mut(&mut tiledata),
-                                        Some(&mut anynul),
-                                        status,
-                                    );
-                                } else if datatype == TBYTE {
-                                    ffgsvb_safe(
-                                        infptr,
-                                        1,
-                                        naxis,
-                                        &naxes,
-                                        &fpixel,
-                                        &lpixel,
-                                        &incre,
-                                        0,
-                                        cast_slice_mut(&mut tiledata),
-                                        Some(&mut anynul),
-                                        status,
-                                    );
-                                } else {
-                                    ffpmsg_str("Error bad datatype of image tile to compress");
-                                    return *status;
-                                }
+    /* set up big loop over up to 6 dimensions */
+    for i5 in (1..=naxes[5]).step_by(tilesize[5] as usize) {
+        fpixel[5] = i5;
+        lpixel[5] = cmp::min(i5 + tilesize[5] - 1, naxes[5]);
+        tile[5] = lpixel[5] - fpixel[5] + 1;
+        for i4 in (1..=naxes[4]).step_by(tilesize[4] as usize) {
+            fpixel[4] = i4;
+            lpixel[4] = cmp::min(i4 + tilesize[4] - 1, naxes[4]);
+            tile[4] = lpixel[4] - fpixel[4] + 1;
+            for i3 in (1..=naxes[3]).step_by(tilesize[3] as usize) {
+                fpixel[3] = i3;
+                lpixel[3] = cmp::min(i3 + tilesize[3] - 1, naxes[3]);
+                tile[3] = lpixel[3] - fpixel[3] + 1;
+                for i2 in (1..=naxes[2]).step_by(tilesize[2] as usize) {
+                    fpixel[2] = i2;
+                    lpixel[2] = cmp::min(i2 + tilesize[2] - 1, naxes[2]);
+                    tile[2] = lpixel[2] - fpixel[2] + 1;
+                    for i1 in (1..=naxes[1]).step_by(tilesize[1] as usize) {
+                        fpixel[1] = i1;
+                        lpixel[1] = cmp::min(i1 + tilesize[1] - 1, naxes[1]);
+                        tile[1] = lpixel[1] - fpixel[1] + 1;
+                        for i0 in (1..=naxes[0]).step_by(tilesize[0] as usize) {
+                            fpixel[0] = i0;
+                            lpixel[0] = cmp::min(i0 + tilesize[0] - 1, naxes[0]);
+                            tile[0] = lpixel[0] - fpixel[0] + 1;
 
-                                /* now compress the tile, and write to row of binary table */
-                                /*   NOTE: we don't have to worry about the presence
-                                   of null values in the array if it is an integer
-                                   array:  the null value is simply encoded in the
-                                   compressed array just like any other pixel value.
+                            /* number of pixels in this tile */
+                            tilelen = tile[0];
+                            for ii in 1..(naxis as usize) {
+                                tilelen *= tile[ii];
+                            }
 
-                                     If it is a floating point array, then we need
-                                   to check for null only if the anynul parameter
-                                   returned a true value when reading the tile
-                                */
-
-                                /* Collapse sizes of higher dimension tiles into 2
-                                dimensional equivalents needed by the quantizing
-                                algorithms for floating point types */
-                                fits_calc_tile_rows(
-                                    &lpixel,
-                                    &fpixel,
+                            /* read next tile of data from image */
+                            anynul = 0;
+                            if datatype == TFLOAT {
+                                ffgsve_safe(
+                                    infptr,
+                                    1,
                                     naxis,
-                                    &mut trowsize,
-                                    &mut ntrows,
+                                    &naxes,
+                                    &fpixel,
+                                    &lpixel,
+                                    &incre,
+                                    FLOATNULLVALUE,
+                                    cast_slice_mut(&mut tiledata),
+                                    Some(&mut anynul),
                                     status,
                                 );
-
-                                if anynul != 0 && datatype == TFLOAT {
-                                    imcomp_compress_tile(
-                                        outfptr,
-                                        row,
-                                        datatype,
-                                        cast_slice_mut(&mut tiledata),
-                                        tilelen,
-                                        trowsize,
-                                        ntrows,
-                                        NullCheckType::None,
-                                        &Some(NullValue::Float(fltnull)),
-                                        status,
-                                    );
-                                } else if anynul != 0 && datatype == TDOUBLE {
-                                    imcomp_compress_tile(
-                                        outfptr,
-                                        row,
-                                        datatype,
-                                        cast_slice_mut(&mut tiledata),
-                                        tilelen,
-                                        trowsize,
-                                        ntrows,
-                                        NullCheckType::SetPixel,
-                                        &Some(NullValue::Double(dblnull)),
-                                        status,
-                                    );
-                                } else {
-                                    imcomp_compress_tile(
-                                        outfptr,
-                                        row,
-                                        datatype,
-                                        cast_slice_mut(&mut tiledata),
-                                        tilelen,
-                                        trowsize,
-                                        ntrows,
-                                        NullCheckType::None,
-                                        &Some(NullValue::Double(dummy)),
-                                        status,
-                                    );
-                                }
-
-                                /* set flag if we found any null values */
-                                if anynul != 0 {
-                                    gotnulls = true;
-                                }
-
-                                /* check for any error in the previous operations */
-                                if *status > 0 {
-                                    ffpmsg_str("Error writing compressed image to table");
-                                    return *status;
-                                }
-
-                                row += 1;
+                            } else if datatype == TDOUBLE {
+                                ffgsvd_safe(
+                                    infptr,
+                                    1,
+                                    naxis,
+                                    &naxes,
+                                    &fpixel,
+                                    &lpixel,
+                                    &incre,
+                                    DOUBLENULLVALUE,
+                                    cast_slice_mut(&mut tiledata),
+                                    Some(&mut anynul),
+                                    status,
+                                );
+                            } else if datatype == TINT {
+                                ffgsvk_safe(
+                                    infptr,
+                                    1,
+                                    naxis,
+                                    &naxes,
+                                    &fpixel,
+                                    &lpixel,
+                                    &incre,
+                                    0,
+                                    cast_slice_mut(&mut tiledata),
+                                    Some(&mut anynul),
+                                    status,
+                                );
+                            } else if datatype == TSHORT {
+                                ffgsvi_safe(
+                                    infptr,
+                                    1,
+                                    naxis,
+                                    &naxes,
+                                    &fpixel,
+                                    &lpixel,
+                                    &incre,
+                                    0,
+                                    cast_slice_mut(&mut tiledata),
+                                    Some(&mut anynul),
+                                    status,
+                                );
+                            } else if datatype == TBYTE {
+                                ffgsvb_safe(
+                                    infptr,
+                                    1,
+                                    naxis,
+                                    &naxes,
+                                    &fpixel,
+                                    &lpixel,
+                                    &incre,
+                                    0,
+                                    cast_slice_mut(&mut tiledata),
+                                    Some(&mut anynul),
+                                    status,
+                                );
+                            } else {
+                                ffpmsg_str("Error bad datatype of image tile to compress");
+                                return *status;
                             }
+
+                            /* now compress the tile, and write to row of binary table */
+                            /*   NOTE: we don't have to worry about the presence
+                               of null values in the array if it is an integer
+                               array:  the null value is simply encoded in the
+                               compressed array just like any other pixel value.
+
+                                 If it is a floating point array, then we need
+                               to check for null only if the anynul parameter
+                               returned a true value when reading the tile
+                            */
+
+                            /* Collapse sizes of higher dimension tiles into 2
+                            dimensional equivalents needed by the quantizing
+                            algorithms for floating point types */
+                            fits_calc_tile_rows(
+                                &lpixel,
+                                &fpixel,
+                                naxis,
+                                &mut trowsize,
+                                &mut ntrows,
+                                status,
+                            );
+
+                            if anynul != 0 && datatype == TFLOAT {
+                                imcomp_compress_tile(
+                                    outfptr,
+                                    row,
+                                    datatype,
+                                    cast_slice_mut(&mut tiledata),
+                                    tilelen,
+                                    trowsize,
+                                    ntrows,
+                                    NullCheckType::None,
+                                    &Some(NullValue::Float(fltnull)),
+                                    status,
+                                );
+                            } else if anynul != 0 && datatype == TDOUBLE {
+                                imcomp_compress_tile(
+                                    outfptr,
+                                    row,
+                                    datatype,
+                                    cast_slice_mut(&mut tiledata),
+                                    tilelen,
+                                    trowsize,
+                                    ntrows,
+                                    NullCheckType::SetPixel,
+                                    &Some(NullValue::Double(dblnull)),
+                                    status,
+                                );
+                            } else {
+                                imcomp_compress_tile(
+                                    outfptr,
+                                    row,
+                                    datatype,
+                                    cast_slice_mut(&mut tiledata),
+                                    tilelen,
+                                    trowsize,
+                                    ntrows,
+                                    NullCheckType::None,
+                                    &Some(NullValue::Double(dummy)),
+                                    status,
+                                );
+                            }
+
+                            /* set flag if we found any null values */
+                            if anynul != 0 {
+                                gotnulls = true;
+                            }
+
+                            /* check for any error in the previous operations */
+                            if *status > 0 {
+                                ffpmsg_str("Error writing compressed image to table");
+                                return *status;
+                            }
+
+                            row += 1;
                         }
                     }
                 }
             }
         }
-
-        /* insert ZBLANK keyword if necessary; only for TFLOAT or TDOUBLE images */
-        if gotnulls {
-            ffgcrd_safe(outfptr, cs!(c"ZCMPTYPE"), &mut card, status);
-            ffikyj_safe(
-                outfptr,
-                cs!(c"ZBLANK"),
-                LONGLONG::from(COMPRESS_NULL_VALUE),
-                Some(cs!(c"null value in the compressed integer array")),
-                status,
-            );
-        }
-
-        *status
     }
+
+    /* insert ZBLANK keyword if necessary; only for TFLOAT or TDOUBLE images */
+    if gotnulls {
+        ffgcrd_safe(outfptr, cs!(c"ZCMPTYPE"), &mut card, status);
+        ffikyj_safe(
+            outfptr,
+            cs!(c"ZBLANK"),
+            LONGLONG::from(COMPRESS_NULL_VALUE),
+            Some(cs!(c"null value in the compressed integer array")),
+            status,
+        );
+    }
+
+    *status
 }
 
 /*--------------------------------------------------------------------------*/
@@ -2380,7 +2378,7 @@ unsafe fn imcomp_compress_image(
 /// that is supported when writing to normal FITS images.  The datatype of the
 /// input array must have the same datatype (either signed or unsigned) as the
 /// output (compressed) FITS image in some cases.
-unsafe fn imcomp_compress_tile(
+fn imcomp_compress_tile(
     outfptr: &mut fitsfile,
     row: c_long, /* tile number = row in the binary table that holds the compressed data */
     datatype: c_int,
@@ -2392,402 +2390,400 @@ unsafe fn imcomp_compress_tile(
     nullflagval: &Option<NullValue>,
     status: &mut c_int,
 ) -> c_int {
-    unsafe {
-        let mut flag: c_int = 1; // true by default; only = 0 if float data couldn't be quantized
-        let mut intlength: c_int = 0; // size of integers to be compressed
+    let mut flag: c_int = 1; // true by default; only = 0 if float data couldn't be quantized
+    let mut intlength: c_int = 0; // size of integers to be compressed
 
-        let clen: usize; // size of cbuf
-        let mut cbuf: Vec<c_short> = Vec::new(); // compressed data
-        let mut nelem: c_int = 0; // number of bytes
-        let tilecol: c_int;
-        let mut gzip_nelem: usize = 0;
+    let clen: usize; // size of cbuf
+    let mut cbuf: Vec<c_short> = Vec::new(); // compressed data
+    let mut nelem: c_int = 0; // number of bytes
+    let tilecol: c_int;
+    let mut gzip_nelem: usize = 0;
 
-        let ihcompscale: c_int;
-        let mut hcompscale: f32;
-        let mut noise2: f64 = 0.0;
-        let mut noise3: f64 = 0.0;
-        let mut noise5: f64 = 0.0;
-        let mut bscale: [f64; 1] = [1.0]; // scaling parameters
-        let mut bzero: [f64; 1] = [0.0]; // scaling parameters
-        let mut hcomp_len: c_long;
+    let ihcompscale: c_int;
+    let mut hcompscale: f32;
+    let mut noise2: f64 = 0.0;
+    let mut noise3: f64 = 0.0;
+    let mut noise5: f64 = 0.0;
+    let mut bscale: [f64; 1] = [1.0]; // scaling parameters
+    let mut bzero: [f64; 1] = [0.0]; // scaling parameters
+    let mut hcomp_len: c_long;
 
-        if *status > 0 {
-            return *status;
-        }
+    if *status > 0 {
+        return *status;
+    }
 
-        /* check for special case of losslessly compressing floating point */
-        /* images.  Only compression algorithm that supports this is GZIP */
-        if (outfptr.Fptr).quantize_level == NO_QUANTIZE
-            && ((outfptr.Fptr).compress_type != GZIP_1)
-            && ((outfptr.Fptr).compress_type != GZIP_2)
-        {
-            match datatype {
-                TFLOAT | TDOUBLE | TCOMPLEX | TDBLCOMPLEX => {
-                    ffpmsg_str(
-                        "Lossless compression of floating point images must use GZIP (imcomp_compress_tile)",
-                    );
-                    *status = DATA_COMPRESSION_ERR;
-                    return *status;
-                }
-                _ => {}
-            }
-        }
-
-        /* free the previously saved tile if the input tile is for the same row */
-        if !(outfptr.Fptr).tilerow.is_null() {
-            /* has the tile cache been allocated? */
-
-            /* calculate the column bin of the compressed tile */
-            tilecol = ((row - 1)
-                % (((((outfptr.Fptr).znaxis[0] - 1) / ((outfptr.Fptr).tilesize[0])) as c_long) + 1))
-                as c_int;
-
-            /* The cached tiles are owned by the TileStruct stored in the global
-            TILE_STRUCTS map (see the decompress path, which reads and writes the
-            cache exclusively through this map). If the cached tile is for this
-            same row it is about to become stale, so invalidate it by clearing the
-            owned buffers and resetting the metadata. The previous code
-            reinterpreted the TileStruct's `Vec<Vec<u8>>` storage as a raw
-            `*mut c_void` array and freed the entries with Vec::from_raw_parts,
-            which double-freed memory still owned by the TileStruct (and, for
-            columns other than the first, used the wrong element stride). */
-            let key = &raw const outfptr.Fptr as usize;
-            let mut tilestruct_lock = TILE_STRUCTS.lock().unwrap();
-            if let Some(tilestruct) = tilestruct_lock.get_mut(&key)
-                && c_long::from(tilestruct.tilerow[tilecol as usize]) == row
-            {
-                tilestruct.tiledata[tilecol as usize] = Vec::new();
-                tilestruct.tilenullarray[tilecol as usize] = Vec::new();
-                tilestruct.tilerow[tilecol as usize] = 0;
-                tilestruct.tiledatasize[tilecol as usize] = 0;
-                tilestruct.tiletype[tilecol as usize] = 0;
-                tilestruct.tileanynull[tilecol as usize] = 0;
-            }
-        }
-
-        if (outfptr.Fptr).compress_type == NOCOMPRESS {
-            /* Special case when using NOCOMPRESS for diagnostic purposes in fpack */
-            if imcomp_write_nocompress_tile(
-                outfptr,
-                row,
-                datatype,
-                tiledata,
-                tilelen,
-                nullcheck,
-                nullflagval,
-                status,
-            ) > 0
-            {
+    /* check for special case of losslessly compressing floating point */
+    /* images.  Only compression algorithm that supports this is GZIP */
+    if (outfptr.Fptr).quantize_level == NO_QUANTIZE
+        && ((outfptr.Fptr).compress_type != GZIP_1)
+        && ((outfptr.Fptr).compress_type != GZIP_2)
+    {
+        match datatype {
+            TFLOAT | TDOUBLE | TCOMPLEX | TDBLCOMPLEX => {
+                ffpmsg_str(
+                    "Lossless compression of floating point images must use GZIP (imcomp_compress_tile)",
+                );
+                *status = DATA_COMPRESSION_ERR;
                 return *status;
             }
+            _ => {}
+        }
+    }
+
+    /* free the previously saved tile if the input tile is for the same row */
+    if !(outfptr.Fptr).tilerow.is_null() {
+        /* has the tile cache been allocated? */
+
+        /* calculate the column bin of the compressed tile */
+        tilecol = ((row - 1)
+            % (((((outfptr.Fptr).znaxis[0] - 1) / ((outfptr.Fptr).tilesize[0])) as c_long) + 1))
+            as c_int;
+
+        /* The cached tiles are owned by the TileStruct stored in the global
+        TILE_STRUCTS map (see the decompress path, which reads and writes the
+        cache exclusively through this map). If the cached tile is for this
+        same row it is about to become stale, so invalidate it by clearing the
+        owned buffers and resetting the metadata. The previous code
+        reinterpreted the TileStruct's `Vec<Vec<u8>>` storage as a raw
+        `*mut c_void` array and freed the entries with Vec::from_raw_parts,
+        which double-freed memory still owned by the TileStruct (and, for
+        columns other than the first, used the wrong element stride). */
+        let key = &raw const outfptr.Fptr as usize;
+        let mut tilestruct_lock = TILE_STRUCTS.lock().unwrap();
+        if let Some(tilestruct) = tilestruct_lock.get_mut(&key)
+            && c_long::from(tilestruct.tilerow[tilecol as usize]) == row
+        {
+            tilestruct.tiledata[tilecol as usize] = Vec::new();
+            tilestruct.tilenullarray[tilecol as usize] = Vec::new();
+            tilestruct.tilerow[tilecol as usize] = 0;
+            tilestruct.tiledatasize[tilecol as usize] = 0;
+            tilestruct.tiletype[tilecol as usize] = 0;
+            tilestruct.tileanynull[tilecol as usize] = 0;
+        }
+    }
+
+    if (outfptr.Fptr).compress_type == NOCOMPRESS {
+        /* Special case when using NOCOMPRESS for diagnostic purposes in fpack */
+        if imcomp_write_nocompress_tile(
+            outfptr,
+            row,
+            datatype,
+            tiledata,
+            tilelen,
+            nullcheck,
+            nullflagval,
+            status,
+        ) > 0
+        {
             return *status;
         }
+        return *status;
+    }
 
-        /* ===========================================================================*/
-        /* initialize various parameters */
+    /* ===========================================================================*/
+    /* initialize various parameters */
 
-        /* zbitpix is the BITPIX keyword value in the uncompressed FITS image */
-        let zbitpix: c_int = (outfptr.Fptr).zbitpix;
+    /* zbitpix is the BITPIX keyword value in the uncompressed FITS image */
+    let zbitpix: c_int = (outfptr.Fptr).zbitpix;
 
-        /* if the tile/image has an integer datatype, see if a null value has */
-        /* been defined (with the BLANK keyword in a normal FITS image).  */
-        /* If so, and if the input tile array also contains null pixels, */
-        /* (represented by pixels that have a value = nullflagval) then  */
-        /* any pixels whose value = nullflagval, must be set to the value = nullval
-         */
-        /* before the pixel array is compressed.  These null pixel values must */
-        /* not be inverse scaled by the BSCALE/BZERO values, if present. */
+    /* if the tile/image has an integer datatype, see if a null value has */
+    /* been defined (with the BLANK keyword in a normal FITS image).  */
+    /* If so, and if the input tile array also contains null pixels, */
+    /* (represented by pixels that have a value = nullflagval) then  */
+    /* any pixels whose value = nullflagval, must be set to the value = nullval
+     */
+    /* before the pixel array is compressed.  These null pixel values must */
+    /* not be inverse scaled by the BSCALE/BZERO values, if present. */
 
-        let cn_zblank: c_int = (outfptr.Fptr).cn_zblank;
-        let nullval: c_int = (outfptr.Fptr).zblank;
+    let cn_zblank: c_int = (outfptr.Fptr).cn_zblank;
+    let nullval: c_int = (outfptr.Fptr).zblank;
 
-        if zbitpix > 0 && cn_zblank != -1 {
-            /* If the integer image has no defined null */
-            nullcheck = NullCheckType::None; /* value, then don't bother checking input array for nulls. */
-        }
+    if zbitpix > 0 && cn_zblank != -1 {
+        /* If the integer image has no defined null */
+        nullcheck = NullCheckType::None; /* value, then don't bother checking input array for nulls. */
+    }
 
-        /* if the BSCALE and BZERO keywords exist, then the input values must */
-        /* be inverse scaled by this factor, before the values are compressed. */
-        /* (The program may have turned off scaling, which over rides the keywords)
-         */
+    /* if the BSCALE and BZERO keywords exist, then the input values must */
+    /* be inverse scaled by this factor, before the values are compressed. */
+    /* (The program may have turned off scaling, which over rides the keywords)
+     */
 
-        let scale: f64 = (outfptr.Fptr).cn_bscale;
-        let zero: f64 = (outfptr.Fptr).cn_bzero;
-        let actual_bzero: f64 = (outfptr.Fptr).cn_actual_bzero;
+    let scale: f64 = (outfptr.Fptr).cn_bscale;
+    let zero: f64 = (outfptr.Fptr).cn_bzero;
+    let actual_bzero: f64 = (outfptr.Fptr).cn_actual_bzero;
 
-        /* ===========================================================================
-         */
-        /* prepare the tile of pixel values for compression */
-        if datatype == TSHORT {
-            imcomp_convert_tile_tshort(
-                outfptr,
-                tiledata,
-                tilelen,
-                nullcheck,
-                nullflagval.as_ref().map(|nv| nv.get_value_as_f64() as _),
-                nullval,
-                zbitpix,
-                scale,
-                zero,
-                actual_bzero,
-                &mut intlength,
-                status,
-            );
-        } else if datatype == TUSHORT {
-            imcomp_convert_tile_tushort(
-                outfptr,
-                tiledata,
-                tilelen,
-                nullcheck,
-                nullflagval.as_ref().map(|nv| nv.get_value_as_f64() as _),
-                nullval,
-                zbitpix,
-                scale,
-                zero,
-                &mut intlength,
-                status,
-            );
-        } else if datatype == TBYTE {
-            imcomp_convert_tile_tbyte(
-                outfptr,
-                tiledata,
-                tilelen,
-                nullcheck,
-                nullflagval.as_ref().map(|nv| nv.get_value_as_f64() as _),
-                nullval,
-                zbitpix,
-                scale,
-                zero,
-                &mut intlength,
-                status,
-            );
-        } else if datatype == TSBYTE {
-            imcomp_convert_tile_tsbyte(
-                outfptr,
-                tiledata,
-                tilelen,
-                nullcheck,
-                nullflagval.as_ref().map(|nv| nv.get_value_as_f64() as _),
-                nullval,
-                zbitpix,
-                scale,
-                zero,
-                &mut intlength,
-                status,
-            );
-        } else if datatype == TINT {
-            imcomp_convert_tile_tint(
-                outfptr,
-                tiledata,
-                tilelen,
-                nullcheck,
-                nullflagval.as_ref().map(|nv| nv.get_value_as_f64() as _),
-                nullval,
-                zbitpix,
-                scale,
-                zero,
-                &mut intlength,
-                status,
-            );
-        } else if datatype == TUINT {
-            imcomp_convert_tile_tuint(
-                outfptr,
-                tiledata,
-                tilelen,
-                nullcheck,
-                nullflagval.as_ref().map(|nv| nv.get_value_as_f64() as _),
-                nullval,
-                zbitpix,
-                scale,
-                zero,
-                &mut intlength,
-                status,
-            );
-        } else if datatype == TLONG && mem::size_of::<c_long>() == 8 {
-            ffpmsg_str(
-                "Integer*8 Long datatype is not supported when writing to compressed images",
-            );
-            *status = BAD_DATATYPE;
+    /* ===========================================================================
+     */
+    /* prepare the tile of pixel values for compression */
+    if datatype == TSHORT {
+        imcomp_convert_tile_tshort(
+            outfptr,
+            tiledata,
+            tilelen,
+            nullcheck,
+            nullflagval.as_ref().map(|nv| nv.get_value_as_f64() as _),
+            nullval,
+            zbitpix,
+            scale,
+            zero,
+            actual_bzero,
+            &mut intlength,
+            status,
+        );
+    } else if datatype == TUSHORT {
+        imcomp_convert_tile_tushort(
+            outfptr,
+            tiledata,
+            tilelen,
+            nullcheck,
+            nullflagval.as_ref().map(|nv| nv.get_value_as_f64() as _),
+            nullval,
+            zbitpix,
+            scale,
+            zero,
+            &mut intlength,
+            status,
+        );
+    } else if datatype == TBYTE {
+        imcomp_convert_tile_tbyte(
+            outfptr,
+            tiledata,
+            tilelen,
+            nullcheck,
+            nullflagval.as_ref().map(|nv| nv.get_value_as_f64() as _),
+            nullval,
+            zbitpix,
+            scale,
+            zero,
+            &mut intlength,
+            status,
+        );
+    } else if datatype == TSBYTE {
+        imcomp_convert_tile_tsbyte(
+            outfptr,
+            tiledata,
+            tilelen,
+            nullcheck,
+            nullflagval.as_ref().map(|nv| nv.get_value_as_f64() as _),
+            nullval,
+            zbitpix,
+            scale,
+            zero,
+            &mut intlength,
+            status,
+        );
+    } else if datatype == TINT {
+        imcomp_convert_tile_tint(
+            outfptr,
+            tiledata,
+            tilelen,
+            nullcheck,
+            nullflagval.as_ref().map(|nv| nv.get_value_as_f64() as _),
+            nullval,
+            zbitpix,
+            scale,
+            zero,
+            &mut intlength,
+            status,
+        );
+    } else if datatype == TUINT {
+        imcomp_convert_tile_tuint(
+            outfptr,
+            tiledata,
+            tilelen,
+            nullcheck,
+            nullflagval.as_ref().map(|nv| nv.get_value_as_f64() as _),
+            nullval,
+            zbitpix,
+            scale,
+            zero,
+            &mut intlength,
+            status,
+        );
+    } else if datatype == TLONG && mem::size_of::<c_long>() == 8 {
+        ffpmsg_str("Integer*8 Long datatype is not supported when writing to compressed images");
+        *status = BAD_DATATYPE;
+        return *status;
+    } else if datatype == TULONG && mem::size_of::<c_long>() == 8 {
+        ffpmsg_cstr(
+            c"Unsigned integer*8 datatype is not supported when writing to compressed images",
+        );
+        *status = BAD_DATATYPE;
+        return *status;
+    } else if datatype == TFLOAT {
+        imcomp_convert_tile_tfloat(
+            outfptr,
+            row,
+            tiledata,
+            tilelen,
+            tilenx,
+            tileny,
+            nullcheck,
+            nullflagval.as_ref().map(|nv| nv.get_value_as_f64() as _),
+            nullval,
+            zbitpix,
+            scale,
+            zero,
+            &mut intlength,
+            &mut flag,
+            &mut bscale[0],
+            &mut bzero[0],
+            status,
+        );
+    } else if datatype == TDOUBLE {
+        imcomp_convert_tile_tdouble(
+            outfptr,
+            row,
+            tiledata,
+            tilelen,
+            tilenx,
+            tileny,
+            nullcheck,
+            nullflagval.as_ref().map(|nv| nv.get_value_as_f64() as _),
+            nullval,
+            zbitpix,
+            scale,
+            zero,
+            &mut intlength,
+            &mut flag,
+            &mut bscale[0],
+            &mut bzero[0],
+            status,
+        );
+    } else {
+        ffpmsg_str("unsupported image datatype (imcomp_compress_tile)");
+        *status = BAD_DATATYPE;
+        return *status;
+    }
+
+    if *status > 0 {
+        return *status; /* return if error occurs */
+    }
+
+    /* =========================================================================== */
+    if flag != 0 {
+        /* now compress the integer data array */
+        /* allocate buffer for the compressed tile bytes */
+        clen = (outfptr.Fptr).maxelem as usize / 2; // Divide by 2 to convert char to short
+        cbuf = Vec::new();
+
+        if cbuf.try_reserve_exact(clen).is_err() {
+            ffpmsg_str("Memory allocation failure. (imcomp_compress_tile)");
+            *status = MEMORY_ALLOCATION;
             return *status;
-        } else if datatype == TULONG && mem::size_of::<c_long>() == 8 {
-            ffpmsg_cstr(
-                c"Unsigned integer*8 datatype is not supported when writing to compressed images",
-            );
-            *status = BAD_DATATYPE;
-            return *status;
-        } else if datatype == TFLOAT {
-            imcomp_convert_tile_tfloat(
-                outfptr,
-                row,
-                tiledata,
-                tilelen,
-                tilenx,
-                tileny,
-                nullcheck,
-                nullflagval.as_ref().map(|nv| nv.get_value_as_f64() as _),
-                nullval,
-                zbitpix,
-                scale,
-                zero,
-                &mut intlength,
-                &mut flag,
-                &mut bscale[0],
-                &mut bzero[0],
-                status,
-            );
-        } else if datatype == TDOUBLE {
-            imcomp_convert_tile_tdouble(
-                outfptr,
-                row,
-                tiledata,
-                tilelen,
-                tilenx,
-                tileny,
-                nullcheck,
-                nullflagval.as_ref().map(|nv| nv.get_value_as_f64() as _),
-                nullval,
-                zbitpix,
-                scale,
-                zero,
-                &mut intlength,
-                &mut flag,
-                &mut bscale[0],
-                &mut bzero[0],
-                status,
-            );
         } else {
-            ffpmsg_str("unsupported image datatype (imcomp_compress_tile)");
-            *status = BAD_DATATYPE;
-            return *status;
-        }
-
-        if *status > 0 {
-            return *status; /* return if error occurs */
+            cbuf.resize(clen, 0);
         }
 
         /* =========================================================================== */
-        if flag != 0 {
-            /* now compress the integer data array */
-            /* allocate buffer for the compressed tile bytes */
-            clen = (outfptr.Fptr).maxelem as usize / 2; // Divide by 2 to convert char to short
-            cbuf = Vec::new();
+        if (outfptr.Fptr).compress_type == RICE_1 {
+            let idata: &mut [c_int] = cast_slice_mut(tiledata); /* may overwrite the input tiledata in place */
 
-            if cbuf.try_reserve_exact(clen).is_err() {
-                ffpmsg_str("Memory allocation failure. (imcomp_compress_tile)");
-                *status = MEMORY_ALLOCATION;
-                return *status;
+            let res = if intlength == 2 {
+                let mut rce = RCEncoder::new(cast_slice_mut(&mut cbuf));
+                rce.set_log_fn(ffpmsg_str);
+                rce.encode_short(
+                    cast_slice(idata),
+                    tilelen as usize,
+                    (outfptr.Fptr).rice_blocksize as usize,
+                )
+            } else if intlength == 1 {
+                let mut rce = RCEncoder::new(cast_slice_mut(&mut cbuf));
+                rce.set_log_fn(ffpmsg_str);
+                rce.encode_byte(
+                    cast_slice(idata),
+                    tilelen as usize,
+                    (outfptr.Fptr).rice_blocksize as usize,
+                )
             } else {
-                cbuf.resize(clen, 0);
+                let mut rce = RCEncoder::new(cast_slice_mut(&mut cbuf));
+                rce.set_log_fn(ffpmsg_str);
+                rce.encode(
+                    cast_slice(idata),
+                    tilelen as usize,
+                    (outfptr.Fptr).rice_blocksize as usize,
+                )
+            };
+
+            if res.is_err() {
+                /* data compression error condition */
+                ffpmsg_str("error Rice compressing image tile (imcomp_compress_tile)");
+                *status = DATA_COMPRESSION_ERR;
+                return *status;
             }
 
-            /* =========================================================================== */
-            if (outfptr.Fptr).compress_type == RICE_1 {
-                let idata: &mut [c_int] = cast_slice_mut(tiledata); /* may overwrite the input tiledata in place */
+            nelem = res.unwrap() as c_int;
 
-                let res = if intlength == 2 {
-                    let mut rce = RCEncoder::new(cast_slice_mut(&mut cbuf));
-                    rce.set_log_fn(ffpmsg_str);
-                    rce.encode_short(
-                        cast_slice(idata),
-                        tilelen as usize,
-                        (outfptr.Fptr).rice_blocksize as usize,
-                    )
-                } else if intlength == 1 {
-                    let mut rce = RCEncoder::new(cast_slice_mut(&mut cbuf));
-                    rce.set_log_fn(ffpmsg_str);
-                    rce.encode_byte(
-                        cast_slice(idata),
-                        tilelen as usize,
-                        (outfptr.Fptr).rice_blocksize as usize,
-                    )
-                } else {
-                    let mut rce = RCEncoder::new(cast_slice_mut(&mut cbuf));
-                    rce.set_log_fn(ffpmsg_str);
-                    rce.encode(
-                        cast_slice(idata),
-                        tilelen as usize,
-                        (outfptr.Fptr).rice_blocksize as usize,
-                    )
-                };
+            /* Write the compressed byte stream. */
+            ffpclb_safe(
+                outfptr,
+                (outfptr.Fptr).cn_compressed,
+                row as LONGLONG,
+                1,
+                LONGLONG::from(nelem),
+                cast_slice(&cbuf),
+                status,
+            );
+        }
+        /* =========================================================================== */
+        else if (outfptr.Fptr).compress_type == PLIO_1 {
+            let idata: &mut [c_int] = cast_slice_mut(tiledata); /* may overwrite the input tiledata in place */
 
-                if res.is_err() {
-                    /* data compression error condition */
-                    ffpmsg_str("error Rice compressing image tile (imcomp_compress_tile)");
+            for ii in 0..(tilelen as usize) {
+                if idata[ii] < 0 || idata[ii] > 16777215 {
+                    /* plio algorithn only supports positive 24 bit ints */
+                    ffpmsg_str("data out of range for PLIO compression (0 - 2**24)");
                     *status = DATA_COMPRESSION_ERR;
                     return *status;
                 }
-
-                nelem = res.unwrap() as c_int;
-
-                /* Write the compressed byte stream. */
-                ffpclb_safe(
-                    outfptr,
-                    (outfptr.Fptr).cn_compressed,
-                    row as LONGLONG,
-                    1,
-                    LONGLONG::from(nelem),
-                    cast_slice(&cbuf),
-                    status,
-                );
             }
-            /* =========================================================================== */
-            else if (outfptr.Fptr).compress_type == PLIO_1 {
-                let idata: &mut [c_int] = cast_slice_mut(tiledata); /* may overwrite the input tiledata in place */
 
-                for ii in 0..(tilelen as usize) {
-                    if idata[ii] < 0 || idata[ii] > 16777215 {
-                        /* plio algorithn only supports positive 24 bit ints */
-                        ffpmsg_str("data out of range for PLIO compression (0 - 2**24)");
-                        *status = DATA_COMPRESSION_ERR;
-                        return *status;
-                    }
-                }
-
-                /* cbuf is sized for the worst case, so None is unreachable */
-                nelem = match pl_p2li(idata, 0, &mut cbuf, tilelen.try_into().unwrap()) {
-                    Some(n) => n as c_int,
-                    None => {
-                        ffpmsg_str("PLIO line list did not fit the tile buffer");
-                        *status = DATA_COMPRESSION_ERR;
-                        return *status;
-                    }
-                };
-
-                if nelem < 0 {
-                    /* data compression error condition */
-                    ffpmsg_str("error PLIO compressing image tile (imcomp_compress_tile)");
+            /* cbuf is sized for the worst case, so None is unreachable */
+            nelem = match pl_p2li(idata, 0, &mut cbuf, tilelen.try_into().unwrap()) {
+                Some(n) => n as c_int,
+                None => {
+                    ffpmsg_str("PLIO line list did not fit the tile buffer");
                     *status = DATA_COMPRESSION_ERR;
                     return *status;
                 }
+            };
 
-                /* Write the compressed byte stream. */
-                ffpcli_safe(
-                    outfptr,
-                    (outfptr.Fptr).cn_compressed,
-                    row as LONGLONG,
-                    1,
-                    LONGLONG::from(nelem),
-                    &cbuf,
-                    status,
-                );
+            if nelem < 0 {
+                /* data compression error condition */
+                ffpmsg_str("error PLIO compressing image tile (imcomp_compress_tile)");
+                *status = DATA_COMPRESSION_ERR;
+                return *status;
             }
-            /* =========================================================================== */
-            else if ((outfptr.Fptr).compress_type == GZIP_1)
-                || ((outfptr.Fptr).compress_type == GZIP_2)
-            {
-                let mut gzip_buf: Vec<u8> = Vec::new(); /* compressed output; grown by compress2mem_from_mem */
-                if (outfptr.Fptr).quantize_level == NO_QUANTIZE && datatype == TFLOAT {
-                    /* Special case of losslessly compressing floating point pixels  with GZIP */
-                    /* In this case we compress the input tile array directly */
 
-                    if BYTESWAPPED {
-                        ffswap4(cast_slice_mut(tiledata), tilelen);
-                    }
+            /* Write the compressed byte stream. */
+            ffpcli_safe(
+                outfptr,
+                (outfptr.Fptr).cn_compressed,
+                row as LONGLONG,
+                1,
+                LONGLONG::from(nelem),
+                &cbuf,
+                status,
+            );
+        }
+        /* =========================================================================== */
+        else if ((outfptr.Fptr).compress_type == GZIP_1)
+            || ((outfptr.Fptr).compress_type == GZIP_2)
+        {
+            let mut gzip_buf: Vec<u8> = Vec::new(); /* compressed output; grown by compress2mem_from_mem */
+            if (outfptr.Fptr).quantize_level == NO_QUANTIZE && datatype == TFLOAT {
+                /* Special case of losslessly compressing floating point pixels  with GZIP */
+                /* In this case we compress the input tile array directly */
 
-                    if (outfptr.Fptr).compress_type == GZIP_2 {
-                        fits_shuffle_4bytes(cast_slice_mut(tiledata), tilelen as LONGLONG, status);
-                    }
+                if BYTESWAPPED {
+                    ffswap4(cast_slice_mut(tiledata), tilelen);
+                }
 
+                if (outfptr.Fptr).compress_type == GZIP_2 {
+                    fits_shuffle_4bytes(cast_slice_mut(tiledata), tilelen as LONGLONG, status);
+                }
+
+                unsafe {
                     compress2mem_from_mem(
                         cast_slice(tiledata),
                         tilelen as usize * mem::size_of::<f32>(),
@@ -2795,17 +2791,19 @@ unsafe fn imcomp_compress_tile(
                         Some(&mut gzip_nelem),
                         status,
                     );
-                } else if (outfptr.Fptr).quantize_level == NO_QUANTIZE && datatype == TDOUBLE {
-                    /* Special case of losslessly compressing double pixels with  GZIP */
-                    /* In this case we compress the input tile array directly */
+                }
+            } else if (outfptr.Fptr).quantize_level == NO_QUANTIZE && datatype == TDOUBLE {
+                /* Special case of losslessly compressing double pixels with  GZIP */
+                /* In this case we compress the input tile array directly */
 
-                    if BYTESWAPPED {
-                        ffswap8(cast_slice_mut(tiledata), tilelen);
-                    }
-                    if (outfptr.Fptr).compress_type == GZIP_2 {
-                        fits_shuffle_8bytes(cast_slice_mut(tiledata), tilelen as LONGLONG, status);
-                    }
+                if BYTESWAPPED {
+                    ffswap8(cast_slice_mut(tiledata), tilelen);
+                }
+                if (outfptr.Fptr).compress_type == GZIP_2 {
+                    fits_shuffle_8bytes(cast_slice_mut(tiledata), tilelen as LONGLONG, status);
+                }
 
+                unsafe {
                     compress2mem_from_mem(
                         cast_slice(tiledata),
                         tilelen as usize * mem::size_of::<f64>(),
@@ -2813,30 +2811,28 @@ unsafe fn imcomp_compress_tile(
                         Some(&mut gzip_nelem),
                         status,
                     );
-                } else {
-                    /* compress the integer idata array */
+                }
+            } else {
+                /* compress the integer idata array */
 
-                    if BYTESWAPPED {
-                        let idata: &mut [c_int] = cast_slice_mut(tiledata); /* may overwrite the input tiledata in place */
-
-                        if intlength == 2 {
-                            ffswap2(cast_slice_mut(idata), tilelen);
-                        } else if intlength == 4 {
-                            ffswap4(idata, tilelen);
-                        }
-                    }
+                if BYTESWAPPED {
+                    let idata: &mut [c_int] = cast_slice_mut(tiledata); /* may overwrite the input tiledata in place */
 
                     if intlength == 2 {
-                        if (outfptr.Fptr).compress_type == GZIP_2 {
-                            fits_shuffle_2bytes(
-                                cast_slice_mut(tiledata),
-                                tilelen as LONGLONG,
-                                status,
-                            );
-                        }
+                        ffswap2(cast_slice_mut(idata), tilelen);
+                    } else if intlength == 4 {
+                        ffswap4(idata, tilelen);
+                    }
+                }
 
-                        let idata: &mut [c_int] = cast_slice_mut(tiledata);
+                if intlength == 2 {
+                    if (outfptr.Fptr).compress_type == GZIP_2 {
+                        fits_shuffle_2bytes(cast_slice_mut(tiledata), tilelen as LONGLONG, status);
+                    }
 
+                    let idata: &mut [c_int] = cast_slice_mut(tiledata);
+
+                    unsafe {
                         compress2mem_from_mem(
                             cast_slice_mut(idata),
                             tilelen as usize * mem::size_of::<c_short>(),
@@ -2844,8 +2840,10 @@ unsafe fn imcomp_compress_tile(
                             Some(&mut gzip_nelem),
                             status,
                         );
-                    } else if intlength == 1 {
-                        let idata: &mut [c_int] = cast_slice_mut(tiledata);
+                    }
+                } else if intlength == 1 {
+                    let idata: &mut [c_int] = cast_slice_mut(tiledata);
+                    unsafe {
                         compress2mem_from_mem(
                             cast_slice(idata),
                             tilelen as usize * mem::size_of::<c_uchar>(),
@@ -2853,17 +2851,15 @@ unsafe fn imcomp_compress_tile(
                             Some(&mut gzip_nelem),
                             status,
                         );
-                    } else {
-                        if (outfptr.Fptr).compress_type == GZIP_2 {
-                            fits_shuffle_4bytes(
-                                cast_slice_mut(tiledata),
-                                tilelen as LONGLONG,
-                                status,
-                            );
-                        }
+                    }
+                } else {
+                    if (outfptr.Fptr).compress_type == GZIP_2 {
+                        fits_shuffle_4bytes(cast_slice_mut(tiledata), tilelen as LONGLONG, status);
+                    }
 
-                        let idata: &mut [c_int] = cast_slice_mut(tiledata);
+                    let idata: &mut [c_int] = cast_slice_mut(tiledata);
 
+                    unsafe {
                         compress2mem_from_mem(
                             cast_slice_mut(idata),
                             tilelen as usize * mem::size_of::<c_int>(),
@@ -2873,44 +2869,46 @@ unsafe fn imcomp_compress_tile(
                         );
                     }
                 }
+            }
 
-                /* Write the compressed byte stream. */
-                ffpclb_safe(
-                    outfptr,
-                    LONGLONG::from((outfptr.Fptr).cn_compressed)
-                        .try_into()
-                        .unwrap(),
-                    row as LONGLONG,
-                    1,
-                    gzip_nelem as LONGLONG,
-                    &gzip_buf,
-                    status,
-                );
+            /* Write the compressed byte stream. */
+            ffpclb_safe(
+                outfptr,
+                LONGLONG::from((outfptr.Fptr).cn_compressed)
+                    .try_into()
+                    .unwrap(),
+                row as LONGLONG,
+                1,
+                gzip_nelem as LONGLONG,
+                &gzip_buf,
+                status,
+            );
 
-            /* =========================================================================== */
-            } else if (outfptr.Fptr).compress_type == BZIP2_1 {
-                #[cfg(feature = "bzip2")]
-                {
-                    use libbz2_rs_sys::BZ2_bzBuffToBuffCompress;
+        /* =========================================================================== */
+        } else if (outfptr.Fptr).compress_type == BZIP2_1 {
+            #[cfg(feature = "bzip2")]
+            {
+                use libbz2_rs_sys::BZ2_bzBuffToBuffCompress;
 
-                    if BYTESWAPPED {
-                        let idata: &mut [c_int] = cast_slice_mut(tiledata);
+                if BYTESWAPPED {
+                    let idata: &mut [c_int] = cast_slice_mut(tiledata);
 
-                        if intlength == 2 {
-                            ffswap2(cast_slice_mut(idata), tilelen);
-                        } else if intlength == 4 {
-                            ffswap4(idata, tilelen);
-                        }
+                    if intlength == 2 {
+                        ffswap2(cast_slice_mut(idata), tilelen);
+                    } else if intlength == 4 {
+                        ffswap4(idata, tilelen);
                     }
+                }
 
-                    /* clen counts c_shorts here; the C's is in bytes */
-                    let mut bzlen: c_uint = (clen * 2) as c_uint;
+                /* clen counts c_shorts here; the C's is in bytes */
+                let mut bzlen: c_uint = (clen * 2) as c_uint;
 
-                    /* call bzip2 with blocksize = 900K, verbosity = 0, and default workfactor */
+                /* call bzip2 with blocksize = 900K, verbosity = 0, and default workfactor */
 
-                    /*  bzip2 is not supported in the public release.  This is only for
-                    test purposes. */
-                    if BZ2_bzBuffToBuffCompress(
+                /*  bzip2 is not supported in the public release.  This is only for
+                test purposes. */
+                if unsafe {
+                    BZ2_bzBuffToBuffCompress(
                         cbuf.as_ptr() as *mut c_char,
                         &mut bzlen,
                         tiledata.as_ptr() as *mut _,
@@ -2918,120 +2916,13 @@ unsafe fn imcomp_compress_tile(
                         9,
                         0,
                         0,
-                    ) != 0
-                    {
-                        ffpmsg_str("bzip2 compression error");
-                        *status = DATA_COMPRESSION_ERR;
-                        return *status;
-                    }
-
-                    /* Write the compressed byte stream. */
-                    ffpclb_safe(
-                        outfptr,
-                        (outfptr.Fptr).cn_compressed,
-                        row as LONGLONG,
-                        1,
-                        LONGLONG::from(bzlen),
-                        cast_slice_mut(&mut cbuf),
-                        status,
-                    );
+                    )
+                } != 0
+                {
+                    ffpmsg_str("bzip2 compression error");
+                    *status = DATA_COMPRESSION_ERR;
+                    return *status;
                 }
-
-            /* =========================================================================== */
-            } else if (outfptr.Fptr).compress_type == HCOMPRESS_1 {
-                /*
-                if hcompscale is positive, then we have to multiply
-                the value by the RMS background noise to get the
-                absolute scale value.  If negative, then it gives the
-                absolute scale value directly.
-                */
-                hcompscale = (outfptr.Fptr).hcomp_scale;
-
-                if hcompscale > 0.0 {
-                    let idata: &mut [c_int] = cast_slice_mut(tiledata);
-
-                    fits_img_stats_int_safe(
-                        idata,
-                        tilenx,
-                        tileny,
-                        nullcheck != NullCheckType::None,
-                        nullval,
-                        None,
-                        None,
-                        None,
-                        None,
-                        None,
-                        None,
-                        Some(&mut noise2),
-                        Some(&mut noise3),
-                        Some(&mut noise5),
-                        status,
-                    );
-
-                    /* use the minimum of the 3 noise estimates */
-                    if noise2 != 0. && noise2 < noise3 {
-                        noise3 = noise2;
-                    }
-                    if noise5 != 0. && noise5 < noise3 {
-                        noise3 = noise5;
-                    }
-
-                    hcompscale = (f64::from(hcompscale) * noise3) as f32;
-                } else if hcompscale < 0.0 {
-                    hcompscale = -hcompscale;
-                }
-
-                ihcompscale = (hcompscale + 0.5) as c_int;
-
-                /* clen counts c_shorts here; the C's is in bytes */
-                hcomp_len = (clen * 2) as c_long; /* allocated size of the buffer */
-
-                /* The C gets the compressed length back from fits_hcompress.
-                HCEncoder returns none, so take it from how far it advanced the
-                output slice -- `Write for &mut [u8]' consumes as it writes. */
-                let mut out: &mut [u8] = cast_slice_mut(&mut cbuf);
-                let capacity = out.len();
-
-                if zbitpix == BYTE_IMG || zbitpix == SHORT_IMG {
-                    let idata: &mut [c_int] = cast_slice_mut(tiledata);
-
-                    let mut hc_enconder = HCEncoder::new(&mut out);
-
-                    let encode_res = hc_enconder.write(
-                        idata,
-                        tilenx.try_into().unwrap(),
-                        tileny.try_into().unwrap(),
-                        ihcompscale,
-                    );
-
-                    if let Err(_e) = encode_res {
-                        *status = DATA_COMPRESSION_ERR;
-                        return *status;
-                    }
-                } else {
-                    /* have to convert idata to an I*8 array, in place */
-                    /* idata must have been allocated large enough to do this */
-                    let idata: &mut [c_int] = cast_slice_mut(tiledata);
-
-                    fits_int_to_longlong_inplace(idata, tilelen, status);
-
-                    let lldata: &mut [LONGLONG] = cast_slice_mut(idata);
-                    let mut hc_enconder = HCEncoder::new(&mut out);
-
-                    let encode_res = hc_enconder.write64(
-                        lldata,
-                        tilenx.try_into().unwrap(),
-                        tileny.try_into().unwrap(),
-                        ihcompscale,
-                    );
-
-                    if let Err(_e) = encode_res {
-                        *status = DATA_COMPRESSION_ERR;
-                        return *status;
-                    }
-                }
-
-                hcomp_len = (capacity - out.len()) as c_long;
 
                 /* Write the compressed byte stream. */
                 ffpclb_safe(
@@ -3039,111 +2930,220 @@ unsafe fn imcomp_compress_tile(
                     (outfptr.Fptr).cn_compressed,
                     row as LONGLONG,
                     1,
-                    hcomp_len as LONGLONG,
-                    cast_slice(&cbuf),
+                    LONGLONG::from(bzlen),
+                    cast_slice_mut(&mut cbuf),
                     status,
                 );
             }
 
-            /* =========================================================================== */
-            if (outfptr.Fptr).cn_zscale > 0 {
-                /* write the linear scaling parameters for this tile */
-                ffpcld_safe(
-                    outfptr,
-                    (outfptr.Fptr).cn_zscale,
-                    row as LONGLONG,
-                    1,
-                    1,
-                    &bscale,
+        /* =========================================================================== */
+        } else if (outfptr.Fptr).compress_type == HCOMPRESS_1 {
+            /*
+            if hcompscale is positive, then we have to multiply
+            the value by the RMS background noise to get the
+            absolute scale value.  If negative, then it gives the
+            absolute scale value directly.
+            */
+            hcompscale = (outfptr.Fptr).hcomp_scale;
+
+            if hcompscale > 0.0 {
+                let idata: &mut [c_int] = cast_slice_mut(tiledata);
+
+                fits_img_stats_int_safe(
+                    idata,
+                    tilenx,
+                    tileny,
+                    nullcheck != NullCheckType::None,
+                    nullval,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    Some(&mut noise2),
+                    Some(&mut noise3),
+                    Some(&mut noise5),
                     status,
                 );
-                ffpcld_safe(
-                    outfptr,
-                    (outfptr.Fptr).cn_zzero,
-                    row as LONGLONG,
-                    1,
-                    1,
-                    &bzero,
-                    status,
-                );
-            }
 
-            /* finished with this buffer */
-
-            /* =========================================================================== */
-        } else {
-            /* if flag == 0., floating point data couldn't be quantized */
-
-            /* losslessly compress the data with gzip. */
-
-            /* if gzip2 compressed data column doesn't exist, create it */
-            if (outfptr.Fptr).cn_gzip_data < 1 {
-                if (outfptr.Fptr).request_huge_hdu != 0 {
-                    fits_insert_col(
-                        outfptr,
-                        999,
-                        cs!(c"GZIP_COMPRESSED_DATA"),
-                        cs!(c"1QB"),
-                        status,
-                    );
-                } else {
-                    fits_insert_col(
-                        outfptr,
-                        999,
-                        cs!(c"GZIP_COMPRESSED_DATA"),
-                        cs!(c"1PB"),
-                        status,
-                    );
+                /* use the minimum of the 3 noise estimates */
+                if noise2 != 0. && noise2 < noise3 {
+                    noise3 = noise2;
+                }
+                if noise5 != 0. && noise5 < noise3 {
+                    noise3 = noise5;
                 }
 
-                if *status <= 0 {
-                    /* save the number of this column */
-                    let mut cn_gzip_data: c_int = 0;
-                    ffgcno_safe(
-                        outfptr,
-                        CASEINSEN.try_into().unwrap(),
-                        cs!(c"GZIP_COMPRESSED_DATA"),
-                        &mut cn_gzip_data,
-                        status,
-                    );
-                    outfptr.Fptr.cn_gzip_data = cn_gzip_data;
-                }
+                hcompscale = (f64::from(hcompscale) * noise3) as f32;
+            } else if hcompscale < 0.0 {
+                hcompscale = -hcompscale;
             }
 
-            let mut gzip_buf: Vec<u8> = Vec::new(); /* compressed output; grown by compress2mem_from_mem */
-            if datatype == TFLOAT {
-                /* allocate buffer for the compressed tile bytes */
-                /* make it 10% larger than the original uncompressed data */
+            ihcompscale = (hcompscale + 0.5) as c_int;
 
-                clen = (tilelen as f64 * mem::size_of::<f32>() as f64 * 1.1 / 2.0) as usize; // Divide by 2 to convert char to short.
+            /* clen counts c_shorts here; the C's is in bytes */
+            hcomp_len = (clen * 2) as c_long; /* allocated size of the buffer */
 
-                cbuf = Vec::new();
+            /* The C gets the compressed length back from fits_hcompress.
+            HCEncoder returns none, so take it from how far it advanced the
+            output slice -- `Write for &mut [u8]' consumes as it writes. */
+            let mut out: &mut [u8] = cast_slice_mut(&mut cbuf);
+            let capacity = out.len();
 
-                if cbuf.try_reserve_exact(clen).is_err() {
-                    ffpmsg_str("Memory allocation error. (imcomp_compress_tile)");
-                    *status = MEMORY_ALLOCATION;
+            if zbitpix == BYTE_IMG || zbitpix == SHORT_IMG {
+                let idata: &mut [c_int] = cast_slice_mut(tiledata);
+
+                let mut hc_enconder = HCEncoder::new(&mut out);
+
+                let encode_res = hc_enconder.write(
+                    idata,
+                    tilenx.try_into().unwrap(),
+                    tileny.try_into().unwrap(),
+                    ihcompscale,
+                );
+
+                if let Err(_e) = encode_res {
+                    *status = DATA_COMPRESSION_ERR;
                     return *status;
-                } else {
-                    cbuf.resize(clen, 0);
                 }
+            } else {
+                /* have to convert idata to an I*8 array, in place */
+                /* idata must have been allocated large enough to do this */
+                let idata: &mut [c_int] = cast_slice_mut(tiledata);
 
-                /* convert null values to NaNs in place, if necessary */
-                if nullcheck == NullCheckType::SetPixel {
-                    let nv = nullflagval.clone().unwrap(); // Must be set if nullcheck is SetPixel
-                    imcomp_float2nan_inplace(
-                        cast_slice_mut(tiledata),
-                        tilelen,
-                        nv.get_value_as_f64() as f32,
-                        status,
-                    );
+                fits_int_to_longlong_inplace(idata, tilelen, status);
+
+                let lldata: &mut [LONGLONG] = cast_slice_mut(idata);
+                let mut hc_enconder = HCEncoder::new(&mut out);
+
+                let encode_res = hc_enconder.write64(
+                    lldata,
+                    tilenx.try_into().unwrap(),
+                    tileny.try_into().unwrap(),
+                    ihcompscale,
+                );
+
+                if let Err(_e) = encode_res {
+                    *status = DATA_COMPRESSION_ERR;
+                    return *status;
                 }
+            }
 
-                if BYTESWAPPED {
-                    ffswap4(cast_slice_mut(tiledata), tilelen);
-                }
+            hcomp_len = (capacity - out.len()) as c_long;
 
-                // WARNING: Potentially unsafe memory issue here given this function
-                // call can reallocate the buffer.
+            /* Write the compressed byte stream. */
+            ffpclb_safe(
+                outfptr,
+                (outfptr.Fptr).cn_compressed,
+                row as LONGLONG,
+                1,
+                hcomp_len as LONGLONG,
+                cast_slice(&cbuf),
+                status,
+            );
+        }
+
+        /* =========================================================================== */
+        if (outfptr.Fptr).cn_zscale > 0 {
+            /* write the linear scaling parameters for this tile */
+            ffpcld_safe(
+                outfptr,
+                (outfptr.Fptr).cn_zscale,
+                row as LONGLONG,
+                1,
+                1,
+                &bscale,
+                status,
+            );
+            ffpcld_safe(
+                outfptr,
+                (outfptr.Fptr).cn_zzero,
+                row as LONGLONG,
+                1,
+                1,
+                &bzero,
+                status,
+            );
+        }
+
+        /* finished with this buffer */
+
+        /* =========================================================================== */
+    } else {
+        /* if flag == 0., floating point data couldn't be quantized */
+
+        /* losslessly compress the data with gzip. */
+
+        /* if gzip2 compressed data column doesn't exist, create it */
+        if (outfptr.Fptr).cn_gzip_data < 1 {
+            if (outfptr.Fptr).request_huge_hdu != 0 {
+                fits_insert_col(
+                    outfptr,
+                    999,
+                    cs!(c"GZIP_COMPRESSED_DATA"),
+                    cs!(c"1QB"),
+                    status,
+                );
+            } else {
+                fits_insert_col(
+                    outfptr,
+                    999,
+                    cs!(c"GZIP_COMPRESSED_DATA"),
+                    cs!(c"1PB"),
+                    status,
+                );
+            }
+
+            if *status <= 0 {
+                /* save the number of this column */
+                let mut cn_gzip_data: c_int = 0;
+                ffgcno_safe(
+                    outfptr,
+                    CASEINSEN.try_into().unwrap(),
+                    cs!(c"GZIP_COMPRESSED_DATA"),
+                    &mut cn_gzip_data,
+                    status,
+                );
+                outfptr.Fptr.cn_gzip_data = cn_gzip_data;
+            }
+        }
+
+        let mut gzip_buf: Vec<u8> = Vec::new(); /* compressed output; grown by compress2mem_from_mem */
+        if datatype == TFLOAT {
+            /* allocate buffer for the compressed tile bytes */
+            /* make it 10% larger than the original uncompressed data */
+
+            clen = (tilelen as f64 * mem::size_of::<f32>() as f64 * 1.1 / 2.0) as usize; // Divide by 2 to convert char to short.
+
+            cbuf = Vec::new();
+
+            if cbuf.try_reserve_exact(clen).is_err() {
+                ffpmsg_str("Memory allocation error. (imcomp_compress_tile)");
+                *status = MEMORY_ALLOCATION;
+                return *status;
+            } else {
+                cbuf.resize(clen, 0);
+            }
+
+            /* convert null values to NaNs in place, if necessary */
+            if nullcheck == NullCheckType::SetPixel {
+                let nv = nullflagval.clone().unwrap(); // Must be set if nullcheck is SetPixel
+                imcomp_float2nan_inplace(
+                    cast_slice_mut(tiledata),
+                    tilelen,
+                    nv.get_value_as_f64() as f32,
+                    status,
+                );
+            }
+
+            if BYTESWAPPED {
+                ffswap4(cast_slice_mut(tiledata), tilelen);
+            }
+
+            // WARNING: Potentially unsafe memory issue here given this function
+            // call can reallocate the buffer.
+            unsafe {
                 compress2mem_from_mem(
                     cast_slice(tiledata),
                     tilelen as usize * mem::size_of::<f32>(),
@@ -3151,37 +3151,39 @@ unsafe fn imcomp_compress_tile(
                     Some(&mut gzip_nelem),
                     status,
                 );
+            }
+        } else {
+            /* datatype == TDOUBLE */
+
+            /* allocate buffer for the compressed tile bytes */
+            /* make it 10% larger than the original uncompressed data */
+            clen = (tilelen as f64 * mem::size_of::<f64>() as f64 * 1.1 / 2.0) as usize; // Divide by 2 to convert char to short
+            if cbuf.try_reserve_exact(clen).is_err() {
+                ffpmsg_str("Memory allocation error. (imcomp_compress_tile)");
+                *status = MEMORY_ALLOCATION;
+                return *status;
             } else {
-                /* datatype == TDOUBLE */
+                cbuf.resize(clen, 0);
+            }
 
-                /* allocate buffer for the compressed tile bytes */
-                /* make it 10% larger than the original uncompressed data */
-                clen = (tilelen as f64 * mem::size_of::<f64>() as f64 * 1.1 / 2.0) as usize; // Divide by 2 to convert char to short
-                if cbuf.try_reserve_exact(clen).is_err() {
-                    ffpmsg_str("Memory allocation error. (imcomp_compress_tile)");
-                    *status = MEMORY_ALLOCATION;
-                    return *status;
-                } else {
-                    cbuf.resize(clen, 0);
-                }
+            /* convert null values to NaNs in place, if necessary */
+            if nullcheck == NullCheckType::SetPixel {
+                let nv = nullflagval.clone().unwrap(); // Must be set if nullcheck is SetPixel
+                imcomp_double2nan_inplace(
+                    cast_slice_mut(tiledata),
+                    tilelen,
+                    nv.get_value_as_f64(),
+                    status,
+                );
+            }
 
-                /* convert null values to NaNs in place, if necessary */
-                if nullcheck == NullCheckType::SetPixel {
-                    let nv = nullflagval.clone().unwrap(); // Must be set if nullcheck is SetPixel
-                    imcomp_double2nan_inplace(
-                        cast_slice_mut(tiledata),
-                        tilelen,
-                        nv.get_value_as_f64(),
-                        status,
-                    );
-                }
+            if BYTESWAPPED {
+                ffswap8(cast_slice_mut(tiledata), tilelen);
+            }
 
-                if BYTESWAPPED {
-                    ffswap8(cast_slice_mut(tiledata), tilelen);
-                }
-
-                // WARNING: Potentially unsafe memory issue here given this function
-                // call can reallocate the buffer.
+            // WARNING: Potentially unsafe memory issue here given this function
+            // call can reallocate the buffer.
+            unsafe {
                 compress2mem_from_mem(
                     cast_slice_mut(tiledata),
                     tilelen as usize * mem::size_of::<f64>(),
@@ -3190,48 +3192,48 @@ unsafe fn imcomp_compress_tile(
                     status,
                 );
             }
+        }
 
-            /* Write the compressed byte stream. */
+        /* Write the compressed byte stream. */
+        ffpclb_safe(
+            outfptr,
+            (outfptr.Fptr).cn_gzip_data,
+            row as LONGLONG,
+            1,
+            gzip_nelem.try_into().unwrap(),
+            &gzip_buf,
+            status,
+        );
+
+        /* we must zero out existing existing compressed data if it exists. */
+        /* otherwise on read this data is read ahead of the gzipped */
+        /* data and will cause a bug. */
+        let mut _test_nelemll: LONGLONG = 0;
+        let mut _test_offset: LONGLONG = 0;
+        ffgdesll_safe(
+            outfptr,
+            (outfptr.Fptr).cn_compressed,
+            row.into(),
+            Some(&mut _test_nelemll),
+            Some(&mut _test_offset),
+            status,
+        );
+        if _test_nelemll != 0 {
             ffpclb_safe(
-                outfptr,
-                (outfptr.Fptr).cn_gzip_data,
-                row as LONGLONG,
-                1,
-                gzip_nelem.try_into().unwrap(),
-                &gzip_buf,
-                status,
-            );
-
-            /* we must zero out existing existing compressed data if it exists. */
-            /* otherwise on read this data is read ahead of the gzipped */
-            /* data and will cause a bug. */
-            let mut _test_nelemll: LONGLONG = 0;
-            let mut _test_offset: LONGLONG = 0;
-            ffgdesll_safe(
                 outfptr,
                 (outfptr.Fptr).cn_compressed,
                 row.into(),
-                Some(&mut _test_nelemll),
-                Some(&mut _test_offset),
+                1,
+                0,
+                &[],
                 status,
             );
-            if _test_nelemll != 0 {
-                ffpclb_safe(
-                    outfptr,
-                    (outfptr.Fptr).cn_compressed,
-                    row.into(),
-                    1,
-                    0,
-                    &[],
-                    status,
-                );
-            }
-
-            /* finished with this buffer */
         }
 
-        *status
+        /* finished with this buffer */
     }
+
+    *status
 }
 
 /*--------------------------------------------------------------------------*/
@@ -5065,20 +5067,18 @@ pub(crate) fn fits_write_compressed_img(
                             );
 
                             /* compress the tile again, and write it back to the FITS file */
-                            unsafe {
-                                imcomp_compress_tile(
-                                    fptr,
-                                    irow,
-                                    datatype,
-                                    cast_slice_mut(buffer),
-                                    thistilesize[0],
-                                    trowsize,
-                                    ntrows,
-                                    nullcheck,
-                                    nullval,
-                                    status,
-                                );
-                            }
+                            imcomp_compress_tile(
+                                fptr,
+                                irow,
+                                datatype,
+                                cast_slice_mut(buffer),
+                                thistilesize[0],
+                                trowsize,
+                                ntrows,
+                                nullcheck,
+                                nullval,
+                                status,
+                            );
                         }
                     }
                 }

--- a/src/putkey.rs
+++ b/src/putkey.rs
@@ -6780,7 +6780,87 @@ mod tests {
         });
     }
 
-    // skipped: fftm2s_safe is todo!() (test_putkey_datetime relies on fftm2s/ffs2tm chains)
+    /// Mirrors test_putkey_datetime in ~/code/cfitsio/tests/test_putkey.c
+    #[test]
+    fn test_putkey_datetime() {
+        let mut status: c_int = 0;
+        let mut yr: c_int = 0;
+        let mut mon: c_int = 0;
+        let mut day: c_int = 0;
+        let mut hr: c_int = 0;
+        let mut min: c_int = 0;
+        let mut sec: c_double = 0.0;
+        let mut datestr = [0 as c_char; 11];
+        let mut timestr = [0 as c_char; 30];
+
+        /* ffdt2s - convert date to string (new format) */
+        fits_date2str(2024, 1, 15, &mut datestr, &mut status);
+        assert_eq!(status, 0);
+        assert_eq!(from_buf(&datestr), "2024-01-15");
+
+        /* ffdt2s - old format date (year 1900-1998) */
+        fits_date2str(1995, 6, 15, &mut datestr, &mut status);
+        assert_eq!(status, 0);
+        assert_eq!(from_buf(&datestr), "15/06/95");
+
+        /* ffs2dt - convert string to date */
+        fits_str2date(
+            Some(&cc("2024-06-20")),
+            Some(&mut yr),
+            Some(&mut mon),
+            Some(&mut day),
+            &mut status,
+        );
+        assert_eq!(status, 0);
+        assert_eq!((yr, mon, day), (2024, 6, 20));
+
+        /* old-style date format */
+        fits_str2date(
+            Some(&cc("15/03/99")),
+            Some(&mut yr),
+            Some(&mut mon),
+            Some(&mut day),
+            &mut status,
+        );
+        assert_eq!(status, 0);
+        assert_eq!((yr, mon, day), (1999, 3, 15));
+
+        /* fftm2s - convert date-time to string */
+        fits_time2str(2024, 7, 4, 12, 30, 45.5, 3, &mut timestr, &mut status);
+        assert_eq!(status, 0);
+        assert_eq!(&from_buf(&timestr)[..19], "2024-07-04T12:30:45");
+
+        /* fftm2s with 0 decimals */
+        fits_time2str(2024, 8, 15, 10, 20, 30.0, 0, &mut timestr, &mut status);
+        assert_eq!(status, 0);
+        assert_eq!(&from_buf(&timestr)[..19], "2024-08-15T10:20:30");
+
+        /* fftm2s with negative decimals (date only) */
+        fits_time2str(2024, 9, 1, 0, 0, 0.0, -1, &mut timestr, &mut status);
+        assert_eq!(status, 0);
+        assert_eq!(from_buf(&timestr), "2024-09-01");
+
+        /* fftm2s with time only (year=month=day=0) */
+        fits_time2str(0, 0, 0, 14, 30, 45.5, 3, &mut timestr, &mut status);
+        assert_eq!(status, 0);
+        assert_eq!(&from_buf(&timestr)[..8], "14:30:45");
+
+        /* ffs2tm - convert string to date-time */
+        fits_str2time(
+            Some(&cc("2024-12-25T08:15:30.123")),
+            Some(&mut yr),
+            Some(&mut mon),
+            Some(&mut day),
+            Some(&mut hr),
+            Some(&mut min),
+            Some(&mut sec),
+            &mut status,
+        );
+        assert_eq!(status, 0);
+        assert_eq!((yr, mon, day), (2024, 12, 25));
+        assert_eq!((hr, min), (8, 15));
+        assert!((sec - 30.123).abs() < 1e-6, "second = {sec}");
+    }
 
     #[test]
     fn test_putkey_tdim() {
@@ -7041,7 +7121,57 @@ mod tests {
         });
     }
 
-    // skipped: ffphext_safe is todo!() (test_putkey_exthead)
+    /// Mirrors test_putkey_exthead in ~/code/cfitsio/tests/test_putkey.c
+    #[test]
+    fn test_putkey_exthead() {
+        with_temp_file(|filename| {
+            let mut status: c_int = 0;
+            let name = to_buf(filename);
+            let naxes: [c_long; 2] = [50, 50];
+
+            let mut f: Option<Box<fitsfile>> = None;
+            fits_create_file(&mut f, &name, &mut status);
+            fits_write_imghdr(f.as_deref_mut().unwrap(), BYTE_IMG, 0, &[], &mut status);
+            fits_create_hdu(f.as_deref_mut().unwrap(), &mut status);
+            fits_write_exthdr(
+                f.as_deref_mut().unwrap(),
+                &cc("IMAGE"),
+                16,
+                2,
+                &naxes,
+                0,
+                1,
+                &mut status,
+            );
+            assert_eq!(status, 0, "ffphext failed");
+            fits_close_file(f.take().unwrap(), &mut status);
+            assert_eq!(status, 0);
+
+            /* the C stops there; check the keywords actually landed */
+            fits_open_file(&mut f, &name, READONLY, &mut status);
+            let mut hdutype: c_int = 0;
+            fits_movabs_hdu(
+                f.as_deref_mut().unwrap(),
+                2,
+                Some(&mut hdutype),
+                &mut status,
+            );
+            assert_eq!(status, 0);
+            assert_eq!(hdutype, IMAGE_HDU);
+
+            let mut bitpix: c_int = 0;
+            let mut naxis: c_int = 0;
+            let mut naxes_out = [0 as c_long; 2];
+            fits_get_img_type(f.as_deref_mut().unwrap(), &mut bitpix, &mut status);
+            fits_get_img_dim(f.as_deref_mut().unwrap(), &mut naxis, &mut status);
+            fits_get_img_size(f.as_deref_mut().unwrap(), 2, &mut naxes_out, &mut status);
+            assert_eq!(status, 0);
+            assert_eq!(bitpix, SHORT_IMG);
+            assert_eq!(naxis, 2);
+            assert_eq!(naxes_out, [50, 50]);
+            fits_close_file(f.take().unwrap(), &mut status);
+        });
+    }
 
     #[test]
     fn test_putkey_updates() {
@@ -7418,7 +7548,37 @@ mod tests {
         assert_eq!(status, BAD_DATE);
     }
 
-    // skipped: fftm2s_safe is todo!() (test_putkey_time_errors)
+    /// Mirrors test_putkey_time_errors in ~/code/cfitsio/tests/test_putkey.c
+    #[test]
+    fn test_putkey_time_errors() {
+        let mut timestr = [0 as c_char; 40];
+
+        /* each out-of-range field must be rejected with BAD_DATE */
+        let cases: [(c_int, c_int, c_int, c_int, c_int, c_double, &str); 6] = [
+            (10000, 1, 1, 0, 0, 0.0, "year > 9999"),
+            (2024, 13, 1, 0, 0, 0.0, "month > 12"),
+            (2024, 1, 32, 0, 0, 0.0, "day > 31"),
+            (2024, 1, 1, 24, 0, 0.0, "hour > 23"),
+            (2024, 1, 1, 0, 60, 0.0, "minute > 59"),
+            (2024, 1, 1, 0, 0, 61.0, "second >= 61"),
+        ];
+
+        for (year, month, day, hour, minute, second, what) in cases {
+            let mut status: c_int = 0;
+            fits_time2str(
+                year,
+                month,
+                day,
+                hour,
+                minute,
+                second,
+                0,
+                &mut timestr,
+                &mut status,
+            );
+            assert_eq!(status, BAD_DATE, "fftm2s accepted {what}");
+        }
+    }
 
     #[test]
     fn test_putkey_verifydate_errors() {
@@ -7772,7 +7932,47 @@ mod tests {
         });
     }
 
-    // skipped: ffphext_safe is todo!() (test_putkey_extheader_3d)
+    /// Mirrors test_putkey_extheader_3d in ~/code/cfitsio/tests/test_putkey.c
+    #[test]
+    fn test_putkey_extheader_3d() {
+        with_temp_file(|filename| {
+            let mut status: c_int = 0;
+            let name = to_buf(filename);
+            let naxes: [c_long; 3] = [10, 20, 5];
+
+            let mut f: Option<Box<fitsfile>> = None;
+            fits_create_file(&mut f, &name, &mut status);
+            fits_write_imghdr(f.as_deref_mut().unwrap(), BYTE_IMG, 0, &[], &mut status);
+            fits_create_hdu(f.as_deref_mut().unwrap(), &mut status);
+            fits_write_exthdr(
+                f.as_deref_mut().unwrap(),
+                &cc("IMAGE"),
+                32,
+                3,
+                &naxes,
+                0,
+                1,
+                &mut status,
+            );
+            assert_eq!(status, 0, "ffphext failed");
+            fits_close_file(f.take().unwrap(), &mut status);
+            assert_eq!(status, 0);
+
+            fits_open_file(&mut f, &name, READONLY, &mut status);
+            fits_movabs_hdu(f.as_deref_mut().unwrap(), 2, None, &mut status);
+            let mut bitpix: c_int = 0;
+            let mut naxis: c_int = 0;
+            let mut naxes_out = [0 as c_long; 3];
+            fits_get_img_type(f.as_deref_mut().unwrap(), &mut bitpix, &mut status);
+            fits_get_img_dim(f.as_deref_mut().unwrap(), &mut naxis, &mut status);
+            fits_get_img_size(f.as_deref_mut().unwrap(), 3, &mut naxes_out, &mut status);
+            assert_eq!(status, 0);
+            assert_eq!(bitpix, LONG_IMG);
+            assert_eq!(naxis, 3);
+            assert_eq!(naxes_out, [10, 20, 5]);
+            fits_close_file(f.take().unwrap(), &mut status);
+        });
+    }
 
     #[test]
     fn test_putkey_empty_string() {
@@ -7810,7 +8010,22 @@ mod tests {
         });
     }
 
-    // skipped: fftm2s_safe is todo!() (test_putkey_timeonly)
+    /// Mirrors test_putkey_timeonly in ~/code/cfitsio/tests/test_putkey.c
+    #[test]
+    fn test_putkey_timeonly() {
+        let mut status: c_int = 0;
+        let mut timestr = [0 as c_char; 40];
+
+        /* year = month = day = 0 selects the time-only format hh:mm:ss.ddd */
+        fits_time2str(0, 0, 0, 14, 30, 45.5, 3, &mut timestr, &mut status);
+        assert_eq!(status, 0);
+
+        let got = from_buf(&timestr);
+        assert!(got.len() >= 8, "too short: {got:?}");
+        assert_eq!(got.as_bytes()[2], b':');
+        assert_eq!(got.as_bytes()[5], b':');
+        assert_eq!(got, "14:30:45.500");
+    }
 
     #[test]
     fn test_putkey_date_edge_cases() {


### PR DESCRIPTION
Two pieces of work, plus two unrelated commits that were already sitting on this branch.

## Transpile the remaining `cfileio` stubs (`d33e985`)

Line-by-line ports of `fits_copy_image2cell`, `fits_select_image_section`, `fits_copy_image_section`, `ffselect_table` and `fits_split_names`, replacing their `todo!()`s. Variable names, structure and the C's comments are kept.

Three translations worth noting. The `char *cptr` that walks the section specifier becomes a `usize` offset, which is what `fits_get_section_range_safe` already takes. The malloc'd `double *` row buffer that the C casts per bitpix becomes one `Vec<f64>` viewed through `cast_slice_mut` in each branch, so the allocation and alignment match. And the two HISTORY strings `fits_copy_image2cell` builds are omitted — both `ffprec()` calls that would write them are commented out upstream, so neither string is ever used, which is how the already-ported `fits_copy_cell2image` handles it too.

`fits_split_names` takes `*mut c_char`, matching the `char *` in `c/fitsio.h` — the `*const` it had was a straight mismatch with the header this crate ships, and forced a `.cast_mut()` in the body to do the very thing the signature disclaimed. It now measures the caller's buffer once and drives the scan as bounds-checked indexing into a slice, taking the unsafe surface from ~20 raw derefs and pointer increments down to two one-liners: measuring, and rebuilding the slice per call. Its cursor is a `thread_local`, so the tests stay parallel-safe.

**Upstream bug, fixed here.** `fits_copy_image_section` passes the file's NAXIS — up to 99 — as the length of a 9-element `long naxes[]`, so an image with NAXIS >= 10 smashes that stack array before the `naxis > 4` check runs. `ffgisz` writes `min(imgdim, nlen)` entries (`cfitsio fitscore.c:7745`), and the pasted code matches upstream verbatim; it is reachable by opening such a file with any section filter. Clamped to the array length: identical for every naxis the C accepts, and the oversized cases now reach the `BAD_NAXIS` error the C already intends to return. `test_copy_image_section_too_many_axes` covers it.

**One thing left deliberately undone.** `ffselect_table`'s in-place branch still bridges through a raw pointer to hand `ffsrow_safe` the aliased `infptr`/`outfptr` the C gives it. That is two live `&mut` to one object, i.e. UB rather than merely ugly, and it is marked `TODO` at the site. The clean fix is an `Option<&mut fitsfile>` output parameter on `ffsrow_safe`, but `outfptr` appears ~29 times interleaved with `infptr` across its 360-line copy loop, so that is a real refactor rather than a mechanical one. Flagging it rather than folding it in.

## Un-skip the tests whose blockers were already implemented (`a02d63b`)

Most of the `"X is todo!()"` skip reasons were stale. Of the nine functions named, only `ffihtps_safe`/`ffchtps_safe` are still stubs — `fftm2s_safe`, `ffphext_safe`, `ffphpsll_safe`, `ffexist_safer`, `ffextn_safer`, `ffimem_safer` and `fits_copy_cell2image_safe` are all implemented. Fourteen tests come back, written from the matching cases in `cfitsio/tests` and named after them.

Where the C only checks that a call returns 0, these read the result back: `test_putkey_exthead`/`_extheader_3d` reopen the file and verify BITPIX/NAXIS/NAXISn, and `test_fits_copy_cell2image` checks all 25 pixels as well as the header. `test_ffimem`/`test_ffomem` exercise the realloc-backed driver path, which the existing `test_ffimem_create_write_read` does not.

The C's three `ffextn` cases are dropped rather than duplicated — `test_ffextn_extension_number`, `test_ffextn_no_extension` and `test_ffextn_binning_returns_one` already cover them, with an extra case each.

Ignored tests: 17 -> 7. What remains is deliberate: four `eval_f` cases gated on Windows `long long`, the 5-D IRAF case `iraftofits` cannot represent, the `edithdu` shared-`Fptr` double free, and `test_ffihtps`, whose reason now reads "still todo!()" so it does not look stale like the others did.

## Also on this branch

`9834eed` is a `rustfmt` pass over `src/bin/fitsverify/` and `fitscore.rs`, and `883203b` narrows `unsafe` in `imcompress.rs` from whole functions (`imcomp_compress_image`, `imcomp_compress_tile`) down to the individual operations. Both were committed to this branch separately and are unrelated to the two above; say the word if they should go somewhere else instead.

## Verification

`cargo test` 30/30 binaries green, 0 failures, 2340 lib tests. `cargo fmt --check` clean across the repo. Clippy unchanged at its pre-existing 126 (all `std_instead_of_alloc`/`std_instead_of_core` from macros in `lib.rs` and `drvrfile.rs`).

The `fits_split_names` expectations were checked against the C compiled standalone — it does **not** merge consecutive delimiters despite the strtok comparison in its doc comment, so `"   a.fits ,, b.fits"` yields `["a.fits", "", "", "b.fits"]`. My first draft of that test assumed otherwise and was wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CnuucR9Sw9aG7AxsQdKX28