### PR TITLE
Fix all clippy failures

### DIFF
--- a/src/bin/fitsverify/fvrf_data.rs
+++ b/src/bin/fitsverify/fvrf_data.rs
@@ -985,15 +985,16 @@ fn test_agap(
                     wrterr(out, &errmes, 1);
                 }
                 nerr += 1;
-            } else if isascii_c(c as c_char) && !isprint_c(c as c_char) {
-                if temp[(j % rowlen) as usize] != 0 {
-                    if nerr == 0 {
-                        spf!(errmes; "row ", (j / rowlen + 1) as i64,
-                            " data contains non-ASCII-text characters.");
-                        wrterr(out, &errmes, 1);
-                    }
-                    nerr += 1;
+            } else if isascii_c(c as c_char)
+                && !isprint_c(c as c_char)
+                && temp[(j % rowlen) as usize] != 0
+            {
+                if nerr == 0 {
+                    spf!(errmes; "row ", (j / rowlen + 1) as i64,
+                        " data contains non-ASCII-text characters.");
+                    wrterr(out, &errmes, 1);
                 }
+                nerr += 1;
             }
             p += 1;
             j += 1;

--- a/src/bin/fitsverify/fvrf_file.rs
+++ b/src/bin/fitsverify/fvrf_file.rs
@@ -40,12 +40,14 @@ fn init_hduname() {
         let mut h = h.borrow_mut();
         h.clear();
         for _i in 0..totalhdu() {
-            let mut e = HduName::default();
-            e.hdutype = -1;
-            e.errnum = 0;
-            e.wrnno = 0;
+            let mut e = HduName {
+                hdutype: -1,
+                errnum: 0,
+                wrnno: 0,
+                extver: 0,
+                ..Default::default()
+            };
             e.extname[0] = 0;
-            e.extver = 0;
             h.push(e);
         }
     });

--- a/src/bin/fitsverify/fvrf_head.rs
+++ b/src/bin/fitsverify/fvrf_head.rs
@@ -1246,14 +1246,13 @@ fn test_prm(
 
     if hduptr.isgroup == 0 {
         key_match(&tmpkwds, numusrkey, cs!(c"EXTEND"), 1, &mut k, &mut n);
-        if k > 0 {
-            if check_log(&hduptr.kwds[k as usize], out) != 0
-                && hduptr.kwds[k as usize].kvalue[0] as u8 != b'T'
-                && totalhdu() > 1
-            {
-                spf!(errmes; "There are extensions but EXTEND = F.");
-                wrterr(out, &errmes, 1);
-            }
+        if k > 0
+            && check_log(&hduptr.kwds[k as usize], out) != 0
+            && hduptr.kwds[k as usize].kvalue[0] as u8 != b'T'
+            && totalhdu() > 1
+        {
+            spf!(errmes; "There are extensions but EXTEND = F.");
+            wrterr(out, &errmes, 1);
         }
     }
 

--- a/src/bin/fitsverify/fvrf_head.rs
+++ b/src/bin/fitsverify/fvrf_head.rs
@@ -3639,7 +3639,7 @@ mod fits_tests {
     fn block(cards: &[&str]) -> String {
         let mut h: String = cards.iter().map(|c| card(c)).collect();
         h.push_str(&card("END"));
-        while h.len() % 2880 != 0 {
+        while !h.len().is_multiple_of(2880) {
             h.push(' ');
         }
         h

--- a/src/bin/fitsverify/fvrf_key.rs
+++ b/src/bin/fitsverify/fvrf_key.rs
@@ -75,7 +75,7 @@ pub(crate) fn fits_parse_card(
     /* Whether the characters in keyword name are valid */
     while kname[p] != 0 {
         let c = kname[p] as u8;
-        if !(b'A'..=b'Z').contains(&c) && !(b'0'..=b'9').contains(&c) && c != b'-' && c != b'_' {
+        if !c.is_ascii_uppercase() && !c.is_ascii_digit() && c != b'-' && c != b'_' {
             spf!(errmes;
                 "Keyword #", kpos, ": Name \"", CS(kname), "\" contains char \"", CHR(kname[p]),
                 "\" which is not upper case letter, digit, \"-\", or \"_\".");

--- a/src/bin/fitsverify/fvrf_key.rs
+++ b/src/bin/fitsverify/fvrf_key.rs
@@ -623,14 +623,12 @@ pub(crate) fn pr_kval_err(
         wrterr(out, &errmes, 1);
     }
 
-    if errnum & UNKNOWN_TYPE != 0 {
-        if kval[0] != 0 {
-            /* don't report null keywords as an error */
-            spf!(errmes;
-                "Keyword #", kpos, ", ", CS(kname), ": Type of value \"", CS(kval),
-                "\" is unknown.");
-            wrterr(out, &errmes, 1);
-        }
+    /* don't report null keywords as an error */
+    if errnum & UNKNOWN_TYPE != 0 && kval[0] != 0 {
+        spf!(errmes;
+            "Keyword #", kpos, ", ", CS(kname), ": Type of value \"", CS(kval),
+            "\" is unknown.");
+        wrterr(out, &errmes, 1);
     }
 }
 

--- a/src/bin/fitsverify/main.rs
+++ b/src/bin/fitsverify/main.rs
@@ -16,6 +16,16 @@ stubs, and main() below is fitsverify.c's main().  */
 // `temp1` buffer, which is filled and then unused. Keeping them preserves the
 // line-by-line correspondence with the original.
 #![allow(unused_assignments, unused_variables)]
+// Same C-shape allowances the library takes (see src/lib.rs): the C declares
+// its locals at the top of a function and indexes its arrays with an explicit
+// counter, and its integer widths are target-dependent, so a cast that looks
+// like a no-op on this target is load-bearing on another.
+#![allow(
+    clippy::needless_late_init,
+    clippy::needless_range_loop,
+    clippy::manual_range_contains,
+    clippy::unnecessary_cast
+)]
 
 use std::process::ExitCode;
 

--- a/src/bin/fitsverify/main.rs
+++ b/src/bin/fitsverify/main.rs
@@ -384,7 +384,6 @@ pub(crate) fn main() -> ExitCode {
 
     if argc == 2 && ceq(&argv[1], b"-h") {
         print!(
-            "{}",
             "fitsverify -- Verify that the input files conform to the FITS Standard.\n\
              \n\
              USAGE:   fitsverify filename ...  - verify one or more FITS files\n\

--- a/src/bin/fpack/cfmt.rs
+++ b/src/bin/fpack/cfmt.rs
@@ -42,6 +42,10 @@ pub(crate) fn not_int(hdusum: c_ulong) -> c_ulong {
 }
 
 #[cfg(test)]
+// 3.14159265 below is a printf input paired with the exact digits C prints for
+// it, not a use of pi as a constant; substituting f64::consts::PI would change
+// the value being formatted.
+#[allow(clippy::approx_constant)]
 mod tests {
     use super::*;
 

--- a/src/bin/fpack/fpackutil.rs
+++ b/src/bin/fpack/fpackutil.rs
@@ -1964,23 +1964,23 @@ pub(crate) fn fp_test(
             }
 
             fits_set_lossy_int(outfptr.as_mut().unwrap(), fpvar.int_to_float, &mut stat);
-            if bitpix > 0 && fpvar.int_to_float != 0 {
-                if noisemin < f64::from(fpvar.n3ratio * fpvar.quantize_level)
-                    || noisemin < f64::from(fpvar.n3min)
-                {
-                    /* image contains too little noise to quantize effectively */
-                    fits_set_lossy_int(outfptr.as_mut().unwrap(), 0, &mut stat);
-                    let infptr = if rescale_flag {
-                        tempfile.as_deref_mut().unwrap()
-                    } else {
-                        inputfptr.as_deref_mut().unwrap()
-                    };
-                    fits_get_hdu_num(infptr, &mut hdunum);
+            if bitpix > 0
+                && fpvar.int_to_float != 0
+                && (noisemin < f64::from(fpvar.n3ratio * fpvar.quantize_level)
+                    || noisemin < f64::from(fpvar.n3min))
+            {
+                /* image contains too little noise to quantize effectively */
+                fits_set_lossy_int(outfptr.as_mut().unwrap(), 0, &mut stat);
+                let infptr = if rescale_flag {
+                    tempfile.as_deref_mut().unwrap()
+                } else {
+                    inputfptr.as_deref_mut().unwrap()
+                };
+                fits_get_hdu_num(infptr, &mut hdunum);
 
-                    pf(&format!(
-                        "    HDU {hdunum} does not meet noise criteria to be quantized, so losslessly compressed.\n"
-                    ));
-                }
+                pf(&format!(
+                    "    HDU {hdunum} does not meet noise criteria to be quantized, so losslessly compressed.\n"
+                ));
             }
 
             /* test compression ratio and speed for each algorithm */

--- a/src/bin/fpack/main.rs
+++ b/src/bin/fpack/main.rs
@@ -255,20 +255,16 @@ pub(crate) fn fp_get_param(argc: c_int, argv: &Argv, fpptr: &mut fpstate) -> FpR
                 fpptr.do_images = 0;
                 /* Do not write this to stdout via fp_msg.  Otherwise it will be placed at start of piped FITS
                 file, which will then be corrupted. */
-                eprint!("Note: The table compression method used by fpack has been\n");
-                eprint!(" officially approved as part of FITS format standard since 2016.\n");
-                eprint!(" However users should be aware that the compressed table files may\n");
-                eprint!(
-                    " only be readable by a limited number of applications (including fpack).\n"
-                );
+                eprintln!("Note: The table compression method used by fpack has been");
+                eprintln!(" officially approved as part of FITS format standard since 2016.");
+                eprintln!(" However users should be aware that the compressed table files may");
+                eprintln!(" only be readable by a limited number of applications (including fpack).");
             } else if strcmp_safe(arg, cs!(c"-table")) == 0 {
                 fpptr.do_tables = 1;
-                eprint!("Note: The table compression method used by fpack has been\n");
-                eprint!(" officially approved as part of FITS format standard since 2016.\n");
-                eprint!(" However users should be aware that the compressed table files may\n");
-                eprint!(
-                    " only be readable by a limited number of applications (including fpack).\n"
-                );
+                eprintln!("Note: The table compression method used by fpack has been");
+                eprintln!(" officially approved as part of FITS format standard since 2016.");
+                eprintln!(" However users should be aware that the compressed table files may");
+                eprintln!(" only be readable by a limited number of applications (including fpack).");
             } else if arg[1] == bb(b't') {
                 if gottile != 0 {
                     fp_msg_str("Error: multiple tile specifications\n");

--- a/src/bin/fpack/main.rs
+++ b/src/bin/fpack/main.rs
@@ -11,6 +11,9 @@
 #![allow(non_camel_case_types, non_snake_case, non_upper_case_globals)]
 #![allow(unused_assignments)]
 #![allow(dead_code)]
+// The C declares its locals at the top of a function, as the library does too
+// (see src/lib.rs).
+#![allow(clippy::needless_late_init)]
 
 mod cfmt;
 mod fpack_h;

--- a/src/bin/funpack/main.rs
+++ b/src/bin/funpack/main.rs
@@ -9,6 +9,9 @@
 #![allow(unused_assignments)]
 // items only the *other* binary uses out of the two shared modules
 #![allow(dead_code)]
+// The C declares its locals at the top of a function, as the library does too
+// (see src/lib.rs).
+#![allow(clippy::needless_late_init)]
 
 /* The C links funpack.o against fpackutil.o; Rust binaries cannot share a
 module tree, so the shared files are pulled in by path. */

--- a/src/drvrfile.rs
+++ b/src/drvrfile.rs
@@ -933,6 +933,9 @@ pub(crate) fn fits_stream_seek(_handle: c_int, _offset: LONGLONG) -> c_int {
 
 /*--------------------------------------------------------------------------*/
 /// reading from stdin stream
+// clippy points ErrorKind at core::io, but that re-export is still behind the
+// unstable `core_io` feature, so the std path has to stay.
+#[allow(clippy::std_instead_of_core)]
 pub(crate) fn fits_stream_read(hdl: c_int, buffer: &mut [u8], nbytes: usize) -> c_int {
     if hdl != 1 {
         return 1; /* can only read from stdin */

--- a/src/fitscore.rs
+++ b/src/fitscore.rs
@@ -12582,9 +12582,9 @@ mod tests {
     #[test]
     fn test_stored_entry_always_fits_the_reader_buffer() {
         /* ffgmsg copies at most FLEN_ERRMSG - 1 bytes, so keeping the chunk
-        size at or below that means no stored entry can ever be truncated on
-        the way out. */
-        assert!(ERRMSG_CHUNK <= FLEN_ERRMSG - 1);
+        size below FLEN_ERRMSG means no stored entry can ever be truncated on
+        the way out.  Both are consts, so check it at compile time. */
+        const { assert!(ERRMSG_CHUNK < FLEN_ERRMSG) };
     }
 
     #[test]

--- a/src/getcol.rs
+++ b/src/getcol.rs
@@ -5823,20 +5823,18 @@ mod tests {
             ];
             let mut anynul = [0 as c_int; 3];
 
-            unsafe {
-                fits_read_cols(
-                    f.as_deref_mut().unwrap(),
-                    3,
-                    &datatypes,
-                    &colnums,
-                    1,
-                    3,
-                    &nulvals,
-                    &mut arrays,
-                    Some(&mut anynul),
-                    &mut status,
-                );
-            }
+            fits_read_cols(
+                f.as_deref_mut().unwrap(),
+                3,
+                &datatypes,
+                &colnums,
+                1,
+                3,
+                &nulvals,
+                &mut arrays,
+                Some(&mut anynul),
+                &mut status,
+            );
             assert_eq!(status, 0);
             assert_eq!(col1_result[0], 100);
             assert_eq!(col1_result[2], 300);

--- a/src/getkey.rs
+++ b/src/getkey.rs
@@ -4140,8 +4140,8 @@ pub unsafe extern "C" fn ffghtb(
         let mut v_ttype = ffgh_str_array(ttype, nelem);
         let mut v_tform = ffgh_str_array(tform, nelem);
         let mut v_tunit = ffgh_str_array(tunit, nelem);
-        let mut v_tbcol = (!tbcol.is_null()).then(|| slice::from_raw_parts_mut(tbcol, nelem));
-        let mut v_extnm = (!extnm.is_null()).then(|| slice::from_raw_parts_mut(extnm, 69));
+        let v_tbcol = (!tbcol.is_null()).then(|| slice::from_raw_parts_mut(tbcol, nelem));
+        let v_extnm = (!extnm.is_null()).then(|| slice::from_raw_parts_mut(extnm, 69));
 
         ffghtb_safe(
             fptr,
@@ -4150,10 +4150,10 @@ pub unsafe extern "C" fn ffghtb(
             naxis2.as_mut(),
             tfields.as_mut(),
             v_ttype.as_deref_mut(),
-            v_tbcol.as_deref_mut(),
+            v_tbcol,
             v_tform.as_deref_mut(),
             v_tunit.as_deref_mut(),
-            v_extnm.as_deref_mut(),
+            v_extnm,
             status,
         )
     }
@@ -4292,7 +4292,7 @@ pub fn ffghtb_safe(
             }
         }
 
-        if let Some(ttype) = ttype.as_deref_mut() {
+        if let Some(ttype) = ttype {
             ffgkns_safe(
                 fptr,
                 cs!(c"TTYPE"),
@@ -4304,7 +4304,7 @@ pub fn ffghtb_safe(
             );
         }
 
-        if let Some(tunit) = tunit.as_deref_mut() {
+        if let Some(tunit) = tunit {
             ffgkns_safe(
                 fptr,
                 cs!(c"TUNIT"),
@@ -4398,8 +4398,8 @@ pub unsafe extern "C" fn ffghtbll(
         let mut v_ttype = ffgh_str_array(ttype, nelem);
         let mut v_tform = ffgh_str_array(tform, nelem);
         let mut v_tunit = ffgh_str_array(tunit, nelem);
-        let mut v_tbcol = (!tbcol.is_null()).then(|| slice::from_raw_parts_mut(tbcol, nelem));
-        let mut v_extnm = (!extnm.is_null()).then(|| slice::from_raw_parts_mut(extnm, 69));
+        let v_tbcol = (!tbcol.is_null()).then(|| slice::from_raw_parts_mut(tbcol, nelem));
+        let v_extnm = (!extnm.is_null()).then(|| slice::from_raw_parts_mut(extnm, 69));
 
         ffghtbll_safe(
             fptr,
@@ -4408,10 +4408,10 @@ pub unsafe extern "C" fn ffghtbll(
             naxis2.as_mut(),
             tfields.as_mut(),
             v_ttype.as_deref_mut(),
-            v_tbcol.as_deref_mut(),
+            v_tbcol,
             v_tform.as_deref_mut(),
             v_tunit.as_deref_mut(),
-            v_extnm.as_deref_mut(),
+            v_extnm,
             status,
         )
     }
@@ -4550,7 +4550,7 @@ pub fn ffghtbll_safe(
             }
         }
 
-        if let Some(ttype) = ttype.as_deref_mut() {
+        if let Some(ttype) = ttype {
             ffgkns_safe(
                 fptr,
                 cs!(c"TTYPE"),
@@ -4562,7 +4562,7 @@ pub fn ffghtbll_safe(
             );
         }
 
-        if let Some(tunit) = tunit.as_deref_mut() {
+        if let Some(tunit) = tunit {
             ffgkns_safe(
                 fptr,
                 cs!(c"TUNIT"),
@@ -4655,7 +4655,7 @@ pub unsafe extern "C" fn ffghbn(
         let mut v_ttype = ffgh_str_array(ttype, nelem);
         let mut v_tform = ffgh_str_array(tform, nelem);
         let mut v_tunit = ffgh_str_array(tunit, nelem);
-        let mut v_extnm = (!extnm.is_null()).then(|| slice::from_raw_parts_mut(extnm, 69));
+        let v_extnm = (!extnm.is_null()).then(|| slice::from_raw_parts_mut(extnm, 69));
 
         ffghbn_safe(
             fptr,
@@ -4665,7 +4665,7 @@ pub unsafe extern "C" fn ffghbn(
             v_ttype.as_deref_mut(),
             v_tform.as_deref_mut(),
             v_tunit.as_deref_mut(),
-            v_extnm.as_deref_mut(),
+            v_extnm,
             pcount.as_mut(),
             status,
         )
@@ -4796,7 +4796,7 @@ pub fn ffghbn_safe(
             }
         }
 
-        if let Some(ttype) = ttype.as_deref_mut() {
+        if let Some(ttype) = ttype {
             ffgkns_safe(
                 fptr,
                 cs!(c"TTYPE"),
@@ -4808,7 +4808,7 @@ pub fn ffghbn_safe(
             );
         }
 
-        if let Some(tunit) = tunit.as_deref_mut() {
+        if let Some(tunit) = tunit {
             ffgkns_safe(
                 fptr,
                 cs!(c"TUNIT"),
@@ -4883,7 +4883,7 @@ pub unsafe extern "C" fn ffghbnll(
         let mut v_ttype = ffgh_str_array(ttype, nelem);
         let mut v_tform = ffgh_str_array(tform, nelem);
         let mut v_tunit = ffgh_str_array(tunit, nelem);
-        let mut v_extnm = (!extnm.is_null()).then(|| slice::from_raw_parts_mut(extnm, 69));
+        let v_extnm = (!extnm.is_null()).then(|| slice::from_raw_parts_mut(extnm, 69));
 
         ffghbnll_safe(
             fptr,
@@ -4893,7 +4893,7 @@ pub unsafe extern "C" fn ffghbnll(
             v_ttype.as_deref_mut(),
             v_tform.as_deref_mut(),
             v_tunit.as_deref_mut(),
-            v_extnm.as_deref_mut(),
+            v_extnm,
             pcount.as_mut(),
             status,
         )
@@ -5023,7 +5023,7 @@ pub fn ffghbnll_safe(
             }
         }
 
-        if let Some(ttype) = ttype.as_deref_mut() {
+        if let Some(ttype) = ttype {
             ffgkns_safe(
                 fptr,
                 cs!(c"TTYPE"),
@@ -5035,7 +5035,7 @@ pub fn ffghbnll_safe(
             );
         }
 
-        if let Some(tunit) = tunit.as_deref_mut() {
+        if let Some(tunit) = tunit {
             ffgkns_safe(
                 fptr,
                 cs!(c"TUNIT"),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -210,7 +210,7 @@ macro_rules! slice_to_str {
         {
             let __b: &[u8] = cast_slice($e);
             let __n = __b.iter().position(|&c| c == 0).unwrap_or(__b.len());
-            ::std::string::String::from_utf8_lossy(&__b[..__n])
+            ::alloc::string::String::from_utf8_lossy(&__b[..__n])
         }
     };
 }

--- a/src/relibc/header/stdio/printf.rs
+++ b/src/relibc/header/stdio/printf.rs
@@ -27,6 +27,12 @@ use crate::relibc::{
 
 pub struct CustomVaList(pub VecDeque<VaArg>);
 
+impl Default for CustomVaList {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl CustomVaList {
     pub fn new() -> Self {
         CustomVaList(VecDeque::new())


### PR DESCRIPTION
Makes `cargo clippy --all` and `cargo clippy --all --all-targets` clean. One commit per lint.

`cargo clippy --all` started at 124 errors and 15 warnings; the two `deny`d lints
in `src/lib.rs` aborted the lib build, which masked the binary targets entirely,
so clearing those exposed a further ~80 warnings in `fitsverify`/`fpack`/`funpack`.

### Library

- **`std_instead_of_alloc`** (123 errors) — `slice_to_str!` named `::std::string::String`,
  tripping the crate-wide deny at each of its 123 expansion sites. The crate root
  already declares `extern crate alloc`, so it now names `::alloc` instead.
- **`std_instead_of_core`** (1) — allowed on `fits_stream_read`. Clippy points
  `std::io::ErrorKind` at `core::io::ErrorKind`, but that re-export is still behind
  the unstable `core_io` feature, so its machine-applicable suggestion does not compile.
- **`needless_option_as_deref`** (14) — for `Option<&mut [T]>`, `as_deref_mut()`
  re-derefs to the same type; all 14 were identity reborrows on a value not used again.
- **`new_without_default`** (1) — `Default` impl for `CustomVaList`.

### Transpiled binaries

`fitsverify`, `fpack` and `funpack` are transpiled C like the library, but their
crate roots did not carry the same allow list, so the C-isms the library already
exempts warned there: top-of-function locals, counter-driven array loops,
target-dependent integer casts. Taking the same allowances clears 65 warnings
without touching the transpiled code.

The rest were fixed properly: `print_with_newline` (8), `collapsible_if` (4),
`field_reassign_with_default`, `manual_is_ascii_check`, `print_literal`.

### Test code (surfaced by `--all-targets`)

`approx_constant` (allowed — the value is a printf input paired with the exact
digits C emits for it), `manual_is_multiple_of`, `unused_unsafe`, and an
`assert!` on two consts turned into a `const` block assertion.

### Verification

- `cargo clippy --all` — clean
- `cargo clippy --all --all-targets` — clean
- `cargo test` — all green (2354 lib + integration + doctests, 0 failures)
