### PR TITLE
Remove the last raw libc string functions from the expression engine

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -2,14 +2,25 @@
 - [ ] Investigate all code with 'WARNING'
 - [ ] Investigate all code with 'TODO'
 - [ ] Remove use a malloc and free
-- [ ] Remove use of libc unsafe functions. The raw C string functions are gone
-      from every file except `eval_y.rs` (38 sites) and `eval_f.rs` (6). Those
-      are one connected knot: the `*mut *mut c_char` per-row string buffers
-      behind `NodeValue::Buffer`, the `sptr1`/`sptr2` aliases into them, and the
-      `bit*` helpers (`bitcmp`, `bitlgte`, `bitand`, `bitor`, `bitnot`) that take
-      raw pointers. Untangling needs the string-node storage reworked, not a
-      call-site swap. `strtok_r`, `strpbrk`, `strspn`, `strcspn`, `strncpy` and
-      `strchr` have been deleted outright as dead.
+- [X] Remove use of libc unsafe functions. Every raw C string function is gone:
+      the whole `strcpy`/`strncpy`/`strcmp`/`strncmp`/`strlen`/`strnlen`/
+      `strchr`/`strstr`/`strcat`/`strncat`/`strtok_r`/`strpbrk`/`strspn`/
+      `strcspn` family has been deleted from `wrappers.rs`, along with the
+      `cbitset` dependency it pulled in. The expression engine reaches its
+      per-row string buffers through `lval::str_row`/`str_row_mut` instead of a
+      `char **` row-pointer array, and `bitand`/`bitor`/`bitnot`/`bitcmp`/
+      `bitlgte`/`cstrmid` are now safe functions taking slices.
+      Remaining follow-up, none of it string-related: stage 3 of
+      `notes/EVAL_STRING_STORAGE.md` (own the row buffers in `ParseData` so the
+      two `str_row` accessors stop being `unsafe`), then stage 4 (the numeric
+      buffers and `value.undef`, ~660 sites, which would remove the last
+      `malloc`/`free` and raw pointer from `NodeValue`).
+- [ ] Fix the Stacked Borrows violation in the lexer's buffer stack. Miri
+      rejects `eval_l.rs:1522` vs `:1703` (`yy_buffer_stack`) on any test that
+      invokes the parser, so Miri cannot currently validate the eval engine.
+      Pre-existing and verified against a clean worktree at fed4b4f. A second,
+      separate one is in the `test_ffcalc_*` tests themselves, which alias
+      `&mut *fp_self` twice to pass one file as both input and output.
 - [ ] Clean up all warnings
 - [ ] Remove clippy allow(unused_assignments)
 - [ ] Remove clippy allow(unused_variables)

--- a/src/eval_defs.rs
+++ b/src/eval_defs.rs
@@ -299,6 +299,43 @@ pub(crate) struct lval {
     pub data: NodeValue,
 }
 
+impl lval {
+    /// The raw start of row `row` of a String/Bits row buffer.
+    ///
+    /// # Safety
+    /// See [`lval::str_row`].
+    pub(crate) unsafe fn str_row_ptr(&self, row: c_long) -> *mut c_char {
+        unsafe { *self.data.str_buf().offset(row as isize) }
+    }
+
+    /// Row `row` of a String/Bits row buffer.
+    ///
+    /// `Allocate_Ptrs` reserves `nelem + 1` characters per row -- the string
+    /// and its terminator -- so that is the length of the slice. This is what
+    /// lets the `Do_*` routines reach a row with the `*_safe` string helpers
+    /// instead of an unbounded `strcpy` on a bare `*mut c_char`.
+    ///
+    /// # Safety
+    /// - The node must hold a live `Text` row buffer from `Allocate_Ptrs`, and
+    ///   `row` must be below the `nRows` it was allocated for.
+    /// - The returned lifetime is unbounded: the slice borrows the heap block,
+    ///   not `self`, which is what lets a caller hold a destination row and two
+    ///   operand rows at the same time. The caller must not create two
+    ///   overlapping `&mut` rows. In the engine the destination is always a
+    ///   freshly allocated node, so it cannot alias an operand.
+    pub(crate) unsafe fn str_row<'a>(&self, row: c_long) -> &'a [c_char] {
+        unsafe { core::slice::from_raw_parts(self.str_row_ptr(row), self.nelem as usize + 1) }
+    }
+
+    /// Row `row` of a String/Bits row buffer, writable.
+    ///
+    /// # Safety
+    /// See [`lval::str_row`].
+    pub(crate) unsafe fn str_row_mut<'a>(&self, row: c_long) -> &'a mut [c_char] {
+        unsafe { core::slice::from_raw_parts_mut(self.str_row_ptr(row), self.nelem as usize + 1) }
+    }
+}
+
 #[derive(Default, Debug, Copy, Clone)]
 pub(crate) struct Node {
     pub operation: c_int,

--- a/src/eval_f.rs
+++ b/src/eval_f.rs
@@ -94,7 +94,7 @@ use crate::getkey::{ffgcrd_safe, ffgknjj_safe};
 use crate::modkey::{ffdkey_safe, ffukyd_safe, ffukyj_safe, ffukyl_safe, ffukys_safe};
 use crate::putcol::{ffiter_safe, fits_iter_set_by_num_safe};
 use crate::putkey::{ffpcom_safe, ffphis_safe, ffpkyj_safe, ffpkys_safe, ffptdm_safe};
-use crate::wrappers::{strcat_safe, strcpy, strcpy_safe, strlen_safe, strncpy_safe};
+use crate::wrappers::{strcat_safe, strcpy_safe, strlen_safe, strncpy_safe};
 use crate::{BL, NullCheckType, cs, fitsio::*, int_snprintf, raw_to_slice};
 use bytemuck::{cast_slice, cast_slice_mut};
 use core::ffi::CStr;
@@ -1621,6 +1621,23 @@ pub(crate) extern "C" fn fits_parser_workfn(
 /// Iterator work function which calls the parser and copies the results
 /// into either an OutputCol or a data pointer supplied in the userPtr
 /// structure.
+/// `strcpy` into one of the iterator's string elements, bounded by the source.
+///
+/// The element width of an iterator string column is not reachable from the
+/// work function: `ffiter` sets `iteratorCol::repeat` to 1 for string columns
+/// and `pv.datasize` is the size of a *pointer*, not of a string. So the
+/// destination slice is built to exactly the bytes a C `strcpy` would write,
+/// terminator included -- the copy is bounded and its length explicit, but the
+/// destination's own capacity still cannot be checked here.
+///
+/// # Safety
+/// `dst` must point at an iterator string element with room for `src` and its
+/// NUL, which is the contract the C `strcpy` already relied on.
+unsafe fn copy_str_elem(dst: *mut c_char, src: &[c_char]) {
+    let n = strlen_safe(src) + 1;
+    unsafe { core::slice::from_raw_parts_mut(dst, n) }.copy_from_slice(&src[..n]);
+}
+
 pub(crate) fn fits_parser_workfn_safe(
     totalrows: c_long,           /* I - Total rows to be processed     */
     offset: c_long,              /* I - Number of rows skipped at start*/
@@ -2107,21 +2124,22 @@ pub(crate) fn fits_parser_workfn_safe(
                         }
                         TSTRING => {
                             if constant != 0 {
+                                let src = *result.value.data.text();
                                 for jj in 0..ntodo {
-                                    strcpy(
+                                    copy_str_elem(
                                         *(pv.Data
                                             .cast::<*mut c_char>()
                                             .add(jj.try_into().unwrap())),
-                                        result.value.data.text().as_ptr(),
+                                        &src,
                                     );
                                 }
                             } else {
                                 for jj in 0..ntodo {
-                                    strcpy(
+                                    copy_str_elem(
                                         *(pv.Data
                                             .cast::<*mut c_char>()
                                             .add(jj.try_into().unwrap())),
-                                        *(result.value.data.str_buf().add(jj.try_into().unwrap())),
+                                        result.value.str_row(jj),
                                     );
                                 }
                             }
@@ -2141,28 +2159,33 @@ pub(crate) fn fits_parser_workfn_safe(
                 ValueSort::String => {
                     if (*(pv.userInfo)).datatype == TSTRING {
                         if constant != 0 {
+                            let src = *result.value.data.text();
                             for jj in 0..ntodo {
-                                strcpy(
+                                copy_str_elem(
                                     *(pv.Data.cast::<*mut c_char>().add(jj.try_into().unwrap())),
-                                    result.value.data.text().as_ptr(),
+                                    &src,
                                 );
                             }
                         } else {
                             for jj in 0..ntodo {
                                 if *(result.value.undef.add(jj.try_into().unwrap())) != 0 {
                                     anyNullThisTime = 1;
-                                    strcpy(
+                                    let nullstr: &[c_char] = cast_slice(
+                                        CStr::from_ptr(*pv.Null.cast::<*mut c_char>())
+                                            .to_bytes_with_nul(),
+                                    );
+                                    copy_str_elem(
                                         *(pv.Data
                                             .cast::<*mut c_char>()
                                             .add(jj.try_into().unwrap())),
-                                        *pv.Null.cast::<*mut c_char>(),
+                                        nullstr,
                                     );
                                 } else {
-                                    strcpy(
+                                    copy_str_elem(
                                         *(pv.Data
                                             .cast::<*mut c_char>()
                                             .add(jj.try_into().unwrap())),
-                                        *(result.value.data.str_buf().add(jj.try_into().unwrap())),
+                                        result.value.str_row(jj),
                                     );
                                 }
                             }
@@ -3693,10 +3716,11 @@ fn fits_uncompress_hkdata(
                         }
                         TSTRING => {
                             let str_array = col_data.array.cast::<*mut c_char>();
-                            strcpy(
-                                *str_array.wrapping_add(currelem as usize),
-                                *str_array.wrapping_add((currelem - 1) as usize),
+                            let prev: &[c_char] = cast_slice(
+                                CStr::from_ptr(*str_array.wrapping_add((currelem - 1) as usize))
+                                    .to_bytes_with_nul(),
                             );
+                            copy_str_elem(*str_array.wrapping_add(currelem as usize), prev);
                         }
                         _ => {}
                     }

--- a/src/eval_y.rs
+++ b/src/eval_y.rs
@@ -159,9 +159,10 @@ use crate::simplerng::{
     simplerng_getnorm, simplerng_getpoisson, simplerng_getuniform, simplerng_srand,
 };
 use crate::wcssub::ffgtcs_safe;
-use crate::wrappers::{strcat, strcmp, strcpy, strlen, strstr};
-use crate::wrappers::{strcmp_safe, strcpy_safe, strlen_safe, strncpy_safe, strstr_safe};
-use crate::{atoi, cs, int_snprintf};
+use crate::wrappers::{
+    strcat_safe, strcmp_safe, strcpy_safe, strlen_safe, strncpy_safe, strstr_safe,
+};
+use crate::{atoi, bb, cs, int_snprintf};
 
 pub type yy_state_t = yytype_int16;
 pub type yytype_int16 = c_short;
@@ -9073,10 +9074,8 @@ fn Do_Unary(lParse: &mut ParseData, this_node_idx: usize) {
                                 0
                             });
                     } else if that_node.ntype == ValueSort::Bits {
-                        bitnot(
-                            (this_node).value.data.text_mut_ptr(),
-                            that_node.value.data.text_mut_ptr(),
-                        );
+                        let src = *that_node.value.data.text_mut();
+                        bitnot((this_node).value.data.text_mut(), &src);
                     }
                 }
                 _ => {}
@@ -9247,8 +9246,8 @@ fn Do_Unary(lParse: &mut ParseData, this_node_idx: usize) {
                                     break;
                                 }
                                 bitnot(
-                                    *((this_node).value.data.str_buf()).offset(elem as isize),
-                                    *(that_node.value.data.str_buf()).offset(elem as isize),
+                                    (this_node).value.str_row_mut(elem),
+                                    that_node.value.str_row(elem),
                                 );
                             }
                         }
@@ -9515,19 +9514,15 @@ fn Do_Offset(lParse: &mut ParseData, this_node_idx: usize) {
                 }
                 match (lParse.Nodes[this_node_idx]).ntype {
                     ValueSort::Bits => {
-                        strcpy(
-                            *((lParse.Nodes[this_node_idx]).value.data.str_buf())
-                                .offset(elem as isize),
-                            *((lParse.Nodes[col_idx]).value.data.str_buf())
-                                .offset((elem + offset) as isize),
+                        strcpy_safe(
+                            (lParse.Nodes[this_node_idx]).value.str_row_mut(elem),
+                            (lParse.Nodes[col_idx]).value.str_row(elem + offset),
                         );
                     }
                     ValueSort::String => {
-                        strcpy(
-                            *((lParse.Nodes[this_node_idx]).value.data.str_buf())
-                                .offset(elem as isize),
-                            *((lParse.Nodes[col_idx]).value.data.str_buf())
-                                .offset((elem + offset) as isize),
+                        strcpy_safe(
+                            (lParse.Nodes[this_node_idx]).value.str_row_mut(elem),
+                            (lParse.Nodes[col_idx]).value.str_row(elem + offset),
                         );
                     }
                     ValueSort::Boolean => {
@@ -9558,8 +9553,6 @@ fn Do_BinOp_bit(lParse: &mut ParseData, this_node_idx: usize) {
     unsafe {
         let mut that1: &mut Node;
         let mut that2: &mut Node;
-        let mut sptr1: *mut c_char = ptr::null_mut();
-        let mut sptr2: *mut c_char = ptr::null_mut();
         let mut const1: c_int = 0;
         let mut const2: c_int = 0;
         let mut rows: c_long = 0;
@@ -9569,16 +9562,21 @@ fn Do_BinOp_bit(lParse: &mut ParseData, this_node_idx: usize) {
 
         const1 = c_int::from((lParse.Nodes[that1_idx]).is_const());
         const2 = c_int::from((lParse.Nodes[that2_idx]).is_const());
-        sptr1 = if const1 != 0 {
-            (lParse.Nodes[that1_idx]).value.data.text_mut_ptr()
-        } else {
-            core::ptr::null_mut::<c_char>()
-        };
-        sptr2 = if const2 != 0 {
-            (lParse.Nodes[that2_idx]).value.data.text_mut_ptr()
-        } else {
-            core::ptr::null_mut::<c_char>()
-        };
+
+        /* A constant operand is copied out of its node once, so that holding a
+        view of it does not keep `lParse.Nodes` borrowed while the destination
+        row is written. A non-constant operand is re-pointed at its row buffer
+        each iteration below; the empty default is never read before then. */
+        let mut const1_buf: [c_char; MAX_STRLEN as usize] = [0; MAX_STRLEN as usize];
+        let mut const2_buf: [c_char; MAX_STRLEN as usize] = [0; MAX_STRLEN as usize];
+        if const1 != 0 {
+            const1_buf = *(lParse.Nodes[that1_idx]).value.data.text_mut();
+        }
+        if const2 != 0 {
+            const2_buf = *(lParse.Nodes[that2_idx]).value.data.text_mut();
+        }
+        let mut sptr1: &[c_char] = &const1_buf;
+        let mut sptr2: &[c_char] = &const2_buf;
         if const1 != 0 && const2 != 0 {
             match Operator::from_operation((lParse.Nodes[this_node_idx]).operation) {
                 /*  BITSTR comparisons  */
@@ -9600,37 +9598,30 @@ fn Do_BinOp_bit(lParse: &mut ParseData, this_node_idx: usize) {
                 /*  BITSTR AND/ORs ...  no UNDEFS in or out */
                 Operator::Pipe => {
                     bitor(
-                        (lParse.Nodes[this_node_idx]).value.data.text_mut_ptr(),
+                        (lParse.Nodes[this_node_idx]).value.data.text_mut(),
                         sptr1,
                         sptr2,
                     );
                 }
                 Operator::Ampersand => {
                     bitand(
-                        (lParse.Nodes[this_node_idx]).value.data.text_mut_ptr(),
+                        (lParse.Nodes[this_node_idx]).value.data.text_mut(),
                         sptr1,
                         sptr2,
                     );
                 }
                 Operator::Plus => {
-                    strcpy(
-                        (lParse.Nodes[this_node_idx]).value.data.text_mut_ptr(),
-                        sptr1,
-                    );
-                    strcat(
-                        (lParse.Nodes[this_node_idx]).value.data.text_mut_ptr(),
-                        sptr2,
-                    );
+                    strcpy_safe((lParse.Nodes[this_node_idx]).value.data.text_mut(), sptr1);
+                    strcat_safe((lParse.Nodes[this_node_idx]).value.data.text_mut(), sptr2);
                 }
                 /* Accumulate 1 bits */
                 Operator::Accum => {
                     (lParse.Nodes[this_node_idx]).value.data = NodeValue::Long(0);
-                    while *sptr1 != 0 {
-                        if c_int::from(*sptr1) == '1' as i32 {
+                    for &c in &sptr1[..strlen_safe(sptr1)] {
+                        if c == bb(b'1') {
                             (lParse.Nodes[this_node_idx]).value.data =
                                 NodeValue::Long((lParse.Nodes[this_node_idx]).value.data.lng() + 1);
                         }
-                        sptr1 = sptr1.offset(1);
                     }
                 }
                 _ => {}
@@ -9653,12 +9644,10 @@ fn Do_BinOp_bit(lParse: &mut ParseData, this_node_idx: usize) {
                             break;
                         }
                         if const1 == 0 {
-                            sptr1 = *((lParse.Nodes[that1_idx]).value.data.str_buf())
-                                .offset(rows as isize);
+                            sptr1 = (lParse.Nodes[that1_idx]).value.str_row(rows);
                         }
                         if const2 == 0 {
-                            sptr2 = *((lParse.Nodes[that2_idx]).value.data.str_buf())
-                                .offset(rows as isize);
+                            sptr2 = (lParse.Nodes[that2_idx]).value.str_row(rows);
                         }
                         match Operator::from_operation((lParse.Nodes[this_node_idx]).operation) {
                             Operator::Ne => {
@@ -9686,36 +9675,30 @@ fn Do_BinOp_bit(lParse: &mut ParseData, this_node_idx: usize) {
                             break;
                         }
                         if const1 == 0 {
-                            sptr1 = *((lParse.Nodes[that1_idx]).value.data.str_buf())
-                                .offset(rows as isize);
+                            sptr1 = (lParse.Nodes[that1_idx]).value.str_row(rows);
                         }
                         if const2 == 0 {
-                            sptr2 = *((lParse.Nodes[that2_idx]).value.data.str_buf())
-                                .offset(rows as isize);
+                            sptr2 = (lParse.Nodes[that2_idx]).value.str_row(rows);
                         }
                         if (lParse.Nodes[this_node_idx]).operation == '|' as i32 {
                             bitor(
-                                *((lParse.Nodes[this_node_idx]).value.data.str_buf())
-                                    .offset(rows as isize),
+                                (lParse.Nodes[this_node_idx]).value.str_row_mut(rows),
                                 sptr1,
                                 sptr2,
                             );
                         } else if (lParse.Nodes[this_node_idx]).operation == '&' as i32 {
                             bitand(
-                                *((lParse.Nodes[this_node_idx]).value.data.str_buf())
-                                    .offset(rows as isize),
+                                (lParse.Nodes[this_node_idx]).value.str_row_mut(rows),
                                 sptr1,
                                 sptr2,
                             );
                         } else {
-                            strcpy(
-                                *((lParse.Nodes[this_node_idx]).value.data.str_buf())
-                                    .offset(rows as isize),
+                            strcpy_safe(
+                                (lParse.Nodes[this_node_idx]).value.str_row_mut(rows),
                                 sptr1,
                             );
-                            strcat(
-                                *((lParse.Nodes[this_node_idx]).value.data.str_buf())
-                                    .offset(rows as isize),
+                            strcat_safe(
+                                (lParse.Nodes[this_node_idx]).value.str_row_mut(rows),
                                 sptr2,
                             );
                         }
@@ -9727,14 +9710,12 @@ fn Do_BinOp_bit(lParse: &mut ParseData, this_node_idx: usize) {
                         previous = (lParse.Nodes[that2_idx]).value.data.lng();
                         i = 0;
                         while i < rows {
-                            sptr1 = *((lParse.Nodes[that1_idx]).value.data.str_buf())
-                                .offset(i as isize);
+                            sptr1 = (lParse.Nodes[that1_idx]).value.str_row(i);
                             curr = 0;
-                            while *sptr1 != 0 {
-                                if c_int::from(*sptr1) == '1' as i32 {
+                            for &c in &sptr1[..strlen_safe(sptr1)] {
+                                if c == bb(b'1') {
                                     curr += 1;
                                 }
-                                sptr1 = sptr1.offset(1);
                             }
                             previous += curr;
                             *((lParse.Nodes[this_node_idx]).value.data.lng_buf())
@@ -9776,8 +9757,8 @@ fn Do_BinOp_str(lParse: &mut ParseData, this_node_idx: usize) {
     unsafe {
         let mut that1: &mut Node;
         let mut that2: &mut Node;
-        let mut sptr1: *mut c_char = ptr::null_mut();
-        let mut sptr2: *mut c_char = ptr::null_mut();
+        let mut const1_buf: [c_char; MAX_STRLEN as usize] = [0; MAX_STRLEN as usize];
+        let mut const2_buf: [c_char; MAX_STRLEN as usize] = [0; MAX_STRLEN as usize];
         let mut null1: c_char = 0;
         let mut null2: c_char = 0;
         let mut const1: c_int = 0;
@@ -9790,27 +9771,28 @@ fn Do_BinOp_str(lParse: &mut ParseData, this_node_idx: usize) {
 
         const1 = c_int::from((lParse.Nodes[that1_idx]).is_const());
         const2 = c_int::from((lParse.Nodes[that2_idx]).is_const());
-        sptr1 = if const1 != 0 {
-            (lParse.Nodes[that1_idx]).value.data.text_mut_ptr()
-        } else {
-            core::ptr::null_mut::<c_char>()
-        };
-        sptr2 = if const2 != 0 {
-            (lParse.Nodes[that2_idx]).value.data.text_mut_ptr()
-        } else {
-            core::ptr::null_mut::<c_char>()
-        };
+        /* As in Do_BinOp_bit: copy a constant operand out of its node once so
+        that viewing it does not keep `lParse.Nodes` borrowed while a
+        destination row is written. */
+        if const1 != 0 {
+            const1_buf = *(lParse.Nodes[that1_idx]).value.data.text_mut();
+        }
+        if const2 != 0 {
+            const2_buf = *(lParse.Nodes[that2_idx]).value.data.text_mut();
+        }
+        let mut sptr1: &[c_char] = &const1_buf;
+        let mut sptr2: &[c_char] = &const2_buf;
         if const1 != 0 && const2 != 0 {
             match Operator::from_operation((lParse.Nodes[this_node_idx]).operation) {
                 /*  Compare Strings  */
                 Operator::Ne | Operator::Eq => {
                     val = c_int::from(
-                        (if c_int::from(*sptr1.offset(0)) < c_int::from(*sptr2.offset(0)) {
+                        (if c_int::from(sptr1[0]) < c_int::from(sptr2[0]) {
                             -(1)
-                        } else if c_int::from(*sptr1.offset(0)) > c_int::from(*sptr2.offset(0)) {
+                        } else if c_int::from(sptr1[0]) > c_int::from(sptr2[0]) {
                             1
                         } else {
-                            strcmp(sptr1, sptr2)
+                            strcmp_safe(sptr1, sptr2)
                         }) == 0,
                     );
                     (lParse.Nodes[this_node_idx]).value.data = NodeValue::Logical(
@@ -9825,12 +9807,12 @@ fn Do_BinOp_str(lParse: &mut ParseData, this_node_idx: usize) {
                 }
                 Operator::Gt => {
                     (lParse.Nodes[this_node_idx]).value.data = NodeValue::Logical(
-                        if (if c_int::from(*sptr1.offset(0)) < c_int::from(*sptr2.offset(0)) {
+                        if (if c_int::from(sptr1[0]) < c_int::from(sptr2[0]) {
                             -(1)
-                        } else if c_int::from(*sptr1.offset(0)) > c_int::from(*sptr2.offset(0)) {
+                        } else if c_int::from(sptr1[0]) > c_int::from(sptr2[0]) {
                             1
                         } else {
-                            strcmp(sptr1, sptr2)
+                            strcmp_safe(sptr1, sptr2)
                         }) > 0
                         {
                             1
@@ -9841,12 +9823,12 @@ fn Do_BinOp_str(lParse: &mut ParseData, this_node_idx: usize) {
                 }
                 Operator::Lt => {
                     (lParse.Nodes[this_node_idx]).value.data = NodeValue::Logical(
-                        if (if c_int::from(*sptr1.offset(0)) < c_int::from(*sptr2.offset(0)) {
+                        if (if c_int::from(sptr1[0]) < c_int::from(sptr2[0]) {
                             -(1)
-                        } else if c_int::from(*sptr1.offset(0)) > c_int::from(*sptr2.offset(0)) {
+                        } else if c_int::from(sptr1[0]) > c_int::from(sptr2[0]) {
                             1
                         } else {
-                            strcmp(sptr1, sptr2)
+                            strcmp_safe(sptr1, sptr2)
                         }) < 0
                         {
                             1
@@ -9857,12 +9839,12 @@ fn Do_BinOp_str(lParse: &mut ParseData, this_node_idx: usize) {
                 }
                 Operator::Gte => {
                     (lParse.Nodes[this_node_idx]).value.data = NodeValue::Logical(
-                        if (if c_int::from(*sptr1.offset(0)) < c_int::from(*sptr2.offset(0)) {
+                        if (if c_int::from(sptr1[0]) < c_int::from(sptr2[0]) {
                             -(1)
-                        } else if c_int::from(*sptr1.offset(0)) > c_int::from(*sptr2.offset(0)) {
+                        } else if c_int::from(sptr1[0]) > c_int::from(sptr2[0]) {
                             1
                         } else {
-                            strcmp(sptr1, sptr2)
+                            strcmp_safe(sptr1, sptr2)
                         }) >= 0
                         {
                             1
@@ -9873,12 +9855,12 @@ fn Do_BinOp_str(lParse: &mut ParseData, this_node_idx: usize) {
                 }
                 Operator::Lte => {
                     (lParse.Nodes[this_node_idx]).value.data = NodeValue::Logical(
-                        if (if c_int::from(*sptr1.offset(0)) < c_int::from(*sptr2.offset(0)) {
+                        if (if c_int::from(sptr1[0]) < c_int::from(sptr2[0]) {
                             -(1)
-                        } else if c_int::from(*sptr1.offset(0)) > c_int::from(*sptr2.offset(0)) {
+                        } else if c_int::from(sptr1[0]) > c_int::from(sptr2[0]) {
                             1
                         } else {
-                            strcmp(sptr1, sptr2)
+                            strcmp_safe(sptr1, sptr2)
                         }) <= 0
                         {
                             1
@@ -9889,14 +9871,8 @@ fn Do_BinOp_str(lParse: &mut ParseData, this_node_idx: usize) {
                 }
                 /*  Concat Strings  */
                 Operator::Plus => {
-                    strcpy(
-                        (lParse.Nodes[this_node_idx]).value.data.text_mut_ptr(),
-                        sptr1,
-                    );
-                    strcat(
-                        (lParse.Nodes[this_node_idx]).value.data.text_mut_ptr(),
-                        sptr2,
-                    );
+                    strcpy_safe((lParse.Nodes[this_node_idx]).value.data.text_mut(), sptr1);
+                    strcat_safe((lParse.Nodes[this_node_idx]).value.data.text_mut(), sptr2);
                 }
                 _ => {}
             }
@@ -9928,22 +9904,18 @@ fn Do_BinOp_str(lParse: &mut ParseData, this_node_idx: usize) {
                             };
                         if *((lParse.Nodes[this_node_idx]).value.undef).offset(rows as isize) == 0 {
                             if const1 == 0 {
-                                sptr1 = *((lParse.Nodes[that1_idx]).value.data.str_buf())
-                                    .offset(rows as isize);
+                                sptr1 = (lParse.Nodes[that1_idx]).value.str_row(rows);
                             }
                             if const2 == 0 {
-                                sptr2 = *((lParse.Nodes[that2_idx]).value.data.str_buf())
-                                    .offset(rows as isize);
+                                sptr2 = (lParse.Nodes[that2_idx]).value.str_row(rows);
                             }
                             val = c_int::from(
-                                (if c_int::from(*sptr1.offset(0)) < c_int::from(*sptr2.offset(0)) {
+                                (if c_int::from(sptr1[0]) < c_int::from(sptr2[0]) {
                                     -(1)
-                                } else if c_int::from(*sptr1.offset(0))
-                                    > c_int::from(*sptr2.offset(0))
-                                {
+                                } else if c_int::from(sptr1[0]) > c_int::from(sptr2[0]) {
                                     1
                                 } else {
-                                    strcmp(sptr1, sptr2)
+                                    strcmp_safe(sptr1, sptr2)
                                 }) == 0,
                             );
                             *((lParse.Nodes[this_node_idx]).value.data.log_buf())
@@ -9976,20 +9948,17 @@ fn Do_BinOp_str(lParse: &mut ParseData, this_node_idx: usize) {
                             };
                         if *((lParse.Nodes[this_node_idx]).value.undef).offset(rows as isize) == 0 {
                             if const1 == 0 {
-                                sptr1 = *((lParse.Nodes[that1_idx]).value.data.str_buf())
-                                    .offset(rows as isize);
+                                sptr1 = (lParse.Nodes[that1_idx]).value.str_row(rows);
                             }
                             if const2 == 0 {
-                                sptr2 = *((lParse.Nodes[that2_idx]).value.data.str_buf())
-                                    .offset(rows as isize);
+                                sptr2 = (lParse.Nodes[that2_idx]).value.str_row(rows);
                             }
-                            val = if c_int::from(*sptr1.offset(0)) < c_int::from(*sptr2.offset(0)) {
+                            val = if c_int::from(sptr1[0]) < c_int::from(sptr2[0]) {
                                 -(1)
-                            } else if c_int::from(*sptr1.offset(0)) > c_int::from(*sptr2.offset(0))
-                            {
+                            } else if c_int::from(sptr1[0]) > c_int::from(sptr2[0]) {
                                 1
                             } else {
-                                strcmp(sptr1, sptr2)
+                                strcmp_safe(sptr1, sptr2)
                             };
                             *((lParse.Nodes[this_node_idx]).value.data.log_buf())
                                 .offset(rows as isize) = (if (lParse.Nodes[this_node_idx]).operation
@@ -10021,20 +9990,17 @@ fn Do_BinOp_str(lParse: &mut ParseData, this_node_idx: usize) {
                             };
                         if *((lParse.Nodes[this_node_idx]).value.undef).offset(rows as isize) == 0 {
                             if const1 == 0 {
-                                sptr1 = *((lParse.Nodes[that1_idx]).value.data.str_buf())
-                                    .offset(rows as isize);
+                                sptr1 = (lParse.Nodes[that1_idx]).value.str_row(rows);
                             }
                             if const2 == 0 {
-                                sptr2 = *((lParse.Nodes[that2_idx]).value.data.str_buf())
-                                    .offset(rows as isize);
+                                sptr2 = (lParse.Nodes[that2_idx]).value.str_row(rows);
                             }
-                            val = if c_int::from(*sptr1.offset(0)) < c_int::from(*sptr2.offset(0)) {
+                            val = if c_int::from(sptr1[0]) < c_int::from(sptr2[0]) {
                                 -(1)
-                            } else if c_int::from(*sptr1.offset(0)) > c_int::from(*sptr2.offset(0))
-                            {
+                            } else if c_int::from(sptr1[0]) > c_int::from(sptr2[0]) {
                                 1
                             } else {
-                                strcmp(sptr1, sptr2)
+                                strcmp_safe(sptr1, sptr2)
                             };
                             *((lParse.Nodes[this_node_idx]).value.data.log_buf())
                                 .offset(rows as isize) = (if (lParse.Nodes[this_node_idx]).operation
@@ -10067,21 +10033,17 @@ fn Do_BinOp_str(lParse: &mut ParseData, this_node_idx: usize) {
                             };
                         if *((lParse.Nodes[this_node_idx]).value.undef).offset(rows as isize) == 0 {
                             if const1 == 0 {
-                                sptr1 = *((lParse.Nodes[that1_idx]).value.data.str_buf())
-                                    .offset(rows as isize);
+                                sptr1 = (lParse.Nodes[that1_idx]).value.str_row(rows);
                             }
                             if const2 == 0 {
-                                sptr2 = *((lParse.Nodes[that2_idx]).value.data.str_buf())
-                                    .offset(rows as isize);
+                                sptr2 = (lParse.Nodes[that2_idx]).value.str_row(rows);
                             }
-                            strcpy(
-                                *((lParse.Nodes[this_node_idx]).value.data.str_buf())
-                                    .offset(rows as isize),
+                            strcpy_safe(
+                                (lParse.Nodes[this_node_idx]).value.str_row_mut(rows),
                                 sptr1,
                             );
-                            strcat(
-                                *((lParse.Nodes[this_node_idx]).value.data.str_buf())
-                                    .offset(rows as isize),
+                            strcat_safe(
+                                (lParse.Nodes[this_node_idx]).value.str_row_mut(rows),
                                 sptr2,
                             );
                         }
@@ -11186,10 +11148,8 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                         (lParse.Nodes[this_node_idx]).value.data =
                             NodeValue::Double(pVals[0].data.dbl());
                     } else if (lParse.Nodes[theParams[0]]).ntype == ValueSort::Bits {
-                        strcpy(
-                            (lParse.Nodes[this_node_idx]).value.data.text_mut_ptr(),
-                            pVals[0].data.text_mut_ptr(),
-                        );
+                        let src = *pVals[0].data.text_mut();
+                        strcpy_safe((lParse.Nodes[this_node_idx]).value.data.text_mut(), &src);
                     }
                     current_block_139 = 7627602990488000394;
                 }
@@ -11270,10 +11230,8 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                         (lParse.Nodes[this_node_idx]).value.data =
                             NodeValue::Double(pVals[0].data.dbl());
                     } else if (lParse.Nodes[this_node_idx]).ntype == ValueSort::String {
-                        strcpy(
-                            (lParse.Nodes[this_node_idx]).value.data.text_mut_ptr(),
-                            pVals[0].data.text_mut_ptr(),
-                        );
+                        let src = *pVals[0].data.text_mut();
+                        strcpy_safe((lParse.Nodes[this_node_idx]).value.data.text_mut(), &src);
                     }
                     current_block_139 = 7627602990488000394;
                 }
@@ -11442,10 +11400,8 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                         (lParse.Nodes[this_node_idx]).value.data =
                             NodeValue::Long(pVals[0].data.lng());
                     } else if (lParse.Nodes[this_node_idx]).ntype == ValueSort::Bits {
-                        strcpy(
-                            (lParse.Nodes[this_node_idx]).value.data.text_mut_ptr(),
-                            pVals[0].data.text_mut_ptr(),
-                        );
+                        let src = *pVals[0].data.text_mut();
+                        strcpy_safe((lParse.Nodes[this_node_idx]).value.data.text_mut(), &src);
                     }
                     current_block_139 = 7627602990488000394;
                 }
@@ -11539,14 +11495,12 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                                 });
                         }
                         ValueSort::String => {
-                            strcpy(
-                                (lParse.Nodes[this_node_idx]).value.data.text_mut_ptr(),
-                                if c_int::from(pVals[2].data.log()) != 0 {
-                                    pVals[0].data.text_mut_ptr()
-                                } else {
-                                    pVals[1].data.text_mut_ptr()
-                                },
-                            );
+                            let src = if c_int::from(pVals[2].data.log()) != 0 {
+                                *pVals[0].data.text_mut()
+                            } else {
+                                *pVals[1].data.text_mut()
+                            };
+                            strcpy_safe((lParse.Nodes[this_node_idx]).value.data.text_mut(), &src);
                         }
                         _ => {}
                     }
@@ -11554,16 +11508,20 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                 }
                 /* String functions */
                 funcOp::STRMID_FCT => {
-                    let dest_str = (lParse.Nodes[this_node_idx]).value.data.text_mut_ptr();
                     let dest_len = (lParse.Nodes[this_node_idx]).value.nelem as c_int;
+                    /* the subject is staged in pVals, so copying it out keeps
+                    the destination the only live borrow of lParse */
+                    let src = *pVals[0].data.text_mut();
+                    let mut dest_str = *(lParse.Nodes[this_node_idx]).value.data.text_mut();
                     cstrmid(
                         lParse,
-                        dest_str,
+                        &mut dest_str,
                         dest_len,
-                        pVals[0].data.text_mut_ptr(),
+                        &src,
                         pVals[0].nelem as c_int,
                         pVals[1].data.lng() as c_int,
                     );
+                    *(lParse.Nodes[this_node_idx]).value.data.text_mut() = dest_str;
                     current_block_139 = 7627602990488000394;
                 }
                 funcOp::STRPOS_FCT => {
@@ -12600,31 +12558,26 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                                     pNull[i as usize] =
                                         *((lParse.Nodes[theParams[i as usize]]).value.undef)
                                             .offset(row as isize);
-                                    strcpy(
-                                        pVals[i as usize].data.text_mut_ptr(),
-                                        *((lParse.Nodes[theParams[i as usize]])
-                                            .value
-                                            .data
-                                            .str_buf())
-                                        .offset(row as isize),
-                                    );
+                                    let src =
+                                        (lParse.Nodes[theParams[i as usize]]).value.str_row(row);
+                                    strcpy_safe(pVals[i as usize].data.text_mut(), src);
                                 }
                             }
                             if pNull[0] != 0 {
                                 *((lParse.Nodes[this_node_idx]).value.undef).offset(row as isize) =
                                     pNull[1];
-                                strcpy(
-                                    *((lParse.Nodes[this_node_idx]).value.data.str_buf())
-                                        .offset(row as isize),
-                                    pVals[1].data.text_mut_ptr(),
+                                let src = *pVals[1].data.text_mut();
+                                strcpy_safe(
+                                    (lParse.Nodes[this_node_idx]).value.str_row_mut(row),
+                                    &src,
                                 );
                             } else {
                                 *((lParse.Nodes[this_node_idx]).value.undef)
                                     .offset(elem as isize) = 0;
-                                strcpy(
-                                    *((lParse.Nodes[this_node_idx]).value.data.str_buf())
-                                        .offset(row as isize),
-                                    pVals[0].data.text_mut_ptr(),
+                                let src = *pVals[0].data.text_mut();
+                                strcpy_safe(
+                                    (lParse.Nodes[this_node_idx]).value.str_row_mut(row),
+                                    &src,
                                 );
                             }
                         },
@@ -14233,14 +14186,9 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                                     break;
                                 }
                                 if vector[i as usize] != 0 {
-                                    strcpy(
-                                        pVals[i as usize].data.text_mut_ptr(),
-                                        *((lParse.Nodes[theParams[i as usize]])
-                                            .value
-                                            .data
-                                            .str_buf())
-                                        .offset(row as isize),
-                                    );
+                                    let src =
+                                        (lParse.Nodes[theParams[i as usize]]).value.str_row(row);
+                                    strcpy_safe(pVals[i as usize].data.text_mut(), src);
                                     pNull[i as usize] =
                                         *((lParse.Nodes[theParams[i as usize]]).value.undef)
                                             .offset(row as isize);
@@ -14251,18 +14199,18 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                             *fresh195 = pNull[2];
                             if *fresh195 == 0 {
                                 if pVals[2].data.log() != 0 {
-                                    strcpy(
-                                        *((lParse.Nodes[this_node_idx]).value.data.str_buf())
-                                            .offset(row as isize),
-                                        pVals[0].data.text_mut_ptr(),
+                                    let src = *pVals[0].data.text_mut();
+                                    strcpy_safe(
+                                        (lParse.Nodes[this_node_idx]).value.str_row_mut(row),
+                                        &src,
                                     );
                                     *((lParse.Nodes[this_node_idx]).value.undef)
                                         .offset(row as isize) = pNull[0];
                                 } else {
-                                    strcpy(
-                                        *((lParse.Nodes[this_node_idx]).value.data.str_buf())
-                                            .offset(row as isize),
-                                        pVals[1].data.text_mut_ptr(),
+                                    let src = *pVals[1].data.text_mut();
+                                    strcpy_safe(
+                                        (lParse.Nodes[this_node_idx]).value.str_row_mut(row),
+                                        &src,
                                     );
                                     *((lParse.Nodes[this_node_idx]).value.undef)
                                         .offset(row as isize) = pNull[1];
@@ -14281,6 +14229,14 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                         let lenconst: c_int = c_int::from((lParse.Nodes[theParams[2]]).is_const());
                         let dest_len: c_int = (lParse.Nodes[this_node_idx]).value.nelem as c_int;
                         let mut src_len: c_int = (lParse.Nodes[theParams[0]]).value.nelem as c_int;
+                        /* A constant subject is the same for every row, so copy
+                        it out once rather than re-borrowing the node inside the
+                        loop while a destination row is being written. */
+                        let const_str: [c_char; MAX_STRLEN as usize] = if strconst != 0 {
+                            *(lParse.Nodes[theParams[0]]).value.data.text_mut()
+                        } else {
+                            [0; MAX_STRLEN as usize]
+                        };
                         loop {
                             let fresh196 = row;
                             row -= 1;
@@ -14289,7 +14245,7 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                             }
                             let mut pos: c_int = 0;
                             let mut len: c_int = 0;
-                            let mut str: *mut c_char = ptr::null_mut();
+                            let mut str: &[c_char] = &const_str;
                             let mut undef: c_int = 0;
                             if posconst != 0 {
                                 pos = (lParse.Nodes[theParams[1]]).value.data.lng() as c_int;
@@ -14304,13 +14260,12 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                                 }
                             }
                             if strconst != 0 {
-                                str = (lParse.Nodes[theParams[0]]).value.data.text_mut_ptr();
+                                str = &const_str;
                                 if src_len == 0 {
-                                    src_len = strlen(str) as c_int;
+                                    src_len = strlen_safe(str) as c_int;
                                 }
                             } else {
-                                str = *((lParse.Nodes[theParams[0]]).value.data.str_buf())
-                                    .offset(row as isize);
+                                str = (lParse.Nodes[theParams[0]]).value.str_row(row);
                                 if *((lParse.Nodes[theParams[0]]).value.undef).offset(row as isize)
                                     != 0
                                 {
@@ -14329,17 +14284,14 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                                     undef = 1;
                                 }
                             }
-                            *(*((lParse.Nodes[this_node_idx]).value.data.str_buf())
-                                .offset(row as isize))
-                            .offset(0) = 0;
+                            (lParse.Nodes[this_node_idx]).value.str_row_mut(row)[0] = 0;
                             if pos == 0 {
                                 undef = 1;
                             }
                             if undef == 0
                                 && cstrmid(
                                     lParse,
-                                    *((lParse.Nodes[this_node_idx]).value.data.str_buf())
-                                        .offset(row as isize),
+                                    (lParse.Nodes[this_node_idx]).value.str_row_mut(row),
                                     len,
                                     str,
                                     src_len,
@@ -14355,20 +14307,31 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                     funcOp::STRPOS_FCT => {
                         let const1: c_int = c_int::from((lParse.Nodes[theParams[0]]).is_const());
                         let const2: c_int = c_int::from((lParse.Nodes[theParams[1]]).is_const());
+                        /* constants are the same every row, so copy them out
+                        once instead of re-borrowing the nodes in the loop */
+                        let const1_buf: [c_char; MAX_STRLEN as usize] = if const1 != 0 {
+                            *(lParse.Nodes[theParams[0]]).value.data.text_mut()
+                        } else {
+                            [0; MAX_STRLEN as usize]
+                        };
+                        let const2_buf: [c_char; MAX_STRLEN as usize] = if const2 != 0 {
+                            *(lParse.Nodes[theParams[1]]).value.data.text_mut()
+                        } else {
+                            [0; MAX_STRLEN as usize]
+                        };
                         loop {
                             let fresh197 = row;
                             row -= 1;
                             if fresh197 == 0 {
                                 break;
                             }
-                            let mut str1: *mut c_char = ptr::null_mut();
-                            let mut str2: *mut c_char = ptr::null_mut();
+                            let mut str1: &[c_char] = &const1_buf;
+                            let mut str2: &[c_char] = &const2_buf;
                             let mut undef_0: c_int = 0;
                             if const1 != 0 {
-                                str1 = (lParse.Nodes[theParams[0]]).value.data.text_mut_ptr();
+                                str1 = &const1_buf;
                             } else {
-                                str1 = *((lParse.Nodes[theParams[0]]).value.data.str_buf())
-                                    .offset(row as isize);
+                                str1 = (lParse.Nodes[theParams[0]]).value.str_row(row);
                                 if *((lParse.Nodes[theParams[0]]).value.undef).offset(row as isize)
                                     != 0
                                 {
@@ -14376,10 +14339,9 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                                 }
                             }
                             if const2 != 0 {
-                                str2 = (lParse.Nodes[theParams[1]]).value.data.text_mut_ptr();
+                                str2 = &const2_buf;
                             } else {
-                                str2 = *((lParse.Nodes[theParams[1]]).value.data.str_buf())
-                                    .offset(row as isize);
+                                str2 = (lParse.Nodes[theParams[1]]).value.str_row(row);
                                 if *((lParse.Nodes[theParams[1]]).value.undef).offset(row as isize)
                                     != 0
                                 {
@@ -14389,15 +14351,16 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                             *((lParse.Nodes[this_node_idx]).value.data.lng_buf())
                                 .offset(row as isize) = 0;
                             if undef_0 == 0 {
-                                let res_0: *mut c_char = strstr(str1, str2);
-                                if res_0.is_null() {
-                                    undef_0 = 1;
-                                    *((lParse.Nodes[this_node_idx]).value.data.lng_buf())
-                                        .offset(row as isize) = 0;
-                                } else {
-                                    *((lParse.Nodes[this_node_idx]).value.data.lng_buf())
-                                        .offset(row as isize) =
-                                        res_0.offset_from(str1) as c_long + 1;
+                                match strstr_safe(str1, str2) {
+                                    None => {
+                                        undef_0 = 1;
+                                        *((lParse.Nodes[this_node_idx]).value.data.lng_buf())
+                                            .offset(row as isize) = 0;
+                                    }
+                                    Some(at) => {
+                                        *((lParse.Nodes[this_node_idx]).value.data.lng_buf())
+                                            .offset(row as isize) = at as c_long + 1;
+                                    }
                                 }
                             }
                             *((lParse.Nodes[this_node_idx]).value.undef).offset(row as isize) =
@@ -15667,433 +15630,141 @@ fn Do_Array(lParse: &mut ParseData, this_node_idx: usize) {
 /*****************************************************************************/
 
 #[allow(clippy::collapsible_match, clippy::collapsible_if)]
-fn bitlgte(mut bits1: *mut c_char, oper: c_int, mut bits2: *mut c_char) -> c_char {
-    unsafe {
-        let mut val1: c_int = 0;
-        let mut val2: c_int = 0;
-        let mut nextbit: c_int = 0;
-        let mut result: c_char = 0;
-        let mut i: c_int = 0;
-        let mut l1: c_int = 0;
-        let mut l2: c_int = 0;
-        let mut length: c_int = 0;
-        let mut ldiff: c_int = 0;
-        let mut stream: *mut c_char = ptr::null_mut();
-        let mut chr1: c_char = 0;
-        let mut chr2: c_char = 0;
-        l1 = strlen(bits1) as c_int;
-        l2 = strlen(bits2) as c_int;
-        length = if l1 > l2 { l1 } else { l2 };
-        /* Same as bitcmp: an owned buffer rather than a raw malloc.  The C
-        does not check this allocation, so there is no failure path to
-        replicate -- but there is also no null to dereference. */
-        let mut stream_vec: Vec<c_char> = vec![0; (length + 1) as usize];
-        stream = stream_vec.as_mut_ptr();
-        if l1 < l2 {
-            ldiff = l2 - l1;
-            i = 0;
-            loop {
-                let fresh218 = ldiff;
-                ldiff -= 1;
-                if fresh218 == 0 {
-                    break;
-                }
-                let fresh219 = i;
-                i += 1;
-                *stream.offset(fresh219 as isize) = b'0' as c_char;
-            }
-            loop {
-                let fresh220 = l1;
-                l1 -= 1;
-                if fresh220 == 0 {
-                    break;
-                }
-                let fresh221 = bits1;
-                bits1 = bits1.offset(1);
-                let fresh222 = i;
-                i += 1;
-                *stream.offset(fresh222 as isize) = *fresh221;
-            }
-            *stream.offset(i as isize) = 0;
-            bits1 = stream;
-        } else if l2 < l1 {
-            ldiff = l1 - l2;
-            i = 0;
-            loop {
-                let fresh223 = ldiff;
-                ldiff -= 1;
-                if fresh223 == 0 {
-                    break;
-                }
-                let fresh224 = i;
-                i += 1;
-                *stream.offset(fresh224 as isize) = b'0' as c_char;
-            }
-            loop {
-                let fresh225 = l2;
-                l2 -= 1;
-                if fresh225 == 0 {
-                    break;
-                }
-                let fresh226 = bits2;
-                bits2 = bits2.offset(1);
-                let fresh227 = i;
-                i += 1;
-                *stream.offset(fresh227 as isize) = *fresh226;
-            }
-            *stream.offset(i as isize) = 0;
-            bits2 = stream;
+/// Left-pad the shorter of two bit strings with `'0'` so the two are the same
+/// length, the way the C did with its `stream` scratch buffer.
+///
+/// `pad` supplies the storage for whichever operand needs widening. The
+/// returned views are exactly `max(strlen(a), strlen(b))` characters long and
+/// carry no terminator, so the callers below can simply zip them.
+fn bit_align<'a>(
+    a: &'a [c_char],
+    b: &'a [c_char],
+    pad: &'a mut Vec<c_char>,
+) -> (&'a [c_char], &'a [c_char]) {
+    let l1 = strlen_safe(a);
+    let l2 = strlen_safe(b);
+    let n = cmp::max(l1, l2);
+
+    match l1.cmp(&l2) {
+        cmp::Ordering::Equal => (&a[..l1], &b[..l2]),
+        cmp::Ordering::Less => {
+            pad.clear();
+            pad.resize(n, bb(b'0'));
+            pad[n - l1..].copy_from_slice(&a[..l1]);
+            (&pad[..], &b[..l2])
         }
-        val2 = 0;
-        val1 = val2;
-        nextbit = 1;
-        loop {
-            let fresh228 = length;
-            length -= 1;
-            if fresh228 == 0 {
-                break;
-            }
-            chr1 = *bits1.offset(length as isize);
-            chr2 = *bits2.offset(length as isize);
-            if c_int::from(chr1) != 'x' as i32
-                && c_int::from(chr1) != 'X' as i32
-                && c_int::from(chr2) != 'x' as i32
-                && c_int::from(chr2) != 'X' as i32
-            {
-                if c_int::from(chr1) == '1' as i32 {
-                    val1 += nextbit;
-                }
-                if c_int::from(chr2) == '1' as i32 {
-                    val2 += nextbit;
-                }
-                nextbit *= 2;
-            }
+        cmp::Ordering::Greater => {
+            pad.clear();
+            pad.resize(n, bb(b'0'));
+            pad[n - l2..].copy_from_slice(&b[..l2]);
+            (&a[..l1], &pad[..])
         }
-        result = 0;
-        match oper {
-            282 => {
-                if val1 < val2 {
-                    result = 1;
-                }
-            }
-            283 => {
-                if val1 <= val2 {
-                    result = 1;
-                }
-            }
-            281 => {
-                if val1 > val2 {
-                    result = 1;
-                }
-            }
-            284 => {
-                if val1 >= val2 {
-                    result = 1;
-                }
-            }
-            _ => {}
-        }
-        /* stream_vec owns the buffer; it is freed when it goes out of scope. */
-        result
-    }
-}
-fn bitand(mut result: *mut c_char, mut bitstrm1: *mut c_char, mut bitstrm2: *mut c_char) {
-    unsafe {
-        let mut i: c_int = 0;
-        let mut l1: c_int = 0;
-        let mut l2: c_int = 0;
-        let mut ldiff: c_int = 0;
-        let mut largestStream: c_int = 0;
-        let mut stream: *mut c_char = ptr::null_mut();
-        let mut chr1: c_char = 0;
-        let mut chr2: c_char = 0;
-        l1 = strlen(bitstrm1) as c_int;
-        l2 = strlen(bitstrm2) as c_int;
-        largestStream = if l1 > l2 { l1 } else { l2 };
-        /* Same as bitcmp: an owned buffer rather than a raw malloc.  The C
-        does not check this allocation, so there is no failure path to
-        replicate -- but there is also no null to dereference. */
-        let mut stream_vec: Vec<c_char> = vec![0; (largestStream + 1) as usize];
-        stream = stream_vec.as_mut_ptr();
-        if l1 < l2 {
-            ldiff = l2 - l1;
-            i = 0;
-            loop {
-                let fresh229 = ldiff;
-                ldiff -= 1;
-                if fresh229 == 0 {
-                    break;
-                }
-                let fresh230 = i;
-                i += 1;
-                *stream.offset(fresh230 as isize) = b'0' as c_char;
-            }
-            loop {
-                let fresh231 = l1;
-                l1 -= 1;
-                if fresh231 == 0 {
-                    break;
-                }
-                let fresh232 = bitstrm1;
-                bitstrm1 = bitstrm1.offset(1);
-                let fresh233 = i;
-                i += 1;
-                *stream.offset(fresh233 as isize) = *fresh232;
-            }
-            *stream.offset(i as isize) = 0;
-            bitstrm1 = stream;
-        } else if l2 < l1 {
-            ldiff = l1 - l2;
-            i = 0;
-            loop {
-                let fresh234 = ldiff;
-                ldiff -= 1;
-                if fresh234 == 0 {
-                    break;
-                }
-                let fresh235 = i;
-                i += 1;
-                *stream.offset(fresh235 as isize) = b'0' as c_char;
-            }
-            loop {
-                let fresh236 = l2;
-                l2 -= 1;
-                if fresh236 == 0 {
-                    break;
-                }
-                let fresh237 = bitstrm2;
-                bitstrm2 = bitstrm2.offset(1);
-                let fresh238 = i;
-                i += 1;
-                *stream.offset(fresh238 as isize) = *fresh237;
-            }
-            *stream.offset(i as isize) = 0;
-            bitstrm2 = stream;
-        }
-        loop {
-            let fresh239 = bitstrm1;
-            bitstrm1 = bitstrm1.offset(1);
-            chr1 = *fresh239;
-            if chr1 == 0 {
-                break;
-            }
-            let fresh240 = bitstrm2;
-            bitstrm2 = bitstrm2.offset(1);
-            chr2 = *fresh240;
-            if c_int::from(chr1) == 'x' as i32 || c_int::from(chr2) == 'x' as i32 {
-                *result = b'x' as c_char;
-            } else if c_int::from(chr1) == '1' as i32 && c_int::from(chr2) == '1' as i32 {
-                *result = b'1' as c_char;
-            } else {
-                *result = b'0' as c_char;
-            }
-            result = result.offset(1);
-        }
-        /* stream_vec owns the buffer; it is freed when it goes out of scope. */
-        *result = 0;
-    }
-}
-fn bitor(mut result: *mut c_char, mut bitstrm1: *mut c_char, mut bitstrm2: *mut c_char) {
-    unsafe {
-        let mut i: c_int = 0;
-        let mut l1: c_int = 0;
-        let mut l2: c_int = 0;
-        let mut ldiff: c_int = 0;
-        let mut largestStream: c_int = 0;
-        let mut stream: *mut c_char = ptr::null_mut();
-        let mut chr1: c_char = 0;
-        let mut chr2: c_char = 0;
-        l1 = strlen(bitstrm1) as c_int;
-        l2 = strlen(bitstrm2) as c_int;
-        largestStream = if l1 > l2 { l1 } else { l2 };
-        /* Same as bitcmp: an owned buffer rather than a raw malloc.  The C
-        does not check this allocation, so there is no failure path to
-        replicate -- but there is also no null to dereference. */
-        let mut stream_vec: Vec<c_char> = vec![0; (largestStream + 1) as usize];
-        stream = stream_vec.as_mut_ptr();
-        if l1 < l2 {
-            ldiff = l2 - l1;
-            i = 0;
-            loop {
-                let fresh241 = ldiff;
-                ldiff -= 1;
-                if fresh241 == 0 {
-                    break;
-                }
-                let fresh242 = i;
-                i += 1;
-                *stream.offset(fresh242 as isize) = b'0' as c_char;
-            }
-            loop {
-                let fresh243 = l1;
-                l1 -= 1;
-                if fresh243 == 0 {
-                    break;
-                }
-                let fresh244 = bitstrm1;
-                bitstrm1 = bitstrm1.offset(1);
-                let fresh245 = i;
-                i += 1;
-                *stream.offset(fresh245 as isize) = *fresh244;
-            }
-            *stream.offset(i as isize) = 0;
-            bitstrm1 = stream;
-        } else if l2 < l1 {
-            ldiff = l1 - l2;
-            i = 0;
-            loop {
-                let fresh246 = ldiff;
-                ldiff -= 1;
-                if fresh246 == 0 {
-                    break;
-                }
-                let fresh247 = i;
-                i += 1;
-                *stream.offset(fresh247 as isize) = b'0' as c_char;
-            }
-            loop {
-                let fresh248 = l2;
-                l2 -= 1;
-                if fresh248 == 0 {
-                    break;
-                }
-                let fresh249 = bitstrm2;
-                bitstrm2 = bitstrm2.offset(1);
-                let fresh250 = i;
-                i += 1;
-                *stream.offset(fresh250 as isize) = *fresh249;
-            }
-            *stream.offset(i as isize) = 0;
-            bitstrm2 = stream;
-        }
-        loop {
-            let fresh251 = bitstrm1;
-            bitstrm1 = bitstrm1.offset(1);
-            chr1 = *fresh251;
-            if chr1 == 0 {
-                break;
-            }
-            let fresh252 = bitstrm2;
-            bitstrm2 = bitstrm2.offset(1);
-            chr2 = *fresh252;
-            if c_int::from(chr1) == '1' as i32 || c_int::from(chr2) == '1' as i32 {
-                *result = b'1' as c_char;
-            } else if c_int::from(chr1) == '0' as i32 || c_int::from(chr2) == '0' as i32 {
-                *result = b'0' as c_char;
-            } else {
-                *result = b'x' as c_char;
-            }
-            result = result.offset(1);
-        }
-        /* stream_vec owns the buffer; it is freed when it goes out of scope. */
-        *result = 0;
-    }
-}
-fn bitnot(mut result: *mut c_char, mut bits: *mut c_char) {
-    unsafe {
-        let mut length: c_int = 0;
-        let mut chr: c_char = 0;
-        length = strlen(bits) as c_int;
-        loop {
-            let fresh253 = length;
-            length -= 1;
-            if fresh253 == 0 {
-                break;
-            }
-            let fresh254 = bits;
-            bits = bits.offset(1);
-            chr = *fresh254;
-            let fresh255 = result;
-            result = result.offset(1);
-            *fresh255 = (if c_int::from(chr) == '1' as i32 {
-                '0' as i32
-            } else if c_int::from(chr) == '0' as i32 {
-                '1' as i32
-            } else {
-                c_int::from(chr)
-            }) as c_char;
-        }
-        *result = 0;
     }
 }
 
-fn bitcmp(bitstrm1: *mut c_char, bitstrm2: *mut c_char) -> c_char {
-    unsafe {
-        let mut i: c_int = 0;
-        let mut ldiff: c_int = 0;
-        let mut largestStream: c_int = 0;
-        let mut chr1: c_char = 0;
-        let mut chr2: c_char = 0;
+fn bitlgte(bits1: &[c_char], oper: c_int, bits2: &[c_char]) -> c_char {
+    let mut pad: Vec<c_char> = Vec::new();
+    let (bits1, bits2) = bit_align(bits1, bits2, &mut pad);
 
-        let mut l1 = strlen(bitstrm1) as c_int;
-        let mut l2 = strlen(bitstrm2) as c_int;
+    let mut val1: c_int = 0;
+    let mut val2: c_int = 0;
+    let mut nextbit: c_int = 1;
 
-        let mut bitstrm1 = core::slice::from_raw_parts_mut(bitstrm1, l1 as usize + 1);
-        let mut bitstrm2 = core::slice::from_raw_parts_mut(bitstrm2, l2 as usize + 1);
+    /* Least significant bit first. A position where either operand is
+    unknown ('x') contributes to neither value and does not advance the
+    bit weight, which is what the C's `nextbit *= 2` inside the test does.
 
-        largestStream = cmp::max(l1, l2);
-
-        let mut stream_vec: Vec<c_char> = vec![0; (largestStream + 1) as usize];
-        let stream = &mut stream_vec[..];
-
-        if l1 < l2 {
-            ldiff = l2 - l1;
-            i = 0;
-
-            while ldiff > 0 {
-                stream[i as usize] = b'0' as c_char;
-                i += 1;
-                ldiff -= 1;
+    NOTE (pre-existing): `nextbit` is a c_int, so a bit string longer than
+    31 known positions overflows it -- undefined behaviour in the C, a
+    debug-build panic here. Kept as-is rather than widened, so the two
+    agree; see the bitlgte entry in notes/. */
+    for (&chr1, &chr2) in bits1.iter().rev().zip(bits2.iter().rev()) {
+        if chr1 != bb(b'x') && chr1 != bb(b'X') && chr2 != bb(b'x') && chr2 != bb(b'X') {
+            if chr1 == bb(b'1') {
+                val1 += nextbit;
             }
-
-            while l1 > 0 {
-                stream[i as usize] = bitstrm1[0];
-                bitstrm1 = &mut bitstrm1[1..];
-                i += 1;
-                l1 -= 1;
+            if chr2 == bb(b'1') {
+                val2 += nextbit;
             }
-
-            stream[i as usize] = 0;
-            bitstrm1 = stream;
-        } else if l2 < l1 {
-            ldiff = l1 - l2;
-            i = 0;
-
-            while ldiff > 0 {
-                stream[i as usize] = b'0' as c_char;
-                i += 1;
-                ldiff -= 1;
-            }
-
-            while l2 > 0 {
-                stream[i as usize] = bitstrm2[0];
-                bitstrm2 = &mut bitstrm2[1..];
-                i += 1;
-                l2 -= 1;
-            }
-
-            stream[i as usize] = 0;
-            bitstrm2 = stream;
+            nextbit *= 2;
         }
-
-        loop {
-            chr1 = bitstrm1[0];
-            if chr1 == 0 {
-                break;
-            }
-            bitstrm1 = &mut bitstrm1[1..];
-
-            chr2 = bitstrm2[0];
-            bitstrm2 = &mut bitstrm2[1..];
-
-            if (chr1 == b'0' as c_char && chr2 == b'1' as c_char)
-                || (chr1 == b'1' as c_char && chr2 == b'0' as c_char)
-            {
-                return 0;
-            }
-        }
-        1
     }
+
+    let holds = match oper {
+        282 => val1 < val2,
+        283 => val1 <= val2,
+        281 => val1 > val2,
+        284 => val1 >= val2,
+        _ => false,
+    };
+
+    c_char::from(holds)
+}
+
+fn bitand(result: &mut [c_char], bitstrm1: &[c_char], bitstrm2: &[c_char]) {
+    let mut pad: Vec<c_char> = Vec::new();
+    let (bitstrm1, bitstrm2) = bit_align(bitstrm1, bitstrm2, &mut pad);
+
+    let mut i = 0;
+    for (&chr1, &chr2) in bitstrm1.iter().zip(bitstrm2.iter()) {
+        result[i] = if chr1 == bb(b'x') || chr2 == bb(b'x') {
+            bb(b'x')
+        } else if chr1 == bb(b'1') && chr2 == bb(b'1') {
+            bb(b'1')
+        } else {
+            bb(b'0')
+        };
+        i += 1;
+    }
+    result[i] = 0;
+}
+
+fn bitor(result: &mut [c_char], bitstrm1: &[c_char], bitstrm2: &[c_char]) {
+    let mut pad: Vec<c_char> = Vec::new();
+    let (bitstrm1, bitstrm2) = bit_align(bitstrm1, bitstrm2, &mut pad);
+
+    let mut i = 0;
+    for (&chr1, &chr2) in bitstrm1.iter().zip(bitstrm2.iter()) {
+        result[i] = if chr1 == bb(b'1') || chr2 == bb(b'1') {
+            bb(b'1')
+        } else if chr1 == bb(b'0') || chr2 == bb(b'0') {
+            bb(b'0')
+        } else {
+            bb(b'x')
+        };
+        i += 1;
+    }
+    result[i] = 0;
+}
+
+fn bitnot(result: &mut [c_char], bits: &[c_char]) {
+    let length = strlen_safe(bits);
+
+    for i in 0..length {
+        let chr = bits[i];
+        result[i] = if chr == bb(b'1') {
+            bb(b'0')
+        } else if chr == bb(b'0') {
+            bb(b'1')
+        } else {
+            chr
+        };
+    }
+    result[length] = 0;
+}
+
+fn bitcmp(bitstrm1: &[c_char], bitstrm2: &[c_char]) -> c_char {
+    let mut pad: Vec<c_char> = Vec::new();
+    let (bitstrm1, bitstrm2) = bit_align(bitstrm1, bitstrm2, &mut pad);
+
+    /* 'x' matches anything; only a hard 0/1 disagreement is a mismatch. */
+    for (&chr1, &chr2) in bitstrm1.iter().zip(bitstrm2.iter()) {
+        if (chr1 == bb(b'0') && chr2 == bb(b'1')) || (chr1 == bb(b'1') && chr2 == bb(b'0')) {
+            return 0;
+        }
+    }
+
+    1
 }
 
 fn bnear(x: c_double, y: c_double, tolerance: c_double) -> c_char {
@@ -16186,23 +15857,20 @@ fn ellipse(
  */
 fn cstrmid(
     lParse: &mut ParseData,
-    dest_str: *mut c_char,
+    dest_str: &mut [c_char],
     dest_len: c_int,
-    src_str: *const c_char,
+    src_str: &[c_char],
     src_len: c_int,
     pos: c_int,
 ) -> c_int {
-    let dest_str = unsafe { core::slice::from_raw_parts_mut(dest_str, (dest_len) as usize + 1) }; // +1 for null terminate
     let dest_len = dest_len as usize;
     let mut src_len = src_len as usize;
 
     let mut endpos: usize = 0;
 
     if src_len == 0 {
-        src_len = unsafe { CStr::from_ptr(src_str).to_bytes().len() };
+        src_len = strlen_safe(src_str);
     } /* .. if constant */
-
-    let src_str = unsafe { core::slice::from_raw_parts(src_str, src_len + 1) };
 
     if pos < 0 {
         fits_parser_yyerror(lParse, cs!(c"STRMID(S,P,N) P must be 0 or greater"));

--- a/src/wrappers.rs
+++ b/src/wrappers.rs
@@ -1,33 +1,14 @@
-use core::{cmp, ffi::CStr, ptr, str::FromStr};
+use core::{cmp, ffi::CStr, str::FromStr};
 
 use bytemuck::cast_slice;
 
-use crate::c_types::{c_char, c_int, c_uchar, size_t};
+use crate::c_types::{c_char, c_int};
 
 use crate::bb;
 
 // Several wrappers in this file were taken from the Redoc Relibc
 // project. The original source code can be found at:
 // https://gitlab.redox-os.org/redox-os/relibc
-
-pub(crate) unsafe fn strcpy(dst: *mut c_char, src: *const c_char) -> *mut c_char {
-    unsafe {
-        let mut i = 0;
-
-        loop {
-            let byte = *src.offset(i);
-            *dst.offset(i) = byte;
-
-            if byte == 0 {
-                break;
-            }
-
-            i += 1;
-        }
-
-        dst
-    }
-}
 
 pub fn strncpy_safe(dst: &mut [c_char], src: &[c_char], n: usize) {
     let mut i = 0;
@@ -113,31 +94,6 @@ pub fn strncmp_safe(cs: &[c_char], ct: &[c_char], n: usize) -> c_int {
     0
 }
 
-pub(crate) unsafe fn strcmp(s1: *const c_char, s2: *const c_char) -> c_int {
-    unsafe { strncmp(s1, s2, size_t::MAX) }
-}
-
-pub(crate) unsafe fn strncmp(s1: *const c_char, s2: *const c_char, n: size_t) -> c_int {
-    unsafe {
-        // Walk one byte at a time. Materialising `n`-length slices up front
-        // would read past the end of a shorter allocation, which is UB even
-        // when the comparison would have stopped at the NUL first.
-        let mut i = 0;
-        while i < n {
-            let a = *s1.add(i).cast::<c_uchar>();
-            let b = *s2.add(i).cast::<c_uchar>();
-
-            if a != b || a == 0 {
-                return c_int::from(a) - c_int::from(b);
-            }
-
-            i += 1;
-        }
-
-        0
-    }
-}
-
 pub(crate) fn strlen_safe_cstr(str: &CStr) -> usize {
     str.to_bytes().len()
 }
@@ -159,23 +115,6 @@ pub fn strlen_safe(cs: &[c_char]) -> usize {
 pub fn strnlen_safe(cs: &[c_char], n: usize) -> usize {
     let limit = cmp::min(n, cs.len());
     cs[..limit].iter().position(|&c| c == 0).unwrap_or(limit)
-}
-
-pub(crate) unsafe fn strlen(s: *const c_char) -> size_t {
-    unsafe { strnlen(s, usize::MAX) }
-}
-
-pub(crate) unsafe fn strnlen(s: *const c_char, size: size_t) -> size_t {
-    unsafe {
-        let mut i = 0;
-        while i < size {
-            if *s.add(i) == 0 {
-                break;
-            }
-            i += 1;
-        }
-        i as size_t
-    }
 }
 
 pub(crate) fn strtol_safe<F: FromStr>(input: &[c_char]) -> Result<(F, usize), <F as FromStr>::Err> {
@@ -227,36 +166,6 @@ pub fn strrchr_safe(cs: &[c_char], c: c_char) -> Option<usize> {
     cs[..len].iter().rposition(|&x| x == c)
 }
 
-unsafe fn inner_strstr(
-    mut haystack: *const c_char,
-    needle: *const c_char,
-    mask: c_char,
-) -> *mut c_char {
-    unsafe {
-        while *haystack != 0 {
-            let mut i = 0;
-            loop {
-                if *needle.offset(i) == 0 {
-                    // We reached the end of the needle, everything matches this far
-                    return haystack as *mut c_char;
-                }
-                if *haystack.offset(i) & mask != *needle.offset(i) & mask {
-                    break;
-                }
-
-                i += 1;
-            }
-
-            haystack = haystack.offset(1);
-        }
-        ptr::null_mut()
-    }
-}
-
-pub(crate) unsafe fn strstr(haystack: *const c_char, needle: *const c_char) -> *mut c_char {
-    unsafe { inner_strstr(haystack, needle, !0) }
-}
-
 /// Index of the first occurrence of the NUL-terminated needle `ct` in the
 /// NUL-terminated haystack `cs`, or `None` if not present. Mirrors C `strstr`:
 /// an empty needle matches at 0, and neither string is read past its NUL, so
@@ -273,29 +182,6 @@ pub fn strstr_safe(cs: &[c_char], ct: &[c_char]) -> Option<usize> {
     }
 
     hay.windows(needle.len()).position(|w| w == needle)
-}
-
-pub(crate) unsafe fn strcat(s1: *mut c_char, s2: *const c_char) -> *mut c_char {
-    unsafe { strncat(s1, s2, usize::MAX) }
-}
-
-pub(crate) unsafe fn strncat(s1: *mut c_char, s2: *const c_char, n: size_t) -> *mut c_char {
-    unsafe {
-        let len = strlen(s1 as *const c_char);
-        let mut i = 0;
-        while i < n {
-            let b = *s2.add(i);
-            if b == 0 {
-                break;
-            }
-
-            *s1.add(len + i) = b;
-            i += 1;
-        }
-        *s1.add(len + i) = 0;
-
-        s1
-    }
 }
 
 pub fn strcat_safe(s: &mut [c_char], ct: &[c_char]) {
@@ -855,25 +741,6 @@ mod tests {
             };
             assert_eq!(strpbrk_safe(s, set), expected, "set {set:?}");
         }
-    }
-
-    #[test]
-    #[cfg_attr(miri, ignore)]
-    fn test_raw_strncmp_stops_at_nul_within_allocation() {
-        /* The raw wrapper used to materialise an n-byte slice up front, which
-        over-read whenever the strings ended sooner. Compare against libc with
-        an n far larger than either allocation. */
-        let a: &[c_char] = bytemuck::cast_slice(b"abc\0");
-        let b: &[c_char] = bytemuck::cast_slice(b"abd\0");
-
-        let ru = unsafe { libc::strncmp(a.as_ptr(), b.as_ptr(), 4096) };
-        let rs = unsafe { strncmp(a.as_ptr(), b.as_ptr(), 4096) };
-        assert_eq!(ru.signum(), rs.signum());
-
-        let ru = unsafe { libc::strcmp(a.as_ptr(), a.as_ptr()) };
-        let rs = unsafe { strcmp(a.as_ptr(), a.as_ptr()) };
-        assert_eq!(ru.signum(), rs.signum());
-        assert_eq!(rs, 0);
     }
 
     // Write test cases for strto_float_impl

--- a/tests/test_eval_bit_strings.rs
+++ b/tests/test_eval_bit_strings.rs
@@ -1,0 +1,206 @@
+//! Per-row values of the bit-string operators in `src/eval_y.rs`.
+//!
+//! `Do_BinOp_bit`, `Do_Unary` and the `bitand`/`bitor`/`bitnot`/`bitcmp`/
+//! `bitlgte` helpers were converted from raw `*mut c_char` walks to slices.
+//! The `eval_corpus` golden covers the *shapes* of these expressions but not
+//! their values -- its probe skips the value of a `TSTRING`-typed result, and a
+//! bit-string result is typed `TSTRING` -- so the arithmetic itself is pinned
+//! here, one boolean per row.
+//!
+//! Expected values are derived by hand from the three BITS rows, `0xF0`,
+//! `0x0F` and `0xAA`, i.e. `11110000`, `00001111` and `10101010`.
+
+mod common;
+
+#[cfg(test)]
+mod tests {
+    use rsfitsio::aliases::rust_api::*;
+    use rsfitsio::c_types::{c_char, c_long};
+    use rsfitsio::fitsio::{BINARY_TBL, BYTE_IMG, LONGLONG, fitsfile};
+
+    const NROWS: c_long = 3;
+
+    fn cc(s: &str) -> Vec<c_char> {
+        let mut v: Vec<c_char> = s.bytes().map(|b| b as c_char).collect();
+        v.push(0);
+        v
+    }
+
+    /// A table with one 8-bit column, the same three rows the corpus uses.
+    fn bits_table() -> Box<fitsfile> {
+        let mut status = 0;
+        let mut f: Option<Box<fitsfile>> = None;
+        fits_create_file(&mut f, &cc("mem://bits.fits"), &mut status);
+        fits_write_imghdr(f.as_deref_mut().unwrap(), BYTE_IMG, 0, &[], &mut status);
+
+        let tt = [cc("BITS"), cc("OTHER")];
+        let tf = [cc("8X"), cc("8X")];
+        let tt_ref: Vec<Option<&[c_char]>> = tt.iter().map(|v| Some(v.as_slice())).collect();
+        let tf_ref: Vec<&[c_char]> = tf.iter().map(|v| v.as_slice()).collect();
+        fits_create_tbl(
+            f.as_deref_mut().unwrap(),
+            BINARY_TBL,
+            NROWS as LONGLONG,
+            2,
+            &tt_ref,
+            &tf_ref,
+            None,
+            None,
+            &mut status,
+        );
+
+        let fp = f.as_deref_mut().unwrap();
+        /* 11110000, 00001111, 10101010 */
+        fits_write_col_byt(fp, 1, 1, 1, 3, &[0xF0, 0x0F, 0xAA], &mut status);
+        /* 10000001, 11111111, 00000000 */
+        fits_write_col_byt(fp, 2, 1, 1, 3, &[0x81, 0xFF, 0x00], &mut status);
+
+        assert_eq!(status, 0, "bits table setup failed");
+        f.unwrap()
+    }
+
+    /// Evaluate a boolean expression over every row.
+    fn rows(f: &mut fitsfile, expr: &str) -> Vec<c_char> {
+        let mut out = [0 as c_char; NROWS as usize];
+        let mut n_good: c_long = 0;
+        let mut status = 0;
+
+        fits_find_rows(f, &cc(expr), 1, NROWS, &mut n_good, &mut out, &mut status);
+        assert_eq!(status, 0, "evaluating `{expr}` failed");
+        out.to_vec()
+    }
+
+    fn t() -> c_char {
+        1
+    }
+    fn f_() -> c_char {
+        0
+    }
+
+    #[test]
+    fn bitand_over_rows() {
+        let mut f = bits_table();
+        /* 11110000 & 10000001 = 10000000 -> only row 1 matches 10000000 */
+        assert_eq!(
+            rows(&mut f, "(BITS & OTHER) == b10000000"),
+            vec![t(), f_(), f_()]
+        );
+        /* 00001111 & 11111111 = 00001111 */
+        assert_eq!(
+            rows(&mut f, "(BITS & OTHER) == b00001111"),
+            vec![f_(), t(), f_()]
+        );
+        /* 10101010 & 00000000 = 00000000 */
+        assert_eq!(
+            rows(&mut f, "(BITS & OTHER) == b00000000"),
+            vec![f_(), f_(), t()]
+        );
+    }
+
+    #[test]
+    fn bitor_over_rows() {
+        let mut f = bits_table();
+        /* 11110000 | 10000001 = 11110001 */
+        assert_eq!(
+            rows(&mut f, "(BITS | OTHER) == b11110001"),
+            vec![t(), f_(), f_()]
+        );
+        /* 00001111 | 11111111 = 11111111 */
+        assert_eq!(
+            rows(&mut f, "(BITS | OTHER) == b11111111"),
+            vec![f_(), t(), f_()]
+        );
+        /* 10101010 | 00000000 = 10101010 */
+        assert_eq!(
+            rows(&mut f, "(BITS | OTHER) == b10101010"),
+            vec![f_(), f_(), t()]
+        );
+    }
+
+    #[test]
+    fn bitnot_over_rows() {
+        /* Do_Unary's Bits arm -- the one bit operator the corpus does not
+        reach, in both its row and its constant form. */
+        let mut f = bits_table();
+        assert_eq!(rows(&mut f, "(!BITS) == b00001111"), vec![t(), f_(), f_()]);
+        assert_eq!(rows(&mut f, "(!BITS) == b11110000"), vec![f_(), t(), f_()]);
+        assert_eq!(rows(&mut f, "(!BITS) == b01010101"), vec![f_(), f_(), t()]);
+        /* constant-folded form */
+        assert_eq!(
+            rows(&mut f, "(!b1010) == b0101"),
+            vec![t(), t(), t()],
+            "constant bitnot"
+        );
+    }
+
+    #[test]
+    fn bit_concatenation_over_rows() {
+        let mut f = bits_table();
+        /* '+' concatenates: 11110000 ++ 10000001 */
+        assert_eq!(
+            rows(&mut f, "(BITS + OTHER) == b1111000010000001"),
+            vec![t(), f_(), f_()]
+        );
+        assert_eq!(
+            rows(&mut f, "(BITS + BITS) == b1111000011110000"),
+            vec![t(), f_(), f_()]
+        );
+    }
+
+    #[test]
+    fn bit_comparisons_over_rows() {
+        let mut f = bits_table();
+        /* bitcmp: equality, with 'x' matching anything */
+        assert_eq!(rows(&mut f, "BITS == b1111xxxx"), vec![t(), f_(), f_()]);
+        assert_eq!(rows(&mut f, "BITS == bxxxx0000"), vec![t(), f_(), f_()]);
+        assert_eq!(rows(&mut f, "BITS != b11110000"), vec![f_(), t(), t()]);
+
+        /* bitlgte: 0xF0=240, 0x0F=15, 0xAA=170 */
+        assert_eq!(rows(&mut f, "BITS > b10101010"), vec![t(), f_(), f_()]);
+        assert_eq!(rows(&mut f, "BITS >= b10101010"), vec![t(), f_(), t()]);
+        assert_eq!(rows(&mut f, "BITS < b10101010"), vec![f_(), t(), f_()]);
+        assert_eq!(rows(&mut f, "BITS <= b10101010"), vec![f_(), t(), t()]);
+    }
+
+    #[test]
+    fn unequal_length_operands_are_left_padded() {
+        /* bit_align: the shorter operand is padded with '0' on the left, so a
+        4-bit literal compares as its 8-bit zero-extension. */
+        let mut f = bits_table();
+        assert_eq!(rows(&mut f, "BITS == b0000"), vec![f_(), f_(), f_()]);
+        assert_eq!(rows(&mut f, "OTHER == b0"), vec![f_(), f_(), t()]);
+        /* 00001111 vs 1111 -> equal once padded */
+        assert_eq!(rows(&mut f, "BITS == b1111"), vec![f_(), t(), f_()]);
+        /* and the padding also applies through & / | */
+        assert_eq!(
+            rows(&mut f, "(BITS & b1111) == b00000000"),
+            vec![t(), f_(), f_()]
+        );
+    }
+
+    #[test]
+    fn constant_folding_matches_the_row_path() {
+        /* Both operands constant takes Do_BinOp_bit's other branch, which
+        writes the scalar Text arm rather than a row buffer. */
+        let mut f = bits_table();
+        assert_eq!(rows(&mut f, "(b101 & b110) == b100"), vec![t(), t(), t()]);
+        assert_eq!(rows(&mut f, "(b101 | b110) == b111"), vec![t(), t(), t()]);
+        assert_eq!(
+            rows(&mut f, "(b101 + b110) == b101110"),
+            vec![t(), t(), t()]
+        );
+        assert_eq!(rows(&mut f, "b101 > b100"), vec![t(), t(), t()]);
+        assert_eq!(rows(&mut f, "b101 < b110"), vec![t(), t(), t()]);
+    }
+
+    #[test]
+    fn row_offset_copies_bit_strings() {
+        /* Do_Offset's Bits arm -- the strcpy that moves a whole row buffer. */
+        let mut f = bits_table();
+        /* row i reads row i+1: rows 1,2 see 00001111 and 10101010 */
+        let got = rows(&mut f, "BITS{1} == b00001111");
+        assert_eq!(got[0], t(), "row 1 offset by 1 should see row 2");
+        let got = rows(&mut f, "BITS{1} == b10101010");
+        assert_eq!(got[1], t(), "row 2 offset by 1 should see row 3");
+    }
+}

--- a/tests/test_eval_string_funcs.rs
+++ b/tests/test_eval_string_funcs.rs
@@ -1,0 +1,193 @@
+//! Per-row values of `STRMID` and `STRSTR`, and of string concatenation and
+//! comparison, in `src/eval_y.rs`.
+//!
+//! `cstrmid` now takes slices instead of raw pointers, and the `STRMID_FCT` /
+//! `STRPOS_FCT` row loops reach their subject through `lval::str_row` rather
+//! than a `char **` row-pointer array. The `eval_corpus` golden covers the
+//! shapes of these expressions, but its probe skips the *value* of a
+//! `TSTRING`-typed result, so `STRMID`'s output and the string operators are
+//! pinned here through boolean comparisons, one per row.
+//!
+//! The rows are `SA = "abcdefg", "xy", "mnop"` in an `8A` column and
+//! `SB = "cd", "xy", "zz"` in a `4A` one. Two things about `STRMID` follow from
+//! the engine rather than from the strings, and the expectations below depend
+//! on both:
+//!
+//!  * the source length is the *column width*, not `strlen` of the row, and
+//!    the reader zero-fills the rest of the field -- so a window past the end
+//!    of a short row yields the empty string rather than an error;
+//!  * a window running off the end copies only as far as the field goes.
+//!
+//! Column names avoid `T` and `F`, which the grammar reads as the FITS logical
+//! constants rather than as column references.
+
+mod common;
+
+#[cfg(test)]
+mod tests {
+    use rsfitsio::aliases::rust_api::*;
+    use rsfitsio::c_types::{c_char, c_long};
+    use rsfitsio::fitsio::{BINARY_TBL, BYTE_IMG, LONGLONG, fitsfile};
+
+    const NROWS: c_long = 3;
+
+    fn cc(s: &str) -> Vec<c_char> {
+        let mut v: Vec<c_char> = s.bytes().map(|b| b as c_char).collect();
+        v.push(0);
+        v
+    }
+
+    /// Two string columns, three rows.
+    fn str_table() -> Box<fitsfile> {
+        let mut status = 0;
+        let mut f: Option<Box<fitsfile>> = None;
+        fits_create_file(&mut f, &cc("mem://strs.fits"), &mut status);
+        fits_write_imghdr(f.as_deref_mut().unwrap(), BYTE_IMG, 0, &[], &mut status);
+
+        let tt = [cc("SA"), cc("SB")];
+        let tf = [cc("8A"), cc("4A")];
+        let tt_ref: Vec<Option<&[c_char]>> = tt.iter().map(|v| Some(v.as_slice())).collect();
+        let tf_ref: Vec<&[c_char]> = tf.iter().map(|v| v.as_slice()).collect();
+        fits_create_tbl(
+            f.as_deref_mut().unwrap(),
+            BINARY_TBL,
+            NROWS as LONGLONG,
+            2,
+            &tt_ref,
+            &tf_ref,
+            None,
+            None,
+            &mut status,
+        );
+
+        let fp = f.as_deref_mut().unwrap();
+        for (i, s) in ["abcdefg", "xy", "mnop"].iter().enumerate() {
+            let sv = cc(s);
+            let arr: [&[c_char]; 1] = [sv.as_slice()];
+            fits_write_col_str(fp, 1, (i + 1) as LONGLONG, 1, 1, &arr, &mut status);
+        }
+        for (i, s) in ["cd", "xy", "zz"].iter().enumerate() {
+            let sv = cc(s);
+            let arr: [&[c_char]; 1] = [sv.as_slice()];
+            fits_write_col_str(fp, 2, (i + 1) as LONGLONG, 1, 1, &arr, &mut status);
+        }
+
+        assert_eq!(status, 0, "string table setup failed");
+        f.unwrap()
+    }
+
+    fn rows(f: &mut fitsfile, expr: &str) -> Vec<c_char> {
+        let mut out = [0 as c_char; NROWS as usize];
+        let mut n_good: c_long = 0;
+        let mut status = 0;
+
+        fits_find_rows(f, &cc(expr), 1, NROWS, &mut n_good, &mut out, &mut status);
+        assert_eq!(status, 0, "evaluating `{expr}` failed");
+        out.to_vec()
+    }
+
+    const T: c_char = 1;
+    const F: c_char = 0;
+
+    #[test]
+    fn strmid_over_row_buffers() {
+        /* cstrmid with a per-row subject. */
+        let mut f = str_table();
+        assert_eq!(rows(&mut f, "STRMID(SA,1,3) == 'abc'"), vec![T, F, F]);
+        assert_eq!(rows(&mut f, "STRMID(SA,1,3) == 'xy'"), vec![F, T, F]);
+        assert_eq!(rows(&mut f, "STRMID(SA,1,3) == 'mno'"), vec![F, F, T]);
+
+        /* A window past the end of a short row lands in the field's zero fill,
+        so rows 2 ("xy") and 3 ("mnop") both come back empty. */
+        assert_eq!(rows(&mut f, "STRMID(SA,5,2) == 'ef'"), vec![T, F, F]);
+        assert_eq!(rows(&mut f, "STRMID(SA,5,2) == ''"), vec![F, T, T]);
+
+        /* A window running off the end copies only to the end of the field. */
+        assert_eq!(rows(&mut f, "STRMID(SA,3,9) == 'cdefg'"), vec![T, F, F]);
+        assert_eq!(rows(&mut f, "STRMID(SA,3,9) == 'op'"), vec![F, F, T]);
+    }
+
+    #[test]
+    fn strmid_over_a_constant_subject() {
+        /* The strconst arm, where the subject is copied out of the node once
+        before the row loop. */
+        let mut f = str_table();
+        assert_eq!(rows(&mut f, "STRMID('abcdef',2,3) == 'bcd'"), vec![T, T, T]);
+        assert_eq!(
+            rows(&mut f, "STRMID('abcdef',1,6) == 'abcdef'"),
+            vec![T, T, T]
+        );
+        /* pos == 0 asks for a null string. The constant path returns it as an
+        empty string; only the per-row path additionally flags it undefined. */
+        assert_eq!(rows(&mut f, "STRMID('abcdef',0,3) == ''"), vec![T, T, T]);
+    }
+
+    #[test]
+    fn strstr_over_row_buffers() {
+        /* STRPOS_FCT: 1-based index. Per-row subject, constant needle. */
+        let mut f = str_table();
+        assert_eq!(rows(&mut f, "STRSTR(SA,'cd') == 3"), vec![T, F, F]);
+        assert_eq!(rows(&mut f, "STRSTR(SA,'y') == 2"), vec![F, T, F]);
+        assert_eq!(rows(&mut f, "STRSTR(SA,'op') == 3"), vec![F, F, T]);
+        /* An absent needle is *undefined* on the per-row path. */
+        assert_eq!(
+            rows(&mut f, "DEFNULL(STRSTR(SA,'zz'),-1) == -1"),
+            vec![T, T, T]
+        );
+    }
+
+    #[test]
+    fn strstr_with_both_operands_per_row() {
+        /* Subject and needle both come from row buffers: "cd" in "abcdefg" at
+        3, "xy" in "xy" at 1, and "zz" absent from "mnop". */
+        let mut f = str_table();
+        assert_eq!(rows(&mut f, "STRSTR(SA,SB) == 3"), vec![T, F, F]);
+        assert_eq!(rows(&mut f, "STRSTR(SA,SB) == 1"), vec![F, T, F]);
+        assert_eq!(
+            rows(&mut f, "DEFNULL(STRSTR(SA,SB),-1) == -1"),
+            vec![F, F, T]
+        );
+    }
+
+    #[test]
+    fn strstr_with_both_operands_constant() {
+        /* The constant-folded branch. Note the asymmetry with the row path
+        above: when the needle is absent this returns 0 rather than marking the
+        result undefined, so DEFNULL has nothing to replace. That is the C's
+        behaviour and is preserved here deliberately. */
+        let mut f = str_table();
+        assert_eq!(rows(&mut f, "STRSTR('abc','b') == 2"), vec![T, T, T]);
+        assert_eq!(rows(&mut f, "STRSTR('abc','a') == 1"), vec![T, T, T]);
+        assert_eq!(rows(&mut f, "STRSTR('abc','z') == 0"), vec![T, T, T]);
+        assert_eq!(
+            rows(&mut f, "DEFNULL(STRSTR('abc','z'),-1) == -1"),
+            vec![F, F, F]
+        );
+    }
+
+    #[test]
+    fn string_concatenation_and_comparison() {
+        /* Do_BinOp_str: '+' concatenates, and the comparisons go through the
+        first-character fast path and then strcmp_safe. */
+        let mut f = str_table();
+        assert_eq!(rows(&mut f, "(SA + SB) == 'abcdefgcd'"), vec![T, F, F]);
+        assert_eq!(rows(&mut f, "(SA + SB) == 'xyxy'"), vec![F, T, F]);
+        assert_eq!(rows(&mut f, "(SB + SB) == 'zzzz'"), vec![F, F, T]);
+
+        assert_eq!(rows(&mut f, "SA == SB"), vec![F, T, F]);
+        assert_eq!(rows(&mut f, "SA != SB"), vec![T, F, T]);
+        assert_eq!(rows(&mut f, "SA < SB"), vec![T, F, T]);
+        assert_eq!(rows(&mut f, "SA > SB"), vec![F, F, F]);
+        assert_eq!(rows(&mut f, "SA <= SB"), vec![T, T, T]);
+    }
+
+    #[test]
+    fn row_offset_copies_strings() {
+        /* Do_Offset's String arm -- the strcpy that moves a whole row. */
+        let mut f = str_table();
+        let got = rows(&mut f, "SA{1} == 'xy'");
+        assert_eq!(got[0], T, "row 1 offset by 1 should see row 2");
+        let got = rows(&mut f, "SA{1} == 'mnop'");
+        assert_eq!(got[1], T, "row 2 offset by 1 should see row 3");
+    }
+}


### PR DESCRIPTION
Finishes the removal of raw C string functions from the crate. The 45 calls
that survived the previous pass — 39 in `eval_y.rs`, 6 in `eval_f.rs` — were
not 45 independent sites but the surface of one storage decision, so they are
dealt with together here.

## The blocker, and what unlocks it

Every remaining call reached a per-row string buffer through the `char **`
array in `NodeValue::Buffer`. Producing a `&[c_char]` for a row meant borrowing
`ParseData::Nodes`, which the caller already held mutably — `Do_BinOp_bit`
writes one node's row while reading two others':

```rust
bitor(
    *(Nodes[this_node_idx].value.data.str_buf()).offset(row),   // write
    *(Nodes[that1_idx    ].value.data.str_buf()).offset(row),   // read
    *(Nodes[that2_idx    ].value.data.str_buf()).offset(row),   // read
);
```

There was already an abandoned `get_this_that1_that2_nodes` in the file for
exactly this, and its own body shows why it was abandoned:
`assert_ne!(that1_idx, that2_idx)`. The two *operands* may legitimately be the
same node (`X | X`), so a three-way mutable split is the wrong primitive.

Two accessors on `lval` solve it instead:

```rust
pub(crate) unsafe fn str_row<'a>(&self, row: c_long) -> &'a [c_char];
pub(crate) unsafe fn str_row_mut<'a>(&self, row: c_long) -> &'a mut [c_char];
```

Both take `&self` and return an unbounded lifetime — correct, because the
buffer is not part of `lval`, only pointed to by it. `Node: Copy` means callers
hold no borrow of `lParse` at all. Constant operands are copied out of their
node once before each row loop, so a `&mut` and a `&` are never live on the
same node.

## What follows

- `bitand`, `bitor`, `bitnot`, `bitcmp`, `bitlgte` and `cstrmid` become
  **fully safe functions** taking slices, sharing a `bit_align` helper for the
  left-pad the C did with a scratch buffer.
- `Do_BinOp_bit`, `Do_BinOp_str`, `Do_Func` and `Do_Offset` use the `*_safe`
  helpers throughout.
- The entire raw wrapper family is then dead and is **deleted**: `strcpy`,
  `strncpy`, `strcmp`, `strncmp`, `strlen`, `strnlen`, `strchr`, `strstr`,
  `strcat`, `strncat`, `strtok_r`, `strpbrk`, `strspn`, `strcspn`,
  `inner_strstr`. The only `libc::str*` references left in the crate are the
  differential tests that check the safe versions against the real thing.

## `eval_f.rs` is a different problem

Those 6 copies write into the *iterator's* `char **` output arrays, and the
string element width is not reachable from the work function: `ffiter` sets
`iteratorCol::repeat` to 1 for string columns and `pv.datasize` is the size of
a pointer, with the real width living in `ffiter`'s private bookkeeping.
Plumbing it would mean widening the public `#[repr(C)] iteratorCol`.

So `copy_str_elem` builds the destination slice to exactly the bytes `strcpy`
would write. **To be explicit: this does not add a destination-capacity
check** — the copy is bounded and its length auditable, but that information
does not exist at that point in the program. Same bytes as before, no worse.

## Tests

The `eval_corpus` golden pins the *shapes* of these expressions, but its probe
skips the value of a `TSTRING` result — and a bit-string result is typed
`TSTRING` — so none of this arithmetic was value-checked. Two new files add 15
tests with hand-derived expectations:

- bit operators per row, including `bitnot`, which the corpus does not reach
  at all;
- unequal-length operand padding through `==`, `&` and `|`;
- `STRMID` / `STRSTR` over both row buffers and constants;
- string concatenation and the six comparisons;
- the `Do_Offset` row copies for both String and Bits.

They pin one behaviour worth knowing about: with an absent needle,
constant-folded `STRSTR` returns 0 while the per-row path marks the result
undefined. That asymmetry is the C's and is preserved deliberately.

Writing them also caught that `STRPOS` is spelled `STRSTR` in the language,
and that a column named `T` parses as the FITS logical literal.

## Verification

- `cargo test` — 2923 passed, 0 failed (2909 before).
- `bash ./testprog_check.sh` — byte-identical, both files.
- `cargo fmt --check` — clean.
- `eval_corpus.golden` — **unchanged**, as it should be for a pure refactor.

**Miri cannot validate this, and that is not new.** A pre-existing Stacked
Borrows violation in the lexer's `yy_buffer_stack` (`eval_l.rs:1522` against
`:1703`) aborts on any test that invokes the parser. I verified this against a
clean worktree at `fed4b4f` rather than assuming it; `eval_l.rs` is untouched
by this PR. A second, separate one is in the `test_ffcalc_*` tests themselves,
which alias `&mut *fp_self` twice. Both are recorded in `TODO.md` — fixing the
first is worth doing *before* the follow-up below, since that is exactly the
kind of change Miri exists to check.

## Follow-up, not in this PR

The two `str_row` accessors are still `unsafe`. Removing that means owning the
row buffers in `ParseData` instead of `malloc`, which also collapses the
redundant `char **` array — the row pointers are just `block + row*(nelem+1)`.
That drags in `load_column`'s `loadData` ABI, which is why it is deferred, and
it would fix an uninitialised read there as a side effect: its TSTRING arm runs
`CStr::from_ptr` over a buffer `Allocate_Ptrs` has not written yet, to decide
how much it may write.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CnuucR9Sw9aG7AxsQdKX28
