### PR TITLE
Own the eval scratch allocations, and fix the leaked parameter arrays in fffrwc

### DIFF
--- a/src/eval_defs.rs
+++ b/src/eval_defs.rs
@@ -105,16 +105,23 @@ pub(crate) enum BufferKind {
 /// matched the node's sort. The accessors below assert it, so that class of
 /// mistake is a panic in a debug build instead of undefined behaviour.
 ///
-/// The buffer is still a raw allocation rather than a `Vec`. The `Do_*`
-/// routines read two operand buffers while writing a third, all indexed out of
-/// `ParseData::Nodes`; owning the storage would make that a borrow conflict,
-/// and untangling it is a separate change from tagging the union.
+/// The buffer is still a raw allocation rather than a `Vec`. Two things stand
+/// in the way, neither of them `Copy`:
+///
+/// * The `Do_*` routines read two operand buffers while writing a third, all
+///   indexed out of `ParseData::Nodes`. That needs one `&mut` and two `&` at
+///   distinct indices -- `split_at_mut` territory, since the two operands may
+///   be the same node.
+/// * Only *computed* nodes own their buffer. `Evaluate_Parser` re-points every
+///   *column* node at `varData[column].data` before each evaluation, and for a
+///   String column that is the iterator's own array, laid out by `ffiter`. An
+///   owning arm would need a borrowed one beside it, and the ownership question
+///   moves to `ffiter`. See `notes/EVAL_STRING_STORAGE.md`.
+///
 /// The `Text` arm makes this 264 bytes where the others need 16. That is the
-/// union's own footprint, so it is not a regression, and boxing it is not an
-/// option while `lval` and `Node` are `Copy` and get copied by value all
-/// through the engine.
+/// union's own footprint, so it is not a regression.
 #[allow(clippy::large_enum_variant)]
-#[derive(Copy, Clone, Default)]
+#[derive(Clone, Default)]
 pub(crate) enum NodeValue {
     /// A freshly allocated node, or one whose buffer has been freed.
     #[default]
@@ -290,7 +297,7 @@ fn wrong_arm(want: &str, got: &NodeValue) -> ! {
     panic!("node value is {got:?}, expected {want}");
 }
 
-#[derive(Default, Debug, Copy, Clone)]
+#[derive(Default, Debug, Clone)]
 pub(crate) struct lval {
     pub nelem: c_long,
     pub naxis: c_int,
@@ -336,7 +343,7 @@ impl lval {
     }
 }
 
-#[derive(Default, Debug, Copy, Clone)]
+#[derive(Default, Debug, Clone)]
 pub(crate) struct Node {
     pub operation: c_int,
     pub DoOp: Option<fn(p: &mut ParseData, this_node_idx: usize)>,

--- a/src/eval_f.rs
+++ b/src/eval_f.rs
@@ -3452,7 +3452,7 @@ pub fn fffrwc_safe(
 
         if fits_uncompress_hkdata(&mut lParse, fptr, ntimes, times, status) == 0 {
             if constant != 0 {
-                let result_node = lParse.Nodes[lParse.resultNode as usize];
+                let result_node = &lParse.Nodes[lParse.resultNode as usize];
                 result = (result_node).value.data.log();
                 let mut elem = ntimes;
                 while elem > 0 {

--- a/src/eval_f.rs
+++ b/src/eval_f.rs
@@ -488,7 +488,6 @@ pub fn ffsrow_safe(
                 .try_reserve_exact(cmp::max(500000, rdlen) as usize)
                 .is_err()
             {
-
                 ffcprs(&mut lParse);
                 *status = MEMORY_ALLOCATION;
                 return *status;
@@ -3364,27 +3363,46 @@ pub fn fffrwc_safe(
         /* Allocate data arrays for each parameter */
         /*******************************************/
 
+        /* The C wrote each array straight into lParse.colData[parNo].array.
+        `iteratorCol` is Copy here, so pulling the descriptor out into a local
+        and assigning through that -- as this used to -- set the field on a
+        copy that was then dropped: the allocation leaked and the parser saw
+        whatever array the descriptor already had. Index the vector directly.
+
+        The arrays are owned for the length of the call instead of malloc'd,
+        so the error return below and every path after it release them without
+        a cleanup loop. Pushing to these outer vectors moves the inner Vec
+        headers but not their heap data, so the pointers handed to colData
+        stay valid. */
+        let mut lng_arrays: Vec<Vec<c_long>> = Vec::new();
+        let mut dbl_arrays: Vec<Vec<c_double>> = Vec::new();
+        let mut str_blocks: Vec<Vec<c_char>> = Vec::new();
+        let mut str_ptrs: Vec<Vec<*mut c_char>> = Vec::new();
+
         parNo = lParse.nCols;
         while parNo > 0 {
             parNo -= 1;
-            let mut col_data = lParse.colData[parNo as usize];
-            match col_data.datatype {
+            match lParse.colData[parNo as usize].datatype {
                 TLONG => {
-                    col_data.array = malloc(((ntimes + 1) as usize) * size_of::<c_long>());
-                    if !col_data.array.is_null() {
-                        let array_ptr = col_data.array.cast::<c_long>();
-                        *array_ptr.wrapping_add(0) = 1234554321;
-                    } else {
+                    let mut v: Vec<c_long> = Vec::new();
+                    if v.try_reserve_exact((ntimes + 1) as usize).is_err() {
                         *status = MEMORY_ALLOCATION;
+                    } else {
+                        v.resize((ntimes + 1) as usize, 0);
+                        v[0] = 1234554321;
+                        lParse.colData[parNo as usize].array = v.as_mut_ptr().cast::<c_void>();
+                        lng_arrays.push(v);
                     }
                 }
                 TDOUBLE => {
-                    col_data.array = malloc(((ntimes + 1) as usize) * size_of::<c_double>());
-                    if !col_data.array.is_null() {
-                        let array_ptr = col_data.array.cast::<c_double>();
-                        *array_ptr.wrapping_add(0) = DOUBLENULLVALUE;
-                    } else {
+                    let mut v: Vec<c_double> = Vec::new();
+                    if v.try_reserve_exact((ntimes + 1) as usize).is_err() {
                         *status = MEMORY_ALLOCATION;
+                    } else {
+                        v.resize((ntimes + 1) as usize, 0.0);
+                        v[0] = DOUBLENULLVALUE;
+                        lParse.colData[parNo as usize].array = v.as_mut_ptr().cast::<c_void>();
+                        dbl_arrays.push(v);
                     }
                 }
                 TSTRING => {
@@ -3398,24 +3416,25 @@ pub fn fffrwc_safe(
                     ) == 0
                     {
                         alen += 1;
-                        col_data.array = malloc(((ntimes + 1) as usize) * size_of::<*mut c_char>());
-                        if !col_data.array.is_null() {
-                            let str_array = col_data.array.cast::<*mut c_char>();
-                            let first_str = malloc(((ntimes + 1) * alen) as usize).cast::<c_char>();
-                            *str_array.wrapping_add(0) = first_str;
-                            if !first_str.is_null() {
-                                for elem in 1..=(ntimes as usize) {
-                                    *str_array.wrapping_add(elem) = (*str_array
-                                        .wrapping_add(elem - 1))
-                                    .wrapping_add(alen as usize);
-                                }
-                                *(*str_array.wrapping_add(0)).wrapping_add(0) = 0;
-                            } else {
-                                free(col_data.array);
-                                *status = MEMORY_ALLOCATION;
-                            }
-                        } else {
+                        let nelems = (ntimes + 1) as usize;
+                        let mut block: Vec<c_char> = Vec::new();
+                        let mut ptrs: Vec<*mut c_char> = Vec::new();
+                        if block.try_reserve_exact(nelems * alen as usize).is_err()
+                            || ptrs.try_reserve_exact(nelems).is_err()
+                        {
                             *status = MEMORY_ALLOCATION;
+                        } else {
+                            /* one block, `alen` characters per element -- the
+                            zero fill also gives element 0 its empty string */
+                            block.resize(nelems * alen as usize, 0);
+                            let base = block.as_mut_ptr();
+                            for elem in 0..nelems {
+                                ptrs.push(base.add(elem * alen as usize));
+                            }
+                            lParse.colData[parNo as usize].array =
+                                ptrs.as_mut_ptr().cast::<c_void>();
+                            str_blocks.push(block);
+                            str_ptrs.push(ptrs);
                         }
                     }
                 }
@@ -3423,19 +3442,6 @@ pub fn fffrwc_safe(
             }
 
             if *status != 0 {
-                while parNo > 0 {
-                    parNo -= 1;
-                    let col_data2 = lParse.colData[parNo as usize];
-                    if (col_data2).datatype == TSTRING {
-                        let str_array = (col_data2).array.cast::<*mut c_char>();
-                        if !str_array.is_null() {
-                            let mut first_str = *str_array.wrapping_add(0);
-                            FREE!(first_str);
-                        }
-                    }
-                    let mut array_ptr = (col_data2).array;
-                    FREE!(array_ptr);
-                }
                 return *status;
             }
         }
@@ -3473,20 +3479,8 @@ pub fn fffrwc_safe(
         /* Clean up */
         /************/
 
-        parNo = lParse.nCols;
-        while parNo > 0 {
-            parNo -= 1;
-            let col_data = lParse.colData[parNo as usize];
-            if (col_data).datatype == TSTRING {
-                let str_array = (col_data).array.cast::<*mut c_char>();
-                if !str_array.is_null() {
-                    let mut first_str = *str_array.wrapping_add(0);
-                    FREE!(first_str);
-                }
-            }
-            let mut array_ptr = (col_data).array;
-            FREE!(array_ptr);
-        }
+        /* No cleanup loop: lng_arrays/dbl_arrays/str_blocks/str_ptrs own the
+        column arrays and drop at the end of this function. */
 
         if constant != 0 {
             lParse.nCols = nCol;

--- a/src/eval_f.rs
+++ b/src/eval_f.rs
@@ -427,19 +427,27 @@ pub fn ffsrow_safe(
         /*  Fill out Info data for parser  */
         /***********************************/
 
-        Info.dataPtr = malloc((inExt.numRows + 1) as usize * size_of::<c_char>());
-        Info.nullPtr = ptr::null_mut();
-        Info.maxRows = inExt.numRows as c_long;
-        Info.parseData = core::ptr::from_mut::<ParseData>(&mut lParse);
-        if Info.dataPtr.is_null() {
+        /* The row-selection flags are owned here and handed to the parser as a
+        raw pointer, so the error returns below cannot leak them. Everything
+        after this point reaches them through Info.dataPtr, never through
+        `row_flags` directly, so the pointer stays the only live borrow. */
+        let mut row_flags: Vec<c_char> = Vec::new();
+        if row_flags
+            .try_reserve_exact((inExt.numRows + 1) as usize)
+            .is_err()
+        {
             ffpmsg_str("Unable to allocate memory for row selection");
             ffcprs(&mut lParse);
             *status = MEMORY_ALLOCATION;
             return *status;
         }
+        /* resize also zero terminates the array */
+        row_flags.resize((inExt.numRows + 1) as usize, 0);
 
-        /* make sure array is zero terminated */
-        *Info.dataPtr.cast::<c_char>().add(inExt.numRows as usize) = 0;
+        Info.dataPtr = row_flags.as_mut_ptr().cast::<c_void>();
+        Info.nullPtr = ptr::null_mut();
+        Info.maxRows = inExt.numRows as c_long;
+        Info.parseData = core::ptr::from_mut::<ParseData>(&mut lParse);
 
         if constant != 0 {
             /*  Set all rows to the same value from constant result  */
@@ -480,7 +488,7 @@ pub fn ffsrow_safe(
                 .try_reserve_exact(cmp::max(500000, rdlen) as usize)
                 .is_err()
             {
-                FREE!(Info.dataPtr);
+
                 ffcprs(&mut lParse);
                 *status = MEMORY_ALLOCATION;
                 return *status;
@@ -658,7 +666,6 @@ pub fn ffsrow_safe(
             } /*  End of HEAP copy  */
         }
 
-        FREE!(Info.dataPtr);
         ffcprs(&mut lParse);
 
         ffcmph_safe(outfptr, status); /* compress heap, deleting any orphaned data */

--- a/src/eval_y.rs
+++ b/src/eval_y.rs
@@ -70,7 +70,6 @@
 
 use alloc::rc::Rc;
 use core::ffi::CStr;
-use core::slice;
 use core::{cmp, ptr};
 
 use bytemuck::{cast_slice, cast_slice_mut};
@@ -528,13 +527,6 @@ impl UnaryOp {
 }
 
 const PARSER_VECTOR_MIN_ADDR: usize = 0x1000;
-
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub(crate) union yyalloc {
-    pub yyss_alloc: yy_state_t,
-    pub yyvs_alloc: FITS_PARSER_YYSTYPE,
-}
 
 /* YYFINAL -- State number of the termination state.  */
 const YYFINAL: usize = 2;
@@ -1463,12 +1455,25 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
         let mut yystate: yy_state_fast_t = 0;
         let mut yyerrstatus: c_int = 0;
         let mut yystacksize: c_long = YYINITDEPTH as c_long;
-        let mut yyssa: [yy_state_t; YYINITDEPTH] = [0; YYINITDEPTH];
-        let mut yyss: &mut [yy_state_t] = &mut yyssa;
+        /* The C started on two YYINITDEPTH stack arrays and, on overflow,
+        carved a replacement for both out of a single alloca-turned-malloc
+        block, stepping through it with the `yyalloc` union to get the
+        alignment right. Two owned stacks do the same job: growing is a
+        `resize`, which keeps what is already there just as the memcpy pair
+        did, and they are released on every exit -- the C leaked them on the
+        error gotos. Starting on the heap also keeps YYINITDEPTH parser values
+        (a few tens of KB) off the call stack. */
+        let mut yyss: Vec<yy_state_t> = Vec::new();
+        let mut yyvs: Vec<FITS_PARSER_YYSTYPE> = Vec::new();
+        if yyss.try_reserve_exact(YYINITDEPTH).is_err()
+            || yyvs.try_reserve_exact(YYINITDEPTH).is_err()
+        {
+            lParse.status = MEMORY_ALLOCATION;
+            return 2; /* as yyexhaustedlab does */
+        }
+        yyss.resize(YYINITDEPTH, 0);
+        yyvs.resize(YYINITDEPTH, FITS_PARSER_YYSTYPE::Empty);
         let mut yyssp: usize = 0;
-        let mut yyvsa: [FITS_PARSER_YYSTYPE; YYINITDEPTH] =
-            [FITS_PARSER_YYSTYPE::Empty; YYINITDEPTH];
-        let mut yyvs: &mut [FITS_PARSER_YYSTYPE] = &mut yyvsa;
         let mut yyvsp: usize = 0;
         let mut yyn: c_int = 0;
         let mut yyresult: c_int = 0;
@@ -1484,7 +1489,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                 eprintln!("Entering state {}", yystate);
             }
             assert!(0 <= yystate && yystate < YYNSTATES as c_int);
-            YY_STACK_PRINT!(yyss, yyssp);
+            YY_STACK_PRINT!(&yyss[..], yyssp);
 
             yyss[yyssp] = yystate as yy_state_t;
             if (yystacksize - 1) as usize <= yyssp {
@@ -1499,58 +1504,17 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                     /* Extend the stack our own way.  */
                     yystacksize = YYMAXDEPTH as c_long;
                 }
-                let yyss1: *mut yy_state_t = yyss.as_mut_ptr();
-                let mut yyptr: *mut yyalloc = malloc(
-                    ((yystacksize
-                        * (::core::mem::size_of::<yy_state_t>() as c_ulong as c_long
-                            + ::core::mem::size_of::<FITS_PARSER_YYSTYPE>() as c_ulong as c_long)
-                        + (::core::mem::size_of::<yyalloc>() as c_ulong as c_long - 1))
-                        as c_ulong)
-                        .try_into()
-                        .unwrap(),
-                )
-                .cast::<yyalloc>();
-                if yyptr.is_null() {
+                let want = yystacksize as usize;
+                if yyss.try_reserve_exact(want - yyss.len()).is_err()
+                    || yyvs.try_reserve_exact(want - yyvs.len()).is_err()
+                {
                     current_block = 11794367917084412820; // goto yyexhaustedlab;
                     break;
                 }
-                let mut yynewbytes: c_long = 0;
-                libc::memcpy(
-                    core::ptr::from_mut::<yy_state_t>(&mut (*yyptr).yyss_alloc).cast::<c_void>(),
-                    yyss.as_ptr().cast::<c_void>(),
-                    (yysize as c_ulong)
-                        .wrapping_mul(::core::mem::size_of::<yy_state_t>() as c_ulong)
-                        as libc::size_t,
-                );
-                yyss =
-                    slice::from_raw_parts_mut(&raw mut (*yyptr).yyss_alloc, yystacksize as usize);
-                yynewbytes = yystacksize
-                    * ::core::mem::size_of::<yy_state_t>() as c_ulong as c_long
-                    + (::core::mem::size_of::<yyalloc>() as c_ulong as c_long - 1);
-                yyptr = yyptr.offset(
-                    (yynewbytes / ::core::mem::size_of::<yyalloc>() as c_ulong as c_long) as isize,
-                );
-                let mut yynewbytes_0: c_long = 0;
-                libc::memcpy(
-                    core::ptr::from_mut::<FITS_PARSER_YYSTYPE>(&mut (*yyptr).yyvs_alloc)
-                        .cast::<c_void>(),
-                    yyvs.as_ptr().cast::<c_void>(),
-                    (yysize as c_ulong)
-                        .wrapping_mul(::core::mem::size_of::<FITS_PARSER_YYSTYPE>() as c_ulong)
-                        as libc::size_t,
-                );
-                yyvs =
-                    slice::from_raw_parts_mut(&raw mut (*yyptr).yyvs_alloc, yystacksize as usize);
-                yynewbytes_0 = yystacksize
-                    * ::core::mem::size_of::<FITS_PARSER_YYSTYPE>() as c_ulong as c_long
-                    + (::core::mem::size_of::<yyalloc>() as c_ulong as c_long - 1);
-                yyptr = yyptr.offset(
-                    (yynewbytes_0 / ::core::mem::size_of::<yyalloc>() as c_ulong as c_long)
-                        as isize,
-                );
-                if yyss1 != yyssa.as_mut_ptr() {
-                    free(yyss1.cast::<c_void>());
-                }
+                /* resize keeps the yysize entries already on the stacks, which
+                is what the C's two memcpys did. */
+                yyss.resize(want, 0);
+                yyvs.resize(want, FITS_PARSER_YYSTYPE::Empty);
                 yyssp = yysize as usize - 1;
                 yyvsp = yysize as usize - 1;
                 if (yystacksize - 1) as usize <= yyssp {
@@ -7608,11 +7572,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
             yyssp -= 1;
         }
 
-        let yyss_tmp_ptr = yyss.as_ptr();
-
-        if yyss_tmp_ptr != yyssa.as_ptr() {
-            free(yyss_tmp_ptr.cast::<c_void>().cast_mut());
-        }
+        /* yyss and yyvs own their storage and release it here. */
         yyresult
     }
 }
@@ -12194,27 +12154,24 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                             let mut dptr: *mut c_long =
                                 (lParse.Nodes[theParams[0]]).value.data.lng_buf();
                             let mut uptr: *mut c_char = (lParse.Nodes[theParams[0]]).value.undef;
-                            let mptr: *mut c_long = malloc(
-                                (::core::mem::size_of::<c_long>() as c_ulong)
-                                    .wrapping_mul(nelem as c_ulong)
-                                    .try_into()
-                                    .unwrap(),
-                            )
-                            .cast::<c_long>();
-                            let mut irow: c_int = 0;
                             /* Allocate temporary storage for this row, since the
-                            quickselect function will scramble the contents */
-                            if mptr.is_null() {
+                            quickselect function will scramble the contents. It is
+                            owned rather than malloc'd, so the early error return
+                            below cannot leak it. */
+                            let mut mvec: Vec<c_long> = Vec::new();
+                            let mut irow: c_int = 0;
+                            if mvec.try_reserve_exact(nelem as usize).is_err() {
                                 fits_parser_yyerror(
                                     lParse,
                                     cs!(c"Could not allocate temporary memory in median function"),
                                 );
                                 free((lParse.Nodes[this_node_idx]).value.data.raw());
                             } else {
+                                mvec.resize(nelem as usize, 0);
                                 irow = 0;
                                 while c_long::from(irow) < row {
-                                    let mut p: *mut c_long = mptr;
                                     let mut nelem1: c_int = nelem as c_int;
+                                    let mut p: usize = 0; /* C: p walked mptr */
                                     loop {
                                         let fresh80 = nelem1;
                                         nelem1 -= 1;
@@ -12222,21 +12179,19 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                                             break;
                                         }
                                         if c_int::from(*uptr) == 0 {
-                                            let fresh81 = p;
-                                            p = p.offset(1);
-                                            *fresh81 = *dptr; /* Only advance the dest pointer if we copied */
+                                            mvec[p] = *dptr; /* Only advance the dest index if we copied */
+                                            p += 1;
                                         }
                                         dptr = dptr.offset(1); /* Advance the source pointer ... */
                                         uptr = uptr.offset(1); /* ... and source "undef" pointer */
                                     }
-                                    nelem1 = p.offset_from(mptr) as c_long as c_int; /* Number of accepted data points */
+                                    nelem1 = p as c_int; /* Number of accepted data points */
                                     if nelem1 > 0 {
                                         *((lParse.Nodes[this_node_idx]).value.undef)
                                             .offset(irow as isize) = 0;
                                         *((lParse.Nodes[this_node_idx]).value.data.lng_buf())
-                                            .offset(irow as isize) = qselect_median(
-                                            slice::from_raw_parts_mut(mptr, nelem1 as usize),
-                                        );
+                                            .offset(irow as isize) =
+                                            qselect_median(&mut mvec[..nelem1 as usize]);
                                     } else {
                                         *((lParse.Nodes[this_node_idx]).value.undef)
                                             .offset(irow as isize) = 1;
@@ -12245,33 +12200,30 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                                     }
                                     irow += 1;
                                 }
-                                free(mptr.cast::<c_void>());
+                                /* mvec owns the scratch; it is freed on scope exit. */
                             }
                         } else {
                             let mut dptr_0: *mut c_double =
                                 (lParse.Nodes[theParams[0]]).value.data.dbl_buf();
                             let mut uptr_0: *mut c_char = (lParse.Nodes[theParams[0]]).value.undef;
-                            let mptr_0: *mut c_double = malloc(
-                                (::core::mem::size_of::<c_double>() as c_ulong)
-                                    .wrapping_mul(nelem as c_ulong)
-                                    .try_into()
-                                    .unwrap(),
-                            )
-                            .cast::<c_double>();
-                            let mut irow_0: c_int = 0;
                             /* Allocate temporary storage for this row, since the
-                            quickselect function will scramble the contents */
-                            if mptr_0.is_null() {
+                            quickselect function will scramble the contents. It is
+                            owned rather than malloc'd, so the early error return
+                            below cannot leak it. */
+                            let mut mvec_0: Vec<c_double> = Vec::new();
+                            let mut irow_0: c_int = 0;
+                            if mvec_0.try_reserve_exact(nelem as usize).is_err() {
                                 fits_parser_yyerror(
                                     lParse,
                                     cs!(c"Could not allocate temporary memory in median function"),
                                 );
                                 free((lParse.Nodes[this_node_idx]).value.data.raw());
                             } else {
+                                mvec_0.resize(nelem as usize, 0.0);
                                 irow_0 = 0;
                                 while c_long::from(irow_0) < row {
-                                    let mut p_0: *mut c_double = mptr_0;
                                     let mut nelem1_0: c_int = nelem as c_int;
+                                    let mut p_0: usize = 0; /* C: p_0 walked mptr_0 */
                                     loop {
                                         let fresh82 = nelem1_0;
                                         nelem1_0 -= 1;
@@ -12279,21 +12231,19 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                                             break;
                                         }
                                         if c_int::from(*uptr_0) == 0 {
-                                            let fresh83 = p_0;
-                                            p_0 = p_0.offset(1);
-                                            *fresh83 = *dptr_0; /* Only advance the dest pointer if we copied */
+                                            mvec_0[p_0] = *dptr_0; /* Only advance the dest index if we copied */
+                                            p_0 += 1;
                                         }
                                         dptr_0 = dptr_0.offset(1); /* Advance the source pointer ... */
                                         uptr_0 = uptr_0.offset(1); /* ... and source "undef" pointer */
                                     }
-                                    nelem1_0 = p_0.offset_from(mptr_0) as c_long as c_int; /* Number of accepted data points */
+                                    nelem1_0 = p_0 as c_int; /* Number of accepted data points */
                                     if nelem1_0 > 0 {
                                         *((lParse.Nodes[this_node_idx]).value.undef)
                                             .offset(irow_0 as isize) = 0;
                                         *((lParse.Nodes[this_node_idx]).value.data.dbl_buf())
-                                            .offset(irow_0 as isize) = qselect_median(
-                                            slice::from_raw_parts_mut(mptr_0, nelem1_0 as usize),
-                                        );
+                                            .offset(irow_0 as isize) =
+                                            qselect_median(&mut mvec_0[..nelem1_0 as usize]);
                                     } else {
                                         *((lParse.Nodes[this_node_idx]).value.undef)
                                             .offset(irow_0 as isize) = 1;
@@ -12302,7 +12252,7 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                                     }
                                     irow_0 += 1;
                                 }
-                                free(mptr_0.cast::<c_void>());
+                                /* mvec_0 owns the scratch; it is freed on scope exit. */
                             }
                         }
                     }

--- a/src/eval_y.rs
+++ b/src/eval_y.rs
@@ -11062,13 +11062,13 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
         let mut theParams: [usize; 10] = [0; 10];
         let mut vector: [c_int; 10] = [0; 10];
         let mut allConst: c_int = 0;
-        let mut pVals: [lval; 10] = [lval {
+        let mut pVals: [lval; 10] = core::array::from_fn(|_| lval {
             nelem: 0,
             naxis: 0,
             naxes: [0; 5],
             undef: core::ptr::null_mut::<c_char>(),
             data: NodeValue::Empty,
-        }; 10];
+        });
         let mut pNull: [c_char; 10] = [0; 10];
         let mut ival: c_long = 0;
         let mut dval: c_double = 0.0;

--- a/tests/test_eval_find_rows_cmp.rs
+++ b/tests/test_eval_find_rows_cmp.rs
@@ -1,0 +1,169 @@
+//! `fits_find_rows_cmp` (`fffrwc`) over a compressed-housekeeping table.
+//!
+//! The table is one row per (time, parameter, value) sample; the call collapses
+//! it to one flag per distinct time. `ffiprs` is told the file is compressed, so
+//! every identifier in the expression is looked up as a *parameter name* in the
+//! parameter column rather than as a table column.
+//!
+//! This function had no coverage at all, which is how the two defects below
+//! survived. Expected values are hand-derived from the rows written below.
+
+mod common;
+
+#[cfg(test)]
+mod tests {
+    use rsfitsio::aliases::rust_api::*;
+    use rsfitsio::c_types::{c_char, c_int, c_long};
+    use rsfitsio::fitsio::{BAD_COL_NUM, BINARY_TBL, BYTE_IMG, LONGLONG, fitsfile};
+
+    fn cc(s: &str) -> Vec<c_char> {
+        let mut v: Vec<c_char> = s.bytes().map(|b| b as c_char).collect();
+        v.push(0);
+        v
+    }
+
+    /// Four samples over two distinct times, two parameters each.
+    ///
+    /// | TIME | PARAM | VALUE |
+    /// |------|-------|-------|
+    /// | 1.0  | TEMP  |  3.0  |
+    /// | 1.0  | PRES  | 10.0  |
+    /// | 2.0  | TEMP  |  7.0  |
+    /// | 2.0  | PRES  | 20.0  |
+    fn hk_table() -> Box<fitsfile> {
+        let mut status = 0;
+        let mut f: Option<Box<fitsfile>> = None;
+        fits_create_file(&mut f, &cc("mem://hk.fits"), &mut status);
+        fits_write_imghdr(f.as_deref_mut().unwrap(), BYTE_IMG, 0, &[], &mut status);
+
+        let tt = [cc("TIME"), cc("PARAM"), cc("VALUE")];
+        let tf = [cc("1D"), cc("8A"), cc("1D")];
+        let ttr: Vec<Option<&[c_char]>> = tt.iter().map(|v| Some(v.as_slice())).collect();
+        let tfr: Vec<&[c_char]> = tf.iter().map(|v| v.as_slice()).collect();
+        fits_create_tbl(
+            f.as_deref_mut().unwrap(),
+            BINARY_TBL,
+            4,
+            3,
+            &ttr,
+            &tfr,
+            None,
+            None,
+            &mut status,
+        );
+
+        let fp = f.as_deref_mut().unwrap();
+        fits_write_col_dbl(fp, 1, 1, 1, 4, &[1.0, 1.0, 2.0, 2.0], &mut status);
+        for (i, s) in ["TEMP", "PRES", "TEMP", "PRES"].iter().enumerate() {
+            let sv = cc(s);
+            let arr: [&[c_char]; 1] = [sv.as_slice()];
+            fits_write_col_str(fp, 2, (i + 1) as LONGLONG, 1, 1, &arr, &mut status);
+        }
+        fits_write_col_dbl(fp, 3, 1, 1, 4, &[3.0, 10.0, 7.0, 20.0], &mut status);
+
+        assert_eq!(status, 0, "hk table setup failed");
+        f.unwrap()
+    }
+
+    /// Returns (status, times, flags).
+    fn find_rows(f: &mut fitsfile, expr: &str) -> (c_int, Vec<f64>, Vec<c_char>) {
+        let mut times = [0.0f64; 2];
+        let mut flags = [0 as c_char; 2];
+        let mut status = 0;
+
+        fits_find_rows_cmp(
+            f,
+            &cc(expr),
+            &cc("TIME"),
+            &cc("PARAM"),
+            &cc("VALUE"),
+            2 as c_long,
+            &mut times,
+            &mut flags,
+            &mut status,
+        );
+        if status != 0 {
+            fits_clear_errmsg();
+        }
+        (status, times.to_vec(), flags.to_vec())
+    }
+
+    #[test]
+    fn constant_expression_flags_every_time() {
+        /* A constant expression takes the `nelem < 0` path, which zeroes nCols
+        and so allocates no parameter arrays at all. The distinct times are
+        still collected. */
+        let mut f = hk_table();
+
+        let (st, times, flags) = find_rows(&mut f, "1 > 0");
+        assert_eq!(st, 0);
+        assert_eq!(times, vec![1.0, 2.0]);
+        assert_eq!(flags, vec![1, 1]);
+
+        let (st, times, flags) = find_rows(&mut f, "0 > 1");
+        assert_eq!(st, 0);
+        assert_eq!(times, vec![1.0, 2.0]);
+        assert_eq!(flags, vec![0, 0]);
+    }
+
+    #[test]
+    fn distinct_times_are_collected_not_the_raw_rows() {
+        /* Four rows, two distinct times: the output is per time, not per row. */
+        let mut f = hk_table();
+        let (st, times, _) = find_rows(&mut f, "1 > 0");
+        assert_eq!(st, 0);
+        assert_eq!(times.len(), 2);
+        assert_eq!(times, vec![1.0, 2.0]);
+    }
+
+    #[test]
+    fn parameter_reference_is_rejected_upstream_bug() {
+        /* NOTE (upstream bug): an expression that names a parameter cannot
+        work. `ffiprs` parses the expression *before* `fits_get_colnum` fills in
+        lParse.valCol, and in compressed mode the parser resolves every
+        identifier to that column number -- still 0 at parse time -- so
+        fits_get_coltype rejects it with BAD_COL_NUM.
+
+        cfitsio's eval_f.c has the calls in exactly this order
+        (`ffiprs(...)` then the three `fits_get_colnum` calls, with
+        `ParseData lParse = {0}`), so the C fails the same way. Reproduced here
+        rather than fixed, and written up in notes/CFITSIO_BUGS_EVAL.md.
+
+        The practical consequence is that only the constant path above is
+        reachable, which is why the parameter-array allocation underneath was
+        able to stay broken unnoticed. */
+        let mut f = hk_table();
+        for expr in ["TEMP > 5", "PRES > 15", "TEMP + PRES > 0"] {
+            let (st, _, _) = find_rows(&mut f, expr);
+            assert_eq!(st, BAD_COL_NUM, "`{expr}` should hit the upstream defect");
+        }
+    }
+
+    #[test]
+    fn a_missing_column_name_is_reported() {
+        let mut f = hk_table();
+        let mut times = [0.0f64; 2];
+        let mut flags = [0 as c_char; 2];
+        let mut status = 0;
+        fits_find_rows_cmp(
+            &mut f,
+            &cc("1 > 0"),
+            &cc("NOSUCH"),
+            &cc("PARAM"),
+            &cc("VALUE"),
+            2 as c_long,
+            &mut times,
+            &mut flags,
+            &mut status,
+        );
+        assert_ne!(status, 0, "an unknown time column should be an error");
+        fits_clear_errmsg();
+    }
+
+    #[test]
+    fn a_non_logical_expression_is_rejected() {
+        let mut f = hk_table();
+        let (st, _, _) = find_rows(&mut f, "1 + 1");
+        assert_ne!(st, 0, "a non-logical expression should be rejected");
+    }
+}

--- a/tests/test_eval_parser_stack.rs
+++ b/tests/test_eval_parser_stack.rs
@@ -1,0 +1,114 @@
+//! Growth of the bison parser's state and value stacks (`fits_parser_yyparse`).
+//!
+//! The two stacks were a pair of `YYINITDEPTH` C arrays that, on overflow, were
+//! replaced by a single `alloca`-turned-`malloc` block carved in two with
+//! alignment arithmetic. They are now owned `Vec`s that `resize`.
+//!
+//! `YYINITDEPTH` is 100 and `YYMAXDEPTH` is 10000, while the deepest expression
+//! in the `eval_corpus` golden nests 20 parentheses -- so nothing there reaches
+//! the growth path at all. These do.
+
+mod common;
+
+#[cfg(test)]
+mod tests {
+    use rsfitsio::aliases::rust_api::*;
+    use rsfitsio::c_types::{c_char, c_int, c_long};
+    use rsfitsio::fitsio::{BINARY_TBL, BYTE_IMG, fitsfile};
+
+    /// `YYINITDEPTH` from eval_y.rs: the depth the stacks start at.
+    const YYINITDEPTH: usize = 100;
+
+    fn cc(s: &str) -> Vec<c_char> {
+        let mut v: Vec<c_char> = s.bytes().map(|b| b as c_char).collect();
+        v.push(0);
+        v
+    }
+
+    fn table() -> Box<fitsfile> {
+        let mut status = 0;
+        let mut f: Option<Box<fitsfile>> = None;
+        fits_create_file(&mut f, &cc("mem://stack.fits"), &mut status);
+        fits_write_imghdr(f.as_deref_mut().unwrap(), BYTE_IMG, 0, &[], &mut status);
+
+        let tt = [cc("X")];
+        let tf = [cc("1J")];
+        let tt_ref: Vec<Option<&[c_char]>> = tt.iter().map(|v| Some(v.as_slice())).collect();
+        let tf_ref: Vec<&[c_char]> = tf.iter().map(|v| v.as_slice()).collect();
+        fits_create_tbl(
+            f.as_deref_mut().unwrap(),
+            BINARY_TBL,
+            2,
+            1,
+            &tt_ref,
+            &tf_ref,
+            None,
+            None,
+            &mut status,
+        );
+        fits_write_col_lng(f.as_deref_mut().unwrap(), 1, 1, 1, 2, &[3, 4], &mut status);
+        assert_eq!(status, 0, "table setup failed");
+        f.unwrap()
+    }
+
+    /// Parse `expr` and return (status, evaluated rows).
+    fn eval(f: &mut fitsfile, expr: &str) -> (c_int, Vec<c_char>) {
+        let mut out = [0 as c_char; 2];
+        let mut n_good: c_long = 0;
+        let mut status = 0;
+        fits_find_rows(f, &cc(expr), 1, 2, &mut n_good, &mut out, &mut status);
+        if status != 0 {
+            fits_clear_errmsg();
+        }
+        (status, out.to_vec())
+    }
+
+    /// `((((…X > 0…))))` with `n` parentheses on each side.
+    fn nested(n: usize) -> String {
+        format!("{}X > 0{}", "(".repeat(n), ")".repeat(n))
+    }
+
+    #[test]
+    fn shallow_nesting_stays_on_the_initial_stack() {
+        let mut f = table();
+        let (st, rows) = eval(&mut f, &nested(10));
+        assert_eq!(st, 0);
+        assert_eq!(rows, vec![1, 1]);
+    }
+
+    #[test]
+    fn nesting_past_the_initial_depth_grows_the_stacks() {
+        /* Each parenthesis pushes, so this is comfortably past YYINITDEPTH and
+        forces at least one resize of both stacks. */
+        let mut f = table();
+        for depth in [YYINITDEPTH + 5, YYINITDEPTH * 2, YYINITDEPTH * 4] {
+            let (st, rows) = eval(&mut f, &nested(depth));
+            assert_eq!(st, 0, "depth {depth} failed to parse");
+            assert_eq!(rows, vec![1, 1], "depth {depth} gave the wrong answer");
+        }
+    }
+
+    #[test]
+    fn values_survive_the_stack_growth() {
+        /* The resize has to preserve what is already on the value stack -- the
+        C did that with a memcpy. If it did not, the operands of the outer
+        expression would be lost, so check a value that depends on tokens
+        pushed before the growth and reduced after it. */
+        let mut f = table();
+        let deep = nested(YYINITDEPTH + 20);
+        assert_eq!(eval(&mut f, &format!("({deep}) && X == 3")).1, vec![1, 0]);
+        assert_eq!(eval(&mut f, &format!("({deep}) && X == 4")).1, vec![0, 1]);
+        /* a long left-associative chain also walks the value stack deep */
+        let sum = std::iter::repeat_n("X", 200).collect::<Vec<_>>().join("+");
+        assert_eq!(eval(&mut f, &format!("({sum}) == X * 200")).1, vec![1, 1]);
+    }
+
+    #[test]
+    fn nesting_past_the_maximum_is_rejected_not_crashed() {
+        /* Beyond YYMAXDEPTH the parser takes yyexhaustedlab. The point is that
+        it reports an error rather than overrunning or aborting. */
+        let mut f = table();
+        let (st, _) = eval(&mut f, &nested(20_000));
+        assert_ne!(st, 0, "an over-deep expression should be rejected");
+    }
+}


### PR DESCRIPTION
Three related changes in the expression evaluator, found while working through
the malloc/free entries in TODO.md.

## Own the eval scratch allocations

Four allocations with a clear single owner, converted to `Vec` +
`try_reserve_exact`:

**The bison parse stacks.** The C started on two `YYINITDEPTH` arrays and, on
overflow, carved a replacement for both out of one `alloca`-turned-`malloc`
block, stepping through it with the `yyalloc` union to get the alignment right.
Two owned `Vec`s do the same job with no arithmetic: growing is a `resize`,
which keeps what is already on the stacks exactly as the two `memcpy`s did.
`yyalloc` is now unused and goes with it. This also moves `YYINITDEPTH` parser
values -- a few tens of KB -- off the call stack, and closes the leak the C had
on every error `goto`.

**`MEDIAN`'s two per-row scratch buffers**, which `qselect_median` already took
as a slice, so the pointer walk becomes an index.

**`ffsrow_safe`'s row-selection flags**, freed at two of the function's exits
but not at the two `return`s in between.

Adds tests for the parser stack: `YYINITDEPTH` is 100 and the deepest
expression in the `eval_corpus` golden nests 20 parentheses, so nothing there
reached the growth path at all.

## Fix the leaked parameter arrays in fffrwc

`fffrwc` allocated a per-parameter array for each column and assigned it to
`col_data.array`, where `col_data` came from

```rust
let mut col_data = lParse.colData[parNo as usize];
```

`iteratorCol` is `Copy`, so that set the field on a copy which was then
dropped: every allocation leaked, and the parser saw whatever array the
descriptor already had. The C assigns into `lParse.colData[parNo].array`
directly. Now it indexes the vector, and the arrays are owned for the length of
the call so the error return releases them without the two cleanup loops.

The function had no tests and no internal callers. It is also why this survived
undetected: **an expression naming a parameter cannot reach the allocation at
all.** `ffiprs` parses the expression before the three `fits_get_colnum` calls
fill in `lParse.valCol`, and in compressed mode the parser resolves every
identifier to that column number -- still 0 -- so `fits_get_coltype` rejects it
with `BAD_COL_NUM`. cfitsio's `eval_f.c:1920` has the calls in the same order
with `ParseData lParse = {0}`, so the C fails identically. Reproduced rather
than fixed, per the porting policy, and pinned by a test. Written up with a
reproduction recipe in `notes/CFITSIO_BUGS_EVAL.md` (untracked -- `/notes` is
gitignored) so it can go upstream.

New tests cover what does work: the constant-expression path, collapsing rows
to distinct times, and the error paths.

## Drop Copy from Node, lval and NodeValue

The comment on `NodeValue` said boxing the buffer "is not an option while
`lval` and `Node` are `Copy` and get copied by value all through the engine".
They are not: removing `Copy` from all three breaks exactly two lines -- an
array-repeat initialiser in `Do_Func` and one copy out of `lParse.Nodes`.
`Vec::resize` needs only `Clone`.

Nothing here starts owning a buffer. This removes a constraint that was
recorded but not real, so the next attempt does not inherit it. The comment now
names the two obstacles that are: the three-way borrow in the `Do_*` routines,
and the fact that only *computed* nodes own a buffer -- `Evaluate_Parser`
re-points every *column* node at `varData[column].data`, which for a String
column is the iterator's own array, laid out by `ffiter`.

## Verification

`cargo test` 2935 passed / 0 failed, `testprog_check.sh` byte-identical,
`cargo fmt --check` and `cargo clippy --all-targets` clean, `eval_corpus.golden`
unchanged.
