### PR TITLE
Fix the lexer's ParseData aliasing and the number parsers

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -22,16 +22,17 @@
       also reaches that buffer; and yy_init_buffer flushed before its own
       writes, so yy_load_buffer_state invalidated them. `b` is a raw pointer
       now and the comparisons go through yy_current_buffer_ptr.
-- [ ] Fix the yyextra_r aliasing in the eval engine. `yyscanner.yyextra_r` is
-      a raw pointer to the same ParseData that ffiprs and fits_parser_yyparse
-      hold as `&mut`, so `&mut *yyscanner.yyextra_r` (eval_l.rs, in
-      yy_get_next_buffer) aliases a strongly-protected argument. This is now
-      the only root cause left in the eval engine, and it accounts for all 258
-      of the tests that used to fail in the buffer stack. Fixing it means
-      ParseData reaching the scanner one way only: either yyparse/ffiprs stop
-      taking `&mut ParseData` and read it back out of yyextra_r, or the
-      scanner stops holding the pointer. Same shape as the FPTR_TABLE and
-      infptr/outfptr entries below.
+- [X] Fix the yyextra_r aliasing in the eval engine. ParseData is passed to
+      yylex as an argument and the yyextra_r field is gone, so the scanner no
+      longer refers to it and cannot alias the `&mut ParseData` that ffiprs
+      and yyparse hold.
+- [ ] Fix the Info.parseData aliasing in the eval engine. `eval_f.rs` stores
+      `Info.parseData = &mut lParse` and then invalidates it two lines later
+      with `&mut lParse.colData[..]`, so the iterator work function's later
+      `as_mut()` on it is UB. This is the front of the queue for the eval
+      engine now that yyextra_r is gone. Same shape as the FPTR_TABLE and
+      infptr/outfptr entries below: a struct holding a pointer to something
+      that is also reached through a `&mut`.
 - [ ] The `test_ffcalc_*` tests alias `&mut *fp_self` twice to pass one file
       as both input and output; see the infptr/outfptr entry below.
 - [ ] Clean up all warnings

--- a/src/eval_f.rs
+++ b/src/eval_f.rs
@@ -71,7 +71,7 @@ use crate::eval_defs::{
     ValueSort, parseInfo,
 };
 use crate::eval_l::{
-    fits_parser_yylex_destroy, fits_parser_yylex_init_extra, fits_parser_yyrestart, yyguts_t,
+    fits_parser_yylex_destroy, fits_parser_yylex_init, fits_parser_yyrestart, yyguts_t,
 };
 use crate::eval_tab::{FITS_PARSER_YYSTYPE, fits_parser_yytokentype};
 use crate::eval_y::{Evaluate_Parser, fits_parser_yyparse, funcOp};
@@ -1468,7 +1468,7 @@ pub(crate) fn ffiprs(
 
     let mut yylex_scanner: Option<Box<yyguts_t>> = None; /* Used internally by FLEX lexer */
 
-    fits_parser_yylex_init_extra(lParse, &mut yylex_scanner);
+    fits_parser_yylex_init(&mut yylex_scanner);
     fits_parser_yyrestart(ptr::null_mut(), yylex_scanner.as_deref_mut().unwrap());
     *status = fits_parser_yyparse(yylex_scanner.as_deref_mut().unwrap(), lParse);
     fits_parser_yylex_destroy(yylex_scanner.unwrap());

--- a/src/eval_l.rs
+++ b/src/eval_l.rs
@@ -60,7 +60,7 @@ use core::slice;
 use std::process::exit;
 
 use bytemuck::cast_slice;
-use libc::{ENOMEM, FILE, atof, atol, fileno, free, fwrite, isatty, size_t};
+use libc::{ENOMEM, FILE, fileno, fwrite, isatty, size_t};
 
 use crate::c_types::{c_char, c_int, c_long, c_short, c_uchar, c_uint, c_void};
 use crate::eval_defs::{MAX_STRLEN, MAXVARNAME, P_ERROR, ParseData, ValueSort};
@@ -69,7 +69,8 @@ use crate::fitsio2::FSTRCMP;
 use crate::helpers::boxed::box_try_new;
 use crate::helpers::vec_raw_parts::vec_into_raw_parts;
 use crate::wrappers::{
-    isdigit_safe, strcat_safe, strcpy_safe, strlen_safe, strncat_safe, strncpy_safe,
+    atof_safe, atol_safe, isdigit_safe, strcat_safe, strcpy_safe, strlen_safe, strncat_safe,
+    strncpy_safe,
 };
 use crate::{STDOUT, cs, eval_tab::*};
 use crate::{
@@ -868,7 +869,7 @@ pub(crate) fn fits_parser_yylex(
                             }
                             8 => {
                                 (*yyscanner.yylval_r) =
-                                    FITS_PARSER_YYSTYPE::Long(atol(yyscanner.yytext_r));
+                                    FITS_PARSER_YYSTYPE::Long(atol_safe(yyscanner.yytext()));
                                 return fits_parser_yytokentype::LONG as c_int;
                             }
                             9 => {
@@ -883,7 +884,7 @@ pub(crate) fn fits_parser_yylex(
                             }
                             10 => {
                                 (*yyscanner.yylval_r) =
-                                    FITS_PARSER_YYSTYPE::Double(atof(yyscanner.yytext_r));
+                                    FITS_PARSER_YYSTYPE::Double(atof_safe(yyscanner.yytext()));
                                 return fits_parser_yytokentype::DOUBLE as c_int;
                             }
                             11 => {
@@ -1890,8 +1891,17 @@ pub(crate) fn fits_parser_yylex_destroy(mut yyscanner: Box<yyguts_t>) -> c_int {
             (*(yyscanner.yy_buffer_stack).add(yyscanner.yy_buffer_stack_top)) = None;
             fits_parser_yypop_buffer_state(&mut yyscanner);
         }
-        /* Destroy the stack itself. */
-        free(yyscanner.yy_buffer_stack.cast::<c_void>());
+        /* Destroy the stack itself. yyensure_buffer_stack builds it as a Rust
+           Vec, so reconstruct and drop it: handing it to libc free is an
+           allocator mismatch. len == capacity == yy_buffer_stack_max, the same
+           convention the grow path in yyensure_buffer_stack uses. */
+        if !(yyscanner.yy_buffer_stack).is_null() {
+            drop(Vec::from_raw_parts(
+                yyscanner.yy_buffer_stack,
+                yyscanner.yy_buffer_stack_max,
+                yyscanner.yy_buffer_stack_max,
+            ));
+        }
         yyscanner.yy_buffer_stack = core::ptr::null_mut();
 
         /* Reset the globals. This is important in a non-reentrant scanner so the next time

--- a/src/eval_l.rs
+++ b/src/eval_l.rs
@@ -183,7 +183,6 @@ pub(crate) struct yyguts_t {
     /* This is a shorthand accessor to get at the "extra" data inside the
     lexer, which in our case is the lParse (ParseData) structure */
     /* How ParseData is accessed from the lexer, i.e. by yyextra */
-    pub(crate) yyextra_r: *mut ParseData,
 
     /* The rest are the same as the globals declared in the non-reentrant scanner. */
     pub(crate) yyin_r: *mut FILE,
@@ -449,6 +448,7 @@ static YY_CHK: [flex_int16_t; 474] = [
 pub(crate) fn fits_parser_yylex(
     yylval_param: &mut FITS_PARSER_YYSTYPE,
     yyscanner: &mut yyguts_t,
+    lParse: &mut ParseData,
 ) -> c_int {
     unsafe {
         let mut yy_amount_of_matched_text: c_int = 0;
@@ -552,7 +552,7 @@ pub(crate) fn fits_parser_yylex(
                                 }
                                 if len >= MAX_STRLEN {
                                     let mut errMsg: [c_char; 100] = [0; 100];
-                                    (*yyscanner.yyextra_r).status = PARSE_SYNTAX_ERR;
+                                    lParse.status = PARSE_SYNTAX_ERR;
                                     strcpy_safe(
                                         &mut errMsg,
                                         cs!(c"Bit string exceeds maximum length: '"),
@@ -578,7 +578,7 @@ pub(crate) fn fits_parser_yylex(
                                 len_0 = strlen_safe(yyscanner.yytext()) as c_int;
                                 if len_0 >= 256 as c_int {
                                     let mut errMsg: [c_char; 100] = [0; 100];
-                                    (*yyscanner.yyextra_r).status = PARSE_SYNTAX_ERR;
+                                    lParse.status = PARSE_SYNTAX_ERR;
                                     strcpy_safe(
                                         &mut errMsg,
                                         cs!(c"Bit string exceeds maximum length: '"),
@@ -654,7 +654,7 @@ pub(crate) fn fits_parser_yylex(
                                     if !chunk.is_empty() {
                                         if bitlen + chunk_len > bitcap {
                                             let mut errMsg: [c_char; 100] = [0; 100];
-                                            (*yyscanner.yyextra_r).status = PARSE_SYNTAX_ERR;
+                                            lParse.status = PARSE_SYNTAX_ERR;
                                             strcpy_safe(
                                                 &mut errMsg,
                                                 cs!(c"Bit string exceeds maximum length: '"),
@@ -687,7 +687,7 @@ pub(crate) fn fits_parser_yylex(
                                 len_1 = strlen_safe(yyscanner.yytext()) as c_int;
                                 if len_1 >= 256 as c_int {
                                     let mut errMsg_0: [c_char; 100] = [0; 100];
-                                    (*yyscanner.yyextra_r).status = PARSE_SYNTAX_ERR;
+                                    lParse.status = PARSE_SYNTAX_ERR;
                                     strcpy_safe(
                                         &mut errMsg_0,
                                         cs!(c"Hex string exceeds maximum length: '"),
@@ -794,7 +794,7 @@ pub(crate) fn fits_parser_yylex(
                                     if !chunk.is_empty() {
                                         if bitlen + chunk_len > bitcap {
                                             let mut errMsg: [c_char; 100] = [0; 100];
-                                            (*yyscanner.yyextra_r).status = PARSE_SYNTAX_ERR;
+                                            lParse.status = PARSE_SYNTAX_ERR;
                                             strcpy_safe(
                                                 &mut errMsg,
                                                 cs!(c"Hex string exceeds maximum length: '"),
@@ -937,7 +937,7 @@ pub(crate) fn fits_parser_yylex(
                                             as c_int;
                                         if len_2 >= MAX_STRLEN - 1 {
                                             let mut errMsg: [c_char; 100] = [0; 100];
-                                            (*yyscanner.yyextra_r).status = PARSE_SYNTAX_ERR;
+                                            lParse.status = PARSE_SYNTAX_ERR;
                                             strcpy_safe(
                                                 &mut errMsg,
                                                 cs!(c"Keyword string exceeds maximum length: '"),
@@ -964,9 +964,10 @@ pub(crate) fn fits_parser_yylex(
                                         CStr::from_ptr(yyscanner.yytext_r).to_bytes_with_nul(),
                                     );
 
-                                    result = ((*yyscanner.yyextra_r).getData)
-                                        .expect("non-null function pointer")(
-                                        &mut *yyscanner.yyextra_r,
+                                    let get_data = (lParse.getData)
+                                        .expect("non-null function pointer");
+                                    result = get_data(
+                                        lParse,
                                         yytext_r_slice,
                                         yyscanner
                                             .yylval_r
@@ -982,7 +983,7 @@ pub(crate) fn fits_parser_yylex(
                                 len_3 = (strlen_safe(yyscanner.yytext())).wrapping_sub(2) as c_int;
                                 if len_3 >= 256 as c_int {
                                     let mut errMsg_1: [c_char; 100] = [0; 100];
-                                    (*yyscanner.yyextra_r).status = PARSE_SYNTAX_ERR;
+                                    lParse.status = PARSE_SYNTAX_ERR;
                                     strcpy_safe(
                                         &mut errMsg_1,
                                         cs!(c"String exceeds maximum length: '"),
@@ -1007,7 +1008,7 @@ pub(crate) fn fits_parser_yylex(
                                 len_4 = strlen_safe(yyscanner.yytext()) as c_int;
                                 if len_4 >= MAX_STRLEN {
                                     let mut errMsg: [c_char; 100] = [0; 100];
-                                    (*yyscanner.yyextra_r).status = PARSE_SYNTAX_ERR;
+                                    lParse.status = PARSE_SYNTAX_ERR;
                                     strcpy_safe(
                                         &mut errMsg,
                                         cs!(c"Variable exceeds maximum length: '"),
@@ -1035,7 +1036,7 @@ pub(crate) fn fits_parser_yylex(
                                 );
 
                                 dtype = fits_parser_yyGetVariable(
-                                    &mut *yyscanner.yyextra_r,
+                                    lParse,
                                     yytext_r_slice,
                                     yyscanner.yylval_r.as_mut().unwrap(),
                                 );
@@ -1047,7 +1048,7 @@ pub(crate) fn fits_parser_yylex(
 
                                 if len >= MAX_STRLEN as usize {
                                     let mut errMsg: [c_char; 100] = [0; 100];
-                                    (*yyscanner.yyextra_r).status = PARSE_SYNTAX_ERR;
+                                    lParse.status = PARSE_SYNTAX_ERR;
                                     strcpy_safe(
                                         &mut errMsg,
                                         cs!(c"Function exceeds maximum length: '"),
@@ -1195,7 +1196,7 @@ pub(crate) fn fits_parser_yylex(
                                         break;
                                     }
                                 } else {
-                                    match yy_get_next_buffer(yyscanner) {
+                                    match yy_get_next_buffer(yyscanner, lParse) {
                                         EOB_ACT_END_OF_FILE => {
                                             yyscanner.yy_did_buffer_switch_on_eof = 0;
                                             if fits_parser_yywrap() != 0 {
@@ -1284,7 +1285,7 @@ pub(crate) fn fits_parser_yylex(
  *	EOB_ACT_CONTINUE_SCAN - continue scanning from current position
  *	EOB_ACT_END_OF_FILE - end of file
  */
-fn yy_get_next_buffer(yyscanner: &mut yyguts_t) -> c_int {
+fn yy_get_next_buffer(yyscanner: &mut yyguts_t, lParse: &mut ParseData) -> c_int {
     unsafe {
         let mut source: *mut c_char = yyscanner.yytext_r;
         let mut number_to_move: c_int = 0;
@@ -1391,7 +1392,7 @@ fn yy_get_next_buffer(yyscanner: &mut yyguts_t) -> c_int {
                (as per old ftools.skel)
             */
             yyscanner.yy_n_chars = expr_read(
-                &mut *yyscanner.yyextra_r,
+                lParse,
                 &mut (top_state.yy_ch_buf).as_deref_mut().unwrap()[number_to_move as usize..],
                 num_to_read,
             );
@@ -1446,7 +1447,9 @@ fn yy_get_next_buffer(yyscanner: &mut yyguts_t) -> c_int {
             YY_END_OF_BUFFER_CHAR;
         (top_state.yy_ch_buf).as_deref_mut().unwrap()[(yyscanner.yy_n_chars + 1) as usize] =
             YY_END_OF_BUFFER_CHAR;
-        yyscanner.yytext_r = &raw mut *(top_state.yy_ch_buf).as_deref_mut().unwrap().as_mut_ptr();
+        /* Take the slice pointer directly rather than round-tripping it
+           through a place expression. */
+        yyscanner.yytext_r = (top_state.yy_ch_buf).as_deref_mut().unwrap().as_mut_ptr();
         ret_val
     }
 }
@@ -1831,29 +1834,15 @@ fn yy_fatal_error(msg: &str) -> ! {
     exit(YY_EXIT_FAILURE);
 }
 
-/** Set the user-defined data. This data is never touched by the scanner.
- * @param user_defined The data to be associated with this scanner.
- * @param yyscanner The scanner object.
+/* Allocate and initialise the scanner.
+ *
+ * The C uses yylex_init_extra to stash a ParseData pointer in the scanner's
+ * yyextra field, which the lexer rules then dereference.  That made ParseData
+ * reachable both through yyextra and through the `&mut ParseData` that ffiprs
+ * and yyparse hold, which is aliasing UB.  ParseData is threaded through
+ * yylex as an argument instead, so the scanner no longer refers to it at all.
  */
-pub(crate) fn fits_parser_yyset_extra(user_defined: &mut ParseData, yyscanner: &mut yyguts_t) {
-    yyscanner.yyextra_r = user_defined;
-}
-
-/* yylex_init_extra has the same functionality as yylex_init, but follows the
- * convention of taking the scanner as the last argument. Note however, that
- * this is a *pointer* to a scanner, as it will be allocated by this call (and
- * is the reason, too, why this function also must handle its own declaration).
- * The user defined value in the first argument will be available to yyalloc in
- * the yyextra field.
- */
-pub(crate) fn fits_parser_yylex_init_extra(
-    yy_user_defined: &mut ParseData,
-    ptr_yy_globals: &mut Option<Box<yyguts_t>>,
-) -> c_int {
-    let mut dummy_yyguts = yyguts_t::default();
-
-    fits_parser_yyset_extra(yy_user_defined, &mut dummy_yyguts);
-
+pub(crate) fn fits_parser_yylex_init(ptr_yy_globals: &mut Option<Box<yyguts_t>>) -> c_int {
     let b = box_try_new(yyguts_t::default());
 
     if b.is_err() {
@@ -1861,11 +1850,7 @@ pub(crate) fn fits_parser_yylex_init_extra(
         return 1;
     }
 
-    let mut b = b.unwrap();
-
-    fits_parser_yyset_extra(yy_user_defined, &mut b);
-
-    *ptr_yy_globals = Some(b);
+    *ptr_yy_globals = Some(b.unwrap());
 
     yy_init_globals(ptr_yy_globals.as_deref_mut().unwrap())
 }

--- a/src/eval_y.rs
+++ b/src/eval_y.rs
@@ -1546,7 +1546,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         if YYDEBUG {
                             eprintln!("Read a token");
                         }
-                        yychar = fits_parser_yylex(&mut yylval, scanner);
+                        yychar = fits_parser_yylex(&mut yylval, scanner, lParse);
                     }
 
                     if yychar <= fits_parser_yytokentype::FITS_PARSER_YYEOF as c_int {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -427,20 +427,23 @@ impl NullValue {
             return None;
         }
 
+        /* `value` is a caller-supplied void*, as in the C, and carries no
+           alignment guarantee for the target type -- it commonly points into
+           a byte buffer. Read unaligned rather than dereferencing. */
         match datatype {
-            TFLOAT => Some(NullValue::Float(unsafe { *value.cast::<f32>() })),
-            TDOUBLE => Some(NullValue::Double(unsafe { *value.cast::<f64>() })),
-            TLONG => Some(NullValue::Long(unsafe { *value.cast::<c_long>() })),
-            TULONG => Some(NullValue::ULong(unsafe { *value.cast::<c_ulong>() })),
-            TLONGLONG => Some(NullValue::LONGLONG(unsafe { *value.cast::<LONGLONG>() })),
-            TULONGLONG => Some(NullValue::ULONGLONG(unsafe { *value.cast::<ULONGLONG>() })),
-            TINT => Some(NullValue::Int(unsafe { *value.cast::<c_int>() })),
-            TUINT => Some(NullValue::UInt(unsafe { *value.cast::<c_uint>() })),
-            TSHORT => Some(NullValue::Short(unsafe { *value.cast::<c_short>() })),
-            TUSHORT => Some(NullValue::UShort(unsafe { *value.cast::<c_ushort>() })),
-            TBYTE => Some(NullValue::UByte(unsafe { *value.cast::<c_uchar>() })),
-            TSBYTE => Some(NullValue::Byte(unsafe { *value.cast::<i8>() })),
-            TLOGICAL => Some(NullValue::Logical(unsafe { *value.cast::<c_char>() })),
+            TFLOAT => Some(NullValue::Float(unsafe { value.cast::<f32>().read_unaligned() })),
+            TDOUBLE => Some(NullValue::Double(unsafe { value.cast::<f64>().read_unaligned() })),
+            TLONG => Some(NullValue::Long(unsafe { value.cast::<c_long>().read_unaligned() })),
+            TULONG => Some(NullValue::ULong(unsafe { value.cast::<c_ulong>().read_unaligned() })),
+            TLONGLONG => Some(NullValue::LONGLONG(unsafe { value.cast::<LONGLONG>().read_unaligned() })),
+            TULONGLONG => Some(NullValue::ULONGLONG(unsafe { value.cast::<ULONGLONG>().read_unaligned() })),
+            TINT => Some(NullValue::Int(unsafe { value.cast::<c_int>().read_unaligned() })),
+            TUINT => Some(NullValue::UInt(unsafe { value.cast::<c_uint>().read_unaligned() })),
+            TSHORT => Some(NullValue::Short(unsafe { value.cast::<c_short>().read_unaligned() })),
+            TUSHORT => Some(NullValue::UShort(unsafe { value.cast::<c_ushort>().read_unaligned() })),
+            TBYTE => Some(NullValue::UByte(unsafe { value.cast::<c_uchar>().read_unaligned() })),
+            TSBYTE => Some(NullValue::Byte(unsafe { value.cast::<i8>().read_unaligned() })),
+            TLOGICAL => Some(NullValue::Logical(unsafe { value.cast::<c_char>().read_unaligned() })),
             TSTRING => {
                 let cstr = unsafe { CStr::from_ptr(value.cast::<c_char>()) };
                 Some(NullValue::String(cstr.to_owned()))

--- a/src/wrappers.rs
+++ b/src/wrappers.rs
@@ -2,7 +2,7 @@ use core::{cmp, ffi::CStr, str::FromStr};
 
 use bytemuck::cast_slice;
 
-use crate::c_types::{c_char, c_int};
+use crate::c_types::{c_char, c_int, c_long};
 
 use crate::bb;
 
@@ -235,6 +235,50 @@ pub(crate) fn isspace(c: c_char) -> bool {
     c == bb(b' ') || c == bb(b'\t') || c == bb(b'\n') || c == bb(b'\r') || c == 0x0b || c == 0x0c
 }
 
+/// C `atol`: leading optional whitespace and sign, then decimal digits.
+///
+/// Matches the C on the two edge cases Rust's `parse` gets differently:
+/// a value that does not fit saturates to `c_long::MIN`/`MAX` rather than
+/// failing, and input with no digits at all yields 0.
+pub fn atol_safe(cs: &[c_char]) -> c_long {
+    let bytes: &[u8] = cast_slice(cs);
+    let mut i = 0;
+
+    while i < bytes.len() && (bytes[i] as char).is_whitespace() {
+        i += 1;
+    }
+
+    let negative = match bytes.get(i) {
+        Some(b'-') => {
+            i += 1;
+            true
+        }
+        Some(b'+') => {
+            i += 1;
+            false
+        }
+        _ => false,
+    };
+
+    let mut acc: c_long = 0;
+    let mut overflow = false;
+    while i < bytes.len() && bytes[i].is_ascii_digit() {
+        let d = c_long::from(bytes[i] - b'0');
+        /* Accumulate negatively so that c_long::MIN is representable. */
+        match acc.checked_mul(10).and_then(|a| a.checked_sub(d)) {
+            Some(next) => acc = next,
+            None => overflow = true,
+        }
+        i += 1;
+    }
+
+    if overflow {
+        return if negative { c_long::MIN } else { c_long::MAX };
+    }
+
+    if negative { acc } else { -acc }
+}
+
 pub fn atof_safe(cs: &[c_char]) -> f64 {
     let mut dummy = 0;
     strtod_safe(cs, &mut dummy)
@@ -261,9 +305,18 @@ fn strto_float_impl(s: &[c_char], endptr: &mut usize) -> f64 {
         si += 1;
     }
 
+    /* Start of the literal itself, sign included: the digit-by-digit
+       accumulation below is not correctly rounded (it compounds a rounding
+       error per fractional digit, so e.g. 12345.6789 comes out as
+       12345.678899999999), so once the extent of the literal is known the
+       decimal case re-parses this span with Rust's correctly-rounded parser
+       and only falls back to the accumulated value if that fails. */
+    let literal_start = si;
+
     let mut result: f64 = 0.0;
     let mut exponent: Option<f64> = None;
     let mut radix = 10;
+    let mut is_inf_or_nan = false;
 
     let result_sign = match s[si] as u8 {
         b'-' => {
@@ -283,11 +336,13 @@ fn strto_float_impl(s: &[c_char], endptr: &mut usize) -> f64 {
     if rust_s.to_lowercase().starts_with("inf") {
         result = f64::INFINITY;
         si += 3;
+        is_inf_or_nan = true;
     } else if rust_s.to_lowercase().starts_with("nan") {
         // we cannot signal negative NaN in LLVM backed languages
         // https://github.com/rust-lang/rust/issues/73328 , https://github.com/rust-lang/rust/issues/81261
         result = f64::NAN;
         si += 3;
+        is_inf_or_nan = true;
     } else {
         if s[si] as u8 == b'0' && s[si + 1] as u8 == b'x' {
             si += 2;
@@ -345,10 +400,17 @@ fn strto_float_impl(s: &[c_char], endptr: &mut usize) -> f64 {
                         _ => unreachable!(),
                     };
 
+                    /* Saturate rather than panic: `1e400` overflows a u128
+                       pow, and the C just returns inf/0 for out-of-range
+                       exponents. The correctly-rounded re-parse below produces
+                       the real value whenever the literal is well-formed. */
+                    let magnitude = exponent_base
+                        .checked_pow(exponent_value)
+                        .map_or(f64::INFINITY, |m| m as f64);
                     if is_exponent_positive {
-                        Some(exponent_base.pow(exponent_value) as f64)
+                        Some(magnitude)
                     } else {
-                        Some(1.0 / (exponent_base.pow(exponent_value) as f64))
+                        Some(1.0 / magnitude)
                     }
                 } else {
                     // Exponent had no valid digits after 'e'/'p' and '+'/'-', rollback
@@ -361,6 +423,15 @@ fn strto_float_impl(s: &[c_char], endptr: &mut usize) -> f64 {
     }
 
     *endptr = si;
+
+    /* Correctly-rounded re-parse of the decimal case; see literal_start. */
+    if !is_inf_or_nan
+        && radix == 10
+        && let Ok(text) = str::from_utf8(cast_slice(&s[literal_start..si]))
+        && let Ok(parsed) = text.parse::<f64>()
+    {
+        return parsed;
+    }
 
     if let Some(exponent) = exponent {
         result_sign * result * exponent
@@ -822,5 +893,76 @@ mod tests {
         let result = strtod_safe(&input[1..], &mut endp);
         assert_eq!(result, 21.0);
         assert_eq!(endp, 2);
+    }
+}
+
+#[cfg(test)]
+mod libc_parity_tests {
+    use super::*;
+    use crate::c_types::c_long;
+
+    /// NUL-terminated `[c_char]` from a `&str`, as the callers always pass.
+    fn cc(s: &str) -> Vec<c_char> {
+        let mut v: Vec<c_char> = s.bytes().map(|b| b as c_char).collect();
+        v.push(0);
+        v
+    }
+
+    /// Inputs exercised against the C: plain values, the precision cases that
+    /// digit-by-digit accumulation gets wrong, signs, whitespace, exponents,
+    /// trailing junk, and the no-digits case.
+    const FLOAT_CASES: &[&str] = &[
+        "0", "1", "1.5", "2.", ".5", "-1.5", "+1.5", "  3.75", "1e3", "1E3", "1.5e-3", "1.5E+3",
+        "3.25", "0.1", "0.2", "0.3", "12345.6789", "1234567.891011", "0.000123456789",
+        "9007199254740993", "1.7976931348623157e308", "2.2250738585072014e-308", "1e-400",
+        "1e400", "123abc", "abc", "", "   ", "-0", "0.0000000000000001",
+    ];
+
+    const LONG_CASES: &[&str] = &[
+        "0", "1", "-1", "+1", "  42", "42abc", "abc", "", "   ", "-0", "2147483647",
+        "-2147483648", "9223372036854775807", "-9223372036854775808",
+        "99999999999999999999", "-99999999999999999999", "007", "-  5", "1 2",
+    ];
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_atof_safe_matches_libc_atof() {
+        for case in FLOAT_CASES {
+            let s = cc(case);
+            let got = atof_safe(&s);
+            let want = unsafe { libc::atof(s.as_ptr()) };
+            assert!(
+                got == want || (got.is_nan() && want.is_nan()),
+                "atof({case:?}): atof_safe gave {got:?}, libc gave {want:?}"
+            );
+        }
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_atol_safe_matches_libc_atol() {
+        for case in LONG_CASES {
+            let s = cc(case);
+            let got = atol_safe(&s);
+            let want: c_long = unsafe { libc::atol(s.as_ptr()) };
+            assert_eq!(got, want, "atol({case:?})");
+        }
+    }
+
+    /// The specific regression: accumulating fractional digits by hand made
+    /// this 12345.678899999999, so row filters comparing it with `==` failed.
+    #[test]
+    fn test_atof_safe_is_correctly_rounded() {
+        assert_eq!(atof_safe(&cc("12345.6789")), 12345.6789);
+        assert_eq!(atof_safe(&cc("0.000123456789")), 0.000123456789);
+        assert_eq!(atof_safe(&cc("1234567.891011")), 1234567.891011);
+    }
+
+    /// C saturates on overflow rather than failing.
+    #[test]
+    fn test_atol_safe_saturates_like_c() {
+        assert_eq!(atol_safe(&cc("99999999999999999999")), c_long::MAX);
+        assert_eq!(atol_safe(&cc("-99999999999999999999")), c_long::MIN);
+        assert_eq!(atol_safe(&cc("-9223372036854775808")), c_long::MIN);
     }
 }

--- a/src/wrappers.rs
+++ b/src/wrappers.rs
@@ -276,7 +276,15 @@ pub fn atol_safe(cs: &[c_char]) -> c_long {
         return if negative { c_long::MIN } else { c_long::MAX };
     }
 
-    if negative { acc } else { -acc }
+    /* acc is accumulated negatively so that c_long::MIN is representable, but
+       that means a positive value of exactly |MIN| lands on MIN without the
+       checked arithmetic above noticing. Negating it would overflow, so
+       saturate as the C does. */
+    if negative {
+        acc
+    } else {
+        acc.checked_neg().unwrap_or(c_long::MAX)
+    }
 }
 
 pub fn atof_safe(cs: &[c_char]) -> f64 {
@@ -956,6 +964,20 @@ mod libc_parity_tests {
         assert_eq!(atof_safe(&cc("12345.6789")), 12345.6789);
         assert_eq!(atof_safe(&cc("0.000123456789")), 0.000123456789);
         assert_eq!(atof_safe(&cc("1234567.891011")), 1234567.891011);
+    }
+
+    /// A positive value equal to |c_long::MIN| accumulates to MIN without
+    /// tripping the checked arithmetic, so negating it at the end overflows.
+    /// Computed rather than hardcoded: c_long is 32-bit on Windows.
+    #[test]
+    fn test_atol_safe_at_the_negation_boundary() {
+        let magnitude = (c_long::MIN as i128).unsigned_abs().to_string();
+        assert_eq!(atol_safe(&cc(&magnitude)), c_long::MAX, "{magnitude}");
+        assert_eq!(
+            atol_safe(&cc(&format!("-{magnitude}"))),
+            c_long::MIN,
+            "-{magnitude}"
+        );
     }
 
     /// C saturates on overflow rather than failing.


### PR DESCRIPTION
Miri work, continuing from #104.

**`yyextra_r`** — the C stashes a ParseData pointer in the scanner's yyextra field and the lexer rules dereference it, so ParseData was reachable both through the scanner and through the `&mut ParseData` that `ffiprs` and `yyparse` hold. Every rule that touched it aliased a strongly-protected argument. This was the largest single source of UB in the suite: 266 tests. ParseData is now passed to `yylex` as an argument and the field is gone, so the scanner cannot refer to it at all.

**`atof_safe`** — accumulated fractional digits by hand, compounding a rounding error per digit, so `12345.6789` parsed as `12345.678899999999`. Row filters comparing a literal against a stored double with `==` silently stopped matching. It also panicked outright on `1e400` via an unchecked `u128::pow`. Both fixed, and `atol_safe` is added because Rust's `parse` fails on overflow where C saturates to `LONG_MAX` (the eval corpus pins this). Covered by differential tests against libc `atof`/`atol`.

Also in here:

- `yylex_destroy` released `yy_buffer_stack` with libc `free`, but `yyensure_buffer_stack` builds it as a Rust `Vec` — an allocator mismatch.
- `NullValue::from_raw_ptr` dereferenced a caller-supplied `void*` as `*value.cast::<T>()`; it commonly points into a byte buffer and carries no alignment guarantee, so it needs `read_unaligned`.

Suite green (35 binaries), clippy clean.

Not fixed here: with these gone, the eval tests reach `Info.parseData = &mut lParse` in `eval_f`, which is invalidated two lines later by `&mut lParse.colData[..]`. That is the same shape as `yyextra_r`, `FPTR_TABLE` and the `infptr == outfptr` signatures — the crate's one structural aliasing issue, now the front of the queue. Noted in TODO.md.