### PR TITLE
Fix the ffiter leak, split_names provenance and fits_recalloc alignment

### DIFF
--- a/src/cfileio.rs
+++ b/src/cfileio.rs
@@ -8897,8 +8897,11 @@ pub unsafe fn fits_split_names_safer(list: *mut c_char) -> *mut c_char {
 
     CURSOR.set(cursor);
 
-    /* the returned pointer is into the caller's own buffer, as in the C */
-    core::ptr::from_mut::<c_char>(&mut buf[start])
+    /* The returned pointer is into the caller's own buffer, as in the C, and
+       the caller reads the whole NUL-terminated name from it. Derive it from
+       the remaining slice: `&mut buf[start]` borrows a single element, so the
+       pointer would only carry provenance over that one byte. */
+    buf[start..].as_mut_ptr()
 }
 
 /*--------------------------------------------------------------------------*/

--- a/src/fitscore.rs
+++ b/src/fitscore.rs
@@ -42,7 +42,7 @@ use core::{slice, str};
 use std::collections::HashMap;
 use std::sync::{LazyLock, Mutex};
 
-use crate::c_types::{c_char, c_int, c_long, c_short, c_uint, c_ulong, c_ushort, c_void, off_t};
+use crate::c_types::{c_char, c_int, c_long, c_short, c_uint, c_ulong, c_ushort, off_t};
 use crate::helpers::vec_raw_parts::vec_into_raw_parts;
 use crate::wrappers::strcpy_safe;
 
@@ -12441,74 +12441,76 @@ pub(crate) fn fits_strncasecmp(s1: &[c_char], s2: &[c_char], n: usize) -> c_int 
  * RETURNS: newly allocated storage
  *
  * */
-pub(crate) unsafe fn fits_recalloc(
-    ptr: *mut c_void,
-    old_num: usize,
-    new_num: usize,
-    size: usize,
-) -> *mut c_void {
+/// Grow, shrink or free a zero-initialised array of `T`, as the C's realloc
+/// idiom in the iterator/histogram code.
+///
+/// Generic over the element type rather than taking a byte size: the layout has
+/// to carry `align_of::<T>()`. The previous version built every layout with
+/// `Layout::array::<u8>(n * size)`, so the allocation was only ever 1-byte
+/// aligned and taking a `&mut T` out of it was UB for any `T` needing more
+/// (Miri rejected `&mut *iterCols.add(n)` for `iteratorCol`, which wants 8).
+///
+/// Returns null on allocation failure, freeing the old block, and returns null
+/// for `new_num == 0` after freeing.
+pub(crate) unsafe fn fits_recalloc<T>(ptr: *mut T, old_num: usize, new_num: usize) -> *mut T {
     unsafe {
         use alloc::alloc::{alloc_zeroed, dealloc, realloc};
         use core::alloc::Layout;
         use core::ptr;
 
+        let old_layout = match Layout::array::<T>(old_num) {
+            Ok(l) => l,
+            Err(_) => return ptr::null_mut(),
+        };
+
         if ptr.is_null() || old_num == 0 {
             /* Starting from nothing */
-            let layout = match Layout::array::<u8>(new_num * size) {
+            if new_num == 0 {
+                return ptr::null_mut();
+            }
+            let layout = match Layout::array::<T>(new_num) {
                 Ok(l) => l,
                 Err(_) => return ptr::null_mut(),
             };
-            return alloc_zeroed(layout).cast::<c_void>();
-        } else if new_num == old_num {
-            /* Same size, do nothing */
-            return ptr;
-        } else if new_num == 0 {
-            /* Freeing */
-            if !ptr.is_null() {
-                let layout = match Layout::array::<u8>(old_num * size) {
-                    Ok(l) => l,
-                    Err(_) => return ptr::null_mut(),
-                };
-                dealloc(ptr.cast::<u8>(), layout);
-            }
-            return ptr::null_mut();
-        } else if new_num < old_num {
-            /* Shrinking */
-            let old_layout = match Layout::array::<u8>(old_num * size) {
-                Ok(l) => l,
-                Err(_) => {
-                    let layout =
-                        Layout::array::<u8>(old_num * size).unwrap_or_else(|_| Layout::new::<u8>());
-                    dealloc(ptr.cast::<u8>(), layout);
-                    return ptr::null_mut();
-                }
-            };
-            let newptr = realloc(ptr.cast::<u8>(), old_layout, new_num * size);
-            if newptr.is_null() {
-                dealloc(ptr.cast::<u8>(), old_layout);
-            }
-            return newptr.cast::<c_void>();
+            return alloc_zeroed(layout).cast::<T>();
         }
 
-        /* Growing */
-        let old_layout = match Layout::array::<u8>(old_num * size) {
+        if new_num == old_num {
+            /* Same size, do nothing */
+            return ptr;
+        }
+
+        if new_num == 0 {
+            /* Freeing */
+            dealloc(ptr.cast::<u8>(), old_layout);
+            return ptr::null_mut();
+        }
+
+        let new_layout = match Layout::array::<T>(new_num) {
             Ok(l) => l,
             Err(_) => {
-                let layout =
-                    Layout::array::<u8>(old_num * size).unwrap_or_else(|_| Layout::new::<u8>());
-                dealloc(ptr.cast::<u8>(), layout);
+                dealloc(ptr.cast::<u8>(), old_layout);
                 return ptr::null_mut();
             }
         };
-        let newptr = realloc(ptr.cast::<u8>(), old_layout, new_num * size);
+
+        /* realloc keeps the alignment of old_layout, which is align_of::<T>() */
+        let newptr = realloc(ptr.cast::<u8>(), old_layout, new_layout.size());
         if newptr.is_null() {
             dealloc(ptr.cast::<u8>(), old_layout);
-            return newptr.cast::<c_void>();
+            return ptr::null_mut();
         }
 
-        /* Zero the new portion of the array */
-        ptr::write_bytes(newptr.add(old_num * size), 0, (new_num - old_num) * size);
-        newptr.cast::<c_void>()
+        if new_num > old_num {
+            /* Zero the new portion of the array */
+            ptr::write_bytes(
+                newptr.add(old_layout.size()),
+                0,
+                new_layout.size() - old_layout.size(),
+            );
+        }
+
+        newptr.cast::<T>()
     }
 }
 

--- a/src/histo.rs
+++ b/src/histo.rs
@@ -4048,13 +4048,7 @@ pub(crate) fn fits_make_histde(
         /* Now make iterator columns for input, as well as any calculated values */
         numAllocCols = 5;
         iterCols = unsafe {
-            fits_recalloc(
-                ptr::null_mut(),
-                0,
-                numAllocCols as usize,
-                core::mem::size_of::<iteratorCol>(),
-            )
-            .cast::<iteratorCol>()
+            fits_recalloc::<iteratorCol>(ptr::null_mut(), 0, numAllocCols as usize)
         };
         if iterCols.is_null() {
             ffpmsg_str("memory allocation failure (fits_make_histde)");
@@ -4187,12 +4181,10 @@ pub(crate) fn fits_make_histde(
                 /* Copy iterator columns from the parser to the master iterator columns */
                 iterCols = unsafe {
                     fits_recalloc(
-                        iterCols.cast::<c_void>(),
+                        iterCols,
                         numAllocCols as usize,
                         (numAllocCols + parsers[ii].nCols) as usize,
-                        core::mem::size_of::<iteratorCol>(),
                     )
-                    .cast::<iteratorCol>()
                 };
                 if iterCols.is_null() {
                     *status = MEMORY_ALLOCATION;
@@ -4273,12 +4265,10 @@ pub(crate) fn fits_make_histde(
             /* Copy iterator columns from the parser to the master iterator columns */
             iterCols = unsafe {
                 fits_recalloc(
-                    iterCols.cast::<c_void>(),
+                    iterCols,
                     numAllocCols as usize,
                     (numAllocCols + parsers[4].nCols) as usize,
-                    core::mem::size_of::<iteratorCol>(),
                 )
-                .cast::<iteratorCol>()
             };
             if iterCols.is_null() {
                 *status = MEMORY_ALLOCATION;

--- a/src/putcol.rs
+++ b/src/putcol.rs
@@ -3974,7 +3974,10 @@ pub fn ffiter_safe(
         /*----------------------------------*/
 
         for jj in 0..n_cols as usize {
-            if cols[jj].datatype == TSTRING && cols[jj].array.is_null() {
+            /* The C guards these on `if (cols[jj].array)`, i.e. non-null.
+               Testing is_null() instead meant the frees only ran for columns
+               that had nothing to free, so every allocated work array leaked. */
+            if cols[jj].datatype == TSTRING && !cols[jj].array.is_null() {
                 stringptr = cols[jj].array.cast::<*mut c_char>();
 
                 free((*stringptr).cast::<c_void>()); /* free the block of strings */
@@ -3982,7 +3985,7 @@ pub fn ffiter_safe(
                     free(ptr.cast::<c_void>()); /* free the null string */
                 }
             }
-            if cols[jj].array.is_null() {
+            if !cols[jj].array.is_null() {
                 free(cols[jj].array);
                 /* memory for the array of values from the col */
             }


### PR DESCRIPTION
Three independent Miri findings, none of them the `&mut` aliasing rework.

**`ffiter` leaked its column work arrays.** The cleanup loop guarded both frees on `cols[jj].array.is_null()`, but the C guards on `if (cols[jj].array)` — non-null. Inverted, the frees only ran for columns that had nothing to free. Miri reports 21 leaked blocks across the fitsverify header tests; they are gone.

**`fits_split_names_safer` returned a one-byte pointer.** It was built with `&mut buf[start]`, which borrows a single element, so the pointer only carried provenance over that byte while callers read the whole NUL-terminated name. Same shape as the `yytext_r` fix in #107.

**`fits_recalloc` allocated everything with alignment 1.** Every layout used `Layout::array::<u8>(n * size)` regardless of the element type, so `&mut *iterCols.add(n)` was UB for `iteratorCol`, which wants 8. It is now generic over `T` and builds layouts with `Layout::array::<T>`, which also drops the error-prone `size` argument and makes the shrink/free paths deallocate with the layout they allocated with. This was latent for any type it allocates, not just the histogram code.

Verified: the split_names tests pass under Miri (0 UB, was 4 failing), leaks are 0 (was 21), and the alignment errors are 0. Suite green (35 binaries), clippy clean.

The histogram tests still fail, but on a different cause now — `histData.iterCols` aliasing, part of the same structural `&mut` issue as `Info.parseData` and `FPTR_TABLE`. `drvrmem`'s libc-realloc-on-a-Rust-Vec is being handled separately since it changes allocation ownership.