### PR TITLE
Mark FFI wrapper unsafe blocks with a // FFI WRAPPER comment

### DIFF
--- a/src/bin/fitsverify/fvrf_data.rs
+++ b/src/bin/fitsverify/fvrf_data.rs
@@ -630,6 +630,7 @@ pub extern "C" fn iterdata(
     iter_col: *mut iteratorCol,
     usrdata: *mut c_void,
 ) -> c_int {
+    // FFI WRAPPER
     let mut i: c_int;
     let mut j: c_long;
     let mut k: c_long;

--- a/src/buffers.rs
+++ b/src/buffers.rs
@@ -31,6 +31,7 @@ pub unsafe extern "C" fn ffmbyt(
     err_mode: c_int,     /* I - 1=ignore error, 0 = return error */
     status: *mut c_int,  /* IO - error status                    */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let fptr = fptr.as_mut().expect(NULL_MSG);
         let status = status.as_mut().expect(NULL_MSG);
@@ -729,6 +730,7 @@ pub unsafe extern "C" fn ffflus(
     fptr: *mut fitsfile, /* I - FITS file pointer                       */
     status: *mut c_int,  /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let fptr = fptr.as_mut().expect(NULL_MSG);
         let status = status.as_mut().expect(NULL_MSG);
@@ -775,6 +777,7 @@ pub unsafe extern "C" fn ffflsh(
     clearbuf: c_int,     /* I - also clear buffer contents? */
     status: *mut c_int,  /* IO - error status               */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let fptr = fptr.as_mut().expect(NULL_MSG);
         let status = status.as_mut().expect(NULL_MSG);
@@ -944,6 +947,7 @@ pub unsafe extern "C" fn ffgrsz(
     ndata: *mut c_long,  /* O - optimal amount of data to access         */
     status: *mut c_int,  /* IO - error status                            */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let fptr = fptr.as_mut().expect(NULL_MSG);
         let status = status.as_mut().expect(NULL_MSG);
@@ -1007,6 +1011,7 @@ pub unsafe extern "C" fn ffgtbb(
     values: *mut c_uchar, /* I - array of bytes to read            */
     status: *mut c_int,   /* IO - error status                     */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -1322,6 +1327,7 @@ pub unsafe extern "C" fn ffptbb(
     values: *const c_uchar, /* I - array of bytes to write           */
     status: *mut c_int,     /* IO - error status                     */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);

--- a/src/cfileio.rs
+++ b/src/cfileio.rs
@@ -156,6 +156,7 @@ pub unsafe extern "C" fn ffomem(
     mem_realloc: unsafe extern "C" fn(p: *mut c_void, newsize: usize) -> *mut c_void, /* function       */
     status: *mut c_int, /* IO - error status                       */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let fptr = fptr.as_mut().expect(NULL_MSG);
         let status = status.as_mut().expect(NULL_MSG);
@@ -456,6 +457,7 @@ pub unsafe extern "C" fn ffdkopn(
     mode: c_int,                      /* I - 0 = open readonly; 1 = read/write   */
     status: *mut c_int,               /* IO - error status                       */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let fptr = fptr.as_mut().expect(NULL_MSG);
         let status = status.as_mut().expect(NULL_MSG);
@@ -494,6 +496,7 @@ pub unsafe extern "C" fn ffdopn(
     mode: c_int,                      /* I - 0 = open readonly; 1 = read/write   */
     status: *mut c_int,               /* IO - error status                       */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let fptr = fptr.as_mut().expect(NULL_MSG);
         let status = status.as_mut().expect(NULL_MSG);
@@ -534,6 +537,7 @@ pub unsafe extern "C" fn ffeopn(
     hdutype: *mut c_int,              /* O - type of extension that is moved to  */
     status: *mut c_int,               /* IO - error status                       */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let fptr = fptr.as_mut().expect(NULL_MSG);
         let status = status.as_mut().expect(NULL_MSG);
@@ -636,6 +640,7 @@ pub unsafe extern "C" fn fftopn(
     mode: c_int,                      /* I - 0 = open readonly; 1 = read/write   */
     status: *mut c_int,               /* IO - error status                       */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let fptr = fptr.as_mut().expect(NULL_MSG);
         let status = status.as_mut().expect(NULL_MSG);
@@ -684,6 +689,7 @@ pub unsafe extern "C" fn ffiopn(
     mode: c_int,                      /* I - 0 = open readonly; 1 = read/write   */
     status: *mut c_int,               /* IO - error status                       */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let fptr = fptr.as_mut().expect(NULL_MSG);
         let status = status.as_mut().expect(NULL_MSG);
@@ -737,6 +743,7 @@ pub unsafe extern "C" fn ffopentest(
     mode: c_int,                      /* I - 0 = open readonly; 1 = read/write   */
     status: *mut c_int,               /* IO - error status                       */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let fptr = fptr.as_mut().expect(NULL_MSG);
         let status = status.as_mut().expect(NULL_MSG);
@@ -787,6 +794,7 @@ pub unsafe extern "C" fn ffopen(
     mode: c_int,                      /* I - 0 = open readonly; 1 = read/write   */
     status: *mut c_int,               /* IO - error status                       */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let fptr = fptr.as_mut().expect(NULL_MSG);
         let status = status.as_mut().expect(NULL_MSG);
@@ -1816,6 +1824,7 @@ pub unsafe extern "C" fn ffreopen(
     newfptr: *mut *mut fitsfile, /* O - pointer to new re opened file   */
     status: *mut c_int,          /* IO - error status                   */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let newfptr = newfptr.as_mut().expect(NULL_MSG);
         let status = status.as_mut().expect(NULL_MSG);
@@ -1892,6 +1901,7 @@ pub unsafe extern "C" fn fits_clear_Fptr(
     Fptr: *mut FITSfile, /* O - FITS file pointer               */
     status: *mut c_int,  /* IO - error status                   */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let lock = FFLOCK();
         for ii in 0..NMAXFILES {
@@ -3341,6 +3351,7 @@ pub unsafe extern "C" fn fits_copy_cell2image(
     rownum: c_long,        /* I - number of the row containing the image */
     status: *mut c_int,    /* IO - error status */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let fptr = fptr.as_mut().expect(NULL_MSG);
         let newptr = newptr.as_mut().expect(NULL_MSG);
@@ -3647,6 +3658,7 @@ pub unsafe extern "C" fn fits_copy_image2cell(
     copykeyflag: c_int,     /* I - controls which keywords to copy */
     status: *mut c_int,     /* IO - error status */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -4002,6 +4014,7 @@ pub unsafe extern "C" fn fits_select_image_section(
     expr: *const c_char,    /* I - Image section expression    */
     status: *mut c_int,
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let fptr = fptr.as_mut().expect(NULL_MSG);
         let status = status.as_mut().expect(NULL_MSG);
@@ -4130,6 +4143,7 @@ pub unsafe extern "C" fn fits_copy_image_section(
     expr: *const c_char,   /* I - Image section expression    */
     status: *mut c_int,
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let fptr = fptr.as_mut().expect(NULL_MSG);
         let newptr = newptr.as_mut().expect(NULL_MSG);
@@ -4631,6 +4645,7 @@ pub unsafe extern "C" fn fits_get_section_range(
     incre: *mut c_long,
     status: *mut c_int,
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let ptr = ptr.as_mut().expect(NULL_MSG);
         let secmin = secmin.as_mut().expect(NULL_MSG);
@@ -5174,6 +5189,7 @@ pub unsafe extern "C" fn ffdkinit(
     name: *const c_char,              /* I - name of file to create              */
     status: *mut c_int,               /* IO - error status                       */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -5218,6 +5234,7 @@ pub unsafe extern "C" fn ffinit(
     name: *const c_char,              /* I - name of file to create              */
     status: *mut c_int,               /* IO - error status                       */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -5450,6 +5467,7 @@ pub unsafe extern "C" fn ffimem(
     mem_realloc: Option<unsafe extern "C" fn(p: *mut c_void, newsize: usize) -> *mut c_void>, /* function       */
     status: *mut c_int, /* IO - error status                       */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let fptr = fptr.as_mut().expect(NULL_MSG);
         let buffptr = buffptr.as_mut().expect(NULL_MSG);
@@ -5586,6 +5604,7 @@ pub fn ffimem_safer(
 /// Initialize anything that is required before using the CFITSIO routines
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn fits_init_cfitsio() -> c_int {
+    // FFI WRAPPER
     fits_init_cfitsio_safer()
 }
 
@@ -6138,6 +6157,7 @@ pub unsafe extern "C" fn ffiurl(
     colspec: *mut c_char,    /* column or keyword modifier expression */
     status: *mut c_int,
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         raw_to_slice!(url);
 
@@ -6208,6 +6228,7 @@ pub unsafe extern "C" fn ffifile(
     pixfilter: *mut c_char,  /* pixel filter expression */
     status: *mut c_int,
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         raw_to_slice!(url);
@@ -6280,6 +6301,7 @@ pub unsafe extern "C" fn ffifile2(
     compspec: *mut c_char,   /* image compression specification */
     status: *mut c_int,
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         raw_to_slice!(url);
 
@@ -7516,6 +7538,7 @@ pub unsafe extern "C" fn ffexist(
     /*   be a http, ftp, gsiftp, smem, or stdin file) */
     status: *mut c_int, /* I/O  status  */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let exists = exists.as_mut().expect(NULL_MSG);
         let status = status.as_mut().expect(NULL_MSG);
@@ -7594,6 +7617,7 @@ pub unsafe extern "C" fn ffrtnm(
     rootname: *mut c_char,
     status: *mut c_int,
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         raw_to_slice!(url);
@@ -7993,6 +8017,7 @@ pub unsafe extern "C" fn ffexts(
     rowexpress: *mut c_char,
     status: *mut c_int,
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let extnum = extnum.as_mut().expect(NULL_MSG);
         let extvers = extvers.as_mut().expect(NULL_MSG);
@@ -8295,6 +8320,7 @@ pub unsafe extern "C" fn ffextn(
     extension_num: *mut c_int, /* O - returned extension number */
     status: *mut c_int,
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let extension_num = extension_num.as_mut().expect(NULL_MSG);
         let status = status.as_mut().expect(NULL_MSG);
@@ -8468,6 +8494,7 @@ pub unsafe extern "C" fn ffurlt(
     urlType: *mut c_char,
     status: *mut c_int,
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let fptr = fptr.as_ref().expect(NULL_MSG);
         let status = status.as_mut().expect(NULL_MSG);
@@ -8500,6 +8527,7 @@ pub unsafe extern "C" fn ffimport_file(
     contents: *mut *mut c_char, /* Pointer to pointer to hold file     */
     status: *mut c_int,         /* CFITSIO error code                  */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         raw_to_slice!(filename);
@@ -8629,6 +8657,7 @@ pub unsafe extern "C" fn fits_get_token(
     token: *mut c_char,
     isanumber: *mut c_int, /* O - is this token a number? */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let ptr = ptr.as_mut().expect(NULL_MSG);
         let isanumber = isanumber.as_mut();
@@ -8735,6 +8764,7 @@ pub unsafe extern "C" fn fits_get_token2(
     isanumber: *mut c_int, /* O - is this token a number? */
     status: *mut c_int,
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let isanumber = isanumber.as_mut();
         let status = status.as_mut().expect(NULL_MSG);
@@ -8800,6 +8830,7 @@ pub unsafe extern "C" fn fits_split_names(
     list: *mut c_char, /* IO  - list of names; the name returned is terminated */
                        /*       in place by overwriting its delimiter with a NUL */
 ) -> *mut c_char {
+    // FFI WRAPPER
     unsafe { fits_split_names_safer(list) }
 }
 
@@ -8898,9 +8929,9 @@ pub unsafe fn fits_split_names_safer(list: *mut c_char) -> *mut c_char {
     CURSOR.set(cursor);
 
     /* The returned pointer is into the caller's own buffer, as in the C, and
-       the caller reads the whole NUL-terminated name from it. Derive it from
-       the remaining slice: `&mut buf[start]` borrows a single element, so the
-       pointer would only carry provenance over that one byte. */
+    the caller reads the whole NUL-terminated name from it. Derive it from
+    the remaining slice: `&mut buf[start]` borrows a single element, so the
+    pointer would only carry provenance over that one byte. */
     buf[start..].as_mut_ptr()
 }
 
@@ -8931,6 +8962,7 @@ pub unsafe extern "C" fn ffclos(
     fptr: Option<Box<fitsfile>>, /* I - FITS file pointer */
     status: *mut c_int,          /* IO - error status     */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
 
@@ -9015,6 +9047,7 @@ pub unsafe extern "C" fn ffdelt(
     mut fptr: *mut fitsfile, /* I - FITS file pointer */
     status: *mut c_int,      /* IO - error status     */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
 
@@ -9260,6 +9293,7 @@ pub unsafe extern "C" fn fftplt(
     tempname: *const c_char,          /* I - name of template file               */
     status: *mut c_int,               /* IO - error status                       */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -9385,6 +9419,7 @@ pub(crate) fn ffoptplt(
 /// Uses C FILE stream.
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffrprt(stream: *mut FILE, status: c_int) {
+    // FFI WRAPPER
     ffrprt_safe(stream, status)
 }
 
@@ -9582,6 +9617,7 @@ pub fn pixel_filter_helper(
 /// This is NOT THREAD-SAFE
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffihtps() {
+    // FFI WRAPPER
     ffihtps_safe()
 }
 
@@ -9597,6 +9633,7 @@ pub fn ffihtps_safe() {
 /// This is NOT THREAD-SAFE
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffchtps() {
+    // FFI WRAPPER
     ffchtps_safe()
 }
 
@@ -9612,6 +9649,7 @@ pub fn ffchtps_safe() {
 /// This is NOT THREAD-SAFE
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffvhtps(flag: c_int) {
+    // FFI WRAPPER
     ffvhtps_safe(flag)
 }
 
@@ -9630,6 +9668,7 @@ pub fn ffvhtps_safe(flag: c_int) {
 /// This is NOT THREAD-SAFE
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffshdwn(flag: c_int) {
+    // FFI WRAPPER
     ffshdwn_safe(flag)
 }
 
@@ -9646,6 +9685,7 @@ pub fn ffshdwn_safe(flag: c_int) {
 /// Get the current network timeout value in seconds
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgtmo() -> c_int {
+    // FFI WRAPPER
     ffgtmo_safer()
 }
 
@@ -9665,6 +9705,7 @@ pub fn ffgtmo_safer() -> c_int {
 /// Set the network timeout value in seconds
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffstmo(sec: c_int, status: *mut c_int) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         ffstmo_safe(sec, status)

--- a/src/checksum.rs
+++ b/src/checksum.rs
@@ -39,6 +39,7 @@ pub unsafe extern "C" fn ffcsum(
     sum: *mut c_ulong,   /* IO - accumulated checksum              */
     status: *mut c_int,  /* IO - error status                      */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         if fptr.is_null() {
             *status = NULL_INPUT_PTR;
@@ -131,6 +132,7 @@ pub unsafe extern "C" fn ffesum(
     complm: c_int,            /* I - = 1 to encode complement of the sum */
     ascii: *mut [c_char; 17], /* O - 16-char ASCII encoded checksum      */
 ) {
+    // FFI WRAPPER
     unsafe {
         let ascii = ascii.as_mut().expect(NULL_MSG);
         ffesum_safe(sum, complm == 1, ascii)
@@ -223,6 +225,7 @@ pub unsafe extern "C" fn ffdsum(
     complm: c_int,        /* I - =1 to decode complement of the   */
     sum: *mut c_ulong,    /* O - 32-bit checksum           */
 ) -> c_ulong {
+    // FFI WRAPPER
     unsafe {
         let sum = sum.as_mut().expect(NULL_MSG);
         let ascii = slice::from_raw_parts(ascii, 17).try_into().unwrap();
@@ -281,6 +284,7 @@ pub unsafe extern "C" fn ffpcks(
     fptr: *mut fitsfile, /* I - FITS file pointer                  */
     status: *mut c_int,  /* IO - error status                      */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -465,6 +469,7 @@ pub unsafe extern "C" fn ffupck(
     fptr: *mut fitsfile, /* I - FITS file pointer                  */
     status: *mut c_int,  /* IO - error status                      */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -600,6 +605,7 @@ pub unsafe extern "C" fn ffvcks(
     /*    -1 verification not correct         */
     status: *mut c_int, /* IO - error status                      */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -694,6 +700,7 @@ pub unsafe extern "C" fn ffgcks(
     hdusum: *mut c_ulong,  /* O - hdu checksum                  */
     status: *mut c_int,    /* IO - error status                 */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);

--- a/src/drvrmem.rs
+++ b/src/drvrmem.rs
@@ -133,7 +133,7 @@ unsafe fn owned_realloc(ptr: *mut c_char, newsize: usize) -> *mut c_char {
 
         let Some((len, capacity)) = allocations.remove(&(ptr as usize)) else {
             /* Not one of ours; refuse rather than free it with the wrong
-               allocator. */
+            allocator. */
             return ptr::null_mut();
         };
 
@@ -1547,7 +1547,7 @@ pub(crate) fn mem_write_unsafe(hdl: c_int, buffer: &[u8], nbytes: usize) -> c_in
             );
 
             /* call the realloc function; see owned_realloc for why a
-               driver-owned buffer cannot go through the C one */
+            driver-owned buffer cannot go through the C one */
             let ptr = if m[hdl].owned_cell.is_null() {
                 (m[hdl].mem_realloc.unwrap())((*(m[hdl].memaddrptr)).cast::<c_void>(), newsize)
                     .cast::<c_char>()

--- a/src/drvrsmem.rs
+++ b/src/drvrsmem.rs
@@ -218,6 +218,7 @@ unsafe fn shared_destroy_entry(idx: usize) -> c_int /* unconditionally destroy s
 /// This must (should) be called during exit/abort
 #[cfg_attr(not(test), unsafe(no_mangle))]
 pub extern "C" fn shared_cleanup() {
+    // FFI WRAPPER
     unsafe {
         let i: c_int = 0;
         let j: c_int = 0;
@@ -351,6 +352,7 @@ pub extern "C" fn shared_cleanup() {
 /// Initialize shared memory stuff, you have to call this routine once
 #[cfg_attr(not(test), unsafe(no_mangle))]
 pub unsafe extern "C" fn shared_init(debug_msgs: c_int) -> c_int {
+    // FFI WRAPPER
     unsafe { shared_init_safer(debug_msgs) }
 }
 
@@ -544,6 +546,7 @@ pub unsafe fn shared_init_safer(debug_msgs: c_int) -> c_int {
 /// try to recover dormant segments after applic crash
 #[cfg_attr(not(test), unsafe(no_mangle))]
 pub unsafe extern "C" fn shared_recover(id: c_int) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let i: c_int = 0;
         let mut r: c_int = 0;
@@ -864,6 +867,7 @@ pub unsafe extern "C" fn shared_malloc(size: c_long, mode: c_int, newhandle: c_i
     let mut key: c_int = 0;
     let filler: semun = semun { val: 0 };
 
+    // FFI WRAPPER
     unsafe {
         /* delayed initialization */
         if !SHARED_INIT_CALLED {
@@ -994,6 +998,7 @@ pub unsafe extern "C" fn shared_malloc(size: c_long, mode: c_int, newhandle: c_i
 
 #[cfg_attr(not(test), unsafe(no_mangle))]
 pub unsafe extern "C" fn shared_attach(idx: usize) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let mut r: c_int = 0;
         let mut r2: c_int = 0;
@@ -1164,6 +1169,7 @@ unsafe fn shared_validate(idx: usize, mode: c_int) -> c_int /* use intrnally ins
 #[cfg_attr(not(test), unsafe(no_mangle))]
 pub unsafe extern "C" fn shared_realloc(idx: usize, newsize: c_int) -> SHARED_P /* realloc shared memory segment */
 {
+    // FFI WRAPPER
     unsafe {
         let mut h: c_int = 0;
         let mut key: c_int = 0;
@@ -1269,6 +1275,7 @@ pub unsafe extern "C" fn shared_realloc(idx: usize, newsize: c_int) -> SHARED_P 
 #[cfg_attr(not(test), unsafe(no_mangle))]
 pub unsafe extern "C" fn shared_free(idx: usize) -> c_int /* detach segment, if last process & !PERSIST, destroy segment */
 {
+    // FFI WRAPPER
     unsafe {
         let mut cnt: c_int = 0;
         let r: c_int = 0;
@@ -1327,6 +1334,7 @@ pub unsafe extern "C" fn shared_free(idx: usize) -> c_int /* detach segment, if 
 #[cfg_attr(not(test), unsafe(no_mangle))]
 pub unsafe extern "C" fn shared_lock(idx: usize, mode: c_int) -> SHARED_P /* lock given segment for exclusive access */
 {
+    // FFI WRAPPER
     unsafe {
         let mut r: c_int = 0;
 
@@ -1381,6 +1389,7 @@ pub unsafe extern "C" fn shared_lock(idx: usize, mode: c_int) -> SHARED_P /* loc
 #[cfg_attr(not(test), unsafe(no_mangle))]
 pub unsafe extern "C" fn shared_unlock(idx: usize) -> c_int /* unlock given segment, assumes seg is locked !! */
 {
+    // FFI WRAPPER
     unsafe {
         let mut r: c_int = 0;
         let mut r2: c_int = 0;
@@ -1422,6 +1431,7 @@ pub unsafe extern "C" fn shared_unlock(idx: usize) -> c_int /* unlock given segm
 #[cfg_attr(not(test), unsafe(no_mangle))]
 pub unsafe extern "C" fn shared_attr(idx: usize) -> c_int /* get the attributes of the shared memory segment */
 {
+    // FFI WRAPPER
     unsafe {
         if shared_check_locked_index(idx) != 0 {
             return SHARED_INVALID;
@@ -1436,6 +1446,7 @@ pub unsafe extern "C" fn shared_attr(idx: usize) -> c_int /* get the attributes 
 #[cfg_attr(not(test), unsafe(no_mangle))]
 pub unsafe extern "C" fn shared_set_attr(idx: usize, newattr: c_int) -> c_int /* get the attributes of the shared memory segment */
 {
+    // FFI WRAPPER
     unsafe {
         if shared_check_locked_index(idx) != 0 {
             return SHARED_INVALID;
@@ -1460,6 +1471,7 @@ pub unsafe extern "C" fn shared_set_attr(idx: usize, newattr: c_int) -> c_int /*
 
 #[cfg_attr(not(test), unsafe(no_mangle))]
 pub unsafe extern "C" fn shared_set_debug(mode: c_int) -> c_int /* set/reset debug mode */ {
+    // FFI WRAPPER
     unsafe {
         let r: c_int = SHARED_DEBUG as c_int;
 
@@ -1470,6 +1482,7 @@ pub unsafe extern "C" fn shared_set_debug(mode: c_int) -> c_int /* set/reset deb
 
 #[cfg_attr(not(test), unsafe(no_mangle))]
 pub unsafe extern "C" fn shared_set_createmode(mode: c_int) -> c_int /* set/reset debug mode */ {
+    // FFI WRAPPER
     unsafe {
         let r: c_int = SHARED_CREATE_MODE;
 
@@ -1480,6 +1493,7 @@ pub unsafe extern "C" fn shared_set_createmode(mode: c_int) -> c_int /* set/rese
 
 #[cfg_attr(not(test), unsafe(no_mangle))]
 pub unsafe extern "C" fn shared_list(id: c_int) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let i: c_int = 0;
         let mut r: c_int = 0;
@@ -1555,6 +1569,7 @@ pub unsafe extern "C" fn shared_list(id: c_int) -> c_int {
 
 #[cfg_attr(not(test), unsafe(no_mangle))]
 pub unsafe extern "C" fn shared_getaddr(id: c_int, address: &mut *mut c_char) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let mut i: c_int = 0;
         let mut segname: [c_char; 10] = [0; 10];
@@ -1586,6 +1601,7 @@ pub unsafe extern "C" fn shared_getaddr(id: c_int, address: &mut *mut c_char) ->
 
 #[cfg_attr(not(test), unsafe(no_mangle))]
 pub unsafe extern "C" fn shared_uncond_delete(id: c_int) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let i: c_int = 0;
         let mut r: c_int = 0;

--- a/src/editcol.rs
+++ b/src/editcol.rs
@@ -57,6 +57,7 @@ pub unsafe extern "C" fn ffrsim(
     naxes: *const c_long, /* I - size of each axis           */
     status: *mut c_int,   /* IO - error status               */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -105,6 +106,7 @@ pub unsafe extern "C" fn ffrsimll(
     naxes: *const LONGLONG, /* I - size of each axis           */
     status: *mut c_int,     /* IO - error status               */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -386,6 +388,7 @@ pub unsafe extern "C" fn ffirow(
     nrows: LONGLONG,    /* I - number of rows to insert                 */
     status: *mut c_int, /* IO - error status                            */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -510,6 +513,7 @@ pub unsafe extern "C" fn ffdrow(
     nrows: LONGLONG,     /* I - number of rows to delete                 */
     status: *mut c_int,  /* IO - error status                            */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -643,6 +647,7 @@ pub unsafe extern "C" fn ffdrrg(
     ranges: *const c_char, /* I - ranges of rows to delete (1 = first)     */
     status: *mut c_int,    /* IO - error status                            */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -766,6 +771,7 @@ pub unsafe extern "C" fn ffdrws(
     nrows: c_long,         /* I - number of rows to delete                 */
     status: *mut c_int,    /* IO - error status                            */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -922,6 +928,7 @@ pub unsafe extern "C" fn ffdrwsll(
     nrows: LONGLONG,         /* I - number of rows to delete                 */
     status: *mut c_int,      /* IO - error status                            */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -1088,6 +1095,7 @@ pub unsafe extern "C" fn ffrwrg(
     maxrow: *mut c_long,    /* O - last row in each range */
     status: *mut c_int,     /* IO - status value */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let numranges = numranges.as_mut().expect(NULL_MSG);
@@ -1283,6 +1291,7 @@ pub unsafe extern "C" fn ffrwrgll(
     maxrow: *mut LONGLONG,  /* O - last row in each range */
     status: *mut c_int,     /* IO - status value */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let numranges = numranges.as_mut().expect(NULL_MSG);
@@ -1471,6 +1480,7 @@ pub unsafe extern "C" fn fficol(
     tform: *const c_char, /* I - format of column (TFORM keyword)         */
     status: *mut c_int,   /* IO - error status                            */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -1513,6 +1523,7 @@ pub unsafe extern "C" fn fficls(
     tform: *const *const c_char, /* I - array of formats of column (TFORM)       */
     status: *mut c_int,          /* IO - error status                            */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -1889,6 +1900,7 @@ pub unsafe extern "C" fn ffmvec(
     newveclen: LONGLONG, /* I - new vector length of column (TFORM)       */
     status: *mut c_int,  /* IO - error status                            */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -2142,6 +2154,7 @@ pub unsafe extern "C" fn ffcpcl(
     create_col: c_int,      /* I - create new col if TRUE, else overwrite */
     status: *mut c_int,     /* IO - error status     */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let infptr = infptr.as_mut().expect(NULL_MSG);
@@ -2721,6 +2734,7 @@ pub unsafe extern "C" fn ffccls(
     create_col: c_int,      /* I - create new col if TRUE, else overwrite */
     status: *mut c_int,     /* IO - error status     */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let infptr = infptr.as_mut().expect(NULL_MSG);
@@ -2984,6 +2998,7 @@ pub unsafe extern "C" fn ffcprw(
     nrows: LONGLONG,        /* I - number of rows to copy  */
     status: *mut c_int,     /* IO - error status     */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let infptr = infptr.as_mut().expect(NULL_MSG);
@@ -3257,6 +3272,7 @@ pub unsafe extern "C" fn ffcpsr(
     row_status: *const c_char, /* I - quality list of rows to keep (1) or not keep (0) */
     status: *mut c_int,        /* IO - error status     */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let infptr = infptr.as_mut().expect(NULL_MSG);
@@ -3568,6 +3584,7 @@ pub unsafe extern "C" fn ffcpky(
     rootname: *const c_char, /* I - root name of the keyword to be copied */
     status: *mut c_int,      /* IO - error status     */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let infptr = infptr.as_mut().expect(NULL_MSG);
@@ -3620,6 +3637,7 @@ pub unsafe extern "C" fn ffdcol(
     colnum: c_int,       /* I - column to delete (1 = 1st)               */
     status: *mut c_int,  /* IO - error status                            */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -3801,6 +3819,7 @@ pub unsafe extern "C" fn ffcins(
     bytepos: LONGLONG,   /* I - rel. position in row to insert bytes     */
     status: *mut c_int,  /* IO - error status                            */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -3979,6 +3998,7 @@ pub unsafe extern "C" fn ffcdel(
     bytepos: LONGLONG,   /* I - rel. position in row to delete bytes     */
     status: *mut c_int,  /* IO - error status                            */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -4105,6 +4125,7 @@ pub unsafe extern "C" fn ffkshf(
     incre: c_int,        /* I - shift index number by this amount        */
     status: *mut c_int,  /* IO - error status                            */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -4222,6 +4243,7 @@ pub unsafe extern "C" fn fffvcl(
     colnums: *mut c_int,  /* O - 1-based variable column positions       */
     status: *mut c_int,   /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -4299,6 +4321,7 @@ pub unsafe extern "C" fn ffshft(
     nshift: LONGLONG,    /* I - size of shift in bytes (+ or -)          */
     status: *mut c_int,  /* IO - error status                            */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);

--- a/src/edithdu.rs
+++ b/src/edithdu.rs
@@ -38,6 +38,7 @@ pub unsafe extern "C" fn ffcopy(
     morekeys: c_int,        /* I - reserve space in output header   */
     status: *mut c_int,     /* IO - error status     */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
 
@@ -114,6 +115,7 @@ pub unsafe extern "C" fn ffcpfl(
     following: c_int,       /* I - copy any following HDUs?   */
     status: *mut c_int,     /* IO - error status     */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
 
@@ -197,6 +199,7 @@ pub unsafe extern "C" fn ffcphd(
     outfptr: *mut fitsfile, /* I - FITS file pointer to output file */
     status: *mut c_int,     /* IO - error status     */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
 
@@ -408,6 +411,7 @@ pub unsafe extern "C" fn ffcpht(
     nrows: LONGLONG,        /* I - number of rows to copy  */
     status: *mut c_int,     /* IO - error status     */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let infptr = infptr.as_mut().expect(NULL_MSG);
@@ -465,6 +469,7 @@ pub unsafe extern "C" fn ffcpdt(
     outfptr: *mut fitsfile, /* I - FITS file pointer to output file */
     status: *mut c_int,     /* IO - error status     */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
 
@@ -554,6 +559,7 @@ pub unsafe extern "C" fn ffwrhdu(
     outstream: *mut FILE,  /* I - stream to write HDU to */
     status: *mut c_int,    /* IO - error status     */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let infptr = infptr.as_mut().expect(NULL_MSG);
         let status = status.as_mut().expect(NULL_MSG);
@@ -605,6 +611,7 @@ pub unsafe extern "C" fn ffiimg(
     naxes: *const c_long, /* I - size of each axis           */
     status: *mut c_int,   /* IO - error status               */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -657,6 +664,7 @@ pub unsafe extern "C" fn ffiimgll(
     naxes: *const LONGLONG, /* I - size of each axis           */
     status: *mut c_int,     /* IO - error status               */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -910,6 +918,7 @@ pub unsafe extern "C" fn ffitab(
     extnmx: *const c_char,       /* I - value of EXTNAME keyword, if any         */
     status: *mut c_int,          /* IO - error status                            */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let fptr = fptr.as_mut().expect(NULL_MSG);
         let status = status.as_mut().expect(NULL_MSG);
@@ -1141,6 +1150,7 @@ pub unsafe extern "C" fn ffibin(
     pcount: LONGLONG,            /* I - size of special data area (heap)         */
     status: *mut c_int,          /* IO - error status                            */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let fptr = fptr.as_mut().expect(NULL_MSG);
         let status = status.as_mut().expect(NULL_MSG);
@@ -1356,6 +1366,7 @@ pub unsafe extern "C" fn ffdhdu(
     hdutype: *mut c_int, /* O - type of the new CHDU after deletion */
     status: *mut c_int,  /* IO - error status                       */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);

--- a/src/eval_f.rs
+++ b/src/eval_f.rs
@@ -145,6 +145,7 @@ pub unsafe extern "C" fn fffrow(
     row_status: *mut c_char,  /* O - Array of boolean results          */
     status: *mut c_int,       /* O - Error status                      */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let fptr = fptr.as_mut().expect(NULL_MSG);
         let status = status.as_mut().expect(NULL_MSG);
@@ -282,6 +283,7 @@ pub unsafe extern "C" fn ffsrow(
     expr: *const c_char,    /* I - Boolean expression                   */
     status: *mut c_int,     /* O - Error status                         */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let infptr = infptr.as_mut().expect(NULL_MSG);
         let outfptr = outfptr.as_mut().expect(NULL_MSG);
@@ -691,6 +693,7 @@ pub unsafe extern "C" fn ffcrow(
     anynul: *mut c_int,    /* O - Were any UNDEFs encountered?         */
     status: *mut c_int,    /* O - Error status                         */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let fptr = fptr.as_mut().expect(NULL_MSG);
         let status = status.as_mut().expect(NULL_MSG);
@@ -803,6 +806,7 @@ pub unsafe extern "C" fn ffcalc(
     parInfo: *const c_char, /* I - Extra information on parameter       */
     status: *mut c_int,     /* O - Error status                         */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let infptr = infptr.as_mut().expect(NULL_MSG);
         let outfptr = outfptr.as_mut().expect(NULL_MSG);
@@ -869,6 +873,7 @@ pub unsafe extern "C" fn ffcalc_rng(
     end: *const c_long,     /* I - Row range info                   */
     status: *mut c_int,     /* O - Error status                     */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         raw_to_slice!(expr);
         raw_to_slice!(parName);
@@ -1290,6 +1295,7 @@ pub unsafe extern "C" fn fftexp(
     naxes: *mut c_long,   /* O - Size of each dimension              */
     status: *mut c_int,   /* O - Error status                        */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let fptr = fptr.as_mut().expect(NULL_MSG);
         let status = status.as_mut().expect(NULL_MSG);
@@ -3240,6 +3246,7 @@ pub unsafe extern "C" fn fffrwc(
     time_status: *mut c_char, /* O - Array of boolean results           */
     status: *mut c_int,       /* O - Error status                       */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let fptr = fptr.as_mut().expect(NULL_MSG);
         let status = status.as_mut().expect(NULL_MSG);
@@ -3501,6 +3508,7 @@ pub unsafe extern "C" fn ffffrw(
     rownum: *mut c_long, /* O - First row of table to eval to T   */
     status: *mut c_int,  /* O - Error status                      */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let fptr = fptr.as_mut().expect(NULL_MSG);
         let status = status.as_mut().expect(NULL_MSG);
@@ -3927,6 +3935,7 @@ pub unsafe extern "C" fn fits_pixel_filter(
     filter: *mut PixelFilter, /* I - pixel filter structure */
     status: *mut c_int,       /* IO - error status */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect("Null status pointer");
         let filter = filter.as_mut().expect("Null filter pointer");

--- a/src/eval_l.rs
+++ b/src/eval_l.rs
@@ -965,8 +965,8 @@ pub(crate) fn fits_parser_yylex(
                                         CStr::from_ptr(yyscanner.yytext_r).to_bytes_with_nul(),
                                     );
 
-                                    let get_data = (lParse.getData)
-                                        .expect("non-null function pointer");
+                                    let get_data =
+                                        (lParse.getData).expect("non-null function pointer");
                                     result = get_data(
                                         lParse,
                                         yytext_r_slice,
@@ -1449,7 +1449,7 @@ fn yy_get_next_buffer(yyscanner: &mut yyguts_t, lParse: &mut ParseData) -> c_int
         (top_state.yy_ch_buf).as_deref_mut().unwrap()[(yyscanner.yy_n_chars + 1) as usize] =
             YY_END_OF_BUFFER_CHAR;
         /* Take the slice pointer directly rather than round-tripping it
-           through a place expression. */
+        through a place expression. */
         yyscanner.yytext_r = (top_state.yy_ch_buf).as_deref_mut().unwrap().as_mut_ptr();
         ret_val
     }
@@ -1892,9 +1892,9 @@ pub(crate) fn fits_parser_yylex_destroy(mut yyscanner: Box<yyguts_t>) -> c_int {
             fits_parser_yypop_buffer_state(&mut yyscanner);
         }
         /* Destroy the stack itself. yyensure_buffer_stack builds it as a Rust
-           Vec, so reconstruct and drop it: handing it to libc free is an
-           allocator mismatch. len == capacity == yy_buffer_stack_max, the same
-           convention the grow path in yyensure_buffer_stack uses. */
+        Vec, so reconstruct and drop it: handing it to libc free is an
+        allocator mismatch. len == capacity == yy_buffer_stack_max, the same
+        convention the grow path in yyensure_buffer_stack uses. */
         if !(yyscanner.yy_buffer_stack).is_null() {
             drop(Vec::from_raw_parts(
                 yyscanner.yy_buffer_stack,

--- a/src/fits_hcompress.rs
+++ b/src/fits_hcompress.rs
@@ -29,6 +29,7 @@ pub unsafe extern "C" fn fits_hcompress(
     nbytes: *mut c_long,
     status: *mut c_int,
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let nbytes = nbytes.as_mut().expect(NULL_MSG);
         let status = status.as_mut().expect(NULL_MSG);
@@ -91,6 +92,7 @@ pub unsafe extern "C" fn fits_hcompress64(
     nbytes: *mut c_long,
     status: *mut c_int,
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let nbytes = nbytes.as_mut().expect(NULL_MSG);
         let status = status.as_mut().expect(NULL_MSG);

--- a/src/fits_hdecompress.rs
+++ b/src/fits_hdecompress.rs
@@ -23,6 +23,7 @@ pub unsafe extern "C" fn fits_hdecompress(
     scale: *mut c_int,
     status: *mut c_int,
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let nx = nx.as_mut().expect(NULL_MSG);
@@ -81,6 +82,7 @@ pub unsafe extern "C" fn fits_hdecompress64(
     scale: *mut c_int,
     status: *mut c_int,
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let nx = nx.as_mut().expect(NULL_MSG);

--- a/src/fitscore.rs
+++ b/src/fitscore.rs
@@ -90,6 +90,7 @@ static ERROR_STACK: LazyLock<Mutex<ErrorStack>> = LazyLock::new(|| Mutex::new(Er
 ///  Note that this method of calculation limits minor/micro fields to < 100.
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffvers(version: *mut f32 /* IO - version number */) -> f32 {
+    // FFI WRAPPER
     unsafe {
         if version.is_null() {
             return 0.0;
@@ -242,6 +243,7 @@ pub unsafe extern "C" fn ffflnm(
     filename: *mut c_char, /* O - name of the file   */
     status: *mut c_int,    /* IO - error status      */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let fptr = fptr.as_mut().expect(NULL_MSG);
         let status = status.as_mut().expect(NULL_MSG);
@@ -270,6 +272,7 @@ pub unsafe extern "C" fn ffflmd(
     filemode: *mut c_int, /* O - open mode of the file  */
     status: *mut c_int,   /* IO - error status      */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let fptr = fptr.as_mut().expect(NULL_MSG);
 
@@ -292,6 +295,7 @@ pub unsafe extern "C" fn ffgerr(
     status: c_int,        /* I - error status value */
     errtext: *mut c_char, /* O - error message (max 30 char long + null) */
 ) {
+    // FFI WRAPPER
     unsafe {
         let errtext = slice::from_raw_parts_mut(errtext, 31);
 
@@ -576,6 +580,7 @@ impl ErrorStack {
 /// put message on to error stack
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffpmsg(err_message: *const c_char) {
+    // FFI WRAPPER
     ffxmsg(PUT_MESG, err_message.cast_mut());
 }
 
@@ -616,6 +621,7 @@ pub(crate) fn ffpmsg_str(err_message: &str) {
 ///  The marker is ignored by the ffgmsg routine.
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffpmrk() {
+    // FFI WRAPPER
     ffpmrk_safe();
 }
 
@@ -634,6 +640,7 @@ pub fn ffpmrk_safe() {
 /// get oldest message from error stack, ignoring markers
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgmsg(err_message: *mut c_char) -> c_int {
+    // FFI WRAPPER
     unsafe {
         ffxmsg(GET_MESG, err_message);
         c_int::from(*err_message)
@@ -666,6 +673,7 @@ pub fn ffgmsg_safe(err_message: &mut [c_char; FLEN_ERRMSG]) -> c_int {
 ///  erase all messages in the error stack
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffcmsg() {
+    // FFI WRAPPER
     let dummy = ptr::null_mut();
     ffxmsg(DEL_ALL, dummy);
 }
@@ -682,6 +690,7 @@ pub fn ffcmsg_safe() {
 /// The marker is also erased in this case.
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffcmrk() {
+    // FFI WRAPPER
     ffcmrk_safe();
 }
 
@@ -845,6 +854,7 @@ pub unsafe extern "C" fn fftkey(
     keyword: *const c_char, /* I -  keyword name */
     status: *mut c_int,     /* IO - error status */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         raw_to_slice!(keyword);
@@ -944,6 +954,7 @@ pub unsafe extern "C" fn fftrec(
     card: *mut c_char,  /* I -  keyword card to test */
     status: *mut c_int, /* IO - error status */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         raw_to_slice!(card);
@@ -1012,6 +1023,7 @@ pub fn fftrec_safe(
 /// convert string to upper case, in place.
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffupch(string: *mut c_char) {
+    // FFI WRAPPER
     unsafe {
         if !string.is_null() {
             // SAFETY: the C contract is a writable, NUL-terminated string.
@@ -1043,6 +1055,7 @@ pub unsafe extern "C" fn ffmkky(
     card: *mut c_char,      /* O - constructed keyword card */
     status: *mut c_int,     /* IO - status value   */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
 
@@ -1426,6 +1439,7 @@ pub unsafe extern "C" fn ffkeyn(
     keyname: *mut c_char,   /* O - output root + index keyword name */
     status: *mut c_int,     /* IO - error status  */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let keyname = slice::from_raw_parts_mut(keyname, FLEN_KEYWORD);
@@ -1446,6 +1460,7 @@ pub unsafe extern "C" fn ffnkey(
     keyname: *mut c_char,   /* O - output root + index keyword name */
     status: *mut c_int,     /* IO - error status  */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let keyname = slice::from_raw_parts_mut(keyname, 9); //Max 8 characters from bottom condition statement
@@ -1496,6 +1511,7 @@ pub unsafe extern "C" fn ffpsvc(
     comm: *mut c_char,   /* O - comment string parsed from the card */
     status: *mut c_int,  /* IO - error status   */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let card: &[c_char] = slice::from_raw_parts(card, FLEN_CARD);
         let value: &mut [c_char] = slice::from_raw_parts_mut(value, FLEN_VALUE);
@@ -1766,6 +1782,7 @@ pub unsafe extern "C" fn ffgthd(
     */
     status: *mut c_int, /* IO - error status   */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let hdtype = hdtype.as_mut().expect(NULL_MSG);
@@ -2186,6 +2203,7 @@ pub unsafe extern "C" fn fits_translate_keyword(
 
     status: *mut c_int, /* IO - error status */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let pat_num = pat_num.as_mut();
@@ -2529,6 +2547,7 @@ pub unsafe extern "C" fn fits_translate_keywords(
     n_range: c_int,  /* I - controls range of 'n' template values of interest (-1,0, or +1) */
     status: *mut c_int, /* IO - error status */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let infptr = infptr.as_mut().expect(NULL_MSG);
@@ -2679,6 +2698,7 @@ pub unsafe extern "C" fn fits_copy_pixlist2image(
     colnum: *const c_int,   /* I - numbers of the columns to be binned  */
     status: *mut c_int,     /* IO - error status */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let infptr = infptr.as_mut().expect(NULL_MSG);
@@ -3204,6 +3224,7 @@ pub unsafe extern "C" fn ffasfm(
     decimals: *mut c_int, /* O - number of decimal places (F, E, D format) */
     status: *mut c_int,   /* IO - error status      */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let dtcode = dtcode.as_mut();
@@ -3400,6 +3421,7 @@ pub unsafe extern "C" fn ffbnfm(
     twidth: *mut c_long,  /* O - width  of the field, in chars */
     status: *mut c_int,   /* IO - error status      */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let dtcode = dtcode.as_mut();
@@ -3648,6 +3670,7 @@ pub unsafe extern "C" fn ffbnfmll(
     twidth: *mut c_long,    /* O - width of the field, in chars */
     status: *mut c_int,     /* IO - error status      */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let dtcode = dtcode.as_mut();
@@ -3994,6 +4017,7 @@ pub unsafe extern "C" fn ffgcno(
     colnum: *mut c_int,    /* O - number of the named column; 1=first col */
     status: *mut c_int,    /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let fptr = fptr.as_mut().expect(NULL_MSG);
         let status = status.as_mut().expect(NULL_MSG);
@@ -4038,6 +4062,7 @@ pub unsafe extern "C" fn ffgcnn(
     colnum: *mut c_int,    /* O - number of the named column; 1=first col */
     status: *mut c_int,    /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -4198,6 +4223,7 @@ pub unsafe extern "C" fn ffcmps(
     matchi: *mut c_int,     /* O - do template and colname match? 1=yes     */
     exact: *mut c_int,      /* O - do strings exactly match, or wildcards   */
 ) {
+    // FFI WRAPPER
     unsafe {
         let matchi = matchi.as_mut().expect(NULL_MSG);
         let exact = exact.as_mut().expect(NULL_MSG);
@@ -4384,6 +4410,7 @@ pub unsafe extern "C" fn ffgtcl(
     width: *mut c_long,   /* O - if ASCII, width of field or unit string */
     status: *mut c_int,   /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -4455,6 +4482,7 @@ pub unsafe extern "C" fn ffgtclll(
     width: *mut LONGLONG,  /* O - if ASCII, width of field or unit string */
     status: *mut c_int,    /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -4566,6 +4594,7 @@ pub unsafe extern "C" fn ffeqty(
     width: *mut c_long,   /* O - if ASCII, width of field or unit string */
     status: *mut c_int,   /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let fptr = fptr.as_mut().expect(NULL_MSG);
         let status = status.as_mut().expect(NULL_MSG);
@@ -4647,6 +4676,7 @@ pub unsafe extern "C" fn ffeqtyll(
     width: *mut LONGLONG,  /* O - if ASCII, width of field or unit string */
     status: *mut c_int,    /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -4854,6 +4884,7 @@ pub unsafe extern "C" fn ffgncl(
     ncols: *mut c_int,   /* O - number of columns in the table          */
     status: *mut c_int,  /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -4901,6 +4932,7 @@ pub unsafe extern "C" fn ffgnrw(
     nrows: *mut c_long,  /* O - number of rows in the table             */
     status: *mut c_int,  /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -4949,6 +4981,7 @@ pub unsafe extern "C" fn ffgnrwll(
     nrows: *mut LONGLONG, /* O - number of rows in the table           */
     status: *mut c_int,   /* IO - error status                         */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -5004,6 +5037,7 @@ pub unsafe extern "C" fn ffgacl(
     tdisp: *mut c_char,  /* O - TDISPn keyword value                   */
     status: *mut c_int,  /* IO - error status                          */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let fptr = fptr.as_mut().expect(NULL_MSG);
         let status = status.as_mut().expect(NULL_MSG);
@@ -5142,6 +5176,7 @@ pub unsafe extern "C" fn ffgbcl(
     tdisp: *mut c_char,      /* O - TDISPn keyword value                   */
     status: *mut c_int,      /* IO - error status                          */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let fptr = fptr.as_mut().expect(NULL_MSG);
         let status = status.as_mut().expect(NULL_MSG);
@@ -5239,6 +5274,7 @@ pub unsafe extern "C" fn ffgbclll(
     tdisp: *mut c_char,      /* O - TDISPn keyword value                   */
     status: *mut c_int,      /* IO - error status                          */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -5400,6 +5436,7 @@ pub unsafe extern "C" fn ffghdn(
     fptr: *mut fitsfile, /* I - FITS file pointer                      */
     chdunum: *mut c_int, /* O - number of the CHDU; 1 = primary array  */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let fptr = fptr.as_mut().expect(NULL_MSG);
 
@@ -5431,6 +5468,7 @@ pub unsafe extern "C" fn ffghadll(
     dataend: *mut LONGLONG,   /* O - byte offset to beginning of next HDU  */
     status: *mut c_int,       /* IO - error status     */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -5490,6 +5528,7 @@ pub unsafe extern "C" fn ffghof(
     dataend: *mut off_t,   /* O - byte offset to beginning of next HDU  */
     status: *mut c_int,    /* IO - error status     */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let fptr = fptr.as_mut().expect(NULL_MSG);
         let status = status.as_mut().expect(NULL_MSG);
@@ -5552,6 +5591,7 @@ pub unsafe extern "C" fn ffghad(
     dataend: *mut c_long,   /* O - byte offset to beginning of next HDU  */
     status: *mut c_int,     /* IO - error status     */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let fptr = fptr.as_mut().expect(NULL_MSG);
         let status = status.as_mut().expect(NULL_MSG);
@@ -5625,6 +5665,7 @@ pub unsafe extern "C" fn ffrhdu(
     hdutype: *mut c_int, /* O - type of HDU       */
     status: *mut c_int,  /* IO - error status     */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let fptr = fptr.as_mut().expect(NULL_MSG);
         let status = status.as_mut().expect(NULL_MSG);
@@ -6577,6 +6618,7 @@ pub unsafe extern "C" fn ffgabc(
     tbcol: *mut c_long,          /* O - starting byte in row for each column     */
     status: *mut c_int,          /* IO - error status                            */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let rowlen = rowlen.as_mut().expect(NULL_MSG);
@@ -7661,6 +7703,7 @@ pub unsafe extern "C" fn fftheap(
     valid: *mut c_int,      /* O - are all the heap addresses valid?         */
     status: *mut c_int,     /* IO - error status                             */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -7833,6 +7876,7 @@ pub unsafe extern "C" fn ffcmph(
     fptr: *mut fitsfile, /* I -FITS file pointer                         */
     status: *mut c_int,  /* IO - error status                            */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let fptr = fptr.as_mut().expect(NULL_MSG);
         let status = status.as_mut().expect(NULL_MSG);
@@ -8090,6 +8134,7 @@ pub unsafe extern "C" fn ffgdes(
     heapaddr: *mut c_long, /* O - heap pointer to the data                  */
     status: *mut c_int,    /* IO - error status                             */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let fptr = fptr.as_mut().expect(NULL_MSG);
         let status = status.as_mut().expect(NULL_MSG);
@@ -8159,6 +8204,7 @@ pub unsafe extern "C" fn ffgdesll(
     heapaddr: *mut LONGLONG, /* O - heap pointer to the data                */
     status: *mut c_int,      /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -8244,6 +8290,7 @@ pub unsafe extern "C" fn ffgdess(
     heapaddr: *mut c_long, /* O - heap pointer to the data                  */
     status: *mut c_int,    /* IO - error status                             */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let fptr = fptr.as_mut().expect(NULL_MSG);
         let status = status.as_mut().expect(NULL_MSG);
@@ -8377,6 +8424,7 @@ pub unsafe extern "C" fn ffgdessll(
     heapaddr: *mut LONGLONG, /* O - heap pointer to the data              */
     status: *mut c_int,      /* IO - error status                             */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let fptr = fptr.as_mut().expect(NULL_MSG);
         let status = status.as_mut().expect(NULL_MSG);
@@ -8503,6 +8551,7 @@ pub unsafe extern "C" fn ffpdes(
     heapaddr: LONGLONG,  /* I - heap pointer to the data                  */
     status: *mut c_int,  /* IO - error status                             */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -8775,6 +8824,7 @@ pub unsafe extern "C" fn ffrdef(
     fptr: *mut fitsfile, /* I - FITS file pointer */
     status: *mut c_int,  /* IO - error status     */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -8890,6 +8940,7 @@ pub unsafe extern "C" fn ffhdef(
     morekeys: c_int,     /* I - reserve space for this many keywords */
     status: *mut c_int,  /* IO - error status                        */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -9147,6 +9198,7 @@ pub unsafe extern "C" fn ffchfl(fptr: *mut fitsfile, status: *mut c_int) -> c_in
     if fptr.is_null() || status.is_null() {
         return NULL_INPUT_PTR;
     }
+    // FFI WRAPPER
     unsafe { ffchfl_safe(&mut *fptr, &mut *status) }
 }
 
@@ -9218,6 +9270,7 @@ pub fn ffchfl_safe(fptr: &mut fitsfile, status: &mut c_int) -> c_int {
 **********************************************************************/
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffcdfl(fptr: *mut fitsfile, status: *mut c_int) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let fptr = fptr.as_mut().expect(NULL_MSG);
         let status = status.as_mut().expect(NULL_MSG);
@@ -9338,6 +9391,7 @@ pub unsafe extern "C" fn ffcrhd(
     fptr: *mut fitsfile, /* I - FITS file pointer */
     status: *mut c_int,  /* IO - error status     */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let fptr = fptr.as_mut().expect(NULL_MSG);
         let status = status.as_mut().expect(NULL_MSG);
@@ -9486,6 +9540,7 @@ pub unsafe extern "C" fn ffghdt(
     /*  for IMAGE_HDU, ASCII_TBL, or BINARY_TBL */
     status: *mut c_int, /* IO - error status                 */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -9542,6 +9597,7 @@ pub fn ffghdt_safe(
 /// environoment.
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn fits_is_reentrant() -> c_int {
+    // FFI WRAPPER
     fits_is_reentrant_safe()
 }
 
@@ -9564,6 +9620,7 @@ pub unsafe extern "C" fn fits_is_compressed_image(
     fptr: *mut fitsfile, /* I - FITS file pointer  */
     status: *mut c_int,  /* IO - error status      */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -9603,6 +9660,7 @@ pub unsafe extern "C" fn ffgipr(
     naxes: *mut c_long,    /* O - size of image dimensions              */
     status: *mut c_int,    /* IO - error status      */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let infptr = infptr.as_mut().expect(NULL_MSG);
@@ -9660,6 +9718,7 @@ pub unsafe extern "C" fn ffgiprll(
     naxes: *mut LONGLONG,  /* O - size of image dimensions              */
     status: *mut c_int,    /* IO - error status      */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let infptr = infptr.as_mut().expect(NULL_MSG);
         let status = status.as_mut().expect(NULL_MSG);
@@ -9714,6 +9773,7 @@ pub unsafe extern "C" fn ffgidt(
     imgtype: *mut c_int, /* O - image data type                         */
     status: *mut c_int,  /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -9778,6 +9838,7 @@ pub unsafe extern "C" fn ffgiet(
     imgtype: *mut c_int, /* O - image data type                         */
     status: *mut c_int,  /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -9938,6 +9999,7 @@ pub unsafe extern "C" fn ffgidm(
     naxis: *mut c_int,   /* O - image dimension (NAXIS value)           */
     status: *mut c_int,  /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -9990,6 +10052,7 @@ pub unsafe extern "C" fn ffgisz(
     naxes: *mut c_long,  /* O - size of image dimensions                */
     status: *mut c_int,  /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -10076,6 +10139,7 @@ pub unsafe extern "C" fn ffgiszll(
     naxes: *mut LONGLONG, /* O - size of image dimensions              */
     status: *mut c_int,
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -10141,6 +10205,7 @@ pub unsafe extern "C" fn ffmahd(
     exttype: *mut c_int, /* O - type of extension, 0, 1, or 2 */
     status: *mut c_int,  /* IO - error status                 */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -10242,6 +10307,7 @@ pub unsafe extern "C" fn ffmrhd(
     exttype: *mut c_int, /* O - type of extension, 0, 1, or 2        */
     status: *mut c_int,  /* IO - error status                        */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -10284,6 +10350,7 @@ pub unsafe extern "C" fn ffmnhd(
     hduver: c_int,
     status: *mut c_int,
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -10456,6 +10523,7 @@ pub unsafe extern "C" fn ffthdu(
     nhdu: *mut c_int,    /* O - number of HDUs in the file           */
     status: *mut c_int,  /* IO - error status                        */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -10748,6 +10816,7 @@ pub(crate) fn ffiblk(
 /// ```
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgkcl(tcard: *mut c_char) -> c_int {
+    // FFI WRAPPER
     unsafe {
         raw_to_slice!(tcard);
 
@@ -11295,6 +11364,7 @@ pub unsafe extern "C" fn ffdtyp(
     dtype: *mut c_char,  /* O - datatype code: C, L, F, I, or X */
     status: *mut c_int,  /* IO - error status */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let dtype = dtype.as_mut().expect(NULL_MSG);
@@ -11348,6 +11418,7 @@ pub unsafe extern "C" fn ffinttyp(
     negative: *mut c_int, /* O - is cval negative? */
     status: *mut c_int,   /* IO - error status */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let dtype = dtype.as_mut().expect(NULL_MSG);

--- a/src/getcol.rs
+++ b/src/getcol.rs
@@ -61,6 +61,7 @@ pub unsafe extern "C" fn ffgpxv(
     anynul: *mut c_int,      /* O - set to 1 if any values are null; else 0 */
     status: *mut c_int,      /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -146,6 +147,7 @@ pub unsafe extern "C" fn ffgpxvll(
     anynul: *mut c_int,        /* O - set to 1 if any values are null; else 0 */
     status: *mut c_int,        /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -783,6 +785,7 @@ pub unsafe extern "C" fn ffgpxf(
     anynul: *mut c_int,      /* O - set to 1 if any values are null; else 0 */
     status: *mut c_int,      /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -872,6 +875,7 @@ pub unsafe extern "C" fn ffgpxfll(
     anynul: *mut c_int,        /* O - set to 1 if any values are null; else 0 */
     status: *mut c_int,        /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -1192,6 +1196,7 @@ pub unsafe extern "C" fn ffgsv(
     anynul: *mut c_int,    /* O - set to 1 if any values are null; else 0 */
     status: *mut c_int,    /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -1636,6 +1641,7 @@ pub unsafe extern "C" fn ffgpv(
     anynul: *mut c_int,    /* O - set to 1 if any values are null; else 0 */
     status: *mut c_int,    /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -1988,6 +1994,7 @@ pub unsafe extern "C" fn ffgpf(
     anynul: *mut c_int,     /* O - set to 1 if any values are null; else 0 */
     status: *mut c_int,     /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -2107,6 +2114,7 @@ pub unsafe extern "C" fn ffgcv(
     anynul: *mut c_int,    /* O - set to 1 if any values are null; else 0 */
     status: *mut c_int,    /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -2871,6 +2879,7 @@ pub unsafe extern "C" fn ffgcvn(
     anynul: *mut c_int, /* O - anynul[i] set to 1 if any values in column i are null; else 0 */
     status: *mut c_int, /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -3110,6 +3119,7 @@ pub unsafe extern "C" fn ffgcf(
     anynul: *mut c_int,     /* O - set to 1 if any values are null; else 0 */
     status: *mut c_int,     /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);

--- a/src/getcolb.rs
+++ b/src/getcolb.rs
@@ -48,6 +48,7 @@ pub unsafe extern "C" fn ffgpvb(
     anynul: *mut c_int,  /* O - set to 1 if any values are null; else 0 */
     status: *mut c_int,  /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -147,6 +148,7 @@ pub unsafe extern "C" fn ffgpfb(
     anynul: *mut c_int,    /* O - set to 1 if any values are null; else 0 */
     status: *mut c_int,    /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -240,6 +242,7 @@ pub unsafe extern "C" fn ffg2db(
     anynul: *mut c_int,  /* O - set to 1 if any values are null; else 0 */
     status: *mut c_int,  /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -302,6 +305,7 @@ pub unsafe extern "C" fn ffg3db(
     anynul: *mut c_int,  /* O - set to 1 if any values are null; else 0 */
     status: *mut c_int,  /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -453,6 +457,7 @@ pub unsafe extern "C" fn ffgsvb(
     anynul: *mut c_int,   /* O - set to 1 if any values are null; else 0   */
     status: *mut c_int,   /* IO - error status                             */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -908,6 +913,7 @@ pub unsafe extern "C" fn ffgsfb(
     anynul: *mut c_int,   /* O - set to 1 if any values are null; else 0   */
     status: *mut c_int,   /* IO - error status                             */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -947,6 +953,7 @@ pub unsafe extern "C" fn ffggpb(
     array: *mut u8,      /* O - array of values that are returned   */
     status: *mut c_int,  /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -1011,6 +1018,7 @@ pub unsafe extern "C" fn ffgcvb(
     anynul: *mut c_int,  /* O - set to 1 if any values are null; else 0 */
     status: *mut c_int,  /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -1087,6 +1095,7 @@ pub unsafe extern "C" fn ffgcfb(
     anynul: *mut c_int,    /* O - set to 1 if any values are null; else 0 */
     status: *mut c_int,    /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -1681,6 +1690,7 @@ pub unsafe extern "C" fn ffgextn(
     buffer: *mut c_void, /* I - stream of bytes to read                  */
     status: *mut c_int,  /* IO - error status                            */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);

--- a/src/getcold.rs
+++ b/src/getcold.rs
@@ -46,6 +46,7 @@ pub unsafe extern "C" fn ffgpvd(
     anynul: *mut c_int,  /* O - set to 1 if any values are null; else 0 */
     status: *mut c_int,  /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -145,6 +146,7 @@ pub unsafe extern "C" fn ffgpfd(
     anynul: *mut c_int,    /* O - set to 1 if any values are null; else 0 */
     status: *mut c_int,    /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -238,6 +240,7 @@ pub unsafe extern "C" fn ffg2dd(
     anynul: *mut c_int,  /* O - set to 1 if any values are null; else 0 */
     status: *mut c_int,  /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -301,6 +304,7 @@ pub unsafe extern "C" fn ffg3dd(
     anynul: *mut c_int,  /* O - set to 1 if any values are null; else 0 */
     status: *mut c_int,  /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -453,6 +457,7 @@ pub unsafe extern "C" fn ffgsvd(
     anynul: *mut c_int,   /* O - set to 1 if any values are null; else 0   */
     status: *mut c_int,   /* IO - error status                             */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -709,6 +714,7 @@ pub unsafe extern "C" fn ffgsfd(
     anynul: *mut c_int,   /* O - set to 1 if any values are null; else 0   */
     status: *mut c_int,   /* IO - error status                             */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -951,6 +957,7 @@ pub unsafe extern "C" fn ffggpd(
     array: *mut f64,     /* O - array of values that are returned   */
     status: *mut c_int,  /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -1018,6 +1025,7 @@ pub unsafe extern "C" fn ffgcvd(
     anynul: *mut c_int,  /* O - set to 1 if any values are null; else 0 */
     status: *mut c_int,  /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -1097,6 +1105,7 @@ pub unsafe extern "C" fn ffgcvm(
     anynul: *mut c_int,  /* O - set to 1 if any values are null; else 0 */
     status: *mut c_int,  /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -1179,6 +1188,7 @@ pub unsafe extern "C" fn ffgcfd(
     anynul: *mut c_int,    /* O - set to 1 if any values are null; else 0 */
     status: *mut c_int,    /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -1251,6 +1261,7 @@ pub unsafe extern "C" fn ffgcfm(
     anynul: *mut c_int,    /* O - set to 1 if any values are null; else 0 */
     status: *mut c_int,    /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);

--- a/src/getcole.rs
+++ b/src/getcole.rs
@@ -46,6 +46,7 @@ pub unsafe extern "C" fn ffgpve(
     anynul: *mut c_int,  /* O - set to 1 if any values are null; else 0 */
     status: *mut c_int,  /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -145,6 +146,7 @@ pub unsafe extern "C" fn ffgpfe(
     anynul: *mut c_int,    /* O - set to 1 if any values are null; else 0 */
     status: *mut c_int,    /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -238,6 +240,7 @@ pub unsafe extern "C" fn ffg2de(
     anynul: *mut c_int,  /* O - set to 1 if any values are null; else 0 */
     status: *mut c_int,  /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -301,6 +304,7 @@ pub unsafe extern "C" fn ffg3de(
     anynul: *mut c_int,  /* O - set to 1 if any values are null; else 0 */
     status: *mut c_int,  /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -453,6 +457,7 @@ pub unsafe extern "C" fn ffgsve(
     anynul: *mut c_int,   /* O - set to 1 if any values are null; else 0   */
     status: *mut c_int,   /* IO - error status                             */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -711,6 +716,7 @@ pub unsafe extern "C" fn ffgsfe(
     anynul: *mut c_int,   /* O - set to 1 if any values are null; else 0   */
     status: *mut c_int,   /* IO - error status                             */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -952,6 +958,7 @@ pub unsafe extern "C" fn ffggpe(
     array: *mut f32,     /* O - array of values that are returned   */
     status: *mut c_int,  /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -1019,6 +1026,7 @@ pub unsafe extern "C" fn ffgcve(
     anynul: *mut c_int,  /* O - set to 1 if any values are null; else 0 */
     status: *mut c_int,  /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -1091,6 +1099,7 @@ pub unsafe extern "C" fn ffgcvc(
     anynul: *mut c_int,  /* O - set to 1 if any values are null; else 0 */
     status: *mut c_int,  /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -1173,6 +1182,7 @@ pub unsafe extern "C" fn ffgcfe(
     anynul: *mut c_int,    /* O - set to 1 if any values are null; else 0 */
     status: *mut c_int,    /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -1245,6 +1255,7 @@ pub unsafe extern "C" fn ffgcfc(
     anynul: *mut c_int,    /* O - set to 1 if any values are null; else 0 */
     status: *mut c_int,    /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);

--- a/src/getcoli.rs
+++ b/src/getcoli.rs
@@ -46,6 +46,7 @@ pub unsafe extern "C" fn ffgpvi(
     anynul: *mut c_int,  /* O - set to 1 if any values are null; else 0 */
     status: *mut c_int,  /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -144,6 +145,7 @@ pub unsafe extern "C" fn ffgpfi(
     anynul: *mut c_int,    /* O - set to 1 if any values are null; else 0 */
     status: *mut c_int,    /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -237,6 +239,7 @@ pub unsafe extern "C" fn ffg2di(
     anynul: *mut c_int,  /* O - set to 1 if any values are null; else 0 */
     status: *mut c_int,  /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -300,6 +303,7 @@ pub unsafe extern "C" fn ffg3di(
     anynul: *mut c_int,  /* O - set to 1 if any values are null; else 0 */
     status: *mut c_int,  /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -451,6 +455,7 @@ pub unsafe extern "C" fn ffgsvi(
     anynul: *mut c_int,   /* O - set to 1 if any values are null; else 0   */
     status: *mut c_int,   /* IO - error status                             */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -708,6 +713,7 @@ pub unsafe extern "C" fn ffgsfi(
     anynul: *mut c_int,   /* O - set to 1 if any values are null; else 0   */
     status: *mut c_int,   /* IO - error status                             */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -946,6 +952,7 @@ pub unsafe extern "C" fn ffggpi(
     array: *mut c_short, /* O - array of values that are returned   */
     status: *mut c_int,  /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -1013,6 +1020,7 @@ pub unsafe extern "C" fn ffgcvi(
     anynul: *mut c_int,  /* O - set to 1 if any values are null; else 0 */
     status: *mut c_int,  /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -1082,6 +1090,7 @@ pub unsafe extern "C" fn ffgcfi(
     anynul: *mut c_int,    /* O - set to 1 if any values are null; else 0 */
     status: *mut c_int,    /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);

--- a/src/getcolj.rs
+++ b/src/getcolj.rs
@@ -46,6 +46,7 @@ pub unsafe extern "C" fn ffgpvj(
     anynul: *mut c_int,  /* O - set to 1 if any values are null; else 0 */
     status: *mut c_int,  /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -147,6 +148,7 @@ pub unsafe extern "C" fn ffgpfj(
     anynul: *mut c_int,    /* O - set to 1 if any values are null; else 0 */
     status: *mut c_int,    /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -242,6 +244,7 @@ pub unsafe extern "C" fn ffg2dj(
     anynul: *mut c_int,  /* O - set to 1 if any values are null; else 0 */
     status: *mut c_int,  /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         /* call the 3D reading routine, with the 3rd dimension = 1 */
 
@@ -307,6 +310,7 @@ pub unsafe extern "C" fn ffg3dj(
     anynul: *mut c_int,  /* O - set to 1 if any values are null; else 0 */
     status: *mut c_int,  /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -461,6 +465,7 @@ pub unsafe extern "C" fn ffgsvj(
     anynul: *mut c_int,   /* O - set to 1 if any values are null; else 0   */
     status: *mut c_int,   /* IO - error status                             */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -714,6 +719,7 @@ pub unsafe extern "C" fn ffgsfj(
     anynul: *mut c_int,   /* O - set to 1 if any values are null; else 0   */
     status: *mut c_int,   /* IO - error status                             */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -949,6 +955,7 @@ pub unsafe extern "C" fn ffggpj(
     array: *mut c_long,  /* O - array of values that are returned       */
     status: *mut c_int,  /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -1016,6 +1023,7 @@ pub unsafe extern "C" fn ffgcvj(
     anynul: *mut c_int,  /* O - set to 1 if any values are null; else 0 */
     status: *mut c_int,  /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -1085,6 +1093,7 @@ pub unsafe extern "C" fn ffgcfj(
     anynul: *mut c_int,    /* O - set to 1 if any values are null; else 0 */
     status: *mut c_int,    /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -2581,6 +2590,7 @@ pub unsafe extern "C" fn ffgpvjj(
     anynul: *mut c_int,   /* O - set to 1 if any values are null; else 0 */
     status: *mut c_int,   /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -2682,6 +2692,7 @@ pub unsafe extern "C" fn ffgpfjj(
     anynul: *mut c_int,    /* O - set to 1 if any values are null; else 0 */
     status: *mut c_int,    /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -2778,6 +2789,7 @@ pub unsafe extern "C" fn ffg2djj(
     anynul: *mut c_int,   /* O - set to 1 if any values are null; else 0 */
     status: *mut c_int,   /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -2841,6 +2853,7 @@ pub unsafe extern "C" fn ffg3djj(
     anynul: *mut c_int,   /* O - set to 1 if any values are null; else 0 */
     status: *mut c_int,   /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -2995,6 +3008,7 @@ pub unsafe extern "C" fn ffgsvjj(
     anynul: *mut c_int,   /* O - set to 1 if any values are null; else 0   */
     status: *mut c_int,   /* IO - error status                             */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -3252,6 +3266,7 @@ pub unsafe extern "C" fn ffgsfjj(
     anynul: *mut c_int,   /* O - set to 1 if any values are null; else 0   */
     status: *mut c_int,   /* IO - error status                             */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -3491,6 +3506,7 @@ pub unsafe extern "C" fn ffggpjj(
     array: *mut LONGLONG, /* O - array of values that are returned       */
     status: *mut c_int,   /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -3559,6 +3575,7 @@ pub unsafe extern "C" fn ffgcvjj(
     anynul: *mut c_int,   /* O - set to 1 if any values are null; else 0 */
     status: *mut c_int,   /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -3636,6 +3653,7 @@ pub unsafe extern "C" fn ffgcfjj(
     anynul: *mut c_int,    /* O - set to 1 if any values are null; else 0 */
     status: *mut c_int,    /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);

--- a/src/getcolk.rs
+++ b/src/getcolk.rs
@@ -50,6 +50,7 @@ pub unsafe extern "C" fn ffgpvk(
     anynul: *mut c_int,  /* O - set to 1 if any values are null; else 0 */
     status: *mut c_int,  /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -150,6 +151,7 @@ pub unsafe extern "C" fn ffgpfk(
     anynul: *mut c_int,    /* O - set to 1 if any values are null; else 0 */
     status: *mut c_int,    /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -243,6 +245,7 @@ pub unsafe extern "C" fn ffg2dk(
     anynul: *mut c_int,  /* O - set to 1 if any values are null; else 0 */
     status: *mut c_int,  /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -306,6 +309,7 @@ pub unsafe extern "C" fn ffg3dk(
     anynul: *mut c_int,  /* O - set to 1 if any values are null; else 0 */
     status: *mut c_int,  /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -457,6 +461,7 @@ pub unsafe extern "C" fn ffgsvk(
     anynul: *mut c_int,   /* O - set to 1 if any values are null; else 0   */
     status: *mut c_int,   /* IO - error status                             */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -713,6 +718,7 @@ pub unsafe extern "C" fn ffgsfk(
     anynul: *mut c_int,   /* O - set to 1 if any values are null; else 0   */
     status: *mut c_int,   /* IO - error status                             */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -954,6 +960,7 @@ pub unsafe extern "C" fn ffggpk(
     array: *mut c_int,   /* O - array of values that are returned   */
     status: *mut c_int,  /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -1021,6 +1028,7 @@ pub unsafe extern "C" fn ffgcvk(
     anynul: *mut c_int,  /* O - set to 1 if any values are null; else 0 */
     status: *mut c_int,  /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -1091,6 +1099,7 @@ pub unsafe extern "C" fn ffgcfk(
     anynul: *mut c_int,    /* O - set to 1 if any values are null; else 0 */
     status: *mut c_int,    /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);

--- a/src/getcoll.rs
+++ b/src/getcoll.rs
@@ -37,6 +37,7 @@ pub unsafe extern "C" fn ffgcvl(
     anynul: *mut c_int,  /* O - set to 1 if any values are null; else 0 */
     status: *mut c_int,  /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -110,6 +111,7 @@ pub unsafe extern "C" fn ffgcl(
     array: *mut c_char,  /* O - array of values                         */
     status: *mut c_int,  /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -175,6 +177,7 @@ pub unsafe extern "C" fn ffgcfl(
     anynul: *mut c_int,    /* O - set to 1 if any values are null; else 0 */
     status: *mut c_int,    /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -415,6 +418,7 @@ pub unsafe extern "C" fn ffgcx(
     larray: *mut c_char, /* O - array of logicals corresponding to bits */
     status: *mut c_int,  /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -597,6 +601,7 @@ pub unsafe extern "C" fn ffgcxui(
     array: *mut c_ushort,    /* O - array of integer values            */
     status: *mut c_int,      /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -794,6 +799,7 @@ pub unsafe extern "C" fn ffgcxuk(
     array: *mut c_uint,      /* O - array of integer values            */
     status: *mut c_int,      /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);

--- a/src/getcols.rs
+++ b/src/getcols.rs
@@ -48,6 +48,7 @@ pub unsafe extern "C" fn ffgcvs(
     anynul: *mut c_int,      /* O - set to 1 if any values are null; else 0 */
     status: *mut c_int,      /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -132,6 +133,7 @@ pub unsafe extern "C" fn ffgcfs(
     anynul: *mut c_int,      /* O - set to 1 if any values are null; else 0 */
     status: *mut c_int,      /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -794,6 +796,7 @@ pub unsafe extern "C" fn ffgcdw(
     width: *mut c_int,   /* O - display width                       */
     status: *mut c_int,  /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);

--- a/src/getcolsb.rs
+++ b/src/getcolsb.rs
@@ -48,6 +48,7 @@ pub unsafe extern "C" fn ffgpvsb(
     anynul: *mut c_int,  /* O - set to 1 if any values are null; else 0 */
     status: *mut c_int,  /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -146,6 +147,7 @@ pub unsafe extern "C" fn ffgpfsb(
     anynul: *mut c_int,    /* O - set to 1 if any values are null; else 0 */
     status: *mut c_int,    /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -239,6 +241,7 @@ pub unsafe extern "C" fn ffg2dsb(
     anynul: *mut c_int,  /* O - set to 1 if any values are null; else 0 */
     status: *mut c_int,  /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -302,6 +305,7 @@ pub unsafe extern "C" fn ffg3dsb(
     anynul: *mut c_int,  /* O - set to 1 if any values are null; else 0 */
     status: *mut c_int,  /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -453,6 +457,7 @@ pub unsafe extern "C" fn ffgsvsb(
     anynul: *mut c_int,   /* O - set to 1 if any values are null; else 0   */
     status: *mut c_int,   /* IO - error status                             */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -709,6 +714,7 @@ pub unsafe extern "C" fn ffgsfsb(
     anynul: *mut c_int,   /* O - set to 1 if any values are null; else 0   */
     status: *mut c_int,   /* IO - error status                             */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -949,6 +955,7 @@ pub unsafe extern "C" fn ffggpsb(
     array: *mut i8,      /* O - array of values that are returned   */
     status: *mut c_int,  /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -1016,6 +1023,7 @@ pub unsafe extern "C" fn ffgcvsb(
     anynul: *mut c_int,  /* O - set to 1 if any values are null; else 0 */
     status: *mut c_int,  /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -1085,6 +1093,7 @@ pub unsafe extern "C" fn ffgcfsb(
     anynul: *mut c_int,    /* O - set to 1 if any values are null; else 0 */
     status: *mut c_int,    /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);

--- a/src/getcolui.rs
+++ b/src/getcolui.rs
@@ -46,6 +46,7 @@ pub unsafe extern "C" fn ffgpvui(
     anynul: *mut c_int,   /* O - set to 1 if any values are null; else 0 */
     status: *mut c_int,   /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -144,6 +145,7 @@ pub unsafe extern "C" fn ffgpfui(
     anynul: *mut c_int,    /* O - set to 1 if any values are null; else 0 */
     status: *mut c_int,    /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -237,6 +239,7 @@ pub unsafe extern "C" fn ffg2dui(
     anynul: *mut c_int,   /* O - set to 1 if any values are null; else 0 */
     status: *mut c_int,   /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -300,6 +303,7 @@ pub unsafe extern "C" fn ffg3dui(
     anynul: *mut c_int,   /* O - set to 1 if any values are null; else 0 */
     status: *mut c_int,   /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -451,6 +455,7 @@ pub unsafe extern "C" fn ffgsvui(
     anynul: *mut c_int,   /* O - set to 1 if any values are null; else 0   */
     status: *mut c_int,   /* IO - error status                             */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -692,6 +697,7 @@ pub unsafe extern "C" fn ffgsfui(
     anynul: *mut c_int,   /* O - set to 1 if any values are null; else 0   */
     status: *mut c_int,   /* IO - error status                             */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -933,6 +939,7 @@ pub unsafe extern "C" fn ffggpui(
     array: *mut c_ushort, /* O - array of values that are returned   */
     status: *mut c_int,   /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -1000,6 +1007,7 @@ pub unsafe extern "C" fn ffgcvui(
     anynul: *mut c_int,   /* O - set to 1 if any values are null; else 0 */
     status: *mut c_int,   /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -1078,6 +1086,7 @@ pub unsafe extern "C" fn ffgcfui(
     anynul: *mut c_int,    /* O - set to 1 if any values are null; else 0 */
     status: *mut c_int,    /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);

--- a/src/getcoluj.rs
+++ b/src/getcoluj.rs
@@ -46,6 +46,7 @@ pub unsafe extern "C" fn ffgpvuj(
     anynul: *mut c_int,  /* O - set to 1 if any values are null; else 0 */
     status: *mut c_int,  /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -147,6 +148,7 @@ pub unsafe extern "C" fn ffgpfuj(
     anynul: *mut c_int,    /* O - set to 1 if any values are null; else 0 */
     status: *mut c_int,    /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -242,6 +244,7 @@ pub unsafe extern "C" fn ffg2duj(
     anynul: *mut c_int,  /* O - set to 1 if any values are null; else 0 */
     status: *mut c_int,  /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         /* call the 3D reading routine, with the 3rd dimension = 1 */
 
@@ -307,6 +310,7 @@ pub unsafe extern "C" fn ffg3duj(
     anynul: *mut c_int,  /* O - set to 1 if any values are null; else 0 */
     status: *mut c_int,  /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -459,6 +463,7 @@ pub unsafe extern "C" fn ffgsvuj(
     anynul: *mut c_int,   /* O - set to 1 if any values are null; else 0   */
     status: *mut c_int,   /* IO - error status                             */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -695,6 +700,7 @@ pub unsafe extern "C" fn ffgsfuj(
     anynul: *mut c_int,   /* O - set to 1 if any values are null; else 0   */
     status: *mut c_int,   /* IO - error status                             */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -933,6 +939,7 @@ pub unsafe extern "C" fn ffggpuj(
     array: *mut c_ulong, /* O - array of values that are returned       */
     status: *mut c_int,  /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -1001,6 +1008,7 @@ pub unsafe extern "C" fn ffgcvuj(
     anynul: *mut c_int,  /* O - set to 1 if any values are null; else 0 */
     status: *mut c_int,  /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -1069,6 +1077,7 @@ pub unsafe extern "C" fn ffgcfuj(
     anynul: *mut c_int,    /* O - set to 1 if any values are null; else 0 */
     status: *mut c_int,    /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -2564,6 +2573,7 @@ pub unsafe extern "C" fn ffgpvujj(
     anynul: *mut c_int,    /* O - set to 1 if any values are null; else 0 */
     status: *mut c_int,    /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -2665,6 +2675,7 @@ pub unsafe extern "C" fn ffgpfujj(
     anynul: *mut c_int,    /* O - set to 1 if any values are null; else 0 */
     status: *mut c_int,    /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -2761,6 +2772,7 @@ pub unsafe extern "C" fn ffg2dujj(
     anynul: *mut c_int,    /* O - set to 1 if any values are null; else 0 */
     status: *mut c_int,    /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -2824,6 +2836,7 @@ pub unsafe extern "C" fn ffg3dujj(
     anynul: *mut c_int,    /* O - set to 1 if any values are null; else 0 */
     status: *mut c_int,    /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -2978,6 +2991,7 @@ pub unsafe extern "C" fn ffgsvujj(
     anynul: *mut c_int,    /* O - set to 1 if any values are null; else 0   */
     status: *mut c_int,    /* IO - error status                             */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -3235,6 +3249,7 @@ pub unsafe extern "C" fn ffgsfujj(
     anynul: *mut c_int,    /* O - set to 1 if any values are null; else 0   */
     status: *mut c_int,    /* IO - error status                             */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -3476,6 +3491,7 @@ pub unsafe extern "C" fn ffggpujj(
     array: *mut ULONGLONG, /* O - array of values that are returned       */
     status: *mut c_int,    /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -3545,6 +3561,7 @@ pub unsafe extern "C" fn ffgcvujj(
     anynul: *mut c_int,    /* O - set to 1 if any values are null; else 0 */
     status: *mut c_int,    /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -3622,6 +3639,7 @@ pub unsafe extern "C" fn ffgcfujj(
     anynul: *mut c_int,    /* O - set to 1 if any values are null; else 0 */
     status: *mut c_int,    /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);

--- a/src/getcoluk.rs
+++ b/src/getcoluk.rs
@@ -48,6 +48,7 @@ pub unsafe extern "C" fn ffgpvuk(
     anynul: *mut c_int,  /* O - set to 1 if any values are null; else 0 */
     status: *mut c_int,  /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -146,6 +147,7 @@ pub unsafe extern "C" fn ffgpfuk(
     anynul: *mut c_int,    /* O - set to 1 if any values are null; else 0 */
     status: *mut c_int,    /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -239,6 +241,7 @@ pub unsafe extern "C" fn ffg2duk(
     anynul: *mut c_int,  /* O - set to 1 if any values are null; else 0 */
     status: *mut c_int,  /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -302,6 +305,7 @@ pub unsafe extern "C" fn ffg3duk(
     anynul: *mut c_int,  /* O - set to 1 if any values are null; else 0 */
     status: *mut c_int,  /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -453,6 +457,7 @@ pub unsafe extern "C" fn ffgsvuk(
     anynul: *mut c_int,   /* O - set to 1 if any values are null; else 0   */
     status: *mut c_int,   /* IO - error status                             */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -696,6 +701,7 @@ pub unsafe extern "C" fn ffgsfuk(
     anynul: *mut c_int,   /* O - set to 1 if any values are null; else 0   */
     status: *mut c_int,   /* IO - error status                             */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -937,6 +943,7 @@ pub unsafe extern "C" fn ffggpuk(
     array: *mut c_uint,  /* O - array of values that are returned   */
     status: *mut c_int,  /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -1004,6 +1011,7 @@ pub unsafe extern "C" fn ffgcvuk(
     anynul: *mut c_int,  /* O - set to 1 if any values are null; else 0 */
     status: *mut c_int,  /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -1073,6 +1081,7 @@ pub unsafe extern "C" fn ffgcfuk(
     anynul: *mut c_int,    /* O - set to 1 if any values are null; else 0 */
     status: *mut c_int,    /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);

--- a/src/getkey.rs
+++ b/src/getkey.rs
@@ -40,6 +40,7 @@ pub unsafe extern "C" fn ffghsp(
     nmore: *mut c_int,   /* O - how many more keywords will fit       */
     status: *mut c_int,  /* IO - error status                         */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -99,6 +100,7 @@ pub unsafe extern "C" fn ffghps(
     position: *mut c_int, /* O - position of next keyword to be read   */
     status: *mut c_int,   /* IO - error status                         */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -149,6 +151,7 @@ pub unsafe extern "C" fn ffnchk(
     fptr: *mut fitsfile, /* I - FITS file pointer                     */
     status: *mut c_int,  /* IO - error status                         */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -218,6 +221,7 @@ pub unsafe extern "C" fn ffmaky(
     nrec: c_int,         /* I - one-based keyword number to move to  */
     status: *mut c_int,  /* IO - error status                        */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -252,6 +256,7 @@ pub unsafe extern "C" fn ffmrky(
     nmove: c_int,        /* I - relative number of keywords to move */
     status: *mut c_int,  /* IO - error status                       */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -355,6 +360,7 @@ pub unsafe extern "C" fn ffgnxk(
     card: *mut c_char,             /* O - first matching keyword         */
     status: *mut c_int,            /* IO - error status                  */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -452,6 +458,7 @@ pub unsafe extern "C" fn ffgky(
     comm: *mut c_char,      /* O - keyword comment          */
     status: *mut c_int,     /* IO - error status            */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let fptr = fptr.as_mut().expect(NULL_MSG);
         let status = status.as_mut().expect(NULL_MSG);
@@ -615,6 +622,7 @@ pub unsafe extern "C" fn ffgkey(
     comm: *mut c_char,      /* O - keyword comment          */
     status: *mut c_int,     /* IO - error status            */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -687,6 +695,7 @@ pub unsafe extern "C" fn ffgrec(
     card: *mut c_char,   /* O - keyword card               */
     status: *mut c_int,  /* IO - error status              */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -751,6 +760,7 @@ pub unsafe extern "C" fn ffgcrd(
     card: *mut c_char,   /* O - keyword card             */
     status: *mut c_int,  /* IO - error status            */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let fptr = fptr.as_mut().expect(NULL_MSG);
         let status = status.as_mut().expect(NULL_MSG);
@@ -964,6 +974,7 @@ pub unsafe extern "C" fn ffgstr(
     card: *mut c_char,     /* O - keyword card             */
     status: *mut c_int,    /* IO - error status            */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -1029,6 +1040,7 @@ pub unsafe extern "C" fn ffgknm(
     length: *mut c_int,  /* O - length of the keyword name     */
     status: *mut c_int,  /* IO - error status                  */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let length = length.as_mut().expect(NULL_MSG);
@@ -1123,6 +1135,7 @@ pub unsafe extern "C" fn ffgunt(
     unit: *mut c_char,      /* O - keyword units             */
     status: *mut c_int,     /* IO - error status             */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -1180,6 +1193,7 @@ pub unsafe extern "C" fn ffgkys(
     comm: *mut c_char,      /* O - keyword comment           */
     status: *mut c_int,     /* IO - error status             */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -1239,6 +1253,7 @@ pub unsafe extern "C" fn ffgksl(
     length: *mut c_int,     /* O - length of the string value    */
     status: *mut c_int,     /* IO - error status                 */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -1284,6 +1299,7 @@ pub unsafe extern "C" fn ffgkcsl(
     comlength: *mut c_int,  /* O - length of comment string      */
     status: *mut c_int,     /* IO - error status                 */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let fptr = fptr.as_mut().expect(NULL_MSG);
         let status = status.as_mut().expect(NULL_MSG);
@@ -1348,6 +1364,7 @@ pub unsafe extern "C" fn ffgkls(
     comm: *mut c_char,       /* O - keyword comment (may be NULL) */
     status: *mut c_int,      /* IO - error status             */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -1528,6 +1545,7 @@ pub unsafe extern "C" fn ffgsky(
     comm: *mut c_char,  /* O - keyword comment (may be NULL) */
     status: *mut c_int, /* IO - error status                 */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -1722,6 +1740,7 @@ pub unsafe extern "C" fn ffgskyc(
     comlen: *mut c_int, /* O - total length of the comment string */
     status: *mut c_int, /* IO - error status                 */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -1948,6 +1967,7 @@ pub unsafe extern "C" fn fffree(
     value: *mut c_void, /* I - pointer to keyword value  */
     status: *mut c_int, /* IO - error status             */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         fffree_safe(value, status)
@@ -2048,6 +2068,7 @@ pub unsafe extern "C" fn ffgkyl(
     comm: *mut c_char,      /* O - keyword comment           */
     status: *mut c_int,     /* IO - error status             */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let value = value.as_mut().expect(NULL_MSG);
@@ -2106,6 +2127,7 @@ pub unsafe extern "C" fn ffgkyj(
     comm: *mut c_char,      /* O - keyword comment           */
     status: *mut c_int,     /* IO - error status             */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let value = value.as_mut().expect(NULL_MSG);
@@ -2165,6 +2187,7 @@ pub unsafe extern "C" fn ffgkyjj(
     comm: *mut c_char,      /* O - keyword comment           */
     status: *mut c_int,     /* IO - error status             */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let value = value.as_mut().expect(NULL_MSG);
@@ -2224,6 +2247,7 @@ pub unsafe extern "C" fn ffgkyujj(
     comm: *mut c_char,
     status: *mut c_int,
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let value = value.as_mut().expect(NULL_MSG);
@@ -2282,6 +2306,7 @@ pub unsafe extern "C" fn ffgkye(
     comm: *mut c_char,      /* O - keyword comment           */
     status: *mut c_int,     /* IO - error status             */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let value = value.as_mut().expect(NULL_MSG);
@@ -2339,6 +2364,7 @@ pub unsafe extern "C" fn ffgkyd(
     comm: *mut c_char,      /* O - keyword comment           */
     status: *mut c_int,     /* IO - error status             */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let value = value.as_mut().expect(NULL_MSG);
@@ -2396,6 +2422,7 @@ pub unsafe extern "C" fn ffgkyc(
     comm: *mut c_char,      /* O - keyword comment           */
     status: *mut c_int,     /* IO - error status             */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let value = value.as_mut().expect(NULL_MSG);
@@ -2478,6 +2505,7 @@ pub unsafe extern "C" fn ffgkym(
     comm: *mut c_char,      /* O - keyword comment           */
     status: *mut c_int,     /* IO - error status             */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let value = value.as_mut().expect(NULL_MSG);
@@ -2565,6 +2593,7 @@ pub unsafe extern "C" fn ffgkyt(
     comm: *mut c_char,      /* O - keyword comment           */
     status: *mut c_int,     /* IO - error status             */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -2644,6 +2673,7 @@ pub unsafe extern "C" fn ffgkyn(
     comm: *mut c_char,    /* O - keyword comment               */
     status: *mut c_int,   /* IO - error status                 */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -2743,6 +2773,7 @@ pub unsafe extern "C" fn ffgkns(
     nfound: *mut c_int,      /* O - number of values that were returned  */
     status: *mut c_int,      /* IO - error status                        */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -2876,6 +2907,7 @@ pub unsafe extern "C" fn ffgknl(
     nfound: *mut c_int,     /* O - number of values that were returned  */
     status: *mut c_int,     /* IO - error status                        */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -3003,6 +3035,7 @@ pub unsafe extern "C" fn ffgknj(
     nfound: *mut c_int,     /* O - number of values that were returned  */
     status: *mut c_int,     /* IO - error status                        */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -3131,6 +3164,7 @@ pub unsafe extern "C" fn ffgknjj(
     nfound: *mut c_int,     /* O - number of values that were returned  */
     status: *mut c_int,     /* IO - error status                        */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -3258,6 +3292,7 @@ pub unsafe extern "C" fn ffgkne(
     nfound: *mut c_int,     /* O - number of values that were returned  */
     status: *mut c_int,     /* IO - error status                        */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -3383,6 +3418,7 @@ pub unsafe extern "C" fn ffgknd(
     nfound: *mut c_int,     /* O - number of values that were returned  */
     status: *mut c_int,     /* IO - error status                        */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -3508,6 +3544,7 @@ pub unsafe extern "C" fn ffgtdm(
     naxes: *mut c_long,  /* O - length of each data axis                 */
     status: *mut c_int,  /* IO - error status                            */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -3557,6 +3594,7 @@ pub unsafe extern "C" fn ffgtdmll(
     naxes: *mut LONGLONG, /* O - length of each data axis                 */
     status: *mut c_int,   /* IO - error status                            */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -3609,6 +3647,7 @@ pub unsafe extern "C" fn ffdtdm(
     naxes: *mut c_long,     /* O - length of each data axis                 */
     status: *mut c_int,     /* IO - error status                            */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -3763,6 +3802,7 @@ pub unsafe extern "C" fn ffdtdmll(
     naxes: *mut LONGLONG,   /* O - length of each data axis                 */
     status: *mut c_int,     /* IO - error status                            */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -3910,6 +3950,7 @@ pub unsafe extern "C" fn ffghpr(
     extend: *mut c_int,  /* O - may FITS file haave extensions?          */
     status: *mut c_int,  /* IO - error status                            */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -4005,6 +4046,7 @@ pub unsafe extern "C" fn ffghprll(
     extend: *mut c_int,   /* O - may FITS file haave extensions?          */
     status: *mut c_int,   /* IO - error status                            */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -4131,6 +4173,7 @@ pub unsafe extern "C" fn ffghtb(
     extnm: *mut c_char,      /* O - value of EXTNAME keyword, if any         */
     status: *mut c_int,      /* IO - error status                            */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -4389,6 +4432,7 @@ pub unsafe extern "C" fn ffghtbll(
     extnm: *mut c_char,      /* O - value of EXTNAME keyword, if any         */
     status: *mut c_int,      /* IO - error status                            */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -4646,6 +4690,7 @@ pub unsafe extern "C" fn ffghbn(
     pcount: *mut c_long,     /* O - value of PCOUNT keyword                  */
     status: *mut c_int,      /* IO - error status                            */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -4874,6 +4919,7 @@ pub unsafe extern "C" fn ffghbnll(
     pcount: *mut LONGLONG,   /* O - value of PCOUNT keyword                  */
     status: *mut c_int,      /* IO - error status                            */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -5945,6 +5991,7 @@ pub unsafe extern "C" fn ffhdr2str(
     nkeys: *mut c_int,             /* O - returned number of 80-char keywords  */
     status: *mut c_int,            /* IO - error status                        */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -6099,6 +6146,7 @@ pub unsafe extern "C" fn ffcnvthdr2str(
     nkeys: *mut c_int,             /* O - returned number of 80-char keywords  */
     status: *mut c_int,            /* IO - error status                        */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);

--- a/src/group.rs
+++ b/src/group.rs
@@ -85,6 +85,7 @@ pub unsafe extern "C" fn ffgtcr(
     grouptype: c_int,       /* code specifying the type of  */
     status: *mut c_int,     /* return status code                        */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -166,6 +167,7 @@ pub unsafe extern "C" fn ffgtis(
     grouptype: c_int,       /* code specifying the type of  */
     status: *mut c_int,     /* return status code                        */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -395,6 +397,7 @@ pub unsafe extern "C" fn ffgtch(
     grouptype: c_int,     /* code specifying the type of  */
     status: *mut c_int,   /* return status code                        */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let gfptr = gfptr.as_mut().expect(NULL_MSG);
@@ -766,6 +769,7 @@ pub unsafe extern "C" fn ffgtrm(
                           and their members (if groups)                */
     status: *mut c_int, /* return status code                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let gfptr = gfptr.as_mut().expect(NULL_MSG);
@@ -890,6 +894,7 @@ pub unsafe extern "C" fn ffgtcp(
                             and their members (if  groups)                  */
     status: *mut c_int, /* return status code                          */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let infptr = infptr.as_mut().expect(NULL_MSG);
@@ -975,6 +980,7 @@ pub unsafe extern "C" fn ffgtmg(
                             OPT_MRG_MOV  (1) ==> move members to target group, source group is deleted after merge    */
     status: *mut c_int, /* return status code                         */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let infptr = infptr.as_mut().expect(NULL_MSG);
@@ -1066,6 +1072,7 @@ pub unsafe extern "C" fn ffgtcm(
                           OPT_CMT_MBR_DEL (11) ==> (1) + delete all compacted groups    */
     status: *mut c_int, /* return status code                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let gfptr = gfptr.as_mut().expect(NULL_MSG);
@@ -1206,6 +1213,7 @@ pub unsafe extern "C" fn ffgtvf(
     firstfailed: *mut c_long, /* Member ID (if positive) of first failed member HDU verify check or GRPID index (if negitive) of first failed group link verify check.                     */
     status: *mut c_int,       /* return status code                     */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let gfptr = gfptr.as_mut().expect(NULL_MSG);
@@ -1338,6 +1346,7 @@ pub unsafe extern "C" fn ffgtop(
     gfptr: *mut *mut fitsfile, /* FITS file pointer to grouping table HDU      */
     status: *mut c_int,        /* return status code                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let mfptr = mfptr.as_mut().expect(NULL_MSG);
@@ -1736,6 +1745,7 @@ pub unsafe extern "C" fn ffgtam(
     hdupos: c_int, /* member HDU position IF in the same file as the grouping table AND mfptr == NULL        */
     status: *mut c_int, /* return status code                          */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let gfptr = gfptr.as_mut().expect(NULL_MSG);
@@ -2627,6 +2637,7 @@ pub unsafe extern "C" fn ffgtnm(
     nmembers: *mut c_long, /* member count of the grouping table         */
     status: *mut c_int,    /* return status code                         */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let gfptr = gfptr.as_mut().expect(NULL_MSG);
@@ -2691,6 +2702,7 @@ pub unsafe extern "C" fn ffgmng(
     ngroups: *mut c_long, /* total number of groups linked to HDU       */
     status: *mut c_int,   /* return status code                         */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let mfptr = mfptr.as_mut().expect(NULL_MSG);
@@ -2856,6 +2868,7 @@ pub unsafe extern "C" fn ffgmop(
     mfptr: *mut *mut fitsfile, /* FITS file pointer to member HDU              */
     status: *mut c_int,        /* return status code                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let gfptr = gfptr.as_mut().expect(NULL_MSG);
@@ -3546,6 +3559,7 @@ pub unsafe extern "C" fn ffgmcp(
                                               entry with member copy  */
     status: *mut c_int, /* return status code                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let mfptr = mfptr.as_mut().expect(NULL_MSG);
@@ -3825,6 +3839,7 @@ pub unsafe extern "C" fn ffgmtf(
                             OPT_MCP_MOV (3) ==> move member to dest.   */
     status: *mut c_int, /* return status code                         */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let infptr = infptr.as_mut().expect(NULL_MSG);
@@ -3906,6 +3921,7 @@ pub unsafe extern "C" fn ffgmrm(
                           OPT_RM_MBR   ==> delete entry and member HDU */
     status: *mut c_int, /* return status code                          */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let gfptr = gfptr.as_mut().expect(NULL_MSG);

--- a/src/grparser.rs
+++ b/src/grparser.rs
@@ -1946,6 +1946,7 @@ pub unsafe extern "C" fn fits_execute_template(
     ngp_template: *const c_char, /* I - template string */
     status: *mut c_int,          /* IO - error status */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let mut r: c_int = 0;
         let mut exit_flg: c_int = 0;

--- a/src/histo.rs
+++ b/src/histo.rs
@@ -648,6 +648,7 @@ pub unsafe extern "C" fn ffbins(
     recip: *mut c_int,                       /* the reciprocal of the weight? */
     status: *mut c_int,
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         raw_to_slice!(binspec);
 
@@ -983,6 +984,7 @@ pub unsafe extern "C" fn ffbinr(
     binname: *mut c_char,
     status: *mut c_int,
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let minin = minin.as_mut().expect(NULL_MSG);
         let maxin = maxin.as_mut().expect(NULL_MSG);
@@ -1352,6 +1354,7 @@ pub unsafe extern "C" fn ffhist2(
     /* is equal to NULL.                           */
     status: *mut c_int,
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let fptr = (fptr).as_mut().expect(NULL_MSG);
         raw_to_slice!(outfile);
@@ -1442,6 +1445,7 @@ pub unsafe extern "C" fn ffhist3(
     /* is equal to NULL.                           */
     status: *mut c_int,
 ) -> *mut fitsfile {
+    // FFI WRAPPER
     unsafe {
         let fptr = &mut ((*fptr).as_mut()).expect(NULL_MSG);
         raw_to_slice!(outfile);
@@ -1694,6 +1698,7 @@ pub unsafe extern "C" fn ffhist(
     /* is equal to NULL.                           */
     status: *mut c_int,
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let fptr = (fptr).as_mut().expect(NULL_MSG);
         raw_to_slice!(outfile);
@@ -2747,6 +2752,7 @@ pub unsafe extern "C" fn fits_calc_binning(
     binsize: *mut f32,  /* O - width of histogram bins/pixels on each axis */
     status: *mut c_int,
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let fptr = fptr.as_mut().expect(NULL_MSG);
         let colname = colname.as_mut().expect(NULL_MSG);
@@ -3437,6 +3443,7 @@ pub unsafe extern "C" fn fits_calc_binningd(
     binsize: *mut f64,  /* O - width of histogram bins/pixels on each axis */
     status: *mut c_int,
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let fptr = fptr.as_mut().expect(NULL_MSG);
         let colname = colname
@@ -3624,6 +3631,7 @@ pub unsafe extern "C" fn fits_write_keys_histo(
     colnum: *const c_int,   /* I - column numbers (array length = naxis)      */
     status: *mut c_int,
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let fptr = fptr.as_mut().expect(NULL_MSG);
         let histptr = histptr.as_mut().expect(NULL_MSG);
@@ -3655,6 +3663,7 @@ pub unsafe extern "C" fn fits_rebin_wcs(
     binsize: *mut f32,   /* I - binning factor for each axis            */
     status: *mut c_int,
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let fptr = fptr.as_mut().expect(NULL_MSG);
         let amin = slice::from_raw_parts_mut(amin, naxis as usize);
@@ -3701,6 +3710,7 @@ pub unsafe extern "C" fn fits_rebin_wcsd(
     binsize: *mut f64,   /* I - binning factor for each axis            */
     status: *mut c_int,
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let fptr = fptr.as_mut().expect(NULL_MSG);
         let amin = slice::from_raw_parts_mut(amin, naxis as usize);
@@ -3867,6 +3877,7 @@ pub unsafe extern "C" fn fits_make_hist(
     /* is equal to NULL.                           */
     status: *mut c_int,
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let fptr = fptr.as_mut().expect(NULL_MSG);
         let histptr = histptr.as_mut().expect(NULL_MSG);
@@ -4047,9 +4058,8 @@ pub(crate) fn fits_make_histde(
     'cleanup: loop {
         /* Now make iterator columns for input, as well as any calculated values */
         numAllocCols = 5;
-        iterCols = unsafe {
-            fits_recalloc::<iteratorCol>(ptr::null_mut(), 0, numAllocCols as usize)
-        };
+        iterCols =
+            unsafe { fits_recalloc::<iteratorCol>(ptr::null_mut(), 0, numAllocCols as usize) };
         if iterCols.is_null() {
             ffpmsg_str("memory allocation failure (fits_make_histde)");
             *status = MEMORY_ALLOCATION;
@@ -4422,6 +4432,7 @@ pub unsafe extern "C" fn fits_make_histd(
     /* is equal to NULL.                           */
     status: *mut c_int,
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let fptr = fptr.as_mut().expect(NULL_MSG);
         let histptr = histptr.as_mut().expect(NULL_MSG);

--- a/src/imcompress.rs
+++ b/src/imcompress.rs
@@ -183,6 +183,7 @@ pub(crate) fn fits_init_randoms() -> c_int {
 /*--------------------------------------------------------------------------*/
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub extern "C" fn bz_internal_error(_errcode: c_int) {
+    // FFI WRAPPER
     /* external function declared by the bzip2 code in bzlib_private.h */
     ffpmsg_str("bzip2 returned an internal error");
     ffpmsg_str("This should never happen");
@@ -201,6 +202,7 @@ pub unsafe extern "C" fn fits_set_compression_type(
     /*  HCOMPRESS_1, BZIP2_1, and NOCOMPRESS               */
     status: *mut c_int, /* IO - error status                                   */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -252,6 +254,7 @@ pub unsafe extern "C" fn fits_set_tile_dim(
     /* default tile size = (NAXIS1, 1, 1, ...)            */
     status: *mut c_int, /* IO - error status                        */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let fptr = fptr.as_mut().expect(NULL_MSG);
         let status = status.as_mut().expect(NULL_MSG);
@@ -302,6 +305,7 @@ pub unsafe extern "C" fn fits_set_quantize_level(
     qlevel: f32,         /* floating point quantization level      */
     status: *mut c_int,  /* IO - error status                */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -343,6 +347,7 @@ pub unsafe extern "C" fn fits_set_quantize_method(
     method: c_int,       /* quantization method       */
     status: *mut c_int,  /* IO - error status                */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let fptr = fptr.as_mut().expect(NULL_MSG);
         let status = status.as_mut().expect(NULL_MSG);
@@ -387,6 +392,7 @@ pub unsafe extern "C" fn fits_set_quantize_dither(
     dither: c_int,       /* dither type      */
     status: *mut c_int,  /* IO - error status                */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let fptr = fptr.as_mut().expect(NULL_MSG);
         let status = status.as_mut().expect(NULL_MSG);
@@ -423,6 +429,7 @@ pub unsafe extern "C" fn fits_set_dither_seed(
     seed: c_int,         /* random dithering seed value (1 to 10000) */
     status: *mut c_int,  /* IO - error status                */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let fptr = fptr.as_mut().expect(NULL_MSG);
         let status = status.as_mut().expect(NULL_MSG);
@@ -467,6 +474,7 @@ pub unsafe extern "C" fn fits_set_dither_offset(
     offset: c_int,       /* random dithering offset value (1 to 10000) */
     status: *mut c_int,  /* IO - error status                */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let fptr = fptr.as_mut().expect(NULL_MSG);
         let status = status.as_mut().expect(NULL_MSG);
@@ -510,6 +518,7 @@ pub unsafe extern "C" fn fits_set_noise_bits(
     /* (default = 4)                    */
     status: *mut c_int, /* IO - error status                */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let fptr = fptr.as_mut().expect(NULL_MSG);
         let status = status.as_mut().expect(NULL_MSG);
@@ -560,6 +569,7 @@ pub unsafe extern "C" fn fits_set_hcomp_scale(
     /* (default = 0.0)                    */
     status: *mut c_int, /* IO - error status                */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -592,6 +602,7 @@ pub unsafe extern "C" fn fits_set_hcomp_smooth(
     /* by the lossy compression    */
     status: *mut c_int, /* IO - error status                */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let fptr = fptr.as_mut().expect(NULL_MSG);
         let status = status.as_mut().expect(NULL_MSG);
@@ -622,6 +633,7 @@ pub unsafe extern "C" fn fits_set_lossy_int(
     lossy_int: c_int,    /* I - True (!= 0) or False (0) */
     status: *mut c_int,  /* IO - error status                */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let fptr = fptr.as_mut().expect(NULL_MSG);
         let status = status.as_mut().expect(NULL_MSG);
@@ -655,6 +667,7 @@ pub unsafe extern "C" fn fits_set_huge_hdu(
     huge: c_int,         /* I - True (!= 0) or False (0) */
     status: *mut c_int,  /* IO - error status                */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let fptr = fptr.as_mut().expect(NULL_MSG);
         let status = status.as_mut().expect(NULL_MSG);
@@ -690,6 +703,7 @@ pub unsafe extern "C" fn fits_get_compression_type(
     /* RICE_1, GZIP_1, GZIP_2, PLIO_1, HCOMPRESS_1, BZIP2_1 */
     status: *mut c_int, /* IO - error status                                   */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let fptr = fptr.as_mut().expect(NULL_MSG);
         let status = status.as_mut().expect(NULL_MSG);
@@ -742,6 +756,7 @@ pub unsafe extern "C" fn fits_get_tile_dim(
     /* default tile size = (NAXIS1, 1, 1, ...)           */
     status: *mut c_int, /* IO - error status                        */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let fptr = fptr.as_mut().expect(NULL_MSG);
         let status = status.as_mut().expect(NULL_MSG);
@@ -787,6 +802,7 @@ pub unsafe extern "C" fn fits_unset_compression_param(
     fptr: *mut fitsfile,
     status: *mut c_int,
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let fptr = fptr.as_mut().expect(NULL_MSG);
         let status = status.as_mut().expect(NULL_MSG);
@@ -816,6 +832,7 @@ pub unsafe extern "C" fn fits_unset_compression_request(
     fptr: *mut fitsfile,
     status: *mut c_int,
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let fptr = fptr.as_mut().expect(NULL_MSG);
         let status = status.as_mut().expect(NULL_MSG);
@@ -852,6 +869,7 @@ pub unsafe extern "C" fn fits_set_compression_pref(
     outfptr: *mut fitsfile,
     status: *mut c_int,
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let infptr = infptr.as_mut().expect(NULL_MSG);
         let outfptr = outfptr.as_mut().expect(NULL_MSG);
@@ -1063,6 +1081,7 @@ pub unsafe extern "C" fn fits_get_noise_bits(
     /* (default = 4)                    */
     status: *mut c_int, /* IO - error status                */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let fptr = fptr.as_mut().expect(NULL_MSG);
         let status = status.as_mut().expect(NULL_MSG);
@@ -1100,6 +1119,7 @@ pub unsafe extern "C" fn fits_get_quantize_level(
     qlevel: *mut f32,    /* quantize level parameter value       */
     status: *mut c_int,  /* IO - error status                */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let fptr = fptr.as_mut().expect(NULL_MSG);
         let status = status.as_mut().expect(NULL_MSG);
@@ -1139,6 +1159,7 @@ pub unsafe extern "C" fn fits_get_dither_seed(
     offset: *mut c_int,  /* dithering offset parameter value       */
     status: *mut c_int,  /* IO - error status                */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let fptr = fptr.as_mut().expect(NULL_MSG);
         let status = status.as_mut().expect(NULL_MSG);
@@ -1173,6 +1194,7 @@ pub unsafe extern "C" fn fits_get_hcomp_scale(
     scale: *mut f32,     /* Hcompress scale parameter value       */
     status: *mut c_int,  /* IO - error status                */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let fptr = fptr.as_mut().expect(NULL_MSG);
         let status = status.as_mut().expect(NULL_MSG);
@@ -1200,6 +1222,7 @@ pub unsafe extern "C" fn fits_get_hcomp_smooth(
     smooth: *mut c_int,  /* Hcompress smooth parameter value       */
     status: *mut c_int,  /* IO - error status                */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let fptr = fptr.as_mut().expect(NULL_MSG);
         let status = status.as_mut().expect(NULL_MSG);
@@ -1236,6 +1259,7 @@ pub unsafe extern "C" fn fits_img_compress(
                             FITS compression utilities.
                             */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let infptr = infptr.as_mut().expect(NULL_MSG);
         let outfptr = outfptr.as_mut().expect(NULL_MSG);
@@ -5443,6 +5467,7 @@ pub unsafe extern "C" fn fits_img_decompress(
     outfptr: *mut fitsfile, /* empty HDU for output uncompressed image */
     status: *mut c_int,     /* IO - error status               */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let infptr = infptr.as_mut().expect(NULL_MSG);
         let outfptr = outfptr.as_mut().expect(NULL_MSG);
@@ -5543,6 +5568,7 @@ pub unsafe extern "C" fn fits_decompress_img(
     outfptr: *mut fitsfile, /* empty HDU for output uncompressed image */
     status: *mut c_int,     /* IO - error status               */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let infptr = infptr.as_mut().expect(NULL_MSG);
         let outfptr = outfptr.as_mut().expect(NULL_MSG);
@@ -5711,6 +5737,7 @@ pub unsafe extern "C" fn fits_img_decompress_header(
     outfptr: *mut fitsfile, /* empty HDU for output uncompressed image */
     status: *mut c_int,     /* IO - error status               */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let infptr = infptr.as_mut().expect(NULL_MSG);
         let outfptr = outfptr.as_mut().expect(NULL_MSG);
@@ -10823,6 +10850,7 @@ pub unsafe extern "C" fn fits_compress_table(
     outfptr: *mut fitsfile,
     status: *mut c_int,
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let infptr = infptr.as_mut().expect(NULL_MSG);
         let outfptr = outfptr.as_mut().expect(NULL_MSG);
@@ -11868,6 +11896,7 @@ pub unsafe extern "C" fn fits_uncompress_table(
     outfptr: *mut fitsfile,
     status: *mut c_int,
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let infptr = infptr.as_mut().expect(NULL_MSG);
         let outfptr = outfptr.as_mut().expect(NULL_MSG);

--- a/src/iraffits.rs
+++ b/src/iraffits.rs
@@ -142,6 +142,7 @@ pub unsafe extern "C" fn fits_delete_iraf_file(
     filename: *const c_char, /* name of input file      */
     status: *mut c_int,      /* IO - error status       */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         raw_to_slice!(filename);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -428,22 +428,48 @@ impl NullValue {
         }
 
         /* `value` is a caller-supplied void*, as in the C, and carries no
-           alignment guarantee for the target type -- it commonly points into
-           a byte buffer. Read unaligned rather than dereferencing. */
+        alignment guarantee for the target type -- it commonly points into
+        a byte buffer. Read unaligned rather than dereferencing. */
         match datatype {
-            TFLOAT => Some(NullValue::Float(unsafe { value.cast::<f32>().read_unaligned() })),
-            TDOUBLE => Some(NullValue::Double(unsafe { value.cast::<f64>().read_unaligned() })),
-            TLONG => Some(NullValue::Long(unsafe { value.cast::<c_long>().read_unaligned() })),
-            TULONG => Some(NullValue::ULong(unsafe { value.cast::<c_ulong>().read_unaligned() })),
-            TLONGLONG => Some(NullValue::LONGLONG(unsafe { value.cast::<LONGLONG>().read_unaligned() })),
-            TULONGLONG => Some(NullValue::ULONGLONG(unsafe { value.cast::<ULONGLONG>().read_unaligned() })),
-            TINT => Some(NullValue::Int(unsafe { value.cast::<c_int>().read_unaligned() })),
-            TUINT => Some(NullValue::UInt(unsafe { value.cast::<c_uint>().read_unaligned() })),
-            TSHORT => Some(NullValue::Short(unsafe { value.cast::<c_short>().read_unaligned() })),
-            TUSHORT => Some(NullValue::UShort(unsafe { value.cast::<c_ushort>().read_unaligned() })),
-            TBYTE => Some(NullValue::UByte(unsafe { value.cast::<c_uchar>().read_unaligned() })),
-            TSBYTE => Some(NullValue::Byte(unsafe { value.cast::<i8>().read_unaligned() })),
-            TLOGICAL => Some(NullValue::Logical(unsafe { value.cast::<c_char>().read_unaligned() })),
+            TFLOAT => Some(NullValue::Float(unsafe {
+                value.cast::<f32>().read_unaligned()
+            })),
+            TDOUBLE => Some(NullValue::Double(unsafe {
+                value.cast::<f64>().read_unaligned()
+            })),
+            TLONG => Some(NullValue::Long(unsafe {
+                value.cast::<c_long>().read_unaligned()
+            })),
+            TULONG => Some(NullValue::ULong(unsafe {
+                value.cast::<c_ulong>().read_unaligned()
+            })),
+            TLONGLONG => Some(NullValue::LONGLONG(unsafe {
+                value.cast::<LONGLONG>().read_unaligned()
+            })),
+            TULONGLONG => Some(NullValue::ULONGLONG(unsafe {
+                value.cast::<ULONGLONG>().read_unaligned()
+            })),
+            TINT => Some(NullValue::Int(unsafe {
+                value.cast::<c_int>().read_unaligned()
+            })),
+            TUINT => Some(NullValue::UInt(unsafe {
+                value.cast::<c_uint>().read_unaligned()
+            })),
+            TSHORT => Some(NullValue::Short(unsafe {
+                value.cast::<c_short>().read_unaligned()
+            })),
+            TUSHORT => Some(NullValue::UShort(unsafe {
+                value.cast::<c_ushort>().read_unaligned()
+            })),
+            TBYTE => Some(NullValue::UByte(unsafe {
+                value.cast::<c_uchar>().read_unaligned()
+            })),
+            TSBYTE => Some(NullValue::Byte(unsafe {
+                value.cast::<i8>().read_unaligned()
+            })),
+            TLOGICAL => Some(NullValue::Logical(unsafe {
+                value.cast::<c_char>().read_unaligned()
+            })),
             TSTRING => {
                 let cstr = unsafe { CStr::from_ptr(value.cast::<c_char>()) };
                 Some(NullValue::String(cstr.to_owned()))

--- a/src/modkey.rs
+++ b/src/modkey.rs
@@ -42,6 +42,7 @@ pub unsafe extern "C" fn ffuky(
     comm: *const c_char,    /* I - keyword comment          */
     status: *mut c_int,     /* IO - error status            */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let fptr = fptr.as_mut().expect(NULL_MSG);
         let status = status.as_mut().expect(NULL_MSG);
@@ -136,6 +137,7 @@ pub unsafe extern "C" fn ffukyu(
     comm: *const c_char,    /* I - keyword comment    */
     status: *mut c_int,     /* IO - error status      */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -177,6 +179,7 @@ pub unsafe extern "C" fn ffukys(
     comm: *const c_char,    /* I - keyword comment    */
     status: *mut c_int,     /* IO - error status      */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -224,6 +227,7 @@ pub unsafe extern "C" fn ffukls(
     comm: *const c_char,    /* I - keyword comment    */
     status: *mut c_int,     /* IO - error status      */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -274,6 +278,7 @@ pub unsafe extern "C" fn ffukyl(
     comm: *const c_char,    /* I - keyword comment    */
     status: *mut c_int,     /* IO - error status      */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -316,6 +321,7 @@ pub unsafe extern "C" fn ffukyj(
     comm: *const c_char,    /* I - keyword comment    */
     status: *mut c_int,     /* IO - error status      */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -358,6 +364,7 @@ pub unsafe extern "C" fn ffukyuj(
     comm: *const c_char,    /* I - keyword comment    */
     status: *mut c_int,     /* IO - error status      */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -401,6 +408,7 @@ pub unsafe extern "C" fn ffukyf(
     comm: *const c_char,    /* I - keyword comment    */
     status: *mut c_int,     /* IO - error status      */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -445,6 +453,7 @@ pub unsafe extern "C" fn ffukye(
     comm: *const c_char,    /* I - keyword comment    */
     status: *mut c_int,     /* IO - error status      */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -489,6 +498,7 @@ pub unsafe extern "C" fn ffukyg(
     comm: *const c_char,    /* I - keyword comment    */
     status: *mut c_int,     /* IO - error status      */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -533,6 +543,7 @@ pub unsafe extern "C" fn ffukyd(
     comm: *const c_char,    /* I - keyword comment    */
     status: *mut c_int,     /* IO - error status      */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -577,6 +588,7 @@ pub unsafe extern "C" fn ffukfc(
     comm: *const c_char,    /* I - keyword comment    */
     status: *mut c_int,     /* IO - error status      */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -621,6 +633,7 @@ pub unsafe extern "C" fn ffukyc(
     comm: *const c_char,    /* I - keyword comment    */
     status: *mut c_int,     /* IO - error status      */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -666,6 +679,7 @@ pub unsafe extern "C" fn ffukfm(
     comm: *const c_char,    /* I - keyword comment    */
     status: *mut c_int,     /* IO - error status      */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -711,6 +725,7 @@ pub unsafe extern "C" fn ffukym(
     comm: *const c_char,    /* I - keyword comment    */
     status: *mut c_int,     /* IO - error status      */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -754,6 +769,7 @@ pub unsafe extern "C" fn ffucrd(
     card: *const c_char,    /* I - card string value  */
     status: *mut c_int,     /* IO - error status      */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let fptr = fptr.as_mut().expect(NULL_MSG);
         let status = status.as_mut().expect(NULL_MSG);
@@ -795,6 +811,7 @@ pub unsafe extern "C" fn ffmrec(
     card: *const c_char, /* I - card string value               */
     status: *mut c_int,  /* IO - error status                   */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -830,6 +847,7 @@ pub unsafe extern "C" fn ffmcrd(
     card: *const c_char,    /* I - card string value  */
     status: *mut c_int,     /* IO - error status      */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -910,6 +928,7 @@ pub unsafe extern "C" fn ffmnam(
     newname: *const c_char, /* I - new name for keyword  */
     status: *mut c_int,     /* IO - error status         */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -955,6 +974,7 @@ pub unsafe extern "C" fn ffmcom(
     comm: *const c_char,    /* I - keyword comment    */
     status: *mut c_int,     /* IO - error status      */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -1006,6 +1026,7 @@ pub unsafe extern "C" fn ffpunt(
     unit: *const c_char,    /* I - keyword unit string */
     status: *mut c_int,     /* IO - error status       */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -1091,6 +1112,7 @@ pub unsafe extern "C" fn ffmkyu(
     comm: *const c_char,    /* I - keyword comment    */
     status: *mut c_int,     /* IO - error status      */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -1151,6 +1173,7 @@ pub unsafe extern "C" fn ffmkys(
     comm: *const c_char,    /* I - keyword comment    */
     status: *mut c_int,     /* IO - error status      */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -1266,6 +1289,7 @@ pub unsafe extern "C" fn ffmkls(
     incomm: *const c_char,  /* I - keyword comment          */
     status: *mut c_int,     /* IO - error status            */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let fptr = fptr.as_mut().expect(NULL_MSG);
         let status = status.as_mut().expect(NULL_MSG);
@@ -1376,6 +1400,7 @@ pub unsafe extern "C" fn ffmkyl(
     comm: *const c_char,    /* I - keyword comment    */
     status: *mut c_int,     /* IO - error status      */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -1437,6 +1462,7 @@ pub unsafe extern "C" fn ffmkyj(
     comm: *const c_char,    /* I - keyword comment    */
     status: *mut c_int,     /* IO - error status      */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -1494,6 +1520,7 @@ pub unsafe extern "C" fn ffmkyuj(
     comm: *const c_char,    /* I - keyword comment    */
     status: *mut c_int,     /* IO - error status      */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -1554,6 +1581,7 @@ pub unsafe extern "C" fn ffmkyf(
     comm: *const c_char,    /* I - keyword comment    */
     status: *mut c_int,     /* IO - error status      */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -1617,6 +1645,7 @@ pub unsafe extern "C" fn ffmkye(
     comm: *const c_char,    /* I - keyword comment    */
     status: *mut c_int,     /* IO - error status      */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -1680,6 +1709,7 @@ pub unsafe extern "C" fn ffmkyg(
     comm: *const c_char,    /* I - keyword comment    */
     status: *mut c_int,     /* IO - error status      */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -1743,6 +1773,7 @@ pub unsafe extern "C" fn ffmkyd(
     comm: *const c_char,    /* I - keyword comment    */
     status: *mut c_int,     /* IO - error status      */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -1806,6 +1837,7 @@ pub unsafe extern "C" fn ffmkfc(
     comm: *const c_char,    /* I - keyword comment    */
     status: *mut c_int,     /* IO - error status      */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let fptr = fptr.as_mut().expect(NULL_MSG);
         let status = status.as_mut().expect(NULL_MSG);
@@ -1881,6 +1913,7 @@ pub unsafe extern "C" fn ffmkyc(
     comm: *const c_char,    /* I - keyword comment    */
     status: *mut c_int,     /* IO - error status      */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let fptr = fptr.as_mut().expect(NULL_MSG);
         let status = status.as_mut().expect(NULL_MSG);
@@ -1956,6 +1989,7 @@ pub unsafe extern "C" fn ffmkfm(
     comm: *const c_char,    /* I - keyword comment    */
     status: *mut c_int,     /* IO - error status      */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let fptr = fptr.as_mut().expect(NULL_MSG);
         let status = status.as_mut().expect(NULL_MSG);
@@ -2031,6 +2065,7 @@ pub unsafe extern "C" fn ffmkym(
     comm: *const c_char,    /* I - keyword comment    */
     status: *mut c_int,     /* IO - error status      */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let fptr = fptr.as_mut().expect(NULL_MSG);
         let status = status.as_mut().expect(NULL_MSG);
@@ -2105,6 +2140,7 @@ pub unsafe extern "C" fn ffikyu(
     comm: *const c_char,    /* I - keyword comment    */
     status: *mut c_int,     /* IO - error status      */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let fptr = fptr.as_mut().expect(NULL_MSG);
         let status = status.as_mut().expect(NULL_MSG);
@@ -2148,6 +2184,7 @@ pub unsafe extern "C" fn ffikys(
     comm: *const c_char,    /* I - keyword comment    */
     status: *mut c_int,     /* IO - error status      */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let fptr = fptr.as_mut().expect(NULL_MSG);
         let status = status.as_mut().expect(NULL_MSG);
@@ -2200,6 +2237,7 @@ pub unsafe extern "C" fn ffikls(
     comm: *const c_char,    /* I - keyword comment          */
     status: *mut c_int,     /* IO - error status            */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -2332,6 +2370,7 @@ pub unsafe extern "C" fn ffikyl(
     comm: *const c_char,    /* I - keyword comment    */
     status: *mut c_int,     /* IO - error status      */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let fptr = fptr.as_mut().expect(NULL_MSG);
         let status = status.as_mut().expect(NULL_MSG);
@@ -2376,6 +2415,7 @@ pub unsafe extern "C" fn ffikyj(
     comm: *const c_char,    /* I - keyword comment    */
     status: *mut c_int,     /* IO - error status      */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -2444,6 +2484,7 @@ pub unsafe extern "C" fn ffikyf(
     comm: *const c_char,    /* I - keyword comment    */
     status: *mut c_int,     /* IO - error status      */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -2465,6 +2506,7 @@ pub unsafe extern "C" fn ffikye(
     comm: *const c_char,    /* I - keyword comment    */
     status: *mut c_int,     /* IO - error status      */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let fptr = fptr.as_mut().expect(NULL_MSG);
         let status = status.as_mut().expect(NULL_MSG);
@@ -2511,6 +2553,7 @@ pub unsafe extern "C" fn ffikyg(
     comm: *const c_char,    /* I - keyword comment    */
     status: *mut c_int,     /* IO - error status      */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let fptr = fptr.as_mut().expect(NULL_MSG);
         let status = status.as_mut().expect(NULL_MSG);
@@ -2557,6 +2600,7 @@ pub unsafe extern "C" fn ffikyd(
     comm: *const c_char,    /* I - keyword comment    */
     status: *mut c_int,     /* IO - error status      */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let fptr = fptr.as_mut().expect(NULL_MSG);
         let status = status.as_mut().expect(NULL_MSG);
@@ -2603,6 +2647,7 @@ pub unsafe extern "C" fn ffikfc(
     comm: *const c_char,    /* I - keyword comment    */
     status: *mut c_int,     /* IO - error status      */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let fptr = fptr.cast_mut().as_mut().expect(NULL_MSG);
         let status = status.as_mut().expect(NULL_MSG);
@@ -2668,6 +2713,7 @@ pub unsafe extern "C" fn ffikyc(
     comm: *const c_char,    /* I - keyword comment    */
     status: *mut c_int,     /* IO - error status      */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let fptr = fptr.cast_mut().as_mut().expect(NULL_MSG);
         let status = status.as_mut().expect(NULL_MSG);
@@ -2733,6 +2779,7 @@ pub unsafe extern "C" fn ffikfm(
     comm: *const c_char,    /* I - keyword comment    */
     status: *mut c_int,     /* IO - error status      */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let fptr = fptr.cast_mut().as_mut().expect(NULL_MSG);
         let status = status.as_mut().expect(NULL_MSG);
@@ -2798,6 +2845,7 @@ pub unsafe extern "C" fn ffikym(
     comm: *const c_char,    /* I - keyword comment    */
     status: *mut c_int,     /* IO - error status      */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let fptr = fptr.as_mut().expect(NULL_MSG);
         let status = status.as_mut().expect(NULL_MSG);
@@ -2861,6 +2909,7 @@ pub unsafe extern "C" fn ffirec(
     card: *const c_char, /* I - card string value              */
     status: *mut c_int,  /* IO - error status                  */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -2897,6 +2946,7 @@ pub unsafe extern "C" fn ffikey(
     card: *const c_char, /* I - card string value  */
     status: *mut c_int,  /* IO - error status      */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -3017,6 +3067,7 @@ pub unsafe extern "C" fn ffdkey(
     keyname: *const c_char, /* I - keyword name       */
     status: *mut c_int,     /* IO - error status      */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -3105,6 +3156,7 @@ pub unsafe extern "C" fn ffdstr(
     string: *const c_char, /* I - keyword name       */
     status: *mut c_int,    /* IO - error status      */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -3198,6 +3250,7 @@ pub unsafe extern "C" fn ffdrec(
     keypos: c_int,       /* I - position in header of keyword to delete */
     status: *mut c_int,  /* IO - error status      */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);

--- a/src/putcol.rs
+++ b/src/putcol.rs
@@ -76,6 +76,7 @@ pub unsafe extern "C" fn ffppx(
     array: *const c_void,    /* I - array of values that are written        */
     status: *mut c_int,      /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let fptr = fptr.as_mut().expect(NULL_MSG);
         let status = status.as_mut().expect(NULL_MSG);
@@ -197,6 +198,7 @@ pub unsafe extern "C" fn ffppxll(
     array: *const c_void,      /* I - array of values that are written        */
     status: *mut c_int,        /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let fptr = fptr.as_mut().expect(NULL_MSG);
         let status = status.as_mut().expect(NULL_MSG);
@@ -318,6 +320,7 @@ pub unsafe extern "C" fn ffppxn(
     nulval: *const c_void, /* I - pointer to the null value               */
     status: *mut c_int,    /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -548,6 +551,7 @@ pub unsafe extern "C" fn ffppxnll(
     nulval: *const c_void,     /* I - pointer to the null value               */
     status: *mut c_int,        /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -775,6 +779,7 @@ pub unsafe extern "C" fn ffppr(
     array: *const c_void, /* I - array of values that are written        */
     status: *mut c_int,   /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let fptr = fptr.as_mut().expect(NULL_MSG);
         let status = status.as_mut().expect(NULL_MSG);
@@ -870,6 +875,7 @@ pub unsafe extern "C" fn ffppn(
     nulval: *const c_void, /* I - pointer to the null value               */
     status: *mut c_int,    /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let fptr = fptr.as_mut().expect(NULL_MSG);
         let status = status.as_mut().expect(NULL_MSG);
@@ -1125,6 +1131,7 @@ pub unsafe extern "C" fn ffpss(
     array: *const c_void, /* I - array of values that are written        */
     status: *mut c_int,   /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -1242,6 +1249,7 @@ pub unsafe extern "C" fn ffpcl(
     array: *const c_void, /* I - array of values that are written        */
     status: *mut c_int,   /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -1531,6 +1539,7 @@ pub unsafe extern "C" fn ffpcn(
     nulval: *const c_void, /* I - pointer to the null value               */
     status: *mut c_int,    /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let fptr = fptr.as_mut().expect(NULL_MSG);
         let status = status.as_mut().expect(NULL_MSG);
@@ -1890,6 +1899,7 @@ pub unsafe extern "C" fn ffpcln(
     nulval: *const *const c_void, /* I - array of pointers to values for undefined pixels */
     status: *mut c_int,           /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -2084,6 +2094,7 @@ pub unsafe extern "C" fn fits_iter_set_by_name(
     datatype: c_int,        /* I - column datatype                        */
     iotype: c_int,          /* I - InputCol, InputOutputCol, or OutputCol */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let col = col.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -2123,6 +2134,7 @@ pub unsafe extern "C" fn fits_iter_set_by_num(
     datatype: c_int,       /* I - column datatype                        */
     iotype: c_int,         /* I - InputCol, InputOutputCol, or OutputCol */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let col = col.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -2155,6 +2167,7 @@ pub unsafe extern "C" fn fits_iter_set_file(
     col: *mut iteratorCol, /* I - iterator column structure   */
     fptr: *mut fitsfile,   /* I - FITS file pointer                      */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let col = col.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -2180,6 +2193,7 @@ pub unsafe extern "C" fn fits_iter_set_colname(
     col: *mut iteratorCol,  /* I - iterator col structure  */
     colname: *const c_char, /* I - column name                            */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let col = col.as_mut().expect(NULL_MSG);
         raw_to_slice!(colname);
@@ -2206,6 +2220,7 @@ pub unsafe extern "C" fn fits_iter_set_colnum(
     col: *mut iteratorCol, /* I - iterator column structure */
     colnum: c_int,         /* I - column number                          */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let col = col.as_mut().expect(NULL_MSG);
         fits_iter_set_colnum_safe(col, colnum)
@@ -2229,6 +2244,7 @@ pub unsafe extern "C" fn fits_iter_set_datatype(
     col: *mut iteratorCol, /* I - iterator col structure */
     datatype: c_int,       /* I - column datatype                        */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let col = col.as_mut().expect(NULL_MSG);
         fits_iter_set_datatype_safe(col, datatype)
@@ -2252,6 +2268,7 @@ pub unsafe extern "C" fn fits_iter_set_iotype(
     col: *mut iteratorCol, /* I - iterator column structure */
     iotype: c_int,         /* I - InputCol, InputOutputCol, or OutputCol */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let col = col.as_mut().expect(NULL_MSG);
         fits_iter_set_iotype_safe(col, iotype)
@@ -2274,6 +2291,7 @@ pub fn fits_iter_set_iotype_safe(
 pub unsafe extern "C" fn fits_iter_get_file(
     col: *mut iteratorCol, /* I -iterator col structure */
 ) -> *mut fitsfile {
+    // FFI WRAPPER
     unsafe {
         let col = col.as_mut().expect(NULL_MSG);
         fits_iter_get_file_safe(col)
@@ -2294,6 +2312,7 @@ pub fn fits_iter_get_file_safe(
 pub unsafe extern "C" fn fits_iter_get_colname(
     col: *mut iteratorCol, /* I -iterator col structure */
 ) -> *const c_char {
+    // FFI WRAPPER
     unsafe {
         let col = col.as_mut().expect(NULL_MSG);
         fits_iter_get_colname_safe(col).as_ptr()
@@ -2314,6 +2333,7 @@ pub fn fits_iter_get_colname_safe(
 pub unsafe extern "C" fn fits_iter_get_colnum(
     col: *mut iteratorCol, /* I - iterator column structure */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let col = col.as_mut().expect(NULL_MSG);
         fits_iter_get_colnum_safe(col)
@@ -2334,6 +2354,7 @@ pub fn fits_iter_get_colnum_safe(
 pub unsafe extern "C" fn fits_iter_get_datatype(
     col: *mut iteratorCol, /* I - iterator col structure */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let col = col.as_mut().expect(NULL_MSG);
         fits_iter_get_datatype_safe(col)
@@ -2354,6 +2375,7 @@ pub fn fits_iter_get_datatype_safe(
 pub unsafe extern "C" fn fits_iter_get_iotype(
     col: *mut iteratorCol, /* I - iterator column structure */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let col = col.as_mut().expect(NULL_MSG);
         fits_iter_get_iotype_safe(col)
@@ -2374,6 +2396,7 @@ pub fn fits_iter_get_iotype_safe(
 pub unsafe extern "C" fn fits_iter_get_array(
     col: *mut iteratorCol, /* I - iterator col structure */
 ) -> *const c_void {
+    // FFI WRAPPER
     unsafe {
         let col = col.as_mut().expect(NULL_MSG);
         fits_iter_get_array_safe(col)
@@ -2394,6 +2417,7 @@ pub fn fits_iter_get_array_safe(
 pub unsafe extern "C" fn fits_iter_get_tlmin(
     col: *mut iteratorCol, /* I - iterator column structure */
 ) -> c_long {
+    // FFI WRAPPER
     unsafe {
         let col = col.as_mut().expect(NULL_MSG);
         fits_iter_get_tlmin_safe(col)
@@ -2414,6 +2438,7 @@ pub fn fits_iter_get_tlmin_safe(
 pub unsafe extern "C" fn fits_iter_get_tlmax(
     col: *mut iteratorCol, /* I - iterator column structure */
 ) -> c_long {
+    // FFI WRAPPER
     unsafe {
         let col = col.as_mut().expect(NULL_MSG);
         fits_iter_get_tlmax_safe(col)
@@ -2434,6 +2459,7 @@ pub fn fits_iter_get_tlmax_safe(
 pub unsafe extern "C" fn fits_iter_get_repeat(
     col: *mut iteratorCol, /* I - iterator col structure */
 ) -> c_long {
+    // FFI WRAPPER
     unsafe {
         let col = col.as_mut().expect(NULL_MSG);
         fits_iter_get_repeat_safe(col)
@@ -2454,6 +2480,7 @@ pub fn fits_iter_get_repeat_safe(
 pub unsafe extern "C" fn fits_iter_get_tunit(
     col: *mut iteratorCol, /* I - iterator col structure */
 ) -> *const c_char {
+    // FFI WRAPPER
     unsafe {
         let col = col.as_mut().expect(NULL_MSG);
         fits_iter_get_tunit_safe(col).as_ptr()
@@ -2474,6 +2501,7 @@ pub fn fits_iter_get_tunit_safe(
 pub unsafe extern "C" fn fits_iter_get_tdisp(
     col: *mut iteratorCol, /* I -iterator col structure   */
 ) -> *const c_char {
+    // FFI WRAPPER
     unsafe {
         let col = col.as_mut().expect(NULL_MSG);
         fits_iter_get_tdisp_safe(col).as_ptr()
@@ -2513,6 +2541,7 @@ pub unsafe extern "C" fn ffiter(
     userPointer: *mut c_void,
     status: *mut c_int,
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let cols = slice::from_raw_parts_mut(cols, n_cols as usize);
@@ -3975,8 +4004,8 @@ pub fn ffiter_safe(
 
         for jj in 0..n_cols as usize {
             /* The C guards these on `if (cols[jj].array)`, i.e. non-null.
-               Testing is_null() instead meant the frees only ran for columns
-               that had nothing to free, so every allocated work array leaked. */
+            Testing is_null() instead meant the frees only ran for columns
+            that had nothing to free, so every allocated work array leaked. */
             if cols[jj].datatype == TSTRING && !cols[jj].array.is_null() {
                 stringptr = cols[jj].array.cast::<*mut c_char>();
 

--- a/src/putcolb.rs
+++ b/src/putcolb.rs
@@ -43,6 +43,7 @@ pub unsafe extern "C" fn ffpprb(
     array: *const u8,    /* I - array of values that are written   */
     status: *mut c_int,  /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let fptr = fptr.as_mut().expect(NULL_MSG);
         let status = status.as_mut().expect(NULL_MSG);
@@ -123,6 +124,7 @@ pub unsafe extern "C" fn ffppnb(
     nulval: u8,          /* I - undefined pixel value              */
     status: *mut c_int,  /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -202,6 +204,7 @@ pub unsafe extern "C" fn ffp2db(
     array: *const u8,    /* I - array to be written               */
     status: *mut c_int,  /* IO - error status                         */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -253,6 +256,7 @@ pub unsafe extern "C" fn ffp3db(
     array: *const u8,    /* I - array to be written               */
     status: *mut c_int,  /* IO - error status                         */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -379,6 +383,7 @@ pub unsafe extern "C" fn ffpssb(
     array: *const u8,      /* I - array to be written                 */
     status: *mut c_int,    /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -560,6 +565,7 @@ pub unsafe extern "C" fn ffpgpb(
     array: *const u8,    /* I - array of values that are written   */
     status: *mut c_int,  /* IO - error status                          */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -624,6 +630,7 @@ pub unsafe extern "C" fn ffpclb(
     array: *const u8,    /* I - array of values to write           */
     status: *mut c_int,  /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -1005,6 +1012,7 @@ pub unsafe extern "C" fn ffpcnb(
     nulvalue: u8,        /* I - flag for undefined pixels        */
     status: *mut c_int,  /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -1204,6 +1212,7 @@ pub unsafe extern "C" fn ffpextn(
     buffer: *const c_void, /* I - stream of bytes to write                 */
     status: *mut c_int,    /* IO - error status                            */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);

--- a/src/putcold.rs
+++ b/src/putcold.rs
@@ -43,6 +43,7 @@ pub unsafe extern "C" fn ffpprd(
     array: *const f64,   /* I - array of values that are written        */
     status: *mut c_int,  /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -122,6 +123,7 @@ pub unsafe extern "C" fn ffppnd(
     nulval: f64,         /* I - undefined pixel value                   */
     status: *mut c_int,  /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -201,6 +203,7 @@ pub unsafe extern "C" fn ffp2dd(
     array: *const f64,   /* I - array to be written                   */
     status: *mut c_int,  /* IO - error status                         */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -251,6 +254,7 @@ pub unsafe extern "C" fn ffp3dd(
     array: *const f64,   /* I - array to be written                   */
     status: *mut c_int,  /* IO - error status                         */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -378,6 +382,7 @@ pub unsafe extern "C" fn ffpssd(
     array: *const f64,     /* I - array to be written                     */
     status: *mut c_int,    /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -558,6 +563,7 @@ pub unsafe extern "C" fn ffpgpd(
     array: *const f64,   /* I - array of values that are written       */
     status: *mut c_int,  /* IO - error status                          */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -621,6 +627,7 @@ pub unsafe extern "C" fn ffpcld(
     array: *const f64,   /* I - array of values to write                */
     status: *mut c_int,  /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -994,6 +1001,7 @@ pub unsafe extern "C" fn ffpclm(
     array: *const f64,   /* I - array of values to write                */
     status: *mut c_int,  /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let fptr = fptr.as_mut().expect(NULL_MSG);
         let status = status.as_mut().expect(NULL_MSG);
@@ -1069,6 +1077,7 @@ pub unsafe extern "C" fn ffpcnd(
     nulvalue: f64,       /* I - value used to flag undefined pixels     */
     status: *mut c_int,  /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);

--- a/src/putcole.rs
+++ b/src/putcole.rs
@@ -47,6 +47,7 @@ pub unsafe extern "C" fn ffppre(
     array: *const f32,   /* I - array of values that are written        */
     status: *mut c_int,  /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -133,6 +134,7 @@ pub unsafe extern "C" fn ffppne(
     nulval: f32,         /* I - undefined pixel value                   */
     status: *mut c_int,  /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -217,6 +219,7 @@ pub unsafe extern "C" fn ffp2de(
     array: *const f32,   /* I - array to be written                   */
     status: *mut c_int,  /* IO - error status                         */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -273,6 +276,7 @@ pub unsafe extern "C" fn ffp3de(
     array: *const f32,   /* I - array to be written                   */
     status: *mut c_int,  /* IO - error status                         */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -403,6 +407,7 @@ pub unsafe extern "C" fn ffpsse(
     array: *const f32,     /* I - array to be written                     */
     status: *mut c_int,    /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -583,6 +588,7 @@ pub unsafe extern "C" fn ffpgpe(
     array: *const f32,   /* I - array of values that are written       */
     status: *mut c_int,  /* IO - error status                          */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -647,6 +653,7 @@ pub unsafe extern "C" fn ffpcle(
     array: *const f32,   /* I - array of values to write                */
     status: *mut c_int,  /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -1015,6 +1022,7 @@ pub unsafe extern "C" fn ffpclc(
     array: *const f32,   /* I - array of values to write                */
     status: *mut c_int,  /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let fptr = fptr.as_mut().expect(NULL_MSG);
         let status = status.as_mut().expect(NULL_MSG);
@@ -1090,6 +1098,7 @@ pub unsafe extern "C" fn ffpcne(
     nulvalue: f32,       /* I - value used to flag undefined pixels     */
     status: *mut c_int,  /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);

--- a/src/putcoli.rs
+++ b/src/putcoli.rs
@@ -43,6 +43,7 @@ pub unsafe extern "C" fn ffppri(
     array: *const c_short, /* I - array of values that are written        */
     status: *mut c_int,    /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -123,6 +124,7 @@ pub unsafe extern "C" fn ffppni(
     nulval: c_short,       /* I - undefined pixel value                   */
     status: *mut c_int,    /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -201,6 +203,7 @@ pub unsafe extern "C" fn ffp2di(
     array: *const c_short, /* I - array to be written                   */
     status: *mut c_int,    /* IO - error status                         */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let fptr = fptr.as_mut().expect(NULL_MSG);
         let status = status.as_mut().expect(NULL_MSG);
@@ -251,6 +254,7 @@ pub unsafe extern "C" fn ffp3di(
     array: *const c_short, /* I - array to be written                   */
     status: *mut c_int,    /* IO - error status                         */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -377,6 +381,7 @@ pub unsafe extern "C" fn ffpssi(
     array: *const c_short, /* I - array to be written                     */
     status: *mut c_int,    /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -558,6 +563,7 @@ pub unsafe extern "C" fn ffpgpi(
     array: *const c_short, /* I - array of values that are written       */
     status: *mut c_int,    /* IO - error status                          */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -622,6 +628,7 @@ pub unsafe extern "C" fn ffpcli(
     array: *const c_short, /* I - array of values to write                */
     status: *mut c_int,    /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -985,6 +992,7 @@ pub unsafe extern "C" fn ffpcni(
     nulvalue: c_short,     /* I - value used to flag undefined pixels     */
     status: *mut c_int,    /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);

--- a/src/putcolj.rs
+++ b/src/putcolj.rs
@@ -43,6 +43,7 @@ pub unsafe extern "C" fn ffpprj(
     array: *const c_long, /* I - array of values that are written        */
     status: *mut c_int,   /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -121,6 +122,7 @@ pub unsafe extern "C" fn ffppnj(
     nulval: c_long,       /* I - undefined pixel value                   */
     status: *mut c_int,   /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -198,6 +200,7 @@ pub unsafe extern "C" fn ffp2dj(
     array: *const c_long, /* I - array to be written                   */
     status: *mut c_int,   /* IO - error status                         */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let fptr = fptr.as_mut().expect(NULL_MSG);
         let status = status.as_mut().expect(NULL_MSG);
@@ -248,6 +251,7 @@ pub unsafe extern "C" fn ffp3dj(
     array: *const c_long, /* I - array to be written                   */
     status: *mut c_int,   /* IO - error status                         */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -375,6 +379,7 @@ pub unsafe extern "C" fn ffpssj(
     array: *const c_long,  /* I - array to be written                     */
     status: *mut c_int,    /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -555,6 +560,7 @@ pub unsafe extern "C" fn ffpgpj(
     array: *const c_long, /* I - array of values that are written       */
     status: *mut c_int,   /* IO - error status                          */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let fptr = fptr.as_mut().expect(NULL_MSG);
         let status = status.as_mut().expect(NULL_MSG);
@@ -619,6 +625,7 @@ pub unsafe extern "C" fn ffpclj(
     array: *const c_long, /* I - array of values to write                */
     status: *mut c_int,   /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -990,6 +997,7 @@ pub unsafe extern "C" fn ffpcnj(
     nulvalue: c_long,     /* I - value used to flag undefined pixels     */
     status: *mut c_int,   /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -1473,6 +1481,7 @@ pub unsafe extern "C" fn ffpprjj(
     array: *const LONGLONG, /* I - array of values that are written       */
     status: *mut c_int,     /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -1544,6 +1553,7 @@ pub unsafe extern "C" fn ffppnjj(
     nulval: LONGLONG,       /* I - undefined pixel value                   */
     status: *mut c_int,     /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -1612,6 +1622,7 @@ pub unsafe extern "C" fn ffp2djj(
     array: *const LONGLONG, /* I - array to be written                   */
     status: *mut c_int,     /* IO - error status                         */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -1662,6 +1673,7 @@ pub unsafe extern "C" fn ffp3djj(
     array: *const LONGLONG, /* I - array to be written                   */
     status: *mut c_int,     /* IO - error status                         */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -1775,6 +1787,7 @@ pub unsafe extern "C" fn ffpssjj(
     array: *const LONGLONG, /* I - array to be written                     */
     status: *mut c_int,     /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -1948,6 +1961,7 @@ pub unsafe extern "C" fn ffpgpjj(
     array: *const LONGLONG, /* I - array of values that are written       */
     status: *mut c_int,     /* IO - error status                          */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -2012,6 +2026,7 @@ pub unsafe extern "C" fn ffpcljj(
     array: *const LONGLONG, /* I - array of values to write               */
     status: *mut c_int,     /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -2383,6 +2398,7 @@ pub unsafe extern "C" fn ffpcnjj(
     nulvalue: LONGLONG,     /* I - value used to flag undefined pixels   */
     status: *mut c_int,     /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);

--- a/src/putcolk.rs
+++ b/src/putcolk.rs
@@ -45,6 +45,7 @@ pub unsafe extern "C" fn ffpprk(
     array: *const c_int, /* I - array of values that are written        */
     status: *mut c_int,  /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -124,6 +125,7 @@ pub unsafe extern "C" fn ffppnk(
     nulval: c_int,       /* I - undefined pixel value                   */
     status: *mut c_int,  /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -202,6 +204,7 @@ pub unsafe extern "C" fn ffp2dk(
     array: *const c_int, /* I - array to be written                   */
     status: *mut c_int,  /* IO - error status                         */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -252,6 +255,7 @@ pub unsafe extern "C" fn ffp3dk(
     array: *const c_int, /* I - array to be written                   */
     status: *mut c_int,  /* IO - error status                         */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -381,6 +385,7 @@ pub unsafe extern "C" fn ffpssk(
     array: *const c_int,   /* I - array to be written                     */
     status: *mut c_int,    /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -560,6 +565,7 @@ pub unsafe extern "C" fn ffpgpk(
     array: *const c_int, /* I - array of values that are written       */
     status: *mut c_int,  /* IO - error status                          */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -623,6 +629,7 @@ pub unsafe extern "C" fn ffpclk(
     array: *const c_int, /* I - array of values to write                */
     status: *mut c_int,  /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -1021,6 +1028,7 @@ pub unsafe extern "C" fn ffpcnk(
     nulvalue: c_int,     /* I - value used to flag undefined pixels     */
     status: *mut c_int,  /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);

--- a/src/putcoll.rs
+++ b/src/putcoll.rs
@@ -32,6 +32,7 @@ pub unsafe extern "C" fn ffpcll(
     array: *const c_char, /* I - array of values to write                */
     status: *mut c_int,   /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -188,6 +189,7 @@ pub unsafe extern "C" fn ffpcnl(
     nulvalue: c_char,     /* I - array flagging undefined pixels if true */
     status: *mut c_int,   /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -352,6 +354,7 @@ pub unsafe extern "C" fn ffpclx(
     larray: *const c_char, /* I - array of logicals corresponding to bits */
     status: *mut c_int,    /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);

--- a/src/putcols.rs
+++ b/src/putcols.rs
@@ -32,6 +32,7 @@ pub unsafe extern "C" fn ffpcls(
     array: *const *const c_char, /* I - array of pointers to strings            */
     status: *mut c_int,          /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -345,6 +346,7 @@ pub unsafe extern "C" fn ffpcns(
     nulvalue: *const c_char,     /* I - string representing a null value        */
     status: *mut c_int,          /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);

--- a/src/putcolsb.rs
+++ b/src/putcolsb.rs
@@ -43,6 +43,7 @@ pub unsafe extern "C" fn ffpprsb(
     array: *const i8,    /* I - array of values that are written     */
     status: *mut c_int,  /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -122,6 +123,7 @@ pub unsafe extern "C" fn ffppnsb(
     nulval: i8,          /* I - undefined pixel value              */
     status: *mut c_int,  /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -200,6 +202,7 @@ pub unsafe extern "C" fn ffp2dsb(
     array: *const i8,    /* I - array to be written               */
     status: *mut c_int,  /* IO - error status                         */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -249,6 +252,7 @@ pub unsafe extern "C" fn ffp3dsb(
     array: *const i8,    /* I - array to be written               */
     status: *mut c_int,  /* IO - error status                         */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -376,6 +380,7 @@ pub unsafe extern "C" fn ffpsssb(
     array: *const i8,      /* I - array to be written                 */
     status: *mut c_int,    /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -557,6 +562,7 @@ pub unsafe extern "C" fn ffpgpsb(
     array: *const i8,    /* I - array of values that are written   */
     status: *mut c_int,  /* IO - error status                          */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -620,6 +626,7 @@ pub unsafe extern "C" fn ffpclsb(
     array: *const i8,    /* I - array of values to write           */
     status: *mut c_int,  /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -983,6 +990,7 @@ pub unsafe extern "C" fn ffpcnsb(
     nulvalue: i8,        /* I - flag for undefined pixels        */
     status: *mut c_int,  /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);

--- a/src/putcolu.rs
+++ b/src/putcolu.rs
@@ -35,6 +35,7 @@ pub unsafe extern "C" fn ffppru(
     nelem: LONGLONG,     /* I - number of values to write              */
     status: *mut c_int,  /* IO - error status                          */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -92,6 +93,7 @@ pub unsafe extern "C" fn ffpprn(
     nelem: LONGLONG,     /* I - number of values to write              */
     status: *mut c_int,  /* IO - error status                          */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -156,6 +158,7 @@ pub unsafe extern "C" fn ffpclu(
     nelempar: LONGLONG,  /* I - number of values to write               */
     status: *mut c_int,  /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -720,6 +723,7 @@ pub unsafe extern "C" fn ffprwu(
     nrows: LONGLONG,
     status: *mut c_int,
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);

--- a/src/putcolui.rs
+++ b/src/putcolui.rs
@@ -43,6 +43,7 @@ pub unsafe extern "C" fn ffpprui(
     array: *const c_ushort, /* I - array of values that are written        */
     status: *mut c_int,     /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -122,6 +123,7 @@ pub unsafe extern "C" fn ffppnui(
     nulval: c_ushort,       /* I - undefined pixel value                   */
     status: *mut c_int,     /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -200,6 +202,7 @@ pub unsafe extern "C" fn ffp2dui(
     array: *const c_ushort, /* I - array to be written                   */
     status: *mut c_int,     /* IO - error status                         */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -250,6 +253,7 @@ pub unsafe extern "C" fn ffp3dui(
     array: *const c_ushort, /* I - array to be written                   */
     status: *mut c_int,     /* IO - error status                         */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -376,6 +380,7 @@ pub unsafe extern "C" fn ffpssui(
     array: *const c_ushort, /* I - array to be written                     */
     status: *mut c_int,     /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -556,6 +561,7 @@ pub unsafe extern "C" fn ffpgpui(
     array: *const c_ushort, /* I - array of values that are written       */
     status: *mut c_int,     /* IO - error status                          */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -620,6 +626,7 @@ pub unsafe extern "C" fn ffpclui(
     array: *const c_ushort, /* I - array of values to write                */
     status: *mut c_int,     /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -957,6 +964,7 @@ pub unsafe extern "C" fn ffpcnui(
     nulvalue: c_ushort,     /* I - value used to flag undefined pixels     */
     status: *mut c_int,     /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);

--- a/src/putcoluj.rs
+++ b/src/putcoluj.rs
@@ -43,6 +43,7 @@ pub unsafe extern "C" fn ffppruj(
     array: *const c_ulong, /* I - array of values that are written        */
     status: *mut c_int,    /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -121,6 +122,7 @@ pub unsafe extern "C" fn ffppnuj(
     nulval: c_ulong,       /* I - undefined pixel value                   */
     status: *mut c_int,    /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -198,6 +200,7 @@ pub unsafe extern "C" fn ffp2duj(
     array: *const c_ulong, /* I - array to be written                   */
     status: *mut c_int,    /* IO - error status                         */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let fptr = fptr.as_mut().expect(NULL_MSG);
         let status = status.as_mut().expect(NULL_MSG);
@@ -247,6 +250,7 @@ pub unsafe extern "C" fn ffp3duj(
     array: *const c_ulong, /* I - array to be written                   */
     status: *mut c_int,    /* IO - error status                         */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -374,6 +378,7 @@ pub unsafe extern "C" fn ffpssuj(
     array: *const c_ulong, /* I - array to be written                     */
     status: *mut c_int,    /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -554,6 +559,7 @@ pub unsafe extern "C" fn ffpgpuj(
     array: *const c_ulong, /* I - array of values that are written       */
     status: *mut c_int,    /* IO - error status                          */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -617,6 +623,7 @@ pub unsafe extern "C" fn ffpcluj(
     array: *const c_ulong, /* I - array of values to write                */
     status: *mut c_int,    /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -955,6 +962,7 @@ pub unsafe extern "C" fn ffpcnuj(
     nulvalue: c_ulong,     /* I - value used to flag undefined pixels     */
     status: *mut c_int,    /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -1432,6 +1440,7 @@ pub unsafe extern "C" fn ffpprujj(
     array: *const ULONGLONG, /* I - array of values that are written       */
     status: *mut c_int,      /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -1502,6 +1511,7 @@ pub unsafe extern "C" fn ffppnujj(
     nulval: ULONGLONG,       /* I - undefined pixel value                   */
     status: *mut c_int,      /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -1569,6 +1579,7 @@ pub unsafe extern "C" fn ffp2dujj(
     array: *const ULONGLONG, /* I - array to be written                   */
     status: *mut c_int,      /* IO - error status                         */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -1619,6 +1630,7 @@ pub unsafe extern "C" fn ffp3dujj(
     array: *const ULONGLONG, /* I - array to be written                   */
     status: *mut c_int,      /* IO - error status                         */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -1732,6 +1744,7 @@ pub unsafe extern "C" fn ffpssujj(
     array: *const ULONGLONG, /* I - array to be written                     */
     status: *mut c_int,      /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -1905,6 +1918,7 @@ pub unsafe extern "C" fn ffpgpujj(
     array: *const ULONGLONG, /* I - array of values that are written       */
     status: *mut c_int,      /* IO - error status                          */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -1968,6 +1982,7 @@ pub unsafe extern "C" fn ffpclujj(
     array: *const ULONGLONG, /* I - array of values to write               */
     status: *mut c_int,      /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -2305,6 +2320,7 @@ pub unsafe extern "C" fn ffpcnujj(
     nulvalue: ULONGLONG,     /* I - value used to flag undefined pixels   */
     status: *mut c_int,      /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);

--- a/src/putcoluk.rs
+++ b/src/putcoluk.rs
@@ -45,6 +45,7 @@ pub unsafe extern "C" fn ffppruk(
     array: *const c_uint, /* I - array of values that are written        */
     status: *mut c_int,   /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -116,6 +117,7 @@ pub unsafe extern "C" fn ffppnuk(
     nulval: c_uint,       /* I - undefined pixel value                   */
     status: *mut c_int,   /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -194,6 +196,7 @@ pub unsafe extern "C" fn ffp2duk(
     array: *const c_uint, /* I - array to be written                   */
     status: *mut c_int,   /* IO - error status                         */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -243,6 +246,7 @@ pub unsafe extern "C" fn ffp3duk(
     array: *const c_uint, /* I - array to be written                   */
     status: *mut c_int,   /* IO - error status                         */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -372,6 +376,7 @@ pub unsafe extern "C" fn ffpssuk(
     array: *const c_uint,  /* I - array to be written                     */
     status: *mut c_int,    /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -565,6 +570,7 @@ pub unsafe extern "C" fn ffpgpuk(
     array: *const c_uint, /* I - array of values that are written       */
     status: *mut c_int,   /* IO - error status                          */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -628,6 +634,7 @@ pub unsafe extern "C" fn ffpcluk(
     array: *const c_uint, /* I - array of values to write                */
     status: *mut c_int,   /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -989,6 +996,7 @@ pub unsafe extern "C" fn ffpcnuk(
     nulvalue: c_uint,     /* I - value used to flag undefined pixels     */
     status: *mut c_int,   /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);

--- a/src/putkey.rs
+++ b/src/putkey.rs
@@ -48,6 +48,7 @@ pub unsafe extern "C" fn ffcrim(
     naxes: *const c_long, /* I - size of each axis           */
     status: *mut c_int,   /* IO - error status               */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let fptr = fptr.as_mut().expect(NULL_MSG);
         let status = status.as_mut().expect(NULL_MSG);
@@ -116,6 +117,7 @@ pub unsafe extern "C" fn ffcrimll(
     naxes: *const LONGLONG, /* I - size of each axis           */
     status: *mut c_int,     /* IO - error status               */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -182,6 +184,7 @@ pub unsafe extern "C" fn ffcrtb(
     extnm: *const c_char,        /* I - value of EXTNAME keyword, if any         */
     status: *mut c_int,          /* IO - error status                            */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -265,6 +268,7 @@ pub unsafe extern "C" fn ffphps(
     naxes: *const c_long, /* I - length of each data axis                 */
     status: *mut c_int,   /* IO - error status                            */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let fptr = fptr.as_mut().expect(NULL_MSG);
         let status = status.as_mut().expect(NULL_MSG);
@@ -310,6 +314,7 @@ pub unsafe extern "C" fn ffphpsll(
     naxes: *const LONGLONG, /* I - length of each data axis                 */
     status: *mut c_int,     /* IO - error status                            */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -354,6 +359,7 @@ pub unsafe extern "C" fn ffphpr(
     extend: c_int,        /* I - may FITS file have extensions?           */
     status: *mut c_int,   /* IO - error status                            */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let fptr = fptr.as_mut().expect(NULL_MSG);
         let status = status.as_mut().expect(NULL_MSG);
@@ -414,6 +420,7 @@ pub unsafe extern "C" fn ffphprll(
     extend: c_int,          /* I - may FITS file have extensions?           */
     status: *mut c_int,     /* IO - error status                            */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -690,6 +697,7 @@ pub unsafe extern "C" fn ffphtb(
     extnmx: *const c_char,       /* I - value of EXTNAME keyword, if any         */
     status: *mut c_int,          /* IO - error status                            */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -974,6 +982,7 @@ pub unsafe extern "C" fn ffphbn(
     pcount: LONGLONG,            /* I - size of the variable length heap area    */
     status: *mut c_int,          /* IO - error status                            */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -1380,6 +1389,7 @@ pub unsafe extern "C" fn ffphext(
     gcount: LONGLONG,         /* I - value for the GCOUNT keyword            */
     status: *mut c_int,       /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -1499,6 +1509,7 @@ pub unsafe extern "C" fn ffprec(
     card: *const c_char, /* I - string to be written     */
     status: *mut c_int,  /* IO - error status            */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let fptr = fptr.as_mut().expect(NULL_MSG);
         let status = status.as_mut().expect(NULL_MSG);
@@ -1603,6 +1614,7 @@ pub unsafe extern "C" fn ffpkyu(
     comm: *const c_char,    /* I - keyword comment          */
     status: *mut c_int,     /* IO - error status            */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -1649,6 +1661,7 @@ pub unsafe extern "C" fn ffpkys(
     comm: *const c_char,    /* I - keyword comment          */
     status: *mut c_int,     /* IO - error status            */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -1702,6 +1715,7 @@ pub unsafe extern "C" fn ffpkyuj(
     comm: *const c_char,    /* I - keyword comment          */
     status: *mut c_int,     /* IO - error status            */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -1750,6 +1764,7 @@ pub unsafe extern "C" fn ffpkyf(
     comm: *const c_char,    /* I - keyword comment                     */
     status: *mut c_int,     /* IO - error status                       */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -1799,6 +1814,7 @@ pub unsafe extern "C" fn ffpkye(
     comm: *const c_char,    /* I - keyword comment                     */
     status: *mut c_int,     /* IO - error status                       */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -1848,6 +1864,7 @@ pub unsafe extern "C" fn ffpkyg(
     comm: *const c_char,    /* I - keyword comment                     */
     status: *mut c_int,     /* IO - error status                       */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let fptr = fptr.as_mut().expect(NULL_MSG);
         let status = status.as_mut().expect(NULL_MSG);
@@ -1897,6 +1914,7 @@ pub unsafe extern "C" fn ffpkyd(
     comm: *const c_char,    /* I - keyword comment                     */
     status: *mut c_int,     /* IO - error status                       */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -1946,6 +1964,7 @@ pub unsafe extern "C" fn ffpkyc(
     comm: *const c_char,    /* I - keyword comment                     */
     status: *mut c_int,     /* IO - error status                       */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -2017,6 +2036,7 @@ pub unsafe extern "C" fn ffpkym(
     comm: *const c_char,    /* I - keyword comment                     */
     status: *mut c_int,     /* IO - error status                       */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -2088,6 +2108,7 @@ pub unsafe extern "C" fn ffpkfc(
     comm: *const c_char,    /* I - keyword comment                     */
     status: *mut c_int,     /* IO - error status                       */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -2158,6 +2179,7 @@ pub unsafe extern "C" fn ffpkfm(
     comm: *const c_char,    /* I - keyword comment                     */
     status: *mut c_int,     /* IO - error status                       */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -2233,6 +2255,7 @@ pub unsafe extern "C" fn ffpkls(
     comm: *const c_char,    /* I - keyword comment          */
     status: *mut c_int,     /* IO - error status            */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -2574,6 +2597,7 @@ pub unsafe extern "C" fn ffplsw(
     fptr: *mut fitsfile, /* I - FITS file pointer  */
     status: *mut c_int,  /* IO - error status       */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -2660,6 +2684,7 @@ pub unsafe extern "C" fn ffpkyl(
     comm: *const c_char,    /* I - keyword comment          */
     status: *mut c_int,     /* IO - error status            */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let fptr = fptr.as_mut().expect(NULL_MSG);
         let status = status.as_mut().expect(NULL_MSG);
@@ -2707,6 +2732,7 @@ pub unsafe extern "C" fn ffpkyj(
     comm: *const c_char,    /* I - keyword comment          */
     status: *mut c_int,     /* IO - error status            */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -2756,6 +2782,7 @@ pub unsafe extern "C" fn ffpkyt(
     comm: *const c_char,    /* I - keyword comment          */
     status: *mut c_int,     /* IO - error status            */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         raw_to_slice!(keyname);
         nullable_slice_cstr!(comm);
@@ -2821,6 +2848,7 @@ pub unsafe extern "C" fn ffpcom(
     comm: *const c_char, /* I - comment string      */
     status: *mut c_int,  /* IO - error status       */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -2870,6 +2898,7 @@ pub unsafe extern "C" fn ffphis(
     history: *const c_char, /* I - history string     */
     status: *mut c_int,     /* IO - error status      */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -2917,6 +2946,7 @@ pub unsafe extern "C" fn ffpdat(
     fptr: *mut fitsfile, /* I - FITS file pointer  */
     status: *mut c_int,  /* IO - error status      */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -2980,6 +3010,7 @@ pub unsafe extern "C" fn ffpkns(
     comm: *const *const c_char,  /* I - array of pointers to keyword comment */
     status: *mut c_int,          /* IO - error status                        */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let fptr = fptr.as_mut().expect(NULL_MSG);
         let status = status.as_mut().expect(NULL_MSG);
@@ -3088,6 +3119,7 @@ pub unsafe extern "C" fn ffpknl(
     comm: *const *const c_char, /* I - array of pointers to keyword comment */
     status: *mut c_int,         /* IO - error status                        */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let fptr = fptr.as_mut().expect(NULL_MSG);
         let status = status.as_mut().expect(NULL_MSG);
@@ -3191,6 +3223,7 @@ pub unsafe extern "C" fn ffpknj(
     comm: *const *const c_char, /* I - array of pointers to keyword comment */
     status: *mut c_int,         /* IO - error status                        */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let fptr = fptr.as_mut().expect(NULL_MSG);
         let status = status.as_mut().expect(NULL_MSG);
@@ -3299,6 +3332,7 @@ pub unsafe extern "C" fn ffpknf(
     comm: *const *const c_char, /* I - array of pointers to keyword comment */
     status: *mut c_int,         /* IO - error status                        */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let fptr = fptr.as_mut().expect(NULL_MSG);
         let status = status.as_mut().expect(NULL_MSG);
@@ -3402,6 +3436,7 @@ pub unsafe extern "C" fn ffpkne(
     comm: *const *const c_char, /* I - array of pointers to keyword comment */
     status: *mut c_int,         /* IO - error status                        */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let fptr = fptr.as_mut().expect(NULL_MSG);
         let status = status.as_mut().expect(NULL_MSG);
@@ -3505,6 +3540,7 @@ pub unsafe extern "C" fn ffpkng(
     comm: *const *const c_char, /* I - array of pointers to keyword comment */
     status: *mut c_int,         /* IO - error status                        */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let fptr = fptr.as_mut().expect(NULL_MSG);
         let status = status.as_mut().expect(NULL_MSG);
@@ -3608,6 +3644,7 @@ pub unsafe extern "C" fn ffpknd(
     comm: *const *const c_char, /* I - array of pointers to keyword comment */
     status: *mut c_int,         /* IO - error status                        */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let fptr = fptr.as_mut().expect(NULL_MSG);
         let status = status.as_mut().expect(NULL_MSG);
@@ -3710,6 +3747,7 @@ pub unsafe extern "C" fn ffpky(
     comm: *const c_char,    /* I - keyword comment          */
     status: *mut c_int,     /* IO - error status            */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -3814,6 +3852,7 @@ pub unsafe extern "C" fn ffpktp(
     filename: *const c_char, /* I - name of template file   */
     status: *mut c_int,      /* IO - error status           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -3916,6 +3955,7 @@ pub unsafe extern "C" fn ffptdm(
     naxes: *const c_long, /* I - length of each data axis                 */
     status: *mut c_int,   /* IO - error status                            */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -4042,6 +4082,7 @@ pub unsafe extern "C" fn ffptdmll(
     naxes: *const LONGLONG, /* I - length of each data axis               */
     status: *mut c_int,     /* IO - error status                            */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -4170,6 +4211,7 @@ pub unsafe extern "C" fn ffgstm(
     timeref: *mut c_int,  /* O - GMT = 0, Local time = 1  */
     status: *mut c_int,   /* IO - error status      */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let timestr = timestr.as_mut().expect(NULL_MSG);
@@ -4217,6 +4259,7 @@ pub unsafe extern "C" fn ffdt2s(
     datestr: *mut c_char, /* O - date string: "YYYY-MM-DD" */
     status: *mut c_int,   /* IO - error status             */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
 
@@ -4268,6 +4311,7 @@ pub unsafe extern "C" fn ffs2dt(
     day: *mut c_int,        /* O - day (1 - 31)                            */
     status: *mut c_int,     /* IO - error status                           */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let year = year.as_mut();
@@ -4411,6 +4455,7 @@ pub unsafe extern "C" fn fftm2s(
     datestr: *mut c_char, /* O - date string: "YYYY-MM-DDThh:mm:ss.ddd" or "hh:mm:ss.ddd" if year, month day = 0 */
     status: *mut c_int,   /* IO - error status             */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let datestr = datestr.as_mut().expect(NULL_MSG);
@@ -4556,6 +4601,7 @@ pub unsafe extern "C" fn ffs2tm(
     second: *mut c_double, /* O - second (0. - 60.9999999)     */
     status: *mut c_int,    /* IO - error status                */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let year = year.as_mut();
@@ -4776,6 +4822,7 @@ pub unsafe extern "C" fn ffgsdt(
     year: *mut c_int,
     status: *mut c_int,
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let day = day.as_mut().expect(NULL_MSG);
@@ -5242,6 +5289,7 @@ pub unsafe extern "C" fn ffverifydate(
     day: c_int,         /* I - day (1-31) */
     status: *mut c_int, /* IO - error status */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         ffverifydate_safe(year, month, day, status)
@@ -5352,6 +5400,7 @@ pub unsafe extern "C" fn ffpknjj(
     comm: *const *const c_char, /* I - array of keyword comments */
     status: *mut c_int,         /* IO - error status */
 ) -> c_int {
+    // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
         let fptr = fptr.as_mut().expect(NULL_MSG);

--- a/src/wrappers.rs
+++ b/src/wrappers.rs
@@ -277,9 +277,9 @@ pub fn atol_safe(cs: &[c_char]) -> c_long {
     }
 
     /* acc is accumulated negatively so that c_long::MIN is representable, but
-       that means a positive value of exactly |MIN| lands on MIN without the
-       checked arithmetic above noticing. Negating it would overflow, so
-       saturate as the C does. */
+    that means a positive value of exactly |MIN| lands on MIN without the
+    checked arithmetic above noticing. Negating it would overflow, so
+    saturate as the C does. */
     if negative {
         acc
     } else {
@@ -314,11 +314,11 @@ fn strto_float_impl(s: &[c_char], endptr: &mut usize) -> f64 {
     }
 
     /* Start of the literal itself, sign included: the digit-by-digit
-       accumulation below is not correctly rounded (it compounds a rounding
-       error per fractional digit, so e.g. 12345.6789 comes out as
-       12345.678899999999), so once the extent of the literal is known the
-       decimal case re-parses this span with Rust's correctly-rounded parser
-       and only falls back to the accumulated value if that fails. */
+    accumulation below is not correctly rounded (it compounds a rounding
+    error per fractional digit, so e.g. 12345.6789 comes out as
+    12345.678899999999), so once the extent of the literal is known the
+    decimal case re-parses this span with Rust's correctly-rounded parser
+    and only falls back to the accumulated value if that fails. */
     let literal_start = si;
 
     let mut result: f64 = 0.0;
@@ -409,9 +409,9 @@ fn strto_float_impl(s: &[c_char], endptr: &mut usize) -> f64 {
                     };
 
                     /* Saturate rather than panic: `1e400` overflows a u128
-                       pow, and the C just returns inf/0 for out-of-range
-                       exponents. The correctly-rounded re-parse below produces
-                       the real value whenever the literal is well-formed. */
+                    pow, and the C just returns inf/0 for out-of-range
+                    exponents. The correctly-rounded re-parse below produces
+                    the real value whenever the literal is well-formed. */
                     let magnitude = exponent_base
                         .checked_pow(exponent_value)
                         .map_or(f64::INFINITY, |m| m as f64);
@@ -920,16 +920,58 @@ mod libc_parity_tests {
     /// digit-by-digit accumulation gets wrong, signs, whitespace, exponents,
     /// trailing junk, and the no-digits case.
     const FLOAT_CASES: &[&str] = &[
-        "0", "1", "1.5", "2.", ".5", "-1.5", "+1.5", "  3.75", "1e3", "1E3", "1.5e-3", "1.5E+3",
-        "3.25", "0.1", "0.2", "0.3", "12345.6789", "1234567.891011", "0.000123456789",
-        "9007199254740993", "1.7976931348623157e308", "2.2250738585072014e-308", "1e-400",
-        "1e400", "123abc", "abc", "", "   ", "-0", "0.0000000000000001",
+        "0",
+        "1",
+        "1.5",
+        "2.",
+        ".5",
+        "-1.5",
+        "+1.5",
+        "  3.75",
+        "1e3",
+        "1E3",
+        "1.5e-3",
+        "1.5E+3",
+        "3.25",
+        "0.1",
+        "0.2",
+        "0.3",
+        "12345.6789",
+        "1234567.891011",
+        "0.000123456789",
+        "9007199254740993",
+        "1.7976931348623157e308",
+        "2.2250738585072014e-308",
+        "1e-400",
+        "1e400",
+        "123abc",
+        "abc",
+        "",
+        "   ",
+        "-0",
+        "0.0000000000000001",
     ];
 
     const LONG_CASES: &[&str] = &[
-        "0", "1", "-1", "+1", "  42", "42abc", "abc", "", "   ", "-0", "2147483647",
-        "-2147483648", "9223372036854775807", "-9223372036854775808",
-        "99999999999999999999", "-99999999999999999999", "007", "-  5", "1 2",
+        "0",
+        "1",
+        "-1",
+        "+1",
+        "  42",
+        "42abc",
+        "abc",
+        "",
+        "   ",
+        "-0",
+        "2147483647",
+        "-2147483648",
+        "9223372036854775807",
+        "-9223372036854775808",
+        "99999999999999999999",
+        "-99999999999999999999",
+        "007",
+        "-  5",
+        "1 2",
     ];
 
     #[test]


### PR DESCRIPTION
Every `extern "C"` entry point in `src/` now carries a `// FFI WRAPPER` comment immediately before its unsafe block, so the unsafe blocks that exist only to marshal raw pointers at the FFI boundary can be told apart from real unsafe code with a grep.

Placement:
- 648 fns whose body is one `unsafe { … }` — comment on the line above.
- `shared_malloc` and `ffchfl` run locals/a null check first, so the comment sits directly above the `unsafe` block rather than at the top of the body.
- ~13 fns with no unsafe block at all (`ffpmrk`, `ffihtps`, `bz_internal_error`, …) get it as the first body line, keeping "every extern fn has the marker" a uniform invariant.

Also picks up pre-existing `cargo fmt` drift in `eval_l.rs`, `drvrmem.rs`, `cfileio.rs` and `putcol.rs`.

Caveat worth noting: the `shared_*` fns in `drvrsmem.rs` (plus `fits_clear_Fptr`, `ffgmsg`, `fits_execute_template`, `iterdata`) are marked but are *not* thin wrappers — their unsafe block is the real implementation. A distinct marker for those could be a follow-up.

Comments only; no behaviour change. Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CnuucR9Sw9aG7AxsQdKX28