### PR TITLE
Transpile the H-compress shims, and refresh cfileio's stale todo!() notes

### DIFF
--- a/src/cfileio.rs
+++ b/src/cfileio.rs
@@ -11288,7 +11288,7 @@ mod tests {
     }
 
     // ------------------------------------------------------------------
-    // ffexist tests (ffexist_safer is todo!())
+    // ffexist (fits_file_exists) tests
     // ------------------------------------------------------------------
 
     /// Mirrors test_ffexist_exists in ~/code/cfitsio/tests/test_cfileio.c
@@ -11540,13 +11540,14 @@ mod tests {
     }
 
     // ------------------------------------------------------------------
-    // ffextn (fits_parse_extnum) tests - ffextn_safer is todo!()
+    // ffextn (fits_parse_extnum) tests
     // ------------------------------------------------------------------
 
-    /* The three ffextn cases the C's test_cfileio.c covers -- an explicit
-    extension number, no extension specifier, and a binning specification --
-    are already covered, with an extra case each, by test_ffextn_extension_number,
-    test_ffextn_no_extension and test_ffextn_binning_returns_one above. */
+    /* The three ffextn cases the C's test_cfileio.c covers -- test_ffextn_number
+    (an explicit extension number), test_ffextn_none (no extension specifier) and
+    test_ffextn_binspec (a binning specification) -- are already covered, with an
+    extra case each, by test_ffextn_extension_number, test_ffextn_no_extension and
+    test_ffextn_binning_returns_one above. */
 
     // ------------------------------------------------------------------
     // Open function variants
@@ -12691,8 +12692,11 @@ mod tests {
             ffdelt_safe(&mut f, &mut status);
             assert_eq!(status, 0, "ffdelt failed");
 
-            // Verify it's gone (use std::fs since ffexist is todo!())
-            assert!(!std::path::Path::new(filename).exists());
+            // Verify it's gone
+            let mut exists: c_int = -99;
+            fits_file_exists(&name, &mut exists, &mut status);
+            assert_eq!(status, 0);
+            assert_eq!(exists, 0);
         });
     }
 
@@ -12974,9 +12978,20 @@ mod tests {
         }
     }
 
+    /// Mirrors test_ffihtps in ~/code/cfitsio/tests/test_cfileio.c
+    ///
+    /// NOTE: the C's `fail_if(status != 0)` cannot be expressed yet -- ffihtps
+    /// and ffchtps return `int` in fitsio.h, but their stubs here return `()`.
+    /// Fixing that is part of implementing them.
     #[test]
     #[ignore = "ffihtps_safe / ffchtps_safe are still todo!() in src/cfileio.rs"]
-    fn test_ffihtps() {}
+    fn test_ffihtps() {
+        /* Initialize HTTPS support. Returns 0 on success or if CURL not configured. */
+        fits_init_https();
+
+        /* Cleanup. */
+        fits_cleanup_https();
+    }
 
     #[test]
     fn test_ffeopn() {

--- a/src/fits_hcompress.rs
+++ b/src/fits_hcompress.rs
@@ -1,8 +1,11 @@
 /* H-compress routines */
 
+use bytemuck::cast_slice_mut;
+use hcompress::write::HCEncoder;
+
 use crate::c_types::{c_char, c_int, c_long};
 
-use crate::fitsio::{LONGLONG, NULL_MSG};
+use crate::fitsio::{DATA_COMPRESSION_ERR, LONGLONG, NULL_MSG};
 
 /* ---------------------------------------------------------------------- */
 /// Compress the input image using the H-compress algorithm
@@ -19,9 +22,12 @@ use crate::fitsio::{LONGLONG, NULL_MSG};
 /// NOTE: the nx and ny dimensions as defined within this code are reversed from
 /// the usual FITS notation.  ny is the fastest varying dimension, which is
 /// usually considered the X axis in the FITS image display
+///
+/// NOTE: `a` is modified in place (the H-transform and digitize steps overwrite
+/// it), which is why it is a `*mut` here and a `&mut [c_int]` in the safe form.
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn fits_hcompress(
-    a: *const c_int,
+    a: *mut c_int,
     ny: c_int,
     nx: c_int,
     scale: c_int,
@@ -33,7 +39,7 @@ pub unsafe extern "C" fn fits_hcompress(
         let nbytes = nbytes.as_mut().expect(NULL_MSG);
         let status = status.as_mut().expect(NULL_MSG);
 
-        let a = core::slice::from_raw_parts(a, nx as usize * ny as usize);
+        let a = core::slice::from_raw_parts_mut(a, nx as usize * ny as usize);
         let output = core::slice::from_raw_parts_mut(output, *nbytes as usize);
 
         fits_hcompress_safe(a, ny, nx, scale, output, nbytes, status)
@@ -56,15 +62,47 @@ pub unsafe extern "C" fn fits_hcompress(
 /// the usual FITS notation.  ny is the fastest varying dimension, which is
 /// usually considered the X axis in the FITS image display
 pub fn fits_hcompress_safe(
-    _a: &[c_int],
-    _ny: c_int,
-    _nx: c_int,
-    _scale: c_int,
-    _output: &mut [c_char],
-    _nbytes: &mut c_long,
-    _status: &mut c_int,
+    a: &mut [c_int],
+    ny: c_int,
+    nx: c_int,
+    scale: c_int,
+    output: &mut [c_char],
+    nbytes: &mut c_long,
+    status: &mut c_int,
 ) -> c_int {
-    todo!()
+    if *status > 0 {
+        return *status;
+    }
+
+    /* The C's htrans() / digitize() / encode() are not in this crate -- they
+    live in the external `hcompress` crate, where HCEncoder::write() is exactly
+    that same sequence.  The C's FFLOCK/FFUNLOCK around encode() guarded the
+    file-scope `noutmax`/bit-buffer globals; the crate keeps that state inside
+    the HCEncoder, so no lock is needed here. */
+
+    /* noutmax = *nbytes;  input value is the allocated size of the array */
+    let noutmax = (*nbytes as usize).min(output.len());
+    *nbytes = 0; /* reset */
+
+    /* DEVIATION: the C's encode() compares its running byte count against
+    `noutmax` and fails with "encode: output buffer too small".  The crate's
+    encoder discards its sink's io::Errors (`let _ = write_all(..)`), so writing
+    straight into `output` would truncate silently.  Encode into a Vec instead
+    and enforce `noutmax` here, so the caller still sees DATA_COMPRESSION_ERR. */
+    let mut buf: Vec<u8> = Vec::with_capacity(noutmax);
+
+    /* H-transform, digitize, then encode and write to the output array */
+    let stat = HCEncoder::new(&mut buf).write(a, ny as usize, nx as usize, scale);
+
+    if stat.is_err() || buf.len() > noutmax {
+        *status = DATA_COMPRESSION_ERR;
+        return *status;
+    }
+
+    cast_slice_mut(&mut output[..buf.len()]).copy_from_slice(&buf);
+    *nbytes = buf.len() as c_long;
+
+    *status
 }
 
 /* ---------------------------------------------------------------------- */
@@ -81,9 +119,11 @@ pub fn fits_hcompress_safe(
 /// NOTE: the nx and ny dimensions as defined within this code are reversed from
 /// the usual FITS notation.  ny is the fastest varying dimension, which is
 /// usually considered the X axis in the FITS image display
+///
+/// NOTE: `a` is modified in place, as in the 32-bit routine above.
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn fits_hcompress64(
-    a: *const LONGLONG,
+    a: *mut LONGLONG,
     ny: c_int,
     nx: c_int,
     scale: c_int,
@@ -95,7 +135,7 @@ pub unsafe extern "C" fn fits_hcompress64(
         let nbytes = nbytes.as_mut().expect(NULL_MSG);
         let status = status.as_mut().expect(NULL_MSG);
 
-        let a = core::slice::from_raw_parts(a, nx as usize * ny as usize);
+        let a = core::slice::from_raw_parts_mut(a, nx as usize * ny as usize);
         let output = core::slice::from_raw_parts_mut(output, *nbytes as usize);
 
         fits_hcompress64_safe(a, ny, nx, scale, output, nbytes, status)
@@ -117,24 +157,50 @@ pub unsafe extern "C" fn fits_hcompress64(
 /// the usual FITS notation.  ny is the fastest varying dimension, which is
 /// usually considered the X axis in the FITS image display
 pub fn fits_hcompress64_safe(
-    _a: &[LONGLONG],
-    _ny: c_int,
-    _nx: c_int,
-    _scale: c_int,
-    _output: &mut [c_char],
-    _nbytes: &mut c_long,
-    _status: &mut c_int,
+    a: &mut [LONGLONG],
+    ny: c_int,
+    nx: c_int,
+    scale: c_int,
+    output: &mut [c_char],
+    nbytes: &mut c_long,
+    status: &mut c_int,
 ) -> c_int {
-    todo!();
+    if *status > 0 {
+        return *status;
+    }
+
+    /* As above: HCEncoder::write64() is the C's htrans64() + digitize64() +
+    encode64(), and it carries its own state so FFLOCK/FFUNLOCK is moot. */
+
+    /* noutmax = *nbytes;  input value is the allocated size of the array */
+    let noutmax = (*nbytes as usize).min(output.len());
+    *nbytes = 0; /* reset */
+
+    /* DEVIATION: see fits_hcompress_safe -- the crate cannot report a full
+    sink, so the C's "output buffer too small" check is done here instead. */
+    let mut buf: Vec<u8> = Vec::with_capacity(noutmax);
+
+    /* H-transform, digitize, then encode and write to the output array */
+    let stat = HCEncoder::new(&mut buf).write64(a, ny as usize, nx as usize, scale);
+
+    if stat.is_err() || buf.len() > noutmax {
+        *status = DATA_COMPRESSION_ERR;
+        return *status;
+    }
+
+    cast_slice_mut(&mut output[..buf.len()]).copy_from_slice(&buf);
+    *nbytes = buf.len() as c_long;
+
+    *status
 }
 
 /// Tests ported from cfitsio's test_hcompress.c
 ///
 /// rsfitsio delegates H-compress to the external `hcompress` crate
-/// (`HCEncoder`/`HCDecoder`), which is what `imcompress` drives internally (the
-/// `fits_hcompress_safe`/`fits_hdecompress_safe` shims in this file are unused
-/// stubs). The original C test exercised `fits_hcompress`/`fits_hdecompress`
-/// directly; here we drive the same round-trips through the crate API.
+/// (`HCEncoder`/`HCDecoder`), which is what `imcompress` drives internally and
+/// what `fits_hcompress_safe`/`fits_hdecompress_safe` are written against. Most
+/// of these tests drive the crate API directly, mirroring the C test's
+/// round-trips; `test_hcompress_safe_*` go through the `_safe` wrappers instead.
 ///
 /// NOTE: like the C API, `HCEncoder::write` takes the dimensions in `(ny, nx)`
 /// order and modifies its input array in place, and `HCDecoder::read` returns
@@ -144,7 +210,10 @@ mod tests {
     use hcompress::read::HCDecoder;
     use hcompress::write::HCEncoder;
 
-    use crate::fitsio::LONGLONG;
+    use super::{fits_hcompress_safe, fits_hcompress64_safe};
+    use crate::c_types::{c_char, c_int, c_long};
+    use crate::fits_hdecompress::{fits_hdecompress_safe, fits_hdecompress64_safe};
+    use crate::fitsio::{DATA_COMPRESSION_ERR, LONGLONG};
 
     /// Compress `original` (32-bit) losslessly-or-lossily, then decompress.
     /// Returns the decompressed image and the `(nx, ny)` reported by the decoder.
@@ -383,5 +452,152 @@ mod tests {
             .map(|i| ((i % nx) * 100 + (i / nx) * 10) as i64)
             .collect();
         let (_rnx, _rny) = roundtrip64(&original, nx, ny, 8, 1);
+    }
+
+    /* ---- round-trips through the `_safe` wrappers themselves ---- */
+
+    /// `fits_hcompress_safe` -> `fits_hdecompress_safe`, lossless.
+    #[test]
+    fn test_hcompress_safe_roundtrip() {
+        let nx: c_int = 17;
+        let ny: c_int = 19;
+        let original: Vec<c_int> = (0..(nx * ny)).map(|i| (i * 7) % 500).collect();
+
+        let mut a = original.clone(); // compression works in place
+        let mut output = vec![0 as c_char; 4 * original.len() + 1024];
+        let mut nbytes = output.len() as c_long;
+        let mut status: c_int = 0;
+
+        fits_hcompress_safe(&mut a, ny, nx, 0, &mut output, &mut nbytes, &mut status);
+        assert_eq!(status, 0);
+        assert!(nbytes > 0 && (nbytes as usize) <= output.len());
+
+        let input: Vec<u8> = output[..nbytes as usize].iter().map(|&c| c as u8).collect();
+        let mut decompressed = vec![0 as c_int; original.len()];
+        let (mut rny, mut rnx, mut rscale) = (0, 0, 0);
+
+        fits_hdecompress_safe(
+            &input,
+            0,
+            &mut decompressed,
+            original.len() as c_int,
+            &mut rny,
+            &mut rnx,
+            &mut rscale,
+            &mut status,
+        );
+        assert_eq!(status, 0);
+        assert_eq!(rnx, nx);
+        assert_eq!(rny, ny);
+        assert_eq!(rscale, 0);
+        assert_eq!(decompressed, original);
+    }
+
+    /// The 64-bit pair. `fits_hdecompress64_safe` packs the I*8 result back
+    /// into an I*4 array in place, as the C does.
+    #[test]
+    fn test_hcompress64_safe_roundtrip() {
+        let nx: c_int = 16;
+        let ny: c_int = 16;
+        let nval = (nx * ny) as usize;
+        let original: Vec<LONGLONG> = (0..nval as LONGLONG).map(|i| i * 13 + 100).collect();
+
+        let mut a = original.clone();
+        let mut output = vec![0 as c_char; 8 * nval + 1024];
+        let mut nbytes = output.len() as c_long;
+        let mut status: c_int = 0;
+
+        fits_hcompress64_safe(&mut a, ny, nx, 0, &mut output, &mut nbytes, &mut status);
+        assert_eq!(status, 0);
+        assert!(nbytes > 0);
+
+        let input: Vec<u8> = output[..nbytes as usize].iter().map(|&c| c as u8).collect();
+        let mut decompressed = vec![0 as LONGLONG; nval];
+        let (mut rny, mut rnx, mut rscale) = (0, 0, 0);
+
+        fits_hdecompress64_safe(
+            &input,
+            0,
+            &mut decompressed,
+            nval as c_int,
+            &mut rny,
+            &mut rnx,
+            &mut rscale,
+            &mut status,
+        );
+        assert_eq!(status, 0);
+        assert_eq!(rnx, nx);
+        assert_eq!(rny, ny);
+
+        /* the values come back packed as I*4 in the first half of the array */
+        let packed: &[c_int] = bytemuck::cast_slice(&decompressed);
+        let got: Vec<LONGLONG> = packed[..nval].iter().map(|&v| v as LONGLONG).collect();
+        assert_eq!(got, original);
+    }
+
+    /// A non-zero input status is passed straight through, untouched.
+    #[test]
+    fn test_hcompress_safe_status_passthrough() {
+        let mut a = vec![0 as c_int; 16];
+        let mut output = vec![0 as c_char; 256];
+        let mut nbytes = output.len() as c_long;
+        let mut status: c_int = 104;
+
+        assert_eq!(
+            fits_hcompress_safe(&mut a, 4, 4, 0, &mut output, &mut nbytes, &mut status),
+            104
+        );
+        assert_eq!(nbytes, 256); /* not reset */
+
+        let mut decompressed = vec![0 as c_int; 16];
+        let (mut rny, mut rnx, mut rscale) = (0, 0, 0);
+        assert_eq!(
+            fits_hdecompress_safe(
+                &[],
+                0,
+                &mut decompressed,
+                16,
+                &mut rny,
+                &mut rnx,
+                &mut rscale,
+                &mut status
+            ),
+            104
+        );
+    }
+
+    /// An output buffer too small for the compressed stream reports
+    /// DATA_COMPRESSION_ERR, as the C's "encode: output buffer too small" does.
+    #[test]
+    fn test_hcompress_safe_buffer_too_small() {
+        let nx: c_int = 16;
+        let ny: c_int = 16;
+        let mut a: Vec<c_int> = (0..(nx * ny)).map(|i| (i * 977) % 65536).collect();
+        let mut output = vec![0 as c_char; 20];
+        let mut nbytes = output.len() as c_long;
+        let mut status: c_int = 0;
+
+        fits_hcompress_safe(&mut a, ny, nx, 0, &mut output, &mut nbytes, &mut status);
+        assert_eq!(status, DATA_COMPRESSION_ERR);
+    }
+
+    /// A truncated/garbage stream is rejected rather than panicking.
+    #[test]
+    fn test_hdecompress_safe_bad_stream() {
+        let mut decompressed = vec![0 as c_int; 256];
+        let (mut rny, mut rnx, mut rscale) = (0, 0, 0);
+        let mut status: c_int = 0;
+
+        fits_hdecompress_safe(
+            &[0xde, 0xad, 0xbe, 0xef],
+            0,
+            &mut decompressed,
+            256,
+            &mut rny,
+            &mut rnx,
+            &mut rscale,
+            &mut status,
+        );
+        assert_ne!(status, 0);
     }
 }

--- a/src/fits_hdecompress.rs
+++ b/src/fits_hdecompress.rs
@@ -1,23 +1,38 @@
+/* H-decompress routines */
+
+use hcompress::read::HCDecoder;
+
 use crate::c_types::{c_int, c_uchar};
 
-use crate::fitsio::{LONGLONG, NULL_MSG};
+use crate::fitsio::{DATA_DECOMPRESSION_ERR, LONGLONG, NULL_MSG};
 
 /* ---------------------------------------------------------------------- */
 /// Decompress the input byte stream using the H-compress algorithm
 ///
 /// input  - input array of compressed bytes
 /// a - pre-allocated array to hold the output uncompressed image
+/// na - number of integers allocated for a (eg, sizeof a / sizeof *a)
 /// nx - returned X axis size
 /// ny - returned Y axis size
 ///
 /// NOTE: the nx and ny dimensions as defined within this code are reversed from
 /// the usual FITS notation.  ny is the fastest varying dimension, which is
 /// usually considered the X axis in the FITS image display
+///
+/// # Safety
+///
+/// The C API gives no length for `input`, so this wrapper cannot derive one:
+/// the caller must guarantee that `input` points at a readable buffer of at
+/// least `na * 4 + HDRSIZE` bytes.  That is the largest stream a valid
+/// H-compressed `na`-pixel image can occupy, so a stream produced by
+/// `fits_hcompress` always fits.  Prefer [`fits_hdecompress_safe`], which takes
+/// the compressed stream as a slice and needs no such assumption.
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn fits_hdecompress(
     input: *const c_uchar,
     smooth: c_int,
     a: *mut c_int,
+    na: c_int,
     ny: *mut c_int,
     nx: *mut c_int,
     scale: *mut c_int,
@@ -29,18 +44,24 @@ pub unsafe extern "C" fn fits_hdecompress(
         let ny = ny.as_mut().expect(NULL_MSG);
         let scale = scale.as_mut().expect(NULL_MSG);
 
-        let a = core::slice::from_raw_parts_mut(a, 42);
-        let input = core::slice::from_raw_parts(input, 42);
+        let a = core::slice::from_raw_parts_mut(a, na as usize);
+        // SAFETY: bound documented above -- the C signature carries no input length.
+        let input = core::slice::from_raw_parts(input, na as usize * 4 + HDRSIZE);
 
-        fits_hdecompress_safe(input, smooth, a, ny, nx, scale, status)
+        fits_hdecompress_safe(input, smooth, a, na, ny, nx, scale, status)
     }
 }
+
+/// Size of the H-compress stream header (magic + nx + ny + scale), plus slack
+/// for the trailing quadtree/bit-plane bookkeeping.
+const HDRSIZE: usize = 1024;
 
 /* ---------------------------------------------------------------------- */
 /// Decompress the input byte stream using the H-compress algorithm
 ///
 /// input  - input array of compressed bytes
 /// a - pre-allocated array to hold the output uncompressed image
+/// na - number of integers allocated for a (eg, sizeof a / sizeof *a)
 /// nx - returned X axis size
 /// ny - returned Y axis size
 ///
@@ -48,15 +69,43 @@ pub unsafe extern "C" fn fits_hdecompress(
 /// the usual FITS notation.  ny is the fastest varying dimension, which is
 /// usually considered the X axis in the FITS image display
 pub fn fits_hdecompress_safe(
-    _input: &[c_uchar],
-    _smooth: c_int,
-    _a: &mut [c_int],
-    _ny: &mut c_int,
-    _nx: &mut c_int,
-    _scale: &mut c_int,
-    _status: &mut c_int,
+    input: &[c_uchar],
+    smooth: c_int,
+    a: &mut [c_int],
+    na: c_int,
+    ny: &mut c_int,
+    nx: &mut c_int,
+    scale: &mut c_int,
+    status: &mut c_int,
 ) -> c_int {
-    todo!();
+    if *status > 0 {
+        return *status;
+    }
+
+    /* decode the input array */
+
+    /* The C's decode() / undigitize() / hinv() are not in this crate -- they
+    live in the external `hcompress` crate, where HCDecoder::read() is exactly
+    that same sequence.  The C took FFLOCK around decode() because decode used
+    the `nextchar` global; the crate reads through a Cursor it owns, so no lock
+    is needed here. */
+    let na = (na as usize).min(a.len());
+
+    match HCDecoder::new().read(input, smooth, &mut a[..na]) {
+        Ok((rnx, rny, rscale)) => {
+            /* decode() returns the dimensions and the digitization scale */
+            *nx = rnx as c_int;
+            *ny = rny as c_int;
+            *scale = rscale;
+        }
+        Err(_) => {
+            /* every failure path in the C's decode()/hinv() returns
+            DATA_DECOMPRESSION_ERR */
+            *status = DATA_DECOMPRESSION_ERR;
+        }
+    }
+
+    *status
 }
 
 /* ---------------------------------------------------------------------- */
@@ -64,6 +113,7 @@ pub fn fits_hdecompress_safe(
 ///
 /// input  - input array of compressed bytes
 /// a - pre-allocated array to hold the output uncompressed image
+/// na - number of integers allocated for a (eg, sizeof a / sizeof *a)
 /// nx - returned X axis size
 /// ny - returned Y axis size
 ///
@@ -71,11 +121,16 @@ pub fn fits_hdecompress_safe(
 /// the usual FITS notation.  ny is the fastest varying dimension, which is
 /// usually considered the X axis in the FITS image display
 ///
+/// # Safety
+///
+/// As for [`fits_hdecompress`], the caller must guarantee `input` points at a
+/// readable buffer of at least `na * 8 + HDRSIZE` bytes.
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn fits_hdecompress64(
     input: *const c_uchar,
     smooth: c_int,
     a: *mut LONGLONG,
+    na: c_int,
     ny: *mut c_int,
     nx: *mut c_int,
     scale: *mut c_int,
@@ -87,10 +142,11 @@ pub unsafe extern "C" fn fits_hdecompress64(
         let ny = ny.as_mut().expect(NULL_MSG);
         let scale = scale.as_mut().expect(NULL_MSG);
 
-        let a = core::slice::from_raw_parts_mut(a, 42);
-        let input = core::slice::from_raw_parts(input, 42);
+        let a = core::slice::from_raw_parts_mut(a, na as usize);
+        // SAFETY: bound documented above -- the C signature carries no input length.
+        let input = core::slice::from_raw_parts(input, na as usize * 8 + HDRSIZE);
 
-        fits_hdecompress64_safe(input, smooth, a, ny, nx, scale, status)
+        fits_hdecompress64_safe(input, smooth, a, na, ny, nx, scale, status)
     }
 }
 
@@ -99,20 +155,46 @@ pub unsafe extern "C" fn fits_hdecompress64(
 ///
 /// input  - input array of compressed bytes
 /// a - pre-allocated array to hold the output uncompressed image
+/// na - number of integers allocated for a (eg, sizeof a / sizeof *a)
 /// nx - returned X axis size
 /// ny - returned Y axis size
 ///
 /// NOTE: the nx and ny dimensions as defined within this code are reversed from
 /// the usual FITS notation.  ny is the fastest varying dimension, which is
 /// usually considered the X axis in the FITS image display
+///
 pub fn fits_hdecompress64_safe(
-    _input: &[c_uchar],
-    _smooth: c_int,
-    _a: &mut [LONGLONG],
-    _ny: &mut c_int,
-    _nx: &mut c_int,
-    _scale: &mut c_int,
-    _status: &mut c_int,
+    input: &[c_uchar],
+    smooth: c_int,
+    a: &mut [LONGLONG],
+    na: c_int,
+    ny: &mut c_int,
+    nx: &mut c_int,
+    scale: &mut c_int,
+    status: &mut c_int,
 ) -> c_int {
-    todo!();
+    if *status > 0 {
+        return *status;
+    }
+
+    /* decode the input array */
+
+    /* HCDecoder::read64() is the C's decode64() + undigitize64() + hinv64(),
+    and it also performs the C's trailing "pack the I*8 values back into an I*4
+    array" loop, so there is nothing left to do here.  As above, the C's FFLOCK
+    guarded decode64's `nextchar` global, which the crate does not have. */
+    let na = (na as usize).min(a.len());
+
+    match HCDecoder::new().read64(input, smooth, &mut a[..na]) {
+        Ok((rnx, rny, rscale)) => {
+            *nx = rnx as c_int;
+            *ny = rny as c_int;
+            *scale = rscale;
+        }
+        Err(_) => {
+            *status = DATA_DECOMPRESSION_ERR;
+        }
+    }
+
+    *status
 }


### PR DESCRIPTION
## Transpile `fits_hcompress` / `fits_hdecompress`

The C bodies call `htrans`/`digitize`/`encode` and `decode`/`undigitize`/`hinv`,
statics that aren't in this repo — they live in the external `hcompress` crate,
where `HCEncoder::write` is exactly `htrans` + `digitize` + `encode` and
`HCDecoder::read` is `decode` + `undigitize` + `hinv`. `read64` also performs the
C's trailing I*8 → I*4 repack, so `fits_hdecompress64_safe` has nothing left to do
after it. The `FFLOCK`/`FFUNLOCK` pairs guarded C file-scope globals (`noutmax`,
the bit buffer, `nextchar`) that the crate keeps in the encoder/`Cursor`, so
they're dropped with a note.

Stub signatures fixed along the way:

- `a` is now `&mut` in both compress routines — the H-transform overwrites it in
  place, matching the C's non-`const int *a`.
- Both decompress routines gain the `na` parameter that `fitsio.h` declares. It
  was previously stood in for by a hardcoded slice length of 42.

One deviation: the crate's encoder discards its sink's `io::Error`s
(`let _ = write_all(..)`), so writing straight into `output` truncates silently
instead of raising the C's `encode: output buffer too small`. It now encodes into
a `Vec` and enforces the caller's buffer size, so callers still get
`DATA_COMPRESSION_ERR`. Marked `DEVIATION` in both bodies.

Adds five tests driving the `_safe` entry points end-to-end.

`fits_hdecompress`'s C signature carries no length for `input`, so the extern
wrapper can't derive one; it's documented as a `# Safety` precondition pointing
callers at the `_safe` form, rather than guessing silently.

## Refresh cfileio's stale `todo!()` notes

`ffexist_safer` and `ffextn_safer` are both implemented now, so three comments
claiming otherwise are out of date. `test_ffdelt` also verifies the deletion with
`fits_file_exists`, as the C's `test_ffdelt` does, rather than reaching for
`std::fs`.

`test_ffihtps` gets the body from the C test. `ffihtps`/`ffchtps` are still
`todo!()`, so it stays ignored — asserting the C's `status == 0` additionally
needs their return type corrected to `c_int`, since `fitsio.h` declares them
`int` but the stubs return `()`.

Full suite green.