### PR TITLE
Replace Box<FITSfile> with a shared handle

### DIFF
--- a/src/buffers.rs
+++ b/src/buffers.rs
@@ -194,7 +194,7 @@ pub(crate) fn ffpbyt(
             /* read next record */
 
             ffread_int(&mut fptr.Fptr, IOBUFLEN as usize, nbuff, status);
-            // ffread(fptr.Fptr.as_mut(), IOBUFLEN, tmp, status);
+            // ffread(fptr.Fptr.as_ptr(), IOBUFLEN, tmp, status);
             fptr.Fptr.io_pos += IOBUFLEN;
         }
 
@@ -227,7 +227,8 @@ pub(crate) fn ffpbyt(
             ntodo -= nwrite; /* decrement remaining number of bytes */
             j += nwrite as usize;
             fptr.Fptr.bytepos += nwrite; /* increment file position pointer */
-            fptr.Fptr.dirty[fptr.Fptr.curbuf as usize] = TRUE as c_int; /* mark record as modified */
+            let curbuf = fptr.Fptr.curbuf as usize;
+            fptr.Fptr.dirty[curbuf] = TRUE as c_int; /* mark record as modified */
             if ntodo != 0 {
                 /* load next record into a buffer */
                 ffldrc(

--- a/src/cfileio.rs
+++ b/src/cfileio.rs
@@ -318,7 +318,7 @@ pub fn ffomem_safer(
 
     let f_fitsfile = box_try_new(fitsfile {
         HDUposition: 0,
-        Fptr,
+        Fptr: FptrRef::new(Fptr),
     });
 
     if f_fitsfile.is_err() {
@@ -334,7 +334,7 @@ pub fn ffomem_safer(
 
     ffldrc(&mut f_fitsfile, 0, REPORT_EOF, status); /* load first record */
 
-    fits_store_Fptr(&mut f_fitsfile.Fptr, status); /* store Fptr address */
+    fits_store_Fptr(f_fitsfile.Fptr.as_ptr(), status); /* store Fptr address */
 
     if ffrhdu_safe(&mut f_fitsfile, Some(&mut hdutyp), status) > 0 {
         /* determine HDU structure */
@@ -1210,7 +1210,7 @@ pub fn ffopen_safe(
             /* allocate fitsfile structure and initialize = 0 */
             let f_fitsfile = box_try_new(fitsfile {
                 HDUposition: 0,
-                Fptr,
+                Fptr: FptrRef::new(Fptr),
             });
 
             if f_fitsfile.is_err() {
@@ -1228,7 +1228,7 @@ pub fn ffopen_safe(
 
             ffldrc(&mut f_fitsfile, 0, REPORT_EOF, status); /* load first record */
 
-            fits_store_Fptr(&mut f_fitsfile.Fptr, status); /* store Fptr address */
+            fits_store_Fptr(f_fitsfile.Fptr.as_ptr(), status); /* store Fptr address */
 
             if ffrhdu_safe(&mut f_fitsfile, Some(&mut hdutyp), status) > 0 {
                 /* determine HDU structure */
@@ -1860,7 +1860,7 @@ pub fn ffreopen_safer(
     // HEAP ALLOCATION
     let mut n = Box::new(fitsfile {
         HDUposition: 0, /* set initial position to primary array */
-        Fptr: unsafe { Box::from_raw(core::ptr::from_mut::<FITSfile>(&mut *openfptr.Fptr)) }, /* both point to the same structure */ // TODO this is very unsafe!
+        Fptr: openfptr.Fptr.share(), /* both point to the same structure */
     });
 
     n.Fptr.open_count += 1; /* increment the file usage counter */
@@ -1872,8 +1872,11 @@ pub fn ffreopen_safer(
 
 /*--------------------------------------------------------------------------*/
 /// store the new Fptr address for future use by fits_already_open
+/// Takes the address rather than a `&mut FITSfile`: the table has to hold the
+/// same pointer the handles deref through, not a reference-derived child of it,
+/// or the entry is invalidated by the next write through any handle.
 pub(crate) fn fits_store_Fptr(
-    Fptr: &mut FITSfile, /* O - FITS file pointer               */
+    Fptr: *mut FITSfile, /* O - FITS file pointer               */
     status: &mut c_int,  /* IO - error status                   */
 ) -> c_int {
     if *status > 0 {
@@ -1918,7 +1921,7 @@ pub unsafe extern "C" fn fits_clear_Fptr(
 /*--------------------------------------------------------------------------*/
 ///  clear the Fptr address from the Fptr Table  
 fn fits_clear_Fptr_safer(
-    Fptr: &mut FITSfile, /* O - FITS file pointer               */
+    Fptr: *mut FITSfile, /* O - FITS file pointer               */
     status: &mut c_int,  /* IO - error status                   */
 ) -> c_int {
     let lock = FFLOCK();
@@ -2130,7 +2133,7 @@ pub(crate) fn fits_already_open(
             // HEAP ALLOCATION
             let f = box_try_new(fitsfile {
                 HDUposition: 0,               /* set initial position */
-                Fptr: Box::from_raw(oldFptr), /* point to the structure */
+                Fptr: FptrRef::from_ptr(oldFptr), /* point to the structure */
             });
 
             if f.is_err() {
@@ -5421,7 +5424,7 @@ pub fn ffinit_safe(
     /* allocate fitsfile structure and initialize = 0 */
     let f_fitsfile = box_try_new(fitsfile {
         HDUposition: 0,
-        Fptr,
+        Fptr: FptrRef::new(Fptr),
     });
 
     if f_fitsfile.is_err() {
@@ -5437,7 +5440,7 @@ pub fn ffinit_safe(
 
     ffldrc(&mut f_fitsfile, 0, IGNORE_EOF, status); /* initialize first record */
 
-    fits_store_Fptr(&mut f_fitsfile.Fptr, status); /* store Fptr address */
+    fits_store_Fptr(f_fitsfile.Fptr.as_ptr(), status); /* store Fptr address */
 
     /* if template file was given, use it to define structure of new file */
 
@@ -5579,7 +5582,7 @@ pub fn ffimem_safer(
 
     let f_fitsfile = box_try_new(fitsfile {
         HDUposition: 0,
-        Fptr,
+        Fptr: FptrRef::new(Fptr),
     });
 
     if f_fitsfile.is_err() {
@@ -5593,7 +5596,7 @@ pub fn ffimem_safer(
     let mut f_fitsfile = f_fitsfile.unwrap();
 
     ffldrc(&mut f_fitsfile, 0, IGNORE_EOF, status); /* initialize first record */
-    fits_store_Fptr(&mut f_fitsfile.Fptr, status); /* store Fptr address */
+    fits_store_Fptr(f_fitsfile.Fptr.as_ptr(), status); /* store Fptr address */
 
     *fptr = Some(f_fitsfile);
 
@@ -9012,9 +9015,12 @@ pub fn ffclos_safe(mut fptr: Box<fitsfile>, status: &mut c_int) -> c_int {
             ffpmsg_cstr(fptr.Fptr.get_filename_as_cstr());
         };
 
-        fits_clear_Fptr_safer(&mut fptr.Fptr, status); /* clear Fptr address */
+        fits_clear_Fptr_safer(fptr.Fptr.as_ptr(), status); /* clear Fptr address */
 
-        drop(fptr);
+        /* Last handle: release the FITSfile itself. FptrRef is a non-owning
+           handle, so this is the one place that frees it. */
+        let fitsfile { HDUposition: _, Fptr } = *fptr;
+        unsafe { Fptr.free() };
     } else {
         /*
            to minimize the fallout from any previous error (e.g., trying to
@@ -9029,13 +9035,10 @@ pub fn ffclos_safe(mut fptr: Box<fitsfile>, status: &mut c_int) -> c_int {
             ffflsh_safe(&mut fptr, false, status);
         }
 
-        // WARNING: In the C version of this code, the inner FITSfile can be shared many times
-        // and as such, given the open_count > 0, the inner FITSfile is not dropped.
-        // To replicate this, we need to deconstruct the fitsfile struct and
-        // drop the inner FITSfile struct, but not the outer one.
-
-        let fitsfile { HDUposition, Fptr } = *fptr;
-        let _ = Box::into_raw(Fptr); // WARNING: Dangling pointer
+        /* Other handles still refer to this FITSfile, so only the outer
+           fitsfile goes away. Dropping the FptrRef is a no-op, which is why
+           this no longer has to leak a Box to avoid a double free. */
+        drop(fptr);
     }
     *status
 }
@@ -9141,10 +9144,17 @@ pub fn ffdelt_safe(
         }
     }
 
-    fits_clear_Fptr_safer(&mut local_fptr.Fptr, status); /* clear Fptr address */
+    fits_clear_Fptr_safer(local_fptr.Fptr.as_ptr(), status); /* clear Fptr address */
     local_fptr.Fptr.validcode = 0; /* magic value to indicate invalid fptr */
 
-    *fptr = None;
+    /* Release the FITSfile. ffdelt deletes the file outright, so unlike ffclos
+       there is no use count to consult; the C frees it here unconditionally.
+       FptrRef is a non-owning handle, so dropping the outer fitsfile below is
+       not enough on its own. */
+    if let Some(f) = fptr.take() {
+        let fitsfile { HDUposition: _, Fptr } = *f;
+        unsafe { Fptr.free() };
+    }
 
     *status
 }

--- a/src/editcol.rs
+++ b/src/editcol.rs
@@ -2324,7 +2324,7 @@ pub fn ffcpcl_safe(
             return *status;
         }
 
-        if core::ptr::eq(infptr.Fptr.as_mut(), outfptr.Fptr.as_mut())
+        if core::ptr::eq(infptr.Fptr.as_ptr(), outfptr.Fptr.as_ptr())
             && (infptr.HDUposition == outfptr.HDUposition)
             && (colnum <= incol)
         {
@@ -2823,7 +2823,7 @@ pub fn ffccls_safe(
 
     /* Do not allow copying multiple columns in the same HDU because the
     permutations of possible overlapping copies is mind-bending */
-    if core::ptr::eq(infptr.Fptr.as_mut(), outfptr.Fptr.as_mut())
+    if core::ptr::eq(infptr.Fptr.as_ptr(), outfptr.Fptr.as_ptr())
         && (infptr.HDUposition == outfptr.HDUposition)
     {
         ffpmsg_str("Copying multiple columns in same HDU is not supported (ffccls)");

--- a/src/edithdu.rs
+++ b/src/edithdu.rs
@@ -521,11 +521,8 @@ pub fn ffcpdt_safe(
     nb = ((indataend - indatastart) / IOBUFLEN) as c_long;
 
     if nb > 0 {
-        if core::ptr::eq(infptr.Fptr.as_mut(), outfptr.Fptr.as_mut()) {
+        if core::ptr::eq(infptr.Fptr.as_ptr(), outfptr.Fptr.as_ptr()) {
             /* copying between 2 HDUs in the SAME file */
-            unreachable!(
-                "Above ptr comparison prevents us from landing here. Matching original code"
-            );
             for _ii in 0..(nb as usize) {
                 ffmbyt_safe(infptr, indatastart, REPORT_EOF, status);
                 ffgbyt(infptr, IOBUFLEN, cast_slice_mut(&mut buffer), status); /* read input block */

--- a/src/fitsio.rs
+++ b/src/fitsio.rs
@@ -6,6 +6,8 @@ use bytemuck::{cast_slice, cast_slice_mut};
 use core::{
     cmp,
     ffi::{CStr, c_char, c_int, c_long, c_longlong},
+    ops::{Deref, DerefMut},
+    ptr,
 };
 use std::os::raw::c_void;
 
@@ -1072,6 +1074,85 @@ impl Drop for FITSfile {
     }
 }
 
+/// Handle to a [`FITSfile`], which several [`fitsfile`]s may share.
+///
+/// CFITSIO lets more than one `fitsfile` refer to the same `FITSfile`, keeping
+/// a use count in its `open_count` field. `Box` cannot express that: two live
+/// `Box`es to one allocation is aliasing UB, and because `Box` is `noalias`
+/// every write through one invalidates pointers derived from the other, which
+/// is what invalidated the entries in `FPTR_TABLE`.
+///
+/// This is a non-owning handle. Exactly one place frees the `FITSfile`:
+/// `ffclos`, once `open_count` reaches zero. There is deliberately no `Drop`
+/// impl, because closing has to flush and close the driver before the free and
+/// a refcount-on-drop would fight the decrement already done there.
+///
+/// `#[repr(transparent)]` over a `NonNull`, so the layout is a single non-null
+/// pointer exactly as `Box<FITSfile>` was and `fitsfile` keeps its C ABI.
+#[repr(transparent)]
+pub struct FptrRef(ptr::NonNull<FITSfile>);
+
+impl FptrRef {
+    /// Allocate a new `FITSfile` and take the first handle to it.
+    pub fn new(f: Box<FITSfile>) -> Self {
+        // SAFETY: Box::into_raw never returns null.
+        FptrRef(unsafe { ptr::NonNull::new_unchecked(Box::into_raw(f)) })
+    }
+
+    /// Another handle to the same `FITSfile`.
+    ///
+    /// The caller is responsible for the `open_count` bookkeeping.
+    pub fn share(&self) -> Self {
+        FptrRef(self.0)
+    }
+
+    /// The address of the `FITSfile`.
+    ///
+    /// Callers that stash this (`FPTR_TABLE`) get the same pointer this handle
+    /// derefs through, not a reference-derived child of it, so it stays valid
+    /// across writes made through any handle.
+    pub fn as_ptr(&self) -> *mut FITSfile {
+        self.0.as_ptr()
+    }
+
+    /// Build a handle from a pointer obtained from [`FptrRef::as_ptr`].
+    ///
+    /// # Safety
+    /// `p` must be non-null and point to a live `FITSfile`.
+    pub unsafe fn from_ptr(p: *mut FITSfile) -> Self {
+        FptrRef(unsafe { ptr::NonNull::new_unchecked(p) })
+    }
+
+    /// Free the `FITSfile`. Only valid once `open_count` has reached zero and
+    /// no other handle remains.
+    ///
+    /// # Safety
+    /// No other `FptrRef` to this `FITSfile` may be used afterwards.
+    pub unsafe fn free(self) {
+        drop(unsafe { Box::from_raw(self.0.as_ptr()) });
+    }
+}
+
+impl Deref for FptrRef {
+    type Target = FITSfile;
+
+    fn deref(&self) -> &FITSfile {
+        // SAFETY: the FITSfile outlives every handle to it; see `free`.
+        unsafe { self.0.as_ref() }
+    }
+}
+
+impl DerefMut for FptrRef {
+    fn deref_mut(&mut self) -> &mut FITSfile {
+        // SAFETY: as above.
+        unsafe { self.0.as_mut() }
+    }
+}
+
+// SAFETY: matches the Send/Sync story Box<FITSfile> had; the handle adds no
+// interior mutability of its own.
+unsafe impl Send for FptrRef {}
+
 #[repr(C)]
 /// Structure used to store basic HDU information
 pub struct fitsfile {
@@ -1079,7 +1160,7 @@ pub struct fitsfile {
     pub HDUposition: c_int,
 
     /// Pointer to FITS file structure
-    pub Fptr: Box<FITSfile>,
+    pub Fptr: FptrRef,
 }
 
 /// Do not change this as it is part of the public API

--- a/src/group.rs
+++ b/src/group.rs
@@ -1774,10 +1774,10 @@ pub fn ffgtam_safe(
     status: &mut c_int, /* return status code                          */
 ) -> c_int {
     /* SPR 3463: consolidates the repeated "are the member and grouping-table
-    files the same?" test. In this port each fitsfile owns a distinct
-    Box<FITSfile>, so the Fptr pointers are never equal even for the same
-    physical file; the rootname comparison is the effective test (matches the
-    C's combined `(tmpfptr->Fptr != gfptr->Fptr) && strncmp(rootnames)`). */
+    files the same?" test, matching the C's combined
+    `(tmpfptr->Fptr != gfptr->Fptr) && strncmp(rootnames)`. Handles that share a
+    FITSfile now compare equal by address, so the first half of the test is
+    effective rather than always true. */
     fn files_differ(tmpfptr: &fitsfile, gfptr: &fitsfile, status: &mut c_int) -> bool {
         let mut tmprootname: [c_char; FLEN_FILENAME] = [0; FLEN_FILENAME];
         let mut grootname: [c_char; FLEN_FILENAME] = [0; FLEN_FILENAME];
@@ -1792,7 +1792,7 @@ pub fn ffgtam_safe(
             fits_parse_rootname(gfn, &mut grootname, status);
         }
 
-        let same_fptr = core::ptr::eq(tmpfptr.Fptr.as_ref(), gfptr.Fptr.as_ref());
+        let same_fptr = core::ptr::eq(tmpfptr.Fptr.as_ptr(), gfptr.Fptr.as_ptr());
         !same_fptr && strncmp_safe(&tmprootname, &grootname, FLEN_FILENAME) != 0
     }
 
@@ -4148,13 +4148,11 @@ pub fn ffgmrm_safe(
                     fits_parse_rootname(gfn, &mut grootname, status);
                 }
 
-                /* In this port each fitsfile owns a distinct Box<FITSfile>, so the
-                Fptr pointers are never equal even for the same physical file; the
-                rootname comparison is the effective test (matches the C's combined
-                condition). */
+                /* The C's combined condition: same FITSfile by address, or
+                failing that the same rootname. */
                 let same_fptr = core::ptr::eq(
-                    mfptr.as_deref().expect(NULL_MSG).Fptr.as_ref(),
-                    gfptr.Fptr.as_ref(),
+                    mfptr.as_deref().expect(NULL_MSG).Fptr.as_ptr(),
+                    gfptr.Fptr.as_ptr(),
                 );
                 if !same_fptr && strncmp_safe(&mrootname, &grootname, FLEN_FILENAME) != 0 {
                     groupExtver = -groupExtver;


### PR DESCRIPTION
Stage 1 of the Fptr ownership work: a mechanical soundness fix, no behaviour change intended.

CFITSIO lets several `fitsfile` handles refer to one `FITSfile`, counted by `open_count`. `Box` cannot express that, so the code faked it — it built a second `Box` over an existing `FITSfile` (`// TODO this is very unsafe!`) and then leaked one with `Box::into_raw` to dodge the double free. Two live `Box`es to one allocation is aliasing UB, and because `Box` is `noalias` every write through one invalidated pointers derived from the other, which is what invalidated the `FPTR_TABLE` entries (20 tests).

`FptrRef` is a non-owning handle, `repr(transparent)` over a `NonNull` so `fitsfile` keeps its C ABI, with `Deref`/`DerefMut` so all ~1800 `.Fptr` field accesses are unchanged — no signature took `Box<FITSfile>` by value. Sharing is `share()`. The `FITSfile` is freed in exactly two places: `ffclos` once `open_count` reaches zero, and `ffdelt`, which deletes outright. The `into_raw` leak is gone, because dropping a non-owning handle is a no-op by construction.

`FPTR_TABLE` now stores `Fptr.as_ptr()` — the same pointer the handles deref through, rather than a pointer derived from a `&mut` borrow that died on the next write.

Two latent bugs fall out, both from comments that assumed handles could never share a `FITSfile`:

- `ffcpdt_safe` had an `unreachable!()` on its same-file branch. Handles from `fits_reopen_file` do share an `Fptr`, so that branch is live and this panicked instead of copying between two HDUs in the same file.
- The `group.rs` identity tests were documented as always-false. They were written as the C's combined condition so they stayed correct, but the address comparison is now effective rather than decorative. Comments corrected, logic untouched.

Comparing two handles no longer takes `&mut` just to read an address, which was itself an aliasing hazard when both sides were the same `FITSfile`.

Verified: `test_copy_image2cell_rejects_non_table_output` — the test that pinned the `FPTR_TABLE` UB — passes under Miri, along with the open/close and delete paths at 0 UB and 0 leaks. Suite green (35 binaries), clippy clean.

Removing `Box`'s `Drop` did leak the `FITSfile` in `ffdelt`, which frees via `*fptr = None` rather than going through `ffclos`; Miri caught it and `ffdelt` now frees explicitly. Other paths that drop a `fitsfile` outside those two would leak the same way, so that is the thing worth a careful look in review.

Not in scope: making `fits_already_open` actually share (stage 2), which would let the `group.rs` rootname fallback revert to the C's pointer-identity test.