### PR TITLE
Move the parser's iterator columns out of ParseData (option A)

### DIFF
--- a/src/eval_defs.rs
+++ b/src/eval_defs.rs
@@ -346,7 +346,7 @@ impl lval {
 #[derive(Default, Debug, Clone)]
 pub(crate) struct Node {
     pub operation: c_int,
-    pub DoOp: Option<fn(p: &mut ParseData, this_node_idx: usize)>,
+    pub DoOp: Option<fn(p: &mut ParseData, colData: &mut [iteratorCol], this_node_idx: usize)>,
     pub nSubNodes: c_int,
     pub SubNodes: [usize; MAXSUBS as usize],
     pub ntype: ValueSort,
@@ -397,12 +397,17 @@ impl Node {
 }
 
 /// Fetches a single named value for the parser (ffcalc's keyword lookup).
-pub(crate) type GetDataFn =
-    fn(p: &mut ParseData, dataName: &[c_char], dataValue: &mut FITS_PARSER_YYSTYPE) -> c_int;
+pub(crate) type GetDataFn = fn(
+    p: &mut ParseData,
+    colData: &mut Vec<iteratorCol>,
+    dataName: &[c_char],
+    dataValue: &mut FITS_PARSER_YYSTYPE,
+) -> c_int;
 
 /// Loads a row range of one parser variable into the caller's buffers.
 pub(crate) type LoadDataFn = fn(
     p: &mut ParseData,
+    colData: &mut [iteratorCol],
     varNum: c_int,
     fRow: c_long,
     nRows: c_long,
@@ -410,6 +415,16 @@ pub(crate) type LoadDataFn = fn(
     undef: *mut c_char,
 ) -> c_int;
 
+/// The parser's state, minus its iterator columns.
+///
+/// The C `ParseData` also held `iteratorCol *colData`. That array is the very
+/// array the iterator (`ffiter`) is handed and holds a `&mut [iteratorCol]`
+/// over for the whole of an iteration, while the work function reaches back
+/// into the `ParseData` through `parseInfo::parseData` -- two live `&mut`s
+/// over the same columns. So the array now lives beside the `ParseData`, owned
+/// by whoever set the parser up, and is threaded in as a separate argument:
+/// `&mut Vec<iteratorCol>` while parsing (`ffiprs`/`find_column` still grow
+/// it), `&mut [iteratorCol]` once the iterator owns it.
 #[derive(Default)]
 pub(crate) struct ParseData {
     pub def_fptr: *mut fitsfile,
@@ -434,7 +449,6 @@ pub(crate) struct ParseData {
     pub nElements: c_long,
     pub nAxis: c_int,
     pub nAxes: [c_long; MAXDIMS as usize],
-    pub colData: Vec<iteratorCol>, // This is a list
     pub varData: Vec<DataInfo>,
     pub pixFilter: *mut PixelFilter,
     pub firstDataRow: c_long,
@@ -470,7 +484,6 @@ impl ParseData {
         self.nElements = Default::default();
         self.nAxis = Default::default();
         self.nAxes = Default::default();
-        self.colData = Default::default();
         self.varData = Default::default();
         self.pixFilter = Default::default();
         self.firstDataRow = Default::default();

--- a/src/eval_f.rs
+++ b/src/eval_f.rs
@@ -178,6 +178,7 @@ pub fn fffrow_safe(
     let mut elem: c_long;
     let result: c_char;
     let mut lParse: ParseData = ParseData::default();
+    let mut colData: Vec<iteratorCol> = Vec::new();
 
     if *status != 0 {
         return *status;
@@ -195,10 +196,11 @@ pub fn fffrow_safe(
         &mut naxis,
         &mut naxes,
         &mut lParse,
+        &mut colData,
         status,
     ) != 0
     {
-        ffcprs(&mut lParse);
+        ffcprs(&mut lParse, &mut colData);
         return *status;
     }
 
@@ -210,7 +212,7 @@ pub fn fffrow_safe(
     }
 
     if Info.datatype != TLOGICAL || nelem != 1 {
-        ffcprs(&mut lParse);
+        ffcprs(&mut lParse, &mut colData);
         ffpmsg_str("Expression does not evaluate to a logical scalar.");
         *status = PARSE_BAD_TYPE;
         return *status;
@@ -231,7 +233,7 @@ pub fn fffrow_safe(
         Info.maxRows = nrows;
         Info.parseData = &raw mut lParse;
 
-        let colData_slice = &mut lParse.colData[..];
+        let colData_slice = &mut colData[..];
         if ffiter_safe(
             lParse.nCols,
             colData_slice,
@@ -265,7 +267,7 @@ pub fn fffrow_safe(
         }
     }
 
-    ffcprs(&mut lParse);
+    ffcprs(&mut lParse, &mut colData);
     *status
 }
 
@@ -340,6 +342,7 @@ pub fn ffsrow_safe(
     let mut outExt: in_out_ext = in_out_ext::default();
 
     let mut lParse: ParseData = ParseData::default();
+    let mut colData: Vec<iteratorCol> = Vec::new();
 
     unsafe {
         if *status != 0 {
@@ -356,10 +359,11 @@ pub fn ffsrow_safe(
             &mut naxis,
             &mut naxes,
             &mut lParse,
+            &mut colData,
             status,
         ) != 0
         {
-            ffcprs(&mut lParse);
+            ffcprs(&mut lParse, &mut colData);
             return *status;
         }
 
@@ -375,7 +379,7 @@ pub fn ffsrow_safe(
         /**********************************************************************/
 
         if Info.datatype != TLOGICAL || nelem != 1 {
-            ffcprs(&mut lParse);
+            ffcprs(&mut lParse, &mut colData);
             ffpmsg_str("Expression does not evaluate to a logical scalar.");
             *status = PARSE_BAD_TYPE;
             return *status;
@@ -389,7 +393,7 @@ pub fn ffsrow_safe(
             ffmahd_safe(infptr, (infptr.HDUposition) + 1, None, status);
         }
         if *status != 0 {
-            ffcprs(&mut lParse);
+            ffcprs(&mut lParse, &mut colData);
             return *status;
         }
         inExt.rowLength = (infptr.Fptr).rowlength as LONGLONG;
@@ -397,7 +401,7 @@ pub fn ffsrow_safe(
         inExt.heapSize = (infptr.Fptr).heapsize;
         if inExt.numRows == 0 {
             /* Nothing to copy */
-            ffcprs(&mut lParse);
+            ffcprs(&mut lParse, &mut colData);
             return *status;
         }
 
@@ -408,7 +412,7 @@ pub fn ffsrow_safe(
             ffrdef_safe(outfptr, status);
         }
         if *status != 0 {
-            ffcprs(&mut lParse);
+            ffcprs(&mut lParse, &mut colData);
             return *status;
         }
         outExt.rowLength = (outfptr.Fptr).rowlength as LONGLONG;
@@ -420,7 +424,7 @@ pub fn ffsrow_safe(
 
         if inExt.rowLength != outExt.rowLength {
             ffpmsg_str("Output table has different row length from input");
-            ffcprs(&mut lParse);
+            ffcprs(&mut lParse, &mut colData);
             *status = PARSE_BAD_OUTPUT;
             return *status;
         }
@@ -439,7 +443,7 @@ pub fn ffsrow_safe(
             .is_err()
         {
             ffpmsg_str("Unable to allocate memory for row selection");
-            ffcprs(&mut lParse);
+            ffcprs(&mut lParse, &mut colData);
             *status = MEMORY_ALLOCATION;
             return *status;
         }
@@ -461,7 +465,7 @@ pub fn ffsrow_safe(
             }
             nGood = if result != 0 { inExt.numRows } else { 0 } as c_long;
         } else {
-            let col_slice = &mut lParse.colData[..];
+            let col_slice = &mut colData[..];
             ffiter_safe(
                 lParse.nCols,
                 col_slice,
@@ -490,7 +494,7 @@ pub fn ffsrow_safe(
                 .try_reserve_exact(cmp::max(500000, rdlen) as usize)
                 .is_err()
             {
-                ffcprs(&mut lParse);
+                ffcprs(&mut lParse, &mut colData);
                 *status = MEMORY_ALLOCATION;
                 return *status;
             } else {
@@ -667,7 +671,7 @@ pub fn ffsrow_safe(
             } /*  End of HEAP copy  */
         }
 
-        ffcprs(&mut lParse);
+        ffcprs(&mut lParse, &mut colData);
 
         ffcmph_safe(outfptr, status); /* compress heap, deleting any orphaned data */
         *status
@@ -732,6 +736,7 @@ pub fn ffcrow_safe(
     let mut nelem1: c_long = 0;
     let mut naxes: [c_long; MAXDIMS as usize] = [0; MAXDIMS as usize];
     let mut lParse: ParseData = ParseData::default();
+    let mut colData: Vec<iteratorCol> = Vec::new();
 
     if *status != 0 {
         return *status;
@@ -747,10 +752,11 @@ pub fn ffcrow_safe(
         &mut naxis,
         &mut naxes,
         &mut lParse,
+        &mut colData,
         status,
     ) != 0
     {
-        ffcprs(&mut lParse);
+        ffcprs(&mut lParse, &mut colData);
         return *status;
     }
     if nelem1 < 0 {
@@ -758,7 +764,7 @@ pub fn ffcrow_safe(
     }
 
     if nelements < nelem1 {
-        ffcprs(&mut lParse);
+        ffcprs(&mut lParse, &mut colData);
         ffpmsg_str("Array not large enough to hold at least one row of data.");
         *status = PARSE_LRG_VECTOR;
         return *status;
@@ -775,7 +781,7 @@ pub fn ffcrow_safe(
     Info.maxRows = nelements / nelem1;
     Info.parseData = &raw mut lParse;
 
-    let colData_slice = &mut lParse.colData[..];
+    let colData_slice = &mut colData[..];
     if ffiter_safe(
         lParse.nCols,
         colData_slice,
@@ -790,7 +796,7 @@ pub fn ffcrow_safe(
     }
 
     *anynul = Info.anyNull;
-    ffcprs(&mut lParse);
+    ffcprs(&mut lParse, &mut colData);
     *status
 }
 
@@ -932,6 +938,7 @@ pub fn ffcalc_rng_safe(
     let mut nullKwd: [c_char; 9] = [0; 9];
     let mut tdimKwd: [c_char; 9] = [0; 9];
     let mut lParse: ParseData = ParseData::default();
+    let mut colData: Vec<iteratorCol> = Vec::new();
 
     let mut parInfo = parInfo;
     let mut parName = parName;
@@ -950,10 +957,11 @@ pub fn ffcalc_rng_safe(
         &mut naxis,
         &mut naxes,
         &mut lParse,
+        &mut colData,
         status,
     ) != 0
     {
-        ffcprs(&mut lParse);
+        ffcprs(&mut lParse, &mut colData);
         return *status;
     }
     if nelem < 0 {
@@ -978,7 +986,7 @@ pub fn ffcalc_rng_safe(
         *status = 0;
         if parName[0] == b'#' as c_char {
             if constant == 0 {
-                ffcprs(&mut lParse);
+                ffcprs(&mut lParse, &mut colData);
                 ffpmsg_str("Cannot put tabular result into keyword (ffcalc)");
                 *status = PARSE_BAD_TYPE;
                 return *status;
@@ -988,7 +996,7 @@ pub fn ffcalc_rng_safe(
                 || fits_strcasecmp(parName, cs!(c"COMMENT")) == 0)
                 && Info.datatype != TSTRING
             {
-                ffcprs(&mut lParse);
+                ffcprs(&mut lParse, &mut colData);
                 ffpmsg_str("HISTORY and COMMENT values must be strings (ffcalc)");
                 *status = PARSE_BAD_TYPE;
                 return *status;
@@ -999,7 +1007,7 @@ pub fn ffcalc_rng_safe(
             if ffgcrd_safe(outfptr, parName, &mut card, status) == KEY_NO_EXIST {
                 colNo = -1;
             } else if *status != 0 {
-                ffcprs(&mut lParse);
+                ffcprs(&mut lParse, &mut colData);
                 return *status;
             }
         } else {
@@ -1040,7 +1048,7 @@ pub fn ffcalc_rng_safe(
                 } else {
                     match Info.datatype {
                         TLOGICAL => {
-                            ffcprs(&mut lParse);
+                            ffcprs(&mut lParse, &mut colData);
                             ffpmsg_str("Cannot create LOGICAL column in ASCII table");
                             *status = NOT_BTABLE;
                             return *status;
@@ -1149,7 +1157,7 @@ pub fn ffcalc_rng_safe(
         if *status != 0 {
             /*  Either some other error happened in ffgcrd   */
             /*  or one happened in ffptdm                    */
-            ffcprs(&mut lParse);
+            ffcprs(&mut lParse, &mut colData);
             return *status;
         }
     }
@@ -1169,13 +1177,13 @@ pub fn ffcalc_rng_safe(
         /*************************************/
 
         col_cnt = lParse.nCols;
-        if fits_parser_allocateCol(&mut lParse, col_cnt, status) != 0 {
-            ffcprs(&mut lParse);
+        if fits_parser_allocateCol(&mut lParse, &mut colData, col_cnt, status) != 0 {
+            ffcprs(&mut lParse, &mut colData);
             return *status;
         }
 
         fits_iter_set_by_num_safe(
-            &mut lParse.colData[col_cnt as usize],
+            &mut colData[col_cnt as usize],
             outfptr,
             colNo,
             0,
@@ -1202,7 +1210,7 @@ pub fn ffcalc_rng_safe(
                 nPerLp = Info.maxRows as c_int;
             }
 
-            let colData_slice = &mut lParse.colData[..];
+            let colData_slice = &mut colData[..];
             if ffiter_safe(
                 lParse.nCols,
                 colData_slice,
@@ -1215,7 +1223,7 @@ pub fn ffcalc_rng_safe(
             {
                 *status = 0;
             } else if *status != 0 {
-                ffcprs(&mut lParse);
+                ffcprs(&mut lParse, &mut colData);
                 return *status;
             }
             if Info.anyNull != 0 {
@@ -1278,7 +1286,7 @@ pub fn ffcalc_rng_safe(
         }
     }
 
-    ffcprs(&mut lParse);
+    ffcprs(&mut lParse, &mut colData);
     *status
 }
 
@@ -1323,6 +1331,7 @@ pub fn fftexp_safe(
     status: &mut c_int,   /* O - Error status                        */
 ) -> c_int {
     let mut lParse: ParseData = ParseData::default();
+    let mut colData: Vec<iteratorCol> = Vec::new();
 
     ffiprs(
         fptr,
@@ -1334,9 +1343,10 @@ pub fn fftexp_safe(
         naxis,
         naxes,
         &mut lParse,
+        &mut colData,
         status,
     );
-    ffcprs(&mut lParse);
+    ffcprs(&mut lParse, &mut colData);
     *status
 }
 
@@ -1344,16 +1354,17 @@ pub fn fftexp_safe(
 /// Initialize the parser and determine what type of result the expression
 /// produces.
 pub(crate) fn ffiprs(
-    fptr: &mut fitsfile,    /* I - Input FITS file                     */
-    compressed: c_int,      /* I - Is FITS file hkunexpanded?          */
-    expr: &[c_char],        /* I - Arithmetic expression               */
-    maxdim: c_int,          /* I - Max Dimension of naxes              */
-    datatype: &mut c_int,   /* O - Data type of result                 */
-    nelem: &mut c_long,     /* O - Vector length of result             */
-    naxis: &mut c_int,      /* O - # of dimensions of result           */
-    naxes: &mut [c_long],   /* O - Size of each dimension              */
-    lParse: &mut ParseData, /* O - parser status                       */
-    status: &mut c_int,     /* O - Error status                        */
+    fptr: &mut fitsfile,            /* I - Input FITS file                     */
+    compressed: c_int,              /* I - Is FITS file hkunexpanded?          */
+    expr: &[c_char],                /* I - Arithmetic expression               */
+    maxdim: c_int,                  /* I - Max Dimension of naxes              */
+    datatype: &mut c_int,           /* O - Data type of result                 */
+    nelem: &mut c_long,             /* O - Vector length of result             */
+    naxis: &mut c_int,              /* O - # of dimensions of result           */
+    naxes: &mut [c_long],           /* O - Size of each dimension              */
+    lParse: &mut ParseData,         /* O - parser status                       */
+    colData: &mut Vec<iteratorCol>, /* O - parser iterator columns     */
+    status: &mut c_int,             /* O - Error status                        */
 ) -> c_int {
     let i: c_int = 0;
     let mut lexpr: c_int = 0;
@@ -1383,7 +1394,7 @@ pub(crate) fn ffiprs(
     lParse.def_fptr = fptr;
     lParse.compressed = compressed;
     lParse.nCols = 0;
-    lParse.colData = Vec::new();
+    colData.clear();
     lParse.varData = Vec::new();
     lParse.getData = Some(find_column);
     lParse.loadData = Some(load_column);
@@ -1476,7 +1487,7 @@ pub(crate) fn ffiprs(
 
     fits_parser_yylex_init(&mut yylex_scanner);
     fits_parser_yyrestart(ptr::null_mut(), yylex_scanner.as_deref_mut().unwrap());
-    *status = fits_parser_yyparse(yylex_scanner.as_deref_mut().unwrap(), lParse);
+    *status = fits_parser_yyparse(yylex_scanner.as_deref_mut().unwrap(), lParse, colData);
     fits_parser_yylex_destroy(yylex_scanner.unwrap());
 
     if *status != 0 {
@@ -1496,16 +1507,16 @@ pub(crate) fn ffiprs(
         return *status;
     }
     if lParse.nCols == 0 {
-        if lParse.colData.try_reserve_exact(1).is_err() {
+        if colData.try_reserve_exact(1).is_err() {
             ffpmsg_str("memory allocation failed (ffiprs)");
             *status = MEMORY_ALLOCATION;
             return *status;
         } else {
-            lParse.colData.resize(1, iteratorCol::default());
+            colData.resize(1, iteratorCol::default());
         }
 
         /* This allows iterator to know value of fptr when no columns are referenced   */
-        (lParse.colData[0]).fptr = fptr;
+        (colData[0]).fptr = fptr;
     }
 
     let result: &Node = &lParse.Nodes[lParse.resultNode as usize];
@@ -1552,7 +1563,7 @@ pub(crate) fn ffiprs(
 
 /*---------------------------------------------------------------------------*/
 /// Clear the parser, making it ready to accept a new expression.
-pub(crate) fn ffcprs(lParse: &mut ParseData) {
+pub(crate) fn ffcprs(lParse: &mut ParseData, colData: &mut Vec<iteratorCol>) {
     unsafe {
         let col: c_int = 0;
         let mut node: c_int = 0;
@@ -1563,7 +1574,7 @@ pub(crate) fn ffcprs(lParse: &mut ParseData) {
         }
 
         if lParse.nCols > 0 {
-            lParse.colData.clear();
+            colData.clear();
 
             for col in 0..lParse.nCols {
                 if lParse.varData[col as usize].undef.is_none() {
@@ -1580,9 +1591,9 @@ pub(crate) fn ffcprs(lParse: &mut ParseData) {
             }
             lParse.varData.clear();
             lParse.nCols = 0;
-        } else if !lParse.colData.is_empty() {
+        } else if !colData.is_empty() {
             /* Special case if colData needed to be created with no columns */
-            lParse.colData.clear();
+            colData.clear();
         }
 
         if lParse.nNodes > 0 {
@@ -1703,9 +1714,13 @@ pub(crate) fn fits_parser_workfn_safe(
             routines are binning multiple columns, and so there are
             multiple parsers being managed at one time.) Upon the first
             call we make sure they match */
-            for jj in 0..(nCols as usize) {
-                lParse.colData[jj].repeat = colData[jj].repeat;
-            }
+            /* The C's `lParse->colData[jj].repeat = colData[jj].repeat` loop
+            is gone: the parser no longer owns a second array. Everything
+            that runs under the iterator -- Setup_DataArrays, Evaluate_Parser
+            and load_column -- now reads the `colData` handed in here, which
+            for the histogramming routines is the index-aligned slice of the
+            master array the parser's columns were copied into. So the two
+            copies are already in step. */
 
             if (*(pv.userInfo)).maxRows > 0 {
                 (*(pv.userInfo)).maxRows = cmp::min(totalrows, (*(pv.userInfo)).maxRows);
@@ -1913,7 +1928,7 @@ pub(crate) fn fits_parser_workfn_safe(
         remain = nrows;
         while remain != 0 {
             ntodo = cmp::min(remain, 10000);
-            Evaluate_Parser(lParse, firstrow, ntodo);
+            Evaluate_Parser(lParse, colData, firstrow, ntodo);
             if lParse.status != 0 {
                 break;
             }
@@ -3303,6 +3318,7 @@ pub fn fffrwc_safe(
         let mut naxes: [c_long; MAXDIMS as usize] = [0; MAXDIMS as usize];
         let mut result: c_char = 0;
         let mut lParse: ParseData = ParseData::default();
+        let mut colData: Vec<iteratorCol> = Vec::new();
 
         if *status != 0 {
             return *status;
@@ -3318,10 +3334,11 @@ pub fn fffrwc_safe(
             &mut naxis,
             &mut naxes,
             &mut lParse,
+            &mut colData,
             status,
         ) != 0
         {
-            ffcprs(&mut lParse);
+            ffcprs(&mut lParse, &mut colData);
             return *status;
         }
 
@@ -3360,7 +3377,7 @@ pub fn fffrwc_safe(
         }
 
         if Info.datatype != TLOGICAL || nelem != 1 {
-            ffcprs(&mut lParse);
+            ffcprs(&mut lParse, &mut colData);
             ffpmsg_str("Expression does not evaluate to a logical scalar.");
             *status = PARSE_BAD_TYPE;
             return *status;
@@ -3389,7 +3406,7 @@ pub fn fffrwc_safe(
         parNo = lParse.nCols;
         while parNo > 0 {
             parNo -= 1;
-            match lParse.colData[parNo as usize].datatype {
+            match colData[parNo as usize].datatype {
                 TLONG => {
                     let mut v: Vec<c_long> = Vec::new();
                     if v.try_reserve_exact((ntimes + 1) as usize).is_err() {
@@ -3397,7 +3414,7 @@ pub fn fffrwc_safe(
                     } else {
                         v.resize((ntimes + 1) as usize, 0);
                         v[0] = 1234554321;
-                        lParse.colData[parNo as usize].array = v.as_mut_ptr().cast::<c_void>();
+                        colData[parNo as usize].array = v.as_mut_ptr().cast::<c_void>();
                         lng_arrays.push(v);
                     }
                 }
@@ -3408,7 +3425,7 @@ pub fn fffrwc_safe(
                     } else {
                         v.resize((ntimes + 1) as usize, 0.0);
                         v[0] = DOUBLENULLVALUE;
-                        lParse.colData[parNo as usize].array = v.as_mut_ptr().cast::<c_void>();
+                        colData[parNo as usize].array = v.as_mut_ptr().cast::<c_void>();
                         dbl_arrays.push(v);
                     }
                 }
@@ -3438,8 +3455,7 @@ pub fn fffrwc_safe(
                             for elem in 0..nelems {
                                 ptrs.push(base.add(elem * alen as usize));
                             }
-                            lParse.colData[parNo as usize].array =
-                                ptrs.as_mut_ptr().cast::<c_void>();
+                            colData[parNo as usize].array = ptrs.as_mut_ptr().cast::<c_void>();
                             str_blocks.push(block);
                             str_ptrs.push(ptrs);
                         }
@@ -3457,7 +3473,7 @@ pub fn fffrwc_safe(
         /* Read data from columns needed for the expression and then parse it */
         /**********************************************************************/
 
-        if fits_uncompress_hkdata(&mut lParse, fptr, ntimes, times, status) == 0 {
+        if fits_uncompress_hkdata(&mut lParse, &mut colData, fptr, ntimes, times, status) == 0 {
             if constant != 0 {
                 let result_node = &lParse.Nodes[lParse.resultNode as usize];
                 result = (result_node).value.data.log();
@@ -3476,7 +3492,7 @@ pub fn fffrwc_safe(
                     1,
                     ntimes,
                     lParse.nCols,
-                    &mut lParse.colData,
+                    &mut colData,
                     core::ptr::from_mut::<parseInfo>(&mut Info).cast::<c_void>(),
                 );
             }
@@ -3493,7 +3509,7 @@ pub fn fffrwc_safe(
             lParse.nCols = nCol;
         }
 
-        ffcprs(&mut lParse);
+        ffcprs(&mut lParse, &mut colData);
         *status
     }
 }
@@ -3537,6 +3553,7 @@ pub fn ffffrw_safer(
     let mut result: c_char = 0;
 
     let mut lParse: ParseData = ParseData::default();
+    let mut colData: Vec<iteratorCol> = Vec::new();
 
     if *status != 0 {
         return *status;
@@ -3551,10 +3568,11 @@ pub fn ffffrw_safer(
         &mut naxis,
         naxes.as_mut_slice(),
         &mut lParse,
+        &mut colData,
         status,
     ) != 0
     {
-        ffcprs(&mut lParse);
+        ffcprs(&mut lParse, &mut colData);
         return *status;
     }
     if nelem < 0 {
@@ -3565,7 +3583,7 @@ pub fn ffffrw_safer(
     }
 
     if dtype != TLOGICAL || nelem != 1 {
-        ffcprs(&mut lParse);
+        ffcprs(&mut lParse, &mut colData);
         ffpmsg_str("Expression does not evaluate to a logical scalar.");
         return {
             *status = PARSE_BAD_TYPE;
@@ -3587,7 +3605,7 @@ pub fn ffffrw_safer(
                 prownum: rownum,
                 lParse: core::ptr::from_mut::<ParseData>(&mut lParse),
             };
-            let colData_slice = &mut lParse.colData[..];
+            let colData_slice = &mut colData[..];
             if ffiter_safe(
                 (lParse).nCols,
                 colData_slice,
@@ -3602,7 +3620,7 @@ pub fn ffffrw_safer(
             };
         }
     }
-    ffcprs(&mut lParse);
+    ffcprs(&mut lParse, &mut colData);
     *status
 }
 
@@ -3610,6 +3628,7 @@ pub fn ffffrw_safer(
 ///  Setup iterator column and parser information to be ready to compute temporary calculator expression
 pub(crate) fn fits_parser_set_temporary_col(
     lParse: &mut ParseData,
+    colData: &mut Vec<iteratorCol>,
     Info: &mut parseInfo,
     nrows: c_long,
     nulval: *mut c_void,
@@ -3621,21 +3640,21 @@ pub(crate) fn fits_parser_set_temporary_col(
 
     let col_cnt: c_int = lParse.nCols;
 
-    if fits_parser_allocateCol(lParse, col_cnt, status) != 0 {
+    if fits_parser_allocateCol(lParse, colData, col_cnt, status) != 0 {
         return *status;
     }
 
     /* Set important variables for TemporaryCol where calculated results end up */
 
     fits_iter_set_by_num_safe(
-        &mut lParse.colData[col_cnt as usize],
+        &mut colData[col_cnt as usize],
         ptr::null_mut(),
         0,
         TDOUBLE,
         TEMPORARY_COL,
     );
 
-    (lParse.colData[col_cnt as usize]).repeat = lParse.nElements;
+    (colData[col_cnt as usize]).repeat = lParse.nElements;
 
     Info.dataPtr = ptr::null_mut();
     Info.nullPtr = nulval;
@@ -3650,6 +3669,7 @@ pub(crate) fn fits_parser_set_temporary_col(
 /// Uncompress housekeeping data from a compressed FITS table
 fn fits_uncompress_hkdata(
     lParse: &mut ParseData,
+    colData: &mut [iteratorCol],
     fptr: &mut fitsfile,
     ntimes: c_long,
     times: &mut [f64],
@@ -3711,7 +3731,7 @@ fn fits_uncompress_hkdata(
                 parNo = lParse.nCols;
                 while parNo > 0 {
                     parNo -= 1;
-                    let col_data = lParse.colData[parNo as usize];
+                    let col_data = colData[parNo as usize];
                     match col_data.datatype {
                         TLONG => {
                             let array = col_data.array.cast::<c_long>();
@@ -3769,7 +3789,7 @@ fn fits_uncompress_hkdata(
 
             if parNo >= 0 {
                 found[parNo as usize] = 1; /* Flag this parameter as found */
-                let col_data = lParse.colData[parNo as usize];
+                let col_data = colData[parNo as usize];
                 match col_data.datatype {
                     TLONG => {
                         let array = col_data.array.cast::<c_long>();
@@ -3873,19 +3893,21 @@ pub(crate) extern "C" fn ffffrw_work(
 ) -> c_int {
     let workData: &mut ffffrw_workdata =
         unsafe { userPtr.cast::<ffffrw_workdata>().as_mut().expect(NULL_MSG) };
+    let colData = unsafe { core::slice::from_raw_parts_mut(colData, nCols as usize) };
 
-    ffffrw_work_safe(totalrows, offset, firstrow, nrows, nCols, workData)
+    ffffrw_work_safe(totalrows, offset, firstrow, nrows, nCols, colData, workData)
 }
 
 /*---------------------------------------------------------------------------*/
 /// Iterator work function which calls the parser and searches for the
 /// first row which evaluates to TRUE.
 pub(crate) fn ffffrw_work_safe(
-    totalrows: c_long, /* I - Total rows to be processed     */
-    offset: c_long,    /* I - Number of rows skipped at start*/
-    firstrow: c_long,  /* I - First row of this iteration    */
-    nrows: c_long,     /* I - Number of rows in this iter    */
-    nCols: c_int,      /* I - Number of columns in use       */
+    totalrows: c_long,           /* I - Total rows to be processed     */
+    offset: c_long,              /* I - Number of rows skipped at start*/
+    firstrow: c_long,            /* I - First row of this iteration    */
+    nrows: c_long,               /* I - Number of rows in this iter    */
+    nCols: c_int,                /* I - Number of columns in use       */
+    colData: &mut [iteratorCol], /* IO- Column information/data        */
     workData: &mut ffffrw_workdata,
 ) -> c_int {
     unsafe {
@@ -3893,7 +3915,7 @@ pub(crate) fn ffffrw_work_safe(
 
         let lParse: &mut ParseData = &mut *workData.lParse;
 
-        Evaluate_Parser(lParse, firstrow, nrows);
+        Evaluate_Parser(lParse, colData, firstrow, nrows);
 
         if (lParse.status) == 0 {
             result = &mut lParse.Nodes[lParse.resultNode as usize];
@@ -3969,6 +3991,7 @@ pub fn fits_pixel_filter_safer(
         let mut msg: [c_char; 256] = [0; 256];
         let mut write_blank_kwd: c_int = 0; /* write BLANK if any output nulls? */
         let mut lParse: ParseData = ParseData::default();
+        let mut colData: Vec<iteratorCol> = Vec::new();
 
         let debug_pixfilter = if std::env::var("DEBUG_PIXFILTER").is_ok() {
             1
@@ -4002,10 +4025,11 @@ pub fn fits_pixel_filter_safer(
             &mut naxis,
             &mut naxes,
             &mut lParse,
+            &mut colData,
             status,
         ) != 0
         {
-            ffcprs(&mut lParse);
+            ffcprs(&mut lParse, &mut colData);
             return *status;
         }
 
@@ -4047,7 +4071,7 @@ pub fn fits_pixel_filter_safer(
                 println!("result type is {} [{}]", rtype, info.datatype);
             }
             if *status != 0 {
-                ffcprs(&mut lParse);
+                ffcprs(&mut lParse, &mut colData);
                 return *status;
             }
         }
@@ -4062,7 +4086,7 @@ pub fn fits_pixel_filter_safer(
         ) != 0
         {
             ffpmsg_str("pixel_filter: unable to read input image parameters");
-            ffcprs(&mut lParse);
+            ffcprs(&mut lParse, &mut colData);
             return *status;
         }
 
@@ -4095,7 +4119,7 @@ pub fn fits_pixel_filter_safer(
         ) != 0
         {
             ffpmsg_str("pixel_filter: unable to create output image");
-            ffcprs(&mut lParse);
+            ffcprs(&mut lParse, &mut colData);
             return *status;
         }
 
@@ -4111,7 +4135,7 @@ pub fn fits_pixel_filter_safer(
             ) != 0
             {
                 ffpmsg_str("pixel_filter: unable to determine number of keycards");
-                ffcprs(&mut lParse);
+                ffcprs(&mut lParse, &mut colData);
                 return *status;
             }
 
@@ -4123,7 +4147,7 @@ pub fn fits_pixel_filter_safer(
                     int_snprintf!(&mut msg, 256, "pixel_filter: unable to read keycard {}", i,);
 
                     ffpmsg_slice(&msg);
-                    ffcprs(&mut lParse);
+                    ffcprs(&mut lParse, &mut colData);
                     return *status;
                 }
 
@@ -4144,7 +4168,7 @@ pub fn fits_pixel_filter_safer(
                         *status,
                     );
                     ffpmsg_slice(&msg);
-                    ffcprs(&mut lParse);
+                    ffcprs(&mut lParse, &mut colData);
                     return *status;
                 }
             }
@@ -4181,7 +4205,7 @@ pub fn fits_pixel_filter_safer(
                 );
                 ffpmsg_slice(&msg);
                 *status = P_ERROR;
-                ffcprs(&mut lParse);
+                ffcprs(&mut lParse, &mut colData);
                 return *status;
             }
         }
@@ -4231,13 +4255,13 @@ pub fn fits_pixel_filter_safer(
             /* Create new iterator Output Column */
             /*************************************/
             col_cnt = lParse.nCols;
-            if fits_parser_allocateCol(&mut lParse, col_cnt, status) != 0 {
-                ffcprs(&mut lParse);
+            if fits_parser_allocateCol(&mut lParse, &mut colData, col_cnt, status) != 0 {
+                ffcprs(&mut lParse, &mut colData);
                 return *status;
             }
             lParse.nCols += 1;
 
-            let colIter: &mut iteratorCol = &mut lParse.colData[col_cnt as usize];
+            let colIter: &mut iteratorCol = &mut colData[col_cnt as usize];
             colIter.fptr = filter.ofptr;
             colIter.iotype = OUTPUT_COL;
 
@@ -4254,7 +4278,7 @@ pub fn fits_pixel_filter_safer(
             info.parseData = &raw mut lParse;
 
             if {
-                let colData_slice = &mut lParse.colData[..];
+                let colData_slice = &mut colData[..];
                 ffiter_safe(
                     lParse.nCols,
                     colData_slice,
@@ -4268,7 +4292,7 @@ pub fn fits_pixel_filter_safer(
             {
                 *status = 0;
             } else if *status != 0 {
-                ffcprs(&mut lParse);
+                ffcprs(&mut lParse, &mut colData);
                 return *status;
             }
 
@@ -4360,7 +4384,7 @@ pub fn fits_pixel_filter_safer(
             }
         }
 
-        ffcprs(&mut lParse);
+        ffcprs(&mut lParse, &mut colData);
         *status
     }
 }
@@ -4440,6 +4464,7 @@ fn set_image_col_types(
 
 fn find_column(
     lParse: &mut ParseData,
+    colData: &mut Vec<iteratorCol>,
     colName: &[c_char],
     itslval: &mut FITS_PARSER_YYSTYPE,
 ) -> c_int {
@@ -4517,14 +4542,14 @@ fn find_column(
             pending error, which is how a syntax error raised earlier in the
             parse used to be lost. */
             let mut tstatus = lParse.status;
-            if fits_parser_allocateCol(lParse, col_cnt, &mut tstatus) != 0 {
+            if fits_parser_allocateCol(lParse, colData, col_cnt, &mut tstatus) != 0 {
                 lParse.status = tstatus;
                 return P_ERROR;
             }
             lParse.status = tstatus;
 
             varInfo = &mut lParse.varData[col_cnt as usize];
-            colIter = &mut lParse.colData[col_cnt as usize];
+            colIter = &mut colData[col_cnt as usize];
 
             if (*lParse.pixFilter).ifptr.add(colnum as usize).is_null() {
                 ffpmsg_str("find_column: PixelFilter missing image pointer");
@@ -4605,14 +4630,14 @@ fn find_column(
             pending error, which is how a syntax error raised earlier in the
             parse used to be lost. */
             let mut tstatus = lParse.status;
-            if fits_parser_allocateCol(lParse, col_cnt, &mut tstatus) != 0 {
+            if fits_parser_allocateCol(lParse, colData, col_cnt, &mut tstatus) != 0 {
                 lParse.status = tstatus;
                 return P_ERROR;
             }
             lParse.status = tstatus;
 
             varInfo = &mut lParse.varData[col_cnt as usize];
-            colIter = &mut lParse.colData[col_cnt as usize];
+            colIter = &mut colData[col_cnt as usize];
 
             fits_iter_set_by_num_safe(colIter, fptr, colnum, 0, INPUT_COL);
         }
@@ -4825,24 +4850,27 @@ fn find_keywd(
 }
 
 /// Allocates parser iterator column storage for 25 columns *more* than nCols
-fn fits_parser_allocateCol(lParse: &mut ParseData, nCol: c_int, status: &mut c_int) -> c_int {
+fn fits_parser_allocateCol(
+    lParse: &mut ParseData,
+    colData: &mut Vec<iteratorCol>,
+    nCol: c_int,
+    status: &mut c_int,
+) -> c_int {
     if (nCol % 25) == 0 {
-        let existing_len = lParse.colData.len();
-        if lParse.colData.try_reserve_exact(25).is_err() {
-            lParse.colData.clear();
+        let existing_len = colData.len();
+        if colData.try_reserve_exact(25).is_err() {
+            colData.clear();
             lParse.varData.clear();
 
             *status = MEMORY_ALLOCATION;
             return *status;
         } else {
-            lParse
-                .colData
-                .resize(existing_len + 25, iteratorCol::default());
+            colData.resize(existing_len + 25, iteratorCol::default());
         }
 
         let existing_len = lParse.varData.len();
         if lParse.varData.try_reserve_exact(25).is_err() {
-            lParse.colData.clear();
+            colData.clear();
             lParse.varData.clear();
 
             *status = MEMORY_ALLOCATION;
@@ -4861,6 +4889,7 @@ fn fits_parser_allocateCol(lParse: &mut ParseData, nCol: c_int, status: &mut c_i
 
 fn load_column(
     lParse: &mut ParseData,
+    colData: &mut [iteratorCol],
     varNum: c_int,
     fRow: c_long,
     nRows: c_long,
@@ -4879,7 +4908,7 @@ fn load_column(
         let mut status: c_int = 0;
         let mut anynul: c_int = 0;
 
-        let var: &mut iteratorCol = &mut lParse.colData[varNum as usize];
+        let var: &mut iteratorCol = &mut colData[varNum as usize];
         if lParse.hdutype == IMAGE_HDU {
             /* This test would need to be on a per varNum basis to support
              * cross HDU operations */

--- a/src/eval_l.rs
+++ b/src/eval_l.rs
@@ -64,7 +64,7 @@ use libc::{ENOMEM, FILE, fileno, fwrite, isatty, size_t};
 
 use crate::c_types::{c_char, c_int, c_long, c_short, c_uchar, c_uint, c_void};
 use crate::eval_defs::{MAX_STRLEN, MAXVARNAME, P_ERROR, ParseData, ValueSort};
-use crate::fitsio::PARSE_SYNTAX_ERR;
+use crate::fitsio::{PARSE_SYNTAX_ERR, iteratorCol};
 use crate::fitsio2::FSTRCMP;
 use crate::helpers::boxed::box_try_new;
 use crate::helpers::vec_raw_parts::vec_into_raw_parts;
@@ -288,6 +288,7 @@ fn expr_read(lParse: &mut ParseData, buf: &mut [c_char], nbytes: c_int) -> c_int
 
 pub(crate) fn fits_parser_yyGetVariable(
     lParse: &mut ParseData,
+    colData: &mut Vec<iteratorCol>,
     varName: &[c_char],
     thelval: &mut FITS_PARSER_YYSTYPE,
 ) -> c_int {
@@ -297,7 +298,9 @@ pub(crate) fn fits_parser_yyGetVariable(
 
     if varNum < 0 {
         if (lParse.getData).is_some() {
-            dtype = (lParse.getData).expect("non-null function pointer")(lParse, varName, thelval);
+            dtype = (lParse.getData).expect("non-null function pointer")(
+                lParse, colData, varName, thelval,
+            );
         } else {
             dtype = -1;
             lParse.status = PARSE_SYNTAX_ERR;
@@ -450,6 +453,7 @@ pub(crate) fn fits_parser_yylex(
     yylval_param: &mut FITS_PARSER_YYSTYPE,
     yyscanner: &mut yyguts_t,
     lParse: &mut ParseData,
+    colData: &mut Vec<iteratorCol>,
 ) -> c_int {
     unsafe {
         let mut yy_amount_of_matched_text: c_int = 0;
@@ -969,6 +973,7 @@ pub(crate) fn fits_parser_yylex(
                                         (lParse.getData).expect("non-null function pointer");
                                     result = get_data(
                                         lParse,
+                                        colData,
                                         yytext_r_slice,
                                         yyscanner
                                             .yylval_r
@@ -1038,6 +1043,7 @@ pub(crate) fn fits_parser_yylex(
 
                                 dtype = fits_parser_yyGetVariable(
                                     lParse,
+                                    colData,
                                     yytext_r_slice,
                                     yyscanner.yylval_r.as_mut().unwrap(),
                                 );

--- a/src/eval_y.rs
+++ b/src/eval_y.rs
@@ -73,7 +73,7 @@ use core::ffi::CStr;
 use core::{cmp, ptr};
 
 use bytemuck::{cast_slice, cast_slice_mut};
-use libc::{calloc, free, malloc, memcpy, time, time_t};
+use libc::{calloc, free, malloc, memcpy};
 
 const APPROX: f64 = 1.0e-7;
 
@@ -9035,7 +9035,14 @@ pub(crate) fn Evaluate_Parser(
 
         /* Initialize the random number generator once and only once */
         if RAND_INITIALIZED == 0 {
-            simplerng_srand(time(core::ptr::null_mut::<time_t>()) as c_uint);
+            /* Seed from the wall clock, as the C's time(NULL) does. Uses
+               SystemTime rather than libc time() so the expression engine has
+               no foreign call on this path -- Miri cannot make it, and it was
+               aborting every test that reaches the evaluator. */
+            let seed = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map_or(0, |d| d.as_secs() as c_uint);
+            simplerng_srand(seed);
             RAND_INITIALIZED = 1;
         }
         lParse.firstRow = firstRow;

--- a/src/eval_y.rs
+++ b/src/eval_y.rs
@@ -147,6 +147,7 @@ use crate::fitscore::ffpmsg_slice;
 use crate::fitscore::{ffgcno_safe, ffghdn_safe, ffmahd_safe, ffmnhd_safe, ffupch_safe};
 use crate::fitsio::{
     LONG_MAX, LONG_MIN, LONGLONG, MEMORY_ALLOCATION, NO_WCS_KEY, PARSE_SYNTAX_ERR, fitsfile,
+    iteratorCol,
 };
 use crate::getcold::ffgcvd_safe;
 use crate::getkey::{ffgkyd_safe, ffgkyj_safe, ffgkys_safe};
@@ -970,7 +971,13 @@ fn New_Offset(lParse: &mut ParseData, ColNum: c_int, offsetNode: c_int) -> c_int
     n
 }
 
-fn New_Unary(lParse: &mut ParseData, returnType: c_int, mut Op: c_int, Node1: c_int) -> c_int {
+fn New_Unary(
+    lParse: &mut ParseData,
+    colData: &mut [iteratorCol],
+    returnType: c_int,
+    mut Op: c_int,
+    Node1: c_int,
+) -> c_int {
     let mut this_node_idx: usize;
 
     let mut i: c_int = 0;
@@ -1027,7 +1034,7 @@ fn New_Unary(lParse: &mut ParseData, returnType: c_int, mut Op: c_int, Node1: c_
         }
 
         if (that_node).is_const() {
-            ((this_node).DoOp).expect("non-null function pointer")(lParse, n as usize);
+            ((this_node).DoOp).expect("non-null function pointer")(lParse, colData, n as usize);
         }
     }
     n
@@ -1035,6 +1042,7 @@ fn New_Unary(lParse: &mut ParseData, returnType: c_int, mut Op: c_int, Node1: c_
 
 fn New_BinOp(
     lParse: &mut ParseData,
+    colData: &mut [iteratorCol],
     returnType: c_int,
     Node1: c_int,
     Op: c_int,
@@ -1118,7 +1126,7 @@ fn New_BinOp(
 
         if constant != 0 {
             ((lParse.Nodes[this_node_idx]).DoOp).expect("non-null function pointer")(
-                lParse, n as usize,
+                lParse, colData, n as usize,
             );
         }
     }
@@ -1127,6 +1135,7 @@ fn New_BinOp(
 
 fn New_Func(
     lParse: &mut ParseData,
+    colData: &mut [iteratorCol],
     returnType: c_int,
     Op: funcOp,
     nNodes: c_int,
@@ -1139,7 +1148,7 @@ fn New_Func(
     Node7: c_int,
 ) -> c_int {
     New_FuncSize(
-        lParse, returnType, Op, nNodes, Node1, Node2, Node3, Node4, Node5, Node6, Node7, 0,
+        lParse, colData, returnType, Op, nNodes, Node1, Node2, Node3, Node4, Node5, Node6, Node7, 0,
     )
 }
 
@@ -1353,6 +1362,7 @@ fn yydestruct(
 /* else return a single value of type returnType                       */
 fn New_FuncSize(
     lParse: &mut ParseData,
+    colData: &mut [iteratorCol],
     returnType: c_int,
     Op: funcOp,
     nNodes: c_int,
@@ -1436,7 +1446,7 @@ fn New_FuncSize(
 
         if constant != 0 {
             ((lParse.Nodes[n as usize]).DoOp).expect("non-null function pointer")(
-                lParse, n as usize,
+                lParse, colData, n as usize,
             );
         }
     }
@@ -1445,7 +1455,11 @@ fn New_FuncSize(
 
 #[allow(clippy::if_same_then_else)]
 // C dispatch chain: distinct conditions deliberately share an action.
-pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData) -> c_int {
+pub(crate) fn fits_parser_yyparse(
+    scanner: &mut yyguts_t,
+    lParse: &mut ParseData,
+    colData: &mut Vec<iteratorCol>,
+) -> c_int {
     unsafe {
         let mut current_block: u64;
         let mut yychar: c_int = 0;
@@ -1546,7 +1560,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         if YYDEBUG {
                             eprintln!("Read a token");
                         }
-                        yychar = fits_parser_yylex(&mut yylval, scanner, lParse);
+                        yychar = fits_parser_yylex(&mut yylval, scanner, lParse, colData);
                     }
 
                     if yychar <= fits_parser_yytokentype::FITS_PARSER_YYEOF as c_int {
@@ -1765,6 +1779,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             {
                                 yyvs[yyvsp - 2] = FITS_PARSER_YYSTYPE::Node(Close_Vec(
                                     lParse,
+                                    colData,
                                     yyvs[yyvsp - 2].node(),
                                 ));
                                 if yyvs[yyvsp - 2].node() < 0 {
@@ -1820,6 +1835,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             {
                                 yyvs[yyvsp - 2] = FITS_PARSER_YYSTYPE::Node(Close_Vec(
                                     lParse,
+                                    colData,
                                     yyvs[yyvsp - 2].node(),
                                 ));
                                 if yyvs[yyvsp - 2].node() < 0 {
@@ -1859,6 +1875,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             {
                                 yyvs[yyvsp - 2] = FITS_PARSER_YYSTYPE::Node(Close_Vec(
                                     lParse,
+                                    colData,
                                     yyvs[yyvsp - 2].node(),
                                 ));
                                 if yyvs[yyvsp - 2].node() < 0 {
@@ -1900,6 +1917,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             {
                                 yyvs[yyvsp - 2] = FITS_PARSER_YYSTYPE::Node(Close_Vec(
                                     lParse,
+                                    colData,
                                     yyvs[yyvsp - 2].node(),
                                 ));
                                 if yyvs[yyvsp - 2].node() < 0 {
@@ -1936,6 +1954,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             /* expr: vector '}'  */
                             yyval = FITS_PARSER_YYSTYPE::Node(Close_Vec(
                                 lParse,
+                                colData,
                                 yyvs[yyvsp - 1].node(),
                             ));
                             if yyval.node() < 0 {
@@ -1948,6 +1967,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             /* bexpr: bvector '}'  */
                             yyval = FITS_PARSER_YYSTYPE::Node(Close_Vec(
                                 lParse,
+                                colData,
                                 yyvs[yyvsp - 1].node(),
                             ));
                             if yyval.node() < 0 {
@@ -2015,6 +2035,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             /* bits: bits '&' bits  */
                             yyval = FITS_PARSER_YYSTYPE::Node(New_BinOp(
                                 lParse,
+                                colData,
                                 fits_parser_yytokentype::BITSTR as c_int,
                                 yyvs[yyvsp - 2].node(),
                                 '&' as i32,
@@ -2041,6 +2062,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             /* bits: bits '|' bits  */
                             yyval = FITS_PARSER_YYSTYPE::Node(New_BinOp(
                                 lParse,
+                                colData,
                                 fits_parser_yytokentype::BITSTR as c_int,
                                 yyvs[yyvsp - 2].node(),
                                 '|' as i32,
@@ -2077,6 +2099,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             } else {
                                 yyval = FITS_PARSER_YYSTYPE::Node(New_BinOp(
                                     lParse,
+                                    colData,
                                     fits_parser_yytokentype::BITSTR as c_int,
                                     yyvs[yyvsp - 2].node(),
                                     '+' as i32,
@@ -2100,6 +2123,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             /* bits: bits '[' expr ']'  */
                             yyval = FITS_PARSER_YYSTYPE::Node(New_Deref(
                                 lParse,
+                                colData,
                                 yyvs[yyvsp - 3].node(),
                                 1,
                                 yyvs[yyvsp - 1].node(),
@@ -2118,6 +2142,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             /* bits: bits '[' expr ',' expr ']'  */
                             yyval = FITS_PARSER_YYSTYPE::Node(New_Deref(
                                 lParse,
+                                colData,
                                 yyvs[yyvsp - 5].node(),
                                 2,
                                 yyvs[yyvsp - 3].node(),
@@ -2136,6 +2161,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             /* bits: bits '[' expr ',' expr ',' expr ']'  */
                             yyval = FITS_PARSER_YYSTYPE::Node(New_Deref(
                                 lParse,
+                                colData,
                                 yyvs[yyvsp - 7].node(),
                                 3 as c_int,
                                 yyvs[yyvsp - 5].node(),
@@ -2154,6 +2180,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             /* bits: bits '[' expr ',' expr ',' expr ',' expr ']'  */
                             yyval = FITS_PARSER_YYSTYPE::Node(New_Deref(
                                 lParse,
+                                colData,
                                 yyvs[yyvsp - 9].node(),
                                 4 as c_int,
                                 yyvs[yyvsp - 7].node(),
@@ -2172,6 +2199,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             /* bits: bits '[' expr ',' expr ',' expr ',' expr ',' expr ']'  */
                             yyval = FITS_PARSER_YYSTYPE::Node(New_Deref(
                                 lParse,
+                                colData,
                                 yyvs[yyvsp - 11].node(),
                                 5 as c_int,
                                 yyvs[yyvsp - 9].node(),
@@ -2190,6 +2218,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             /* bits: NOT bits  */
                             yyval = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                 lParse,
+                                colData,
                                 fits_parser_yytokentype::BITSTR as c_int,
                                 fits_parser_yytokentype::NOT as c_int,
                                 yyvs[yyvsp].node(),
@@ -2276,6 +2305,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             /* expr: ROWREF  */
                             yyval = FITS_PARSER_YYSTYPE::Node(New_Func(
                                 lParse,
+                                colData,
                                 fits_parser_yytokentype::LONG as c_int,
                                 funcOp::ROW_FCT,
                                 0,
@@ -2293,6 +2323,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             /* expr: NULLREF  */
                             yyval = FITS_PARSER_YYSTYPE::Node(New_Func(
                                 lParse,
+                                colData,
                                 fits_parser_yytokentype::LONG as c_int,
                                 funcOp::NULL_FCT,
                                 0,
@@ -2313,6 +2344,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             {
                                 yyvs[yyvsp] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                     lParse,
+                                    colData,
                                     ((lParse.Nodes)[yyvs[yyvsp - 2].node() as usize])
                                         .ntype
                                         .code(),
@@ -2324,6 +2356,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             {
                                 yyvs[yyvsp - 2] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                     lParse,
+                                    colData,
                                     (lParse.Nodes[yyvs[yyvsp].node() as usize]).ntype.code(),
                                     0,
                                     yyvs[yyvsp - 2].node(),
@@ -2331,6 +2364,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             }
                             yyval = FITS_PARSER_YYSTYPE::Node(New_BinOp(
                                 lParse,
+                                colData,
                                 (lParse.Nodes[yyvs[yyvsp - 2].node() as usize]).ntype.code(),
                                 yyvs[yyvsp - 2].node(),
                                 '%' as i32,
@@ -2349,6 +2383,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             {
                                 yyvs[yyvsp] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                     lParse,
+                                    colData,
                                     ((lParse.Nodes)[yyvs[yyvsp - 2].node() as usize])
                                         .ntype
                                         .code(),
@@ -2360,6 +2395,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             {
                                 yyvs[yyvsp - 2] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                     lParse,
+                                    colData,
                                     (lParse.Nodes[yyvs[yyvsp].node() as usize]).ntype.code(),
                                     0,
                                     yyvs[yyvsp - 2].node(),
@@ -2367,6 +2403,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             }
                             yyval = FITS_PARSER_YYSTYPE::Node(New_BinOp(
                                 lParse,
+                                colData,
                                 (lParse.Nodes[yyvs[yyvsp - 2].node() as usize]).ntype.code(),
                                 yyvs[yyvsp - 2].node(),
                                 '+' as i32,
@@ -2385,6 +2422,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             {
                                 yyvs[yyvsp] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                     lParse,
+                                    colData,
                                     ((lParse.Nodes)[yyvs[yyvsp - 2].node() as usize])
                                         .ntype
                                         .code(),
@@ -2396,6 +2434,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             {
                                 yyvs[yyvsp - 2] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                     lParse,
+                                    colData,
                                     (lParse.Nodes[yyvs[yyvsp].node() as usize]).ntype.code(),
                                     0,
                                     yyvs[yyvsp - 2].node(),
@@ -2403,6 +2442,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             }
                             yyval = FITS_PARSER_YYSTYPE::Node(New_BinOp(
                                 lParse,
+                                colData,
                                 (lParse.Nodes[yyvs[yyvsp - 2].node() as usize]).ntype.code(),
                                 yyvs[yyvsp - 2].node(),
                                 '-' as i32,
@@ -2421,6 +2461,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             {
                                 yyvs[yyvsp] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                     lParse,
+                                    colData,
                                     ((lParse.Nodes)[yyvs[yyvsp - 2].node() as usize])
                                         .ntype
                                         .code(),
@@ -2432,6 +2473,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             {
                                 yyvs[yyvsp - 2] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                     lParse,
+                                    colData,
                                     (lParse.Nodes[yyvs[yyvsp].node() as usize]).ntype.code(),
                                     0,
                                     yyvs[yyvsp - 2].node(),
@@ -2439,6 +2481,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             }
                             yyval = FITS_PARSER_YYSTYPE::Node(New_BinOp(
                                 lParse,
+                                colData,
                                 (lParse.Nodes[yyvs[yyvsp - 2].node() as usize]).ntype.code(),
                                 yyvs[yyvsp - 2].node(),
                                 '*' as i32,
@@ -2457,6 +2500,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             {
                                 yyvs[yyvsp] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                     lParse,
+                                    colData,
                                     ((lParse.Nodes)[yyvs[yyvsp - 2].node() as usize])
                                         .ntype
                                         .code(),
@@ -2468,6 +2512,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             {
                                 yyvs[yyvsp - 2] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                     lParse,
+                                    colData,
                                     (lParse.Nodes[yyvs[yyvsp].node() as usize]).ntype.code(),
                                     0,
                                     yyvs[yyvsp - 2].node(),
@@ -2475,6 +2520,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             }
                             yyval = FITS_PARSER_YYSTYPE::Node(New_BinOp(
                                 lParse,
+                                colData,
                                 (lParse.Nodes[yyvs[yyvsp - 2].node() as usize]).ntype.code(),
                                 yyvs[yyvsp - 2].node(),
                                 '/' as i32,
@@ -2498,6 +2544,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             } else {
                                 yyval = FITS_PARSER_YYSTYPE::Node(New_BinOp(
                                     lParse,
+                                    colData,
                                     ((lParse.Nodes)[yyvs[yyvsp - 2].node() as usize])
                                         .ntype
                                         .code(),
@@ -2520,6 +2567,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             } else {
                                 yyval = FITS_PARSER_YYSTYPE::Node(New_BinOp(
                                     lParse,
+                                    colData,
                                     ((lParse.Nodes)[yyvs[yyvsp - 2].node() as usize])
                                         .ntype
                                         .code(),
@@ -2542,6 +2590,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             } else {
                                 yyval = FITS_PARSER_YYSTYPE::Node(New_BinOp(
                                     lParse,
+                                    colData,
                                     ((lParse.Nodes)[yyvs[yyvsp - 2].node() as usize])
                                         .ntype
                                         .code(),
@@ -2559,6 +2608,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             {
                                 yyvs[yyvsp] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                     lParse,
+                                    colData,
                                     ((lParse.Nodes)[yyvs[yyvsp - 2].node() as usize])
                                         .ntype
                                         .code(),
@@ -2570,6 +2620,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             {
                                 yyvs[yyvsp - 2] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                     lParse,
+                                    colData,
                                     (lParse.Nodes[yyvs[yyvsp].node() as usize]).ntype.code(),
                                     0,
                                     yyvs[yyvsp - 2].node(),
@@ -2577,6 +2628,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             }
                             yyval = FITS_PARSER_YYSTYPE::Node(New_BinOp(
                                 lParse,
+                                colData,
                                 (lParse.Nodes[yyvs[yyvsp - 2].node() as usize]).ntype.code(),
                                 yyvs[yyvsp - 2].node(),
                                 fits_parser_yytokentype::POWER as c_int,
@@ -2597,6 +2649,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             /* expr: '-' expr  */
                             yyval = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                 lParse,
+                                colData,
                                 (lParse.Nodes[yyvs[yyvsp].node() as usize]).ntype.code(),
                                 fits_parser_yytokentype::UMINUS as c_int,
                                 yyvs[yyvsp].node(),
@@ -2616,12 +2669,14 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             /* expr: expr '*' bexpr  */
                             yyvs[yyvsp] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                 lParse,
+                                colData,
                                 (lParse.Nodes[yyvs[yyvsp - 2].node() as usize]).ntype.code(),
                                 0,
                                 yyvs[yyvsp].node(),
                             ));
                             yyval = FITS_PARSER_YYSTYPE::Node(New_BinOp(
                                 lParse,
+                                colData,
                                 (lParse.Nodes[yyvs[yyvsp - 2].node() as usize]).ntype.code(),
                                 yyvs[yyvsp - 2].node(),
                                 '*' as i32,
@@ -2637,12 +2692,14 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             /* expr: bexpr '*' expr  */
                             yyvs[yyvsp - 2] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                 lParse,
+                                colData,
                                 (lParse.Nodes[yyvs[yyvsp].node() as usize]).ntype.code(),
                                 0,
                                 yyvs[yyvsp - 2].node(),
                             ));
                             yyval = FITS_PARSER_YYSTYPE::Node(New_BinOp(
                                 lParse,
+                                colData,
                                 (lParse.Nodes[yyvs[yyvsp].node() as usize]).ntype.code(),
                                 yyvs[yyvsp - 2].node(),
                                 '*' as i32,
@@ -2661,6 +2718,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             {
                                 yyvs[yyvsp] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                     lParse,
+                                    colData,
                                     ((lParse.Nodes)[yyvs[yyvsp - 2].node() as usize])
                                         .ntype
                                         .code(),
@@ -2672,6 +2730,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             {
                                 yyvs[yyvsp - 2] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                     lParse,
+                                    colData,
                                     (lParse.Nodes[yyvs[yyvsp].node() as usize]).ntype.code(),
                                     0,
                                     yyvs[yyvsp - 2].node(),
@@ -2686,6 +2745,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             } else {
                                 yyval = FITS_PARSER_YYSTYPE::Node(New_Func(
                                     lParse,
+                                    colData,
                                     0,
                                     funcOp::IFTHENELSE_FCT,
                                     3 as c_int,
@@ -2738,6 +2798,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             {
                                 yyvs[yyvsp] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                     lParse,
+                                    colData,
                                     ((lParse.Nodes)[yyvs[yyvsp - 2].node() as usize])
                                         .ntype
                                         .code(),
@@ -2749,6 +2810,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             {
                                 yyvs[yyvsp - 2] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                     lParse,
+                                    colData,
                                     (lParse.Nodes[yyvs[yyvsp].node() as usize]).ntype.code(),
                                     0,
                                     yyvs[yyvsp - 2].node(),
@@ -2763,6 +2825,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             } else {
                                 yyval = FITS_PARSER_YYSTYPE::Node(New_Func(
                                     lParse,
+                                    colData,
                                     0,
                                     funcOp::IFTHENELSE_FCT,
                                     3 as c_int,
@@ -2815,6 +2878,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             {
                                 yyvs[yyvsp] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                     lParse,
+                                    colData,
                                     ((lParse.Nodes)[yyvs[yyvsp - 2].node() as usize])
                                         .ntype
                                         .code(),
@@ -2826,6 +2890,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             {
                                 yyvs[yyvsp - 2] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                     lParse,
+                                    colData,
                                     (lParse.Nodes[yyvs[yyvsp].node() as usize]).ntype.code(),
                                     0,
                                     yyvs[yyvsp - 2].node(),
@@ -2840,6 +2905,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             } else {
                                 yyval = FITS_PARSER_YYSTYPE::Node(New_Func(
                                     lParse,
+                                    colData,
                                     0,
                                     funcOp::IFTHENELSE_FCT,
                                     3 as c_int,
@@ -2902,6 +2968,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 /* Scalar RANDOM() */
                                 yyval = FITS_PARSER_YYSTYPE::Node(New_Func(
                                     lParse,
+                                    colData,
                                     fits_parser_yytokentype::DOUBLE as c_int,
                                     funcOp::RND_FCT,
                                     0,
@@ -2929,6 +2996,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 /*Scalar RANDOMN()*/
                                 yyval = FITS_PARSER_YYSTYPE::Node(New_Func(
                                     lParse,
+                                    colData,
                                     fits_parser_yytokentype::DOUBLE as c_int,
                                     funcOp::GASRND_FCT,
                                     0,
@@ -2972,6 +3040,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             {
                                 yyval = FITS_PARSER_YYSTYPE::Node(New_Func(
                                     lParse,
+                                    colData,
                                     fits_parser_yytokentype::LONG as c_int,
                                     funcOp::SUM_FCT,
                                     1,
@@ -3030,6 +3099,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
 
                                 yyval = FITS_PARSER_YYSTYPE::Node(New_BinOp(
                                     lParse,
+                                    colData,
                                     fits_parser_yytokentype::LONG as c_int,
                                     yyvs[yyvsp - 1].node(),
                                     fits_parser_yytokentype::ACCUM as c_int,
@@ -3096,6 +3166,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     {
                                         yyvs[yyvsp - 1] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                             lParse,
+                                            colData,
                                             fits_parser_yytokentype::LONG as c_int,
                                             0,
                                             yyvs[yyvsp - 1].node(),
@@ -3103,6 +3174,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     }
                                     yyval = FITS_PARSER_YYSTYPE::Node(New_Func(
                                         lParse,
+                                        colData,
                                         0,
                                         funcOp::AXISELEM_FCT,
                                         2,
@@ -3169,6 +3241,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     {
                                         yyvs[yyvsp - 1] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                             lParse,
+                                            colData,
                                             fits_parser_yytokentype::LONG as c_int,
                                             0,
                                             yyvs[yyvsp - 1].node(),
@@ -3220,6 +3293,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 /* NAXES(bexpr,n) */
                                 yyval = FITS_PARSER_YYSTYPE::Node(New_Array(
                                     lParse,
+                                    colData,
                                     yyvs[yyvsp - 3].node(),
                                     yyvs[yyvsp - 1].node(),
                                 ));
@@ -3286,6 +3360,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             {
                                 yyval = FITS_PARSER_YYSTYPE::Node(New_Func(
                                     lParse,
+                                    colData,
                                     fits_parser_yytokentype::LONG as c_int,
                                     funcOp::NONNULL_FCT,
                                     1,
@@ -3378,6 +3453,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             {
                                 yyval = FITS_PARSER_YYSTYPE::Node(New_Func(
                                     lParse,
+                                    colData,
                                     fits_parser_yytokentype::LONG as c_int,
                                     funcOp::SUM_FCT,
                                     1,
@@ -3404,6 +3480,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             {
                                 yyval = FITS_PARSER_YYSTYPE::Node(New_Func(
                                     lParse,
+                                    colData,
                                     ((lParse.Nodes)[yyvs[yyvsp - 1].node() as usize])
                                         .ntype
                                         .code(), /* Force 1D result */
@@ -3444,6 +3521,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
 
                                 yyval = FITS_PARSER_YYSTYPE::Node(New_BinOp(
                                     lParse,
+                                    colData,
                                     fits_parser_yytokentype::LONG as c_int,
                                     yyvs[yyvsp - 1].node(),
                                     fits_parser_yytokentype::ACCUM as c_int,
@@ -3464,6 +3542,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             {
                                 yyval = FITS_PARSER_YYSTYPE::Node(New_Func(
                                     lParse,
+                                    colData,
                                     ((lParse.Nodes)[yyvs[yyvsp - 1].node() as usize])
                                         .ntype
                                         .code(), /* Force 1D result */
@@ -3513,6 +3592,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             {
                                 yyval = FITS_PARSER_YYSTYPE::Node(New_Func(
                                     lParse,
+                                    colData,
                                     ((lParse.Nodes)[yyvs[yyvsp - 1].node() as usize])
                                         .ntype
                                         .code(),
@@ -3541,6 +3621,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             {
                                 yyval = FITS_PARSER_YYSTYPE::Node(New_Func(
                                     lParse,
+                                    colData,
                                     fits_parser_yytokentype::DOUBLE as c_int,
                                     funcOp::AVERAGE_FCT,
                                     1,
@@ -3567,6 +3648,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             {
                                 yyval = FITS_PARSER_YYSTYPE::Node(New_Func(
                                     lParse,
+                                    colData,
                                     fits_parser_yytokentype::DOUBLE as c_int,
                                     funcOp::STDDEV_FCT,
                                     1,
@@ -3593,6 +3675,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             {
                                 yyval = FITS_PARSER_YYSTYPE::Node(New_Func(
                                     lParse,
+                                    colData,
                                     ((lParse.Nodes)[yyvs[yyvsp - 1].node() as usize])
                                         .ntype
                                         .code(),
@@ -3645,6 +3728,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             {
                                 yyval = FITS_PARSER_YYSTYPE::Node(New_Func(
                                     lParse,
+                                    colData,
                                     fits_parser_yytokentype::LONG as c_int,
                                     funcOp::NONNULL_FCT,
                                     1,
@@ -3684,6 +3768,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
 
                                 yyval = FITS_PARSER_YYSTYPE::Node(New_BinOp(
                                     lParse,
+                                    colData,
                                     fits_parser_yytokentype::LONG as c_int,
                                     yyvs[yyvsp - 1].node(),
                                     fits_parser_yytokentype::ACCUM as c_int,
@@ -3714,6 +3799,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
 
                                 yyval = FITS_PARSER_YYSTYPE::Node(New_BinOp(
                                     lParse,
+                                    colData,
                                     fits_parser_yytokentype::DOUBLE as c_int,
                                     yyvs[yyvsp - 1].node(),
                                     fits_parser_yytokentype::ACCUM as c_int,
@@ -3744,6 +3830,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
 
                                 yyval = FITS_PARSER_YYSTYPE::Node(New_BinOp(
                                     lParse,
+                                    colData,
                                     fits_parser_yytokentype::LONG as c_int,
                                     yyvs[yyvsp - 1].node(),
                                     fits_parser_yytokentype::DIFF as c_int,
@@ -3774,6 +3861,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
 
                                 yyval = FITS_PARSER_YYSTYPE::Node(New_BinOp(
                                     lParse,
+                                    colData,
                                     fits_parser_yytokentype::DOUBLE as c_int,
                                     yyvs[yyvsp - 1].node(),
                                     fits_parser_yytokentype::DIFF as c_int,
@@ -3794,6 +3882,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             {
                                 yyval = FITS_PARSER_YYSTYPE::Node(New_Func(
                                     lParse,
+                                    colData,
                                     0,
                                     funcOp::ABS_FCT,
                                     1,
@@ -3820,6 +3909,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             {
                                 yyval = FITS_PARSER_YYSTYPE::Node(New_Func(
                                     lParse,
+                                    colData,
                                     ((lParse.Nodes)[yyvs[yyvsp - 1].node() as usize])
                                         .ntype
                                         .code(), /* Force 1D result */
@@ -3848,6 +3938,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             {
                                 yyval = FITS_PARSER_YYSTYPE::Node(New_Func(
                                     lParse,
+                                    colData,
                                     ((lParse.Nodes)[yyvs[yyvsp - 1].node() as usize])
                                         .ntype
                                         .code(), /* Force 1D result */
@@ -3877,6 +3968,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 /* Vector RANDOM() */
                                 yyval = FITS_PARSER_YYSTYPE::Node(New_Func(
                                     lParse,
+                                    colData,
                                     0,
                                     funcOp::RND_FCT,
                                     1,
@@ -3909,6 +4001,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             {
                                 yyval = FITS_PARSER_YYSTYPE::Node(New_Func(
                                     lParse,
+                                    colData,
                                     0,
                                     funcOp::GASRND_FCT,
                                     1,
@@ -3953,6 +4046,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 } else {
                                     yyval = FITS_PARSER_YYSTYPE::Node(New_Func(
                                         lParse,
+                                        colData,
                                         0,
                                         funcOp::ELEMNUM_FCT,
                                         1,
@@ -4023,6 +4117,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 {
                                     yyvs[yyvsp - 1] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                         lParse,
+                                        colData,
                                         fits_parser_yytokentype::DOUBLE as c_int,
                                         0,
                                         yyvs[yyvsp - 1].node(),
@@ -4042,6 +4137,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 {
                                     yyval = FITS_PARSER_YYSTYPE::Node(New_Func(
                                         lParse,
+                                        colData,
                                         0,
                                         funcOp::SIN_FCT,
                                         1,
@@ -4068,6 +4164,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 {
                                     yyval = FITS_PARSER_YYSTYPE::Node(New_Func(
                                         lParse,
+                                        colData,
                                         0,
                                         funcOp::COS_FCT,
                                         1,
@@ -4094,6 +4191,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 {
                                     yyval = FITS_PARSER_YYSTYPE::Node(New_Func(
                                         lParse,
+                                        colData,
                                         0,
                                         funcOp::TAN_FCT,
                                         1,
@@ -4131,6 +4229,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 {
                                     yyval = FITS_PARSER_YYSTYPE::Node(New_Func(
                                         lParse,
+                                        colData,
                                         0,
                                         funcOp::ASIN_FCT,
                                         1,
@@ -4168,6 +4267,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 {
                                     yyval = FITS_PARSER_YYSTYPE::Node(New_Func(
                                         lParse,
+                                        colData,
                                         0,
                                         funcOp::ACOS_FCT,
                                         1,
@@ -4205,6 +4305,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 {
                                     yyval = FITS_PARSER_YYSTYPE::Node(New_Func(
                                         lParse,
+                                        colData,
                                         0,
                                         funcOp::ATAN_FCT,
                                         1,
@@ -4231,6 +4332,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 {
                                     yyval = FITS_PARSER_YYSTYPE::Node(New_Func(
                                         lParse,
+                                        colData,
                                         0,
                                         funcOp::SINH_FCT,
                                         1,
@@ -4257,6 +4359,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 {
                                     yyval = FITS_PARSER_YYSTYPE::Node(New_Func(
                                         lParse,
+                                        colData,
                                         0,
                                         funcOp::COSH_FCT,
                                         1,
@@ -4283,6 +4386,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 {
                                     yyval = FITS_PARSER_YYSTYPE::Node(New_Func(
                                         lParse,
+                                        colData,
                                         0,
                                         funcOp::TANH_FCT,
                                         1,
@@ -4309,6 +4413,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 {
                                     yyval = FITS_PARSER_YYSTYPE::Node(New_Func(
                                         lParse,
+                                        colData,
                                         0,
                                         funcOp::EXP_FCT,
                                         1,
@@ -4335,6 +4440,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 {
                                     yyval = FITS_PARSER_YYSTYPE::Node(New_Func(
                                         lParse,
+                                        colData,
                                         0,
                                         funcOp::LOG_FCT,
                                         1,
@@ -4361,6 +4467,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 {
                                     yyval = FITS_PARSER_YYSTYPE::Node(New_Func(
                                         lParse,
+                                        colData,
                                         0,
                                         funcOp::LOG10_FCT,
                                         1,
@@ -4387,6 +4494,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 {
                                     yyval = FITS_PARSER_YYSTYPE::Node(New_Func(
                                         lParse,
+                                        colData,
                                         0,
                                         funcOp::SQRT_FCT,
                                         1,
@@ -4413,6 +4521,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 {
                                     yyval = FITS_PARSER_YYSTYPE::Node(New_Func(
                                         lParse,
+                                        colData,
                                         0,
                                         funcOp::ROUND_FCT,
                                         1,
@@ -4439,6 +4548,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 {
                                     yyval = FITS_PARSER_YYSTYPE::Node(New_Func(
                                         lParse,
+                                        colData,
                                         0,
                                         funcOp::FLOOR_FCT,
                                         1,
@@ -4465,6 +4575,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 {
                                     yyval = FITS_PARSER_YYSTYPE::Node(New_Func(
                                         lParse,
+                                        colData,
                                         0,
                                         funcOp::CEIL_FCT,
                                         1,
@@ -4491,6 +4602,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 {
                                     yyval = FITS_PARSER_YYSTYPE::Node(New_Func(
                                         lParse,
+                                        colData,
                                         0,
                                         funcOp::POIRND_FCT,
                                         1,
@@ -4539,6 +4651,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             {
                                 yyval = FITS_PARSER_YYSTYPE::Node(New_Func(
                                     lParse,
+                                    colData,
                                     fits_parser_yytokentype::LONG as c_int,
                                     funcOp::STRPOS_FCT,
                                     2,
@@ -4596,6 +4709,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     {
                                         yyvs[yyvsp - 1] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                             lParse,
+                                            colData,
                                             ((lParse.Nodes)[yyvs[yyvsp - 3].node() as usize])
                                                 .ntype
                                                 .code(),
@@ -4608,6 +4722,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     {
                                         yyvs[yyvsp - 3] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                             lParse,
+                                            colData,
                                             ((lParse.Nodes)[yyvs[yyvsp - 1].node() as usize])
                                                 .ntype
                                                 .code(),
@@ -4617,6 +4732,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     }
                                     yyval = FITS_PARSER_YYSTYPE::Node(New_Func(
                                         lParse,
+                                        colData,
                                         0,
                                         funcOp::DEFNULL_FCT,
                                         2,
@@ -4657,6 +4773,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 {
                                     yyvs[yyvsp - 3] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                         lParse,
+                                        colData,
                                         fits_parser_yytokentype::DOUBLE as c_int,
                                         0,
                                         yyvs[yyvsp - 3].node(),
@@ -4667,6 +4784,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 {
                                     yyvs[yyvsp - 1] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                         lParse,
+                                        colData,
                                         fits_parser_yytokentype::DOUBLE as c_int,
                                         0,
                                         yyvs[yyvsp - 1].node(),
@@ -4677,6 +4795,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 {
                                     yyval = FITS_PARSER_YYSTYPE::Node(New_Func(
                                         lParse,
+                                        colData,
                                         0,
                                         funcOp::ATAN2_FCT,
                                         2,
@@ -4726,6 +4845,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 {
                                     yyvs[yyvsp - 1] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                         lParse,
+                                        colData,
                                         ((lParse.Nodes)[yyvs[yyvsp - 3].node() as usize])
                                             .ntype
                                             .code(),
@@ -4737,6 +4857,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 {
                                     yyvs[yyvsp - 3] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                         lParse,
+                                        colData,
                                         ((lParse.Nodes)[yyvs[yyvsp - 1].node() as usize])
                                             .ntype
                                             .code(),
@@ -4749,6 +4870,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 {
                                     yyval = FITS_PARSER_YYSTYPE::Node(New_Func(
                                         lParse,
+                                        colData,
                                         0,
                                         funcOp::MIN2_FCT,
                                         2,
@@ -4798,6 +4920,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 {
                                     yyvs[yyvsp - 1] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                         lParse,
+                                        colData,
                                         ((lParse.Nodes)[yyvs[yyvsp - 3].node() as usize])
                                             .ntype
                                             .code(),
@@ -4809,6 +4932,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 {
                                     yyvs[yyvsp - 3] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                         lParse,
+                                        colData,
                                         ((lParse.Nodes)[yyvs[yyvsp - 1].node() as usize])
                                             .ntype
                                             .code(),
@@ -4821,6 +4945,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 {
                                     yyval = FITS_PARSER_YYSTYPE::Node(New_Func(
                                         lParse,
+                                        colData,
                                         0,
                                         funcOp::MAX2_FCT,
                                         2,
@@ -4884,6 +5009,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     {
                                         yyvs[yyvsp - 3] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                             lParse,
+                                            colData,
                                             ((lParse.Nodes)[yyvs[yyvsp - 1].node() as usize])
                                                 .ntype
                                                 .code(),
@@ -4893,6 +5019,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     }
                                     yyval = FITS_PARSER_YYSTYPE::Node(New_Func(
                                         lParse,
+                                        colData,
                                         0,
                                         funcOp::SETNULL_FCT,
                                         2,
@@ -4949,6 +5076,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     {
                                         yyvs[yyvsp - 1] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                             lParse,
+                                            colData,
                                             fits_parser_yytokentype::LONG as c_int,
                                             0,
                                             yyvs[yyvsp - 1].node(),
@@ -4956,6 +5084,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     }
                                     yyval = FITS_PARSER_YYSTYPE::Node(New_Func(
                                         lParse,
+                                        colData,
                                         0,
                                         funcOp::AXISELEM_FCT,
                                         2,
@@ -5022,6 +5151,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     {
                                         yyvs[yyvsp - 1] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                             lParse,
+                                            colData,
                                             fits_parser_yytokentype::LONG as c_int,
                                             0,
                                             yyvs[yyvsp - 1].node(),
@@ -5074,6 +5204,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 /* NAXES(expr,n) */
                                 yyval = FITS_PARSER_YYSTYPE::Node(New_Array(
                                     lParse,
+                                    colData,
                                     yyvs[yyvsp - 3].node(),
                                     yyvs[yyvsp - 1].node(),
                                 ));
@@ -5115,6 +5246,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 {
                                     yyvs[yyvsp - 7] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                         lParse,
+                                        colData,
                                         fits_parser_yytokentype::DOUBLE as c_int,
                                         0,
                                         yyvs[yyvsp - 7].node(),
@@ -5125,6 +5257,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 {
                                     yyvs[yyvsp - 5] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                         lParse,
+                                        colData,
                                         fits_parser_yytokentype::DOUBLE as c_int,
                                         0,
                                         yyvs[yyvsp - 5].node(),
@@ -5135,6 +5268,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 {
                                     yyvs[yyvsp - 3] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                         lParse,
+                                        colData,
                                         fits_parser_yytokentype::DOUBLE as c_int,
                                         0,
                                         yyvs[yyvsp - 3].node(),
@@ -5145,6 +5279,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 {
                                     yyvs[yyvsp - 1] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                         lParse,
+                                        colData,
                                         fits_parser_yytokentype::DOUBLE as c_int,
                                         0,
                                         yyvs[yyvsp - 1].node(),
@@ -5165,6 +5300,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 {
                                     yyval = FITS_PARSER_YYSTYPE::Node(New_Func(
                                         lParse,
+                                        colData,
                                         0,
                                         funcOp::ANGSEP_FCT,
                                         4 as c_int,
@@ -5227,6 +5363,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             /* expr: GTIOVERLAP STRING ',' expr ',' expr ')'  */
                             yyval = FITS_PARSER_YYSTYPE::Node(New_GTI(
                                 lParse,
+                                colData,
                                 funcOp::GTIOVER_FCT,
                                 yyvs[yyvsp - 5].text_mut_ptr(),
                                 yyvs[yyvsp - 3].node(),
@@ -5244,6 +5381,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             /* expr: GTIOVERLAP STRING ',' expr ',' expr ',' STRING ',' STRING ')'  */
                             yyval = FITS_PARSER_YYSTYPE::Node(New_GTI(
                                 lParse,
+                                colData,
                                 funcOp::GTIOVER_FCT,
                                 yyvs[yyvsp - 9].text_mut_ptr(),
                                 yyvs[yyvsp - 7].node(),
@@ -5261,6 +5399,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             /* expr: expr '[' expr ']'  */
                             yyval = FITS_PARSER_YYSTYPE::Node(New_Deref(
                                 lParse,
+                                colData,
                                 yyvs[yyvsp - 3].node(),
                                 1,
                                 yyvs[yyvsp - 1].node(),
@@ -5279,6 +5418,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             /* expr: expr '[' expr ',' expr ']'  */
                             yyval = FITS_PARSER_YYSTYPE::Node(New_Deref(
                                 lParse,
+                                colData,
                                 yyvs[yyvsp - 5].node(),
                                 2,
                                 yyvs[yyvsp - 3].node(),
@@ -5297,6 +5437,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             /* expr: expr '[' expr ',' expr ',' expr ']'  */
                             yyval = FITS_PARSER_YYSTYPE::Node(New_Deref(
                                 lParse,
+                                colData,
                                 yyvs[yyvsp - 7].node(),
                                 3 as c_int,
                                 yyvs[yyvsp - 5].node(),
@@ -5315,6 +5456,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             /* expr: expr '[' expr ',' expr ',' expr ',' expr ']'  */
                             yyval = FITS_PARSER_YYSTYPE::Node(New_Deref(
                                 lParse,
+                                colData,
                                 yyvs[yyvsp - 9].node(),
                                 4 as c_int,
                                 yyvs[yyvsp - 7].node(),
@@ -5333,6 +5475,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             /* expr: expr '[' expr ',' expr ',' expr ',' expr ',' expr ']'  */
                             yyval = FITS_PARSER_YYSTYPE::Node(New_Deref(
                                 lParse,
+                                colData,
                                 yyvs[yyvsp - 11].node(),
                                 5 as c_int,
                                 yyvs[yyvsp - 9].node(),
@@ -5351,6 +5494,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             /* expr: INTCAST expr  */
                             yyval = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                 lParse,
+                                colData,
                                 fits_parser_yytokentype::LONG as c_int,
                                 fits_parser_yytokentype::INTCAST as c_int,
                                 yyvs[yyvsp].node(),
@@ -5365,6 +5509,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             /* expr: INTCAST bexpr  */
                             yyval = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                 lParse,
+                                colData,
                                 fits_parser_yytokentype::LONG as c_int,
                                 fits_parser_yytokentype::INTCAST as c_int,
                                 yyvs[yyvsp].node(),
@@ -5379,6 +5524,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             /* expr: FLTCAST expr  */
                             yyval = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                 lParse,
+                                colData,
                                 fits_parser_yytokentype::DOUBLE as c_int,
                                 fits_parser_yytokentype::FLTCAST as c_int,
                                 yyvs[yyvsp].node(),
@@ -5393,6 +5539,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             /* expr: FLTCAST bexpr  */
                             yyval = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                 lParse,
+                                colData,
                                 fits_parser_yytokentype::DOUBLE as c_int,
                                 fits_parser_yytokentype::FLTCAST as c_int,
                                 yyvs[yyvsp].node(),
@@ -5459,6 +5606,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             /* bexpr: bits EQ bits  */
                             yyval = FITS_PARSER_YYSTYPE::Node(New_BinOp(
                                 lParse,
+                                colData,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
                                 yyvs[yyvsp - 2].node(),
                                 fits_parser_yytokentype::EQ as c_int,
@@ -5475,6 +5623,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             /* bexpr: bits NE bits  */
                             yyval = FITS_PARSER_YYSTYPE::Node(New_BinOp(
                                 lParse,
+                                colData,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
                                 yyvs[yyvsp - 2].node(),
                                 fits_parser_yytokentype::NE as c_int,
@@ -5491,6 +5640,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             /* bexpr: bits LT bits  */
                             yyval = FITS_PARSER_YYSTYPE::Node(New_BinOp(
                                 lParse,
+                                colData,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
                                 yyvs[yyvsp - 2].node(),
                                 fits_parser_yytokentype::LT as c_int,
@@ -5507,6 +5657,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             /* bexpr: bits LTE bits  */
                             yyval = FITS_PARSER_YYSTYPE::Node(New_BinOp(
                                 lParse,
+                                colData,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
                                 yyvs[yyvsp - 2].node(),
                                 fits_parser_yytokentype::LTE as c_int,
@@ -5523,6 +5674,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             /* bexpr: bits GT bits  */
                             yyval = FITS_PARSER_YYSTYPE::Node(New_BinOp(
                                 lParse,
+                                colData,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
                                 yyvs[yyvsp - 2].node(),
                                 fits_parser_yytokentype::GT as c_int,
@@ -5539,6 +5691,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             /* bexpr: bits GTE bits  */
                             yyval = FITS_PARSER_YYSTYPE::Node(New_BinOp(
                                 lParse,
+                                colData,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
                                 yyvs[yyvsp - 2].node(),
                                 fits_parser_yytokentype::GTE as c_int,
@@ -5558,6 +5711,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             {
                                 yyvs[yyvsp] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                     lParse,
+                                    colData,
                                     ((lParse.Nodes)[yyvs[yyvsp - 2].node() as usize])
                                         .ntype
                                         .code(),
@@ -5569,6 +5723,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             {
                                 yyvs[yyvsp - 2] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                     lParse,
+                                    colData,
                                     (lParse.Nodes[yyvs[yyvsp].node() as usize]).ntype.code(),
                                     0,
                                     yyvs[yyvsp - 2].node(),
@@ -5576,6 +5731,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             }
                             yyval = FITS_PARSER_YYSTYPE::Node(New_BinOp(
                                 lParse,
+                                colData,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
                                 yyvs[yyvsp - 2].node(),
                                 fits_parser_yytokentype::GT as c_int,
@@ -5594,6 +5750,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             {
                                 yyvs[yyvsp] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                     lParse,
+                                    colData,
                                     ((lParse.Nodes)[yyvs[yyvsp - 2].node() as usize])
                                         .ntype
                                         .code(),
@@ -5605,6 +5762,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             {
                                 yyvs[yyvsp - 2] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                     lParse,
+                                    colData,
                                     (lParse.Nodes[yyvs[yyvsp].node() as usize]).ntype.code(),
                                     0,
                                     yyvs[yyvsp - 2].node(),
@@ -5612,6 +5770,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             }
                             yyval = FITS_PARSER_YYSTYPE::Node(New_BinOp(
                                 lParse,
+                                colData,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
                                 yyvs[yyvsp - 2].node(),
                                 fits_parser_yytokentype::LT as c_int,
@@ -5630,6 +5789,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             {
                                 yyvs[yyvsp] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                     lParse,
+                                    colData,
                                     ((lParse.Nodes)[yyvs[yyvsp - 2].node() as usize])
                                         .ntype
                                         .code(),
@@ -5641,6 +5801,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             {
                                 yyvs[yyvsp - 2] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                     lParse,
+                                    colData,
                                     (lParse.Nodes[yyvs[yyvsp].node() as usize]).ntype.code(),
                                     0,
                                     yyvs[yyvsp - 2].node(),
@@ -5648,6 +5809,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             }
                             yyval = FITS_PARSER_YYSTYPE::Node(New_BinOp(
                                 lParse,
+                                colData,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
                                 yyvs[yyvsp - 2].node(),
                                 fits_parser_yytokentype::GTE as c_int,
@@ -5666,6 +5828,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             {
                                 yyvs[yyvsp] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                     lParse,
+                                    colData,
                                     ((lParse.Nodes)[yyvs[yyvsp - 2].node() as usize])
                                         .ntype
                                         .code(),
@@ -5677,6 +5840,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             {
                                 yyvs[yyvsp - 2] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                     lParse,
+                                    colData,
                                     (lParse.Nodes[yyvs[yyvsp].node() as usize]).ntype.code(),
                                     0,
                                     yyvs[yyvsp - 2].node(),
@@ -5684,6 +5848,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             }
                             yyval = FITS_PARSER_YYSTYPE::Node(New_BinOp(
                                 lParse,
+                                colData,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
                                 yyvs[yyvsp - 2].node(),
                                 fits_parser_yytokentype::LTE as c_int,
@@ -5702,6 +5867,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             {
                                 yyvs[yyvsp] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                     lParse,
+                                    colData,
                                     ((lParse.Nodes)[yyvs[yyvsp - 2].node() as usize])
                                         .ntype
                                         .code(),
@@ -5713,6 +5879,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             {
                                 yyvs[yyvsp - 2] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                     lParse,
+                                    colData,
                                     (lParse.Nodes[yyvs[yyvsp].node() as usize]).ntype.code(),
                                     0,
                                     yyvs[yyvsp - 2].node(),
@@ -5720,6 +5887,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             }
                             yyval = FITS_PARSER_YYSTYPE::Node(New_BinOp(
                                 lParse,
+                                colData,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
                                 yyvs[yyvsp - 2].node(),
                                 '~' as i32,
@@ -5738,6 +5906,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             {
                                 yyvs[yyvsp] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                     lParse,
+                                    colData,
                                     ((lParse.Nodes)[yyvs[yyvsp - 2].node() as usize])
                                         .ntype
                                         .code(),
@@ -5749,6 +5918,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             {
                                 yyvs[yyvsp - 2] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                     lParse,
+                                    colData,
                                     (lParse.Nodes[yyvs[yyvsp].node() as usize]).ntype.code(),
                                     0,
                                     yyvs[yyvsp - 2].node(),
@@ -5756,6 +5926,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             }
                             yyval = FITS_PARSER_YYSTYPE::Node(New_BinOp(
                                 lParse,
+                                colData,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
                                 yyvs[yyvsp - 2].node(),
                                 fits_parser_yytokentype::EQ as c_int,
@@ -5774,6 +5945,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             {
                                 yyvs[yyvsp] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                     lParse,
+                                    colData,
                                     ((lParse.Nodes)[yyvs[yyvsp - 2].node() as usize])
                                         .ntype
                                         .code(),
@@ -5785,6 +5957,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             {
                                 yyvs[yyvsp - 2] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                     lParse,
+                                    colData,
                                     (lParse.Nodes[yyvs[yyvsp].node() as usize]).ntype.code(),
                                     0,
                                     yyvs[yyvsp - 2].node(),
@@ -5792,6 +5965,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             }
                             yyval = FITS_PARSER_YYSTYPE::Node(New_BinOp(
                                 lParse,
+                                colData,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
                                 yyvs[yyvsp - 2].node(),
                                 fits_parser_yytokentype::NE as c_int,
@@ -5807,6 +5981,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             /* bexpr: sexpr EQ sexpr  */
                             yyval = FITS_PARSER_YYSTYPE::Node(New_BinOp(
                                 lParse,
+                                colData,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
                                 yyvs[yyvsp - 2].node(),
                                 fits_parser_yytokentype::EQ as c_int,
@@ -5823,6 +5998,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             /* bexpr: sexpr NE sexpr  */
                             yyval = FITS_PARSER_YYSTYPE::Node(New_BinOp(
                                 lParse,
+                                colData,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
                                 yyvs[yyvsp - 2].node(),
                                 fits_parser_yytokentype::NE as c_int,
@@ -5839,6 +6015,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             /* bexpr: sexpr GT sexpr  */
                             yyval = FITS_PARSER_YYSTYPE::Node(New_BinOp(
                                 lParse,
+                                colData,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
                                 yyvs[yyvsp - 2].node(),
                                 fits_parser_yytokentype::GT as c_int,
@@ -5855,6 +6032,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             /* bexpr: sexpr GTE sexpr  */
                             yyval = FITS_PARSER_YYSTYPE::Node(New_BinOp(
                                 lParse,
+                                colData,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
                                 yyvs[yyvsp - 2].node(),
                                 fits_parser_yytokentype::GTE as c_int,
@@ -5871,6 +6049,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             /* bexpr: sexpr LT sexpr  */
                             yyval = FITS_PARSER_YYSTYPE::Node(New_BinOp(
                                 lParse,
+                                colData,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
                                 yyvs[yyvsp - 2].node(),
                                 fits_parser_yytokentype::LT as c_int,
@@ -5887,6 +6066,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             /* bexpr: sexpr LTE sexpr  */
                             yyval = FITS_PARSER_YYSTYPE::Node(New_BinOp(
                                 lParse,
+                                colData,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
                                 yyvs[yyvsp - 2].node(),
                                 fits_parser_yytokentype::LTE as c_int,
@@ -5903,6 +6083,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             /* bexpr: bexpr AND bexpr  */
                             yyval = FITS_PARSER_YYSTYPE::Node(New_BinOp(
                                 lParse,
+                                colData,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
                                 yyvs[yyvsp - 2].node(),
                                 fits_parser_yytokentype::AND as c_int,
@@ -5918,6 +6099,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             /* bexpr: bexpr OR bexpr  */
                             yyval = FITS_PARSER_YYSTYPE::Node(New_BinOp(
                                 lParse,
+                                colData,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
                                 yyvs[yyvsp - 2].node(),
                                 fits_parser_yytokentype::OR as c_int,
@@ -5933,6 +6115,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             /* bexpr: bexpr EQ bexpr  */
                             yyval = FITS_PARSER_YYSTYPE::Node(New_BinOp(
                                 lParse,
+                                colData,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
                                 yyvs[yyvsp - 2].node(),
                                 fits_parser_yytokentype::EQ as c_int,
@@ -5948,6 +6131,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             /* bexpr: bexpr NE bexpr  */
                             yyval = FITS_PARSER_YYSTYPE::Node(New_BinOp(
                                 lParse,
+                                colData,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
                                 yyvs[yyvsp - 2].node(),
                                 fits_parser_yytokentype::NE as c_int,
@@ -5966,6 +6150,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             {
                                 yyvs[yyvsp - 2] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                     lParse,
+                                    colData,
                                     ((lParse.Nodes)[yyvs[yyvsp - 4].node() as usize])
                                         .ntype
                                         .code(),
@@ -5977,6 +6162,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             {
                                 yyvs[yyvsp - 4] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                     lParse,
+                                    colData,
                                     ((lParse.Nodes)[yyvs[yyvsp - 2].node() as usize])
                                         .ntype
                                         .code(),
@@ -5989,6 +6175,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             {
                                 yyvs[yyvsp] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                     lParse,
+                                    colData,
                                     ((lParse.Nodes)[yyvs[yyvsp - 4].node() as usize])
                                         .ntype
                                         .code(),
@@ -6000,6 +6187,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             {
                                 yyvs[yyvsp - 4] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                     lParse,
+                                    colData,
                                     (lParse.Nodes[yyvs[yyvsp].node() as usize]).ntype.code(),
                                     0,
                                     yyvs[yyvsp - 4].node(),
@@ -6010,6 +6198,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             {
                                 yyvs[yyvsp] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                     lParse,
+                                    colData,
                                     ((lParse.Nodes)[yyvs[yyvsp - 2].node() as usize])
                                         .ntype
                                         .code(),
@@ -6021,6 +6210,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             {
                                 yyvs[yyvsp - 2] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                     lParse,
+                                    colData,
                                     (lParse.Nodes[yyvs[yyvsp].node() as usize]).ntype.code(),
                                     0,
                                     yyvs[yyvsp - 2].node(),
@@ -6028,6 +6218,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             }
                             yyvs[yyvsp - 2] = FITS_PARSER_YYSTYPE::Node(New_BinOp(
                                 lParse,
+                                colData,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
                                 yyvs[yyvsp - 2].node(),
                                 fits_parser_yytokentype::LTE as c_int,
@@ -6035,6 +6226,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             ));
                             yyvs[yyvsp] = FITS_PARSER_YYSTYPE::Node(New_BinOp(
                                 lParse,
+                                colData,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
                                 yyvs[yyvsp - 4].node(),
                                 fits_parser_yytokentype::LTE as c_int,
@@ -6042,6 +6234,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             ));
                             yyval = FITS_PARSER_YYSTYPE::Node(New_BinOp(
                                 lParse,
+                                colData,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
                                 yyvs[yyvsp - 2].node(),
                                 fits_parser_yytokentype::AND as c_int,
@@ -6064,6 +6257,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             } else {
                                 yyval = FITS_PARSER_YYSTYPE::Node(New_Func(
                                     lParse,
+                                    colData,
                                     0,
                                     funcOp::IFTHENELSE_FCT,
                                     3 as c_int,
@@ -6121,6 +6315,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             {
                                 yyval = FITS_PARSER_YYSTYPE::Node(New_Func(
                                     lParse,
+                                    colData,
                                     0,
                                     funcOp::ISNULL_FCT,
                                     1,
@@ -6164,6 +6359,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             {
                                 yyval = FITS_PARSER_YYSTYPE::Node(New_Func(
                                     lParse,
+                                    colData,
                                     0,
                                     funcOp::ISNULL_FCT,
                                     1,
@@ -6207,6 +6403,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             {
                                 yyval = FITS_PARSER_YYSTYPE::Node(New_Func(
                                     lParse,
+                                    colData,
                                     fits_parser_yytokentype::BOOLEAN as c_int,
                                     funcOp::ISNULL_FCT,
                                     1,
@@ -6259,6 +6456,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 {
                                     yyval = FITS_PARSER_YYSTYPE::Node(New_Func(
                                         lParse,
+                                        colData,
                                         0,
                                         funcOp::DEFNULL_FCT,
                                         2,
@@ -6297,6 +6495,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             {
                                 yyvs[yyvsp - 5] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                     lParse,
+                                    colData,
                                     fits_parser_yytokentype::DOUBLE as c_int,
                                     0,
                                     yyvs[yyvsp - 5].node(),
@@ -6307,6 +6506,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             {
                                 yyvs[yyvsp - 3] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                     lParse,
+                                    colData,
                                     fits_parser_yytokentype::DOUBLE as c_int,
                                     0,
                                     yyvs[yyvsp - 3].node(),
@@ -6317,6 +6517,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             {
                                 yyvs[yyvsp - 1] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                     lParse,
+                                    colData,
                                     fits_parser_yytokentype::DOUBLE as c_int,
                                     0,
                                     yyvs[yyvsp - 1].node(),
@@ -6349,6 +6550,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             {
                                 yyval = FITS_PARSER_YYSTYPE::Node(New_Func(
                                     lParse,
+                                    colData,
                                     fits_parser_yytokentype::BOOLEAN as c_int,
                                     funcOp::NEAR_FCT,
                                     3 as c_int,
@@ -6402,6 +6604,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             {
                                 yyvs[yyvsp - 9] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                     lParse,
+                                    colData,
                                     fits_parser_yytokentype::DOUBLE as c_int,
                                     0,
                                     yyvs[yyvsp - 9].node(),
@@ -6412,6 +6615,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             {
                                 yyvs[yyvsp - 7] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                     lParse,
+                                    colData,
                                     fits_parser_yytokentype::DOUBLE as c_int,
                                     0,
                                     yyvs[yyvsp - 7].node(),
@@ -6422,6 +6626,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             {
                                 yyvs[yyvsp - 5] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                     lParse,
+                                    colData,
                                     fits_parser_yytokentype::DOUBLE as c_int,
                                     0,
                                     yyvs[yyvsp - 5].node(),
@@ -6432,6 +6637,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             {
                                 yyvs[yyvsp - 3] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                     lParse,
+                                    colData,
                                     fits_parser_yytokentype::DOUBLE as c_int,
                                     0,
                                     yyvs[yyvsp - 3].node(),
@@ -6442,6 +6648,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             {
                                 yyvs[yyvsp - 1] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                     lParse,
+                                    colData,
                                     fits_parser_yytokentype::DOUBLE as c_int,
                                     0,
                                     yyvs[yyvsp - 1].node(),
@@ -6484,6 +6691,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             {
                                 yyval = FITS_PARSER_YYSTYPE::Node(New_Func(
                                     lParse,
+                                    colData,
                                     fits_parser_yytokentype::BOOLEAN as c_int,
                                     funcOp::CIRCLE_FCT,
                                     5 as c_int,
@@ -6555,6 +6763,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             {
                                 yyvs[yyvsp - 13] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                     lParse,
+                                    colData,
                                     fits_parser_yytokentype::DOUBLE as c_int,
                                     0,
                                     yyvs[yyvsp - 13].node(),
@@ -6565,6 +6774,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             {
                                 yyvs[yyvsp - 11] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                     lParse,
+                                    colData,
                                     fits_parser_yytokentype::DOUBLE as c_int,
                                     0,
                                     yyvs[yyvsp - 11].node(),
@@ -6575,6 +6785,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             {
                                 yyvs[yyvsp - 9] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                     lParse,
+                                    colData,
                                     fits_parser_yytokentype::DOUBLE as c_int,
                                     0,
                                     yyvs[yyvsp - 9].node(),
@@ -6585,6 +6796,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             {
                                 yyvs[yyvsp - 7] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                     lParse,
+                                    colData,
                                     fits_parser_yytokentype::DOUBLE as c_int,
                                     0,
                                     yyvs[yyvsp - 7].node(),
@@ -6595,6 +6807,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             {
                                 yyvs[yyvsp - 5] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                     lParse,
+                                    colData,
                                     fits_parser_yytokentype::DOUBLE as c_int,
                                     0,
                                     yyvs[yyvsp - 5].node(),
@@ -6605,6 +6818,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             {
                                 yyvs[yyvsp - 3] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                     lParse,
+                                    colData,
                                     fits_parser_yytokentype::DOUBLE as c_int,
                                     0,
                                     yyvs[yyvsp - 3].node(),
@@ -6615,6 +6829,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             {
                                 yyvs[yyvsp - 1] = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                     lParse,
+                                    colData,
                                     fits_parser_yytokentype::DOUBLE as c_int,
                                     0,
                                     yyvs[yyvsp - 1].node(),
@@ -6668,6 +6883,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 {
                                     yyval = FITS_PARSER_YYSTYPE::Node(New_Func(
                                         lParse,
+                                        colData,
                                         fits_parser_yytokentype::BOOLEAN as c_int,
                                         funcOp::BOX_FCT,
                                         7 as c_int,
@@ -6694,6 +6910,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 {
                                     yyval = FITS_PARSER_YYSTYPE::Node(New_Func(
                                         lParse,
+                                        colData,
                                         fits_parser_yytokentype::BOOLEAN as c_int,
                                         funcOp::ELPS_FCT,
                                         7 as c_int,
@@ -6819,6 +7036,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             /* Use defaults for all elements */
                             yyval = FITS_PARSER_YYSTYPE::Node(New_GTI(
                                 lParse,
+                                colData,
                                 funcOp::GTIFILT_FCT,
                                 c"".as_ptr().cast_mut(),
                                 -99,
@@ -6837,6 +7055,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             /* Use defaults for all except filename */
                             yyval = FITS_PARSER_YYSTYPE::Node(New_GTI(
                                 lParse,
+                                colData,
                                 funcOp::GTIFILT_FCT,
                                 yyvs[yyvsp - 1].text_mut_ptr(),
                                 -99,
@@ -6854,6 +7073,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             /* bexpr: GTIFILTER STRING ',' expr ')'  */
                             yyval = FITS_PARSER_YYSTYPE::Node(New_GTI(
                                 lParse,
+                                colData,
                                 funcOp::GTIFILT_FCT,
                                 yyvs[yyvsp - 3].text_mut_ptr(),
                                 yyvs[yyvsp - 1].node(),
@@ -6871,6 +7091,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             /* bexpr: GTIFILTER STRING ',' expr ',' STRING ',' STRING ')'  */
                             yyval = FITS_PARSER_YYSTYPE::Node(New_GTI(
                                 lParse,
+                                colData,
                                 funcOp::GTIFILT_FCT,
                                 yyvs[yyvsp - 7].text_mut_ptr(),
                                 yyvs[yyvsp - 5].node(),
@@ -6890,6 +7111,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             /* Use defaults for all elements */
                             yyval = FITS_PARSER_YYSTYPE::Node(New_GTI(
                                 lParse,
+                                colData,
                                 funcOp::GTIFIND_FCT,
                                 c"".as_ptr().cast_mut(),
                                 -99,
@@ -6907,6 +7129,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             /* bexpr: GTIFIND STRING ')'  *//* Use defaults for all except filename */
                             yyval = FITS_PARSER_YYSTYPE::Node(New_GTI(
                                 lParse,
+                                colData,
                                 funcOp::GTIFIND_FCT,
                                 yyvs[yyvsp - 1].text_mut_ptr(),
                                 -99,
@@ -6924,6 +7147,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             /* bexpr: GTIFIND STRING ',' expr ')'  */
                             yyval = FITS_PARSER_YYSTYPE::Node(New_GTI(
                                 lParse,
+                                colData,
                                 funcOp::GTIFIND_FCT,
                                 yyvs[yyvsp - 3].text_mut_ptr(),
                                 yyvs[yyvsp - 1].node(),
@@ -6941,6 +7165,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             /* bexpr: GTIFIND STRING ',' expr ',' STRING ',' STRING ')'  */
                             yyval = FITS_PARSER_YYSTYPE::Node(New_GTI(
                                 lParse,
+                                colData,
                                 funcOp::GTIFIND_FCT,
                                 yyvs[yyvsp - 7].text_mut_ptr(),
                                 yyvs[yyvsp - 5].node(),
@@ -6959,6 +7184,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             let mut dummy = [0];
                             yyval = FITS_PARSER_YYSTYPE::Node(New_REG(
                                 lParse,
+                                colData,
                                 yyvs[yyvsp - 1].text_mut_ptr(),
                                 -99,
                                 -99,
@@ -6975,6 +7201,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             let mut dummy = [0];
                             yyval = FITS_PARSER_YYSTYPE::Node(New_REG(
                                 lParse,
+                                colData,
                                 yyvs[yyvsp - 5].text_mut_ptr(),
                                 yyvs[yyvsp - 3].node(),
                                 yyvs[yyvsp - 1].node(),
@@ -6990,6 +7217,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             /* bexpr: REGFILTER STRING ',' expr ',' expr ',' STRING ')'  */
                             yyval = FITS_PARSER_YYSTYPE::Node(New_REG(
                                 lParse,
+                                colData,
                                 yyvs[yyvsp - 7].text_mut_ptr(),
                                 yyvs[yyvsp - 5].node(),
                                 yyvs[yyvsp - 3].node(),
@@ -7005,6 +7233,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             /* bexpr: bexpr '[' expr ']'  */
                             yyval = FITS_PARSER_YYSTYPE::Node(New_Deref(
                                 lParse,
+                                colData,
                                 yyvs[yyvsp - 3].node(),
                                 1,
                                 yyvs[yyvsp - 1].node(),
@@ -7023,6 +7252,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             /* bexpr: bexpr '[' expr ',' expr ']'  */
                             yyval = FITS_PARSER_YYSTYPE::Node(New_Deref(
                                 lParse,
+                                colData,
                                 yyvs[yyvsp - 5].node(),
                                 2,
                                 yyvs[yyvsp - 3].node(),
@@ -7041,6 +7271,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             /* bexpr: bexpr '[' expr ',' expr ',' expr ']'  */
                             yyval = FITS_PARSER_YYSTYPE::Node(New_Deref(
                                 lParse,
+                                colData,
                                 yyvs[yyvsp - 7].node(),
                                 3 as c_int,
                                 yyvs[yyvsp - 5].node(),
@@ -7059,6 +7290,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             /* bexpr: bexpr '[' expr ',' expr ',' expr ',' expr ']'  */
                             yyval = FITS_PARSER_YYSTYPE::Node(New_Deref(
                                 lParse,
+                                colData,
                                 yyvs[yyvsp - 9].node(),
                                 4 as c_int,
                                 yyvs[yyvsp - 7].node(),
@@ -7077,6 +7309,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             /* bexpr: bexpr '[' expr ',' expr ',' expr ',' expr ',' expr ']'  */
                             yyval = FITS_PARSER_YYSTYPE::Node(New_Deref(
                                 lParse,
+                                colData,
                                 yyvs[yyvsp - 11].node(),
                                 5 as c_int,
                                 yyvs[yyvsp - 9].node(),
@@ -7095,6 +7328,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             /* bexpr: NOT bexpr  */
                             yyval = FITS_PARSER_YYSTYPE::Node(New_Unary(
                                 lParse,
+                                colData,
                                 fits_parser_yytokentype::BOOLEAN as c_int,
                                 fits_parser_yytokentype::NOT as c_int,
                                 yyvs[yyvsp].node(),
@@ -7169,6 +7403,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             /* sexpr: SNULLREF  */
                             yyval = FITS_PARSER_YYSTYPE::Node(New_Func(
                                 lParse,
+                                colData,
                                 fits_parser_yytokentype::STRING as c_int,
                                 funcOp::NULL_FCT,
                                 0,
@@ -7201,6 +7436,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             } else {
                                 yyval = FITS_PARSER_YYSTYPE::Node(New_BinOp(
                                     lParse,
+                                    colData,
                                     fits_parser_yytokentype::STRING as c_int,
                                     yyvs[yyvsp - 2].node(),
                                     '+' as i32,
@@ -7249,6 +7485,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 }
                                 yyval = FITS_PARSER_YYSTYPE::Node(New_FuncSize(
                                     lParse,
+                                    colData,
                                     0,
                                     funcOp::IFTHENELSE_FCT,
                                     3 as c_int,
@@ -7309,6 +7546,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                 }
                                 yyval = FITS_PARSER_YYSTYPE::Node(New_FuncSize(
                                     lParse,
+                                    colData,
                                     0,
                                     funcOp::DEFNULL_FCT,
                                     2,
@@ -7402,6 +7640,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                                     } else {
                                         yyval = FITS_PARSER_YYSTYPE::Node(New_FuncSize(
                                             lParse,
+                                            colData,
                                             0,
                                             funcOp::STRMID_FCT,
                                             3 as c_int,
@@ -7579,6 +7818,7 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
 
 fn New_Deref(
     lParse: &mut ParseData,
+    colData: &mut [iteratorCol],
     Var: c_int,
     nDim: c_int,
     Dim1: c_int,
@@ -7687,6 +7927,7 @@ fn New_Deref(
         if constant != 0 {
             ((lParse.Nodes[this_node_idx]).DoOp).expect("non-null function pointer")(
                 lParse,
+                colData,
                 this_node_idx,
             );
         }
@@ -8040,6 +8281,7 @@ fn load_gti(
 
 fn New_GTI(
     lParse: &mut ParseData,
+    colData: &mut Vec<iteratorCol>,
     Op: funcOp,
     fname: *mut c_char,
     mut Node1: c_int,
@@ -8075,7 +8317,7 @@ fn New_GTI(
             || Op as c_uint == funcOp::GTIFIND_FCT as c_int as c_uint)
             && Node1 == -99
         {
-            type_0 = fits_parser_yyGetVariable(lParse, cs!(c"TIME"), &mut colVal);
+            type_0 = fits_parser_yyGetVariable(lParse, colData, cs!(c"TIME"), &mut colVal);
             if type_0 == fits_parser_yytokentype::COLUMN as c_int {
                 Node1 = New_Column(lParse, colVal.lng() as c_int);
             } else {
@@ -8096,14 +8338,26 @@ fn New_GTI(
                 return -(1);
             }
             /* Also case TIME_STOP to double precision */
-            Node2 = New_Unary(lParse, fits_parser_yytokentype::DOUBLE as c_int, 0, Node2);
+            Node2 = New_Unary(
+                lParse,
+                colData,
+                fits_parser_yytokentype::DOUBLE as c_int,
+                0,
+                Node2,
+            );
             if Node2 < 0 {
                 return -(1);
             }
         }
 
         /* Type cast TIME to double precision */
-        Node1 = New_Unary(lParse, fits_parser_yytokentype::DOUBLE as c_int, 0, Node1);
+        Node1 = New_Unary(
+            lParse,
+            colData,
+            fits_parser_yytokentype::DOUBLE as c_int,
+            0,
+            Node1,
+        );
         Node0 = Alloc_Node(lParse); /* This will hold the START/STOP times */
 
         if Node1 < 0 || Node0 < 0 {
@@ -8198,6 +8452,7 @@ fn New_GTI(
             {
                 ((lParse.Nodes[this_node_idx]).DoOp).expect("non-null function pointer")(
                     lParse,
+                    colData,
                     this_node_idx,
                 );
             }
@@ -8275,6 +8530,7 @@ fn load_region(
 
 fn New_REG(
     lParse: &mut ParseData,
+    colData: &mut Vec<iteratorCol>,
     fname: *mut c_char,
     mut NodeX: c_int,
     mut NodeY: c_int,
@@ -8292,7 +8548,7 @@ fn New_REG(
         let mut cY: *mut c_char = ptr::null_mut();
         let mut colVal: FITS_PARSER_YYSTYPE = FITS_PARSER_YYSTYPE::Empty;
         if NodeX == -99 {
-            type_0 = fits_parser_yyGetVariable(lParse, cs!(c"X"), &mut colVal);
+            type_0 = fits_parser_yyGetVariable(lParse, colData, cs!(c"X"), &mut colVal);
             if type_0 == fits_parser_yytokentype::COLUMN as c_int {
                 NodeX = New_Column(lParse, colVal.lng() as c_int);
             } else {
@@ -8301,7 +8557,7 @@ fn New_REG(
             }
         }
         if NodeY == -99 {
-            type_0 = fits_parser_yyGetVariable(lParse, cs!(c"Y"), &mut colVal);
+            type_0 = fits_parser_yyGetVariable(lParse, colData, cs!(c"Y"), &mut colVal);
             if type_0 == fits_parser_yytokentype::COLUMN as c_int {
                 NodeY = New_Column(lParse, colVal.lng() as c_int);
             } else {
@@ -8309,8 +8565,20 @@ fn New_REG(
                 return -(1);
             }
         }
-        NodeX = New_Unary(lParse, fits_parser_yytokentype::DOUBLE as c_int, 0, NodeX);
-        NodeY = New_Unary(lParse, fits_parser_yytokentype::DOUBLE as c_int, 0, NodeY);
+        NodeX = New_Unary(
+            lParse,
+            colData,
+            fits_parser_yytokentype::DOUBLE as c_int,
+            0,
+            NodeX,
+        );
+        NodeY = New_Unary(
+            lParse,
+            colData,
+            fits_parser_yytokentype::DOUBLE as c_int,
+            0,
+            NodeY,
+        );
         Node0 = Alloc_Node(lParse); /* This will hold the Region Data */
         if NodeX < 0 || NodeY < 0 || Node0 < 0 {
             return -(1);
@@ -8409,8 +8677,8 @@ fn New_REG(
                 }
             } else {
                 /*  Try to find columns used in X/Y expressions  */
-                Xcol = Locate_Col(lParse, &(lParse.Nodes)[NodeX as usize]);
-                Ycol = Locate_Col(lParse, &(lParse.Nodes)[NodeY as usize]);
+                Xcol = Locate_Col(lParse, colData, &(lParse.Nodes)[NodeX as usize]);
+                Ycol = Locate_Col(lParse, colData, &(lParse.Nodes)[NodeY as usize]);
                 if Xcol < 0 || Ycol < 0 {
                     fits_parser_yyerror(
                         lParse,
@@ -8445,6 +8713,7 @@ fn New_REG(
             {
                 ((lParse.Nodes[this_node_idx]).DoOp).expect("non-null function pointer")(
                     lParse,
+                    colData,
                     this_node_idx,
                 );
             }
@@ -8468,7 +8737,7 @@ fn New_Vector(lParse: &mut ParseData, subNode: c_int) -> c_int {
     n
 }
 
-fn Close_Vec(lParse: &mut ParseData, vecNode: c_int) -> c_int {
+fn Close_Vec(lParse: &mut ParseData, colData: &mut [iteratorCol], vecNode: c_int) -> c_int {
     let mut n: c_int = 0;
     let mut nelem: c_int = 0;
 
@@ -8482,6 +8751,7 @@ fn Close_Vec(lParse: &mut ParseData, vecNode: c_int) -> c_int {
 
             subnode = New_Unary(
                 lParse,
+                colData,
                 (lParse.Nodes[this_node_idx]).ntype.code(),
                 0,
                 (lParse.Nodes[this_node_idx]).SubNodes[n as usize] as c_int,
@@ -8506,7 +8776,12 @@ fn Close_Vec(lParse: &mut ParseData, vecNode: c_int) -> c_int {
     vecNode
 }
 
-fn New_Array(lParse: &mut ParseData, valueNode: c_int, mut dimNode: c_int) -> c_int {
+fn New_Array(
+    lParse: &mut ParseData,
+    colData: &mut [iteratorCol],
+    valueNode: c_int,
+    mut dimNode: c_int,
+) -> c_int {
     let mut naxis: c_long = 0;
     let mut nelem: c_long = 0;
     let mut naxes: [c_long; 5] = [0; 5];
@@ -8534,7 +8809,13 @@ fn New_Array(lParse: &mut ParseData, valueNode: c_int, mut dimNode: c_int) -> c_
         /* ARRAY(V,n) is a constant integer */
 
         if ((lParse.Nodes)[dimNode as usize]).ntype != ValueSort::Long {
-            dimNode = New_Unary(lParse, fits_parser_yytokentype::LONG as c_int, 0, dimNode);
+            dimNode = New_Unary(
+                lParse,
+                colData,
+                fits_parser_yytokentype::LONG as c_int,
+                0,
+                dimNode,
+            );
         }
         if dimNode < 0 {
             return -(1);
@@ -8559,6 +8840,7 @@ fn New_Array(lParse: &mut ParseData, valueNode: c_int, mut dimNode: c_int) -> c_
             {
                 (lParse.Nodes[dims]).SubNodes[i as usize] = New_Unary(
                     lParse,
+                    colData,
                     fits_parser_yytokentype::LONG as c_int,
                     0,
                     (lParse.Nodes[dims]).SubNodes[i as usize] as c_int,
@@ -8635,21 +8917,21 @@ fn New_Array(lParse: &mut ParseData, valueNode: c_int, mut dimNode: c_int) -> c_
 
 /*  Locate the TABLE column number of any columns in "this" calculation.  */
 /*  Return ZERO if none found, or negative if more than 1 found.          */
-fn Locate_Col(lParse: &ParseData, this: &Node) -> c_int {
+fn Locate_Col(lParse: &ParseData, colData: &[iteratorCol], this: &Node) -> c_int {
     let mut i: c_int = 0;
     let mut col: c_int = 0;
     let mut newCol: c_int = 0;
     let mut nfound: c_int = 0;
 
     if this.nSubNodes == 0 && this.is_column() {
-        return ((lParse.colData)[this.column() as usize]).colnum;
+        return (colData[this.column() as usize]).colnum;
     }
 
     i = 0;
     while i < this.nSubNodes {
         let that = &(lParse.Nodes)[this.SubNodes[i as usize] as usize];
         if that.is_computed() {
-            newCol = Locate_Col(lParse, that);
+            newCol = Locate_Col(lParse, colData, that);
             if newCol <= 0 {
                 nfound += -newCol;
             } else if nfound == 0 {
@@ -8660,7 +8942,7 @@ fn Locate_Col(lParse: &ParseData, this: &Node) -> c_int {
             }
         } else if !that.is_const() {
             /*  Found a Column  */
-            newCol = ((lParse.colData)[that.column() as usize]).colnum;
+            newCol = (colData[that.column() as usize]).colnum;
             if nfound == 0 {
                 col = newCol;
                 nfound += 1;
@@ -8738,7 +9020,12 @@ fn Copy_Dims(lParse: &mut ParseData, Node1: c_int, Node2: c_int) {
 /*  point to the appropriate column arrays.                            */
 /*  Finally, call Evaluate_Node for final node.                        */
 /***********************************************************************/
-pub(crate) fn Evaluate_Parser(lParse: &mut ParseData, firstRow: c_long, nRows: c_long) {
+pub(crate) fn Evaluate_Parser(
+    lParse: &mut ParseData,
+    colData: &mut [iteratorCol],
+    firstRow: c_long,
+    nRows: c_long,
+) {
     unsafe {
         let mut i: c_int = 0;
         let mut column: c_int = 0;
@@ -8828,7 +9115,7 @@ pub(crate) fn Evaluate_Parser(lParse: &mut ParseData, firstRow: c_long, nRows: c
             }
             i += 1;
         }
-        Evaluate_Node(lParse, lParse.resultNode);
+        Evaluate_Node(lParse, colData, lParse.resultNode);
     }
 }
 
@@ -8836,7 +9123,7 @@ pub(crate) fn Evaluate_Parser(lParse: &mut ParseData, firstRow: c_long, nRows: c
 /*  Recursively evaluate thisNode's subNodes, then call one of the    */
 /*  Do_<Action> functions pointed to by thisNode's DoOp element.      */
 /**********************************************************************/
-fn Evaluate_Node(lParse: &mut ParseData, thisNode: c_int) {
+fn Evaluate_Node(lParse: &mut ParseData, colData: &mut [iteratorCol], thisNode: c_int) {
     let mut this_node_idx: usize;
     let mut i: c_int = 0;
     if lParse.status != 0 {
@@ -8856,6 +9143,7 @@ fn Evaluate_Node(lParse: &mut ParseData, thisNode: c_int) {
 
             Evaluate_Node(
                 lParse,
+                colData,
                 (lParse.Nodes)[thisNode as usize].SubNodes[i as usize] as c_int,
             );
 
@@ -8865,6 +9153,7 @@ fn Evaluate_Node(lParse: &mut ParseData, thisNode: c_int) {
         }
         ((lParse.Nodes[thisNode as usize]).DoOp).expect("non-null function pointer")(
             lParse,
+            colData,
             thisNode as usize,
         );
     }
@@ -8995,7 +9284,7 @@ unsafe fn free_node_buffer(node: &mut Node) {
     }
 }
 
-fn Do_Unary(lParse: &mut ParseData, this_node_idx: usize) {
+fn Do_Unary(lParse: &mut ParseData, colData: &mut [iteratorCol], this_node_idx: usize) {
     unsafe {
         let mut that: &mut Node;
         let mut elem: c_long = 0;
@@ -9257,7 +9546,7 @@ fn Do_Unary(lParse: &mut ParseData, this_node_idx: usize) {
     }
 }
 
-fn Do_Offset(lParse: &mut ParseData, this_node_idx: usize) {
+fn Do_Offset(lParse: &mut ParseData, colData: &mut [iteratorCol], this_node_idx: usize) {
     unsafe {
         let mut fRow: c_long = 0;
         let mut nRowOverlap: c_long = 0;
@@ -9428,6 +9717,7 @@ fn Do_Offset(lParse: &mut ParseData, this_node_idx: usize) {
                 ValueSort::Bits | ValueSort::String => {
                     status = (lParse.loadData).expect("non-null function pointer")(
                         lParse,
+                        colData,
                         -(lParse.Nodes[col_idx]).operation,
                         fRow,
                         nRowReload,
@@ -9440,6 +9730,7 @@ fn Do_Offset(lParse: &mut ParseData, this_node_idx: usize) {
                 ValueSort::Boolean => {
                     status = (lParse.loadData).expect("non-null function pointer")(
                         lParse,
+                        colData,
                         -(lParse.Nodes[col_idx]).operation,
                         fRow,
                         nRowReload,
@@ -9452,6 +9743,7 @@ fn Do_Offset(lParse: &mut ParseData, this_node_idx: usize) {
                 ValueSort::Long => {
                     status = (lParse.loadData).expect("non-null function pointer")(
                         lParse,
+                        colData,
                         -(lParse.Nodes[col_idx]).operation,
                         fRow,
                         nRowReload,
@@ -9464,6 +9756,7 @@ fn Do_Offset(lParse: &mut ParseData, this_node_idx: usize) {
                 ValueSort::Double => {
                     status = (lParse.loadData).expect("non-null function pointer")(
                         lParse,
+                        colData,
                         -(lParse.Nodes[col_idx]).operation,
                         fRow,
                         nRowReload,
@@ -9541,7 +9834,7 @@ fn Do_Offset(lParse: &mut ParseData, this_node_idx: usize) {
         }
     }
 }
-fn Do_BinOp_bit(lParse: &mut ParseData, this_node_idx: usize) {
+fn Do_BinOp_bit(lParse: &mut ParseData, colData: &mut [iteratorCol], this_node_idx: usize) {
     unsafe {
         let mut that1: &mut Node;
         let mut that2: &mut Node;
@@ -9745,7 +10038,7 @@ fn Do_BinOp_bit(lParse: &mut ParseData, this_node_idx: usize) {
     }
 }
 
-fn Do_BinOp_str(lParse: &mut ParseData, this_node_idx: usize) {
+fn Do_BinOp_str(lParse: &mut ParseData, colData: &mut [iteratorCol], this_node_idx: usize) {
     unsafe {
         let mut that1: &mut Node;
         let mut that2: &mut Node;
@@ -10066,7 +10359,7 @@ fn Do_BinOp_str(lParse: &mut ParseData, this_node_idx: usize) {
         }
     }
 }
-fn Do_BinOp_log(lParse: &mut ParseData, this_node_idx: usize) {
+fn Do_BinOp_log(lParse: &mut ParseData, colData: &mut [iteratorCol], this_node_idx: usize) {
     unsafe {
         let mut that1: &mut Node;
         let mut that2: &mut Node;
@@ -10305,7 +10598,7 @@ fn Do_BinOp_log(lParse: &mut ParseData, this_node_idx: usize) {
     }
 }
 
-fn Do_BinOp_lng(lParse: &mut ParseData, this_node_idx: usize) {
+fn Do_BinOp_lng(lParse: &mut ParseData, colData: &mut [iteratorCol], this_node_idx: usize) {
     unsafe {
         let mut vector1: c_int = 0;
         let mut vector2: c_int = 0;
@@ -10640,7 +10933,7 @@ fn validate_double_vector(lParse: &mut ParseData, node_idx: usize) -> c_int {
     1
 }
 
-fn Do_BinOp_dbl(lParse: &mut ParseData, this_node_idx: usize) {
+fn Do_BinOp_dbl(lParse: &mut ParseData, colData: &mut [iteratorCol], this_node_idx: usize) {
     unsafe {
         let mut that1: &mut Node;
         let mut that2: &mut Node;
@@ -11057,7 +11350,7 @@ pub(crate) fn angsep_calc(
     2.0 * atan2((a).sqrt(), (1.0 - a).sqrt()) / DEG
 }
 
-fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
+fn Do_Func(lParse: &mut ParseData, colData: &mut [iteratorCol], this_node_idx: usize) {
     unsafe {
         let mut theParams: [usize; 10] = [0; 10];
         let mut vector: [c_int; 10] = [0; 10];
@@ -14369,7 +14662,7 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
     }
 }
 
-fn Do_Deref(lParse: &mut ParseData, this_node_idx: usize) {
+fn Do_Deref(lParse: &mut ParseData, colData: &mut [iteratorCol], this_node_idx: usize) {
     unsafe {
         let mut theVar: &mut Node;
         let mut theDims: [usize; MAXDIMS as usize] = [0; MAXDIMS as usize];
@@ -14781,7 +15074,7 @@ fn Do_Deref(lParse: &mut ParseData, this_node_idx: usize) {
     }
 }
 
-fn Do_GTI(lParse: &mut ParseData, this_node_idx: usize) {
+fn Do_GTI(lParse: &mut ParseData, colData: &mut [iteratorCol], this_node_idx: usize) {
     unsafe {
         let mut theExpr: &mut Node;
         let mut theTimes: &mut Node;
@@ -14895,7 +15188,7 @@ fn Do_GTI(lParse: &mut ParseData, this_node_idx: usize) {
     }
 }
 
-fn Do_GTI_Over(lParse: &mut ParseData, this_node_idx: usize) {
+fn Do_GTI_Over(lParse: &mut ParseData, colData: &mut [iteratorCol], this_node_idx: usize) {
     unsafe {
         let mut theTimes: &mut Node;
         let mut theStart: &mut Node;
@@ -15187,7 +15480,7 @@ fn Search_GTI(
         gti
     }
 }
-fn Do_REG(lParse: &mut ParseData, this_node_idx: usize) {
+fn Do_REG(lParse: &mut ParseData, colData: &mut [iteratorCol], this_node_idx: usize) {
     unsafe {
         let mut theRegion: &mut Node;
         let mut theX: &mut Node;
@@ -15375,7 +15668,7 @@ fn get_this_that1_that2_nodes<T>(
 }
 */
 
-fn Do_Vector(lParse: &mut ParseData, this_node_idx: usize) {
+fn Do_Vector(lParse: &mut ParseData, colData: &mut [iteratorCol], this_node_idx: usize) {
     unsafe {
         let mut that: &mut Node;
         let mut row: c_long = 0;
@@ -15483,7 +15776,7 @@ fn Do_Vector(lParse: &mut ParseData, this_node_idx: usize) {
     }
 }
 
-fn Do_Array(lParse: &mut ParseData, this_node_idx: usize) {
+fn Do_Array(lParse: &mut ParseData, colData: &mut [iteratorCol], this_node_idx: usize) {
     unsafe {
         let mut that: &mut Node;
         let mut row: c_long = 0;

--- a/src/histo.rs
+++ b/src/histo.rs
@@ -1207,6 +1207,7 @@ pub(crate) fn ffhist2e(
             let mut nelem: c_long = 0;
             let mut naxes: [c_long; MAXDIMS as usize] = [0; MAXDIMS as usize];
             let mut lParse: ParseData = ParseData::default();
+            let mut colData: Vec<iteratorCol> = Vec::new();
 
             ffiprs(
                 fptr_inner,
@@ -1218,9 +1219,10 @@ pub(crate) fn ffhist2e(
                 &mut naxis1,
                 &mut naxes,
                 &mut lParse,
+                &mut colData,
                 status,
             );
-            ffcprs(&mut lParse);
+            ffcprs(&mut lParse, &mut colData);
             if nelem < 0 {
                 nelem = 1; /* If it's a constant expression */
             }
@@ -3061,6 +3063,7 @@ pub(crate) fn fits_calc_binningde(
             let mut naxes: [c_long; MAXDIMS as usize] = [0; MAXDIMS as usize];
             let mut naxis: c_int = 0;
             let mut lParse: ParseData = ParseData::default();
+            let mut colData: Vec<iteratorCol> = Vec::new();
 
             /* Initialize the parser so that we can determine the datatype
             of the returned type as well as the vector dimensions */
@@ -3075,6 +3078,7 @@ pub(crate) fn fits_calc_binningde(
                 &mut naxis,
                 &mut naxes,
                 &mut lParse,
+                &mut colData,
                 status,
             ) != 0
             {
@@ -3082,7 +3086,7 @@ pub(crate) fn fits_calc_binningde(
                 let errmsg_len = strlen_safe(&errmsg);
                 strncat_safe(&mut errmsg, ce[ii].unwrap(), FLEN_ERRMSG - errmsg_len - 1);
                 ffpmsg_slice(&errmsg);
-                ffcprs(&mut lParse);
+                ffcprs(&mut lParse, &mut colData);
                 return *status;
             }
             if nelem < 0 {
@@ -3094,7 +3098,7 @@ pub(crate) fn fits_calc_binningde(
             /* We require lParse.nCols columns to be read from input,
             plus one for the Temporary calculator result */
             ncols = lParse.nCols + 1;
-            ffcprs(&mut lParse);
+            ffcprs(&mut lParse, &mut colData);
         }
 
         /* Not sure why this repeat limitation is here -- CM
@@ -3996,6 +4000,9 @@ pub(crate) fn fits_make_histde(
     let mut imagepars: [iteratorCol; 1] = [iteratorCol::default(); 1];
     let mut nrows: c_long = -1;
     let mut parsers: [ParseData; 5] = array::from_fn(|_| ParseData::default());
+    /* The parser iterator columns now live alongside, not inside, the
+    ParseData, so each of the five parsers gets its own array. */
+    let mut parserCols: [Vec<iteratorCol>; 5] = array::from_fn(|_| Vec::new());
     let mut infos: [parseInfo; 5] = array::from_fn(|_| parseInfo::default());
     let mut numAllocCols: c_int = 0;
     let mut startCol: c_int = -1;
@@ -4164,6 +4171,7 @@ pub(crate) fn fits_make_histde(
                     &mut naxis1,
                     &mut naxes,
                     &mut (parsers[ii]),
+                    &mut (parserCols[ii]),
                     status,
                 );
                 if *status != 0 {
@@ -4179,6 +4187,7 @@ pub(crate) fn fits_make_histde(
                 fits_get_num_rows(fptr, &mut nrows, status);
                 if fits_parser_set_temporary_col(
                     &mut (parsers[ii]),
+                    &mut (parserCols[ii]),
                     &mut (infos[ii]),
                     nrows,
                     core::ptr::from_mut::<f64>(&mut (double_nulval)).cast::<c_void>(),
@@ -4202,7 +4211,7 @@ pub(crate) fn fits_make_histde(
                 }
                 numAllocCols += parsers[ii].nCols;
                 for jj in 0..parsers[ii].nCols as usize {
-                    unsafe { *iterCols.add(startCol as usize) = parsers[ii].colData[jj] };
+                    unsafe { *iterCols.add(startCol as usize) = parserCols[ii][jj] };
                     startCol += 1;
                 }
             } else {
@@ -4249,6 +4258,7 @@ pub(crate) fn fits_make_histde(
                 &mut wtnaxis,
                 &mut wtnaxes,
                 &mut (parsers[4]),
+                &mut (parserCols[4]),
                 status,
             );
             if *status != 0 {
@@ -4263,6 +4273,7 @@ pub(crate) fn fits_make_histde(
             fits_get_num_rows(fptr, &mut nrows, status);
             if fits_parser_set_temporary_col(
                 &mut (parsers[4]),
+                &mut (parserCols[4]),
                 &mut (infos[4]),
                 nrows,
                 core::ptr::from_mut::<f64>(&mut (double_nulval)).cast::<c_void>(),
@@ -4286,7 +4297,7 @@ pub(crate) fn fits_make_histde(
             }
             numAllocCols += parsers[ii].nCols;
             for jj in 0..parsers[4].nCols as usize {
-                unsafe { *iterCols.add(startCol as usize) = parsers[4].colData[jj] };
+                unsafe { *iterCols.add(startCol as usize) = parserCols[4][jj] };
                 startCol += 1;
             }
         } else if weight == DOUBLENULLVALUE {
@@ -4402,7 +4413,7 @@ pub(crate) fn fits_make_histde(
     /* ... and parsers */
     for ii in 0..=4 {
         if parsers[ii].nCols > 0 {
-            ffcprs(&mut (parsers[ii]));
+            ffcprs(&mut (parsers[ii]), &mut (parserCols[ii]));
         }
     }
     *status
@@ -4622,6 +4633,7 @@ fn fits_get_expr_minmax(
 ) -> c_int {
     let mut Info: parseInfo = parseInfo::default();
     let mut lParse: ParseData = ParseData::default();
+    let mut colData: Vec<iteratorCol> = Vec::new();
     let mut minmaxWorkFn: histo_minmax_workfn_struct = histo_minmax_workfn_struct::default();
     let mut naxis: c_int = 0;
     let constant: c_int = 0;
@@ -4668,10 +4680,11 @@ fn fits_get_expr_minmax(
         &mut naxis,
         &mut naxes,
         &mut lParse,
+        &mut colData,
         status,
     ) != 0
     {
-        ffcprs(&mut lParse);
+        ffcprs(&mut lParse, &mut colData);
         return *status;
     }
 
@@ -4729,11 +4742,11 @@ fn fits_get_expr_minmax(
             }
             _ => {
                 // For any other data types, we don't handle constants
-                ffcprs(&mut lParse);
+                ffcprs(&mut lParse, &mut colData);
                 return *status;
             }
         }
-        ffcprs(&mut lParse);
+        ffcprs(&mut lParse, &mut colData);
         return *status;
     }
 
@@ -4742,13 +4755,14 @@ fn fits_get_expr_minmax(
     /* Add a temporary column which contains the expression value */
     if fits_parser_set_temporary_col(
         &mut lParse,
+        &mut colData,
         &mut Info,
         nrows,
         core::ptr::from_mut::<f64>(&mut double_nulval).cast::<c_void>(),
         status,
     ) != 0
     {
-        ffcprs(&mut lParse);
+        ffcprs(&mut lParse, &mut colData);
         return *status;
     }
 
@@ -4761,7 +4775,7 @@ fn fits_get_expr_minmax(
 
     if ffiter_safe(
         lParse.nCols,
-        &mut lParse.colData,
+        &mut colData,
         0,
         0,
         histo_minmax_expr_workfn
@@ -4788,7 +4802,7 @@ fn fits_get_expr_minmax(
         *datamax = minmaxWorkFn.datamax;
     }
 
-    ffcprs(&mut lParse);
+    ffcprs(&mut lParse, &mut colData);
     *status
 }
 


### PR DESCRIPTION
**One of two alternative fixes for the same bug — see the sibling PR. Only one should be merged.**

Miri reports Stacked Borrows UB on ~205 tests, all one root cause. `ffiter_safe` takes `cols: &mut [iteratorCol]`, which is strongly protected for the whole call, while the work function it invokes builds a `&mut ParseData` (via `parseInfo.parseData`) covering `lParse.colData` — the same array. The parser genuinely reads that array *during* iteration (`load_column`, reached through the `loadData` function pointer), so it cannot simply be moved out for the duration.

**This option** removes `colData` from `ParseData` entirely, so a `&mut ParseData` no longer covers the array, and threads it to the functions that need it during iteration. `GetDataFn`, `LoadDataFn` and `Node::DoOp` each gain a parameter; 24 functions in `eval_y.rs` thread it through.

A useful side effect: parse-phase functions take `&mut Vec<iteratorCol>` (they can grow the array) and iteration-phase ones take `&mut [iteratorCol]`. That distinction was previously invisible.

Also included: the RNG seed now uses `SystemTime` rather than libc `time()`. That was the last foreign call on the evaluator's path, and it aborted every test reaching the evaluator once the aliasing was fixed, making the fix impossible to measure.

**Verification** — suite green (35 binaries, 2935 passed / 0 failed), clippy clean, zero warnings. On a 30-test sample drawn from the exact 205 affected tests: **19 pass, 11 fail, 0 leaks**.

The 11 stragglers are *different* root causes, not this one. Nine are a pre-existing bug already flagged in `main`:

```rust
// WARNING - THIS IS DANGEROUS. If nCols = 0, points to invalid memory.
outcol = colData.as_mut_ptr().offset((nCols - 1) as isize)
```

With `nCols == 0` that is `offset(-1)`; Miri reports offsetting 272 bytes before the start of the allocation. Untouched here and worth its own fix. The other two are `eval_tab.rs` `text_mut_ptr` and one `eval_y` site.

One behavioural edit worth the closest review: the work function's first-call `lParse->colData[jj].repeat = colData[jj].repeat` sync loop is removed, because the parser no longer keeps a second array. The histogram path passes `&mut iterCols[startCol..][..nCols]`, which is index-aligned with that parser's columns, so the two were already in step. I verified that indexing independently.

Not addressed: `fits_parser_set_temporary_col` stashes a raw pointer derived from its `&mut ParseData` parameter while the caller keeps using `lParse`.