### PR TITLE
Stop the iterator holding an exclusive borrow of the column array (option B)

### DIFF
--- a/src/eval_f.rs
+++ b/src/eval_f.rs
@@ -92,7 +92,7 @@ use crate::getcols::{ffgcfs_safe, ffgcvs_safe};
 use crate::getkey::ffgkyj_safe;
 use crate::getkey::{ffgcrd_safe, ffgknjj_safe};
 use crate::modkey::{ffdkey_safe, ffukyd_safe, ffukyj_safe, ffukyl_safe, ffukys_safe};
-use crate::putcol::{ffiter_safe, fits_iter_set_by_num_safe};
+use crate::putcol::{ffiter_internal, fits_iter_set_by_num_safe};
 use crate::putkey::{ffpcom_safe, ffphis_safe, ffpkyj_safe, ffpkys_safe, ffptdm_safe};
 use crate::wrappers::{strcat_safe, strcpy_safe, strlen_safe, strncpy_safe};
 use crate::{BL, NullCheckType, cs, fitsio::*, int_snprintf, raw_to_slice};
@@ -229,16 +229,25 @@ pub fn fffrow_safe(
         Info.dataPtr = row_status.as_mut_ptr().cast::<c_void>();
         Info.nullPtr = ptr::null_mut();
         Info.maxRows = nrows;
+
+        /* The iterator's column array *is* `lParse.colData`, and the work
+        function reaches it again through `Info.parseData`. Take the raw
+        pointer to the array first, then (re-)establish `Info.parseData`:
+        borrowing `lParse` mutably would invalidate a raw pointer taken
+        before it. */
+        let n_cols = lParse.nCols;
+        let cols_ptr = lParse.colData.as_mut_ptr();
+        let cols_len = lParse.colData.len();
         Info.parseData = &raw mut lParse;
 
-        let colData_slice = &mut lParse.colData[..];
-        if ffiter_safe(
-            lParse.nCols,
-            colData_slice,
+        if ffiter_internal(
+            n_cols,
+            cols_ptr,
+            cols_len,
             firstrow - 1,
             0,
             fits_parser_workfn,
-            core::ptr::from_ref(&Info) as *mut c_void,
+            core::ptr::from_mut::<parseInfo>(&mut Info).cast::<c_void>(),
             status,
         ) == -1
         {
@@ -447,7 +456,7 @@ pub fn ffsrow_safe(
 
     /* The row-selection flags are owned here and handed to the parser as a
     raw pointer, so the error returns below cannot leak them.  `Info.dataPtr`
-    is what `fits_parser_workfn` writes through during `ffiter_safe`; every
+    is what `fits_parser_workfn` writes through during `ffiter_internal`; every
     access from this function reads `row_flags` directly instead, so no raw
     pointer into the Vec is live once the iterator has returned. */
     let mut row_flags: Vec<c_char> = Vec::new();
@@ -478,10 +487,18 @@ pub fn ffsrow_safe(
         }
         nGood = if result != 0 { inExt.numRows } else { 0 } as c_long;
     } else {
-        let col_slice = &mut lParse.colData[..];
-        ffiter_safe(
-            lParse.nCols,
-            col_slice,
+        /* Take the raw pointer to `lParse.colData` before re-establishing
+        `Info.parseData`: the work function reaches the same array through
+        both, so neither may be derived from the other. */
+        let n_cols = lParse.nCols;
+        let cols_ptr = lParse.colData.as_mut_ptr();
+        let cols_len = lParse.colData.len();
+        Info.parseData = core::ptr::from_mut::<ParseData>(&mut lParse);
+
+        ffiter_internal(
+            n_cols,
+            cols_ptr,
+            cols_len,
             0,
             0,
             fits_parser_workfn,
@@ -804,7 +821,7 @@ pub fn ffsrow_inplace_safe(
 
     /* The row-selection flags are owned here and handed to the parser as a
     raw pointer, so the error returns below cannot leak them.  `Info.dataPtr`
-    is what `fits_parser_workfn` writes through during `ffiter_safe`; every
+    is what `fits_parser_workfn` writes through during `ffiter_internal`; every
     access from this function reads `row_flags` directly instead, so no raw
     pointer into the Vec is live once the iterator has returned. */
     let mut row_flags: Vec<c_char> = Vec::new();
@@ -835,10 +852,18 @@ pub fn ffsrow_inplace_safe(
         }
         nGood = if result != 0 { inExt.numRows } else { 0 } as c_long;
     } else {
-        let col_slice = &mut lParse.colData[..];
-        ffiter_safe(
-            lParse.nCols,
-            col_slice,
+        /* Take the raw pointer to `lParse.colData` before re-establishing
+        `Info.parseData`: the work function reaches the same array through
+        both, so neither may be derived from the other. */
+        let n_cols = lParse.nCols;
+        let cols_ptr = lParse.colData.as_mut_ptr();
+        let cols_len = lParse.colData.len();
+        Info.parseData = core::ptr::from_mut::<ParseData>(&mut lParse);
+
+        ffiter_internal(
+            n_cols,
+            cols_ptr,
+            cols_len,
             0,
             0,
             fits_parser_workfn,
@@ -1039,12 +1064,17 @@ pub fn ffcrow_safe(
     Info.dataPtr = array.as_mut_ptr().cast::<c_void>();
     Info.nullPtr = nulval.cast_mut();
     Info.maxRows = nelements / nelem1;
+    /* Take the raw pointer to `lParse.colData` before re-establishing
+    `Info.parseData`: the work function reaches the same array through both. */
+    let n_cols = lParse.nCols;
+    let cols_ptr = lParse.colData.as_mut_ptr();
+    let cols_len = lParse.colData.len();
     Info.parseData = &raw mut lParse;
 
-    let colData_slice = &mut lParse.colData[..];
-    if ffiter_safe(
-        lParse.nCols,
-        colData_slice,
+    if ffiter_internal(
+        n_cols,
+        cols_ptr,
+        cols_len,
         firstrow - 1,
         0,
         fits_parser_workfn,
@@ -1525,14 +1555,22 @@ pub fn ffcalc_rng_safe(
                 nPerLp = Info.maxRows as c_int;
             }
 
-            let colData_slice = &mut lParse.colData[..];
-            if ffiter_safe(
-                lParse.nCols,
-                colData_slice,
+            /* Take the raw pointer to `lParse.colData` before re-establishing
+            `Info.parseData`: the work function reaches the same array through
+            both. */
+            let n_cols = lParse.nCols;
+            let cols_ptr = lParse.colData.as_mut_ptr();
+            let cols_len = lParse.colData.len();
+            Info.parseData = &raw mut lParse;
+
+            if ffiter_internal(
+                n_cols,
+                cols_ptr,
+                cols_len,
                 start[i as usize] - 1,
                 c_long::from(nPerLp),
                 fits_parser_workfn,
-                core::ptr::from_ref(&Info) as *mut c_void,
+                core::ptr::from_mut::<parseInfo>(&mut Info).cast::<c_void>(),
                 status,
             ) == -1
             {
@@ -1913,14 +1951,22 @@ pub fn ffcalc_rng_inplace_safe(
                 nPerLp = Info.maxRows as c_int;
             }
 
-            let colData_slice = &mut lParse.colData[..];
-            if ffiter_safe(
-                lParse.nCols,
-                colData_slice,
+            /* Take the raw pointer to `lParse.colData` before re-establishing
+            `Info.parseData`: the work function reaches the same array through
+            both. */
+            let n_cols = lParse.nCols;
+            let cols_ptr = lParse.colData.as_mut_ptr();
+            let cols_len = lParse.colData.len();
+            Info.parseData = &raw mut lParse;
+
+            if ffiter_internal(
+                n_cols,
+                cols_ptr,
+                cols_len,
                 start[i as usize] - 1,
                 c_long::from(nPerLp),
                 fits_parser_workfn,
-                core::ptr::from_ref(&Info) as *mut c_void,
+                core::ptr::from_mut::<parseInfo>(&mut Info).cast::<c_void>(),
                 status,
             ) == -1
             {
@@ -2335,8 +2381,6 @@ pub(crate) extern "C" fn fits_parser_workfn(
     colData: *mut iteratorCol, /* IO- Column information/data        */
     userPtr: *mut c_void,      /* I - Data handling instructions     */
 ) -> c_int {
-    let colData = unsafe { core::slice::from_raw_parts_mut(colData, nCols as usize) };
-
     fits_parser_workfn_safe(totalrows, offset, firstrow, nrows, nCols, colData, userPtr)
 }
 
@@ -2367,9 +2411,14 @@ pub(crate) fn fits_parser_workfn_safe(
     mut firstrow: c_long,        /* I - First row of this iteration    */
     mut nrows: c_long,           /* I - Number of rows in this iter    */
     nCols: c_int,                /* I - Number of columns in use       */
-    colData: &mut [iteratorCol], /* IO- Column information/data        */
+    colData: *mut iteratorCol,   /* IO- Column information/data        */
     userPtr: *mut c_void,        /* I - Data handling instructions     */
 ) -> c_int {
+    /* `colData` is a raw pointer rather than a `&mut [iteratorCol]` because it
+    may be the very same array as `lParse.colData` -- the parser's own copy,
+    reached below through `userPtr->parseData`. An exclusive slice borrow held
+    across those accesses would be invalidated by them, so the array is
+    re-borrowed from `colData` at each point of use instead. */
     unsafe {
         let mut status: c_int = 0;
         let mut constant: c_int = 0;
@@ -2415,7 +2464,10 @@ pub(crate) fn fits_parser_workfn_safe(
             multiple parsers being managed at one time.) Upon the first
             call we make sure they match */
             for jj in 0..(nCols as usize) {
-                lParse.colData[jj].repeat = colData[jj].repeat;
+                /* Read through `colData` first: writing to `lParse.colData`
+                is the other route to (possibly) the same element. */
+                let repeat = (*colData.add(jj)).repeat;
+                lParse.colData[jj].repeat = repeat;
             }
 
             if (*(pv.userInfo)).maxRows > 0 {
@@ -2432,7 +2484,7 @@ pub(crate) fn fits_parser_workfn_safe(
             means that the first value will be a null value and the remaining
             values will be the where the outputs are placed */
             if (*(pv.userInfo)).dataPtr.is_null() {
-                outcol = &mut colData[(nCols - 1) as usize]; // Re-bind
+                outcol = &mut *colData.add((nCols - 1) as usize); // Re-bind
                 if outcol.iotype == INPUT_COL {
                     ffpmsg_str("Output column for parser results not found!");
                     return PARSE_NO_OUTPUT;
@@ -2557,7 +2609,7 @@ pub(crate) fn fits_parser_workfn_safe(
         */
 
         if (*(pv.userInfo)).dataPtr.is_null() {
-            outcol = &mut colData[(nCols - 1) as usize]; // Re-bind
+            outcol = &mut *colData.add((nCols - 1) as usize); // Re-bind
 
             /* First, reset Data pointer to start of output array, plus 1
             because the 0th element is the null value (cute undocumented
@@ -2612,7 +2664,13 @@ pub(crate) fn fits_parser_workfn_safe(
         let Data0: *mut c_void = pv.Data; /* Record starting point */
         nrows = cmp::min(nrows, (pv.lastRow) - firstrow + 1);
 
-        Setup_DataArrays(lParse, nCols, colData, firstrow, nrows);
+        Setup_DataArrays(
+            lParse,
+            nCols,
+            core::slice::from_raw_parts_mut(colData, nCols as usize),
+            firstrow,
+            nrows,
+        );
 
         /* Parser allocates arrays for each column and calculation it performs. */
         /* Limit number of rows processed during each pass to reduce memory     */
@@ -2966,11 +3024,7 @@ pub(crate) fn fits_parser_workfn_safe(
 
         // WARNING - THIS IS DANGEROUS. If nCols = 0, points to invalid memory.
         // In the case of the where expr = "#ROW > 2" there are no columns.
-        outcol = colData
-            .as_mut_ptr()
-            .offset((nCols - 1) as isize)
-            .as_mut()
-            .unwrap();
+        outcol = colData.offset((nCols - 1) as isize).as_mut().unwrap();
         // outcol = &mut colData[(nCols - 1) as usize]; // Re-bind
 
         if pv.Null != outcol.array
@@ -4181,13 +4235,17 @@ pub fn fffrwc_safe(
             Info.dataPtr = time_status.as_mut_ptr().cast::<c_void>();
             Info.nullPtr = ptr::null_mut();
             Info.maxRows = ntimes;
+            /* Address the columns through the vector's own pointer: the
+            work function reaches the same array through `parseData`. */
+            let n_cols = lParse.nCols;
+            let cols_ptr = lParse.colData.as_mut_ptr();
             *status = fits_parser_workfn_safe(
                 ntimes,
                 0,
                 1,
                 ntimes,
-                lParse.nCols,
-                &mut lParse.colData,
+                n_cols,
+                cols_ptr,
                 core::ptr::from_mut::<parseInfo>(&mut Info).cast::<c_void>(),
             );
         }
@@ -4293,14 +4351,20 @@ pub fn ffffrw_safer(
                 };
             };
         } else {
+            /* Take the raw pointer to `lParse.colData` before handing a raw
+            `lParse` to the work function: the work function reaches the same
+            array through both, so neither may be derived from the other. */
+            let n_cols = lParse.nCols;
+            let cols_ptr = lParse.colData.as_mut_ptr();
+            let cols_len = lParse.colData.len();
             let mut workData = ffffrw_workdata {
                 prownum: rownum,
                 lParse: core::ptr::from_mut::<ParseData>(&mut lParse),
             };
-            let colData_slice = &mut lParse.colData[..];
-            if ffiter_safe(
-                (lParse).nCols,
-                colData_slice,
+            if ffiter_internal(
+                n_cols,
+                cols_ptr,
+                cols_len,
                 0,
                 0,
                 ffffrw_work,
@@ -4966,20 +5030,25 @@ pub fn fits_pixel_filter_safer(
             );
 
             info.maxRows = -1;
+
+            /* Take the raw pointer to `lParse.colData` before establishing
+            `info.parseData`: the work function reaches the same array through
+            both. */
+            let n_cols = lParse.nCols;
+            let cols_ptr = lParse.colData.as_mut_ptr();
+            let cols_len = lParse.colData.len();
             info.parseData = &raw mut lParse;
 
-            if {
-                let colData_slice = &mut lParse.colData[..];
-                ffiter_safe(
-                    lParse.nCols,
-                    colData_slice,
-                    0,
-                    0,
-                    fits_parser_workfn,
-                    core::ptr::from_mut::<parseInfo>(&mut info).cast::<c_void>(),
-                    status,
-                )
-            } == -1
+            if ffiter_internal(
+                n_cols,
+                cols_ptr,
+                cols_len,
+                0,
+                0,
+                fits_parser_workfn,
+                core::ptr::from_mut::<parseInfo>(&mut info).cast::<c_void>(),
+                status,
+            ) == -1
             {
                 *status = 0;
             } else if *status != 0 {

--- a/src/eval_y.rs
+++ b/src/eval_y.rs
@@ -73,7 +73,7 @@ use core::ffi::CStr;
 use core::{cmp, ptr};
 
 use bytemuck::{cast_slice, cast_slice_mut};
-use libc::{calloc, free, malloc, memcpy, time, time_t};
+use libc::{calloc, free, malloc, memcpy};
 
 const APPROX: f64 = 1.0e-7;
 
@@ -8748,7 +8748,14 @@ pub(crate) fn Evaluate_Parser(lParse: &mut ParseData, firstRow: c_long, nRows: c
 
         /* Initialize the random number generator once and only once */
         if RAND_INITIALIZED == 0 {
-            simplerng_srand(time(core::ptr::null_mut::<time_t>()) as c_uint);
+            /* Seed from the wall clock, as the C's time(NULL) does. Uses
+               SystemTime rather than libc time() so the expression engine has
+               no foreign call on this path -- Miri cannot make it, and it was
+               aborting every test that reaches the evaluator. */
+            let seed = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map_or(0, |d| d.as_secs() as c_uint);
+            simplerng_srand(seed);
             RAND_INITIALIZED = 1;
         }
         lParse.firstRow = firstRow;

--- a/src/histo.rs
+++ b/src/histo.rs
@@ -25,7 +25,7 @@ use crate::fitscore::ffpmsg_slice;
 use crate::fitscore::ffpmsg_str;
 use crate::fitscore::fits_copy_pixlist2image_safe;
 use crate::fitscore::fits_recalloc;
-use crate::putcol::ffiter_safe;
+use crate::putcol::ffiter_internal;
 use crate::putcol::fits_iter_set_by_num_safe;
 
 use crate::aliases::rust_api::*;
@@ -4565,7 +4565,6 @@ extern "C" fn histo_minmax_expr_workfn(
     colData: *mut iteratorCol, /* IO- Column information/data        */
     userPtr: *mut c_void,      /* I - Data handling instructions     */
 ) -> c_int {
-    let colData = unsafe { slice::from_raw_parts_mut(colData, nCols as usize) };
     let userPtr = unsafe { &mut *userPtr.cast::<histo_minmax_workfn_struct>() };
     let mut status: c_int = 0;
     let mut i: c_long;
@@ -4585,7 +4584,9 @@ extern "C" fn histo_minmax_expr_workfn(
         wf.Info.cast::<c_void>(),
     );
 
-    let outcol: &mut iteratorCol = &mut (colData[nCols as usize - 1]);
+    /* Re-borrow from `colData` only now: the parser work function above may
+    have reached the same array by its own route. */
+    let outcol: &mut iteratorCol = unsafe { &mut *colData.add(nCols as usize - 1) };
 
     /* The result of the calculation is in pv->Data, and null value in pv->Null */
     let data = unsafe {
@@ -4752,6 +4753,16 @@ fn fits_get_expr_minmax(
         return *status;
     }
 
+    /* Take the raw pointer to `lParse.colData` before re-establishing
+    `Info.parseData`: the work function reaches the same array through both, so
+    neither may be derived from the other. `Info.parseData` must also be written
+    before `&raw mut Info` is taken below, since writing to `Info` through the
+    local invalidates that pointer. */
+    let n_cols = lParse.nCols;
+    let cols_ptr = lParse.colData.as_mut_ptr();
+    let cols_len = lParse.colData.len();
+    Info.parseData = &raw mut lParse;
+
     /* Initialize the work function computing min/max */
     minmaxWorkFn.Info = &raw mut Info;
     minmaxWorkFn.datamax = DOUBLENULLVALUE;
@@ -4759,9 +4770,10 @@ fn fits_get_expr_minmax(
     minmaxWorkFn.ngood = 0;
     minmaxWorkFn.ntotal = 0;
 
-    if ffiter_safe(
-        lParse.nCols,
-        &mut lParse.colData,
+    if ffiter_internal(
+        n_cols,
+        cols_ptr,
+        cols_len,
         0,
         0,
         histo_minmax_expr_workfn
@@ -4876,13 +4888,18 @@ fn ffwritehisto_safe(
     let n_cols = histData.numIterCols;
 
     // TODO / WARNING this is super unsafe
-    unsafe {
+    {
+        /* `ffcalchist` reaches `histData.iterCols` again through `histData`
+        itself, so the iterator must not hold an exclusive borrow of it. */
+        /* Length first: `<[T]>::len` re-borrows the slice, which would
+        invalidate a pointer taken before it. */
+        let iterCols_len = histData.iterCols.len();
         let iterCols = histData.iterCols.as_mut_ptr();
-        let iterCols = slice::from_raw_parts_mut(iterCols, n_cols as usize);
 
-        ffiter_safe(
+        ffiter_internal(
             n_cols,
             iterCols,
+            iterCols_len,
             offset,
             rows_per_loop,
             ffcalchist
@@ -4914,7 +4931,10 @@ extern "C" fn ffcalchist(
     colpars: *mut iteratorCol,
     userPointer: *mut c_void,
 ) -> c_int {
-    let colpars = unsafe { &mut *colpars };
+    /* `colpars` is left as the raw pointer the iterator handed us: every access
+    to the column array below goes through it rather than through
+    `histData.iterCols`, so that those accesses and the iterator's own stay
+    siblings instead of invalidating one another. */
     let userPointer = unsafe { &mut *userPointer.cast::<HistType>() };
     let mut ii: c_long;
     let mut ipix: c_long;
@@ -4949,8 +4969,16 @@ extern "C" fn ffcalchist(
         /* We have a parser for this, evaluate it */
         if histData.parsers[ii].nCols > 0 {
             let nCols: c_int = histData.parsers[ii].nCols;
-            let colData_slice: &mut [iteratorCol] =
-                &mut histData.iterCols[startCol as usize..][..nCols as usize];
+            /* Address the columns through the iterator's own pointer rather
+            than an exclusive slice borrow: the parser work function reaches
+            this array again through its `parseInfo`. */
+            let colData_ptr: *mut iteratorCol = unsafe { colpars.add(startCol as usize) };
+
+            /* Re-take `parseData` here: the pointer stored by
+            `fits_parser_set_temporary_col` predates `histData.parsers` and
+            every read of `histData.parsers[..]` since. It names the same
+            `ParseData` either way. */
+            histData.infos[ii].parseData = &raw mut histData.parsers[ii];
 
             status = fits_parser_workfn_safe(
                 totalrows,
@@ -4958,16 +4986,16 @@ extern "C" fn ffcalchist(
                 firstrow,
                 nrows,
                 nCols,
-                colData_slice,
+                colData_ptr,
                 core::ptr::from_mut::<parseInfo>(&mut (histData.infos[ii])).cast::<c_void>(),
             );
             if status != 0 {
                 return status;
             }
             /* Output column is last iterator column, which better be a TemporaryCol */
-            outcol = Some(&mut histData.iterCols[(startCol + nCols - 1) as usize]);
+            outcol = Some(unsafe { &mut *colpars.add((startCol + nCols - 1) as usize) });
         } else {
-            outcol = Some(&mut histData.iterCols[startCol as usize]);
+            outcol = Some(unsafe { &mut *colpars.add(startCol as usize) });
         }
 
         if let Some(outcol) = outcol {

--- a/src/putcol.rs
+++ b/src/putcol.rs
@@ -2568,6 +2568,61 @@ pub unsafe extern "C" fn ffiter(
 pub fn ffiter_safe(
     n_cols: c_int,
     cols: &mut [iteratorCol],
+    offset: c_long,
+    n_per_loop: c_long,
+    workfn: extern "C" fn(
+        total_n: c_long,
+        offset: c_long,
+        first_n: c_long,
+        n_values: c_long,
+        n_cols: c_int,
+        cols: *mut iteratorCol,
+        userPointer: *mut c_void,
+    ) -> c_int,
+    userPointer: *mut c_void,
+    status: &mut c_int,
+) -> c_int {
+    let cols_len = cols.len();
+    ffiter_internal(
+        n_cols,
+        cols.as_mut_ptr(),
+        cols_len,
+        offset,
+        n_per_loop,
+        workfn,
+        userPointer,
+        status,
+    )
+}
+
+/*--------------------------------------------------------------------------*/
+/// The body of [`ffiter_safe`], with the column array passed as a raw pointer
+/// instead of as a `&mut [iteratorCol]`.
+///
+/// The work function is free to reach the very same `iteratorCol` array by a
+/// second route -- the parser's work function does exactly that, because
+/// `ParseData::colData` *is* the array handed to the iterator. A `&mut` slice
+/// parameter cannot express that: it is exclusive for the whole call, so the
+/// work function's own access to the array would invalidate it.
+///
+/// `cols_ptr` is therefore kept as a raw pointer for the lifetime of the
+/// iteration and re-borrowed as a slice only between work-function calls; the
+/// pointer handed to the work function is `cols_ptr` itself, not a pointer
+/// derived from the local re-borrow, so that the two routes to the array are
+/// siblings rather than parent and child. Every work-function call is followed
+/// by a fresh re-borrow, because the call may have written to the array through
+/// the other route.
+///
+/// # Safety
+/// `cols_ptr` must point at `cols_len` initialised `iteratorCol`s that stay put
+/// (and stay allocated) for the whole call, and no `&mut` derived from it may
+/// be live in the caller across the call. `cols_len` must be at least
+/// `max(n_cols, 1)`.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn ffiter_internal(
+    n_cols: c_int,
+    cols_ptr: *mut iteratorCol,
+    cols_len: usize,
     mut offset: c_long,
     n_per_loop: c_long,
     workfn: extern "C" fn(
@@ -2582,6 +2637,9 @@ pub fn ffiter_safe(
     userPointer: *mut c_void,
     status: &mut c_int,
 ) -> c_int {
+    /* Re-borrowed from `cols_ptr` again after every work-function call. */
+    let mut cols: &mut [iteratorCol] = unsafe { slice::from_raw_parts_mut(cols_ptr, cols_len) };
+
     // Structure to store the column null value
     #[derive(Default, Clone, Copy)]
     struct ColNulls {
@@ -3796,26 +3854,16 @@ pub fn ffiter_safe(
                 /* call work function */
 
                 if hdutype == IMAGE_HDU {
-                    *status = workfn(
-                        totaln,
-                        offset,
-                        felement,
-                        ntodo,
-                        n_cols,
-                        cols.as_mut_ptr(),
-                        userPointer,
-                    );
+                    *status =
+                        workfn(totaln, offset, felement, ntodo, n_cols, cols_ptr, userPointer);
                 } else {
-                    *status = workfn(
-                        totaln,
-                        offset,
-                        frow,
-                        ntodo,
-                        n_cols,
-                        cols.as_mut_ptr(),
-                        userPointer,
-                    );
+                    *status = workfn(totaln, offset, frow, ntodo, n_cols, cols_ptr, userPointer);
                 }
+
+                /* The work function may have reached the column array by its
+                own route, so the previous re-borrow is stale: take a fresh
+                one from `cols_ptr` before touching the columns again. */
+                cols = slice::from_raw_parts_mut(cols_ptr, cols_len);
 
                 if *status > 0 || *status < -1 {
                     break; /* looks like an error occurred; quit immediately */


### PR DESCRIPTION
**One of two alternative fixes for the same bug — alternative to #115. Only one should be merged.**

Miri reports Stacked Borrows UB on ~205 tests, all one root cause. `ffiter_safe` takes `cols: &mut [iteratorCol]`, which is strongly protected for the whole call, while the work function it invokes builds a `&mut ParseData` (via `parseInfo.parseData`) covering `lParse.colData` — the same array. The parser genuinely reads that array *during* iteration (`load_column`, reached through the `loadData` function pointer), so it cannot simply be moved out for the duration.

**This option** keeps `ParseData` intact and instead stops the iterator claiming exclusivity. `ffiter_safe` becomes a thin wrapper with its public signature unchanged; the body moves to an internal entry point taking the columns as a raw pointer plus length. Nothing is a strongly-protected parameter across the work-function call, and the local slice is re-derived after each call. All ~183 `cols[jj]` sites are untouched.

Why this is sound: `ParseData::colData` is a `Vec`, so the array lives in its own heap allocation. `Vec::as_mut_ptr` does not retag — it loads the pointer stored in `RawVec`, carrying the allocation's root tag — so retagging `&mut ParseData` touches only the `ParseData`/Vec-header bytes, never the buffer's borrow stack. The two routes to the array are therefore siblings under a common root rather than parent and child. The pointer handed to the work function is that root pointer, not `cols.as_mut_ptr()`, so the callback's derivations are not grandchildren of the iterator's local re-borrow.

That model was validated against a standalone reduction of both shapes under Stacked Borrows *and* Tree Borrows: the old shape reproduces the exact error the real code gives, the new shape is clean, and the `histData.iterCols[..]`-in-callback variant is UB — which is why `ffcalchist` now addresses columns through its `colpars` parameter.

Three further latent UB fixed in passing: `from_ref(&Info) as *mut` (writing through a `&`-derived pointer), the `Info.parseData` / `&raw mut Info` ordering in `fits_get_expr_minmax`, and the `histData.parsers` / `infos[ii].parseData` provenance.

Also included: the RNG seed now uses `SystemTime` rather than libc `time()`. That was the last foreign call on the evaluator's path, and it aborted every test reaching the evaluator once the aliasing was fixed, making the fix impossible to measure.

**Verification** — suite green (35 binaries, 2945 passed / 0 failed), clippy clean, zero warnings. On a 30-test sample drawn from the exact 205 affected tests: **19 pass, 11 fail, 0 leaks** — identical to #115.

The 11 stragglers are *different* root causes. Nine are a pre-existing bug already flagged in `main` (`outcol = colData.as_mut_ptr().offset((nCols - 1))` with `nCols == 0`, i.e. `offset(-1)`), untouched here and worth its own fix. The other two are `eval_tab.rs` `text_mut_ptr` and one `eval_y` site.

Not addressed: `fffrwc_safe` never sets `Info.parseData`, so its non-constant branch would null-deref. Behaviour left unchanged.