### PR TITLE
Test the element, not its address, in the pixel-filter guards

### DIFF
--- a/src/eval_f.rs
+++ b/src/eval_f.rs
@@ -2437,6 +2437,15 @@ pub(crate) fn fits_parser_workfn_safe(
             .parseData
             .as_mut()
             .unwrap();
+        /* `pv` borrows only the parseVariables field, while `pv.userInfo`
+        below points at the whole parseInfo containing it. That is not an
+        aliasing problem: every later access goes through
+        `(*(pv.userInfo)).field`, a raw place expression that touches only
+        that field's bytes, and borrows are tracked per location. The only
+        whole-struct `&mut parseInfo` retags are the two above, both taken
+        before `pv` exists. Keep it that way -- reintroducing a
+        `userPtr.cast::<parseInfo>().as_mut()` below this point would
+        invalidate `pv`. */
         let pv: &mut ParseStatusVariables =
             &mut userPtr.cast::<parseInfo>().as_mut().unwrap().parseVariables;
 

--- a/src/eval_f.rs
+++ b/src/eval_f.rs
@@ -4239,6 +4239,11 @@ pub fn fffrwc_safe(
             work function reaches the same array through `parseData`. */
             let n_cols = lParse.nCols;
             let cols_ptr = lParse.colData.as_mut_ptr();
+            /* The work function's first act is
+               `userPtr.parseData.as_mut().unwrap()`, so this branch used to
+               unwrap a null: unlike every other caller, it never set the
+               field. Taken after cols_ptr, as elsewhere. */
+            Info.parseData = core::ptr::from_mut::<ParseData>(&mut lParse);
             *status = fits_parser_workfn_safe(
                 ntimes,
                 0,
@@ -5268,7 +5273,11 @@ fn find_column(
 
             colnum = -1;
             for i in 0..(*lParse.pixFilter).count {
-                if !(*lParse.pixFilter).tag.add(i as usize).is_null()
+                /* The C is `pixFilter->tag[i] &&`, i.e. it tests the element.
+                Testing `tag.add(i)` tests the address, which is never null for
+                a non-null tag, so the guard never fired and a NULL tag[i] went
+                straight into CStr::from_ptr below. */
+                if !(*lParse.pixFilter).tag.add(i as usize).read().is_null()
                     && fits_strcasecmp(
                         colName,
                         cast_slice::<u8, c_char>(
@@ -5308,7 +5317,10 @@ fn find_column(
             varInfo = &mut lParse.varData[col_cnt as usize];
             colIter = &mut lParse.colData[col_cnt as usize];
 
-            if (*lParse.pixFilter).ifptr.add(colnum as usize).is_null() {
+            /* As above: the C is `pixFilter->ifptr[colnum] == NULL`, testing
+            the element. The address form never fired, so a NULL ifptr[colnum]
+            reached the `&mut *fptr` below. */
+            if (*lParse.pixFilter).ifptr.add(colnum as usize).read().is_null() {
                 ffpmsg_str("find_column: PixelFilter missing image pointer");
                 lParse.status = COL_NOT_FOUND;
                 return P_ERROR;


### PR DESCRIPTION
Three small findings in the expression engine, none of them aliasing.

**Two dead null guards in `find_column`.** Both tested the address of an array element rather than the element:

```rust
(*pixFilter).tag.add(i).is_null()
(*pixFilter).ifptr.add(colnum).is_null()
```

`base.add(i)` is never null for a non-null base, so neither guard could ever fire. The C tests the element in both cases — `pixFilter->tag[i] &&` and `pixFilter->ifptr[colnum] == NULL` — and in both the value is read and dereferenced on the next statement, so a NULL element reached `CStr::from_ptr` and `&mut *fptr` respectively. Now reads the element and tests that.

The adjacent risk of `colnum` still being `-1` from the search loop is already guarded above, so that path is fine.

**`fffrwc_safe` never set `Info.parseData`.** Every other caller does, and the work function's first act is `userPtr.parseData.as_mut().unwrap()`, so this branch would have unwrapped a null.

Worth being precise about severity: it is **not reachable today**. A parameter reference is rejected with `BAD_COL_NUM` further up by the upstream ordering defect recorded in `notes/CFITSIO_BUGS_EVAL.md` (`ffiprs` parses before `fits_get_colnum` fills in the column number), which is exactly why this went unnoticed — as `tests/test_eval_find_rows_cmp.rs` already notes, only the constant path is reachable. The fix is defensive and becomes live if that ordering is ever corrected.

**A comment, not a change, for `pv` / `pv.userInfo`.** The work function holds a `&mut` to `parseInfo`'s `parseVariables` field while `pv.userInfo` points at the whole `parseInfo` containing it. That was raised as possible aliasing; it is sound, and the reasoning is now written down instead of left to be re-derived: every access after initialisation is `(*(pv.userInfo)).field`, a raw place expression touching one field's bytes, and borrows are tracked per location — so `pv`'s range is never disturbed. The only whole-struct `&mut parseInfo` retags happen before `pv` exists. The comment also flags what would break it.

Suite green (35 binaries, 0 failed), clippy clean, zero warnings.