### PR TITLE
Do not index colData[-1] when the expression names no columns

### DIFF
--- a/src/eval_f.rs
+++ b/src/eval_f.rs
@@ -3031,14 +3031,22 @@ pub(crate) fn fits_parser_workfn_safe(
         /* If a TemporaryCol output is used, we want to inform the caller
         what the null value is expected to be */
 
-        // WARNING - THIS IS DANGEROUS. If nCols = 0, points to invalid memory.
-        // In the case of the where expr = "#ROW > 2" there are no columns.
-        outcol = colData.offset((nCols - 1) as isize).as_mut().unwrap();
-        // outcol = &mut colData[(nCols - 1) as usize]; // Re-bind
+        /* The C computes `colData[nCols-1]` unconditionally here. When the
+        expression names no columns -- `where` expressions such as "#ROW > 2"
+        -- nCols is 0 and that offsets one element before the start of the
+        array, which is out of bounds however the result is used. There is no
+        output column to describe in that case, so skip it: the two blocks
+        below only report what the output column's null value should be. */
+        let outcol_ptr: *mut iteratorCol = if nCols > 0 {
+            colData.offset((nCols - 1) as isize)
+        } else {
+            ptr::null_mut()
+        };
 
-        if pv.Null != outcol.array
+        if !outcol_ptr.is_null()
+            && pv.Null != (*outcol_ptr).array
             && (Data0)
-                == outcol
+                == (*outcol_ptr)
                     .array
                     .cast::<c_char>()
                     .add((pv.datasize).try_into().unwrap())
@@ -3046,12 +3054,12 @@ pub(crate) fn fits_parser_workfn_safe(
         {
             if (*(pv.userInfo)).datatype == TSTRING {
                 memcpy(
-                    outcol.array,
+                    (*outcol_ptr).array,
                     (*pv.Null.cast::<*mut c_char>()).cast::<c_void>(),
                     2,
                 );
             } else {
-                memcpy(outcol.array, pv.Null, pv.datasize.try_into().unwrap());
+                memcpy((*outcol_ptr).array, pv.Null, pv.datasize.try_into().unwrap());
             }
         }
 
@@ -3060,7 +3068,7 @@ pub(crate) fn fits_parser_workfn_safe(
 
         if anyNullThisTime != 0 {
             (*(pv.userInfo)).anyNull = 1;
-        } else if pv.Null == outcol.array {
+        } else if !outcol_ptr.is_null() && pv.Null == (*outcol_ptr).array {
             if (*(pv.userInfo)).datatype == TSTRING {
                 memcpy(
                     (*pv.Null.cast::<*mut c_char>()).cast::<c_void>(),


### PR DESCRIPTION
The work function reports what the output column's null value should be by reading `colData[nCols - 1]`. The C does that unconditionally, and the port carried a comment saying so:

```rust
// WARNING - THIS IS DANGEROUS. If nCols = 0, points to invalid memory.
// In the case of the where expr = "#ROW > 2" there are no columns.
outcol = colData.offset((nCols - 1) as isize).as_mut().unwrap();
```

With a `where` expression that names no columns, `nCols` is 0 and this offsets one element before the start of the array. Miri: *"in-bounds pointer arithmetic failed: attempting to offset pointer by -16 bytes, but got alloc… which is at the beginning of the allocation"*. This is a genuine out-of-bounds pointer, not a model technicality.

There is no output column to describe in that case, so both blocks that report one are now skipped. The two other `colData[nCols - 1]` sites in the same function are already inside `if (*(pv.userInfo)).dataPtr.is_null()`, which is the iterator-derived-output-column case and so implies `nCols >= 1`; they are unaffected and left alone.

**Verification** — suite green (35 binaries, 0 failed), clippy clean, zero warnings. Re-ran the exact 23 tests that Miri reported at this site: **0 offset errors remaining, 19 of 23 now pass**. The 4 stragglers fail on unrelated `eval_l.rs` sites (827, 855, 1041) that are already on the list.