### PR TITLE
Fix two pointer bugs in the expression evaluator

### DIFF
--- a/src/eval_defs.rs
+++ b/src/eval_defs.rs
@@ -67,7 +67,7 @@ pub(crate) struct DataInfo {
     pub nelem: c_long,
     pub naxis: c_int,
     pub naxes: [c_long; MAXDIMS as usize],
-    pub undef: Option<Box<[c_char]>>,
+    pub undef: Option<Vec<c_char>>,
     pub data: *mut c_void,
 }
 

--- a/src/eval_f.rs
+++ b/src/eval_f.rs
@@ -3223,7 +3223,7 @@ fn Setup_DataArrays(
                             v.resize(len as usize, 0);
                         }
 
-                        varData.undef = Some(v.into_boxed_slice());
+                        varData.undef = Some(v);
                     }
                     row = nRows;
                     while row > 0 {
@@ -3256,7 +3256,7 @@ fn Setup_DataArrays(
                             v.resize(len as usize, 0);
                         }
 
-                        varData.undef = Some(v.into_boxed_slice());
+                        varData.undef = Some(v);
                     }
                     while len > 0 {
                         len -= 1;
@@ -3282,7 +3282,7 @@ fn Setup_DataArrays(
                             v.resize(len as usize, 0);
                         }
 
-                        varData.undef = Some(v.into_boxed_slice());
+                        varData.undef = Some(v);
                     }
                     while len > 0 {
                         len -= 1;
@@ -3309,7 +3309,7 @@ fn Setup_DataArrays(
                             v.resize(len as usize, 0);
                         }
 
-                        varData.undef = Some(v.into_boxed_slice());
+                        varData.undef = Some(v);
                     }
                     while len > 0 {
                         len -= 1;

--- a/src/eval_y.rs
+++ b/src/eval_y.rs
@@ -8843,9 +8843,20 @@ pub(crate) fn Evaluate_Parser(lParse: &mut ParseData, firstRow: c_long, nRows: c
                 column = -((lParse.Nodes)[i as usize]).operation;
                 offset = ((lParse.varData)[column as usize]).nelem * rowOffset;
 
+                /* Take the pointer with Vec::as_mut_ptr rather than through a
+                `&mut [c_char]`: the node keeps it until the row is evaluated,
+                and a reference to the contents would be a child of this borrow
+                of lParse, so the next loop iteration invalidated it. Reading
+                the Vec's own pointer carries the buffer's root tag instead. */
                 (((lParse.Nodes)[i as usize]).value).undef =
-                    match (((lParse.varData)[column as usize]).undef).as_deref_mut() {
-                        Some(ud) => ud[(offset as usize)..].as_mut_ptr(),
+                    match (((lParse.varData)[column as usize]).undef).as_mut() {
+                        Some(ud) => {
+                            assert!(
+                                (offset as usize) <= ud.len(),
+                                "undef offset past the end of the column buffer"
+                            );
+                            ud.as_mut_ptr().add(offset as usize)
+                        }
                         None => ptr::null_mut(),
                     };
 

--- a/src/eval_y.rs
+++ b/src/eval_y.rs
@@ -3676,8 +3676,6 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             {
                                 let mut zero_1: c_long = 0;
 
-                                let rc_parse: Rc<ParseData> = Rc::from_raw(lParse);
-
                                 let new_node = New_Const(
                                     lParse,
                                     fits_parser_yytokentype::LONG as c_int,


### PR DESCRIPTION
Two unrelated bugs in `eval_y.rs`, both found by Miri.

## A bogus `Rc::from_raw`

The `Long` branch of the `ACCUM` action did:

```rust
let rc_parse: Rc<ParseData> = Rc::from_raw(lParse);
```

`lParse` never came from `Rc::into_raw`. The binding is unused, so it drops at the end of the block — a refcount decrement against a header that does not exist, followed by a free with `Rc`'s layout. The `Double` branch immediately below is otherwise identical and has no such line, which is what the code should look like.

Only one test reached it, but the consequence is heap corruption rather than a read of stale data, so it is the more serious of the two. Worth noting the crate-level `allow(unused_variables)` is why a dead binding with a catastrophic `Drop` drew no warning at all.

## Column `undef` pointers with borrowed provenance

`Setup_DataArrays` stores a pointer to each column's undef buffer in the node, and the node keeps it until the row is evaluated. It was taken as:

```rust
match varData[column].undef.as_deref_mut() {
    Some(ud) => ud[(offset as usize)..].as_mut_ptr(),
    ...
```

`as_deref_mut()` produces a `&mut [c_char]` reached from `lParse`, so the pointer is a child of that borrow — and the *next iteration of the same loop* invalidated it. The later read in `Evaluate_Node` was through a dead tag. 25 tests.

Now read with `Vec::as_mut_ptr`, which loads the buffer's own pointer rather than deriving a reference to its contents, so it carries the allocation's root tag and survives later borrows of `lParse`. This is why `DataInfo::undef` becomes a `Vec<c_char>` rather than a `Box<[c_char]>` — `Box` has no equivalent, because dereferencing it retags. Only five construction sites needed touching.

The old panic-on-overrun is kept as an assert, since `add` would otherwise be silent.

**Verification** — suite green (35 binaries, 0 failed), clippy clean, zero warnings. On 25 of the affected tests: **0 UB, 24 of 25 pass** (from 1). The remaining failure is a C-heap leak in `test_ffcrow_gtioverlap`, a separate pre-existing category.