### PR TITLE
Free the histogram iterator columns instead of leaking them

### DIFF
--- a/src/histo.rs
+++ b/src/histo.rs
@@ -4396,8 +4396,12 @@ pub(crate) fn fits_make_histde(
     // cleanup:
     /* Free any allocated memory ... */
     if !iterCols.is_null() {
-        // SAFETY / TODO
-        // unsafe { free(iterCols as *mut c_void) };
+        /* The C frees this with free(). It comes from fits_recalloc, i.e. the
+        Rust allocator, so hand it back the same way -- new_num == 0 is
+        fits_recalloc's deallocate case, and it uses the layout it allocated
+        with. Leaving it unfreed leaked the array on every call. */
+        unsafe { fits_recalloc::<iteratorCol>(iterCols, numAllocCols as usize, 0) };
+        iterCols = ptr::null_mut();
     }
     /* ... and parsers */
     for ii in 0..=4 {


### PR DESCRIPTION
`fits_make_histde` allocates `iterCols` with `fits_recalloc` and grows it once per parser, but the cleanup was disabled:

```rust
if !iterCols.is_null() {
    // SAFETY / TODO
    // unsafe { free(iterCols as *mut c_void) };
}
```

Commenting out the C's `free()` was right — it is a Rust allocation — but nothing replaced it, so the array leaked on every call. Miri reports it on seven histogram tests.

`fits_recalloc` takes the element type since #108, so `new_num == 0` is its deallocate case and it uses the layout it allocated with. `numAllocCols` is the array's current length at that point.

**Verification** — suite green (35 binaries, 0 failed), clippy clean, zero warnings. All seven affected tests under Miri: **7 passed, 0 leaks, 0 UB**.

## Not fixed here: the eighth leak

`test_fffrow_snull_constant` leaks 120 bytes of C heap from `Allocate_Ptrs` (`eval_y.rs`), which `malloc`s a row-pointer array plus one backing block for Bits/String nodes. There is a matching `free_node_buffer`, but it is only ever called from `Do_Offset`; the `Do_Func` path that allocated here has no pairing.

I have deliberately left it. The node-buffer ownership protocol is that each `Do_*` frees its children's buffers after consuming them, so a result node nothing consumes is never freed — and `ffcprs`'s teardown only frees GTIFILT sub-node buffers before dropping the `Nodes` vector, which cannot free the raw pointers inside it. Blanket-freeing there would be a double free: column nodes' `value.data` points into `varData`, which they do not own.

Fixing it properly means establishing which nodes own their buffers rather than guessing, and a double free in the parser would be considerably worse than a 120-byte leak. Worth its own change.