### PR TITLE
Release the parser's row buffers when the parse is torn down

### DIFF
--- a/src/eval_f.rs
+++ b/src/eval_f.rs
@@ -74,7 +74,7 @@ use crate::eval_l::{
     fits_parser_yylex_destroy, fits_parser_yylex_init, fits_parser_yyrestart, yyguts_t,
 };
 use crate::eval_tab::{FITS_PARSER_YYSTYPE, fits_parser_yytokentype};
-use crate::eval_y::{Evaluate_Parser, fits_parser_yyparse, funcOp};
+use crate::eval_y::{free_node_buffer, Evaluate_Parser, fits_parser_yyparse, funcOp};
 use crate::fitscore::{
     ffcmph_safe, ffcmsg_safe, ffgcno_safe, ffgdesll_safe, ffgncl_safe, ffgnrw_safe, ffiblk,
     ffkeyn_safe, ffmahd_safe, ffpdes_safe, ffpmrk_safe, fits_strcasecmp,
@@ -2355,6 +2355,17 @@ pub(crate) fn ffcprs(lParse: &mut ParseData) {
                 /* REGFILT nodes used to be freed here by hand. The region now
                 lives in lParse.regions behind an Rc, so it goes when the
                 ParseData does. */
+
+                /* Release any row buffer the node still owns. Allocate_Ptrs
+                mallocs these and the Do_* kernels free their children after
+                consuming them, so whatever is left here -- the result node
+                above all -- had nothing to free it and leaked. Only computed
+                nodes own their buffer: a column node's points into
+                varData, which it does not own. free_node_buffer marks the
+                value Empty, so the nodes already freed above are a no-op. */
+                if (lParse.Nodes[node as usize]).is_computed() {
+                    free_node_buffer(&mut (lParse.Nodes[node as usize]));
+                }
             }
             lParse.nNodes = 0;
         }

--- a/src/eval_y.rs
+++ b/src/eval_y.rs
@@ -9066,7 +9066,7 @@ fn Allocate_Ptrs(lParse: &mut ParseData, this_node_idx: usize) {
     }
 }
 
-unsafe fn free_node_buffer(node: &mut Node) {
+pub(crate) unsafe fn free_node_buffer(node: &mut Node) {
     unsafe {
         if node.ntype == ValueSort::Bits || node.ntype == ValueSort::String {
             if !node.value.data.str_buf().is_null() {
@@ -9341,7 +9341,7 @@ fn Do_Unary(lParse: &mut ParseData, this_node_idx: usize) {
         let that_idx = (lParse.Nodes[this_node_idx]).SubNodes[0];
 
         if (lParse.Nodes[that_idx]).is_computed() {
-            free((lParse.Nodes[that_idx]).value.data.raw());
+            free_node_buffer(&mut (lParse.Nodes[that_idx]));
         }
     }
 }
@@ -9812,24 +9812,10 @@ fn Do_BinOp_bit(lParse: &mut ParseData, this_node_idx: usize) {
             }
         }
         if (lParse.Nodes[that1_idx]).is_computed() {
-            free((*((lParse.Nodes[that1_idx]).value.data.str_buf()).offset(0)).cast::<c_void>());
-            free(
-                (lParse.Nodes[that1_idx])
-                    .value
-                    .data
-                    .str_buf()
-                    .cast::<c_void>(),
-            );
+            free_node_buffer(&mut (lParse.Nodes[that1_idx]));
         }
         if (lParse.Nodes[that2_idx]).is_computed() {
-            free((*((lParse.Nodes[that2_idx]).value.data.str_buf()).offset(0)).cast::<c_void>());
-            free(
-                (lParse.Nodes[that2_idx])
-                    .value
-                    .data
-                    .str_buf()
-                    .cast::<c_void>(),
-            );
+            free_node_buffer(&mut (lParse.Nodes[that2_idx]));
         }
     }
 }
@@ -10134,24 +10120,10 @@ fn Do_BinOp_str(lParse: &mut ParseData, this_node_idx: usize) {
             }
         }
         if (lParse.Nodes[that1_idx]).is_computed() {
-            free((*((lParse.Nodes[that1_idx]).value.data.str_buf()).offset(0)).cast::<c_void>());
-            free(
-                (lParse.Nodes[that1_idx])
-                    .value
-                    .data
-                    .str_buf()
-                    .cast::<c_void>(),
-            );
+            free_node_buffer(&mut (lParse.Nodes[that1_idx]));
         }
         if (lParse.Nodes[that2_idx]).is_computed() {
-            free((*((lParse.Nodes[that2_idx]).value.data.str_buf()).offset(0)).cast::<c_void>());
-            free(
-                (lParse.Nodes[that2_idx])
-                    .value
-                    .data
-                    .str_buf()
-                    .cast::<c_void>(),
-            );
+            free_node_buffer(&mut (lParse.Nodes[that2_idx]));
         }
     }
 }
@@ -10386,10 +10358,10 @@ fn Do_BinOp_log(lParse: &mut ParseData, this_node_idx: usize) {
             }
         }
         if (lParse.Nodes[that1_idx]).is_computed() {
-            free((lParse.Nodes[that1_idx]).value.data.raw());
+            free_node_buffer(&mut (lParse.Nodes[that1_idx]));
         }
         if (lParse.Nodes[that2_idx]).is_computed() {
-            free((lParse.Nodes[that2_idx]).value.data.raw());
+            free_node_buffer(&mut (lParse.Nodes[that2_idx]));
         }
     }
 }
@@ -10702,10 +10674,10 @@ fn Do_BinOp_lng(lParse: &mut ParseData, this_node_idx: usize) {
             }
         }
         if (lParse.Nodes[that1_idx]).is_computed() {
-            free((lParse.Nodes[that1_idx]).value.data.raw());
+            free_node_buffer(&mut (lParse.Nodes[that1_idx]));
         }
         if (lParse.Nodes[that2_idx]).is_computed() {
-            free((lParse.Nodes[that2_idx]).value.data.raw());
+            free_node_buffer(&mut (lParse.Nodes[that2_idx]));
         }
     }
 }
@@ -11015,10 +10987,10 @@ fn Do_BinOp_dbl(lParse: &mut ParseData, this_node_idx: usize) {
             }
         }
         if (lParse.Nodes[that1_idx]).is_computed() {
-            free((lParse.Nodes[that1_idx]).value.data.raw());
+            free_node_buffer(&mut (lParse.Nodes[that1_idx]));
         }
         if (lParse.Nodes[that2_idx]).is_computed() {
-            free((lParse.Nodes[that2_idx]).value.data.raw());
+            free_node_buffer(&mut (lParse.Nodes[that2_idx]));
         }
     }
 }
@@ -11686,7 +11658,7 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                                 lParse,
                                 cs!(c"AXISELEM(V,n) n value exceeded maximum dimension"),
                             );
-                            free((lParse.Nodes[this_node_idx]).value.data.raw());
+                            free_node_buffer(&mut (lParse.Nodes[this_node_idx]));
                         } else {
                             ielem = 0;
                             while ielem < elem {
@@ -12254,7 +12226,7 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                                     lParse,
                                     cs!(c"Could not allocate temporary memory in median function"),
                                 );
-                                free((lParse.Nodes[this_node_idx]).value.data.raw());
+                                free_node_buffer(&mut (lParse.Nodes[this_node_idx]));
                             } else {
                                 mvec.resize(nelem as usize, 0);
                                 irow = 0;
@@ -12306,7 +12278,7 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
                                     lParse,
                                     cs!(c"Could not allocate temporary memory in median function"),
                                 );
-                                free((lParse.Nodes[this_node_idx]).value.data.raw());
+                                free_node_buffer(&mut (lParse.Nodes[this_node_idx]));
                             } else {
                                 mvec_0.resize(nelem as usize, 0.0);
                                 irow_0 = 0;
@@ -14452,7 +14424,7 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
             }
             if (lParse.Nodes[theParams[i as usize]]).is_computed() {
                 /*  Currently only numeric params allowed  */
-                free((lParse.Nodes[theParams[i as usize]]).value.data.raw());
+                free_node_buffer(&mut (lParse.Nodes[theParams[i as usize]]));
             }
         }
     }
@@ -14852,18 +14824,14 @@ fn Do_Deref(lParse: &mut ParseData, this_node_idx: usize) {
             }
         }
         if (lParse.Nodes[theVar]).is_computed() {
-            if (lParse.Nodes[theVar]).ntype == ValueSort::String
-                || (lParse.Nodes[theVar]).ntype == ValueSort::Bits
-            {
-                free((*((lParse.Nodes[theVar]).value.data.str_buf()).offset(0)).cast::<c_void>());
-            } else {
-                free((lParse.Nodes[theVar]).value.data.raw());
-            }
+            /* free_node_buffer covers both shapes; the String/Bits arm here
+            used to free only the backing block and leak the pointer array. */
+            free_node_buffer(&mut (lParse.Nodes[theVar]));
         }
         i = 0;
         while i < nDims {
             if (lParse.Nodes[theDims[i as usize]]).is_computed() {
-                free((lParse.Nodes[theDims[i as usize]]).value.data.raw());
+                free_node_buffer(&mut (lParse.Nodes[theDims[i as usize]]));
             }
             i += 1;
         }
@@ -14979,7 +14947,7 @@ fn Do_GTI(lParse: &mut ParseData, this_node_idx: usize) {
             }
         }
         if (lParse.Nodes[theExpr]).is_computed() {
-            free((lParse.Nodes[theExpr]).value.data.raw());
+            free_node_buffer(&mut (lParse.Nodes[theExpr]));
         }
     }
 }
@@ -15099,10 +15067,10 @@ fn Do_GTI_Over(lParse: &mut ParseData, this_node_idx: usize) {
             }
         }
         if (lParse.Nodes[theStart]).is_computed() {
-            free((lParse.Nodes[theStart]).value.data.raw());
+            free_node_buffer(&mut (lParse.Nodes[theStart]));
         }
         if (lParse.Nodes[theStop]).is_computed() {
-            free((lParse.Nodes[theStop]).value.data.raw());
+            free_node_buffer(&mut (lParse.Nodes[theStop]));
         }
     }
 }
@@ -15377,10 +15345,10 @@ fn Do_REG(lParse: &mut ParseData, this_node_idx: usize) {
             }
         }
         if (lParse.Nodes[theX]).is_computed() {
-            free((lParse.Nodes[theX]).value.data.raw());
+            free_node_buffer(&mut (lParse.Nodes[theX]));
         }
         if (lParse.Nodes[theY]).is_computed() {
-            free((lParse.Nodes[theY]).value.data.raw());
+            free_node_buffer(&mut (lParse.Nodes[theY]));
         }
     }
 }
@@ -15559,13 +15527,9 @@ fn Do_Vector(lParse: &mut ParseData, this_node_idx: usize) {
                 .operation
                 > 0
             {
-                free(
-                    ((lParse.Nodes)
-                        [(lParse.Nodes[this_node_idx]).SubNodes[node as usize] as usize])
-                        .value
-                        .data
-                        .raw(),
-                );
+                let sub_idx =
+                    (lParse.Nodes[this_node_idx]).SubNodes[node as usize] as usize;
+                free_node_buffer(&mut ((lParse.Nodes)[sub_idx]));
             }
             node += 1;
         }
@@ -15684,12 +15648,8 @@ fn Do_Array(lParse: &mut ParseData, this_node_idx: usize) {
             }
 
             if ((lParse.Nodes)[lParse.Nodes[this_node_idx].SubNodes[0]]).is_computed() {
-                free(
-                    ((lParse.Nodes)[lParse.Nodes[this_node_idx].SubNodes[0]])
-                        .value
-                        .data
-                        .raw(),
-                );
+                let sub_idx = lParse.Nodes[this_node_idx].SubNodes[0];
+                free_node_buffer(&mut ((lParse.Nodes)[sub_idx]));
             }
         }
     }


### PR DESCRIPTION
The last of the Miri leaks, and the one #121 deliberately left alone because the obvious fix would have been a double free.

`Allocate_Ptrs` mallocs a row buffer for each computed node, and the `Do_*` kernels free their children's buffers after consuming them. Nothing frees a node that no parent consumes — the result node above all — and `ffcprs` drops the `Nodes` vector with raw pointers still inside it, which frees nothing.

Freeing every node in `ffcprs` is not safe: a column node's `value.data` points into `varData`, which it does not own. Two changes make it so.

**Every raw `free()` of a node buffer now goes through `free_node_buffer`.** That helper already existed but was called from `Do_Offset` only. It frees both parts of a String/Bits buffer and — the part that matters here — sets the value to `Empty`. Freeing therefore becomes idempotent, so the teardown cannot double-free something a kernel already released. 20 sites converted.

One of them was itself a partial leak: the String/Bits arm freed the backing block but not the pointer array.

**`ffcprs` then releases whatever a computed node still holds**, guarded on `is_computed()`, which is the same predicate the kernels already use before freeing a child.

**Verification** — suite green (35 binaries, 0 failed), clippy clean, zero warnings. Miri over 31 eval tests including `test_fffrow_snull_constant`: **0 leaks, 0 UB**. Miri detects double frees, so a wrong ownership rule here would have shown up rather than passing quietly.

`test_ffcrow_power` still fails under Miri on `assertion failed: (results[1] - 4.0).abs() < 0.1`. It fails identically on `main` with the same assertion and value, so it is pre-existing and unrelated — but worth someone's attention separately, since it passes natively and only misbehaves under Miri.