### PR TITLE
Re-take the parse's file pointers before the iterator runs

### DIFF
--- a/src/eval_f.rs
+++ b/src/eval_f.rs
@@ -235,6 +235,7 @@ pub fn fffrow_safe(
         pointer to the array first, then (re-)establish `Info.parseData`:
         borrowing `lParse` mutably would invalidate a raw pointer taken
         before it. */
+        refresh_file_ptrs(&mut lParse, fptr);
         let n_cols = lParse.nCols;
         let cols_ptr = lParse.colData.as_mut_ptr();
         let cols_len = lParse.colData.len();
@@ -490,6 +491,7 @@ pub fn ffsrow_safe(
         /* Take the raw pointer to `lParse.colData` before re-establishing
         `Info.parseData`: the work function reaches the same array through
         both, so neither may be derived from the other. */
+        refresh_file_ptrs(&mut lParse, infptr);
         let n_cols = lParse.nCols;
         let cols_ptr = lParse.colData.as_mut_ptr();
         let cols_len = lParse.colData.len();
@@ -855,6 +857,7 @@ pub fn ffsrow_inplace_safe(
         /* Take the raw pointer to `lParse.colData` before re-establishing
         `Info.parseData`: the work function reaches the same array through
         both, so neither may be derived from the other. */
+        refresh_file_ptrs(&mut lParse, fptr);
         let n_cols = lParse.nCols;
         let cols_ptr = lParse.colData.as_mut_ptr();
         let cols_len = lParse.colData.len();
@@ -1066,6 +1069,7 @@ pub fn ffcrow_safe(
     Info.maxRows = nelements / nelem1;
     /* Take the raw pointer to `lParse.colData` before re-establishing
     `Info.parseData`: the work function reaches the same array through both. */
+    refresh_file_ptrs(&mut lParse, fptr);
     let n_cols = lParse.nCols;
     let cols_ptr = lParse.colData.as_mut_ptr();
     let cols_len = lParse.colData.len();
@@ -1558,6 +1562,7 @@ pub fn ffcalc_rng_safe(
             /* Take the raw pointer to `lParse.colData` before re-establishing
             `Info.parseData`: the work function reaches the same array through
             both. */
+            refresh_file_ptrs(&mut lParse, infptr);
             let n_cols = lParse.nCols;
             let cols_ptr = lParse.colData.as_mut_ptr();
             let cols_len = lParse.colData.len();
@@ -1954,6 +1959,7 @@ pub fn ffcalc_rng_inplace_safe(
             /* Take the raw pointer to `lParse.colData` before re-establishing
             `Info.parseData`: the work function reaches the same array through
             both. */
+            refresh_file_ptrs(&mut lParse, fptr);
             let n_cols = lParse.nCols;
             let cols_ptr = lParse.colData.as_mut_ptr();
             let cols_len = lParse.colData.len();
@@ -2100,6 +2106,29 @@ pub fn fftexp_safe(
 /*--------------------------------------------------------------------------*/
 /// Initialize the parser and determine what type of result the expression
 /// produces.
+/// Re-establish the file pointers the parse recorded.
+///
+/// `ffiprs` stores `fptr` in `ParseData::def_fptr`, and `find_column` copies
+/// that into each `iteratorCol`. Every later call taking `fptr: &mut fitsfile`
+/// -- `ffgcno_safe` and friends -- is a protected retag that invalidates those
+/// copies, and the iterator then dereferences them. Re-take them here from one
+/// raw pointer, so the columns and def_fptr share a tag that is live at the
+/// point of use.
+///
+/// Only columns that pointed at the same file are rewritten; a cross-HDU
+/// column legitimately refers to a different one. Comparing the addresses does
+/// not dereference them, so it is fine to do with the stale values.
+fn refresh_file_ptrs(lParse: &mut ParseData, fptr: &mut fitsfile) {
+    let old = lParse.def_fptr;
+    let raw: *mut fitsfile = fptr;
+    lParse.def_fptr = raw;
+    for col in lParse.colData.iter_mut() {
+        if core::ptr::eq(col.fptr, old) {
+            col.fptr = raw;
+        }
+    }
+}
+
 pub(crate) fn ffiprs(
     fptr: &mut fitsfile,    /* I - Input FITS file                     */
     compressed: c_int,      /* I - Is FITS file hkunexpanded?          */
@@ -4265,6 +4294,7 @@ pub fn fffrwc_safe(
             Info.maxRows = ntimes;
             /* Address the columns through the vector's own pointer: the
             work function reaches the same array through `parseData`. */
+            refresh_file_ptrs(&mut lParse, fptr);
             let n_cols = lParse.nCols;
             let cols_ptr = lParse.colData.as_mut_ptr();
             /* The work function's first act is
@@ -4387,6 +4417,7 @@ pub fn ffffrw_safer(
             /* Take the raw pointer to `lParse.colData` before handing a raw
             `lParse` to the work function: the work function reaches the same
             array through both, so neither may be derived from the other. */
+            refresh_file_ptrs(&mut lParse, fptr);
             let n_cols = lParse.nCols;
             let cols_ptr = lParse.colData.as_mut_ptr();
             let cols_len = lParse.colData.len();


### PR DESCRIPTION
The largest remaining real cause: 17 tests.

`ffiprs` records `fptr` in `ParseData::def_fptr`, and `find_column` copies that into each `iteratorCol`. Both are taken from a `&mut fitsfile` argument, so every later call taking one — `ffgcno_safe` and the rest of the output-column setup — is a strongly-protected function-entry retag that invalidates them. The iterator then dereferences the stale copies inside `ffiter_internal`.

The site count was misleading: there are only ten `def_fptr` references in the crate, but the pointer *propagates* into the column array, so the use is nowhere near the store.

`refresh_file_ptrs` re-takes them from a single raw pointer immediately before the iteration, so the columns and `def_fptr` share one tag that is live where it is used. Taking a single raw pointer and copying it matters: coercing the `&mut` separately per column would give each its own tag, and using one as `&mut` would then invalidate the others.

Only columns that pointed at the same file are rewritten — a cross-HDU column legitimately refers to a different one. Comparing the addresses does not dereference them, so it is safe to do with the stale values.

`fits_pixel_filter_safer` is not affected and is left alone: it sets the column pointers from `filter.ofptr`, not from `def_fptr`.

**Verification** — suite green (35 binaries, 0 failed), clippy clean, zero warnings. All 17 affected tests under Miri: **17 passed, 0 UB, 0 leaks**.

This is the fifth instance of the same pattern, after `FPTR_TABLE`, `yyextra_r`, `Info.parseData` and `histData.iterCols`: a struct holding a pointer to something that is also reached through a `&mut`.