### PR TITLE
Fix the lexer's narrowed and borrowed buffer pointers

### DIFF
--- a/src/eval_l.rs
+++ b/src/eval_l.rs
@@ -123,7 +123,7 @@ pub type flex_int16_t = int16_t;
 #[derive(Default)]
 pub struct yy_buffer_state {
     pub yy_input_file: *mut FILE,
-    pub yy_ch_buf: Option<Box<[c_char]>>,
+    pub yy_ch_buf: Option<Vec<c_char>>,
     pub yy_buf_pos: usize,
     pub yy_buf_size: c_int,
     pub yy_n_chars: c_int,
@@ -824,9 +824,9 @@ pub(crate) fn fits_parser_yylex(
                             5 => {
                                 let mut constval: c_long = 0;
                                 let mut p: *mut c_char = core::ptr::null_mut::<c_char>();
-                                p = core::ptr::from_mut::<c_char>(
-                                    &mut *(yyscanner.yytext_r).offset(2 as c_int as isize),
-                                );
+                                /* Plain pointer arithmetic: `&mut *ptr.offset(2)` borrows a single
+                                   byte, so the scan below immediately ran past that provenance. */
+                                p = (yyscanner.yytext_r).offset(2 as c_int as isize);
                                 while *p != 0 {
                                     constval = constval << 1
                                         | c_int::from(c_int::from(*p) == '1' as i32) as c_long;
@@ -838,9 +838,9 @@ pub(crate) fn fits_parser_yylex(
                             6 => {
                                 let mut constval_0: c_long = 0;
                                 let mut p_0: *mut c_char = core::ptr::null_mut::<c_char>();
-                                p_0 = core::ptr::from_mut::<c_char>(
-                                    &mut *(yyscanner.yytext_r).offset(2 as c_int as isize),
-                                );
+                                /* Plain pointer arithmetic: `&mut *ptr.offset(2)` borrows a single
+                                   byte, so the scan below immediately ran past that provenance. */
+                                p_0 = (yyscanner.yytext_r).offset(2 as c_int as isize);
                                 while *p_0 != 0 {
                                     constval_0 = constval_0 << 3 as c_int
                                         | c_long::from(c_int::from(*p_0) - '0' as i32);
@@ -852,9 +852,9 @@ pub(crate) fn fits_parser_yylex(
                             7 => {
                                 let mut constval_1: c_long = 0;
                                 let mut p_1: *mut c_char = core::ptr::null_mut::<c_char>();
-                                p_1 = core::ptr::from_mut::<c_char>(
-                                    &mut *(yyscanner.yytext_r).offset(2 as c_int as isize),
-                                );
+                                /* Plain pointer arithmetic: `&mut *ptr.offset(2)` borrows a single
+                                   byte, so the scan below immediately ran past that provenance. */
+                                p_1 = (yyscanner.yytext_r).offset(2 as c_int as isize);
                                 while *p_1 != 0 {
                                     let v: c_int = if isdigit_safe(*p_1) {
                                         c_int::from(*p_1) - '0' as i32
@@ -961,9 +961,13 @@ pub(crate) fn fits_parser_yylex(
                                         yyscanner.yytext_r = (*yyscanner.yylval_r).text_mut_ptr();
                                     }
 
-                                    let yytext_r_slice = cast_slice(
-                                        CStr::from_ptr(yyscanner.yytext_r).to_bytes_with_nul(),
-                                    );
+                                    /* yytext_r points into the same yylval slot that is passed as
+                                       `&mut` below, so the two arguments would alias. Copy the name
+                                       out first -- owned, so an overlong name keeps its terminator
+                                       rather than being truncated out of one. */
+                                    let name_owned: Vec<c_char> =
+                                        cast_slice(CStr::from_ptr(yyscanner.yytext_r).to_bytes_with_nul()).to_vec();
+                                    let yytext_r_slice: &[c_char] = &name_owned;
 
                                     let get_data =
                                         (lParse.getData).expect("non-null function pointer");
@@ -1032,9 +1036,13 @@ pub(crate) fn fits_parser_yylex(
                                     yyscanner.yytext_r = (*yyscanner.yylval_r).text_mut_ptr();
                                 }
 
-                                let yytext_r_slice = cast_slice(
-                                    CStr::from_ptr(yyscanner.yytext_r).to_bytes_with_nul(),
-                                );
+                                /* yytext_r points into the same yylval slot that is passed as
+                                   `&mut` below, so the two arguments would alias. Copy the name
+                                   out first -- owned, so an overlong name keeps its terminator
+                                   rather than being truncated out of one. */
+                                let name_owned: Vec<c_char> =
+                                    cast_slice(CStr::from_ptr(yyscanner.yytext_r).to_bytes_with_nul()).to_vec();
+                                let yytext_r_slice: &[c_char] = &name_owned;
 
                                 dtype = fits_parser_yyGetVariable(
                                     lParse,
@@ -1296,12 +1304,13 @@ fn yy_get_next_buffer(yyscanner: &mut yyguts_t, lParse: &mut ParseData) -> c_int
         let top_state = (*(yyscanner.yy_buffer_stack).add(yyscanner.yy_buffer_stack_top))
             .as_deref_mut()
             .unwrap();
-        let mut dest: *mut c_char = top_state.yy_ch_buf.as_deref_mut().unwrap().as_mut_ptr();
+        /* One root pointer for the buffer: `as_deref_mut()` hands out a
+        reference to the contents, so taking `dest` that way and then taking
+        another for the bound below invalidated the first. */
+        let buf_base: *mut c_char = top_state.yy_ch_buf.as_mut().unwrap().as_mut_ptr();
+        let mut dest: *mut c_char = buf_base;
 
-        if yyscanner.yy_c_buf_p
-            > (top_state.yy_ch_buf).as_deref_mut().unwrap()[(yyscanner.yy_n_chars + 1) as usize..]
-                .as_mut_ptr()
-        {
+        if yyscanner.yy_c_buf_p > buf_base.add((yyscanner.yy_n_chars + 1) as usize) {
             yy_fatal_error("fatal flex scanner internal error--end of buffer missed");
         }
 
@@ -1368,7 +1377,7 @@ fn yy_get_next_buffer(yyscanner: &mut yyguts_t, lParse: &mut ParseData) -> c_int
                         v.push(*i);
                     }
 
-                    (top_state).yy_ch_buf = Some(v.into_boxed_slice());
+                    (top_state).yy_ch_buf = Some(v);
                 } else {
                     /* Can't grow it, we don't own it. */
                     (top_state).yy_ch_buf = None;
@@ -1436,7 +1445,7 @@ fn yy_get_next_buffer(yyscanner: &mut yyguts_t, lParse: &mut ParseData) -> c_int
                 v.push(*i);
             }
 
-            top_state.yy_ch_buf = Some(v.into_boxed_slice());
+            top_state.yy_ch_buf = Some(v);
 
             /* "- 2" to take care of EOB's */
             top_state.yy_buf_size = new_size_0 - 2;
@@ -1450,7 +1459,11 @@ fn yy_get_next_buffer(yyscanner: &mut yyguts_t, lParse: &mut ParseData) -> c_int
             YY_END_OF_BUFFER_CHAR;
         /* Take the slice pointer directly rather than round-tripping it
         through a place expression. */
-        yyscanner.yytext_r = (top_state.yy_ch_buf).as_deref_mut().unwrap().as_mut_ptr();
+        /* Vec::as_mut_ptr, not as_deref_mut(): yytext_r outlives this borrow of
+        the buffer, and a reference to the contents would be invalidated by the
+        next as_deref_mut() on the same slot. Reading the Vec's own pointer
+        carries the buffer's root tag. */
+        yyscanner.yytext_r = (top_state.yy_ch_buf).as_mut().unwrap().as_mut_ptr();
         ret_val
     }
 }
@@ -1629,7 +1642,7 @@ pub(crate) fn fits_parser_yy_create_buffer(
     }
 
     b.yy_ch_buf = None;
-    b.yy_ch_buf = Some(v.into_boxed_slice());
+    b.yy_ch_buf = Some(v);
     b.yy_is_our_buffer = true;
 
     fits_parser_yy_init_buffer(&raw mut *b, file, yyscanner);

--- a/src/eval_y.rs
+++ b/src/eval_y.rs
@@ -8882,11 +8882,20 @@ pub(crate) fn Evaluate_Parser(lParse: &mut ParseData, firstRow: c_long, nRows: c
                                 .offset(rowOffset as isize)
                                 .cast(),
                         );
-                        let fresh15 = &mut (((lParse.Nodes)[i as usize]).value).undef;
-                        *fresh15 = (((lParse.varData)[column as usize]).undef)
-                            .as_deref_mut()
-                            .unwrap()[(rowOffset as usize)..]
-                            .as_mut_ptr();
+                        /* Vec::as_mut_ptr, as in the other arm: the node keeps
+                        this pointer, so a reference to the contents would be a
+                        child of this borrow of lParse and die with it. */
+                        let undef_ptr = {
+                            let ud = (((lParse.varData)[column as usize]).undef)
+                                .as_mut()
+                                .unwrap();
+                            assert!(
+                                (rowOffset as usize) <= ud.len(),
+                                "undef offset past the end of the column buffer"
+                            );
+                            ud.as_mut_ptr().add(rowOffset as usize)
+                        };
+                        (((lParse.Nodes)[i as usize]).value).undef = undef_ptr;
                     }
                     ValueSort::Boolean => {
                         (((lParse.Nodes)[i as usize]).value).data.set_buffer(


### PR DESCRIPTION
Four related problems, all pointers into a buffer outliving the borrow they were taken from. 13 tests.

**Three narrowed scan pointers.** The lexer built a scan pointer as:

```rust
p = core::ptr::from_mut::<c_char>(&mut *(yyscanner.yytext_r).offset(2));
while *p != 0 { ... }
```

`&mut *ptr.offset(2)` borrows a *single byte*, so the loop ran past that provenance on its very first step. Take the offset pointer directly. Same shape as the `yytext_r` and `fits_split_names_safer` fixes in #107 and #108.

**Two calls whose second argument killed the first.** `fits_parser_yyGetVariable` and the `getData` callback were passed a `&[c_char]` cut from the yylval slot alongside a `&mut` to that same slot — and `yytext_r` points *into* that slot, so they genuinely alias. The name is now copied out first.

That copy is owned rather than a fixed-size array: my first attempt used a `[c_char; MAX_STRLEN]` and truncated, which dropped the NUL terminator for an overlong name and made `strlen_safe` panic. `overlong_keyword_reference_is_rejected` caught it.

**Two pointers taken from `yy_ch_buf` with `as_deref_mut()`.** That hands out a reference to the *contents*, so the next `as_deref_mut()` on the same slot invalidated them — and both `yytext_r` and the scan destination outlive that borrow. Read the `Vec`'s own pointer instead, which carries the buffer's root tag. This is why `yy_ch_buf` becomes a `Vec<c_char>` rather than a `Box<[c_char]>`: `Box` has no equivalent, since dereferencing it retags.

**A site #120 missed.** `Setup_DataArrays` has two `undef` arms; #120 fixed only the one using `offset`, not the one using `rowOffset`. Same fix, now that `undef` is a `Vec`.

**Verification** — suite green (35 binaries, 0 failed), clippy clean, zero warnings. All 13 affected tests under Miri: **13 passed, 0 UB, 0 leaks**.