### PR TITLE
Round integer exponentiation instead of truncating it

### DIFF
--- a/src/eval_y.rs
+++ b/src/eval_y.rs
@@ -10482,8 +10482,13 @@ fn Do_BinOp_lng(lParse: &mut ParseData, this_node_idx: usize) {
                     }
                 }
                 Operator::Power => {
-                    (lParse.Nodes[this_node_idx]).value.data =
-                        NodeValue::Long(pow(val1 as c_double, val2 as c_double) as c_long);
+                    /* Round, don't truncate. Both operands are integers, so the
+                    result is one too, but powf need not land exactly on it --
+                    5**2 comes back as 24.999999999999996 under some libm
+                    implementations, and `as c_long` then yields 24. */
+                    (lParse.Nodes[this_node_idx]).value.data = NodeValue::Long(
+                        pow(val1 as c_double, val2 as c_double).round() as c_long,
+                    );
                 }
                 Operator::Accum => {
                     (lParse.Nodes[this_node_idx]).value.data = NodeValue::Long(val1);
@@ -10672,9 +10677,10 @@ fn Do_BinOp_lng(lParse: &mut ParseData, this_node_idx: usize) {
                             }
                         }
                         Operator::Power => {
+                            /* Rounded, as in the scalar case above. */
                             *((lParse.Nodes[this_node_idx]).value.data.lng_buf())
                                 .offset(elem as isize) =
-                                pow(val1 as c_double, val2 as c_double) as c_long;
+                                pow(val1 as c_double, val2 as c_double).round() as c_long;
                         }
                         _ => {}
                     }


### PR DESCRIPTION
A wrong answer rather than a crash, which makes it the odd one out among the remaining Miri findings.

`INTCOL ** 2` over five rows returns `[1, 4, 9, 16, 24]`. The last one should be 25.

Both operands are integers, so the result is one too, but it is computed in floating point:

```rust
NodeValue::Long(pow(val1 as c_double, val2 as c_double) as c_long)
```

`powf` need not land exactly on the integer — 5\*\*2 comes back as `24.999999999999996` under some libm implementations — and `as c_long` **truncates**, giving 24.

glibc on x86 happens to return exactly 25.0, which is why the native suite never caught this. Miri's software `powf` does not, and neither need any other platform or libm. So this is a real portability bug that Miri surfaced incidentally rather than a Miri artifact: the same build on a different libm could return 24 in production.

Rounding both integer `Power` sites — the scalar one and the per-element one — makes the result exact regardless. The floating-point `Power` paths are untouched, since truncation was never involved there.

**Verification** — suite green (35 binaries, 0 failed), clippy clean, zero warnings. `test_ffcrow_power` and `test_ffcrow_power_caret` both pass under Miri, having failed there before.