### PR TITLE
Free the BITSTR column buffers

### DIFF
--- a/src/eval_f.rs
+++ b/src/eval_f.rs
@@ -2352,14 +2352,23 @@ pub(crate) fn ffcprs(lParse: &mut ParseData) {
             lParse.colData.clear();
 
             for col in 0..lParse.nCols {
-                if lParse.varData[col as usize].undef.is_none() {
-                    continue;
-                }
-
                 if lParse.varData[col as usize].dtype == ValueSort::Bits {
-                    let data_ptr = lParse.varData[col as usize].data.cast::<*mut c_char>();
-                    let mut first_ptr = *data_ptr;
-                    FREE!(first_ptr);
+                    /* Two allocations to release: the row-pointer array in
+                    `data`, and the one block every row points into, at
+                    data[0]. Only Bits columns own their `data`; for the other
+                    types it points into the iterator's own array.
+
+                    This used to sit below an `undef.is_none()` skip, but a
+                    Bits column has no undef array -- see "No need for UNDEF
+                    array" in Setup_DataArrays -- so the skip fired every time
+                    and the free below it was unreachable. */
+                    let mut data_ptr = lParse.varData[col as usize].data.cast::<*mut c_char>();
+                    if !data_ptr.is_null() {
+                        let mut first_ptr = *data_ptr;
+                        FREE!(first_ptr);
+                        FREE!(data_ptr);
+                        lParse.varData[col as usize].data = ptr::null_mut();
+                    }
                 }
 
                 lParse.varData[col as usize].undef = None;
@@ -3379,7 +3388,13 @@ fn Setup_DataArrays(
                     j -= 1;
                     let varData = &mut lParse.varData[j];
                     if varData.dtype == ValueSort::Bits {
-                        FREE!(*varData.data.cast::<*mut c_char>().add(0));
+                        /* The array as well as the block; see ffcprs. */
+                        let mut data_ptr = varData.data.cast::<*mut c_char>();
+                        if !data_ptr.is_null() {
+                            FREE!(*data_ptr);
+                            FREE!(data_ptr);
+                            varData.data = ptr::null_mut();
+                        }
                     }
                     varData.undef = None;
                 }


### PR DESCRIPTION
`Setup_DataArrays` mallocs two blocks per Bits column — a row-pointer array in `varData.data`, and the single block every row points into at `data[0]` — and neither was released on the normal path. Miri reports the leak on 17 tests.

The interesting part is that `ffcprs` already had a free written for exactly this case:

```rust
for col in 0..lParse.nCols {
    if lParse.varData[col].undef.is_none() { continue; }   // <-- always true for Bits

    if lParse.varData[col].dtype == ValueSort::Bits {
        ...free...
    }
}
```

A Bits column has **no undef array** — `Setup_DataArrays` says so in a comment ("No need for UNDEF array") and leaves the assignment commented out. So the skip fired for every Bits column and the free written beneath it was unreachable for the only type it applied to.

Both that free and the one on the error path also released only the block at `data[0]`, not the pointer array itself. Both now release both, and only for Bits columns: for the other types `varData.data` points into the iterator's own array, which the parser does not own.

**Verification** — suite green (35 binaries, 0 failed), clippy clean, zero warnings. All 17 affected tests under Miri: **0 leaks, 0 UB**.

## Why this is still `malloc`

Worth recording, since it is the obvious follow-up. `DataInfo::data` is a `*mut c_void` for two reasons: it is type-erased across `*mut c_char`, `c_char`, `c_long` and `f64` columns, and for the non-Bits types the stored pointer is deliberately offset one element past the allocation base (`barray.add(1)`, `iarray.add(1)`, …), with element 0 kept as the sentinel the undef loop reads back. No owning Rust container expresses "owns this block but points one past its start", which is why the naive `Vec` conversion does not work here.

Owning these properly means an enum per element type holding the base buffer plus an accessor returning the offset pointer — the shape `NodeValue` already uses — which would delete this leak class rather than patch it. There are only 11 `varData.data` references, so it is tractable; it is deliberately left as its own change so this one stays a bug fix.