### PR TITLE
Release const nodes' row buffers too

### DIFF
--- a/src/eval_f.rs
+++ b/src/eval_f.rs
@@ -2397,11 +2397,17 @@ pub(crate) fn ffcprs(lParse: &mut ParseData) {
                 /* Release any row buffer the node still owns. Allocate_Ptrs
                 mallocs these and the Do_* kernels free their children after
                 consuming them, so whatever is left here -- the result node
-                above all -- had nothing to free it and leaked. Only computed
-                nodes own their buffer: a column node's points into
+                above all -- had nothing to free it and leaked. Computed and
+                const nodes own their buffer; a column node's points into
                 varData, which it does not own. free_node_buffer marks the
-                value Empty, so the nodes already freed above are a no-op. */
-                if (lParse.Nodes[node as usize]).is_computed() {
+                value Empty, so the nodes already freed above are a no-op.
+
+                CONST_OP is -1000, so is_computed() alone excluded const nodes
+                and left the buffers Allocate_Ptrs makes for string and bit
+                constants leaking. */
+                if (lParse.Nodes[node as usize]).is_computed()
+                    || (lParse.Nodes[node as usize]).is_const()
+                {
                     free_node_buffer(&mut (lParse.Nodes[node as usize]));
                 }
             }

--- a/src/eval_y.rs
+++ b/src/eval_y.rs
@@ -9077,6 +9077,12 @@ fn Allocate_Ptrs(lParse: &mut ParseData, this_node_idx: usize) {
 
 pub(crate) unsafe fn free_node_buffer(node: &mut Node) {
     unsafe {
+        /* Only a Buffer variant owns a heap allocation. A const node keeps its
+        value inline -- Text, Long, Double -- and asking those for a buffer
+        panics, so leave them alone. */
+        if !matches!(node.value.data, NodeValue::Buffer { .. }) {
+            return;
+        }
         if node.ntype == ValueSort::Bits || node.ntype == ValueSort::String {
             if !node.value.data.str_buf().is_null() {
                 /* the row pointers all point into one block, allocated at [0] */


### PR DESCRIPTION
A follow-up to #122, which did not go far enough.

#122 released a node's row buffer at teardown only when `is_computed()`. `CONST_OP` is `-1000` and `is_computed()` is `operation > 0`, so **const nodes were excluded** — and the buffers `Allocate_Ptrs` makes for string and bit constants, along with `New_GTI`'s interval buffer, were still leaked. Miri reports it on three tests.

Widening the guard to `is_computed() || is_const()` is not sufficient on its own, and the native suite says so loudly: seven tests panic with

```
node value is Text(..), expected Buffer(Text)
```

A const node may hold its value **inline** — `Text`, `Long`, `Double` — rather than as a heap `Buffer`, and `free_node_buffer` asked for a buffer unconditionally. It now returns early unless the value really is a `Buffer`, which also makes it safe to call on any node rather than only ones the caller has already classified.

Column nodes stay excluded: their `value.data` points into `varData`, which they do not own.

**Verification** — suite green (35 binaries, 0 failed), clippy clean, zero warnings. Miri over 13 tests spanning the leaking cases and the const-node cases that the first attempt broke: **13 passed, 0 leaks, 0 UB**.