### PR TITLE
Use flate2's miniz_oxide backend to dodge a zlib-rs soundness bug

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,16 @@ memchr = { version = "2.8.3", default-features = false }
 errno = "0.3.14"
 # Used by the fpack/funpack binaries: temporary output files (fpack's fp_tmpnam)
 # and `funpack -Z` gzipping.  Binaries cannot see [dev-dependencies], so these
-# live here.  flate2 is pinned to the zlib-rs backend so it shares the
-# libz-rs-sys already in the tree rather than pulling in a second zlib.
+# live here.
+#
+# flate2 uses the pure-Rust miniz_oxide backend rather than the zlib-rs one that
+# would share the libz-rs-sys already in the tree.  zlib-rs's `stable` API -- the
+# one flate2's zlib-rs backend drives, and the only part of zlib-rs that is not
+# reached through libz-rs-sys's C entry points -- has a soundness bug: DeflateStream
+# holds `state: &'a mut State<'a>` pointing into the block that `deflate::end` then
+# frees while that reference is still a protected function argument, so miri reports
+# "deallocating while item is strongly protected" from GzEncoder::finish.  Present in
+# 0.6.6 and 0.6.7 and on upstream main.  libz-rs-sys's own deflateEnd is unaffected,
+# so this only concerns flate2.  Revert to `features = ["zlib-rs"]` once it is fixed.
 tempfile = "3.27"
-flate2 = { version = "1.1", default-features = false, features = ["zlib-rs"] }
+flate2 = { version = "1.1", default-features = false, features = ["rust_backend"] }

--- a/TODO.md
+++ b/TODO.md
@@ -55,6 +55,18 @@
 - [ ] Report the CFITSIO defects the fpack/funpack port turned up. Two are
       already filed upstream (heasarc/cfitsio#134 and #136); the rest are
       marked NOTE (upstream bug N) in src/bin/fpack/
+- [ ] Report the zlib-rs soundness bug upstream, then revert Cargo.toml to
+      `flate2 = { ..., features = ["zlib-rs"] }` so flate2 shares the
+      libz-rs-sys already in the tree instead of pulling in miniz_oxide.
+      `DeflateStream` holds `state: &'a mut State<'a>` pointing into the block
+      that `deflate::end` then frees while that reference is still a protected
+      function argument, so `GzEncoder::finish` is UB: miri reports
+      "deallocating while item is strongly protected". A 12-line GzEncoder
+      write-and-finish reproduces it with no rsfitsio code involved. Present in
+      0.6.6, 0.6.7 and upstream main. Only zlib-rs's `stable` API is affected --
+      libz-rs-sys's C `deflateEnd` builds its `&mut DeflateStream` differently
+      and is clean -- so the library's own GZIP paths were never involved, only
+      the two fpack/funpack gzip tests.
 - [ ] Restructure modules, ::api ??
 - [X] Every extern function should be a wrapper around a safe interface
 - [ ] Keep shrinking `unsafe` outside the FFI wrappers. Measure with


### PR DESCRIPTION
`fpackutil::tests::test_gzip_file_replaces_the_input` fails under miri in both the fpack and funpack binaries with "deallocating while item [Unique for <...>] is strongly protected".

The bug is in zlib-rs, not here. `DeflateStream` holds `state: &'a mut State<'a>` pointing into the block that `deflate::end` then frees while that reference is still a strongly-protected function argument. A 12-line `GzEncoder` write-and-finish reproduces it with no rsfitsio code involved; it is present in 0.6.6, 0.6.7 and upstream main, so no version bump helps.

Only zlib-rs's `stable` API is affected. libz-rs-sys's C `deflateEnd` builds its `&mut DeflateStream` differently and is miri-clean, so the library's own GZIP paths were never involved — just flate2, which is used solely by the fpack/funpack binaries.

Switching flate2 to `rust_backend` (miniz_oxide, pure safe Rust) makes both tests pass. libz-rs-sys stays as the library's GZIP, so the only cost is miniz_oxide in the binary builds. TODO.md tracks reverting this once upstream is fixed.

Both tests pass under miri; `cargo test --lib` and `cargo test` are green.