### PR TITLE
Fix the last two Stacked Borrows violations from the miri run

### DIFF
--- a/src/cfileio.rs
+++ b/src/cfileio.rs
@@ -153,7 +153,7 @@ pub unsafe extern "C" fn ffomem(
     fptr: *mut Option<Box<fitsfile>>, /* O - FITS file pointer                   */
     name: *const c_char,              /* I - name of file to open                */
     mode: c_int,                      /* I - 0 = open readonly; 1 = read/write   */
-    buffptr: *const *const c_void,    /* I - address of memory pointer           */
+    buffptr: *mut *mut c_void,        /* I - address of memory pointer           */
     buffsize: *mut usize,             /* I - size of buffer, in bytes            */
     deltasize: usize,                 /* I - increment for future realloc's      */
     mem_realloc: unsafe extern "C" fn(p: *mut c_void, newsize: usize) -> *mut c_void, /* function       */
@@ -184,7 +184,7 @@ pub fn ffomem_safer(
     fptr: &mut Option<Box<fitsfile>>, /* O - FITS file pointer                   */
     name: &[c_char],                  /* I - name of file to open                */
     mode: c_int,                      /* I - 0 = open readonly; 1 = read/write   */
-    buffptr: *const *const c_void,    /* I - address of memory pointer           */
+    buffptr: *mut *mut c_void,        /* I - address of memory pointer           */
     buffsize: &mut usize,             /* I - size of buffer, in bytes            */
     deltasize: usize,                 /* I - increment for future realloc's      */
     mem_realloc: unsafe extern "C" fn(p: *mut c_void, newsize: usize) -> *mut c_void, /* function       */
@@ -5502,7 +5502,7 @@ pub fn ffimem_safer(
     /* call driver routine to "open" the memory file */
     let lock = FFLOCK(); /* lock this while searching for vacant handle */
     *status = mem_openmem(
-        buffptr as *const *const c_void,
+        buffptr,
         buffsize,
         deltasize,
         mem_realloc,
@@ -12881,7 +12881,7 @@ mod tests {
             &mut f2,
             &str_to_c_array("mem://"),
             READONLY,
-            (&raw const buffer).cast::<*const c_void>(),
+            (&raw mut buffer).cast::<*mut c_void>(),
             &mut bufsize,
             0,
             libc::realloc,

--- a/src/drvrmem.rs
+++ b/src/drvrmem.rs
@@ -261,7 +261,7 @@ pub(crate) fn mem_create_comp_unsafe(
 /*--------------------------------------------------------------------------*/
 /// lowest level routine to open a pre-existing memory file.
 pub(crate) fn mem_openmem(
-    buffptr: *const *const c_void, /* I - address of memory pointer          */
+    buffptr: *mut *mut c_void, /* I - address of memory pointer          */
     buffsize: &mut usize,          /* I - size of buffer, in bytes           */
     deltasize: usize,              /* I - increment for future realloc's     */
     memrealloc: Option<unsafe extern "C" fn(p: *mut c_void, newsize: usize) -> *mut c_void>, /* function (may be NULL)  */
@@ -287,7 +287,7 @@ pub(crate) fn mem_openmem(
         return TOO_MANY_FILES; /* too many files opened */
     }
 
-    m[ii].memaddrptr = buffptr as *mut *mut c_char; /* pointer to start addres */
+    m[ii].memaddrptr = buffptr.cast::<*mut c_char>(); /* pointer to start addres */
     m[ii].memsizeptr = buffsize; /* allocated size of memory */
     m[ii].deltasize = deltasize; /* suggested realloc increment */
     m[ii].fitsfilesize = *buffsize as LONGLONG; /* size of FITS file (upper limit) */

--- a/src/getcol.rs
+++ b/src/getcol.rs
@@ -3062,6 +3062,11 @@ pub fn ffgcvn_safe(
         for icol in 0..(ncols as usize) {
             let nelem1: LONGLONG = nread * repeats[icol];
 
+            /* bytes_per_datatype gives the size of one element, so this is
+            already the whole of the caller's buffer for this column: one
+            element for each of the nrows rows times the column's repeat.
+            Scaling it by nrows * repeats a second time claimed a buffer
+            (nrows * repeats) times larger than the caller allocated. */
             let bytes = match bytes_per_datatype(datatype[icol]) {
                 Some(x) => x * nrows as usize * repeats[icol] as usize,
                 None => {
@@ -3070,12 +3075,7 @@ pub fn ffgcvn_safe(
                 }
             };
 
-            let arr = unsafe {
-                slice::from_raw_parts_mut(
-                    array[icol].cast::<u8>(),
-                    bytes * (nrows * repeats[icol]) as usize,
-                )
-            };
+            let arr = unsafe { slice::from_raw_parts_mut(array[icol].cast::<u8>(), bytes) };
             let array1 =
                 &mut arr[(repeats[icol] * ndone) as usize * (sizes[datatype[icol] as usize])..];
 


### PR DESCRIPTION
The two remaining UB sites from the full miri run.

**`ffgcvn_safe` (getcol.rs)** — `bytes_per_datatype` returns the size of *one element*, so `bytes` was already the whole of the caller's buffer for that column. It was then multiplied by `nrows * repeats` a second time, making the slice `(nrows * repeats)` times longer than the allocation. miri reports a dangling `&mut [u8]`.

**`ffomem` (cfileio.rs / drvrmem.rs)** — declared `buffptr: *const *const c_void` where the C has `void **buffptr`. The mem driver writes the reallocated address back through it (`mem_truncate`, `*(m[handle].memaddrptr) = ptr`), so a caller that derives the pointer from a shared borrow — which is exactly what the const signature invites, and what `test_ffomem` did — turns that into a write through a SharedReadOnly tag. `ffimem` already declared it `*mut *mut c_void`; `ffomem`, `ffomem_safer` and `mem_openmem` now agree with it and with the C, and `ffimem`'s `as *const *const c_void` downcast at the call site is gone.

`getcol::tests::test_ffgcvn` and `cfileio::tests::test_ffomem` pass under miri. `cargo test --lib` and `cargo test` are green (5311 passed, 0 failed).

With these, all 7 UB findings from the last full run are addressed.