### PR TITLE
Free both row buffers when a dereference fails

### DIFF
--- a/src/eval_y.rs
+++ b/src/eval_y.rs
@@ -14451,6 +14451,13 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
     }
 }
 
+/* NOTE: the error paths below release the result node with free_node_buffer,
+not value.data.free_buffer().  For a Bits or String node Allocate_Ptrs makes
+two allocations -- the row-pointer array in `data`, and the single block every
+row points into, at data[0] -- and free_buffer releases only the array.  It
+also leaves the value Empty, so the teardown in ffcprs then skipped the node
+and the block at data[0] leaked.  BITS[9] is the smallest case: an out-of-range
+index on an 8X column. */
 fn Do_Deref(lParse: &mut ParseData, this_node_idx: usize) {
     unsafe {
         let mut theVar: &mut Node;
@@ -14566,7 +14573,7 @@ fn Do_Deref(lParse: &mut ParseData, this_node_idx: usize) {
                     }
                 } else {
                     fits_parser_yyerror(lParse, cs!(c"Index out of range"));
-                    (lParse.Nodes[this_node_idx]).value.data.free_buffer();
+                    free_node_buffer(&mut (lParse.Nodes[this_node_idx]));
                 }
             } else if allConst != 0 && nDims == 1 {
                 /* Reduce dimensions by 1, using a constant index */
@@ -14577,7 +14584,7 @@ fn Do_Deref(lParse: &mut ParseData, this_node_idx: usize) {
                             [((lParse.Nodes[theVar]).value.naxis - 1) as usize]
                 {
                     fits_parser_yyerror(lParse, cs!(c"Index out of range"));
-                    (lParse.Nodes[this_node_idx]).value.data.free_buffer();
+                    free_node_buffer(&mut (lParse.Nodes[this_node_idx]));
                 } else if (lParse.Nodes[this_node_idx]).ntype == ValueSort::Bits
                     || (lParse.Nodes[this_node_idx]).ntype == ValueSort::String
                 {
@@ -14671,7 +14678,7 @@ fn Do_Deref(lParse: &mut ParseData, this_node_idx: usize) {
                                     lParse,
                                     cs!(c"Null encountered as vector index"),
                                 );
-                                (lParse.Nodes[this_node_idx]).value.data.free_buffer();
+                                free_node_buffer(&mut (lParse.Nodes[this_node_idx]));
                                 break;
                             } else {
                                 dimVals[i as usize] =
@@ -14742,7 +14749,7 @@ fn Do_Deref(lParse: &mut ParseData, this_node_idx: usize) {
                         }
                     } else {
                         fits_parser_yyerror(lParse, cs!(c"Index out of range"));
-                        (lParse.Nodes[this_node_idx]).value.data.free_buffer();
+                        free_node_buffer(&mut (lParse.Nodes[this_node_idx]));
                     }
                     row += 1;
                 }
@@ -14753,7 +14760,7 @@ fn Do_Deref(lParse: &mut ParseData, this_node_idx: usize) {
                     /* Index cannot be a constant */
                     if *((lParse.Nodes[theDims[0]]).value.undef).offset(row as isize) != 0 {
                         fits_parser_yyerror(lParse, cs!(c"Null encountered as vector index"));
-                        (lParse.Nodes[this_node_idx]).value.data.free_buffer();
+                        free_node_buffer(&mut (lParse.Nodes[this_node_idx]));
                         break;
                     } else {
                         dimVals[0] =
@@ -14764,7 +14771,7 @@ fn Do_Deref(lParse: &mut ParseData, this_node_idx: usize) {
                                     [((lParse.Nodes[theVar]).value.naxis - 1) as usize]
                         {
                             fits_parser_yyerror(lParse, cs!(c"Index out of range"));
-                            (lParse.Nodes[this_node_idx]).value.data.free_buffer();
+                            free_node_buffer(&mut (lParse.Nodes[this_node_idx]));
                         } else if (lParse.Nodes[this_node_idx]).ntype == ValueSort::Bits
                             || (lParse.Nodes[this_node_idx]).ntype == ValueSort::String
                         {

--- a/tests/test_eval_corpus.rs
+++ b/tests/test_eval_corpus.rs
@@ -434,4 +434,37 @@ mod tests {
             panic!("{diffs} corpus line(s) diverge from the golden file:\n{msg}");
         }
     }
+
+    /// A failed dereference must still release the result node's row buffers.
+    ///
+    /// `Allocate_Ptrs` gives a Bits or String node two allocations -- the
+    /// row-pointer array, and the single block every row points into at
+    /// `data[0]`.  `Do_Deref`'s error paths used to release only the array,
+    /// which also left the value Empty so that `ffcprs` skipped the node and
+    /// the block leaked.  `BITS[9]` is the smallest case: an out-of-range
+    /// index into the 8X column, which the golden file records as EVALERR 431.
+    ///
+    /// The leak is only observable under miri; this runs in seconds, where
+    /// reaching the same expression through the corpus above takes hours.
+    #[test]
+    fn failed_deref_releases_the_row_buffer() {
+        let mut f = create_corpus_table();
+        let mut st = 0;
+        let mut anynul = 0;
+        let mut results = vec![0.0f64; NROWS as usize];
+        fits_calc_rows(
+            &mut f,
+            TDOUBLE,
+            &cc("BITS[9]"),
+            1,
+            NROWS,
+            core::ptr::null(),
+            as_bytes_mut(&mut results),
+            &mut anynul,
+            &mut st,
+        );
+        assert_eq!(st, 431, "expected the recorded out-of-range error");
+        fits_clear_errmsg();
+        fits_close_file(f, &mut st);
+    }
 }


### PR DESCRIPTION
The one leak left over from the miri run — the corpus test reported it as a single 9-byte block after 2.3 hours.

`Allocate_Ptrs` gives a Bits or String node **two** allocations: the row-pointer array in `value.data`, and the single block every row points into, at `data[0]`. `Do_Deref`'s six error paths ("Index out of range", "Null encountered as vector index") released the node with `value.data.free_buffer()`, which frees only the array. Worse, it leaves the value `Empty`, so the teardown in `ffcprs` — which only frees nodes still holding a `Buffer` — then skipped the node entirely and the block at `data[0]` leaked.

All six now use `free_node_buffer`, which already knew to free `data[0]` first and is what the non-error paths use.

`BITS[9]` — an out-of-range index into the `8X` column — is the smallest reproducer, and the golden file already records it as `EVALERR 431`. It is now a test in `test_eval_corpus.rs`, reusing that file's table builder: it runs in ~22s under miri, where reaching the same expression through the corpus itself takes hours.

`cargo test --lib` and `cargo test` are green (5312 passed, 0 failed).