### PR TITLE
docs: convert the C comment style to rustdoc

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,21 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  docs:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v7
+    - name: Temporarily modify the rust toolchain version
+      run: rustup override set 1.96.0
+
+    # The docs are warning-free; keep them that way. No --lib: that would only
+    # cover the library and leave the utility binaries' docs unchecked.
+    - name: Build the documentation
+      env:
+        RUSTDOCFLAGS: -D warnings
+      run: cargo doc --no-deps
+
   build-on-linux-x64:
     runs-on: ubuntu-latest
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,3 +1,12 @@
+- [X] Convert the inherited C comment style to rustdoc. Done across all 109
+      files in `src/`: the C banner headers are `//!` module docs, the 2372
+      `/*-----*/` separators are gone, the 10589 trailing `/* I - ... */`
+      parameter comments are `# Parameters` sections keeping their I/O/IO
+      markers, and struct fields and constants carry `///`. Comments inside
+      function bodies were left alone. `#![warn(missing_docs)]` is on at the
+      crate root and in every module, so the state cannot regress; the
+      flex/bison output and the vendored relibc carry a commented
+      `#![allow(missing_docs)]` instead.
 - [ ] Refactor the NullCheckType and NullValue. NullValue isn't Copy and these concepts are intrinsicly linked.
 - [ ] Investigate all code with 'WARNING'
 - [ ] Investigate all code with 'TODO'

--- a/src/aliases.rs
+++ b/src/aliases.rs
@@ -1,5 +1,24 @@
 #![allow(deprecated)]
 #![allow(unused_imports)]
+//! The public entry points, under CFITSIO's own names.
+//!
+//! This module mirrors CFITSIO's `fitsio.h` and `longnam.h` exactly, and is the
+//! only intended path to a routine — the implementation modules are exposed so
+//! that the port can be read against the original C, not so that they are
+//! called directly.
+//!
+//! Each routine appears twice:
+//!
+//! * in [`c_api`], under both its `ffxyz` and its `fits_*` spelling, as the
+//!   `unsafe extern "C"` entry point;
+//! * in [`rust_api`], under both its `fits_*` and its `ffxyz_safe` spelling, as
+//!   the safe form taking references, slices and `Option`s.
+//!
+//! `./scripts/check_api.py` diffs this module against `fitsio.h` and
+//! `longnam.h` and fails on a missing name, an invented one, or an alias
+//! pointing at the wrong routine. See `PUBLIC_API.md` for the rules and for
+//! what is deliberately hidden.
+#![warn(missing_docs)]
 
 use crate::c_types::{c_char, c_int};
 use crate::fitsio::CFITSIO_SONAME;
@@ -7,6 +26,11 @@ use crate::fitsio::fitsfile;
 
 pub(crate) use crate::cfileio::ffourl as fits_parse_output_url;
 
+/// The C ABI entry points: `unsafe extern "C"` functions taking raw pointers.
+///
+/// These are `#[deprecated]` so that callers inside the crate reach for
+/// [`rust_api`] instead; the attribute is not a statement about the C API's
+/// future.
 pub mod c_api {
     use super::*;
 
@@ -23,11 +47,34 @@ pub mod c_api {
     pub use crate::histo::ffbinr as fits_parse_binrange;
     pub use crate::histo::ffbins as fits_parse_binspec;
 
-    /*
-    use the following special macro to test that the fitsio.h include file
-    that was used to build the CFITSIO library is compatible with the version
-    as included when compiling the application program
-    */
+    /// Opens an existing FITS file, checking that the caller was built against
+    /// a compatible version of the library.
+    ///
+    /// In C this is a macro that passes `CFITSIO_SONAME` through to
+    /// `ffopentest`, so that a program compiled against one `fitsio.h` and
+    /// linked against a different library is caught at run time rather than
+    /// misbehaving.
+    ///
+    /// # Parameters
+    ///
+    /// * `A` — (O) the opened file
+    /// * `B` — (I) name of the file to open
+    /// * `C` — (I) [`READONLY`](crate::fitsio::READONLY) or
+    ///   [`READWRITE`](crate::fitsio::READWRITE)
+    /// * `D` — (IO) error status
+    ///
+    /// # Returns
+    ///
+    /// The error status; `0` on success.
+    ///
+    /// # Safety
+    ///
+    /// `A`, `B` and `D` must be non-null and valid, and `B` must point at a
+    /// nul-terminated string.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `A` or `D` is null.
     #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
     pub unsafe extern "C" fn fits_open_file(
         A: *mut Option<Box<fitsfile>>,
@@ -669,19 +716,35 @@ pub mod c_api {
     };
     pub use crate::quantize::{fits_img_stats_float, fits_img_stats_int, fits_img_stats_short};
 
+    /// Entry points CFITSIO exports but does not declare in `fitsio.h`.
+    ///
+    /// Programs that link against the C library can still reach these by
+    /// declaring them themselves, so the port provides them for ABI
+    /// compatibility. They are not part of the documented API.
     pub mod unofficial {
         use crate::c_types::{c_int, c_long, c_void};
         use crate::fitsio::{FITSfile, LONGLONG};
         use crate::fitsio::{NULL_MSG, fitsfile};
 
-        /*--------------------------------------------------------------------------*/
-        /// low level routine to read bytes from a file.
+        /// Low level routine to read bytes from a file.
+        ///
+        /// # Parameters
+        ///
+        /// * `fptr`   — (I) FITS file pointer
+        /// * `nbytes` — (I) number of bytes to read
+        /// * `buffer` — (O) buffer to read into
+        /// * `status` — (O) error status
+        ///
+        /// # Safety
+        ///
+        /// `fptr`, `status` and `buffer` must be non-null and valid, and
+        /// `buffer` must be writable for at least `nbytes` bytes.
         #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
         unsafe extern "C" fn ffread(
-            fptr: *mut FITSfile, /* I - FITS file pointer              */
-            nbytes: c_long,      /* I - number of bytes to read        */
-            buffer: *mut c_void, /* O - buffer to read into            */
-            status: *mut c_int,  /* O - error status                   */
+            fptr: *mut FITSfile,
+            nbytes: c_long,
+            buffer: *mut c_void,
+            status: *mut c_int,
         ) -> c_int {
             unsafe {
                 let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -692,31 +755,50 @@ pub mod c_api {
             }
         }
 
-        /*--------------------------------------------------------------------------*/
-        /// low level routine to seek to a position in a file.
+        /// Low level routine to seek to a position in a file.
+        ///
+        /// # Parameters
+        ///
+        /// * `fptr`     — (I) FITS file pointer
+        /// * `position` — (I) byte position to seek to
+        ///
+        /// # Safety
+        ///
+        /// `fptr` must be non-null and valid.
         #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
-        unsafe extern "C" fn ffseek(
-            fptr: *mut FITSfile, /* I - FITS file pointer              */
-            position: LONGLONG,  /* I - byte position to seek to       */
-        ) -> c_int {
+        unsafe extern "C" fn ffseek(fptr: *mut FITSfile, position: LONGLONG) -> c_int {
             unsafe {
                 let fptr = fptr.as_mut().expect(NULL_MSG);
                 crate::cfileio::ffseek(fptr, position)
             }
         }
 
-        /*--------------------------------------------------------------------------*/
         /// Get (read) the requested number of bytes from the file, starting at
-        /// the current file position.  This function combines ffmbyt and ffgbyt
-        /// for increased efficiency.
+        /// the current file position.
+        ///
+        /// Combines `ffmbyt` and `ffgbyt` for increased efficiency.
+        ///
+        /// # Parameters
+        ///
+        /// * `fptr`    — (I) FITS file pointer
+        /// * `gsize`   — (I) size of each group of bytes
+        /// * `ngroups` — (I) number of groups to read
+        /// * `offset`  — (I) size of the gap between groups, which may be < 0
+        /// * `buffer`  — (I) buffer to be filled
+        /// * `status`  — (IO) error status
+        ///
+        /// # Safety
+        ///
+        /// `fptr`, `status` and `buffer` must be non-null and valid, and
+        /// `buffer` must be writable for at least `ngroups * gsize` bytes.
         #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
         unsafe extern "C" fn ffgbytoff(
-            fptr: *mut fitsfile, /* I - FITS file pointer                   */
-            gsize: c_long,       /* I - size of each group of bytes         */
-            ngroups: c_long,     /* I - number of groups to read            */
-            offset: c_long,      /* I - size of gap between groups (may be < 0) */
-            buffer: *mut c_void, /* I - buffer to be filled                 */
-            status: *mut c_int,  /* IO - error status                       */
+            fptr: *mut fitsfile,
+            gsize: c_long,
+            ngroups: c_long,
+            offset: c_long,
+            buffer: *mut c_void,
+            status: *mut c_int,
         ) -> c_int {
             unsafe {
                 let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -732,6 +814,10 @@ pub mod c_api {
     }
 }
 
+/// The safe entry points, taking references, slices and `Option`s.
+///
+/// An opened file is an `Option<Box<fitsfile>>`. This is the module to call
+/// from Rust.
 #[deny(unsafe_code, unsafe_op_in_unsafe_fn, deprecated)]
 pub mod rust_api {
     use super::*;
@@ -749,11 +835,25 @@ pub mod rust_api {
     pub use crate::histo::ffbinr_safe as fits_parse_binrange;
     pub use crate::histo::ffbins_safe as fits_parse_binspec;
 
-    /*
-    use the following special macro to test that the fitsio.h include file
-    that was used to build the CFITSIO library is compatible with the version
-    as included when compiling the application program
-    */
+    /// Opens an existing FITS file, checking that the caller was built against
+    /// a compatible version of the library.
+    ///
+    /// In C this is a macro that passes `CFITSIO_SONAME` through to
+    /// `ffopentest`, so that a program compiled against one `fitsio.h` and
+    /// linked against a different library is caught at run time rather than
+    /// misbehaving.
+    ///
+    /// # Parameters
+    ///
+    /// * `A` — (O) the opened file
+    /// * `B` — (I) name of the file to open
+    /// * `C` — (I) [`READONLY`](crate::fitsio::READONLY) or
+    ///   [`READWRITE`](crate::fitsio::READWRITE)
+    /// * `D` — (IO) error status
+    ///
+    /// # Returns
+    ///
+    /// The error status; `0` on success.
     pub fn fits_open_file(
         A: &mut Option<Box<fitsfile>>,
         B: &[c_char],

--- a/src/bin/fitscopy/main.rs
+++ b/src/bin/fitscopy/main.rs
@@ -1,3 +1,7 @@
+//! Transpiled from cfitsio/utilities/fitscopy.c: copies a FITS file, applying
+//! any filters given in the input file's extended name.
+#![warn(missing_docs)]
+
 use std::ffi::CString;
 use std::process::ExitCode;
 
@@ -13,6 +17,7 @@ use rsfitsio::{
     fitsio::fitsfile,
 };
 
+/// Entry point: copies the input file to the output file.
 pub fn main() -> ExitCode {
     /* FITS file pointers defined in fitsio.h */
     let mut infptr: Option<Box<fitsfile>> = None;

--- a/src/bin/fitsverify/common.rs
+++ b/src/bin/fitsverify/common.rs
@@ -1,11 +1,14 @@
-/* Transpiled from cfitsio/utilities/fverify.h, plus the small amount of
-infrastructure that C gets for free from <stdio.h>/<ctype.h>/<stdlib.h>.
-
-The C globals declared here (errmes, comm, prhead, testdata, ...) are file
-statics / externs in the C.  Buffers that are only ever "printf into it, then
-immediately consume it" (errmes, comm, temp) become locals at each use site,
-which is semantically identical and avoids global mutable state.  The truly
-persistent globals (the flags and counters) live in `flags` below.  */
+//! Transpiled from cfitsio/utilities/fverify.h, plus the small amount of
+//! infrastructure that C gets for free from <stdio.h>/<ctype.h>/<stdlib.h>.
+//!
+//! The C globals declared here (errmes, comm, prhead, testdata, ...) are
+//! file
+//! statics / externs in the C.  Buffers that are only ever "printf into it, then
+//! immediately consume it" (errmes, comm, temp) become locals at each use
+//! site,
+//! which is semantically identical and avoids global mutable state.  The truly
+//! persistent globals (the flags and counters) live in `flags` below.
+#![warn(missing_docs)]
 
 use std::cell::{Cell, RefCell};
 use std::cmp::Ordering;
@@ -410,6 +413,7 @@ fn pad(v: &mut Vec<u8>, b: &[u8], width: i32) {
 /* Formats the arguments and stores the result NUL-terminated in `dst'.
 C's sprintf() would run off the end of these fixed buffers; we truncate. */
 #[macro_export]
+/// `sprintf` into a `[c_char]` buffer, as the C does.
 macro_rules! spf {
     ($dst:expr; $($x:expr),* $(,)?) => {{
         let mut __v: Vec<u8> = Vec::new();
@@ -420,6 +424,7 @@ macro_rules! spf {
 
 /* Formats the arguments and appends them, NUL-terminated, to `dst' (strcat). */
 #[macro_export]
+/// `sprintf` appended to what is already in a `[c_char]` buffer.
 macro_rules! scat {
     ($dst:expr; $($x:expr),* $(,)?) => {{
         let mut __v: Vec<u8> = Vec::new();
@@ -430,6 +435,7 @@ macro_rules! scat {
 
 /* printf() */
 #[macro_export]
+/// `printf` to the report output stream.
 macro_rules! pf {
     ($out:expr; $($x:expr),* $(,)?) => {{
         let mut __v: Vec<u8> = Vec::new();

--- a/src/bin/fitsverify/fvrf_data.rs
+++ b/src/bin/fitsverify/fvrf_data.rs
@@ -1,9 +1,11 @@
-/* Transpiled from cfitsio/utilities/fvrf_data.c
-
-The CFITSIO iterator hands its work function a `void *userPointer' and an
-array of iteratorCol whose `array' member is a raw buffer, so test_data /
-iterdata keep the C's pointer arithmetic inside small unsafe blocks.  All
-the other column reads use the typed safe wrappers.  */
+//! Transpiled from cfitsio/utilities/fvrf_data.c
+//!
+//! The CFITSIO iterator hands its work function a `void *userPointer' and
+//! an array of iteratorCol whose `array' member is a raw buffer, so
+//! test_data /
+//! iterdata keep the C's pointer arithmetic inside small unsafe blocks.  All
+//! the other column reads use the typed safe wrappers.
+#![warn(missing_docs)]
 
 use std::cell::{Cell, RefCell};
 
@@ -32,16 +34,27 @@ use crate::{scat, spf};
 /* flag for input only iterator column (fitsio.h InputCol) */
 const InputCol: c_int = 0;
 
+/// State carried through the column iterator while checking a table's data.
 struct UserIter {
+    /// Number of numeric columns.
     nnum: c_int,
+    /// Number of complex columns.
     ncmp: c_int,
+    /// Number of floating point columns.
     nfloat: c_int,
+    /// Datatype code of each column being checked.
     indatatyp: Vec<c_int>,
+    /// Largest value seen in each column.
     datamax: Vec<f64>,
+    /// Smallest value seen in each column.
     datamin: Vec<f64>,
+    /// Null value of each column.
     tnull: Vec<f64>,
-    mask: Vec<c_uchar>, /* for bit X column only */
+    /// Bit mask, for a bit (`X`) column only.
+    mask: Vec<c_uchar>,
+    /// Number of text columns.
     ntxt: c_int,
+    /// Where the report is written.
     out: Out,
 }
 
@@ -68,11 +81,12 @@ struct UserIter {
 *  this routine does not read the image pixels.
 *
 *************************************************************/
-pub(crate) fn test_data(
-    infits: &mut fitsfile, /* input fits file   */
-    out: Out,              /* output ascii file */
-    hduptr: &mut FitsHdu,  /* fits hdu pointer  */
-) {
+/// # Parameters
+///
+/// * `infits` — input fits file
+/// * `out`    — output ascii file
+/// * `hduptr` — fits hdu pointer
+pub(crate) fn test_data(infits: &mut fitsfile, out: Out, hduptr: &mut FitsHdu) {
     let mut iter_col: Vec<iteratorCol> = Vec::new();
     let ncols: c_int;
 
@@ -594,7 +608,6 @@ pub(crate) fn test_data(
     }
 }
 
-/***********************************************************************/
 /* iterator work function */
 
 /* The C keeps its per-table state in function statics; the same state lives
@@ -884,11 +897,12 @@ pub extern "C" fn iterdata(
 *   Test the bytes between the ASCII table column.
 *
 *************************************************************/
-fn test_agap(
-    infits: &mut fitsfile, /* input fits file   */
-    out: Out,              /* output ascii file */
-    hduptr: &mut FitsHdu,  /* fits hdu pointer  */
-) {
+/// # Parameters
+///
+/// * `infits` — input fits file
+/// * `out`    — output ascii file
+/// * `hduptr` — fits hdu pointer
+fn test_agap(infits: &mut fitsfile, out: Out, hduptr: &mut FitsHdu) {
     let ncols: c_int;
     let mut nrows: LONGLONG = 0;
     let mut irows: c_long = 0;
@@ -1017,10 +1031,11 @@ fn test_agap(
 *   Test the checksum of the hdu
 *
 *************************************************************/
-fn test_checksum(
-    infits: &mut fitsfile, /* input fits file   */
-    out: Out,              /* output ascii file */
-) {
+/// # Parameters
+///
+/// * `infits` — input fits file
+/// * `out`    — output ascii file
+fn test_checksum(infits: &mut fitsfile, out: Out) {
     let mut status: c_int = 0;
     let mut dataok: c_int = 0;
     let mut hduok: c_int = 0;

--- a/src/bin/fitsverify/fvrf_file.rs
+++ b/src/bin/fitsverify/fvrf_file.rs
@@ -1,7 +1,8 @@
-/* Transpiled from cfitsio/utilities/fvrf_file.c
-
-`static HduName **hduname' becomes a thread-local Vec<HduName>; the C's
-malloc/calloc/free bookkeeping is dropped in favour of RAII.  */
+//! Transpiled from cfitsio/utilities/fvrf_file.c
+//!
+//! `static HduName **hduname` becomes a thread-local `Vec<HduName>`; the C's
+//! malloc/calloc/free bookkeeping is dropped in favour of RAII.
+#![warn(missing_docs)]
 
 use std::cell::{Cell, RefCell};
 
@@ -54,11 +55,17 @@ fn init_hduname() {
 }
 
 /* set the hduname memeber hdutype, extname, extver */
+/// # Parameters
+///
+/// * `hdunum`  — hdu number
+/// * `hdutype` — hdutype
+/// * `extname` — extension name
+/// * `extver`  — extension version
 pub(crate) fn set_hduname(
-    hdunum: c_int,              /* hdu number */
-    hdutype: c_int,             /* hdutype */
-    extname: Option<&[c_char]>, /* extension name */
-    extver: c_int,              /* extension version */
+    hdunum: c_int,
+    hdutype: c_int,
+    extname: Option<&[c_char]>,
+    extver: c_int,
 ) {
     let i = (hdunum - 1) as usize;
     HDUNAME.with(|h| {
@@ -98,10 +105,11 @@ pub(crate) fn set_hdubasic(hdunum: c_int, hdutype: c_int) {
 
 /* test to see whether the two extension having the same name */
 /* return 1: identical 0: different */
-pub(crate) fn test_hduname(
-    hdunum1: c_int, /* index of first hdu */
-    hdunum2: c_int, /* index of second hdu */
-) -> c_int {
+/// # Parameters
+///
+/// * `hdunum1` — index of first hdu
+/// * `hdunum2` — index of second hdu
+pub(crate) fn test_hduname(hdunum1: c_int, hdunum2: c_int) -> c_int {
     HDUNAME.with(|h| {
         let h = h.borrow();
         let p1 = &h[(hdunum1 - 1) as usize];
@@ -282,10 +290,11 @@ pub(crate) fn test_end(infits: &mut fitsfile, out: Out) {
 *      Initialize the fverify report
 *
 *******************************************************************************/
-pub(crate) fn init_report(
-    out: Out,            /* output file */
-    _rootnam: &[c_char], /* input file name */
-) {
+/// # Parameters
+///
+/// * `out`      — output file
+/// * `_rootnam` — input file name
+pub(crate) fn init_report(out: Out, _rootnam: &[c_char]) {
     let mut comm: [c_char; COMM_LEN] = [0; COMM_LEN];
     spf!(comm; "\n", totalhdu(), " Header-Data Units in this file.");
     wrtout(out, &comm);

--- a/src/bin/fitsverify/fvrf_head.rs
+++ b/src/bin/fitsverify/fvrf_head.rs
@@ -1,9 +1,10 @@
-/* Transpiled from cfitsio/utilities/fvrf_head.c
-
-The `char **' working arrays (cards, tmpkwds, ttype, tform, tunit) are
-file-statics in the C; here they are thread-locals holding owned copies.
-`temp' / `ptemp' were only ever used to hand a pattern to key_match(), so
-the pattern is passed directly instead.  */
+//! Transpiled from cfitsio/utilities/fvrf_head.c
+//!
+//! The `char **' working arrays (cards, tmpkwds, ttype, tform, tunit) are
+//! file-statics in the C; here they are thread-locals holding owned copies.
+//! `temp' / `ptemp' were only ever used to hand a pattern to key_match(),
+//! so the pattern is passed directly instead.
+#![warn(missing_docs)]
 
 use std::cell::{Cell, RefCell};
 use std::cmp::Ordering;
@@ -161,7 +162,6 @@ pub(crate) fn verify_fits(infile: &mut [c_char], out: Out) -> c_int {
 
     /* initialize the report */
     init_report(out, &rootnam);
-    /*------------------  Hdu Loop --------------------------------*/
     i = 1;
     while i <= totalhdu() {
         /* move to the right hdu and do the CFITSIO test */
@@ -214,7 +214,6 @@ pub(crate) fn verify_fits(infile: &mut [c_char], out: Out) -> c_int {
     /* test the end of file  */
     test_end(&mut infits, out);
 
-    /*------------------ Closing  --------------------------------*/
     /* closing the report*/
     close_report(out);
 
@@ -251,13 +250,13 @@ fn close_err(out: Out) {
 *
 *
 *************************************************************/
-fn init_hdu(
-    infits: &mut fitsfile, /* input fits file   */
-    out: Out,              /* output ascii file */
-    hdunum: c_int,         /* hdu index 	     */
-    hdutype: c_int,        /* hdutype	     */
-    hduptr: &mut FitsHdu,
-) {
+/// # Parameters
+///
+/// * `infits`  — input fits file
+/// * `out`     — output ascii file
+/// * `hdunum`  — hdu index
+/// * `hdutype` — hdutype
+fn init_hdu(infits: &mut fitsfile, out: Out, hdunum: c_int, hdutype: c_int, hduptr: &mut FitsHdu) {
     let mut morekeys: c_int;
     let mut i: usize;
     let mut j: usize;
@@ -619,11 +618,11 @@ fn init_hdu(
 *    This includes many tests of WCS keywords
 *
 *************************************************************/
-fn test_hdu(
-    infits: &mut fitsfile, /* input fits file   */
-    out: Out,              /* output ascii file */
-    hduptr: &mut FitsHdu,
-) {
+/// # Parameters
+///
+/// * `infits` — input fits file
+/// * `out`    — output ascii file
+fn test_hdu(infits: &mut fitsfile, out: Out, hduptr: &mut FitsHdu) {
     let mut status: c_int = 0;
     let numusrkey: c_int;
     let hdunum: c_int;
@@ -1193,11 +1192,12 @@ fn test_hdu(
 *   Test the primary array header
 *
 *************************************************************/
-fn test_prm(
-    infits: &mut fitsfile, /* input fits file   */
-    out: Out,              /* output ascii file */
-    hduptr: &mut FitsHdu,  /* hdu information structure */
-) {
+/// # Parameters
+///
+/// * `infits` — input fits file
+/// * `out`    — output ascii file
+/// * `hduptr` — hdu information structure
+fn test_prm(infits: &mut fitsfile, out: Out, hduptr: &mut FitsHdu) {
     let mut i: c_int;
     let mut j: c_int;
     let mut k: c_int = 0;
@@ -1417,11 +1417,12 @@ fn test_prm(
 *   Test the extension header
 *
 *************************************************************/
-fn test_ext(
-    _infits: &mut fitsfile, /* input fits file   */
-    out: Out,               /* output ascii file */
-    hduptr: &mut FitsHdu,   /* information about header */
-) {
+/// # Parameters
+///
+/// * `_infits` — input fits file
+/// * `out`     — output ascii file
+/// * `hduptr`  — information about header
+fn test_ext(_infits: &mut fitsfile, out: Out, hduptr: &mut FitsHdu) {
     let mut i: c_int;
     let mut j: c_int;
     let mut k: c_int = 0;
@@ -1526,11 +1527,12 @@ fn test_ext(
 *   Test the image extension header
 *
 *************************************************************/
-fn test_img_ext(
-    infits: &mut fitsfile, /* input fits file   */
-    out: Out,              /* output ascii file */
-    hduptr: &mut FitsHdu,  /* information about header */
-) {
+/// # Parameters
+///
+/// * `infits` — input fits file
+/// * `out`    — output ascii file
+/// * `hduptr` — information about header
+fn test_img_ext(infits: &mut fitsfile, out: Out, hduptr: &mut FitsHdu) {
     let mut errmes: [c_char; ERRMES_LEN] = [0; ERRMES_LEN];
 
     test_ext(infits, out, hduptr);
@@ -1559,11 +1561,12 @@ fn test_img_ext(
 * and image Extension.
 *
 *************************************************************/
-fn test_array(
-    _infits: &mut fitsfile, /* input fits file   */
-    out: Out,               /* output ascii file */
-    hduptr: &mut FitsHdu,   /* information about header */
-) {
+/// # Parameters
+///
+/// * `_infits` — input fits file
+/// * `out`     — output ascii file
+/// * `hduptr`  — information about header
+fn test_array(_infits: &mut fitsfile, out: Out, hduptr: &mut FitsHdu) {
     let mut p: usize;
     let mut j: c_int;
     let mut k: c_int = 0;
@@ -1697,11 +1700,12 @@ fn test_array(
 *   tunit.
 *
 *************************************************************/
-fn test_tbl(
-    _infits: &mut fitsfile, /* input fits file   */
-    out: Out,               /* output ascii file */
-    hduptr: &mut FitsHdu,   /* information about header */
-) {
+/// # Parameters
+///
+/// * `_infits` — input fits file
+/// * `out`     — output ascii file
+/// * `hduptr`  — information about header
+fn test_tbl(_infits: &mut fitsfile, out: Out, hduptr: &mut FitsHdu) {
     let mut p: usize;
     let mut m: c_int;
     let mut n: c_int = 0;
@@ -2198,11 +2202,12 @@ fn test_tbl(
 *   Test the ascii table extension header
 *
 *************************************************************/
-fn test_asc_ext(
-    infits: &mut fitsfile, /* input fits file   */
-    out: Out,              /* output ascii file */
-    hduptr: &mut FitsHdu,  /* information about header */
-) {
+/// # Parameters
+///
+/// * `infits` — input fits file
+/// * `out`    — output ascii file
+/// * `hduptr` — information about header
+fn test_asc_ext(infits: &mut fitsfile, out: Out, hduptr: &mut FitsHdu) {
     let mut p: usize;
     let mut i: c_int;
     let mut j: c_int;
@@ -2372,11 +2377,12 @@ fn test_asc_ext(
 *   Test the binary table extension header
 *
 *************************************************************/
-fn test_bin_ext(
-    infits: &mut fitsfile, /* input fits file   */
-    out: Out,              /* output ascii file */
-    hduptr: &mut FitsHdu,  /* information about header */
-) {
+/// # Parameters
+///
+/// * `infits` — input fits file
+/// * `out`    — output ascii file
+/// * `hduptr` — information about header
+fn test_bin_ext(infits: &mut fitsfile, out: Out, hduptr: &mut FitsHdu) {
     let mut i: c_int;
     let mut j: c_int;
     let mut k: c_int = 0;
@@ -2665,11 +2671,12 @@ fn test_bin_ext(
 *   Test the general keywords that can be in any header
 *
 *************************************************************/
-fn test_header(
-    _infits: &mut fitsfile, /* input fits file   */
-    out: Out,               /* output ascii file */
-    hduptr: &mut FitsHdu,   /* information about header  */
-) {
+/// # Parameters
+///
+/// * `_infits` — input fits file
+/// * `out`     — output ascii file
+/// * `hduptr`  — information about header
+fn test_header(_infits: &mut fitsfile, out: Out, hduptr: &mut FitsHdu) {
     /* common mandatory  keywords */
     let mandkey: [&std::ffi::CStr; 5] = [c"SIMPLE", c"BITPIX", c"NAXIS", c"XTENSION", c"END"];
     let nmandkey = 5;
@@ -3014,19 +3021,22 @@ fn test_header(
 *   name is stored in a sorted array.
 *
 *************************************************************/
+/// # Parameters
+///
+/// * `strs`    — fits keyname array
+/// * `nstr`    — total number of keys
+/// * `pattern` — wanted pattern
+/// * `exact`   — exact matching or pattern matching exact = 1: exact matching. exact =
+///              0: pattern matching. Any keywords with "patten"* is included
+/// * `ikey`    — The element number of first key Return -99 if not found
+/// * `mkey`    — total number of key matched return -999 if not found
 fn key_match(
-    strs: &[[c_char; FLEN_KEYWORD]], /* fits keyname  array */
-    nstr: c_int,                     /* total number of keys */
-    pattern: &[c_char],              /* wanted pattern  */
-    exact: c_int,                    /* exact matching or pattern matching
-                                     exact = 1: exact matching.
-                                     exact = 0: pattern matching.
-                                     Any keywords with "patten"* is included
-                                     */
-    ikey: &mut c_int, /* The element number of first key
-                      Return -99 if not found */
-    mkey: &mut c_int, /* total number of key matched
-                      return -999 if not found */
+    strs: &[[c_char; FLEN_KEYWORD]],
+    nstr: c_int,
+    pattern: &[c_char],
+    exact: c_int,
+    ikey: &mut c_int,
+    mkey: &mut c_int,
 ) {
     let mut i: c_int;
     let fnpt: fn(&[c_char], &[c_char]) -> Ordering = if exact != 0 { compstre } else { compstrp };
@@ -3170,14 +3180,20 @@ fn test_colnam(out: Out, hduptr: &FitsHdu) {
 *   Parse the tform of the variable length vector.
 *
 *************************************************************/
+/// # Parameters
+///
+/// * `colnum`    — column number
+/// * `datacode`  — data code
+/// * `maxlen`    — maximum length of the vector
+/// * `isQFormat` — true if var col is 'Q' format
 pub(crate) fn parse_vtform(
     infits: &mut fitsfile,
     out: Out,
     _hduptr: &FitsHdu,
-    colnum: c_int,         /* column number */
-    datacode: &mut c_int,  /* data code */
-    maxlen: &mut c_long,   /* maximum length of the vector */
-    isQFormat: &mut c_int, /* true if var col is 'Q' format */
+    colnum: c_int,
+    datacode: &mut c_int,
+    maxlen: &mut c_long,
+    isQFormat: &mut c_int,
 ) {
     let mut i: c_int = 0;
     let mut status: c_int = 0;
@@ -3338,11 +3354,11 @@ fn print_header(out: Out) {
 *  Print out the summary of this hdu.
 *
 **************************************************************/
-fn print_summary(
-    _infits: &mut fitsfile, /* input fits file   */
-    out: Out,               /* output ascii file */
-    hduptr: &FitsHdu,
-) {
+/// # Parameters
+///
+/// * `_infits` — input fits file
+/// * `out`     — output ascii file
+fn print_summary(_infits: &mut fitsfile, out: Out, hduptr: &FitsHdu) {
     let mut extver: [c_char; 10] = [0; 10];
     let mut extnv: [c_char; 2 * FLEN_VALUE + 4] = [0; 2 * FLEN_VALUE + 4];
     let mut npix: c_long;
@@ -3717,14 +3733,10 @@ mod fits_tests {
         (get_total_err(), get_total_warn())
     }
 
-    /*--- clean input reports nothing -------------------------------------*/
-
     #[test]
     fn test_clean_primary_array() {
         assert_eq!(counts(&pw(&[])), (0, 0));
     }
-
-    /*--- warnings --------------------------------------------------------*/
 
     #[test]
     fn test_simple_false_warns() {
@@ -3784,8 +3796,6 @@ mod fits_tests {
         assert_eq!(counts(&img(&["BSCALE  =                  0.0"])), (0, 1));
     }
 
-    /*--- keyword syntax errors -------------------------------------------*/
-
     #[test]
     fn test_lower_case_keyword_name_errors() {
         assert_eq!(counts(&pw(&["lowerkey=                    1"])), (1, 0));
@@ -3810,8 +3820,6 @@ mod fits_tests {
         assert!(e > 0, "a complex value with no comma must be reported");
     }
 
-    /*--- keywords in the wrong kind of HDU -------------------------------*/
-
     #[test]
     fn test_xtension_in_primary_errors() {
         assert_eq!(counts(&pw(&["XTENSION= 'IMAGE   '"])), (2, 0));
@@ -3826,8 +3834,6 @@ mod fits_tests {
     fn test_blank_with_floating_point_data_errors() {
         assert_eq!(counts(&img(&["BLANK   =                   -1"])), (1, 0));
     }
-
-    /*--- WCS -------------------------------------------------------------*/
 
     #[test]
     fn test_wcs_cdelt_zero_warns() {
@@ -3872,8 +3878,6 @@ mod fits_tests {
         assert_eq!(counts(&img(&["RADESYS = 'BOGUS   '"])), (0, 1));
         assert_eq!(counts(&img(&["SPECSYS = 'NOPE    '"])), (0, 1));
     }
-
-    /*--- tables ----------------------------------------------------------*/
 
     #[test]
     fn test_tdim_not_allowed_in_ascii_table() {
@@ -4004,8 +4008,6 @@ mod fits_tests {
             (2, 0)
         );
     }
-
-    /*--- file structure --------------------------------------------------*/
 
     #[test]
     fn test_extraneous_bytes_after_last_hdu_error() {

--- a/src/bin/fitsverify/fvrf_key.rs
+++ b/src/bin/fitsverify/fvrf_key.rs
@@ -1,8 +1,9 @@
-/* Transpiled from cfitsio/utilities/fvrf_key.c
-
-The C walks the card with `char *' cursors; here every cursor is an index
-into the card slice, and the `char **pt' in/out cursor parameters become
-`pt: &mut usize'.  */
+//! Transpiled from cfitsio/utilities/fvrf_key.c
+//!
+//! The C walks the card with `char *' cursors; here every cursor is an
+//! index into the card slice, and the `char **pt' in/out cursor parameters
+//! become `pt: &mut usize'.
+#![warn(missing_docs)]
 
 use rsfitsio::c_types::{c_char, c_int, c_ulong};
 use rsfitsio::fitsio::{FLEN_CARD, FLEN_COMMENT, FLEN_KEYWORD, FLEN_VALUE};
@@ -14,14 +15,23 @@ use crate::{scat, spf};
 /* Ref: Defininition of the Flexible Image Transport System(FITS),
     Sec. 5.1 and 5.2.
 */
+/// # Parameters
+///
+/// * `out`    — output file pointer
+/// * `kpos`   — keyposition starting from 1
+/// * `card`   — key card
+/// * `kname`  — key name
+/// * `ktype`  — key type
+/// * `kvalue` — key value
+/// * `kcomm`  — comment
 pub(crate) fn fits_parse_card(
-    out: Out,                           /* output file pointer */
-    kpos: c_int,                        /* keyposition starting from 1 */
-    card: &mut [c_char],                /* key card */
-    kname: &mut [c_char; FLEN_KEYWORD], /* key name */
-    ktype: &mut kwdtyp,                 /* key type */
-    kvalue: &mut [c_char; FLEN_VALUE],  /* key value */
-    kcomm: &mut [c_char],               /* comment */
+    out: Out,
+    kpos: c_int,
+    card: &mut [c_char],
+    kname: &mut [c_char; FLEN_KEYWORD],
+    ktype: &mut kwdtyp,
+    kvalue: &mut [c_char; FLEN_VALUE],
+    kcomm: &mut [c_char],
 ) -> c_int {
     let mut vind: [c_char; 3] = [0; 3];
     let mut p: usize;
@@ -229,12 +239,13 @@ pub(crate) fn fits_parse_card(
 }
 
 /* parse And test the string keys */
-pub(crate) fn get_str(
-    card: &[c_char],       /* card string from character 11*/
-    pt: &mut usize,        /* cursor into card */
-    kvalue: &mut [c_char], /* key value string */
-    stat: &mut c_ulong,    /* error number */
-) {
+/// # Parameters
+///
+/// * `card`   — card string from character 11
+/// * `pt`     — cursor into card
+/// * `kvalue` — key value string
+/// * `stat`   — error number
+pub(crate) fn get_str(card: &[c_char], pt: &mut usize, kvalue: &mut [c_char], stat: &mut c_ulong) {
     let mut pi: usize;
     let mut prev: u8; /* previous char */
     let mut nchar: isize;
@@ -285,12 +296,13 @@ pub(crate) fn get_str(
 }
 
 /* parse and test the logical keys */
-pub(crate) fn get_log(
-    card: &[c_char],       /* card string */
-    pt: &mut usize,        /* cursor into card */
-    kvalue: &mut [c_char], /* key value string */
-    stat: &mut c_ulong,    /* error number */
-) {
+/// # Parameters
+///
+/// * `card`   — card string
+/// * `pt`     — cursor into card
+/// * `kvalue` — key value string
+/// * `stat`   — error number
+pub(crate) fn get_log(card: &[c_char], pt: &mut usize, kvalue: &mut [c_char], stat: &mut c_ulong) {
     let mut p: usize;
 
     p = *pt;
@@ -307,12 +319,18 @@ pub(crate) fn get_log(
 }
 
 /* parse and test the numerical keys */
+/// # Parameters
+///
+/// * `card`   — card string
+/// * `pt`     — cursor into card
+/// * `kvalue` — comment string
+/// * `stat`   — error number
 pub(crate) fn get_num(
-    card: &[c_char],       /* card string */
-    pt: &mut usize,        /* cursor into card */
-    kvalue: &mut [c_char], /* comment string */
+    card: &[c_char],
+    pt: &mut usize,
+    kvalue: &mut [c_char],
     ktype: &mut kwdtyp,
-    stat: &mut c_ulong, /* error number */
+    stat: &mut c_ulong,
 ) {
     let pi: usize;
     let mut set_deci = 0;
@@ -379,12 +397,18 @@ pub(crate) fn get_num(
 }
 
 /* parse and test the complex keys */
+/// # Parameters
+///
+/// * `incard` — card string
+/// * `pt`     — cursor into card
+/// * `kvalue` — comment string
+/// * `stat`   — error number
 pub(crate) fn get_cmp(
-    incard: &[c_char],     /* card string */
-    pt: &mut usize,        /* cursor into card */
-    kvalue: &mut [c_char], /* comment string */
+    incard: &[c_char],
+    pt: &mut usize,
+    kvalue: &mut [c_char],
     ktype: &mut kwdtyp,
-    stat: &mut c_ulong, /* error number */
+    stat: &mut c_ulong,
 ) {
     let mut p: usize;
     let mut pr_beg: usize;
@@ -486,12 +510,13 @@ pub(crate) fn get_cmp(
 }
 
 /* parse and test the comment keys */
-fn get_comm(
-    card: &[c_char],      /* card string */
-    pt: &mut usize,       /* cursor into card */
-    kcomm: &mut [c_char], /* comment string */
-    stat: &mut c_ulong,   /* error number */
-) {
+/// # Parameters
+///
+/// * `card`  — card string
+/// * `pt`    — cursor into card
+/// * `kcomm` — comment string
+/// * `stat`  — error number
+fn get_comm(card: &[c_char], pt: &mut usize, kcomm: &mut [c_char], stat: &mut c_ulong) {
     let pi: usize;
     let nchar: usize;
     let mut p: usize;
@@ -514,12 +539,18 @@ fn get_comm(
 }
 
 /* parsing the unknown keyword */
+/// # Parameters
+///
+/// * `card`   — card string
+/// * `pt`     — cursor into card
+/// * `kvalue` — comment string
+/// * `stat`   — error number
 pub(crate) fn get_unknown(
-    card: &[c_char],       /* card string */
-    pt: &mut usize,        /* cursor into card */
-    kvalue: &mut [c_char], /* comment string */
+    card: &[c_char],
+    pt: &mut usize,
+    kvalue: &mut [c_char],
     ktype: &mut kwdtyp,
-    stat: &mut c_ulong, /* error number */
+    stat: &mut c_ulong,
 ) {
     let mut p: usize;
     let mut p1: usize;
@@ -541,12 +572,19 @@ pub(crate) fn get_unknown(
 }
 
 /* routine to print out the error of keyword value/comment */
+/// # Parameters
+///
+/// * `out`    — output FILE
+/// * `kpos`   — keyposition starting from 1
+/// * `kname`  — keyword name
+/// * `kval`   — keyword value
+/// * `errnum` — error number
 pub(crate) fn pr_kval_err(
-    out: Out,         /* output  FILE */
-    kpos: c_int,      /* keyposition starting from 1 */
-    kname: &[c_char], /* keyword name */
-    kval: &[c_char],  /* keyword value */
-    errnum: c_ulong,  /* error number */
+    out: Out,
+    kpos: c_int,
+    kname: &[c_char],
+    kval: &[c_char],
+    errnum: c_ulong,
 ) {
     let mut errmes: [c_char; ERRMES_LEN] = [0; ERRMES_LEN];
 

--- a/src/bin/fitsverify/fvrf_misc.rs
+++ b/src/bin/fitsverify/fvrf_misc.rs
@@ -1,13 +1,15 @@
-/******************************************************************************
-* Function
-*      wrtout: print messages in the streams of stdout and out.
-*      wrterr: print erro messages  in the streams of stderr and out.
-*      wrtferr: print cfitsio erro messages in the streams of stderr and out.
-*      wrtwrn: print warning messages in the streams of stdout and out.
-*      wrtsep: print seperators.
-*      num_err_wrn: Return the number of errors and  warnings.
-*
-*******************************************************************************/
+//! ****************************************************************************
+//! Function
+//! wrtout: print messages in the streams of stdout and out.
+//! wrterr: print erro messages  in the streams of stderr and out.
+//! wrtferr: print cfitsio erro messages in the streams of stderr and out.
+//! wrtwrn: print warning messages in the streams of stdout and out.
+//! wrtsep: print seperators.
+//! num_err_wrn: Return the number of errors and  warnings.
+//!
+//! *****************************************************************************
+#![warn(missing_docs)]
+
 /* Transpiled from cfitsio/utilities/fvrf_misc.c */
 
 use std::cell::Cell;

--- a/src/bin/fitsverify/main.rs
+++ b/src/bin/fitsverify/main.rs
@@ -1,9 +1,9 @@
-/* Transpiled from cfitsio/utilities/ftverify.c and fitsverify.c.
-
-ftverify.c #includes fitsverify.c for the STANDALONE build, so both live
-here: `main_ftverify' holds ftverify_work()/update_parfile() and the PIL
-stubs, and main() below is fitsverify.c's main().  */
-
+//! Transpiled from cfitsio/utilities/ftverify.c and fitsverify.c.
+//!
+//! ftverify.c #includes fitsverify.c for the STANDALONE build, so both live
+//! here: `main_ftverify' holds ftverify_work()/update_parfile() and the PIL
+//! stubs, and main() below is fitsverify.c's main().
+#![warn(missing_docs)]
 // kwdtyp, FitsHdu and friends keep their fitsverify C spellings.
 #![allow(non_camel_case_types, non_snake_case, non_upper_case_globals)]
 #![allow(clippy::upper_case_acronyms)]
@@ -43,9 +43,7 @@ use rsfitsio::fitsio::FLEN_FILENAME;
 
 use crate::common::*;
 
-/*---------------------------------------------------------------------------*/
 /*  ftverify.c                                                               */
-/*---------------------------------------------------------------------------*/
 pub(crate) mod main_ftverify {
     use std::io::BufRead;
 
@@ -63,13 +61,16 @@ pub(crate) mod main_ftverify {
 
     const PIL_LINESIZE: usize = 1024;
 
-    /*---------------------------------------------------------------------------*/
     /* call work function to verify that infile conforms to the FITS
     standard and write report to the output file */
     #[allow(clippy::too_many_arguments)]
+    /// # Parameters
+    ///
+    /// * `infile`  — (I) Input file name (Fits)
+    /// * `outfile` — (I) Output file name (ASCII)
     pub(crate) fn ftverify_work(
-        infile: &[c_char],  /* I - Input file name (Fits) */
-        outfile: &[c_char], /* I - Output file name (ASCII) */
+        infile: &[c_char],
+        outfile: &[c_char],
         _prehead: c_int,
         prstat: c_int,
         errreport: &[c_char],
@@ -364,9 +365,7 @@ pub(crate) mod main_ftverify {
 
 use main_ftverify::ftverify_work;
 
-/*---------------------------------------------------------------------------*/
 /*  fitsverify.c                                                             */
-/*---------------------------------------------------------------------------*/
 pub(crate) fn main() -> ExitCode {
     let mut status: c_int_alias = 0;
     let mut invalid = 0;

--- a/src/bin/fpack/cfmt.rs
+++ b/src/bin/fpack/cfmt.rs
@@ -1,8 +1,9 @@
-/* C printf conversions that Rust's format!() cannot express: %g in any form,
- * and the `#' alternate flag.  Everything format!() can do is left to it at
- * the call sites; the double conversions come through here so that there is
- * one rounding and one specials-spelling engine, and it is the C one.
- */
+//! C printf conversions that Rust's format!() cannot express: %g in any
+//! form,
+//! and the `#' alternate flag.  Everything format!() can do is left to it at
+//! the call sites; the double conversions come through here so that there
+//! is one rounding and one specials-spelling engine, and it is the C one.
+#![warn(missing_docs)]
 
 use std::ffi::CStr;
 

--- a/src/bin/fpack/fpack_h.rs
+++ b/src/bin/fpack/fpack_h.rs
@@ -1,17 +1,15 @@
-/* Transpiled from cfitsio/utilities/fpack.h
- *
- * used by FPACK and FUNPACK
- * R. Seaman, NOAO
- * W. Pence, NASA/GSFC
- *
- * The C header is just constants, two structs and the prototypes; the
- * prototypes are carried by Rust's module system instead.
- *
- * DEVIATION: each `exit(n)' becomes `return Err(FpExit(n))', propagated to
- * main().  This keeps every error path reachable from a unit test instead of
- * killing the test runner, and is the only structural change to the control
- * flow.
- */
+//! Transpiled from cfitsio/utilities/fpack.h
+//!
+//! used by FPACK and FUNPACK R. Seaman, NOAO W. Pence, NASA/GSFC
+//!
+//! The C header is just constants, two structs and the prototypes; the
+//! prototypes are carried by Rust's module system instead.
+//!
+//! DEVIATION: each `exit(n)' becomes `return Err(FpExit(n))', propagated to
+//! main().  This keeps every error path reachable from a unit test instead of
+//! killing the test runner, and is the only structural change to the
+//! control flow.
+#![warn(missing_docs)]
 
 use rsfitsio::c_types::{c_char, c_float, c_int, c_long};
 use rsfitsio::fitsio::MAX_COMPRESS_DIM;

--- a/src/bin/fpack/fpackutil.rs
+++ b/src/bin/fpack/fpackutil.rs
@@ -1,22 +1,21 @@
-/* Transpiled from cfitsio/utilities/fpackutil.c
- *
- * FPACK utility routines
- * R. Seaman, NOAO & W. Pence, NASA/GSFC
- *
- * Shared by both binaries, as the C links fpackutil.o into both.  Nothing here
- * calls fp_usage/fp_help or fu_usage/fu_help, so funpack/main.rs can
- * #[path]-include it unchanged.
- *
- * DEVIATIONS from the C, each also marked at its site:
- *
- *   exit()      -> Err(FpExit(n)); see fpack_h.rs.
- *   temp files  tempfile::TempPath instead of the abort_fpack signal handler
- *               and its three globals, which are not ported.
- *   system()    funpack -Z streams through flate2 rather than `gzip -1'.
- *   bug fixes   Only where the C is undefined and Rust cannot reproduce it.
- *               Everything else upstream gets wrong is reproduced faithfully,
- *               marked NOTE (upstream bug N) at its site.
- */
+//! Transpiled from cfitsio/utilities/fpackutil.c
+//!
+//! FPACK utility routines R. Seaman, NOAO & W. Pence, NASA/GSFC
+//!
+//! Shared by both binaries, as the C links fpackutil.o into both.  Nothing here
+//! calls fp_usage/fp_help or fu_usage/fu_help, so funpack/main.rs can
+//! `#[path]`-include it unchanged.
+//!
+//! DEVIATIONS from the C, each also marked at its site:
+//!
+//! exit()      -> Err(FpExit(n)); see fpack_h.rs.
+//! temp files  tempfile::TempPath instead of the abort_fpack signal handler
+//! and its three globals, which are not ported.
+//! system()    funpack -Z streams through flate2 rather than `gzip -1'.
+//! bug fixes   Only where the C is undefined and Rust cannot reproduce it.
+//! Everything else upstream gets wrong is reproduced faithfully,
+//! marked NOTE (upstream bug N) at its site.
+#![warn(missing_docs)]
 
 use std::cell::{Cell, RefCell};
 use std::fs::File;
@@ -153,7 +152,6 @@ pub(crate) fn c_argv() -> Argv {
         .collect()
 }
 
-/*--------------------------------------------------------------------------*/
 pub(crate) fn fp_msg(msg: &[c_char]) -> c_int {
     fp_msg_bytes(cbytes(msg))
 }
@@ -192,12 +190,10 @@ fn report(text: &str) {
     });
 }
 
-/*--------------------------------------------------------------------------*/
 pub(crate) fn fp_noop() -> c_int {
     fp_msg_str("Input and output files are unchanged.\n");
     0
 }
-/*--------------------------------------------------------------------------*/
 /// C: `fp_abort_output(...)`, which ends in `exit (stat)` -- hence the FpExit
 /// return.  Both files are taken by value: one is closed, the other deleted.
 pub(crate) fn fp_abort_output(
@@ -236,7 +232,6 @@ pub(crate) fn fp_abort_output(
     FpExit(stat)
 }
 
-/*--------------------------------------------------------------------------*/
 pub(crate) fn fp_version() -> c_int {
     let mut version: f32 = 0.0;
 
@@ -250,7 +245,6 @@ pub(crate) fn fp_version() -> c_int {
     fp_msg_str("\n");
     0
 }
-/*--------------------------------------------------------------------------*/
 pub(crate) fn fp_access(filename: &[c_char]) -> c_int {
     /* test if a file exists */
 
@@ -259,7 +253,6 @@ pub(crate) fn fp_access(filename: &[c_char]) -> c_int {
         Err(_) => -1,
     }
 }
-/*--------------------------------------------------------------------------*/
 /// C: `fp_tmpnam(suffix, rootname, tmpnam)`, transpiled verbatim -- including
 /// its check-then-use race -- because its names appear in the C's messages.
 /// Callers wrap the result in a `TempPath`.
@@ -316,7 +309,6 @@ fn fp_tmpnam_guard(
     Ok(TempPath::try_from_path(cpath(tmpnam)).expect("temp file name has no interior NUL"))
 }
 
-/*--------------------------------------------------------------------------*/
 pub(crate) fn fp_init(fpptr: &mut fpstate) -> c_int {
     let mut ii: usize;
 
@@ -367,7 +359,6 @@ pub(crate) fn fp_init(fpptr: &mut fpstate) -> c_int {
     fpptr.preflight_checked = 0;
     0
 }
-/*--------------------------------------------------------------------------*/
 pub(crate) fn fp_list(argc: c_int, argv: &Argv, fpvar: fpstate) -> FpResult<c_int> {
     let mut infits: [c_char; SZ_STR] = [0; SZ_STR];
     let mut hdunum: c_int = 0;
@@ -435,7 +426,6 @@ pub(crate) fn fp_list(argc: c_int, argv: &Argv, fpvar: fpstate) -> FpResult<c_in
     }
     Ok(0)
 }
-/*--------------------------------------------------------------------------*/
 /// Takes the owning `Option` because `fp_abort_output` closes the file.
 pub(crate) fn fp_info_hdu(infptr: &mut Option<Box<fitsfile>>) -> FpResult<c_int> {
     /* NOTE (upstream bug 5): declared once but reread every pass, so a
@@ -572,7 +562,6 @@ pub(crate) fn fp_info_hdu(infptr: &mut Option<Box<fitsfile>>) -> FpResult<c_int>
     Ok(0)
 }
 
-/*--------------------------------------------------------------------------*/
 pub(crate) fn fp_preflight(
     argc: c_int,
     argv: &Argv,
@@ -890,7 +879,6 @@ pub(crate) fn fp_preflight(
     Ok(0)
 }
 
-/*--------------------------------------------------------------------------*/
 /* must run fp_preflight() before fp_loop()
  */
 pub(crate) fn fp_loop(argc: c_int, argv: &Argv, unpack: c_int, fpvar: fpstate) -> FpResult<c_int> {
@@ -1276,7 +1264,6 @@ fn gzip_file(file: &[c_char]) -> std::io::Result<()> {
     std::fs::remove_file(&src)
 }
 
-/*--------------------------------------------------------------------------*/
 /* fp_pack assumes the output file does not exist (checked by preflight)
  */
 pub(crate) fn fp_pack(
@@ -1352,7 +1339,6 @@ pub(crate) fn fp_pack(
     Ok(0)
 }
 
-/*--------------------------------------------------------------------------*/
 /* fp_unpack assumes the output file does not exist
  */
 pub(crate) fn fp_unpack(infits: &[c_char], outfits: &[c_char], fpvar: fpstate) -> FpResult<c_int> {
@@ -1610,7 +1596,6 @@ fn strtol_c(s: &[c_char]) -> (c_long, usize) {
     (val, i)
 }
 
-/*--------------------------------------------------------------------------*/
 /* fp_test assumes the output files do not exist
  */
 pub(crate) fn fp_test(
@@ -2154,7 +2139,6 @@ fn snprintf_into(buf: &mut [c_char], text: &str) {
     buf[n] = 0;
 }
 
-/*--------------------------------------------------------------------------*/
 pub(crate) fn fp_pack_hdu(
     infptr: &mut fitsfile,
     outfptr: &mut fitsfile,
@@ -2415,7 +2399,6 @@ pub(crate) fn fp_pack_hdu(
     0
 }
 
-/*--------------------------------------------------------------------------*/
 pub(crate) fn fp_unpack_hdu(
     infptr: &mut fitsfile,
     outfptr: &mut fitsfile,
@@ -2465,7 +2448,6 @@ pub(crate) fn fp_unpack_hdu(
 
     0
 }
-/*--------------------------------------------------------------------------*/
 /// DEVIATION: the C guards each output pointer against NULL; no call site
 /// passes one, so they are plain `&mut` here.
 pub(crate) fn fits_read_image_speed(
@@ -2725,7 +2707,6 @@ pub(crate) fn fits_read_image_speed(
 
     *status
 }
-/*--------------------------------------------------------------------------*/
 pub(crate) fn fp_test_hdu(
     infptr: &mut fitsfile,
     outfptr: &mut fitsfile,
@@ -2900,7 +2881,6 @@ pub(crate) fn fp_test_hdu(
     *status = stat;
     0
 }
-/*--------------------------------------------------------------------------*/
 pub(crate) fn fp_test_table(
     infptr: &mut fitsfile,
     outfptr: &mut fitsfile,
@@ -2969,7 +2949,6 @@ pub(crate) fn fp_test_table(
 
     0
 }
-/*--------------------------------------------------------------------------*/
 pub(crate) fn marktime(status: &mut c_int) -> c_int {
     /* the C reads gettimeofday on unix and gives up on elapsed time elsewhere;
     Instant is monotonic and available on both, so only the reporting in
@@ -2979,7 +2958,6 @@ pub(crate) fn marktime(status: &mut c_int) -> c_int {
 
     *status
 }
-/*--------------------------------------------------------------------------*/
 pub(crate) fn gettime(elapse: &mut f32, elapscpu: &mut f32, status: &mut c_int) -> c_int {
     let ecpu = cpu_seconds();
     let scpu = SCPU.get();
@@ -2999,7 +2977,6 @@ pub(crate) fn gettime(elapse: &mut f32, elapscpu: &mut f32, status: &mut c_int) 
 
     *status
 }
-/*--------------------------------------------------------------------------*/
 pub(crate) fn fp_i2stat(
     infptr: &mut fitsfile,
     naxis: c_int,
@@ -3143,7 +3120,6 @@ pub(crate) fn fp_i2stat(
 
     *status
 }
-/*--------------------------------------------------------------------------*/
 pub(crate) fn fp_i4stat(
     infptr: &mut fitsfile,
     naxis: c_int,
@@ -3285,7 +3261,6 @@ pub(crate) fn fp_i4stat(
 
     *status
 }
-/*--------------------------------------------------------------------------*/
 pub(crate) fn fp_r4stat(
     infptr: &mut fitsfile,
     naxis: c_int,
@@ -3415,7 +3390,6 @@ pub(crate) fn fp_r4stat(
 
     *status
 }
-/*--------------------------------------------------------------------------*/
 pub(crate) fn fp_i2rescale(
     infptr: &mut fitsfile,
     naxis: c_int,
@@ -3504,7 +3478,6 @@ pub(crate) fn fp_i2rescale(
 
     *status
 }
-/*--------------------------------------------------------------------------*/
 pub(crate) fn fp_i4rescale(
     infptr: &mut fitsfile,
     naxis: c_int,

--- a/src/bin/fpack/main.rs
+++ b/src/bin/fpack/main.rs
@@ -1,11 +1,9 @@
-/* Transpiled from cfitsio/utilities/fpack.c
- *
- * FPACK
- * R. Seaman, NOAO, with a few enhancements by W. Pence, HEASARC
- *
- * Calls fits_img_compress in the CFITSIO library by W. Pence, HEASARC
- */
-
+//! Transpiled from cfitsio/utilities/fpack.c
+//!
+//! FPACK, by R. Seaman, NOAO, with a few enhancements by W. Pence, HEASARC.
+//!
+//! Calls fits_img_compress in the CFITSIO library by W. Pence, HEASARC
+#![warn(missing_docs)]
 // The C's names, its dead stores, and the items only the *other* binary uses
 // out of the two shared modules.
 #![allow(non_camel_case_types, non_snake_case, non_upper_case_globals)]
@@ -34,6 +32,7 @@ use crate::fpackutil::{
 };
 
 /* ================================================================== */
+/// Entry point: parses the command line and compresses each named file.
 pub fn main() -> ExitCode {
     /* C: `exit (n)'; see fpack_h.rs.  exit(-1) and ExitCode::from(255) are
     the same 255 to the shell. */

--- a/src/bin/funpack/main.rs
+++ b/src/bin/funpack/main.rs
@@ -1,10 +1,7 @@
-/* Transpiled from cfitsio/utilities/funpack.c
- *
- * FUNPACK
- * R. Seaman, NOAO
- * uses fits_img_compress by W. Pence, HEASARC
- */
-
+//! Transpiled from cfitsio/utilities/funpack.c
+//!
+//! FUNPACK, by R. Seaman, NOAO. Uses fits_img_compress by W. Pence, HEASARC.
+#![warn(missing_docs)]
 #![allow(non_camel_case_types, non_snake_case, non_upper_case_globals)]
 #![allow(unused_assignments)]
 // items only the *other* binary uses out of the two shared modules
@@ -33,6 +30,7 @@ use crate::fpackutil::{
     Argv, c_argv, fp_init, fp_list, fp_loop, fp_msg, fp_msg_str, fp_preflight, fp_version,
 };
 
+/// Entry point: parses the command line and uncompresses each named file.
 pub fn main() -> ExitCode {
     /* C: `exit (n)'; see fpack_h.rs. */
     match run() {

--- a/src/bin/imcopy/main.rs
+++ b/src/bin/imcopy/main.rs
@@ -1,3 +1,6 @@
+//! Transpiled from cfitsio/utilities/imcopy.c: copies an image HDU, optionally
+//! compressing or uncompressing it on the way.
+#![warn(missing_docs)]
 // C: `for (; !status; hdupos++)` -- hdupos is only read before the loop, so
 // the increment is dead there too. Kept for fidelity with imcopy.c.
 #![allow(unused_assignments)]
@@ -26,6 +29,7 @@ use rsfitsio::{
     fitsio::fitsfile,
 };
 
+/// Entry point: copies the input image to the output file.
 pub fn main() -> ExitCode {
     /* FITS file pointers defined in fitsio.h */
     let mut infptr: Option<Box<fitsfile>> = None;

--- a/src/bin/smem/main.rs
+++ b/src/bin/smem/main.rs
@@ -1,3 +1,7 @@
+//! Transpiled from cfitsio/utilities/smem.c: a utility for listing and
+//! removing the shared memory segments the shmem:// driver creates.
+#![warn(missing_docs)]
+
 #[cfg(not(windows))]
 use libc::{c_char, c_int};
 #[cfg(not(windows))]
@@ -7,6 +11,7 @@ use rsfitsio::drvrsmem::{
 use std::ptr;
 use std::{ffi::CStr, process::ExitCode};
 
+/// Entry point on Windows, where System V shared memory does not exist.
 #[cfg(windows)]
 pub fn main() -> ExitCode {
     println!("smem not supported on windows");
@@ -32,6 +37,8 @@ fn scan_int(s: &str) -> Option<c_int> {
     digits.parse::<c_int>().ok().map(|v| sign * v)
 }
 
+/// Entry point: lists, recovers or removes the shared memory segments the
+/// `shmem://` driver has created.
 #[cfg(not(windows))]
 pub fn main() -> ExitCode {
     let mut cmdok: bool = true;

--- a/src/bin/speed/main.rs
+++ b/src/bin/speed/main.rs
@@ -1,5 +1,8 @@
-// TODO: still on the C ABI; convert to the _safe/alias API (see plan Phase 6).
+//! Transpiled from cfitsio/utilities/speed.c: a benchmark that times reading
+//! and writing images and tables through the library.
+#![warn(missing_docs)]
 #![allow(deprecated)]
+// TODO: still on the C ABI; convert to the _safe/alias API (see plan Phase 6).
 
 // Purposed keep using the C API so that we can switch out the linked library to test speed
 
@@ -32,6 +35,7 @@ const BROWS: usize = 2500000;
 /* no. of rows in ASCII table */
 const AROWS: usize = 400000;
 
+/// Entry point: runs the read and write benchmarks and prints the timings.
 pub fn main() -> ExitCode {
     /*************************************************************************
     This program tests the speed of writing/reading FITS files with cfitsio
@@ -189,7 +193,6 @@ pub fn main() -> ExitCode {
     ExitCode::from(0)
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write the primary array containing a 2-D image
 fn writeimage(fptr: &mut fitsfile, sarray: &[c_long], status: &mut c_int) -> c_int {
     let mut ii: c_long;
@@ -248,7 +251,6 @@ fn writeimage(fptr: &mut fitsfile, sarray: &[c_long], status: &mut c_int) -> c_i
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write the primary array containing a 2-D image
 fn writesimage(fptr: &mut fitsfile, ssarray: &[c_short], status: &mut c_int) -> c_int {
     let mut elapcpu: f32 = 0.0;
@@ -298,7 +300,6 @@ fn writesimage(fptr: &mut fitsfile, ssarray: &[c_short], status: &mut c_int) -> 
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Create a binary table extension containing 3 columns
 fn writebintable(fptr: &mut fitsfile, sarray: &[c_long], status: &mut c_int) -> c_int {
     let tfields: c_int = 2;
@@ -390,7 +391,6 @@ fn writebintable(fptr: &mut fitsfile, sarray: &[c_long], status: &mut c_int) -> 
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Create an ASCII table extension containing 2 columns
 fn writeasctable(fptr: &mut fitsfile, sarray: &[c_long], status: &mut c_int) -> c_int {
     let tfields: c_int = 2;
@@ -482,7 +482,6 @@ fn writeasctable(fptr: &mut fitsfile, sarray: &[c_long], status: &mut c_int) -> 
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read a FITS image
 fn readimage(fptr: &mut fitsfile, sarray: &mut [c_long], status: &mut c_int) -> c_int {
     let mut anynull: c_int = 0;
@@ -531,7 +530,6 @@ fn readimage(fptr: &mut fitsfile, sarray: &mut [c_long], status: &mut c_int) -> 
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// read and print data values from the binary table
 fn readbtable(fptr: &mut fitsfile, sarray: &mut [c_long], status: &mut c_int) -> c_int {
     let mut hdutype: c_int = 0;
@@ -602,7 +600,6 @@ fn readbtable(fptr: &mut fitsfile, sarray: &mut [c_long], status: &mut c_int) ->
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// read and print data values from an ASCII or binary table
 fn readatable(fptr: &mut fitsfile, sarray: &mut [c_long], status: &mut c_int) -> c_int {
     let mut hdutype: c_int = 0;
@@ -673,7 +670,6 @@ fn readatable(fptr: &mut fitsfile, sarray: &mut [c_long], status: &mut c_int) ->
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Print out cfitsio error messages and exit program
 fn printerror(status: c_int) {
     let mut status_str = [0u8; FLEN_STATUS];

--- a/src/buffers.rs
+++ b/src/buffers.rs
@@ -1,3 +1,21 @@
+//! The low-level I/O buffering layer.
+//!
+//! Every read and write of a FITS file goes through a pool of
+//! [`NIOBUF`] buffers of
+//! [`IOBUFLEN`] bytes -- one FITS block each. Large
+//! transfers bypass the pool and go straight to disk; smaller ones are
+//! accumulated in a buffer first, which is what makes reading a table one
+//! element at a time tolerable.
+//!
+//! Buffers are evicted least-recently-used, tracked by the `ageindex` field of
+//! [`FITSfile`], and a buffer marked `dirty` is
+//! written back before it is reused.
+//!
+//! Ported from CFITSIO's `buffers.c`, written by William Pence at the High
+//! Energy Astrophysics Science Archive Research Center (HEASARC), NASA Goddard
+//! Space Flight Center.
+#![warn(missing_docs)]
+
 use core::cmp;
 use core::slice;
 
@@ -17,19 +35,25 @@ use bytemuck::{cast_slice, cast_slice_mut};
 
 use crate::c_types::{c_char, c_int, c_long, c_short, c_uchar};
 
-/*--------------------------------------------------------------------------*/
 /// Move to the input byte location in the file.
 ///
 /// When writing to a file, a move
 /// may sometimes be made to a position beyond the current EOF.  The err_mode
 /// parameter determines whether such conditions should be returned as an error
 /// or simply ignored.
+///
+/// # Parameters
+///
+/// * `fptr`     — (I) FITS file pointer
+/// * `bytepos`  — (I) byte position in file to move to
+/// * `err_mode` — (I) 1=ignore error, 0 = return error
+/// * `status`   — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffmbyt(
-    fptr: *mut fitsfile, /* I - FITS file pointer                */
-    bytepos: LONGLONG,   /* I - byte position in file to move to */
-    err_mode: c_int,     /* I - 1=ignore error, 0 = return error */
-    status: *mut c_int,  /* IO - error status                    */
+    fptr: *mut fitsfile,
+    bytepos: LONGLONG,
+    err_mode: c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -40,16 +64,22 @@ pub unsafe extern "C" fn ffmbyt(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Move to the input byte location in the file.  When writing to a file, a move
 /// may sometimes be made to a position beyond the current EOF.  The err_mode
 /// parameter determines whether such conditions should be returned as an error
 /// or simply ignored.
+///
+/// # Parameters
+///
+/// * `fptr`     — (I) FITS file pointer
+/// * `bytepos`  — (I) byte position in file to move to
+/// * `err_mode` — (I) 1=ignore error, 0 = return error
+/// * `status`   — (IO) error status
 pub fn ffmbyt_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                */
-    bytepos: LONGLONG,   /* I - byte position in file to move to */
-    err_mode: c_int,     /* I - 1=ignore error, 0 = return error */
-    status: &mut c_int,  /* IO - error status                    */
+    fptr: &mut fitsfile,
+    bytepos: LONGLONG,
+    err_mode: c_int,
+    status: &mut c_int,
 ) -> c_int {
     if *status > 0 {
         return *status;
@@ -78,15 +108,21 @@ pub fn ffmbyt_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
-/// put (write) the buffer of bytes to the output FITS file, starting at
+/// Put (write) the buffer of bytes to the output FITS file, starting at
 /// the current file position.  Write large blocks of data directly to disk;
 /// write smaller segments to intermediate IO buffers to improve efficiency.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `nbytes` — (I) number of bytes to write
+/// * `buffer` — (I) buffer containing the bytes to write
+/// * `status` — (IO) error status
 pub(crate) fn ffpbyt(
-    fptr: &mut fitsfile, /* I - FITS file pointer                    */
-    nbytes: LONGLONG,    /* I - number of bytes to write             */
-    buffer: &[u8],       /* I - buffer containing the bytes to write */
-    status: &mut c_int,  /* IO - error status                        */
+    fptr: &mut fitsfile,
+    nbytes: LONGLONG,
+    buffer: &[u8],
+    status: &mut c_int,
 ) -> c_int {
     let nbuff;
     let mut filepos: LONGLONG;
@@ -245,17 +281,25 @@ pub(crate) fn ffpbyt(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
-/// put (write) the buffer of bytes to the output FITS file, with an offset
+/// Put (write) the buffer of bytes to the output FITS file, with an offset
 /// between each group of bytes.  This function combines ffmbyt and ffpbyt
 /// for increased efficiency.
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `gsize`   — (I) size of each group of bytes
+/// * `ngroups` — (I) number of groups to write
+/// * `offset`  — (I) size of gap between groups
+/// * `buffer`  — (I) buffer to be written
+/// * `status`  — (IO) error status
 pub(crate) fn ffpbytoff(
-    fptr: &mut fitsfile, /* I - FITS file pointer                       */
-    gsize: c_long,       /* I - size of each group of bytes         */
-    ngroups: c_long,     /* I - number of groups to write           */
-    offset: c_long,      /* I - size of gap between groups          */
-    buffer: &[u8],       /* I - buffer to be written                */
-    status: &mut c_int,  /* IO - error status                       */
+    fptr: &mut fitsfile,
+    gsize: c_long,
+    ngroups: c_long,
+    offset: c_long,
+    buffer: &[u8],
+    status: &mut c_int,
 ) -> c_int {
     let mut bcurrent: c_int;
     let mut bufpos: LONGLONG;
@@ -374,15 +418,21 @@ pub(crate) fn ffpbytoff(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
-/// get (read) the requested number of bytes from the file, starting at
+/// Get (read) the requested number of bytes from the file, starting at
 /// the current file position.  Read large blocks of data directly from disk;
 /// read smaller segments via intermediate IO buffers to improve efficiency.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `nbytes` — (I) number of bytes to read
+/// * `buffer` — (O) buffer to read into
+/// * `status` — (IO) error status
 pub(crate) fn ffgbyt(
-    fptr: &mut fitsfile, /* I - FITS file pointer             */
-    nbytes: LONGLONG,    /* I - number of bytes to read       */
-    buffer: &mut [u8],   /* O - buffer to read into           */
-    status: &mut c_int,  /* IO - error status                 */
+    fptr: &mut fitsfile,
+    nbytes: LONGLONG,
+    buffer: &mut [u8],
+    status: &mut c_int,
 ) -> c_int {
     let mut ii: usize;
     let filepos: LONGLONG;
@@ -484,17 +534,25 @@ pub(crate) fn ffgbyt(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Get (read) the requested number of bytes from the file, starting at
 /// the current file position.  This function combines ffmbyt and ffgbyt
 /// for increased efficiency.
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `gsize`   — (I) size of each group of bytes
+/// * `ngroups` — (I) number of groups to read
+/// * `offset`  — (I) size of gap between groups (may be < 0)
+/// * `buffer`  — (I) buffer to be filled
+/// * `status`  — (IO) error status
 pub(crate) fn ffgbytoff(
-    fptr: &mut fitsfile, /* I - FITS file pointer                   */
-    gsize: c_long,       /* I - size of each group of bytes         */
-    ngroups: c_long,     /* I - number of groups to read            */
-    offset: c_long,      /* I - size of gap between groups (may be < 0) */
-    buffer: &mut [u8],   /* I - buffer to be filled                 */
-    status: &mut c_int,  /* IO - error status                       */
+    fptr: &mut fitsfile,
+    gsize: c_long,
+    ngroups: c_long,
+    offset: c_long,
+    buffer: &mut [u8],
+    status: &mut c_int,
 ) -> c_int {
     let mut bcurrent: c_int;
     let mut bufpos: c_long;
@@ -608,16 +666,22 @@ pub(crate) fn ffgbytoff(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
-/// low-level routine to load a specified record from a file into
+/// Low-level routine to load a specified record from a file into
 /// a physical buffer, if it is not already loaded.  Reset all
 /// pointers to make this the new current record for that file.
 /// Update ages of all the physical buffers.
+///
+/// # Parameters
+///
+/// * `fptr`     — (I) FITS file pointer
+/// * `record`   — (I) record number to be loaded
+/// * `err_mode` — (I) 1=ignore EOF, 0 = return EOF error
+/// * `status`   — (IO) error status
 pub(crate) fn ffldrc(
-    fptr: &mut fitsfile, /* I - FITS file pointer             */
-    record: c_long,      /* I - record number to be loaded    */
-    err_mode: c_int,     /* I - 1=ignore EOF, 0 = return EOF error */
-    status: &mut c_int,  /* IO - error status                 */
+    fptr: &mut fitsfile,
+    record: c_long,
+    err_mode: c_int,
+    status: &mut c_int,
 ) -> c_int {
     let mut updatebuf = false;
     let mut ibuff: c_int;
@@ -713,24 +777,26 @@ pub(crate) fn ffldrc(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// decide which buffer to (re)use to hold a new file record
-pub(crate) fn ffwhbf(
-    fptr: &mut fitsfile, /* I - FITS file pointer             */
-    nbuff: &mut c_int,   /* O - which buffer to use           */
-) -> c_int {
+///
+/// # Parameters
+///
+/// * `fptr`  — (I) FITS file pointer
+/// * `nbuff` — (O) which buffer to use
+pub(crate) fn ffwhbf(fptr: &mut fitsfile, nbuff: &mut c_int) -> c_int {
     *nbuff = fptr.Fptr.ageindex[0]; /* return oldest buffer */
     *nbuff
 }
 
-/*--------------------------------------------------------------------------*/
 /// Flush all the data in the current FITS file to disk. This ensures that if
 /// the program subsequently dies, the disk FITS file will be closed correctly.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
-pub unsafe extern "C" fn ffflus(
-    fptr: *mut fitsfile, /* I - FITS file pointer                       */
-    status: *mut c_int,  /* IO - error status                           */
-) -> c_int {
+pub unsafe extern "C" fn ffflus(fptr: *mut fitsfile, status: *mut c_int) -> c_int {
     // FFI WRAPPER
     unsafe {
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -740,13 +806,14 @@ pub unsafe extern "C" fn ffflus(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Flush all the data in the current FITS file to disk. This ensures that if
 /// the program subsequently dies, the disk FITS file will be closed correctly.
-pub fn ffflus_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                       */
-    status: &mut c_int,  /* IO - error status                           */
-) -> c_int {
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `status` — (IO) error status
+pub fn ffflus_safe(fptr: &mut fitsfile, status: &mut c_int) -> c_int {
     let mut hdunum: c_int = 0;
     let mut hdutype: c_int = 0;
 
@@ -770,14 +837,15 @@ pub fn ffflus_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// flush all dirty IO buffers associated with the file to disk
+///
+/// # Parameters
+///
+/// * `fptr`     — (I) FITS file pointer
+/// * `clearbuf` — (I) also clear buffer contents?
+/// * `status`   — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
-pub unsafe extern "C" fn ffflsh(
-    fptr: *mut fitsfile, /* I - FITS file pointer           */
-    clearbuf: c_int,     /* I - also clear buffer contents? */
-    status: *mut c_int,  /* IO - error status               */
-) -> c_int {
+pub unsafe extern "C" fn ffflsh(fptr: *mut fitsfile, clearbuf: c_int, status: *mut c_int) -> c_int {
     // FFI WRAPPER
     unsafe {
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -787,13 +855,14 @@ pub unsafe extern "C" fn ffflsh(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// flush all dirty IO buffers associated with the file to disk
-pub fn ffflsh_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer           */
-    clearbuf: bool,      /* I - also clear buffer contents? */
-    status: &mut c_int,  /* IO - error status               */
-) -> c_int {
+///
+/// # Parameters
+///
+/// * `fptr`     — (I) FITS file pointer
+/// * `clearbuf` — (I) also clear buffer contents?
+/// * `status`   — (IO) error status
+pub fn ffflsh_safe(fptr: &mut fitsfile, clearbuf: bool, status: &mut c_int) -> c_int {
     /*
        no need to move to a different HDU
 
@@ -818,12 +887,13 @@ pub fn ffflsh_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// clear any buffers beyond the end of file
-pub(crate) fn ffbfeof(
-    fptr: &mut fitsfile, /* I - FITS file pointer           */
-    status: &mut c_int,  /* IO - error status               */
-) -> c_int {
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `status` — (IO) error status
+pub(crate) fn ffbfeof(fptr: &mut fitsfile, status: &mut c_int) -> c_int {
     for ii in 0..(NIOBUF as usize) {
         if (fptr.Fptr.bufrecnum[ii] as LONGLONG) * IOBUFLEN >= fptr.Fptr.filesize {
             fptr.Fptr.bufrecnum[ii] = -1; /* set contents of buffer as undefined */
@@ -832,16 +902,17 @@ pub(crate) fn ffbfeof(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// write contents of buffer to file;  If the position of the buffer
 /// is beyond the current EOF, then the file may need to be extended
 /// with fill values, and/or with the contents of some of the other
 /// i/o buffers.
-pub(crate) fn ffbfwt(
-    Fptr: &mut FITSfile, /* I - FITS file pointer           */
-    nbuff: c_int,        /* I - which buffer to write          */
-    status: &mut c_int,  /* IO - error status                  */
-) -> c_int {
+///
+/// # Parameters
+///
+/// * `Fptr`   — (I) FITS file pointer
+/// * `nbuff`  — (I) which buffer to write
+/// * `status` — (IO) error status
+pub(crate) fn ffbfwt(Fptr: &mut FITSfile, nbuff: c_int, status: &mut c_int) -> c_int {
     let mut ibuff: usize;
     let mut jj: c_long;
     let mut irec: c_long;
@@ -937,16 +1008,21 @@ pub(crate) fn ffbfwt(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Returns an optimal value for the number of rows in a binary table
 /// or the number of pixels in an image that should be read or written
 /// at one time for maximum efficiency. Accessing more data than this
 /// may cause excessive flushing and rereading of buffers to/from disk.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pionter
+/// * `ndata`  — (O) optimal amount of data to access
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgrsz(
-    fptr: *mut fitsfile, /* I - FITS file pionter                        */
-    ndata: *mut c_long,  /* O - optimal amount of data to access         */
-    status: *mut c_int,  /* IO - error status                            */
+    fptr: *mut fitsfile,
+    ndata: *mut c_long,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -958,16 +1034,17 @@ pub unsafe extern "C" fn ffgrsz(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Returns an optimal value for the number of rows in a binary table
 /// or the number of pixels in an image that should be read or written
 /// at one time for maximum efficiency. Accessing more data than this
 /// may cause excessive flushing and rereading of buffers to/from disk.
-pub fn ffgrsz_safe(
-    fptr: &mut fitsfile, /* I - FITS file pionter                        */
-    ndata: &mut c_long,  /* O - optimal amount of data to access         */
-    status: &mut c_int,  /* IO - error status                            */
-) -> c_int {
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pionter
+/// * `ndata`  — (O) optimal amount of data to access
+/// * `status` — (IO) error status
+pub fn ffgrsz_safe(fptr: &mut fitsfile, ndata: &mut c_long, status: &mut c_int) -> c_int {
     let mut typecode = 0;
     let bytesperpixel;
 
@@ -999,18 +1076,26 @@ pub fn ffgrsz_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// read a consecutive string of bytes from an ascii or binary table.
 /// This will span multiple rows of the table if nchars + firstchar is
 /// greater than the length of a row.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `firstrow`  — (I) starting row (1 = first row)
+/// * `firstchar` — (I) starting byte in row (1=first)
+/// * `nchars`    — (I) number of bytes to read
+/// * `values`    — (I) array of bytes to read
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgtbb(
-    fptr: *mut fitsfile,  /* I - FITS file pointer                 */
-    firstrow: LONGLONG,   /* I - starting row (1 = first row)      */
-    firstchar: LONGLONG,  /* I - starting byte in row (1=first)    */
-    nchars: LONGLONG,     /* I - number of bytes to read           */
-    values: *mut c_uchar, /* I - array of bytes to read            */
-    status: *mut c_int,   /* IO - error status                     */
+    fptr: *mut fitsfile,
+    firstrow: LONGLONG,
+    firstchar: LONGLONG,
+    nchars: LONGLONG,
+    values: *mut c_uchar,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -1022,17 +1107,25 @@ pub unsafe extern "C" fn ffgtbb(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// read a consecutive string of bytes from an ascii or binary table.
 /// This will span multiple rows of the table if nchars + firstchar is
 /// greater than the length of a row.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `firstrow`  — (I) starting row (1 = first row)
+/// * `firstchar` — (I) starting byte in row (1=first)
+/// * `nchars`    — (I) number of bytes to read
+/// * `values`    — (I) array of bytes to read
+/// * `status`    — (IO) error status
 pub fn ffgtbb_safe(
-    fptr: &mut fitsfile,    /* I - FITS file pointer                 */
-    firstrow: LONGLONG,     /* I - starting row (1 = first row)      */
-    firstchar: LONGLONG,    /* I - starting byte in row (1=first)    */
-    nchars: LONGLONG,       /* I - number of bytes to read           */
-    values: &mut [c_uchar], /* I - array of bytes to read            */
-    status: &mut c_int,     /* IO - error status                     */
+    fptr: &mut fitsfile,
+    firstrow: LONGLONG,
+    firstchar: LONGLONG,
+    nchars: LONGLONG,
+    values: &mut [c_uchar],
+    status: &mut c_int,
 ) -> c_int {
     if *status > 0 || nchars <= 0 {
         return *status;
@@ -1066,16 +1159,24 @@ pub fn ffgtbb_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// get (read) the array of values from the FITS file, doing machine dependent
 /// format conversion (e.g. byte-swapping) if necessary.
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `byteloc` — (I) position within file to start reading
+/// * `nvals`   — (I) number of pixels to read
+/// * `incre`   — (I) byte increment between pixels
+/// * `values`  — (O) returned array of values
+/// * `status`  — (IO) error status
 pub(crate) fn ffgi1b(
-    fptr: &mut fitsfile,    /* I - FITS file pointer                         */
-    byteloc: LONGLONG,      /* I - position within file to start reading     */
-    nvals: c_long,          /* I - number of pixels to read                  */
-    incre: c_long,          /* I - byte increment between pixels             */
-    values: &mut [c_uchar], /* O - returned array of values           */
-    status: &mut c_int,     /* IO - error status                             */
+    fptr: &mut fitsfile,
+    byteloc: LONGLONG,
+    nvals: c_long,
+    incre: c_long,
+    values: &mut [c_uchar],
+    status: &mut c_int,
 ) -> c_int {
     let postemp: LONGLONG;
 
@@ -1104,16 +1205,24 @@ pub(crate) fn ffgi1b(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// get (read) the array of values from the FITS file, doing machine dependent
 /// format conversion (e.g. byte-swapping) if necessary.
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `byteloc` — (I) position within file to start reading
+/// * `nvals`   — (I) number of pixels to read
+/// * `incre`   — (I) byte increment between pixels
+/// * `values`  — (O) returned array of values
+/// * `status`  — (IO) error status
 pub(crate) fn ffgi2b(
-    fptr: &mut fitsfile,    /* I - FITS file pointer                        */
-    byteloc: LONGLONG,      /* I - position within file to start reading    */
-    nvals: c_long,          /* I - number of pixels to read                 */
-    incre: c_long,          /* I - byte increment between pixels            */
-    values: &mut [c_short], /* O - returned array of values                 */
-    status: &mut c_int,     /* IO - error status                            */
+    fptr: &mut fitsfile,
+    byteloc: LONGLONG,
+    nvals: c_long,
+    incre: c_long,
+    values: &mut [c_short],
+    status: &mut c_int,
 ) -> c_int {
     if incre == 2 {
         /* read all the values at once (contiguous bytes) */
@@ -1145,16 +1254,24 @@ pub(crate) fn ffgi2b(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// get (read) the array of values from the FITS file, doing machine dependent
 /// format conversion (e.g. byte-swapping) if necessary.
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `byteloc` — (I) position within file to start reading
+/// * `nvals`   — (I) number of pixels to read
+/// * `incre`   — (I) byte increment between pixels
+/// * `values`  — (O) returned array of values
+/// * `status`  — (IO) error status
 pub(crate) fn ffgi4b(
-    fptr: &mut fitsfile,     /* I - FITS file pointer                        */
-    byteloc: LONGLONG,       /* I - position within file to start reading    */
-    nvals: c_long,           /* I - number of pixels to read                 */
-    incre: c_long,           /* I - byte increment between pixels            */
-    values: &mut [INT32BIT], /* O - returned array of values                */
-    status: &mut c_int,      /* IO - error status                            */
+    fptr: &mut fitsfile,
+    byteloc: LONGLONG,
+    nvals: c_long,
+    incre: c_long,
+    values: &mut [INT32BIT],
+    status: &mut c_int,
 ) -> c_int {
     if incre == 4 {
         /* read all the values at once (contiguous bytes) */
@@ -1185,7 +1302,6 @@ pub(crate) fn ffgi4b(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// get (read) the array of values from the FITS file, doing machine dependent
 /// format conversion (e.g. byte-swapping) if necessary.
 ///
@@ -1195,13 +1311,22 @@ pub(crate) fn ffgi4b(
 /// as long as 'values' has been allocated to large enough to hold
 /// 8 * nvals bytes of data.
 /// !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `byteloc` — (I) position within file to start reading
+/// * `nvals`   — (I) number of pixels to read
+/// * `incre`   — (I) byte increment between pixels
+/// * `values`  — (O) returned array of values
+/// * `status`  — (IO) error status
 pub(crate) fn ffgi8b(
-    fptr: &mut fitsfile,   /* I - FITS file pointer                        */
-    byteloc: LONGLONG,     /* I - position within file to start reading    */
-    nvals: c_long,         /* I - number of pixels to read                 */
-    incre: c_long,         /* I - byte increment between pixels            */
-    values: &mut [c_long], /* O - returned array of values                 */
-    status: &mut c_int,    /* IO - error status                            */
+    fptr: &mut fitsfile,
+    byteloc: LONGLONG,
+    nvals: c_long,
+    incre: c_long,
+    values: &mut [c_long],
+    status: &mut c_int,
 ) -> c_int {
     if incre == 8 {
         /* read all the values at once (contiguous bytes) */
@@ -1233,16 +1358,24 @@ pub(crate) fn ffgi8b(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// get (read) the array of values from the FITS file, doing machine dependent
 /// format conversion (e.g. byte-swapping) if necessary.
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `byteloc` — (I) position within file to start reading
+/// * `nvals`   — (I) number of pixels to read
+/// * `incre`   — (I) byte increment between pixels
+/// * `values`  — (O) returned array of values
+/// * `status`  — (IO) error status
 pub(crate) fn ffgr4b(
-    fptr: &mut fitsfile, /* I - FITS file pointer                        */
-    byteloc: LONGLONG,   /* I - position within file to start reading    */
-    nvals: c_long,       /* I - number of pixels to read                 */
-    incre: c_long,       /* I - byte increment between pixels            */
-    values: &mut [f32],  /* O - returned array of values                 */
-    status: &mut c_int,  /* IO - error status                            */
+    fptr: &mut fitsfile,
+    byteloc: LONGLONG,
+    nvals: c_long,
+    incre: c_long,
+    values: &mut [f32],
+    status: &mut c_int,
 ) -> c_int {
     if incre == 4 {
         /* read all the values at once (contiguous bytes) */
@@ -1274,16 +1407,24 @@ pub(crate) fn ffgr4b(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// get (read) the array of values from the FITS file, doing machine dependent
 /// format conversion (e.g. byte-swapping) if necessary.
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `byteloc` — (I) position within file to start reading
+/// * `nvals`   — (I) number of pixels to read
+/// * `incre`   — (I) byte increment between pixels
+/// * `values`  — (O) returned array of values
+/// * `status`  — (IO) error status
 pub(crate) fn ffgr8b(
-    fptr: &mut fitsfile, /* I - FITS file pointer                        */
-    byteloc: LONGLONG,   /* I - position within file to start reading    */
-    nvals: c_long,       /* I - number of pixels to read                 */
-    incre: c_long,       /* I - byte increment between pixels            */
-    values: &mut [f64],  /* O - returned array of values                 */
-    status: &mut c_int,  /* IO - error status                            */
+    fptr: &mut fitsfile,
+    byteloc: LONGLONG,
+    nvals: c_long,
+    incre: c_long,
+    values: &mut [f64],
+    status: &mut c_int,
 ) -> c_int {
     if incre == 8 {
         /* read all the values at once (contiguous bytes) */
@@ -1315,18 +1456,26 @@ pub(crate) fn ffgr8b(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// write a consecutive string of bytes to an ascii or binary table.
 /// This will span multiple rows of the table if nchars + firstchar is
 /// greater than the length of a row.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `firstrow`  — (I) starting row (1 = first row)
+/// * `firstchar` — (I) starting byte in row (1=first)
+/// * `nchars`    — (I) number of bytes to write
+/// * `values`    — (I) array of bytes to write
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffptbb(
-    fptr: *mut fitsfile,    /* I - FITS file pointer                 */
-    firstrow: LONGLONG,     /* I - starting row (1 = first row)      */
-    firstchar: LONGLONG,    /* I - starting byte in row (1=first)    */
-    nchars: LONGLONG,       /* I - number of bytes to write          */
-    values: *const c_uchar, /* I - array of bytes to write           */
-    status: *mut c_int,     /* IO - error status                     */
+    fptr: *mut fitsfile,
+    firstrow: LONGLONG,
+    firstchar: LONGLONG,
+    nchars: LONGLONG,
+    values: *const c_uchar,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -1338,17 +1487,25 @@ pub unsafe extern "C" fn ffptbb(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// write a consecutive string of bytes to an ascii or binary table.
 /// This will span multiple rows of the table if nchars + firstchar is
 /// greater than the length of a row.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `firstrow`  — (I) starting row (1 = first row)
+/// * `firstchar` — (I) starting byte in row (1=first)
+/// * `nchars`    — (I) number of bytes to write
+/// * `values`    — (I) array of bytes to write
+/// * `status`    — (IO) error status
 pub fn ffptbb_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                 */
-    firstrow: LONGLONG,  /* I - starting row (1 = first row)      */
-    firstchar: LONGLONG, /* I - starting byte in row (1=first)    */
-    nchars: LONGLONG,    /* I - number of bytes to write          */
-    values: &[c_uchar],  /* I - array of bytes to write           */
-    status: &mut c_int,  /* IO - error status                     */
+    fptr: &mut fitsfile,
+    firstrow: LONGLONG,
+    firstchar: LONGLONG,
+    nchars: LONGLONG,
+    values: &[c_uchar],
+    status: &mut c_int,
 ) -> c_int {
     let nrows: LONGLONG;
     let mut message: [c_char; FLEN_ERRMSG] = [0; FLEN_ERRMSG];
@@ -1409,15 +1566,22 @@ pub fn ffptbb_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// put (write) the array of values to the FITS file, doing machine dependent
 /// format conversion (e.g. byte-swapping) if necessary.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `nvals`  — (I) number of pixels in the values array
+/// * `incre`  — (I) byte increment between pixels
+/// * `values` — (I) array of values to write
+/// * `status` — (IO) error status
 pub(crate) fn ffpi1b(
-    fptr: &mut fitsfile, /* I - FITS file pointer                         */
-    nvals: c_long,       /* I - number of pixels in the values array      */
-    incre: c_long,       /* I - byte increment between pixels             */
-    values: &[u8],       /* I - array of values to write           */
-    status: &mut c_int,  /* IO - error status                             */
+    fptr: &mut fitsfile,
+    nvals: c_long,
+    incre: c_long,
+    values: &[u8],
+    status: &mut c_int,
 ) -> c_int {
     if incre == 1 {
         /* write all the values at once (contiguous bytes) */
@@ -1430,15 +1594,22 @@ pub(crate) fn ffpi1b(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// put (write) the array of values to the FITS file, doing machine dependent
 /// format conversion (e.g. byte-swapping) if necessary.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `nvals`  — (I) number of pixels in the values array
+/// * `incre`  — (I) byte increment between pixels
+/// * `values` — (I) array of values to write
+/// * `status` — (IO) error status
 pub(crate) fn ffpi2b(
-    fptr: &mut fitsfile, /* I - FITS file pointer                         */
-    nvals: c_long,       /* I - number of pixels in the values array      */
-    incre: c_long,       /* I - byte increment between pixels             */
-    values: &[c_short],  /* I - array of values to write                  */
-    status: &mut c_int,  /* IO - error status                             */
+    fptr: &mut fitsfile,
+    nvals: c_long,
+    incre: c_long,
+    values: &[c_short],
+    status: &mut c_int,
 ) -> c_int {
     // Copy slice so that we don't change the original values
     let mut v: Vec<c_short> = values.to_vec();
@@ -1457,15 +1628,22 @@ pub(crate) fn ffpi2b(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// put (write) the array of values to the FITS file, doing machine dependent
 /// format conversion (e.g. byte-swapping) if necessary.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `nvals`  — (I) number of pixels in the values array
+/// * `incre`  — (I) byte increment between pixels
+/// * `values` — (I) array of values to write
+/// * `status` — (IO) error status
 pub(crate) fn ffpi4b(
-    fptr: &mut fitsfile, /* I - FITS file pointer                         */
-    nvals: c_long,       /* I - number of pixels in the values array      */
-    incre: c_long,       /* I - byte increment between pixels             */
-    values: &[INT32BIT], /* I - array of values to write                */
-    status: &mut c_int,  /* IO - error status                             */
+    fptr: &mut fitsfile,
+    nvals: c_long,
+    incre: c_long,
+    values: &[INT32BIT],
+    status: &mut c_int,
 ) -> c_int {
     // Copy slice so that we don't change the original values
     let mut v: Vec<INT32BIT> = values.to_vec();
@@ -1486,7 +1664,6 @@ pub(crate) fn ffpi4b(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// put (write) the array of values to the FITS file, doing machine dependent
 /// format conversion (e.g. byte-swapping) if necessary.
 ///
@@ -1496,12 +1673,20 @@ pub(crate) fn ffpi4b(
 /// as long as 'values' has been allocated to large enough to hold
 /// 8 * nvals bytes of data.
 /// !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `nvals`  — (I) number of pixels in the values array
+/// * `incre`  — (I) byte increment between pixels
+/// * `values` — (I) array of values to write
+/// * `status` — (IO) error status
 pub(crate) fn ffpi8b(
-    fptr: &mut fitsfile, /* I - FITS file pointer                         */
-    nvals: c_long,       /* I - number of pixels in the values array      */
-    incre: c_long,       /* I - byte increment between pixels             */
-    values: &[c_long],   /* I - array of values to write                */
-    status: &mut c_int,  /* IO - error status                             */
+    fptr: &mut fitsfile,
+    nvals: c_long,
+    incre: c_long,
+    values: &[c_long],
+    status: &mut c_int,
 ) -> c_int {
     // Copy slice so that we don't change the original values
     let mut v: Vec<c_long> = values.to_vec();
@@ -1520,15 +1705,22 @@ pub(crate) fn ffpi8b(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// put (write) the array of values to the FITS file, doing machine dependent
 /// format conversion (e.g. byte-swapping) if necessary.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `nvals`  — (I) number of pixels in the values array
+/// * `incre`  — (I) byte increment between pixels
+/// * `values` — (I) array of values to write
+/// * `status` — (IO) error status
 pub(crate) fn ffpr4b(
-    fptr: &mut fitsfile, /* I - FITS file pointer                         */
-    nvals: c_long,       /* I - number of pixels in the values array      */
-    incre: c_long,       /* I - byte increment between pixels             */
-    values: &[f32],      /* I - array of values to write                  */
-    status: &mut c_int,  /* IO - error status                             */
+    fptr: &mut fitsfile,
+    nvals: c_long,
+    incre: c_long,
+    values: &[f32],
+    status: &mut c_int,
 ) -> c_int {
     // Copy slice so that we don't change the original values
     let mut v: Vec<f32> = values.to_vec();
@@ -1548,15 +1740,22 @@ pub(crate) fn ffpr4b(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// put (write) the array of values to the FITS file, doing machine dependent
 /// format conversion (e.g. byte-swapping) if necessary.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `nvals`  — (I) number of pixels in the values array
+/// * `incre`  — (I) byte increment between pixels
+/// * `values` — (I) array of values to write
+/// * `status` — (IO) error status
 pub(crate) fn ffpr8b(
-    fptr: &mut fitsfile, /* I - FITS file pointer                         */
-    nvals: c_long,       /* I - number of pixels in the values array      */
-    incre: c_long,       /* I - byte increment between pixels             */
-    values: &[f64],      /* I - array of values to write                  */
-    status: &mut c_int,  /* IO - error status                             */
+    fptr: &mut fitsfile,
+    nvals: c_long,
+    incre: c_long,
+    values: &[f64],
+    status: &mut c_int,
 ) -> c_int {
     // Copy slice so that we don't change the original values
     let mut v: Vec<f64> = values.to_vec();

--- a/src/bzip2.rs
+++ b/src/bzip2.rs
@@ -1,3 +1,9 @@
+//! The bzip2 entry points used by the `BZIP2_1` tile compressor.
+//!
+//! Re-exported from `libbz2-rs-sys` behind the default `bzip2` feature. BZIP2
+//! is not publicly supported by CFITSIO and exists for test purposes only.
+#![warn(missing_docs)]
+
 use crate::c_types::{c_int, c_void, FILE};
 
 pub use bzip2_sys::{

--- a/src/c_types.rs
+++ b/src/c_types.rs
@@ -1,3 +1,12 @@
+//! The C scalar types the port is written against.
+//!
+//! Re-exported from `libc` in one place so the transpiled code can say
+//! `c_int` / `c_long` / `LONGLONG` exactly as the original CFITSIO C does.
+//! Their widths are target-dependent — `c_long` is 64-bit on Linux and macOS
+//! but 32-bit on Windows — which is why the port uses them rather than `i32` /
+//! `i64`.
+#![warn(missing_docs)]
+
 pub use libc::{
     FILE, c_char, c_double, c_float, c_int, c_long, c_longlong, c_schar, c_short, c_uchar, c_uint,
     c_ulong, c_ulonglong, c_ushort, c_void, intmax_t, off_t, ptrdiff_t, size_t, ssize_t, uintmax_t,

--- a/src/cfileio.rs
+++ b/src/cfileio.rs
@@ -1,8 +1,22 @@
-/*  This file, cfileio.rs, contains the low-level file access routines.     */
-
-/*  The FITSIO software was written by William Pence at the High Energy    */
-/*  Astrophysic Science Archive Research Center (HEASARC) at the NASA      */
-/*  Goddard Space Flight Center.                                           */
+//! The low-level file access routines, and the extended filename syntax.
+//!
+//! Opening a file here is more than opening a path. CFITSIO accepts an extended
+//! filename syntax in which the name carries a driver prefix (`file://`,
+//! `mem://`, `ftp://`, `shmem://`, …), an HDU or extension to move to, an image
+//! section, a row filter, a column filter and a tile-compression specification.
+//! This module parses that syntax, dispatches to the right driver from the
+//! table below, and applies the filters -- which is why opening a file can
+//! create a temporary in-memory file and copy a filtered subset into it.
+//!
+//! Drivers register themselves into `DRIVER_TABLE` at first use, each supplying
+//! the open / close / seek / read / write hooks of [`fitsdriver`]. The
+//! individual drivers live in the `drvr*` modules.
+//!
+//! Ported from CFITSIO's `cfileio.c`, written by William Pence at the High
+//! Energy Astrophysics Science Archive Research Center (HEASARC), NASA Goddard
+//! Space Flight Center. The filename syntax is documented in full in the
+//! "Extended File Name Syntax" chapter of the CFITSIO User's Reference Guide.
+#![warn(missing_docs)]
 
 use core::ffi::CStr;
 use core::slice;
@@ -92,8 +106,10 @@ use crate::{buffers::*, raw_to_slice};
 use crate::{fitsio::*, int_snprintf};
 use crate::{fitsio2::*, slice_to_str};
 
-pub const MAX_PREFIX_LEN: usize = 20; /* max length of file type prefix (e.g. 'http://') */
-pub const MAX_DRIVERS: usize = 31; /* max number of file I/O drivers */
+/// Maximum length of a file type prefix, e.g. `http://`.
+pub const MAX_PREFIX_LEN: usize = 20;
+/// Maximum number of file I/O drivers that can be registered.
+pub const MAX_DRIVERS: usize = 31;
 
 pub(crate) trait Driver {}
 
@@ -108,56 +124,90 @@ pub type CheckFileFn = fn(
 /// A driver's `open` hook.
 pub type DriverOpenFn = fn(filename: &mut [c_char], rwmode: c_int, handle: &mut c_int) -> c_int;
 
+/// One registered I/O driver: the hooks that implement a filename prefix.
+///
+/// A driver is selected by matching the prefix of the file name. `close`,
+/// `size`, `seek`, `read` and `write` are required; the rest are optional and
+/// are skipped when absent.
 pub struct fitsdriver {
-    /* structure containing pointers to I/O driver functions */
+    /// File name prefix this driver handles, e.g. `mem://`.
     pub prefix: [c_char; MAX_PREFIX_LEN],
+    /// Called once when the driver is first registered.
     pub init: Option<fn() -> c_int>,
+    /// Called when the library shuts down.
     pub shutdown: Option<fn() -> c_int>,
+    /// Set a driver-specific option.
     pub setoptions: Option<fn(option: c_int) -> c_int>,
+    /// Read back the driver-specific options.
     pub getoptions: Option<fn(options: &mut c_int) -> c_int>,
+    /// Report the driver's version.
     pub getversion: Option<fn(version: &mut c_int) -> c_int>,
+    /// Inspect and possibly rewrite the file names before opening.
     pub checkfile: Option<CheckFileFn>,
+    /// Open an existing file.
     pub open: Option<DriverOpenFn>,
+    /// Create a new file.
     pub create:
         Option<fn(filename: &mut [c_char; FLEN_FILENAME], drivehandle: &mut c_int) -> c_int>,
+    /// Truncate the file to `size` bytes.
     pub truncate: Option<fn(drivehandle: c_int, size: usize) -> c_int>,
+    /// Close an open file.
     pub close: fn(drivehandle: c_int) -> c_int,
+    /// Delete a file by name.
     pub remove: Option<fn(filename: &[c_char]) -> c_int>,
+    /// Report the current size of the file in bytes.
     pub size: fn(drivehandle: c_int, size: &mut usize) -> c_int,
+    /// Flush any buffered writes to the underlying medium.
     pub flush: Option<fn(drivehandle: c_int) -> c_int>,
+    /// Seek to a byte offset.
     pub seek: fn(drivehandle: c_int, offset: LONGLONG) -> c_int,
+    /// Read `nbytes` bytes into `buffer`.
     pub read: fn(drivehandle: c_int, buffer: &mut [u8], nbytes: usize) -> c_int,
+    /// Write `nbyte` bytes from `buffer`.
     pub write: fn(drivehandle: c_int, buffer: &[u8], nbyte: usize) -> c_int,
 }
 
-pub static DRIVER_TABLE: OnceLock<Vec<fitsdriver>> = OnceLock::new(); /* allocate driver tables */
+/// The registered I/O drivers, populated on first use.
+pub static DRIVER_TABLE: OnceLock<Vec<fitsdriver>> = OnceLock::new();
 
-/* this table of Fptr pointers is used by fits_already_open */
+/// Every currently open file, used by `fits_already_open` to notice when a file
+/// is opened a second time so that both handles share one [`FITSfile`].
 pub static mut FPTR_TABLE: [*mut FITSfile; NMAXFILES] =
     [core::ptr::null_mut::<FITSfile>(); NMAXFILES];
 
-pub static NEED_TO_INITIALIZE: Mutex<bool> = Mutex::new(true); /* true if CFITSIO has not been initialized */
+/// True until the library has been initialized and the drivers registered.
+pub static NEED_TO_INITIALIZE: Mutex<bool> = Mutex::new(true);
 
-pub static STREAM_DRIVER: Mutex<c_int> = Mutex::new(0); /* number of currently defined I/O drivers */
+/// Index of the `stream://` driver in [`DRIVER_TABLE`].
+pub static STREAM_DRIVER: Mutex<c_int> = Mutex::new(0);
 
-/*--------------------------------------------------------------------------*/
 pub(crate) fn fitsio_init_lock() -> c_int {
     0
 }
 
-/*--------------------------------------------------------------------------*/
 /// Open an existing FITS file in core memory.  This is a specialized version
 /// of ffopen.
+///
+/// # Parameters
+///
+/// * `fptr`        — (O) FITS file pointer
+/// * `name`        — (I) name of file to open
+/// * `mode`        — (I) 0 = open readonly; 1 = read/write
+/// * `buffptr`     — (I) address of memory pointer
+/// * `buffsize`    — (I) size of buffer, in bytes
+/// * `deltasize`   — (I) increment for future realloc's
+/// * `mem_realloc` — function
+/// * `status`      — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffomem(
-    fptr: *mut Option<Box<fitsfile>>, /* O - FITS file pointer                   */
-    name: *const c_char,              /* I - name of file to open                */
-    mode: c_int,                      /* I - 0 = open readonly; 1 = read/write   */
-    buffptr: *mut *mut c_void,        /* I - address of memory pointer           */
-    buffsize: *mut usize,             /* I - size of buffer, in bytes            */
-    deltasize: usize,                 /* I - increment for future realloc's      */
-    mem_realloc: unsafe extern "C" fn(p: *mut c_void, newsize: usize) -> *mut c_void, /* function       */
-    status: *mut c_int, /* IO - error status                       */
+    fptr: *mut Option<Box<fitsfile>>,
+    name: *const c_char,
+    mode: c_int,
+    buffptr: *mut *mut c_void,
+    buffsize: *mut usize,
+    deltasize: usize,
+    mem_realloc: unsafe extern "C" fn(p: *mut c_void, newsize: usize) -> *mut c_void,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -180,15 +230,25 @@ pub unsafe extern "C" fn ffomem(
     }
 }
 
+/// # Parameters
+///
+/// * `fptr`        — (O) FITS file pointer
+/// * `name`        — (I) name of file to open
+/// * `mode`        — (I) 0 = open readonly; 1 = read/write
+/// * `buffptr`     — (I) address of memory pointer
+/// * `buffsize`    — (I) size of buffer, in bytes
+/// * `deltasize`   — (I) increment for future realloc's
+/// * `mem_realloc` — function
+/// * `status`      — (IO) error status
 pub fn ffomem_safer(
-    fptr: &mut Option<Box<fitsfile>>, /* O - FITS file pointer                   */
-    name: &[c_char],                  /* I - name of file to open                */
-    mode: c_int,                      /* I - 0 = open readonly; 1 = read/write   */
-    buffptr: *mut *mut c_void,        /* I - address of memory pointer           */
-    buffsize: &mut usize,             /* I - size of buffer, in bytes            */
-    deltasize: usize,                 /* I - increment for future realloc's      */
-    mem_realloc: unsafe extern "C" fn(p: *mut c_void, newsize: usize) -> *mut c_void, /* function       */
-    status: &mut c_int, /* IO - error status                       */
+    fptr: &mut Option<Box<fitsfile>>,
+    name: &[c_char],
+    mode: c_int,
+    buffptr: *mut *mut c_void,
+    buffsize: &mut usize,
+    deltasize: usize,
+    mem_realloc: unsafe extern "C" fn(p: *mut c_void, newsize: usize) -> *mut c_void,
+    status: &mut c_int,
 ) -> c_int {
     let mut driver: c_int = 0;
     let mut handle: c_int = 0;
@@ -444,17 +504,23 @@ pub fn ffomem_safer(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Open an existing FITS file on magnetic disk with either readonly or
 /// read/write access.  The routine does not support CFITSIO's extended
 /// filename syntax and simply uses the entire input 'name' string as
 /// the name of the file.
+///
+/// # Parameters
+///
+/// * `fptr`   — (O) FITS file pointer
+/// * `name`   — (I) full name of file to open
+/// * `mode`   — (I) 0 = open readonly; 1 = read/write
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffdkopn(
-    fptr: *mut Option<Box<fitsfile>>, /* O - FITS file pointer                   */
-    name: *const c_char,              /* I - full name of file to open           */
-    mode: c_int,                      /* I - 0 = open readonly; 1 = read/write   */
-    status: *mut c_int,               /* IO - error status                       */
+    fptr: *mut Option<Box<fitsfile>>,
+    name: *const c_char,
+    mode: c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -467,11 +533,17 @@ pub unsafe extern "C" fn ffdkopn(
     }
 }
 
+/// # Parameters
+///
+/// * `fptr`   — (O) FITS file pointer
+/// * `name`   — (I) full name of file to open
+/// * `mode`   — (I) 0 = open readonly; 1 = read/write
+/// * `status` — (IO) error status
 pub fn ffdkopn_safer(
-    fptr: &mut Option<Box<fitsfile>>, /* O - FITS file pointer                   */
-    name: &[c_char],                  /* I - full name of file to open           */
-    mode: c_int,                      /* I - 0 = open readonly; 1 = read/write   */
-    status: &mut c_int,               /* IO - error status                       */
+    fptr: &mut Option<Box<fitsfile>>,
+    name: &[c_char],
+    mode: c_int,
+    status: &mut c_int,
 ) -> c_int {
     if *status > 0 {
         return *status;
@@ -484,16 +556,28 @@ pub fn ffdkopn_safer(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
-/// Open an existing FITS file with either readonly or read/write access. and
+/// Open an existing FITS file with either readonly or read/write access.
+///
+/// The name may use the extended filename syntax: a driver prefix, an HDU or
+/// extension to move to, an image section, a row or column filter, and a
+/// tile-compression specification. Applying a filter produces a temporary
+/// in-memory file holding the filtered subset, so the returned handle may not
+/// refer to the named file on disk. See the module documentation. and
 /// move to the first HDU that contains 'interesting' data, if the primary
 /// array contains a null image (i.e., NAXIS = 0).
+///
+/// # Parameters
+///
+/// * `fptr`   — (O) FITS file pointer
+/// * `name`   — (I) full name of file to open
+/// * `mode`   — (I) 0 = open readonly; 1 = read/write
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffdopn(
-    fptr: *mut Option<Box<fitsfile>>, /* O - FITS file pointer                   */
-    name: *const c_char,              /* I - full name of file to open           */
-    mode: c_int,                      /* I - 0 = open readonly; 1 = read/write   */
-    status: *mut c_int,               /* IO - error status                       */
+    fptr: *mut Option<Box<fitsfile>>,
+    name: *const c_char,
+    mode: c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -505,11 +589,17 @@ pub unsafe extern "C" fn ffdopn(
     }
 }
 
+/// # Parameters
+///
+/// * `fptr`   — (O) FITS file pointer
+/// * `name`   — (I) full name of file to open
+/// * `mode`   — (I) 0 = open readonly; 1 = read/write
+/// * `status` — (IO) error status
 pub fn ffdopn_safer(
-    fptr: &mut Option<Box<fitsfile>>, /* O - FITS file pointer                   */
-    name: &[c_char],                  /* I - full name of file to open           */
-    mode: c_int,                      /* I - 0 = open readonly; 1 = read/write   */
-    status: &mut c_int,               /* IO - error status                       */
+    fptr: &mut Option<Box<fitsfile>>,
+    name: &[c_char],
+    mode: c_int,
+    status: &mut c_int,
 ) -> c_int {
     if *status > 0 {
         return *status;
@@ -522,19 +612,33 @@ pub fn ffdopn_safer(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
-/// Open an existing FITS file with either readonly or read/write access. and
+/// Open an existing FITS file with either readonly or read/write access.
+///
+/// The name may use the extended filename syntax: a driver prefix, an HDU or
+/// extension to move to, an image section, a row or column filter, and a
+/// tile-compression specification. Applying a filter produces a temporary
+/// in-memory file holding the filtered subset, so the returned handle may not
+/// refer to the named file on disk. See the module documentation. and
 /// if the primary array contains a null image (i.e., NAXIS = 0) then attempt to
 /// move to the first extension named in the extlist of extension names. If
 /// none are found, then simply move to the 2nd extension.
+///
+/// # Parameters
+///
+/// * `fptr`    — (O) FITS file pointer
+/// * `name`    — (I) full name of file to open
+/// * `mode`    — (I) 0 = open readonly; 1 = read/write
+/// * `extlist` — (I) list of 'good' extensions to move to
+/// * `hdutype` — (O) type of extension that is moved to
+/// * `status`  — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffeopn(
-    fptr: *mut Option<Box<fitsfile>>, /* O - FITS file pointer                   */
-    name: *const c_char,              /* I - full name of file to open           */
-    mode: c_int,                      /* I - 0 = open readonly; 1 = read/write   */
-    extlist: *mut c_char,             /* I - list of 'good' extensions to move to */
-    hdutype: *mut c_int,              /* O - type of extension that is moved to  */
-    status: *mut c_int,               /* IO - error status                       */
+    fptr: *mut Option<Box<fitsfile>>,
+    name: *const c_char,
+    mode: c_int,
+    extlist: *mut c_char,
+    hdutype: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -555,18 +659,32 @@ pub unsafe extern "C" fn ffeopn(
     }
 }
 
-/*--------------------------------------------------------------------------*/
-/// Open an existing FITS file with either readonly or read/write access. and
+/// Open an existing FITS file with either readonly or read/write access.
+///
+/// The name may use the extended filename syntax: a driver prefix, an HDU or
+/// extension to move to, an image section, a row or column filter, and a
+/// tile-compression specification. Applying a filter produces a temporary
+/// in-memory file holding the filtered subset, so the returned handle may not
+/// refer to the named file on disk. See the module documentation. and
 /// if the primary array contains a null image (i.e., NAXIS = 0) then attempt to
 /// move to the first extension named in the extlist of extension names. If
 /// none are found, then simply move to the 2nd extension.
+///
+/// # Parameters
+///
+/// * `fptr`    — (O) FITS file pointer
+/// * `name`    — (I) full name of file to open
+/// * `mode`    — (I) 0 = open readonly; 1 = read/write
+/// * `extlist` — (I) list of 'good' extensions to move to
+/// * `hdutype` — (O) type of extension that is moved to
+/// * `status`  — (IO) error status
 pub fn ffeopn_safe(
-    fptr: &mut Option<Box<fitsfile>>, /* O - FITS file pointer                   */
-    name: &[c_char],                  /* I - full name of file to open           */
-    mode: c_int,                      /* I - 0 = open readonly; 1 = read/write   */
-    extlist: Option<&[c_char]>,       /* I - list of 'good' extensions to move to */
-    hdutype: Option<&mut c_int>,      /* O - type of extension that is moved to  */
-    status: &mut c_int,               /* IO - error status                       */
+    fptr: &mut Option<Box<fitsfile>>,
+    name: &[c_char],
+    mode: c_int,
+    extlist: Option<&[c_char]>,
+    hdutype: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     let mut hdunum: c_int = 0;
     let mut naxis: c_int = 0;
@@ -629,15 +747,27 @@ pub fn ffeopn_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
-/// Open an existing FITS file with either readonly or read/write access. and
+/// Open an existing FITS file with either readonly or read/write access.
+///
+/// The name may use the extended filename syntax: a driver prefix, an HDU or
+/// extension to move to, an image section, a row or column filter, and a
+/// tile-compression specification. Applying a filter produces a temporary
+/// in-memory file holding the filtered subset, so the returned handle may not
+/// refer to the named file on disk. See the module documentation. and
 /// move to the first HDU that contains 'interesting' table (not an image).
+///
+/// # Parameters
+///
+/// * `fptr`   — (O) FITS file pointer
+/// * `name`   — (I) full name of file to open
+/// * `mode`   — (I) 0 = open readonly; 1 = read/write
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn fftopn(
-    fptr: *mut Option<Box<fitsfile>>, /* O - FITS file pointer                   */
-    name: *const c_char,              /* I - full name of file to open           */
-    mode: c_int,                      /* I - 0 = open readonly; 1 = read/write   */
-    status: *mut c_int,               /* IO - error status                       */
+    fptr: *mut Option<Box<fitsfile>>,
+    name: *const c_char,
+    mode: c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -650,14 +780,26 @@ pub unsafe extern "C" fn fftopn(
     }
 }
 
-/*--------------------------------------------------------------------------*/
-/// Open an existing FITS file with either readonly or read/write access. and
+/// Open an existing FITS file with either readonly or read/write access.
+///
+/// The name may use the extended filename syntax: a driver prefix, an HDU or
+/// extension to move to, an image section, a row or column filter, and a
+/// tile-compression specification. Applying a filter produces a temporary
+/// in-memory file holding the filtered subset, so the returned handle may not
+/// refer to the named file on disk. See the module documentation. and
 /// move to the first HDU that contains 'interesting' table (not an image).
+///
+/// # Parameters
+///
+/// * `fptr`   — (O) FITS file pointer
+/// * `name`   — (I) full name of file to open
+/// * `mode`   — (I) 0 = open readonly; 1 = read/write
+/// * `status` — (IO) error status
 pub fn fftopn_safe(
-    fptr: &mut Option<Box<fitsfile>>, /* O - FITS file pointer                   */
-    name: &[c_char],                  /* I - full name of file to open           */
-    mode: c_int,                      /* I - 0 = open readonly; 1 = read/write   */
-    status: &mut c_int,               /* IO - error status                       */
+    fptr: &mut Option<Box<fitsfile>>,
+    name: &[c_char],
+    mode: c_int,
+    status: &mut c_int,
 ) -> c_int {
     let mut hdutype: c_int = 0;
 
@@ -678,15 +820,27 @@ pub fn fftopn_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
-/// Open an existing FITS file with either readonly or read/write access. and
+/// Open an existing FITS file with either readonly or read/write access.
+///
+/// The name may use the extended filename syntax: a driver prefix, an HDU or
+/// extension to move to, an image section, a row or column filter, and a
+/// tile-compression specification. Applying a filter produces a temporary
+/// in-memory file holding the filtered subset, so the returned handle may not
+/// refer to the named file on disk. See the module documentation. and
 /// move to the first HDU that contains 'interesting' image (not an table).
+///
+/// # Parameters
+///
+/// * `fptr`   — (O) FITS file pointer
+/// * `name`   — (I) full name of file to open
+/// * `mode`   — (I) 0 = open readonly; 1 = read/write
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffiopn(
-    fptr: *mut Option<Box<fitsfile>>, /* O - FITS file pointer                   */
-    name: *const c_char,              /* I - full name of file to open           */
-    mode: c_int,                      /* I - 0 = open readonly; 1 = read/write   */
-    status: *mut c_int,               /* IO - error status                       */
+    fptr: *mut Option<Box<fitsfile>>,
+    name: *const c_char,
+    mode: c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -699,14 +853,26 @@ pub unsafe extern "C" fn ffiopn(
     }
 }
 
-/*--------------------------------------------------------------------------*/
-/// Open an existing FITS file with either readonly or read/write access. and
+/// Open an existing FITS file with either readonly or read/write access.
+///
+/// The name may use the extended filename syntax: a driver prefix, an HDU or
+/// extension to move to, an image section, a row or column filter, and a
+/// tile-compression specification. Applying a filter produces a temporary
+/// in-memory file holding the filtered subset, so the returned handle may not
+/// refer to the named file on disk. See the module documentation. and
 /// move to the first HDU that contains 'interesting' image (not an table).
+///
+/// # Parameters
+///
+/// * `fptr`   — (O) FITS file pointer
+/// * `name`   — (I) full name of file to open
+/// * `mode`   — (I) 0 = open readonly; 1 = read/write
+/// * `status` — (IO) error status
 pub fn ffiopn_safer(
-    fptr: &mut Option<Box<fitsfile>>, /* O - FITS file pointer                   */
-    name: &[c_char],                  /* I - full name of file to open           */
-    mode: c_int,                      /* I - 0 = open readonly; 1 = read/write   */
-    status: &mut c_int,               /* IO - error status                       */
+    fptr: &mut Option<Box<fitsfile>>,
+    name: &[c_char],
+    mode: c_int,
+    status: &mut c_int,
 ) -> c_int {
     let mut hdutype: c_int = 0;
 
@@ -727,20 +893,33 @@ pub fn ffiopn_safer(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Open an existing FITS file with either readonly or read/write access.
+///
+/// The name may use the extended filename syntax: a driver prefix, an HDU or
+/// extension to move to, an image section, a row or column filter, and a
+/// tile-compression specification. Applying a filter produces a temporary
+/// in-memory file holding the filtered subset, so the returned handle may not
+/// refer to the named file on disk. See the module documentation.
 ///
 /// First test that the SONAME of fitsio.h used to build the CFITSIO library
 /// is the same as was used in compiling the application program that
 /// links to the library.
+///
+/// # Parameters
+///
+/// * `soname` — (I) CFITSIO shared library version
+/// * `fptr`   — (O) FITS file pointer
+/// * `name`   — (I) full name of file to open
+/// * `mode`   — (I) 0 = open readonly; 1 = read/write
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffopentest(
-    soname: c_int, /* I - CFITSIO shared library version     */
+    soname: c_int,
     /*     application program (fitsio.h file) */
-    fptr: *mut Option<Box<fitsfile>>, /* O - FITS file pointer                   */
-    name: *const c_char,              /* I - full name of file to open           */
-    mode: c_int,                      /* I - 0 = open readonly; 1 = read/write   */
-    status: *mut c_int,               /* IO - error status                       */
+    fptr: *mut Option<Box<fitsfile>>,
+    name: *const c_char,
+    mode: c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -753,18 +932,31 @@ pub unsafe extern "C" fn ffopentest(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Open an existing FITS file with either readonly or read/write access.
+///
+/// The name may use the extended filename syntax: a driver prefix, an HDU or
+/// extension to move to, an image section, a row or column filter, and a
+/// tile-compression specification. Applying a filter produces a temporary
+/// in-memory file holding the filtered subset, so the returned handle may not
+/// refer to the named file on disk. See the module documentation.
 ///
 /// First test that the SONAME of fitsio.h used to build the CFITSIO library
 /// is the same as was used in compiling the application program that
 /// links to the library.
+///
+/// # Parameters
+///
+/// * `soname` — (I) CFITSIO shared library version application program (fitsio.h file)
+/// * `fptr`   — (O) FITS file pointer
+/// * `name`   — (I) full name of file to open
+/// * `mode`   — (I) 0 = open readonly; 1 = read/write
+/// * `status` — (IO) error status
 pub fn ffopentest_safe(
-    soname: c_int, /* I - CFITSIO shared library version  application program (fitsio.h file) */
-    fptr: &mut Option<Box<fitsfile>>, /* O - FITS file pointer                   */
-    name: &[c_char], /* I - full name of file to open           */
-    mode: c_int,   /* I - 0 = open readonly; 1 = read/write   */
-    status: &mut c_int, /* IO - error status                       */
+    soname: c_int,
+    fptr: &mut Option<Box<fitsfile>>,
+    name: &[c_char],
+    mode: c_int,
+    status: &mut c_int,
 ) -> c_int {
     if soname != CFITSIO_SONAME as c_int {
         println!("\nERROR: Mismatch in the CFITSIO_SONAME value in the fitsio.h include file");
@@ -784,14 +976,26 @@ pub fn ffopentest_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Open an existing FITS file with either readonly or read/write access.
+///
+/// The name may use the extended filename syntax: a driver prefix, an HDU or
+/// extension to move to, an image section, a row or column filter, and a
+/// tile-compression specification. Applying a filter produces a temporary
+/// in-memory file holding the filtered subset, so the returned handle may not
+/// refer to the named file on disk. See the module documentation.
+///
+/// # Parameters
+///
+/// * `fptr`   — (O) FITS file pointer
+/// * `name`   — (I) full name of file to open
+/// * `mode`   — (I) 0 = open readonly; 1 = read/write
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffopen(
-    fptr: *mut Option<Box<fitsfile>>, /* O - FITS file pointer                   */
-    name: *const c_char,              /* I - full name of file to open           */
-    mode: c_int,                      /* I - 0 = open readonly; 1 = read/write   */
-    status: *mut c_int,               /* IO - error status                       */
+    fptr: *mut Option<Box<fitsfile>>,
+    name: *const c_char,
+    mode: c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -803,13 +1007,25 @@ pub unsafe extern "C" fn ffopen(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Open an existing FITS file with either readonly or read/write access.
+///
+/// The name may use the extended filename syntax: a driver prefix, an HDU or
+/// extension to move to, an image section, a row or column filter, and a
+/// tile-compression specification. Applying a filter produces a temporary
+/// in-memory file holding the filtered subset, so the returned handle may not
+/// refer to the named file on disk. See the module documentation.
+///
+/// # Parameters
+///
+/// * `fptr`   — (O) FITS file pointer
+/// * `name`   — (I) full name of file to open
+/// * `mode`   — (I) 0 = open readonly; 1 = read/write
+/// * `status` — (IO) error status
 pub fn ffopen_safe(
-    fptr: &mut Option<Box<fitsfile>>, /* O - FITS file pointer                   */
-    name: &[c_char],                  /* I - full name of file to open           */
-    mode: c_int,                      /* I - 0 = open readonly; 1 = read/write   */
-    status: &mut c_int,               /* IO - error status                       */
+    fptr: &mut Option<Box<fitsfile>>,
+    name: &[c_char],
+    mode: c_int,
+    status: &mut c_int,
 ) -> c_int {
     let mut newptr: Option<Box<fitsfile>> = None;
     let mut driver = 0;
@@ -1043,9 +1259,7 @@ pub fn ffopen_safe(
         };
     }
 
-    /*-------------------------------------------------------------------*/
     /* special cases:                                                    */
-    /*-------------------------------------------------------------------*/
 
     histfilename[0] = 0;
     filtfilename[0] = 0;
@@ -1066,9 +1280,7 @@ pub fn ffopen_safe(
         outfile[0] = 0;
     }
 
-    /*-------------------------------------------------------------------*/
     /* check if this same file is already open, and if so, attach to it  */
-    /*-------------------------------------------------------------------*/
 
     let lock = FFLOCK();
 
@@ -1804,17 +2016,22 @@ pub fn ffopen_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Reopen an existing FITS file with either readonly or read/write access.
 ///
 /// The reopened file shares the same FITSfile structure but may point to a
 /// different HDU within the file.
 /// SAFETY: This is in no ways safe, multiple fptrs sharing the same underlying data
+///
+/// # Parameters
+///
+/// * `openfptr` — (I) FITS file pointer to open file
+/// * `newfptr`  — (O) pointer to new re opened file
+/// * `status`   — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffreopen(
-    openfptr: *mut fitsfile,     /* I - FITS file pointer to open file  */
-    newfptr: *mut *mut fitsfile, /* O - pointer to new re opened file   */
-    status: *mut c_int,          /* IO - error status                   */
+    openfptr: *mut fitsfile,
+    newfptr: *mut *mut fitsfile,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -1833,10 +2050,15 @@ pub unsafe extern "C" fn ffreopen(
     }
 }
 
+/// # Parameters
+///
+/// * `openfptr` — (I) FITS file pointer to open file
+/// * `newfptr`  — (O) pointer to new re opened file
+/// * `status`   — (IO) error status
 pub fn ffreopen_safer(
-    openfptr: &mut fitsfile,     /* I - FITS file pointer to open file  */
-    newfptr: &mut *mut fitsfile, /* O - pointer to new re opened file   */
-    status: &mut c_int,          /* IO - error status                   */
+    openfptr: &mut fitsfile,
+    newfptr: &mut *mut fitsfile,
+    status: &mut c_int,
 ) -> c_int {
     if *status > 0 {
         return *status;
@@ -1862,15 +2084,16 @@ pub fn ffreopen_safer(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// store the new Fptr address for future use by fits_already_open
 /// Takes the address rather than a `&mut FITSfile`: the table has to hold the
 /// same pointer the handles deref through, not a reference-derived child of it,
 /// or the entry is invalidated by the next write through any handle.
-pub(crate) fn fits_store_Fptr(
-    Fptr: *mut FITSfile, /* O - FITS file pointer               */
-    status: &mut c_int,  /* IO - error status                   */
-) -> c_int {
+///
+/// # Parameters
+///
+/// * `Fptr`   — (O) FITS file pointer
+/// * `status` — (IO) error status
+pub(crate) fn fits_store_Fptr(Fptr: *mut FITSfile, status: &mut c_int) -> c_int {
     if *status > 0 {
         return *status;
     }
@@ -1889,13 +2112,14 @@ pub(crate) fn fits_store_Fptr(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 ///  clear the Fptr address from the Fptr Table  
+///
+/// # Parameters
+///
+/// * `Fptr`   — (O) FITS file pointer
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
-pub unsafe extern "C" fn fits_clear_Fptr(
-    Fptr: *mut FITSfile, /* O - FITS file pointer               */
-    status: *mut c_int,  /* IO - error status                   */
-) -> c_int {
+pub unsafe extern "C" fn fits_clear_Fptr(Fptr: *mut FITSfile, status: *mut c_int) -> c_int {
     // FFI WRAPPER
     unsafe {
         let lock = FFLOCK();
@@ -1910,12 +2134,13 @@ pub unsafe extern "C" fn fits_clear_Fptr(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 ///  clear the Fptr address from the Fptr Table  
-fn fits_clear_Fptr_safer(
-    Fptr: *mut FITSfile, /* O - FITS file pointer               */
-    status: &mut c_int,  /* IO - error status                   */
-) -> c_int {
+///
+/// # Parameters
+///
+/// * `Fptr`   — (O) FITS file pointer
+/// * `status` — (IO) error status
+fn fits_clear_Fptr_safer(Fptr: *mut FITSfile, status: &mut c_int) -> c_int {
     let lock = FFLOCK();
     for ii in 0..NMAXFILES {
         unsafe {
@@ -1929,7 +2154,6 @@ fn fits_clear_Fptr_safer(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Check if the file to be opened is already open.  If so, then attach to it.
 ///
 /// the input strings must not exceed the standard lengths
@@ -1945,8 +2169,16 @@ fn fits_clear_Fptr_safer(
 /// version of this function would not have reconized that the two files
 /// were the same. This version does recognize that the two files are
 /// the same.
+///
+/// # Parameters
+///
+/// * `fptr`     — I/O - FITS file pointer
+/// * `mode`     — (I) 0 = open readonly; 1 = read/write
+/// * `noextsyn` — (I) 0 = ext syntax may be used; 1 = ext syntax disabled
+/// * `isopen`   — (O) 1 = file is already open
+/// * `status`   — (IO) error status
 pub(crate) fn fits_already_open(
-    fptr: &mut Option<Box<fitsfile>>, /* I/O - FITS file pointer       */
+    fptr: &mut Option<Box<fitsfile>>,
     url: &[c_char],
     urltype: &mut [c_char],
     infile: &mut [c_char],
@@ -1954,10 +2186,10 @@ pub(crate) fn fits_already_open(
     rowfilter: &mut [c_char],
     binspec: &mut [c_char],
     colspec: &mut [c_char],
-    mode: c_int,        /* I - 0 = open readonly; 1 = read/write   */
-    noextsyn: bool,     /* I - 0 = ext syntax may be used; 1 = ext syntax disabled */
-    isopen: &mut c_int, /* O - 1 = file is already open            */
-    status: &mut c_int, /* IO - error status                       */
+    mode: c_int,
+    noextsyn: bool,
+    isopen: &mut c_int,
+    status: &mut c_int,
 ) -> c_int {
     let mut iMatch = None;
     let mut oldurltype: [c_char; MAX_PREFIX_LEN] = [0; MAX_PREFIX_LEN];
@@ -2156,7 +2388,6 @@ pub(crate) fn fits_already_open(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 pub(crate) fn check_is_file_fits(fp: &mut File) -> c_int {
     const NBYTES: usize = 1000;
     let mut buf: [c_char; NBYTES] = [0; NBYTES];
@@ -2180,7 +2411,6 @@ pub(crate) fn check_is_file_fits(fp: &mut File) -> c_int {
 
     check_is_mem_fits(&buf, nread)
 }
-/*--------------------------------------------------------------------------*/
 pub(crate) fn check_is_mem_fits(inputmem: &[c_char], len: usize) -> c_int {
     let mut isFits = 0;
 
@@ -2220,7 +2450,6 @@ pub(crate) fn check_is_mem_fits(inputmem: &[c_char], len: usize) -> c_int {
     isFits
 }
 
-/*--------------------------------------------------------------------------*/
 /// Utility function for common operation in fits_already_open
 /// fullpath:  I/O string to be standardized. Assume len = FLEN_FILENAME
 fn standardize_path(fullpath: &mut [c_char], status: &mut c_int) -> c_int {
@@ -2248,7 +2477,6 @@ fn standardize_path(fullpath: &mut [c_char], status: &mut c_int) -> c_int {
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// This differs from the standardize_path utility function in that this is
 /// intended to perform '/./' and '/../' conversion for both absolute and relative
 /// input paths. standardize_path only operates on relative input paths.
@@ -2279,7 +2507,6 @@ fn normalize_path(fullpath: &mut [c_char], status: &mut c_int) -> c_int {
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 fn exclude_path(testpath: &[c_char]) -> c_int {
     const NEXCLUDE: usize = 2;
     let excludeStrs: [&[c_char]; NEXCLUDE] = [cs!(c"/etc/"), cs!(c"/var/")];
@@ -2309,7 +2536,6 @@ fn exclude_path(testpath: &[c_char]) -> c_int {
     }
     exclude
 }
-/*--------------------------------------------------------------------------*/
 fn skip_host_string(testpath: &[c_char]) -> &[c_char] {
     if strlen_safe(testpath) < 2 || testpath[0] == bb(b'~') || testpath[0] == bb(b'/') {
         return testpath;
@@ -2347,7 +2573,6 @@ fn skip_host_string(testpath: &[c_char]) -> &[c_char] {
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// specialized routine that returns 1 if the file is known to be a temporary
 /// copy of the originally opened file.  Otherwise it returns 0.
 pub(crate) fn fits_is_this_a_copy(urltype: [c_char; 20] /* I - type of file */) -> c_int {
@@ -2372,7 +2597,6 @@ pub(crate) fn fits_is_this_a_copy(urltype: [c_char; 20] /* I - type of file */) 
     iscopy
 }
 
-/*--------------------------------------------------------------------------*/
 /// Look for the closing single quote character in the input string
 fn find_quote(string: &[c_char]) -> Option<usize> {
     let mut i = 0;
@@ -2389,7 +2613,6 @@ fn find_quote(string: &[c_char]) -> Option<usize> {
     None /* opps, didn't find the closing character */
 }
 
-/*--------------------------------------------------------------------------*/
 /*
   Find matching delimiter, respecting quoting and (potentially nested) parentheses
 
@@ -2413,7 +2636,6 @@ pub(crate) fn fits_find_match_delim(string: &[c_char], delim: c_char) -> Option<
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Look for the closing double quote character in the input string
 fn find_doublequote(string: &[c_char]) -> Option<usize> {
     let mut i = 0;
@@ -2430,7 +2652,6 @@ fn find_doublequote(string: &[c_char]) -> Option<usize> {
     None /* opps, didn't find the closing character */
 }
 
-/*--------------------------------------------------------------------------*/
 /// look for the closing parenthesis character in the input string
 fn find_paren(string: &[c_char]) -> Option<usize> {
     let mut i = 0;
@@ -2468,7 +2689,6 @@ fn find_paren(string: &[c_char]) -> Option<usize> {
     None /* opps, didn't find the closing character */
 }
 
-/*--------------------------------------------------------------------------*/
 /// look for the closing bracket character in the input string
 fn find_bracket(string: &[c_char]) -> Option<usize> {
     let mut i = 0;
@@ -2506,7 +2726,6 @@ fn find_bracket(string: &[c_char]) -> Option<usize> {
     None /* opps, didn't find the closing character */
 }
 
-/*--------------------------------------------------------------------------*/
 /// look for the closing curly bracket character in the input string
 fn find_curlybracket(string: &[c_char]) -> Option<usize> {
     let mut i = 0;
@@ -2544,7 +2763,6 @@ fn find_curlybracket(string: &[c_char]) -> Option<usize> {
     None /* opps, didn't find the closing character */
 }
 
-/*--------------------------------------------------------------------------*/
 /// replace commas with semicolons, unless the comma is within a quoted or bracketed expression
 fn comma2semicolon(string: &mut [c_char]) -> c_int {
     let mut i = 0;
@@ -2600,13 +2818,18 @@ fn comma2semicolon(string: &mut [c_char]) -> c_int {
     0 /* reached end of string */
 }
 
-/*--------------------------------------------------------------------------*/
 /// modify columns in a table and/or header keywords in the HDU
+///
+/// # Parameters
+///
+/// * `infptr`  — (IO) pointer to input table; on output it
+/// * `outfile` — (I) name for output file
+/// * `expr`    — (I) column edit expression
 pub(crate) fn ffedit_columns(
-    infptr: &mut Option<Box<fitsfile>>, /* IO - pointer to input table; on output it  */
+    infptr: &mut Option<Box<fitsfile>>,
     /*      points to the new selected rows table */
-    outfile: &[c_char],  /* I - name for output file */
-    expr: &mut [c_char], /* I - column edit expression    */
+    outfile: &[c_char],
+    expr: &mut [c_char],
     status: &mut c_int,
 ) -> c_int {
     let mut newptr: Option<Box<fitsfile>> = None;
@@ -3322,19 +3545,26 @@ pub(crate) fn ffedit_columns(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy a table cell of a given row and column into an image extension.
 /// The output file must already have been created.  A new image
 /// extension will be created in that file.
 ///
 /// This routine was written by Craig Markwardt, GSFC
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) point to input table
+/// * `newptr`  — (O) existing output file; new image HDU will be appended to it
+/// * `colname` — (I) column name / number containing the image
+/// * `rownum`  — (I) number of the row containing the image
+/// * `status`  — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn fits_copy_cell2image(
-    fptr: *mut fitsfile,                  /* I - point to input table */
-    newptr: *mut fitsfile, /* O - existing output file; new image HDU will be appended to it */
-    colname: *const [c_char; FLEN_VALUE], /* I - column name / number containing the image*/
-    rownum: c_long,        /* I - number of the row containing the image */
-    status: *mut c_int,    /* IO - error status */
+    fptr: *mut fitsfile,
+    newptr: *mut fitsfile,
+    colname: *const [c_char; FLEN_VALUE],
+    rownum: c_long,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -3348,18 +3578,25 @@ pub unsafe extern "C" fn fits_copy_cell2image(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy a table cell of a given row and column into an image extension.
 /// The output file must already have been created.  A new image
 /// extension will be created in that file.
 ///
 /// This routine was written by Craig Markwardt, GSFC
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) point to input table
+/// * `newptr`  — (O) existing output file; new image HDU will be appended to it
+/// * `colname` — (I) column name / number containing the image
+/// * `rownum`  — (I) number of the row containing the image
+/// * `status`  — (IO) error status
 pub fn fits_copy_cell2image_safe(
-    fptr: &mut fitsfile,   /* I - point to input table */
-    newptr: &mut fitsfile, /* O - existing output file; new image HDU will be appended to it */
-    colname: &[c_char],    /* I - column name / number containing the image*/
-    rownum: c_long,        /* I - number of the row containing the image */
-    status: &mut c_int,    /* IO - error status */
+    fptr: &mut fitsfile,
+    newptr: &mut fitsfile,
+    colname: &[c_char],
+    rownum: c_long,
+    status: &mut c_int,
 ) -> c_int {
     let mut buffer: [u8; 30000] = [0; 30000];
     let mut hdutype: c_int = 0;
@@ -3476,9 +3713,7 @@ pub fn fits_copy_cell2image_safe(
         return *status;
     }
 
-    /*---------------------------------------------------*/
     /*  Check input and get parameters about the column: */
-    /*---------------------------------------------------*/
     if ffgcprll(
         fptr,
         colnum,
@@ -3620,7 +3855,6 @@ pub fn fits_copy_cell2image_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy an image extension into a table cell at a given row and
 /// column.  The table must have already been created.  If the "colname"
 /// column exists, it will be used, otherwise a new column will be created
@@ -3634,14 +3868,23 @@ pub fn fits_copy_cell2image_safe(
 /// copykeyflag = 2  -- copy only the WCS related keywords
 ///
 /// This routine was written by Craig Markwardt, GSFC
+///
+/// # Parameters
+///
+/// * `fptr`        — (I) pointer to input image extension
+/// * `newptr`      — (I) pointer to output table
+/// * `colname`     — (I) name of column containing the image
+/// * `rownum`      — (I) number of the row containing the image
+/// * `copykeyflag` — (I) controls which keywords to copy
+/// * `status`      — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn fits_copy_image2cell(
-    fptr: *mut fitsfile,    /* I - pointer to input image extension */
-    newptr: *mut fitsfile,  /* I - pointer to output table */
-    colname: *const c_char, /* I - name of column containing the image    */
-    rownum: c_long,         /* I - number of the row containing the image */
-    copykeyflag: c_int,     /* I - controls which keywords to copy */
-    status: *mut c_int,     /* IO - error status */
+    fptr: *mut fitsfile,
+    newptr: *mut fitsfile,
+    colname: *const c_char,
+    rownum: c_long,
+    copykeyflag: c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -3654,7 +3897,6 @@ pub unsafe extern "C" fn fits_copy_image2cell(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy an image extension into a table cell at a given row and
 /// column.  The table must have already been created.  If the "colname"
 /// column exists, it will be used, otherwise a new column will be created
@@ -3668,13 +3910,22 @@ pub unsafe extern "C" fn fits_copy_image2cell(
 /// copykeyflag = 2  -- copy only the WCS related keywords
 ///
 /// This routine was written by Craig Markwardt, GSFC
+///
+/// # Parameters
+///
+/// * `fptr`        — (I) pointer to input image extension
+/// * `newptr`      — (I) pointer to output table
+/// * `colname`     — (I) name of column containing the image
+/// * `rownum`      — (I) number of the row containing the image
+/// * `copykeyflag` — (I) controls which keywords to copy
+/// * `status`      — (IO) error status
 pub fn fits_copy_image2cell_safe(
-    fptr: &mut fitsfile,   /* I - pointer to input image extension */
-    newptr: &mut fitsfile, /* I - pointer to output table */
-    colname: &[c_char],    /* I - name of column containing the image */
-    rownum: c_long,        /* I - number of the row containing the image */
-    copykeyflag: c_int,    /* I - controls which keywords to copy */
-    status: &mut c_int,    /* IO - error status */
+    fptr: &mut fitsfile,
+    newptr: &mut fitsfile,
+    colname: &[c_char],
+    rownum: c_long,
+    copykeyflag: c_int,
+    status: &mut c_int,
 ) -> c_int {
     let mut buffer: [u8; 30000] = [0; 30000];
     let mut hdutype: c_int = 0;
@@ -3987,16 +4238,21 @@ pub fn fits_copy_image2cell_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// copies an image section from the input file to a new output file.
 /// Any HDUs preceding or following the image are also copied to the
 /// output file.
+///
+/// # Parameters
+///
+/// * `fptr`    — (IO) pointer to input image; on output it
+/// * `outfile` — (I) name for output file
+/// * `expr`    — (I) Image section expression
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn fits_select_image_section(
-    fptr: *mut Option<Box<fitsfile>>, /* IO - pointer to input image; on output it  */
+    fptr: *mut Option<Box<fitsfile>>,
     /*      points to the new subimage */
-    outfile: *const c_char, /* I - name for output file        */
-    expr: *const c_char,    /* I - Image section expression    */
+    outfile: *const c_char,
+    expr: *const c_char,
     status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
@@ -4011,15 +4267,20 @@ pub unsafe extern "C" fn fits_select_image_section(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// copies an image section from the input file to a new output file.
 /// Any HDUs preceding or following the image are also copied to the
 /// output file.
+///
+/// # Parameters
+///
+/// * `fptr`    — (IO) pointer to input image; on output it
+/// * `outfile` — (I) name for output file
+/// * `expr`    — (I) Image section expression
 pub fn fits_select_image_section_safe(
-    fptr: &mut Option<Box<fitsfile>>, /* IO - pointer to input image; on output it  */
+    fptr: &mut Option<Box<fitsfile>>,
     /*      points to the new subimage */
-    outfile: &[c_char], /* I - name for output file        */
-    expr: &[c_char],    /* I - Image section expression    */
+    outfile: &[c_char],
+    expr: &[c_char],
     status: &mut c_int,
 ) -> c_int {
     let mut newptr: Option<Box<fitsfile>> = None;
@@ -4119,13 +4380,18 @@ pub fn fits_select_image_section_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// copies an image section from the input file to a new output HDU
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) pointer to input image
+/// * `newptr` — (I) pointer to output image
+/// * `expr`   — (I) Image section expression
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn fits_copy_image_section(
-    fptr: *mut fitsfile,   /* I - pointer to input image */
-    newptr: *mut fitsfile, /* I - pointer to output image */
-    expr: *const c_char,   /* I - Image section expression    */
+    fptr: *mut fitsfile,
+    newptr: *mut fitsfile,
+    expr: *const c_char,
     status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
@@ -4140,12 +4406,17 @@ pub unsafe extern "C" fn fits_copy_image_section(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// copies an image section from the input file to a new output HDU
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) pointer to input image
+/// * `newptr` — (I) pointer to output image
+/// * `expr`   — (I) Image section expression
 pub fn fits_copy_image_section_safer(
-    fptr: &mut fitsfile,   /* I - pointer to input image */
-    newptr: &mut fitsfile, /* I - pointer to output image */
-    expr: &[c_char],       /* I - Image section expression    */
+    fptr: &mut fitsfile,
+    newptr: &mut fitsfile,
+    expr: &[c_char],
     status: &mut c_int,
 ) -> c_int {
     let mut bitpix: c_int = 0;
@@ -4618,7 +4889,6 @@ pub fn fits_copy_image_section_safer(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Parse the input image section specification string, returning
 /// the  min, max and increment values.
 /// Typical string =   "1:512:2"  or "1:512"
@@ -4652,9 +4922,14 @@ pub unsafe extern "C" fn fits_get_section_range(
 /// Parse the input image section specification string, returning
 /// the  min, max and increment values.
 /// Typical string =   "1:512:2"  or "1:512"
+///
+/// # Parameters
+///
+/// * `ptr`       — (I) the image section specifier string
+/// * `ptr_index` — (IO) current parse offset into ptr; advanced
 pub fn fits_get_section_range_safe(
-    ptr: &[c_char],        /* I - the image section specifier string         */
-    ptr_index: &mut usize, /* IO - current parse offset into ptr; advanced   */
+    ptr: &[c_char],
+    ptr_index: &mut usize,
     secmin: &mut c_long,
     secmax: &mut c_long,
     incre: &mut c_long,
@@ -4784,12 +5059,16 @@ pub fn fits_get_section_range_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
+/// # Parameters
+///
+/// * `fptr`    — (IO) pointer to input table; on output it
+/// * `outfile` — (I) name for output file
+/// * `expr`    — (I) Boolean expression
 pub(crate) fn ffselect_table(
-    fptr: &mut Option<Box<fitsfile>>, /* IO - pointer to input table; on output it  */
+    fptr: &mut Option<Box<fitsfile>>,
     /*      points to the new selected rows table */
-    outfile: &[c_char; FLEN_FILENAME], /* I - name for output file */
-    expr: &[c_char; FLEN_FILENAME],    /* I - Boolean expression    */
+    outfile: &[c_char; FLEN_FILENAME],
+    expr: &[c_char; FLEN_FILENAME],
     status: &mut c_int,
 ) -> c_int {
     let mut newptr: Option<Box<fitsfile>> = None;
@@ -4934,11 +5213,10 @@ pub(crate) fn ffselect_table(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Parse the image compression specification that was give in square brackets
 /// following the output FITS file name, as in these examples:
 ///
-///   myfile.fits[compress]  - default Rice compression, row by row
+///   `myfile.fits[compress]`  - default Rice compression, row by row
 ///   myfile.fits[compress TYPE] -  the first letter of TYPE defines the
 ///                                 compression algorithm:
 ///                                  R = Rice
@@ -4961,10 +5239,16 @@ pub(crate) fn ffselect_table(
 ///
 /// The compression parameters are saved in the fptr->Fptr structure for use
 /// when writing FITS images.
+///
+/// # Parameters
+///
+/// * `fptr`     — (I) FITS file pointer
+/// * `compspec` — (I) image compression specification
+/// * `status`   — (IO) error status
 pub(crate) fn ffparsecompspec(
-    fptr: &mut fitsfile, /* I - FITS file pointer               */
-    compspec: &[c_char], /* I - image compression specification */
-    status: &mut c_int,  /* IO - error status                       */
+    fptr: &mut fitsfile,
+    compspec: &[c_char],
+    status: &mut c_int,
 ) -> c_int {
     /* the C walks `compspec` with a `char *ptr1`; we use an index instead */
     let mut ptr1: usize;
@@ -5154,16 +5438,21 @@ pub(crate) fn ffparsecompspec(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Create and initialize a new FITS file on disk.  This routine differs
 /// from ffinit in that the input 'name' is literally taken as the name
 /// of the disk file to be created, and it does not support CFITSIO's
 /// extended filename syntax.
+///
+/// # Parameters
+///
+/// * `fptr`   — (O) FITS file pointer
+/// * `name`   — (I) name of file to create
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffdkinit(
-    fptr: *mut Option<Box<fitsfile>>, /* O - FITS file pointer                   */
-    name: *const c_char,              /* I - name of file to create              */
-    status: *mut c_int,               /* IO - error status                       */
+    fptr: *mut Option<Box<fitsfile>>,
+    name: *const c_char,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -5175,10 +5464,15 @@ pub unsafe extern "C" fn ffdkinit(
     }
 }
 
+/// # Parameters
+///
+/// * `fptr`   — (O) FITS file pointer
+/// * `name`   — (I) name of file to create
+/// * `status` — (IO) error status
 pub fn ffdkinit_safer(
-    fptr: &mut Option<Box<fitsfile>>, /* O - FITS file pointer                   */
-    name: &[c_char],                  /* I - name of file to create              */
-    status: &mut c_int,               /* IO - error status                       */
+    fptr: &mut Option<Box<fitsfile>>,
+    name: &[c_char],
+    status: &mut c_int,
 ) -> c_int {
     /* initialize null file pointer */
     let f_tmp = fptr.take();
@@ -5202,13 +5496,18 @@ pub fn ffdkinit_safer(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Create and initialize a new FITS file.
+///
+/// # Parameters
+///
+/// * `fptr`   — (O) FITS file pointer
+/// * `name`   — (I) name of file to create
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffinit(
-    fptr: *mut Option<Box<fitsfile>>, /* O - FITS file pointer                   */
-    name: *const c_char,              /* I - name of file to create              */
-    status: *mut c_int,               /* IO - error status                       */
+    fptr: *mut Option<Box<fitsfile>>,
+    name: *const c_char,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -5220,13 +5519,14 @@ pub unsafe extern "C" fn ffinit(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Create and initialize a new FITS file.
-pub fn ffinit_safe(
-    fptr: &mut Option<Box<fitsfile>>, /* O - FITS file pointer                   */
-    name: &[c_char],                  /* I - name of file to create              */
-    status: &mut c_int,               /* IO - error status                       */
-) -> c_int {
+///
+/// # Parameters
+///
+/// * `fptr`   — (O) FITS file pointer
+/// * `name`   — (I) name of file to create
+/// * `status` — (IO) error status
+pub fn ffinit_safe(fptr: &mut Option<Box<fitsfile>>, name: &[c_char], status: &mut c_int) -> c_int {
     let mut driver: c_int = 0;
     let mut clobber: c_int = 0;
 
@@ -5431,17 +5731,25 @@ pub fn ffinit_safe(
     *status /* successful return */
 }
 
-/*--------------------------------------------------------------------------*/
 /// ffimem == fits_create_memfile
 /// Create and initialize a new FITS file in memory
+///
+/// # Parameters
+///
+/// * `fptr`        — (O) FITS file pointer
+/// * `buffptr`     — (I) address of memory pointer
+/// * `buffsize`    — (I) size of buffer, in bytes
+/// * `deltasize`   — (I) increment for future realloc's
+/// * `mem_realloc` — function
+/// * `status`      — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffimem(
-    fptr: *mut Option<Box<fitsfile>>, /* O - FITS file pointer                   */
-    buffptr: *mut *mut c_void,        /* I - address of memory pointer           */
-    buffsize: *mut usize,             /* I - size of buffer, in bytes            */
-    deltasize: usize,                 /* I - increment for future realloc's      */
-    mem_realloc: Option<unsafe extern "C" fn(p: *mut c_void, newsize: usize) -> *mut c_void>, /* function       */
-    status: *mut c_int, /* IO - error status                       */
+    fptr: *mut Option<Box<fitsfile>>,
+    buffptr: *mut *mut c_void,
+    buffsize: *mut usize,
+    deltasize: usize,
+    mem_realloc: Option<unsafe extern "C" fn(p: *mut c_void, newsize: usize) -> *mut c_void>,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -5454,15 +5762,23 @@ pub unsafe extern "C" fn ffimem(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Create and initialize a new FITS file in memory
+///
+/// # Parameters
+///
+/// * `fptr`        — (O) FITS file pointer
+/// * `buffptr`     — (I) address of memory pointer
+/// * `buffsize`    — (I) size of buffer, in bytes
+/// * `deltasize`   — (I) increment for future realloc's
+/// * `mem_realloc` — function
+/// * `status`      — (IO) error status
 pub fn ffimem_safer(
-    fptr: &mut Option<Box<fitsfile>>, /* O - FITS file pointer                   */
-    buffptr: *mut *mut c_void,        /* I - address of memory pointer           */
-    buffsize: &mut usize,             /* I - size of buffer, in bytes            */
-    deltasize: usize,                 /* I - increment for future realloc's      */
-    mem_realloc: Option<unsafe extern "C" fn(p: *mut c_void, newsize: usize) -> *mut c_void>, /* function       */
-    status: &mut c_int, /* IO - error status                       */
+    fptr: &mut Option<Box<fitsfile>>,
+    buffptr: *mut *mut c_void,
+    buffsize: &mut usize,
+    deltasize: usize,
+    mem_realloc: Option<unsafe extern "C" fn(p: *mut c_void, newsize: usize) -> *mut c_void>,
+    status: &mut c_int,
 ) -> c_int {
     let mut driver: c_int = 0;
     let mut handle: c_int = 0;
@@ -5501,13 +5817,7 @@ pub fn ffimem_safer(
 
     /* call driver routine to "open" the memory file */
     let lock = FFLOCK(); /* lock this while searching for vacant handle */
-    *status = mem_openmem(
-        buffptr,
-        buffsize,
-        deltasize,
-        mem_realloc,
-        &mut handle,
-    );
+    *status = mem_openmem(buffptr, buffsize, deltasize, mem_realloc, &mut handle);
     FFUNLOCK(lock);
 
     if *status > 0 {
@@ -5576,7 +5886,6 @@ pub fn ffimem_safer(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Initialize anything that is required before using the CFITSIO routines
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn fits_init_cfitsio() -> c_int {
@@ -5584,7 +5893,6 @@ pub unsafe extern "C" fn fits_init_cfitsio() -> c_int {
     fits_init_cfitsio_safer()
 }
 
-/*--------------------------------------------------------------------------*/
 /// Initialize anything that is required before using the CFITSIO routines
 pub fn fits_init_cfitsio_safer() -> c_int {
     pub union u_tag {
@@ -6044,7 +6352,6 @@ pub fn fits_init_cfitsio_safer() -> c_int {
     status
 }
 
-/*--------------------------------------------------------------------------*/
 /// register all the functions needed to support an I/O driver
 pub(crate) fn fits_register_driver(
     drivers: &mut Vec<fitsdriver>,
@@ -6117,20 +6424,30 @@ pub(crate) fn fits_register_driver(
     0
 }
 
-/*--------------------------------------------------------------------------*/
 /// fits_parse_input_url
 /// parse the input URL into its basic components.
 /// This routine does not support the pixfilter or compspec components.
+///
+/// # Parameters
+///
+/// * `url`        — input filename
+/// * `urltype`    — e.g., 'file://', 'http://', 'mem://'
+/// * `infilex`    — root filename (may be complete path)
+/// * `outfile`    — optional output file name
+/// * `extspec`    — extension spec: +n or [extname, extver]
+/// * `rowfilterx` — boolean row filter expression
+/// * `binspec`    — histogram binning specifier
+/// * `colspec`    — column or keyword modifier expression
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffiurl(
-    url: *const c_char,      /* input filename */
-    urltype: *mut c_char,    /* e.g., 'file://', 'http://', 'mem://' */
-    infilex: *mut c_char,    /* root filename (may be complete path) */
-    outfile: *mut c_char,    /* optional output file name            */
-    extspec: *mut c_char,    /* extension spec: +n or [extname, extver]  */
-    rowfilterx: *mut c_char, /* boolean row filter expression */
-    binspec: *mut c_char,    /* histogram binning specifier   */
-    colspec: *mut c_char,    /* column or keyword modifier expression */
+    url: *const c_char,
+    urltype: *mut c_char,
+    infilex: *mut c_char,
+    outfile: *mut c_char,
+    extspec: *mut c_char,
+    rowfilterx: *mut c_char,
+    binspec: *mut c_char,
+    colspec: *mut c_char,
     status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
@@ -6167,19 +6484,29 @@ pub unsafe extern "C" fn ffiurl(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// fits_parse_input_url
 /// parse the input URL into its basic components.
 /// This routine does not support the pixfilter or compspec components.
+///
+/// # Parameters
+///
+/// * `url`        — input filename
+/// * `urltype`    — e.g., 'file://', 'http://', 'mem://'
+/// * `infilex`    — root filename (may be complete path)
+/// * `outfile`    — optional output file name
+/// * `extspec`    — extension spec: +n or [extname, extver]
+/// * `rowfilterx` — boolean row filter expression
+/// * `binspec`    — histogram binning specifier
+/// * `colspec`    — column or keyword modifier expression
 pub fn ffiurl_safe(
-    url: &[c_char],                    /* input filename */
-    urltype: Option<&mut [c_char]>,    /* e.g., 'file://', 'http://', 'mem://' */
-    infilex: Option<&mut [c_char]>,    /* root filename (may be complete path) */
-    outfile: Option<&mut [c_char]>,    /* optional output file name            */
-    extspec: Option<&mut [c_char]>,    /* extension spec: +n or [extname, extver]  */
-    rowfilterx: Option<&mut [c_char]>, /* boolean row filter expression */
-    binspec: Option<&mut [c_char]>,    /* histogram binning specifier   */
-    colspec: Option<&mut [c_char]>,    /* column or keyword modifier expression */
+    url: &[c_char],
+    urltype: Option<&mut [c_char]>,
+    infilex: Option<&mut [c_char]>,
+    outfile: Option<&mut [c_char]>,
+    extspec: Option<&mut [c_char]>,
+    rowfilterx: Option<&mut [c_char]>,
+    binspec: Option<&mut [c_char]>,
+    colspec: Option<&mut [c_char]>,
     status: &mut c_int,
 ) -> c_int {
     ffifile2_safe(
@@ -6187,21 +6514,32 @@ pub fn ffiurl_safe(
     )
 }
 
-/*--------------------------------------------------------------------------*/
 /// fits_parse_input_filename
 /// parse the input URL into its basic components.
 /// This routine does not support the compspec component.
+///
+/// # Parameters
+///
+/// * `url`        — input filename
+/// * `urltype`    — e.g., 'file://', 'http://', 'mem://'
+/// * `infilex`    — root filename (may be complete path)
+/// * `outfile`    — optional output file name
+/// * `extspec`    — extension spec: +n or [extname, extver]
+/// * `rowfilterx` — boolean row filter expression
+/// * `binspec`    — histogram binning specifier
+/// * `colspec`    — column or keyword modifier expression
+/// * `pixfilter`  — pixel filter expression
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffifile(
-    url: *const c_char,      /* input filename */
-    urltype: *mut c_char,    /* e.g., 'file://', 'http://', 'mem://' */
-    infilex: *mut c_char,    /* root filename (may be complete path) */
-    outfile: *mut c_char,    /* optional output file name            */
-    extspec: *mut c_char,    /* extension spec: +n or [extname, extver]  */
-    rowfilterx: *mut c_char, /* boolean row filter expression */
-    binspec: *mut c_char,    /* histogram binning specifier   */
-    colspec: *mut c_char,    /* column or keyword modifier expression */
-    pixfilter: *mut c_char,  /* pixel filter expression */
+    url: *const c_char,
+    urltype: *mut c_char,
+    infilex: *mut c_char,
+    outfile: *mut c_char,
+    extspec: *mut c_char,
+    rowfilterx: *mut c_char,
+    binspec: *mut c_char,
+    colspec: *mut c_char,
+    pixfilter: *mut c_char,
     status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
@@ -6241,16 +6579,27 @@ pub unsafe extern "C" fn ffifile(
     }
 }
 
+/// # Parameters
+///
+/// * `url`        — input filename
+/// * `urltype`    — e.g., 'file://', 'http://', 'mem://'
+/// * `infilex`    — root filename (may be complete path)
+/// * `outfile`    — optional output file name
+/// * `extspec`    — extension spec: +n or [extname, extver]
+/// * `rowfilterx` — boolean row filter expression
+/// * `binspec`    — histogram binning specifier
+/// * `colspec`    — column or keyword modifier expression
+/// * `pixfilter`  — pixel filter expression
 pub fn ffifile_safe(
-    url: &[c_char],                    /* input filename */
-    urltype: Option<&mut [c_char]>,    /* e.g., 'file://', 'http://', 'mem://' */
-    infilex: Option<&mut [c_char]>,    /* root filename (may be complete path) */
-    outfile: Option<&mut [c_char]>,    /* optional output file name            */
-    extspec: Option<&mut [c_char]>,    /* extension spec: +n or [extname, extver]  */
-    rowfilterx: Option<&mut [c_char]>, /* boolean row filter expression */
-    binspec: Option<&mut [c_char]>,    /* histogram binning specifier   */
-    colspec: Option<&mut [c_char]>,    /* column or keyword modifier expression */
-    pixfilter: Option<&mut [c_char]>,  /* pixel filter expression */
+    url: &[c_char],
+    urltype: Option<&mut [c_char]>,
+    infilex: Option<&mut [c_char]>,
+    outfile: Option<&mut [c_char]>,
+    extspec: Option<&mut [c_char]>,
+    rowfilterx: Option<&mut [c_char]>,
+    binspec: Option<&mut [c_char]>,
+    colspec: Option<&mut [c_char]>,
+    pixfilter: Option<&mut [c_char]>,
     status: &mut c_int,
 ) -> c_int {
     ffifile2_safe(
@@ -6259,22 +6608,34 @@ pub fn ffifile_safe(
     )
 }
 
-/*--------------------------------------------------------------------------*/
 /// fits_parse_input_filename
 /// parse the input URL into its basic components.
 /// This routine is big and ugly and should be redesigned someday!
+///
+/// # Parameters
+///
+/// * `url`        — input filename
+/// * `urltype`    — e.g., 'file://', 'http://', 'mem://'
+/// * `infilex`    — root filename (may be complete path)
+/// * `outfile`    — optional output file name
+/// * `extspec`    — extension spec: +n or [extname, extver]
+/// * `rowfilterx` — boolean row filter expression
+/// * `binspec`    — histogram binning specifier
+/// * `colspec`    — column or keyword modifier expression
+/// * `pixfilter`  — pixel filter expression
+/// * `compspec`   — image compression specification
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffifile2(
-    url: *const c_char,      /* input filename */
-    urltype: *mut c_char,    /* e.g., 'file://', 'http://', 'mem://' */
-    infilex: *mut c_char,    /* root filename (may be complete path) */
-    outfile: *mut c_char,    /* optional output file name            */
-    extspec: *mut c_char,    /* extension spec: +n or [extname, extver]  */
-    rowfilterx: *mut c_char, /* boolean row filter expression */
-    binspec: *mut c_char,    /* histogram binning specifier   */
-    colspec: *mut c_char,    /* column or keyword modifier expression */
-    pixfilter: *mut c_char,  /* pixel filter expression */
-    compspec: *mut c_char,   /* image compression specification */
+    url: *const c_char,
+    urltype: *mut c_char,
+    infilex: *mut c_char,
+    outfile: *mut c_char,
+    extspec: *mut c_char,
+    rowfilterx: *mut c_char,
+    binspec: *mut c_char,
+    colspec: *mut c_char,
+    pixfilter: *mut c_char,
+    compspec: *mut c_char,
     status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
@@ -6317,7 +6678,6 @@ pub unsafe extern "C" fn ffifile2(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// fits_parse_input_filename
 /// Parse the input filename or URL into its component parts, namely:
 /// the file type (file://, ftp://, http://, etc),
@@ -6329,17 +6689,30 @@ pub unsafe extern "C" fn ffifile2(
 /// the column specifier,
 /// and the image pixel filtering specifier.
 /// A null pointer (0) may be be specified for any of the output string arguments that are not needed. Null strings will be returned for any components that are not present in the input file name. The calling routine must allocate sufficient memory to hold the returned character strings. Allocating the string lengths equal to FLEN_FILENAME is guaranteed to be safe. These routines are mainly for internal use by other CFITSIO routines.
+///
+/// # Parameters
+///
+/// * `url`        — input filename
+/// * `urltype`    — e.g., 'file://', 'http://', 'mem://'
+/// * `infilex`    — root filename (may be complete path)
+/// * `outfile`    — optional output file name
+/// * `extspec`    — extension spec: +n or [extname, extver]
+/// * `rowfilterx` — boolean row filter expression
+/// * `binspec`    — histogram binning specifier
+/// * `colspec`    — column or keyword modifier expression
+/// * `pixfilter`  — pixel filter expression
+/// * `compspec`   — image compression specification
 pub fn ffifile2_safe(
-    url: &[c_char],                        /* input filename */
-    mut urltype: Option<&mut [c_char]>,    /* e.g., 'file://', 'http://', 'mem://' */
-    mut infilex: Option<&mut [c_char]>,    /* root filename (may be complete path) */
-    mut outfile: Option<&mut [c_char]>,    /* optional output file name            */
-    mut extspec: Option<&mut [c_char]>,    /* extension spec: +n or [extname, extver]  */
-    mut rowfilterx: Option<&mut [c_char]>, /* boolean row filter expression */
-    mut binspec: Option<&mut [c_char]>,    /* histogram binning specifier   */
-    mut colspec: Option<&mut [c_char]>,    /* column or keyword modifier expression */
-    mut pixfilter: Option<&mut [c_char]>,  /* pixel filter expression */
-    mut compspec: Option<&mut [c_char]>,   /* image compression specification */
+    url: &[c_char],
+    mut urltype: Option<&mut [c_char]>,
+    mut infilex: Option<&mut [c_char]>,
+    mut outfile: Option<&mut [c_char]>,
+    mut extspec: Option<&mut [c_char]>,
+    mut rowfilterx: Option<&mut [c_char]>,
+    mut binspec: Option<&mut [c_char]>,
+    mut colspec: Option<&mut [c_char]>,
+    mut pixfilter: Option<&mut [c_char]>,
+    mut compspec: Option<&mut [c_char]>,
     status: &mut c_int,
 ) -> c_int {
     let mut infilelen = 0;
@@ -7500,19 +7873,24 @@ pub fn ffifile2_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// test if the input file specifier is an existing file on disk
 /// If the specified file can't be found, it then searches for a
 /// compressed version of the file.
+///
+/// # Parameters
+///
+/// * `infile` — (I) input filename or URL
+/// * `exists` — (O) 2 = a compressed version of file exists
+/// * `status` — I/O status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffexist(
-    infile: *const c_char, /* I - input filename or URL */
-    exists: *mut c_int,    /* O -  2 = a compressed version of file exists */
+    infile: *const c_char,
+    exists: *mut c_int,
     /*      1 = yes, disk file exists               */
     /*      0 = no, disk file could not be found    */
     /*     -1 = infile is not a disk file (could    */
     /*   be a http, ftp, gsiftp, smem, or stdin file) */
-    status: *mut c_int, /* I/O  status  */
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -7524,18 +7902,23 @@ pub unsafe extern "C" fn ffexist(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// test if the input file specifier is an existing file on disk
 /// If the specified file can't be found, it then searches for a
 /// compressed version of the file.
+///
+/// # Parameters
+///
+/// * `infile` — (I) input filename or URL
+/// * `exists` — (O) 2 = a compressed version of file exists
+/// * `status` — I/O - error status
 pub fn ffexist_safer(
-    infile: &[c_char],  /* I - input filename or URL */
-    exists: &mut c_int, /* O -  2 = a compressed version of file exists */
+    infile: &[c_char],
+    exists: &mut c_int,
     /*      1 = yes, disk file exists               */
     /*      0 = no, disk file could not be found    */
     /*     -1 = infile is not a disk file (could    */
     /*   be a http, ftp, gsiftp, smem, or stdin file) */
-    status: &mut c_int, /* I/O - error status */
+    status: &mut c_int,
 ) -> c_int {
     let mut rootname: [c_char; FLEN_FILENAME] = [0; FLEN_FILENAME];
 
@@ -7585,7 +7968,6 @@ pub fn ffexist_safer(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// parse the input URL, returning the root name (filetype://basename).
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffrtnm(
@@ -7604,7 +7986,6 @@ pub unsafe extern "C" fn ffrtnm(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// parse the input URL, returning the root name (filetype://basename).
 pub fn ffrtnm_safe(url: &[c_char], rootname: &mut [c_char], status: &mut c_int) -> c_int {
     let mut ii: isize;
@@ -7817,14 +8198,21 @@ pub fn ffrtnm_safe(url: &[c_char], rootname: &mut [c_char], status: &mut c_int) 
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// parse the output URL into its basic components.
+///
+/// # Parameters
+///
+/// * `url`      — (I) full input URL
+/// * `urltype`  — (O) url type
+/// * `outfile`  — (O) base file name
+/// * `tpltfile` — (O) template file name, if any
+/// * `compspec` — (O) compression specification, if any
 pub(crate) fn ffourl(
-    url: &[c_char],          /* I - full input URL   */
-    urltype: &mut [c_char],  /* O - url type         */
-    outfile: &mut [c_char],  /* O - base file name   */
-    tpltfile: &mut [c_char], /* O - template file name, if any */
-    compspec: &mut [c_char], /* O - compression specification, if any */
+    url: &[c_char],
+    urltype: &mut [c_char],
+    outfile: &mut [c_char],
+    tpltfile: &mut [c_char],
+    compspec: &mut [c_char],
     status: &mut c_int,
 ) -> c_int {
     if *status > 0 {
@@ -7974,7 +8362,6 @@ pub(crate) fn ffourl(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Parse the input extension specification string, returning either the
 /// extension number or the values of the EXTNAME, EXTVERS, and XTENSION
 /// keywords in desired extension. Also return the name of the column containing
@@ -8024,7 +8411,6 @@ pub unsafe extern "C" fn ffexts(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Parse the input extension specification string, returning either the
 /// extension number or the values of the EXTNAME, EXTVERS, and XTENSION
 /// keywords in desired extension. Also return the name of the column containing
@@ -8261,7 +8647,6 @@ pub fn ffexts_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Parse the input url string and return the number of the extension that
 /// CFITSIO would automatically move to if CFITSIO were to open this input URL.
 /// The extension numbers are one's based, so 1 = the primary array, 2 = the
@@ -8277,11 +8662,11 @@ pub fn ffexts_safe(
 ///    within a single cell of a binary table is opened.
 ///
 /// 2.  Else if the input URL specifies an extension number (e.g.,
-///     'myfile.fits[3]' or 'myfile.fits+3') then the specified extension
+///     `myfile.fits[3]` or `myfile.fits+3`) then the specified extension
 ///     number (+ 1) is returned.  
 ///
 /// 3.  Else if the extension name is specified in brackets
-///     (e.g., this 'myfile.fits[EVENTS]') then the file will be opened and searched
+///     (e.g., this `myfile.fits[EVENTS]`) then the file will be opened and searched
 ///     for the extension number.  If the input URL is '-'  (reading from the stdin
 ///     file stream) this is not possible and an error will be returned.
 ///
@@ -8290,10 +8675,15 @@ pub fn ffexts_safe(
 ///     extension was specified.  This feature is mainly for compatibility with
 ///     existing FTOOLS software.  CFITSIO would open the primary array by default
 ///     (extension_num = 1) in this case.
+///
+/// # Parameters
+///
+/// * `url`           — (I) input filename/URL
+/// * `extension_num` — (O) returned extension number
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffextn(
-    url: *const c_char,        /* I - input filename/URL  */
-    extension_num: *mut c_int, /* O - returned extension number */
+    url: *const c_char,
+    extension_num: *mut c_int,
     status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
@@ -8307,7 +8697,6 @@ pub unsafe extern "C" fn ffextn(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Parse the input url string and return the number of the extension that
 /// CFITSIO would automatically move to if CFITSIO were to open this input URL.
 /// The extension numbers are one's based, so 1 = the primary array, 2 = the
@@ -8323,11 +8712,11 @@ pub unsafe extern "C" fn ffextn(
 ///    within a single cell of a binary table is opened.
 ///
 /// 2.  Else if the input URL specifies an extension number (e.g.,
-///     'myfile.fits[3]' or 'myfile.fits+3') then the specified extension
+///     `myfile.fits[3]` or `myfile.fits+3`) then the specified extension
 ///     number (+ 1) is returned.  
 ///
 /// 3.  Else if the extension name is specified in brackets
-///     (e.g., this 'myfile.fits[EVENTS]') then the file will be opened and searched
+///     (e.g., this `myfile.fits[EVENTS]`) then the file will be opened and searched
 ///     for the extension number.  If the input URL is '-'  (reading from the stdin
 ///     file stream) this is not possible and an error will be returned.
 ///
@@ -8336,11 +8725,12 @@ pub unsafe extern "C" fn ffextn(
 ///     extension was specified.  This feature is mainly for compatibility with
 ///     existing FTOOLS software.  CFITSIO would open the primary array by default
 ///     (extension_num = 1) in this case.
-pub fn ffextn_safer(
-    url: &[c_char],            /* I - input filename/URL  */
-    extension_num: &mut c_int, /* O - returned extension number */
-    status: &mut c_int,
-) -> c_int {
+///
+/// # Parameters
+///
+/// * `url`           — (I) input filename/URL
+/// * `extension_num` — (O) returned extension number
+pub fn ffextn_safer(url: &[c_char], extension_num: &mut c_int, status: &mut c_int) -> c_int {
     let mut fptr: Option<Box<fitsfile>> = None;
     let mut urltype: [c_char; 20] = [0; 20];
     let mut infile: [c_char; FLEN_FILENAME] = [0; FLEN_FILENAME];
@@ -8461,7 +8851,6 @@ pub fn ffextn_safer(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// return the prefix string associated with the driver in use by the
 /// fitsfile pointer fptr
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
@@ -8480,7 +8869,6 @@ pub unsafe extern "C" fn ffurlt(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// return the prefix string associated with the driver in use by the
 /// fitsfile pointer fptr
 pub fn ffurlt_safe(fptr: &fitsfile, urlType: &mut [c_char], status: &mut c_int) -> c_int {
@@ -8491,17 +8879,22 @@ pub fn ffurlt_safe(fptr: &fitsfile, urlType: &mut [c_char], status: &mut c_int) 
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read and concatenate all the lines from the given text file.  User
 /// must free the pointer returned in contents.  Pointer is guaranteed
 /// to hold 2 characters more than the length of the text... allows the
 /// calling routine to append (or prepend) a newline (or quotes?) without
 /// reallocating memory.
+///
+/// # Parameters
+///
+/// * `filename` — Text file to read
+/// * `contents` — Pointer to pointer to hold file
+/// * `status`   — CFITSIO error code
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffimport_file(
-    filename: *const c_char,    /* Text file to read                   */
-    contents: *mut *mut c_char, /* Pointer to pointer to hold file     */
-    status: *mut c_int,         /* CFITSIO error code                  */
+    filename: *const c_char,
+    contents: *mut *mut c_char,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -8523,16 +8916,21 @@ pub unsafe extern "C" fn ffimport_file(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read and concatenate all the lines from the given text file.  User
 /// must free the pointer returned in contents.  Pointer is guaranteed
 /// to hold 2 characters more than the length of the text... allows the
 /// calling routine to append (or prepend) a newline (or quotes?) without
 /// reallocating memory.
+///
+/// # Parameters
+///
+/// * `filename` — Text file to read
+/// * `contents` — Pointer to pointer to hold file
+/// * `status`   — CFITSIO error code
 pub fn ffimport_file_safe(
-    filename: &[c_char],                /* Text file to read                   */
-    contents: &mut Option<Vec<c_char>>, /* Pointer to pointer to hold file     */
-    status: &mut c_int,                 /* CFITSIO error code                  */
+    filename: &[c_char],
+    contents: &mut Option<Vec<c_char>>,
+    status: &mut c_int,
 ) -> c_int {
     let mut eoline = true;
     let mut line: [c_char; 256] = [0; 256];
@@ -8622,16 +9020,19 @@ pub fn ffimport_file_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// parse off the next token, delimited by a character in 'delimiter',
 /// from the input ptr string;  increment *ptr to the end of the token.
 /// Returns the length of the token, not including the delimiter char;
+///
+/// # Parameters
+///
+/// * `isanumber` — (O) is this token a number?
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn fits_get_token(
     ptr: *mut *mut c_char,
     delimiter: *const c_char,
     token: *mut c_char,
-    isanumber: *mut c_int, /* O - is this token a number? */
+    isanumber: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -8650,17 +9051,20 @@ pub unsafe extern "C" fn fits_get_token(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// parse off the next token, delimited by a character in 'delimiter',
 /// from the input ptr string;  increment *ptr to the end of the token.
 /// Returns the length of the token, not including the delimiter char;
 ///
 /// Safe wrapper for fits_get_token - copies token to provided String buffer
+///
+/// # Parameters
+///
+/// * `isanumber` — (O) is this token a number?
 pub fn fits_get_token_safe(
     ptr: &mut *mut c_char,
     delimiter: &[c_char],
     token: &mut [c_char],
-    isanumber: Option<&mut c_int>, /* O - is this token a number? */
+    isanumber: Option<&mut c_int>,
 ) -> c_int {
     let mut loc: c_char = 0;
     let mut tval: [c_char; 73] = [0; 73];
@@ -8726,18 +9130,21 @@ pub fn fits_get_token_safe(
     slen as c_int
 }
 
-/*--------------------------------------------------------------------------*/
 /// parse off the next token, delimited by a character in 'delimiter',
 /// from the input ptr string;  increment *ptr to the end of the token.
 /// Returns the length of the token, not including the delimiter char;
 ///
 /// This routine allocates the *token string;  the calling routine must free it
+///
+/// # Parameters
+///
+/// * `isanumber` — (O) is this token a number?
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn fits_get_token2(
     ptr: *mut *mut c_char,
     delimiter: *const c_char,
     token: *mut *mut c_char,
-    isanumber: *mut c_int, /* O - is this token a number? */
+    isanumber: *mut c_int,
     status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
@@ -8774,7 +9181,6 @@ pub unsafe extern "C" fn fits_get_token2(
     }
 }
 
-/*---------------------------------------------------------------------------*/
 /// A sequence of calls to fits_split_names will split the input string
 /// into name tokens.  The string typically contains a list of file or
 /// column names.  The names must be delimited by a comma and/or spaces.
@@ -8801,10 +9207,14 @@ pub unsafe extern "C" fn fits_get_token2(
 /// NOTE:  This routine is not thread-safe.  
 /// This routine is simply provided as a utility routine for other external
 /// software. It is not used by any CFITSIO routine.
+///
+/// # Parameters
+///
+/// * `list` — (IO) list of names; the name returned is terminated
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn fits_split_names(
-    list: *mut c_char, /* IO  - list of names; the name returned is terminated */
-                       /*       in place by overwriting its delimiter with a NUL */
+    list: *mut c_char,
+    /*       in place by overwriting its delimiter with a NUL */
 ) -> *mut c_char {
     // FFI WRAPPER
     unsafe { fits_split_names_safer(list) }
@@ -8911,7 +9321,6 @@ pub unsafe fn fits_split_names_safer(list: *mut c_char) -> *mut c_char {
     buf[start..].as_mut_ptr()
 }
 
-/*--------------------------------------------------------------------------*/
 /// compare input URL with list of known drivers, returning the
 /// matching driver numberL.
 pub(crate) fn urltype2driver(urltype: &[c_char], driver: &mut c_int) -> c_int {
@@ -8930,14 +9339,15 @@ pub(crate) fn urltype2driver(urltype: &[c_char], driver: &mut c_int) -> c_int {
     NO_MATCHING_DRIVER
 }
 
-/*--------------------------------------------------------------------------*/
 /// close the FITS file by completing the current HDU, flushing it to disk,
 /// then calling the system dependent routine to physically close the FITS file
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
-pub unsafe extern "C" fn ffclos(
-    fptr: Option<Box<fitsfile>>, /* I - FITS file pointer */
-    status: *mut c_int,          /* IO - error status     */
-) -> c_int {
+pub unsafe extern "C" fn ffclos(fptr: Option<Box<fitsfile>>, status: *mut c_int) -> c_int {
     // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
@@ -8952,7 +9362,6 @@ pub unsafe extern "C" fn ffclos(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// close the FITS file by completing the current HDU, flushing it to disk,
 /// then calling the system dependent routine to physically close the FITS file
 pub fn ffclos_safe(mut fptr: Box<fitsfile>, status: &mut c_int) -> c_int {
@@ -9019,13 +9428,14 @@ pub fn ffclos_safe(mut fptr: Box<fitsfile>, status: &mut c_int) -> c_int {
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// close and DELETE the FITS file.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
-pub unsafe extern "C" fn ffdelt(
-    mut fptr: *mut fitsfile, /* I - FITS file pointer */
-    status: *mut c_int,      /* IO - error status     */
-) -> c_int {
+pub unsafe extern "C" fn ffdelt(mut fptr: *mut fitsfile, status: *mut c_int) -> c_int {
     // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
@@ -9047,12 +9457,13 @@ pub unsafe extern "C" fn ffdelt(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// close and DELETE the FITS file.
-pub fn ffdelt_safe(
-    fptr: &mut Option<Box<fitsfile>>, /* I - FITS file pointer */
-    status: &mut c_int,               /* IO - error status     */
-) -> c_int {
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `status` — (IO) error status
+pub fn ffdelt_safe(fptr: &mut Option<Box<fitsfile>>, status: &mut c_int) -> c_int {
     let mut basename: Vec<c_char> = Vec::new();
     let mut slen: c_int = 0;
     let mut tstatus = NO_CLOSE_ERROR;
@@ -9138,13 +9549,14 @@ pub fn ffdelt_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// low level routine to truncate a file to a new smaller size.
-pub(crate) fn fftrun(
-    fptr: &mut fitsfile, /* I - FITS file pointer           */
-    filesize: LONGLONG,  /* I - size to truncate the file   */
-    status: &mut c_int,  /* O - error status                */
-) -> c_int {
+///
+/// # Parameters
+///
+/// * `fptr`     — (I) FITS file pointer
+/// * `filesize` — (I) size to truncate the file
+/// * `status`   — (O) error status
+pub(crate) fn fftrun(fptr: &mut fitsfile, filesize: LONGLONG, status: &mut c_int) -> c_int {
     //let d = driverTable.lock().unwrap();
     let d = DRIVER_TABLE.get().unwrap();
     let truncate = d[fptr.Fptr.driver as usize].truncate;
@@ -9163,7 +9575,6 @@ pub(crate) fn fftrun(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// low level routine to flush internal file buffers to the file.
 pub(crate) fn ffflushx(fptr: &mut FITSfile, /* I - FITS file pointer                  */) -> c_int {
     let d = DRIVER_TABLE.get().unwrap();
@@ -9174,23 +9585,30 @@ pub(crate) fn ffflushx(fptr: &mut FITSfile, /* I - FITS file pointer            
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// low level routine to seek to a position in a file.
-pub(crate) fn ffseek(
-    fptr: &mut FITSfile, /* I - FITS file pointer              */
-    position: LONGLONG,  /* I - byte position to seek to       */
-) -> c_int {
+///
+/// # Parameters
+///
+/// * `fptr`     — (I) FITS file pointer
+/// * `position` — (I) byte position to seek to
+pub(crate) fn ffseek(fptr: &mut FITSfile, position: LONGLONG) -> c_int {
     let d = DRIVER_TABLE.get().unwrap();
     (d[fptr.driver as usize].seek)(fptr.filehandle, position)
 }
 
-/*--------------------------------------------------------------------------*/
 /// low level routine to write bytes to a file.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `nbytes` — (I) number of bytes to write
+/// * `buffer` — (I) buffer to write
+/// * `status` — (O) error status
 pub(crate) fn ffwrite(
-    fptr: &mut FITSfile, /* I - FITS file pointer              */
-    nbytes: c_long,      /* I - number of bytes to write       */
-    buffer: &[u8],       /* I - buffer to write                */
-    status: &mut c_int,  /* O - error status                   */
+    fptr: &mut FITSfile,
+    nbytes: c_long,
+    buffer: &[u8],
+    status: &mut c_int,
 ) -> c_int {
     {
         let d = DRIVER_TABLE.get().unwrap();
@@ -9204,13 +9622,19 @@ pub(crate) fn ffwrite(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// low level routine to write bytes to a file.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `nbytes` — (I) number of bytes to write
+/// * `nbuff`  — (I) buffer offset to write to
+/// * `status` — (O) error status
 pub(crate) fn ffwrite_int(
-    fptr: &mut FITSfile, /* I - FITS file pointer              */
-    nbytes: usize,       /* I - number of bytes to write       */
-    nbuff: usize,        /* I - buffer offset to write to      */
-    status: &mut c_int,  /* O - error status                   */
+    fptr: &mut FITSfile,
+    nbytes: usize,
+    nbuff: usize,
+    status: &mut c_int,
 ) -> c_int {
     {
         let d = DRIVER_TABLE.get().unwrap();
@@ -9225,13 +9649,19 @@ pub(crate) fn ffwrite_int(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// low level routine to read bytes from a file.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `nbytes` — (I) number of bytes to read
+/// * `buffer` — (O) buffer to read into
+/// * `status` — (O) error status
 pub(crate) fn ffread(
-    fptr: &FITSfile,    /* I - FITS file pointer              */
-    nbytes: c_long,     /* I - number of bytes to read        */
-    buffer: &mut [u8],  /* O - buffer to read into            */
-    status: &mut c_int, /* O - error status                   */
+    fptr: &FITSfile,
+    nbytes: c_long,
+    buffer: &mut [u8],
+    status: &mut c_int,
 ) -> c_int {
     let d = DRIVER_TABLE.get().unwrap();
     let readstatus = (d[fptr.driver as usize].read)(fptr.filehandle, buffer, nbytes as usize);
@@ -9248,13 +9678,19 @@ pub(crate) fn ffread(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// low level routine to read bytes from a file.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `nbytes` — (I) number of bytes to read
+/// * `nbuff`  — (I) buffer offset to read into
+/// * `status` — (O) error status
 pub(crate) fn ffread_int(
-    fptr: &mut FITSfile, /* I - FITS file pointer              */
-    nbytes: usize,       /* I - number of bytes to read        */
-    nbuff: usize,        /* I - buffer offset to read into            */
-    status: &mut c_int,  /* O - error status                   */
+    fptr: &mut FITSfile,
+    nbytes: usize,
+    nbuff: usize,
+    status: &mut c_int,
 ) -> c_int {
     let d = DRIVER_TABLE.get().unwrap();
     let buffer = cast_slice_mut(&mut fptr.iobuffer[(nbuff * IOBUFLEN as usize)..]);
@@ -9272,15 +9708,21 @@ pub(crate) fn ffread_int(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Create and initialize a new FITS file  based on a template file.
 /// Uses C fopen and fgets functions.
+///
+/// # Parameters
+///
+/// * `fptr`     — (O) FITS file pointer
+/// * `filename` — (I) name of file to create
+/// * `tempname` — (I) name of template file
+/// * `status`   — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn fftplt(
-    fptr: *mut Option<Box<fitsfile>>, /* O - FITS file pointer                   */
-    filename: *const c_char,          /* I - name of file to create              */
-    tempname: *const c_char,          /* I - name of template file               */
-    status: *mut c_int,               /* IO - error status                       */
+    fptr: *mut Option<Box<fitsfile>>,
+    filename: *const c_char,
+    tempname: *const c_char,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -9293,14 +9735,20 @@ pub unsafe extern "C" fn fftplt(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Create and initialize a new FITS file  based on a template file.
 /// Uses C fopen and fgets functions.
+///
+/// # Parameters
+///
+/// * `fptr`     — (O) FITS file pointer
+/// * `filename` — (I) name of file to create
+/// * `tempname` — (I) name of template file
+/// * `status`   — (IO) error status
 pub fn fftplt_safer(
-    fptr: &mut Option<Box<fitsfile>>, /* O - FITS file pointer                   */
-    filename: &[c_char],              /* I - name of file to create              */
-    tempname: &[c_char],              /* I - name of template file               */
-    status: &mut c_int,               /* IO - error status                       */
+    fptr: &mut Option<Box<fitsfile>>,
+    filename: &[c_char],
+    tempname: &[c_char],
+    status: &mut c_int,
 ) -> c_int {
     /* initialize null file pointer */
     let f_tmp = fptr.take();
@@ -9329,13 +9777,14 @@ pub fn fftplt_safer(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// open template file and use it to create new file
-pub(crate) fn ffoptplt(
-    fptr: &mut fitsfile, /* O - FITS file pointer                   */
-    tempname: &[c_char], /* I - name of template file               */
-    status: &mut c_int,  /* IO - error status                       */
-) -> c_int {
+///
+/// # Parameters
+///
+/// * `fptr`     — (O) FITS file pointer
+/// * `tempname` — (I) name of template file
+/// * `status`   — (IO) error status
+pub(crate) fn ffoptplt(fptr: &mut fitsfile, tempname: &[c_char], status: &mut c_int) -> c_int {
     let mut tptr = None;
     let mut tstatus: c_int = 0;
     let mut nkeys: c_int = 0;
@@ -9401,7 +9850,6 @@ pub(crate) fn ffoptplt(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Print out report of cfitsio error status and messages on the error stack.
 /// Uses C FILE stream.
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
@@ -9410,7 +9858,6 @@ pub unsafe extern "C" fn ffrprt(stream: *mut FILE, status: c_int) {
     ffrprt_safe(stream, status)
 }
 
-/*--------------------------------------------------------------------------*/
 /// Print out report of cfitsio error status and messages on the error stack.
 /// Uses C FILE stream.
 pub fn ffrprt_safe(stream: *mut FILE, status: c_int) {
@@ -9448,12 +9895,16 @@ pub fn ffrprt_safe(stream: *mut FILE, status: c_int) {
     }
 }
 
-/*--------------------------------------------------------------------------*/
+/// # Parameters
+///
+/// * `fptr`      — (IO) pointer to input image; on output it
+/// * `outfile`   — (I) name for output file
+/// * `pixfilter` — (I) Image filter expression
 pub fn pixel_filter_helper(
-    fptr: &mut Option<Box<fitsfile>>, /* IO - pointer to input image; on output it  */
+    fptr: &mut Option<Box<fitsfile>>,
     /*      points to the new image */
-    outfile: [c_char; FLEN_FILENAME], /* I - name for output file        */
-    pixfilter: [c_char; FLEN_FILENAME], /* I - Image filter expression    */
+    outfile: [c_char; FLEN_FILENAME],
+    pixfilter: [c_char; FLEN_FILENAME],
     status: &mut c_int,
 ) -> c_int {
     let mut hdunum: c_int = 0;
@@ -9599,7 +10050,6 @@ pub fn pixel_filter_helper(
     *status
 }
 
-/*-------------------------------------------------------------------*/
 /// Wrapper function for global initialization of curl library.
 /// This is NOT THREAD-SAFE
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
@@ -9608,14 +10058,12 @@ pub unsafe extern "C" fn ffihtps() {
     ffihtps_safe()
 }
 
-/*-------------------------------------------------------------------*/
 /// Wrapper function for global initialization of curl library.
 /// This is NOT THREAD-SAFE
 pub fn ffihtps_safe() {
     todo!();
 }
 
-/*-------------------------------------------------------------------*/
 /// Wrapper function for global cleanup of curl library.
 /// This is NOT THREAD-SAFE
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
@@ -9624,14 +10072,12 @@ pub unsafe extern "C" fn ffchtps() {
     ffchtps_safe()
 }
 
-/*-------------------------------------------------------------------*/
 /// Wrapper function for global cleanup of curl library.
 /// This is NOT THREAD-SAFE
 pub fn ffchtps_safe() {
     todo!();
 }
 
-/*-------------------------------------------------------------------*/
 /// Turn libcurl's verbose output on (1) or off (0).
 /// This is NOT THREAD-SAFE
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
@@ -9640,7 +10086,6 @@ pub unsafe extern "C" fn ffvhtps(flag: c_int) {
     ffvhtps_safe(flag)
 }
 
-/*-------------------------------------------------------------------*/
 /// Turn libcurl's verbose output on (1) or off (0).
 /// This is NOT THREAD-SAFE
 pub fn ffvhtps_safe(flag: c_int) {
@@ -9649,7 +10094,6 @@ pub fn ffvhtps_safe(flag: c_int) {
     }
 }
 
-/*-------------------------------------------------------------------*/
 /// Display download status bar (to stderr), where applicable.
 /// This is NOT THREAD-SAFE
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
@@ -9658,7 +10102,6 @@ pub unsafe extern "C" fn ffshdwn(flag: c_int) {
     ffshdwn_safe(flag)
 }
 
-/*-------------------------------------------------------------------*/
 /// Display download status bar (to stderr), where applicable.
 /// This is NOT THREAD-SAFE
 pub fn ffshdwn_safe(flag: c_int) {
@@ -9667,7 +10110,6 @@ pub fn ffshdwn_safe(flag: c_int) {
     }
 }
 
-/*-------------------------------------------------------------------*/
 /// Get the current network timeout value in seconds
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgtmo() -> c_int {
@@ -9675,7 +10117,6 @@ pub unsafe extern "C" fn ffgtmo() -> c_int {
     ffgtmo_safer()
 }
 
-/*-------------------------------------------------------------------*/
 /// Get the current network timeout value in seconds (safe wrapper)
 pub fn ffgtmo_safer() -> c_int {
     let mut timeout = 0;
@@ -9687,7 +10128,6 @@ pub fn ffgtmo_safer() -> c_int {
     timeout
 }
 
-/*-------------------------------------------------------------------*/
 /// Set the network timeout value in seconds
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffstmo(sec: c_int, status: *mut c_int) -> c_int {
@@ -9698,7 +10138,6 @@ pub unsafe extern "C" fn ffstmo(sec: c_int, status: *mut c_int) -> c_int {
     }
 }
 
-/*-------------------------------------------------------------------*/
 /// Set the network timeout value in seconds (safe wrapper)
 pub fn ffstmo_safe(sec: c_int, status: &mut c_int) -> c_int {
     if *status > 0 {
@@ -9719,18 +10158,21 @@ pub fn ffstmo_safe(sec: c_int, status: &mut c_int) -> c_int {
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// parse off the next token, delimited by a character in 'delimiter',
 /// from the input ptr string;  increment *ptr to the end of the token.
 /// Returns the length of the token, not including the delimiter char;
 ///
 /// This routine allocates the *token string;  the calling routine must free it
+///
+/// # Parameters
+///
+/// * `isanumber` — (O) is this token a number?
 pub fn fits_get_token2_safe(
     ptr: &[c_char],
     ptr_index: &mut usize,
     delimiter: &[c_char],
     token: &mut Option<Vec<c_char>>,
-    isanumber: Option<&mut c_int>, /* O - is this token a number? */
+    isanumber: Option<&mut c_int>,
     status: &mut c_int,
 ) -> c_int {
     let mut tval: [c_char; 73] = [0; 73];

--- a/src/checksum.rs
+++ b/src/checksum.rs
@@ -1,9 +1,22 @@
-/*  This file, checksum.rs, contains the checksum-related routines in the   */
-/*  FITSIO library.                                                        */
-/*  The FITSIO software was written by William Pence at the High Energy    */
-/*  Astrophysic Science Archive Research Center (HEASARC) at the NASA      */
-/*  Goddard Space Flight Center.                                           */
-/*------------------------------------------------------------------------*/
+//! The checksum-related routines.
+//!
+//! FITS records the integrity of an HDU in two keywords: `DATASUM` holds the
+//! checksum of the data unit as a decimal string, and `CHECKSUM` holds an
+//! ASCII-encoded value chosen so that the checksum of the *entire* HDU, header
+//! and data together, comes out as zero. Verifying an HDU therefore means
+//! recomputing both and checking that the data sum matches `DATASUM` and that
+//! the whole-HDU sum is zero.
+//!
+//! The algorithm is the 32-bit 1's complement checksum developed by Rob Seaman
+//! at NOAO and presented at the 1994 ADASS conference, in which the overflow
+//! bits are permuted back into the sum so that all bit positions are sampled
+//! evenly.
+//!
+//! Ported from CFITSIO's `checksum.c`, written by William Pence at the High
+//! Energy Astrophysics Science Archive Research Center (HEASARC), NASA Goddard
+//! Space Flight Center. The routine descriptions draw on the "File Checksum
+//! Routines" section of the CFITSIO User's Reference Guide.
+#![warn(missing_docs)]
 
 use core::slice;
 
@@ -23,21 +36,20 @@ use crate::swapproc::ffswap2;
 use crate::wrappers::*;
 use crate::{buffers::*, int_snprintf};
 
-/*--------------------------------------------------------------------------*/
 /// Calculate a 32-bit 1's complement checksum of the FITS 2880-byte blocks.
 ///
-/// This routine is based on the C algorithm developed by Rob
-/// Seaman at NOAO that was presented at the 1994 ADASS conference,  
-/// published in the Astronomical Society of the Pacific Conference Series.
-/// This uses a 32-bit 1's complement checksum in which the overflow bits
-/// are permuted back into the sum and therefore all bit positions are
-/// sampled evenly.
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `nrec`   — (I) number of 2880-byte blocks to sum
+/// * `sum`    — (IO) accumulated checksum
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffcsum(
-    fptr: *mut fitsfile, /* I - FITS file pointer                  */
-    nrec: c_long,        /* I - number of 2880-byte blocks to sum  */
-    sum: *mut c_ulong,   /* IO - accumulated checksum              */
-    status: *mut c_int,  /* IO - error status                      */
+    fptr: *mut fitsfile,
+    nrec: c_long,
+    sum: *mut c_ulong,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -54,7 +66,6 @@ pub unsafe extern "C" fn ffcsum(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Calculate a 32-bit 1's complement checksum of the FITS 2880-byte blocks.
 /// This routine is based on the C algorithm developed by Rob
 /// Seaman at NOAO that was presented at the 1994 ADASS conference,  
@@ -62,11 +73,18 @@ pub unsafe extern "C" fn ffcsum(
 /// This uses a 32-bit 1's complement checksum in which the overflow bits
 /// are permuted back into the sum and therefore all bit positions are
 /// sampled evenly.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `nrec`   — (I) number of 2880-byte blocks to sum
+/// * `sum`    — (IO) accumulated checksum
+/// * `status` — (IO) error status
 pub fn ffcsum_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                  */
-    nrec: c_long,        /* I - number of 2880-byte blocks to sum  */
-    sum: &mut c_ulong,   /* IO - accumulated checksum              */
-    status: &mut c_int,  /* IO - error status                      */
+    fptr: &mut fitsfile,
+    nrec: c_long,
+    sum: &mut c_ulong,
+    status: &mut c_int,
 ) -> c_int {
     let mut ii: usize;
     let mut sbuf: [u16; 1440] = [0; 1440];
@@ -115,23 +133,20 @@ pub fn ffcsum_safe(
     *status
 }
 
-/*-------------------------------------------------------------------------*/
-/// encode the 32 bit checksum by converting every
-/// 2 bits of each byte into an ASCII character (32 bit word encoded
-/// as 16 character string).   Only ASCII letters and digits are used
-/// to encode the values (no ASCII punctuation characters).
+/// Encode a 32-bit checksum into a 16-character ASCII string.
+///
+/// Every 2 bits of each byte become one ASCII character. Only letters and
+/// digits are used, no punctuation.
 ///
 /// If complm=TRUE, then the complement of the sum will be encoded.
 ///
-/// This routine is based on the C algorithm developed by Rob
-/// Seaman at NOAO that was presented at the 1994 ADASS conference,
-/// published in the Astronomical Society of the Pacific Conference Series.
+/// # Parameters
+///
+/// * `sum`    — (I) accumulated checksum
+/// * `complm` — (I) = 1 to encode complement of the sum
+/// * `ascii`  — (O) 16-char ASCII encoded checksum
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
-pub unsafe extern "C" fn ffesum(
-    sum: c_ulong,             /* I - accumulated checksum                */
-    complm: c_int,            /* I - = 1 to encode complement of the sum */
-    ascii: *mut [c_char; 17], /* O - 16-char ASCII encoded checksum      */
-) {
+pub unsafe extern "C" fn ffesum(sum: c_ulong, complm: c_int, ascii: *mut [c_char; 17]) {
     // FFI WRAPPER
     unsafe {
         let ascii = ascii.as_mut().expect(NULL_MSG);
@@ -139,22 +154,19 @@ pub unsafe extern "C" fn ffesum(
     }
 }
 
-/*-------------------------------------------------------------------------*/
-/// encode the 32 bit checksum by converting every
-/// 2 bits of each byte into an ASCII character (32 bit word encoded
-/// as 16 character string).   Only ASCII letters and digits are used
-/// to encode the values (no ASCII punctuation characters).
+/// Encode a 32-bit checksum into a 16-character ASCII string.
+///
+/// Every 2 bits of each byte become one ASCII character. Only letters and
+/// digits are used, no punctuation.
 ///
 /// If complm=TRUE, then the complement of the sum will be encoded.
 ///
-/// This routine is based on the C algorithm developed by Rob
-/// Seaman at NOAO that was presented at the 1994 ADASS conference,
-/// published in the Astronomical Society of the Pacific Conference Series.
-pub fn ffesum_safe(
-    sum: c_ulong,             /* I - accumulated checksum                */
-    complm: bool,             /* I - = 1 to encode complement of the sum */
-    ascii: &mut [c_char; 17], /* O - 16-char ASCII encoded checksum      */
-) {
+/// # Parameters
+///
+/// * `sum`    — (I) accumulated checksum
+/// * `complm` — (I) = 1 to encode complement of the sum
+/// * `ascii`  — (O) 16-char ASCII encoded checksum
+pub fn ffesum_safe(sum: c_ulong, complm: bool, ascii: &mut [c_char; 17]) {
     let exclude: [c_uint; 13] = [
         0x3a, 0x3b, 0x3c, 0x3d, 0x3e, 0x3f, 0x40, 0x5b, 0x5c, 0x5d, 0x5e, 0x5f, 0x60,
     ];
@@ -212,19 +224,17 @@ pub fn ffesum_safe(
     ascii[16] = 0;
 }
 
-/*-------------------------------------------------------------------------*/
-/// decode the 16-char ASCII encoded checksum into an unsigned 32-bit long.
+/// Decode a 16-character ASCII encoded checksum into an unsigned 32-bit
+/// value.
 /// If complm=TRUE, then the complement of the sum will be decoded.
 ///
-/// This routine is based on the C algorithm developed by Rob
-/// Seaman at NOAO that was presented at the 1994 ADASS conference,
-/// published in the Astronomical Society of the Pacific Conference Series.
+/// # Parameters
+///
+/// * `ascii`  — (I) 16-char ASCII encoded checksum
+/// * `complm` — (I) =1 to decode complement of the
+/// * `sum`    — (O) 32-bit checksum
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
-pub unsafe extern "C" fn ffdsum(
-    ascii: *const c_char, /* I - 16-char ASCII encoded checksum   */
-    complm: c_int,        /* I - =1 to decode complement of the   */
-    sum: *mut c_ulong,    /* O - 32-bit checksum           */
-) -> c_ulong {
+pub unsafe extern "C" fn ffdsum(ascii: *const c_char, complm: c_int, sum: *mut c_ulong) -> c_ulong {
     // FFI WRAPPER
     unsafe {
         let sum = sum.as_mut().expect(NULL_MSG);
@@ -234,17 +244,19 @@ pub unsafe extern "C" fn ffdsum(
     }
 }
 
-/*-------------------------------------------------------------------------*/
-/// decode the 16-char ASCII encoded checksum into an unsigned 32-bit long.
+/// Decode a 16-character ASCII encoded checksum into an unsigned 32-bit
+/// value.
 /// If complm=TRUE, then the complement of the sum will be decoded.
 /// This routine is based on the C algorithm developed by Rob
 /// Seaman at NOAO that was presented at the 1994 ADASS conference,
 /// published in the Astronomical Society of the Pacific Conference Series.
-pub fn ffdsum_safe(
-    ascii: &[c_char; 17], /* I - 16-char ASCII encoded checksum   */
-    complm: bool,         /* I - =1 to decode complement of the   */
-    sum: &mut c_ulong,    /* O - 32-bit checksum           */
-) -> c_ulong {
+///
+/// # Parameters
+///
+/// * `ascii`  — (I) 16-char ASCII encoded checksum
+/// * `complm` — (I) =1 to decode complement of the
+/// * `sum`    — (O) 32-bit checksum
+pub fn ffdsum_safe(ascii: &[c_char; 17], complm: bool, sum: &mut c_ulong) -> c_ulong {
     let mut cbuf: [c_char; 16] = [0; 16];
     let mut hi: c_ulong = 0;
     let mut lo: c_ulong = 0;
@@ -275,15 +287,18 @@ pub fn ffdsum_safe(
     *sum
 }
 
-/*------------------------------------------------------------------------*/
-/// Create or update the checksum keywords in the CHDU.  These keywords
-/// provide a checksum verification of the FITS HDU based on the ASCII
-/// coded 1's complement checksum algorithm developed by Rob Seaman at NOAO.
+/// Compute and write the DATASUM and CHECKSUM keyword values for the CHDU.
+///
+/// If the keywords already exist their values are updated only if necessary,
+/// that is, if the file has been modified since the original values were
+/// computed.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
-pub unsafe extern "C" fn ffpcks(
-    fptr: *mut fitsfile, /* I - FITS file pointer                  */
-    status: *mut c_int,  /* IO - error status                      */
-) -> c_int {
+pub unsafe extern "C" fn ffpcks(fptr: *mut fitsfile, status: *mut c_int) -> c_int {
     // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
@@ -293,14 +308,17 @@ pub unsafe extern "C" fn ffpcks(
     }
 }
 
-/*------------------------------------------------------------------------*/
-/// Create or update the checksum keywords in the CHDU.  These keywords
-/// provide a checksum verification of the FITS HDU based on the ASCII
-/// coded 1's complement checksum algorithm developed by Rob Seaman at NOAO.
-pub fn ffpcks_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                  */
-    status: &mut c_int,  /* IO - error status                      */
-) -> c_int {
+/// Compute and write the DATASUM and CHECKSUM keyword values for the CHDU.
+///
+/// If the keywords already exist their values are updated only if necessary,
+/// that is, if the file has been modified since the original values were
+/// computed.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `status` — (IO) error status
+pub fn ffpcks_safe(fptr: &mut fitsfile, status: &mut c_int) -> c_int {
     let mut datestr: [c_char; 20] = [0; 20];
     let mut checksum: [c_char; FLEN_VALUE] = [0; FLEN_VALUE];
     let mut datasum: [c_char; FLEN_VALUE] = [0; FLEN_VALUE];
@@ -461,14 +479,19 @@ pub fn ffpcks_safe(
     *status
 }
 
-/*------------------------------------------------------------------------*/
-/// Update the CHECKSUM keyword value.  This assumes that the DATASUM
-/// keyword exists and has the correct value.
+/// Update the CHECKSUM keyword value, assuming the DATASUM keyword exists and
+/// already has the correct value.
+///
+/// Calculates the new checksum for the current header unit, adds it to the data
+/// unit checksum, encodes the result into an ASCII string and writes that to
+/// the CHECKSUM keyword.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
-pub unsafe extern "C" fn ffupck(
-    fptr: *mut fitsfile, /* I - FITS file pointer                  */
-    status: *mut c_int,  /* IO - error status                      */
-) -> c_int {
+pub unsafe extern "C" fn ffupck(fptr: *mut fitsfile, status: *mut c_int) -> c_int {
     // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
@@ -478,13 +501,18 @@ pub unsafe extern "C" fn ffupck(
     }
 }
 
-/*------------------------------------------------------------------------*/
-/// Update the CHECKSUM keyword value.  This assumes that the DATASUM
-/// keyword exists and has the correct value.
-pub fn ffupck_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                  */
-    status: &mut c_int,  /* IO - error status                      */
-) -> c_int {
+/// Update the CHECKSUM keyword value, assuming the DATASUM keyword exists and
+/// already has the correct value.
+///
+/// Calculates the new checksum for the current header unit, adds it to the data
+/// unit checksum, encodes the result into an ASCII string and writes that to
+/// the CHECKSUM keyword.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `status` — (IO) error status
+pub fn ffupck_safe(fptr: &mut fitsfile, status: &mut c_int) -> c_int {
     let mut datestr: [c_char; 20] = [0; 20];
     let mut chkcomm: [c_char; FLEN_COMMENT] = [0; FLEN_COMMENT];
     let mut comm: [c_char; FLEN_COMMENT] = [0; FLEN_COMMENT];
@@ -592,18 +620,31 @@ pub fn ffupck_safe(
     *status
 }
 
-/*------------------------------------------------------------------------*/
 /// Verify the HDU by comparing the value of the computed checksums against
 /// the values of the DATASUM and CHECKSUM keywords if they are present.
+///
+/// The data unit verifies correctly if the computed checksum equals the value
+/// of the DATASUM keyword. The checksum for the entire HDU, header plus data
+/// unit, is correct if it equals zero.
+///
+/// # Parameters
+///
+/// * `fptr`       — (I) FITS file pointer
+/// * `datastatus` — (O) data checksum status
+/// * `hdustatus`  — (O) HDU checksum status
+/// * `status`     — (IO) error status
+///
+/// `datastatus` and `hdustatus` are each set to:
+///
+/// * ` 1` — verification is correct
+/// * ` 0` — the checksum keyword is not present
+/// * `-1` — verification is not correct
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffvcks(
-    fptr: *mut fitsfile,    /* I - FITS file pointer                  */
-    datastatus: *mut c_int, /* O - data checksum status               */
-    hdustatus: *mut c_int,  /* O - hdu checksum status                */
-    /*     1  verification is correct         */
-    /*     0  checksum keyword is not present */
-    /*    -1 verification not correct         */
-    status: *mut c_int, /* IO - error status                      */
+    fptr: *mut fitsfile,
+    datastatus: *mut c_int,
+    hdustatus: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -616,17 +657,30 @@ pub unsafe extern "C" fn ffvcks(
     }
 }
 
-/*------------------------------------------------------------------------*/
 /// Verify the HDU by comparing the value of the computed checksums against
 /// the values of the DATASUM and CHECKSUM keywords if they are present.
+///
+/// The data unit verifies correctly if the computed checksum equals the value
+/// of the DATASUM keyword. The checksum for the entire HDU, header plus data
+/// unit, is correct if it equals zero.
+///
+/// # Parameters
+///
+/// * `fptr`       — (I) FITS file pointer
+/// * `datastatus` — (O) data checksum status
+/// * `hdustatus`  — (O) HDU checksum status
+/// * `status`     — (IO) error status
+///
+/// `datastatus` and `hdustatus` are each set to:
+///
+/// * ` 1` — verification is correct
+/// * ` 0` — the checksum keyword is not present
+/// * `-1` — verification is not correct
 pub fn ffvcks_safe(
-    fptr: &mut fitsfile,    /* I - FITS file pointer                  */
-    datastatus: &mut c_int, /* O - data checksum status               */
-    hdustatus: &mut c_int,  /* O - hdu checksum status                */
-    /*     1  verification is correct         */
-    /*     0  checksum keyword is not present */
-    /*    -1 verification not correct         */
-    status: &mut c_int, /* IO - error status                      */
+    fptr: &mut fitsfile,
+    datastatus: &mut c_int,
+    hdustatus: &mut c_int,
+    status: &mut c_int,
 ) -> c_int {
     let mut datasum: c_ulong = 0;
     let mut hdusum: c_ulong = 0;
@@ -691,14 +745,24 @@ pub fn ffvcks_safe(
     *status
 }
 
-/*------------------------------------------------------------------------*/
-/// calculate the checksums of the data unit and the total HDU
+/// Compute and return the checksum values for the CHDU, without creating or
+/// modifying the CHECKSUM and DATASUM keywords.
+///
+/// Used internally by [`ffvcks_safe`], but may be useful in other situations as
+/// well.
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `datasum` — (O) data checksum
+/// * `hdusum`  — (O) HDU checksum
+/// * `status`  — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgcks(
-    fptr: *mut fitsfile,   /* I - FITS file pointer             */
-    datasum: *mut c_ulong, /* O - data checksum                 */
-    hdusum: *mut c_ulong,  /* O - hdu checksum                  */
-    status: *mut c_int,    /* IO - error status                 */
+    fptr: *mut fitsfile,
+    datasum: *mut c_ulong,
+    hdusum: *mut c_ulong,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -711,13 +775,23 @@ pub unsafe extern "C" fn ffgcks(
     }
 }
 
-/*------------------------------------------------------------------------*/
-/// calculate the checksums of the data unit and the total HDU
+/// Compute and return the checksum values for the CHDU, without creating or
+/// modifying the CHECKSUM and DATASUM keywords.
+///
+/// Used internally by [`ffvcks_safe`], but may be useful in other situations as
+/// well.
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `datasum` — (O) data checksum
+/// * `hdusum`  — (O) HDU checksum
+/// * `status`  — (IO) error status
 pub fn ffgcks_safe(
-    fptr: &mut fitsfile,   /* I - FITS file pointer             */
-    datasum: &mut c_ulong, /* O - data checksum                 */
-    hdusum: &mut c_ulong,  /* O - hdu checksum                  */
-    status: &mut c_int,    /* IO - error status                 */
+    fptr: &mut fitsfile,
+    datasum: &mut c_ulong,
+    hdusum: &mut c_ulong,
+    status: &mut c_int,
 ) -> c_int {
     let mut headstart: LONGLONG = 0;
     let mut datastart: LONGLONG = 0;

--- a/src/drvrfile.rs
+++ b/src/drvrfile.rs
@@ -1,8 +1,14 @@
-/*  This file, drvrfile.rs contains driver routines for disk files.         */
-
-/*  The FITSIO software was written by William Pence at the High Energy    */
-/*  Astrophysic Science Archive Research Center (HEASARC) at the NASA      */
-/*  Goddard Space Flight Center.                                           */
+//! The driver for ordinary disk files.
+//!
+//! The default driver, and the one behind the `file://` prefix. It also handles
+//! the compressed variants: opening a `.gz`, `.Z` or `.zip` file decompresses
+//! it into a memory file and hands that to [`crate::drvrmem`] instead, which is
+//! why a compressed FITS file is readable but not writable in place.
+//!
+//! Ported from CFITSIO's `drvrfile.c`, written by William Pence at the High
+//! Energy Astrophysics Science Archive Research Center (HEASARC), NASA Goddard
+//! Space Flight Center.
+#![warn(missing_docs)]
 
 use alloc::ffi::CString;
 use core::ffi::CStr;
@@ -45,7 +51,6 @@ pub(crate) struct diskdriver {
 /* allocate diskfile handle tables */
 pub(crate) static HANDLE_TABLE: Mutex<Vec<diskdriver>> = Mutex::new(Vec::new());
 
-/*--------------------------------------------------------------------------*/
 pub(crate) fn file_init() -> c_int {
     let mut h = HANDLE_TABLE.lock().unwrap();
 
@@ -61,30 +66,25 @@ pub(crate) fn file_init() -> c_int {
     0
 }
 
-/*--------------------------------------------------------------------------*/
 pub(crate) fn file_setoptions(_options: c_int) -> c_int {
     /* do something with the options argument, to stop compiler warning */
     0
 }
 
-/*--------------------------------------------------------------------------*/
 pub(crate) fn file_getoptions(options: &mut c_int) -> c_int {
     *options = 0;
     0
 }
 
-/*--------------------------------------------------------------------------*/
 pub(crate) fn file_getversion(version: &mut c_int) -> c_int {
     *version = 10;
     0
 }
 
-/*--------------------------------------------------------------------------*/
 pub(crate) fn file_shutdown() -> c_int {
     0
 }
 
-/*--------------------------------------------------------------------------*/
 pub(crate) fn file_open(filename: &mut [c_char], rwmode: c_int, handle: &mut c_int) -> c_int {
     let mut copyhandle = 0;
     let mut ii = 0;
@@ -176,7 +176,6 @@ pub(crate) fn file_open(filename: &mut [c_char], rwmode: c_int, handle: &mut c_i
     status
 }
 
-/*--------------------------------------------------------------------------*/
 /// lowest level routine to physically open a disk file
 pub(crate) fn file_openfile(
     filename: &[c_char],
@@ -297,7 +296,6 @@ pub(crate) fn file_openfile(
     0
 }
 
-/*--------------------------------------------------------------------------*/
 pub(crate) fn file_create(filename: &mut [c_char; FLEN_FILENAME], handle: &mut c_int) -> c_int {
     let mut mode: [c_char; 4] = [0; 4]; /* make sure the CWD ends with slash */
     let mut status = 0;
@@ -466,7 +464,6 @@ pub(crate) fn file_create(filename: &mut [c_char; FLEN_FILENAME], handle: &mut c
     0
 }
 
-/*--------------------------------------------------------------------------*/
 /// truncate the diskfile to a new smaller size
 pub(crate) fn file_truncate(handle: c_int, filesize: usize) -> c_int {
     if HAVE_FTRUNCATE {
@@ -488,7 +485,6 @@ pub(crate) fn file_truncate(handle: c_int, filesize: usize) -> c_int {
     0
 }
 
-/*--------------------------------------------------------------------------*/
 /// return the size of the file in bytes
 pub(crate) fn file_size(handle: c_int, filesize: &mut usize) -> c_int {
     //let h = handleTable.lock().unwrap();
@@ -505,7 +501,6 @@ pub(crate) fn file_size(handle: c_int, filesize: &mut usize) -> c_int {
     0
 }
 
-/*--------------------------------------------------------------------------*/
 /// close the file
 pub(crate) fn file_close(handle: c_int) -> c_int {
     //let mut h = handleTable.lock().unwrap();
@@ -523,7 +518,6 @@ pub(crate) fn file_close(handle: c_int) -> c_int {
     0
 }
 
-/*--------------------------------------------------------------------------*/
 /// delete the file from disk
 pub(crate) fn file_remove(filename: &[c_char]) -> c_int {
     let filename = CStr::from_bytes_until_nul(cast_slice(filename)).unwrap();
@@ -534,7 +528,6 @@ pub(crate) fn file_remove(filename: &[c_char]) -> c_int {
     0
 }
 
-/*--------------------------------------------------------------------------*/
 /// flush the file
 pub(crate) fn file_flush(handle: c_int) -> c_int {
     let mut h = HANDLE_TABLE.lock().unwrap();
@@ -557,7 +550,6 @@ pub(crate) fn file_flush(handle: c_int) -> c_int {
     0
 }
 
-/*--------------------------------------------------------------------------*/
 /// seek to position relative to start of the file
 pub(crate) fn file_seek(handle: c_int, offset: LONGLONG) -> c_int {
     //let mut h = handleTable.lock().unwrap();
@@ -566,7 +558,6 @@ pub(crate) fn file_seek(handle: c_int, offset: LONGLONG) -> c_int {
     file_seek_internal(&mut h[handle as usize], offset as u64)
 }
 
-/*--------------------------------------------------------------------------*/
 /// seek to position relative to start of the file
 fn file_seek_internal(handle: &mut diskdriver, offset: u64) -> c_int {
     //let mut h = handleTable.lock().unwrap();
@@ -582,7 +573,6 @@ fn file_seek_internal(handle: &mut diskdriver, offset: u64) -> c_int {
     0
 }
 
-/*--------------------------------------------------------------------------*/
 /// read bytes from the current position in the file
 // clippy points ErrorKind at core::io, but that re-export is still behind the
 // unstable `core_io` feature, so the std path has to stay.
@@ -634,7 +624,6 @@ pub(crate) fn file_read(hdl: c_int, buffer: &mut [u8], nbytes: usize) -> c_int {
     0
 }
 
-/*--------------------------------------------------------------------------*/
 /// write bytes at the current position in the file
 pub(crate) fn file_write(hdl: c_int, buffer: &[u8], nbytes: usize) -> c_int {
     //let h = handleTable.lock().unwrap();
@@ -659,7 +648,6 @@ pub(crate) fn file_write(hdl: c_int, buffer: &[u8], nbytes: usize) -> c_int {
     0
 }
 
-/*--------------------------------------------------------------------------*/
 /// This routine opens the compressed diskfile by creating a new uncompressed
 /// file then opening it.  The input file name (the name of the compressed
 /// file) gets replaced with the name of the uncompressed file, which is
@@ -760,7 +748,6 @@ pub(crate) fn file_compress_open(filename: &mut [c_char], rwmode: c_int, hdl: &m
     status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Test if the disk file is compressed.  Returns 1 if compressed, 0 if not.
 /// This may modify the filename string by appending a compression suffix.
 /// WARNING: Need to hope that enough memory was allocated for extending the filename
@@ -832,7 +819,6 @@ pub(crate) fn file_is_compressed(filename: &mut [c_char; FLEN_FILENAME]) -> c_in
     }
 }
 
-/*--------------------------------------------------------------------------*/
 pub(crate) fn file_checkfile(
     urltype: &mut [c_char; MAX_PREFIX_LEN],
     infile: &mut [c_char; FLEN_FILENAME],
@@ -881,13 +867,6 @@ pub(crate) fn file_checkfile(
     0
 }
 
-/**********************************************************************/
-/**********************************************************************/
-/**********************************************************************/
-
-/****  driver routines for stream//: device (stdin or stdout)  ********/
-
-/*--------------------------------------------------------------------------*/
 /// read from stdin
 pub(crate) fn fits_stream_open(
     _filename: &mut [c_char],
@@ -899,7 +878,6 @@ pub(crate) fn fits_stream_open(
     0
 }
 
-/*--------------------------------------------------------------------------*/
 ///  write to stdout
 pub(crate) fn fits_stream_create(
     _filename: &mut [c_char; FLEN_FILENAME],
@@ -910,7 +888,6 @@ pub(crate) fn fits_stream_create(
     0
 }
 
-/*--------------------------------------------------------------------------*/
 /// return the size of the file in bytes
 pub(crate) fn fits_stream_size(_handle: c_int, filesize: &mut usize) -> c_int {
     /* this operation is not supported in a stream; return large value */
@@ -918,13 +895,11 @@ pub(crate) fn fits_stream_size(_handle: c_int, filesize: &mut usize) -> c_int {
     0
 }
 
-/*--------------------------------------------------------------------------*/
 /// don't have to close stdin or stdout
 pub(crate) fn fits_stream_close(_handle: c_int) -> c_int {
     0
 }
 
-/*--------------------------------------------------------------------------*/
 /// flush the file
 pub(crate) fn fits_stream_flush(handle: c_int) -> c_int {
     if handle == 2 && std::io::stdout().flush().is_err() {
@@ -935,13 +910,11 @@ pub(crate) fn fits_stream_flush(handle: c_int) -> c_int {
 
     0
 }
-/*--------------------------------------------------------------------------*/
 /// seeking is not allowed in a stream
 pub(crate) fn fits_stream_seek(_handle: c_int, _offset: LONGLONG) -> c_int {
     1
 }
 
-/*--------------------------------------------------------------------------*/
 /// reading from stdin stream
 // clippy points ErrorKind at core::io, but that re-export is still behind the
 // unstable `core_io` feature, so the std path has to stay.
@@ -960,7 +933,6 @@ pub(crate) fn fits_stream_read(hdl: c_int, buffer: &mut [u8], nbytes: usize) -> 
     }
 }
 
-/*--------------------------------------------------------------------------*/
 ///  write bytes at the current position in the file
 pub(crate) fn fits_stream_write(hdl: c_int, buffer: &[u8], nbytes: usize) -> c_int {
     if hdl != 2 {

--- a/src/drvrgsiftp.rs
+++ b/src/drvrgsiftp.rs
@@ -1,1 +1,7 @@
+//! The `gsiftp://` driver, which this port does not implement.
+//!
+//! CFITSIO builds `drvrgsiftp.c` only when configured against the Globus
+//! toolkit; there is no Rust equivalent, so the module is empty.
+#![warn(missing_docs)]
+
 // NOT IMPLEMENTED

--- a/src/drvrmem.rs
+++ b/src/drvrmem.rs
@@ -1,8 +1,14 @@
-/*  This file, drvrmem.rs, contains driver routines for memory files.        */
-
-/*  The FITSIO software was written by William Pence at the High Energy    */
-/*  Astrophysic Science Archive Research Center (HEASARC) at the NASA      */
-/*  Goddard Space Flight Center.                                           */
+//! The driver for in-memory files, behind the `mem://` prefix.
+//!
+//! A memory file is a growable byte buffer that behaves like a file. It backs
+//! `mem://` names, the decompression of a `.gz` or `.Z` file by
+//! [`crate::drvrfile`], and the temporary file that
+//! [`crate::cfileio`] creates when a filter is applied to an input file.
+//!
+//! Ported from CFITSIO's `drvrmem.c`, written by William Pence at the High
+//! Energy Astrophysics Science Archive Research Center (HEASARC), NASA Goddard
+//! Space Flight Center.
+#![warn(missing_docs)]
 
 use core::ffi::CStr;
 use core::slice;
@@ -39,6 +45,7 @@ use crate::zcompress::{compress2file_from_mem, uncompress2mem, uncompress2mem_fr
 use crate::{BL, STDIN, STDOUT};
 use crate::{bb, cs};
 
+/// Size of the record buffer used when reading a file from stdin.
 pub const RECBUFLEN: usize = 1000;
 
 static STDIN_OUTFILE: Mutex<[c_char; FLEN_FILENAME]> = Mutex::new([0; FLEN_FILENAME]);
@@ -52,22 +59,37 @@ static STDIN_OUTFILE: Mutex<[c_char; FLEN_FILENAME]> = Mutex::new([0; FLEN_FILEN
 /// reports as a Stacked Borrows violation.  A separate allocation keeps the
 /// pointer's provenance independent of the table.
 #[derive(Debug, Copy, Clone)]
+/// The address and size cell a memory file owns, when the caller did not
+/// supply one of its own.
 struct OwnedMem {
+    /// Address of the allocation.
     addr: *mut c_char,
+    /// Size of the allocation in bytes.
     size: usize,
 }
 
-/* structure containing mem file structure */
+/// One open memory file.
 #[derive(Debug, Copy, Clone)]
 struct memdriver {
-    memaddrptr: *mut *mut c_char, /* Pointer to memory address pointer; points either into the caller's variables or into owned_cell. */
-    memsizeptr: *mut usize, /* Pointer to the size of the memory allocation; points either into the caller's variables or into owned_cell. */
-    owned_cell: *mut OwnedMem, /* non-null iff this slot allocated its own address/size cell (see mem_createmem) */
-    deltasize: usize,          /* Suggested increment for reallocating memory */
-    mem_realloc: Option<unsafe extern "C" fn(p: *mut c_void, newsize: usize) -> *mut c_void>, /* realloc function */
-    currentpos: LONGLONG,   /* current file position, relative to start */
-    fitsfilesize: LONGLONG, /* size of the FITS file (always <= *memsizeptr) */
-    fileptr: *mut FILE,     /* pointer to compressed output disk file */
+    /// Pointer to the memory address pointer; points either into the caller's
+    /// variables or into `owned_cell`.
+    memaddrptr: *mut *mut c_char,
+    /// Pointer to the size of the memory allocation; points either into the
+    /// caller's variables or into `owned_cell`.
+    memsizeptr: *mut usize,
+    /// Non-null if and only if this slot allocated its own address and size
+    /// cell; see `mem_createmem`.
+    owned_cell: *mut OwnedMem,
+    /// Suggested increment for reallocating memory.
+    deltasize: usize,
+    /// Reallocation function used to grow the buffer.
+    mem_realloc: Option<unsafe extern "C" fn(p: *mut c_void, newsize: usize) -> *mut c_void>,
+    /// Current file position, relative to the start.
+    currentpos: LONGLONG,
+    /// Size of the FITS file, always no greater than `*memsizeptr`.
+    fitsfilesize: LONGLONG,
+    /// Pointer to the compressed output disk file.
+    fileptr: *mut FILE,
 }
 
 impl Default for memdriver {
@@ -101,7 +123,6 @@ static MEM_TABLE: Mutex<[memdriver; NMAXFILES]> = Mutex::new(
     }; NMAXFILES],
 );
 
-/*--------------------------------------------------------------------------*/
 /// Mark a table slot as free, releasing the address/size cell if this slot
 /// owned one.  A null `memaddrptr` is what marks the slot empty.
 fn release_owned_cell(d: &mut memdriver) {
@@ -115,7 +136,6 @@ fn release_owned_cell(d: &mut memdriver) {
     d.memsizeptr = ptr::null_mut();
 }
 
-/*--------------------------------------------------------------------------*/
 /// Resize a driver-owned buffer, returning the new address or null on failure.
 ///
 /// mem_createmem allocates the buffer with Rust's allocator (a `Vec`), so it
@@ -154,31 +174,25 @@ unsafe fn owned_realloc(ptr: *mut c_char, newsize: usize) -> *mut c_char {
     }
 }
 
-/*--------------------------------------------------------------------------*/
 pub(crate) fn mem_init() -> c_int {
     0
 }
 
-/*--------------------------------------------------------------------------*/
 pub(crate) fn mem_setoptions(_options: c_int) -> c_int {
     0
 }
-/*--------------------------------------------------------------------------*/
 pub(crate) fn mem_getoptions(options: &mut c_int) -> c_int {
     *options = 0;
     0
 }
-/*--------------------------------------------------------------------------*/
 pub(crate) fn mem_getversion(version: &mut c_int) -> c_int {
     *version = 10;
     0
 }
-/*--------------------------------------------------------------------------*/
 pub(crate) fn mem_shutdown() -> c_int {
     0
 }
 
-/*--------------------------------------------------------------------------*/
 /// Create a new empty memory file for subsequent writes.
 /// The file name is ignored in this case.
 pub(crate) fn mem_create(_filename: &mut [c_char; FLEN_FILENAME], handle: &mut c_int) -> c_int {
@@ -193,7 +207,6 @@ pub(crate) fn mem_create(_filename: &mut [c_char; FLEN_FILENAME], handle: &mut c
     0
 }
 
-/*--------------------------------------------------------------------------*/
 /// Create a new empty memory file for subsequent writes.
 /// Also create an empty compressed .gz file.  The memory file
 /// will be compressed and written to the disk file when the file is closed.
@@ -258,13 +271,19 @@ pub(crate) fn mem_create_comp_unsafe(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// lowest level routine to open a pre-existing memory file.
+///
+/// # Parameters
+///
+/// * `buffptr`    — (I) address of memory pointer
+/// * `buffsize`   — (I) size of buffer, in bytes
+/// * `deltasize`  — (I) increment for future realloc's
+/// * `memrealloc` — function (may be NULL)
 pub(crate) fn mem_openmem(
-    buffptr: *mut *mut c_void, /* I - address of memory pointer          */
-    buffsize: &mut usize,          /* I - size of buffer, in bytes           */
-    deltasize: usize,              /* I - increment for future realloc's     */
-    memrealloc: Option<unsafe extern "C" fn(p: *mut c_void, newsize: usize) -> *mut c_void>, /* function (may be NULL)  */
+    buffptr: *mut *mut c_void,
+    buffsize: &mut usize,
+    deltasize: usize,
+    memrealloc: Option<unsafe extern "C" fn(p: *mut c_void, newsize: usize) -> *mut c_void>,
     handle: &mut c_int,
 ) -> c_int {
     *handle = -1;
@@ -296,7 +315,6 @@ pub(crate) fn mem_openmem(
     0
 }
 
-/*--------------------------------------------------------------------------*/
 ///  lowest level routine to allocate a memory file.
 pub(crate) fn mem_createmem(msize: usize, handle: &mut c_int) -> c_int {
     *handle = -1;
@@ -360,7 +378,6 @@ pub(crate) fn mem_createmem(msize: usize, handle: &mut c_int) -> c_int {
     0
 }
 
-/*--------------------------------------------------------------------------*/
 /// truncate the file to a new size
 pub(crate) fn mem_truncate_unsafe(handle: c_int, filesize: usize) -> c_int {
     unsafe {
@@ -405,7 +422,6 @@ pub(crate) fn mem_truncate_unsafe(handle: c_int, filesize: usize) -> c_int {
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// do any special case checking when opening a file on the stdin stream
 pub(crate) fn stdin_checkfile(
     urltype: &mut [c_char; MAX_PREFIX_LEN],
@@ -426,7 +442,6 @@ pub(crate) fn stdin_checkfile(
     0
 }
 
-/*--------------------------------------------------------------------------*/
 /// open a FITS file from the stdin file stream by copying it into memory
 /// The file name is ignored in this case.
 pub(crate) fn stdin_open(filename: &mut [c_char], rwmode: c_int, handle: &mut c_int) -> c_int {
@@ -506,7 +521,6 @@ pub(crate) fn stdin_open(filename: &mut [c_char], rwmode: c_int, handle: &mut c_
     status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy the stdin stream into memory.  Fill whatever amount of memory
 /// has already been allocated, then realloc more memory if necessary.
 pub(crate) unsafe fn stdin2mem(hd: c_int) -> c_int {
@@ -595,7 +609,6 @@ pub(crate) unsafe fn stdin2mem(hd: c_int) -> c_int {
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy the stdin stream to a file.
 pub(crate) fn stdin2file(handle: c_int) -> c_int {
     /* handle number */
@@ -668,7 +681,6 @@ pub(crate) fn stdin2file(handle: c_int) -> c_int {
     status
 }
 
-/*--------------------------------------------------------------------------*/
 /// copy the memory file to stdout, then free the memory
 pub(crate) fn stdout_close_unsafe(handle: c_int) -> c_int {
     unsafe {
@@ -700,7 +712,6 @@ pub(crate) fn stdout_close_unsafe(handle: c_int) -> c_int {
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// This routine opens the compressed diskfile and creates an empty memory
 /// buffer with an appropriate size, then calls mem_uncompress2mem. It allows
 /// the memory 'file' to be opened with READWRITE access.
@@ -712,7 +723,6 @@ pub(crate) fn mem_compress_openrw(
     mem_compress_open(filename, READONLY, hdl)
 }
 
-/*--------------------------------------------------------------------------*/
 /// This routine opens the compressed diskfile and creates an empty memory
 /// buffer with an appropriate size, then calls mem_uncompress2mem.
 pub(crate) fn mem_compress_open(filename: &mut [c_char], rwmode: c_int, hdl: &mut c_int) -> c_int {
@@ -896,7 +906,6 @@ pub(crate) fn mem_compress_open(filename: &mut [c_char], rwmode: c_int, hdl: &mu
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// This routine reads the compressed input stream and creates an empty memory
 /// buffer, then calls mem_uncompress2mem.
 pub(crate) unsafe fn mem_compress_stdin_open(
@@ -955,7 +964,6 @@ pub(crate) unsafe fn mem_compress_stdin_open(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// This routine creates an empty memory buffer, then calls iraf2mem to
 /// open the IRAF disk file and convert it to a FITS file in memeory.
 pub(crate) fn mem_iraf_open(filename: &mut [c_char], _rwmode: c_int, hdl: &mut c_int) -> c_int {
@@ -1003,7 +1011,6 @@ pub(crate) fn mem_iraf_open(filename: &mut [c_char], _rwmode: c_int, hdl: &mut c
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// This routine creates an empty memory buffer, writes a minimal
 /// image header, then copies the image data from the raw file into
 /// memory.  It will byteswap the pixel values if the raw array
@@ -1253,7 +1260,6 @@ pub(crate) fn mem_rawfile_open(filename: &mut [c_char], rwmode: c_int, hdl: &mut
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// lower level routine to uncompress a file into memory.  The file
 /// has already been opened and the memory buffer has been allocated.
 #[cfg(unix)]
@@ -1322,7 +1328,6 @@ pub(crate) unsafe fn mem_uncompress2mem<T: Read + AsRawFd>(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// lower level routine to uncompress a file into memory.  The file
 /// has already been opened and the memory buffer has been allocated.
 #[cfg(windows)]
@@ -1387,7 +1392,6 @@ pub(crate) unsafe fn mem_uncompress2mem<T: Read + AsRawHandle>(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// return the size of the file; only called when the file is first opened
 pub(crate) fn mem_size(handle: c_int, filesize: &mut usize) -> c_int {
     let handle = handle as usize;
@@ -1398,7 +1402,6 @@ pub(crate) fn mem_size(handle: c_int, filesize: &mut usize) -> c_int {
     0
 }
 
-/*--------------------------------------------------------------------------*/
 /// close the file and free the memory.
 pub(crate) fn mem_close_free_unsafe(handle: c_int) -> c_int {
     unsafe {
@@ -1426,7 +1429,6 @@ pub(crate) fn mem_close_free_unsafe(handle: c_int) -> c_int {
         0
     }
 }
-/*--------------------------------------------------------------------------*/
 ///  close the memory file but do not free the memory.
 pub(crate) fn mem_close_keep(handle: c_int) -> c_int {
     let handle = handle as usize;
@@ -1437,7 +1439,6 @@ pub(crate) fn mem_close_keep(handle: c_int) -> c_int {
     0
 }
 
-/*--------------------------------------------------------------------------*/
 /// Compress the memory file, writing it out to the fileptr (which might be stdout)
 pub(crate) fn mem_close_comp_unsafe(handle: c_int) -> c_int {
     unsafe {
@@ -1478,7 +1479,6 @@ pub(crate) fn mem_close_comp_unsafe(handle: c_int) -> c_int {
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// seek to position relative to start of the file.
 pub(crate) fn mem_seek(handle: c_int, offset: LONGLONG) -> c_int {
     let handle = handle as usize;
@@ -1492,7 +1492,6 @@ pub(crate) fn mem_seek(handle: c_int, offset: LONGLONG) -> c_int {
     m[handle].currentpos = offset;
     0
 }
-/*--------------------------------------------------------------------------*/
 /// read bytes from the current position in the file
 pub(crate) fn mem_read_unsafe(hdl: c_int, buffer: &mut [u8], nbytes: usize) -> c_int {
     unsafe {
@@ -1520,7 +1519,6 @@ pub(crate) fn mem_read_unsafe(hdl: c_int, buffer: &mut [u8], nbytes: usize) -> c
     }
 }
 
-/*--------------------------------------------------------------------------*/
 ///  write bytes at the current position in the file
 pub(crate) fn mem_write_unsafe(hdl: c_int, buffer: &[u8], nbytes: usize) -> c_int {
     unsafe {
@@ -1578,7 +1576,6 @@ pub(crate) fn mem_write_unsafe(hdl: c_int, buffer: &[u8], nbytes: usize) -> c_in
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// uncompress input buffer, length nbytes and write bytes to current
 /// position in file.  output buffer needs to be at position 0 to start.
 pub(crate) unsafe fn mem_zuncompress_and_write(hdl: c_int, buffer: &[u8], nbytes: usize) -> c_int {
@@ -1614,7 +1611,6 @@ pub(crate) unsafe fn mem_zuncompress_and_write(hdl: c_int, buffer: &[u8], nbytes
     }
 }
 
-/*--------------------------------------------------------------------------*/
 #[cfg(feature = "bzip2")]
 pub(crate) unsafe fn bzip2uncompress2mem(
     filename: &[c_char],

--- a/src/drvrnet.rs
+++ b/src/drvrnet.rs
@@ -1,3 +1,10 @@
+//! What remains of the network drivers.
+//!
+//! CFITSIO's `drvrnet.c` implements `http://`, `ftp://` and `root://` access.
+//! This port does not: only the HTTPS configuration hooks that the public API
+//! exposes are kept, so that a program calling them still links.
+#![warn(missing_docs)]
+
 use std::sync::Mutex;
 
 use crate::c_types::{c_int, c_uint};

--- a/src/drvrsmem.rs
+++ b/src/drvrsmem.rs
@@ -1,4 +1,14 @@
 #![allow(static_mut_refs)]
+//! The driver for System V shared memory segments, behind the `shmem://`
+//! prefix.
+//!
+//! A FITS file living in a shared memory segment can be read and written by
+//! several processes at once, so this driver carries the locking the others do
+//! not: each segment has a semaphore, and readers and writers take it for
+//! shared or exclusive access.
+//!
+//! Ported from CFITSIO's `drvrsmem.c`.
+#![warn(missing_docs)]
 
 /* configuration parameters */
 
@@ -87,56 +97,90 @@ shared and regular) to allow automatic recognition of segments type */
 
 #[repr(C, align(8))]
 #[derive(Debug, Copy, Clone)]
+/// The header written at the start of every segment, shared or regular, so
+/// that a segment's type can be recognized from its contents.
 struct BLKHEAD {
-    ID: [c_char; 2], /* ID = 'JB', just as a checkpoint */
-    tflag: c_char,   /* is it shared memory or regular one ? */
-    handle: c_int,   /* this is not necessary, used only for non-resizeable objects via ptr */
+    /// `'JB'`, just as a checkpoint.
+    ID: [c_char; 2],
+    /// Whether this is shared memory or a regular allocation.
+    tflag: c_char,
+    /// Not strictly necessary; used only for non-resizeable objects reached
+    /// through a pointer.
+    handle: c_int,
 }
 
-type SHARED_P = *const c_void; /* generic type of shared memory pointer */
+/// Generic shared memory pointer.
+type SHARED_P = *const c_void;
 
 #[repr(C)]
-struct SHARED_GTAB /* data type used in global table */ {
-    sem: c_int,        /* access semaphore (1 field): process count */
-    semkey: c_int,     /* key value used to generate semaphore handle */
-    key: c_int,        /* key value used to generate shared memory handle (realloc changes it) */
-    handle: c_int,     /* handle of shared memory segment */
-    size: c_int,       /* size of shared memory segment */
-    nprocdebug: c_int, /* attached proc counter, helps remove zombie segments */
-    attr: c_char,      /* attributes of shared memory object */
+/// One entry of the global table, which lives in shared memory and is seen by
+/// every process using the driver.
+struct SHARED_GTAB {
+    /// Access semaphore, one field: the process count.
+    sem: c_int,
+    /// Key value used to generate the semaphore handle.
+    semkey: c_int,
+    /// Key value used to generate the shared memory handle; `realloc` changes
+    /// it.
+    key: c_int,
+    /// Handle of the shared memory segment.
+    handle: c_int,
+    /// Size of the shared memory segment.
+    size: c_int,
+    /// Attached-process counter, which helps remove zombie segments.
+    nprocdebug: c_int,
+    /// Attributes of the shared memory object.
+    attr: c_char,
 }
 
 #[derive(Default, Clone)]
 #[repr(C)]
-struct SHARED_LTAB /* data type used in local table */ {
-    p: Option<*const BLKHEAD>, /* pointer to segment (may be null) */
-    tcnt: c_int,               /* number of threads in this process attached to segment */
-    lkcnt: c_int,              /* >=0 <- number of read locks, -1 - write lock */
-    seekpos: c_long,           /* current pointer position, read/write/seek operations change it */
+/// One entry of the local table, which is private to this process and tracks
+/// how it is using a segment.
+struct SHARED_LTAB {
+    /// Pointer to the segment, or `None` if it is not attached.
+    p: Option<*const BLKHEAD>,
+    /// Number of threads in this process attached to the segment.
+    tcnt: c_int,
+    /// Lock state: `>= 0` is that many read locks, `-1` is a write lock.
+    lkcnt: c_int,
+    /// Current pointer position; read, write and seek all change it.
+    seekpos: c_long,
 }
 
 unsafe impl Send for SHARED_LTAB {}
 
 /* system dependent definitions */
 
+/// The `fcntl` record lock structure.
 type flock_t = flock;
 
 #[derive(Clone, Copy)]
 #[repr(C)]
+/// The argument to `semctl`, which the System V API passes as a union.
 union semun {
+    /// Value, for `SETVAL`.
     val: c_int,
+    /// Buffer, for `IPC_STAT` and `IPC_SET`.
     buf: *mut semid_ds,
+    /// Array, for `GETALL` and `SETALL`.
     array: *mut c_ushort,
 }
 
+/// Alias matching the C's `typedef` spelling.
 type DAL_SHM_SEGHEAD = DAL_SHM_SEGHEAD_STRUCT;
 
 #[repr(C)]
+/// The header of a DAL shared memory segment.
 struct DAL_SHM_SEGHEAD_STRUCT {
-    ID: c_int,      /* ID for debugging */
-    h: c_int,       /* handle of sh. mem */
-    size: c_int,    /* size of data area */
-    nodeidx: c_int, /* offset of root object (node struct typically) */
+    /// Identifier, for debugging.
+    ID: c_int,
+    /// Handle of the shared memory segment.
+    h: c_int,
+    /// Size of the data area.
+    size: c_int,
+    /// Offset of the root object, typically a node struct.
+    nodeidx: c_int,
 }
 
 /*              S H A R E D   M E M O R Y   D R I V E R
@@ -995,6 +1039,11 @@ pub unsafe extern "C" fn shared_malloc(size: c_long, mode: c_int, newhandle: c_i
 }
 
 #[cfg_attr(not(test), unsafe(no_mangle))]
+/// Attach the calling process to the shared memory segment at `idx`.
+///
+/// # Safety
+///
+/// `idx` must index a segment this process has open.
 pub unsafe extern "C" fn shared_attach(idx: usize) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -1165,8 +1214,16 @@ unsafe fn shared_validate(idx: usize, mode: c_int) -> c_int /* use intrnally ins
 }
 
 #[cfg_attr(not(test), unsafe(no_mangle))]
-pub unsafe extern "C" fn shared_realloc(idx: usize, newsize: c_int) -> SHARED_P /* realloc shared memory segment */
-{
+/// Reallocate the shared memory segment at `idx` to `newsize` bytes.
+///
+/// # Returns
+///
+/// The new address of the segment, which may differ from the old one.
+///
+/// # Safety
+///
+/// `idx` must index a segment this process has locked for writing.
+pub unsafe extern "C" fn shared_realloc(idx: usize, newsize: c_int) -> SHARED_P {
     // FFI WRAPPER
     unsafe {
         let mut h: c_int = 0;
@@ -1270,8 +1327,13 @@ pub unsafe extern "C" fn shared_realloc(idx: usize, newsize: c_int) -> SHARED_P 
 }
 
 #[cfg_attr(not(test), unsafe(no_mangle))]
-pub unsafe extern "C" fn shared_free(idx: usize) -> c_int /* detach segment, if last process & !PERSIST, destroy segment */
-{
+/// Detach from the segment at `idx`; if this is the last process using it and
+/// it is not `SHARED_PERSIST`, destroy the segment.
+///
+/// # Safety
+///
+/// `idx` must index a segment this process has open.
+pub unsafe extern "C" fn shared_free(idx: usize) -> c_int {
     // FFI WRAPPER
     unsafe {
         let mut cnt: c_int = 0;
@@ -1329,8 +1391,23 @@ pub unsafe extern "C" fn shared_free(idx: usize) -> c_int /* detach segment, if 
 }
 
 #[cfg_attr(not(test), unsafe(no_mangle))]
-pub unsafe extern "C" fn shared_lock(idx: usize, mode: c_int) -> SHARED_P /* lock given segment for exclusive access */
-{
+/// Lock the segment at `idx` for access, blocking or failing according to
+/// `mode`.
+///
+/// # Parameters
+///
+/// * `idx`  — (I) index of the segment to lock
+/// * `mode` — (I) `SHARED_RDONLY` or `SHARED_RDWRITE`, optionally with
+///   `SHARED_NOWAIT`
+///
+/// # Returns
+///
+/// The address of the locked segment.
+///
+/// # Safety
+///
+/// `idx` must index a segment this process has open.
+pub unsafe extern "C" fn shared_lock(idx: usize, mode: c_int) -> SHARED_P {
     // FFI WRAPPER
     unsafe {
         let mut r: c_int = 0;
@@ -1384,8 +1461,13 @@ pub unsafe extern "C" fn shared_lock(idx: usize, mode: c_int) -> SHARED_P /* loc
 }
 
 #[cfg_attr(not(test), unsafe(no_mangle))]
-pub unsafe extern "C" fn shared_unlock(idx: usize) -> c_int /* unlock given segment, assumes seg is locked !! */
-{
+/// Unlock the segment at `idx`.
+///
+/// # Safety
+///
+/// The segment must currently be locked by this process; the routine does not
+/// check.
+pub unsafe extern "C" fn shared_unlock(idx: usize) -> c_int {
     // FFI WRAPPER
     unsafe {
         let mut r: c_int = 0;
@@ -1426,8 +1508,12 @@ pub unsafe extern "C" fn shared_unlock(idx: usize) -> c_int /* unlock given segm
 /* API routines - support and info routines */
 
 #[cfg_attr(not(test), unsafe(no_mangle))]
-pub unsafe extern "C" fn shared_attr(idx: usize) -> c_int /* get the attributes of the shared memory segment */
-{
+/// Get the attributes of the shared memory segment at `idx`.
+///
+/// # Safety
+///
+/// `idx` must index a segment this process has open.
+pub unsafe extern "C" fn shared_attr(idx: usize) -> c_int {
     // FFI WRAPPER
     unsafe {
         if shared_check_locked_index(idx) != 0 {
@@ -1441,8 +1527,12 @@ pub unsafe extern "C" fn shared_attr(idx: usize) -> c_int /* get the attributes 
 }
 
 #[cfg_attr(not(test), unsafe(no_mangle))]
-pub unsafe extern "C" fn shared_set_attr(idx: usize, newattr: c_int) -> c_int /* get the attributes of the shared memory segment */
-{
+/// Set the attributes of the shared memory segment at `idx`.
+///
+/// # Safety
+///
+/// `idx` must index a segment this process has open.
+pub unsafe extern "C" fn shared_set_attr(idx: usize, newattr: c_int) -> c_int {
     // FFI WRAPPER
     unsafe {
         if shared_check_locked_index(idx) != 0 {
@@ -1467,7 +1557,12 @@ pub unsafe extern "C" fn shared_set_attr(idx: usize, newattr: c_int) -> c_int /*
 }
 
 #[cfg_attr(not(test), unsafe(no_mangle))]
-pub unsafe extern "C" fn shared_set_debug(mode: c_int) -> c_int /* set/reset debug mode */ {
+/// Set or reset the driver's debug mode.
+///
+/// # Safety
+///
+/// Writes a process-wide static; not safe to call concurrently.
+pub unsafe extern "C" fn shared_set_debug(mode: c_int) -> c_int {
     // FFI WRAPPER
     unsafe {
         let r: c_int = SHARED_DEBUG as c_int;
@@ -1478,7 +1573,12 @@ pub unsafe extern "C" fn shared_set_debug(mode: c_int) -> c_int /* set/reset deb
 }
 
 #[cfg_attr(not(test), unsafe(no_mangle))]
-pub unsafe extern "C" fn shared_set_createmode(mode: c_int) -> c_int /* set/reset debug mode */ {
+/// Set the permissions new segments are created with.
+///
+/// # Safety
+///
+/// Writes a process-wide static; not safe to call concurrently.
+pub unsafe extern "C" fn shared_set_createmode(mode: c_int) -> c_int {
     // FFI WRAPPER
     unsafe {
         let r: c_int = SHARED_CREATE_MODE;
@@ -1489,6 +1589,12 @@ pub unsafe extern "C" fn shared_set_createmode(mode: c_int) -> c_int /* set/rese
 }
 
 #[cfg_attr(not(test), unsafe(no_mangle))]
+/// Print a listing of the shared memory segments, or of the one with the given
+/// `id`.
+///
+/// # Safety
+///
+/// Reads the driver's process-wide tables.
 pub unsafe extern "C" fn shared_list(id: c_int) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -1565,6 +1671,16 @@ pub unsafe extern "C" fn shared_list(id: c_int) -> c_int {
 }
 
 #[cfg_attr(not(test), unsafe(no_mangle))]
+/// Get the address at which the segment with the given `id` is mapped.
+///
+/// # Parameters
+///
+/// * `id`      — (I) identifier of the segment
+/// * `address` — (O) where the segment is mapped
+///
+/// # Safety
+///
+/// Reads the driver's process-wide tables.
 pub unsafe extern "C" fn shared_getaddr(id: c_int, address: &mut *mut c_char) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -1603,6 +1719,13 @@ pub unsafe extern "C" fn shared_getaddr(id: c_int, address: &mut *mut c_char) ->
 }
 
 #[cfg_attr(not(test), unsafe(no_mangle))]
+/// Destroy the segment with the given `id` regardless of how many processes
+/// are attached to it.
+///
+/// # Safety
+///
+/// Other processes may still be using the segment; their mappings become
+/// invalid.
 pub unsafe extern "C" fn shared_uncond_delete(id: c_int) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -1658,8 +1781,6 @@ pub unsafe extern "C" fn shared_uncond_delete(id: c_int) -> c_int {
         r /* table full */
     }
 }
-
-/************************* CFITSIO DRIVER FUNCTIONS ***************************/
 
 pub(crate) fn smem_init() -> c_int {
     0

--- a/src/editcol.rs
+++ b/src/editcol.rs
@@ -1,9 +1,15 @@
-/*  This file, editcol.rs, contains the set of FITSIO routines that    */
-/*  insert or delete rows or columns in a table or resize an image    */
-
-/*  The FITSIO software was written by William Pence at the High Energy    */
-/*  Astrophysic Science Archive Research Center (HEASARC) at the NASA      */
-/*  Goddard Space Flight Center.                                           */
+//! Routines that insert or delete rows or columns in a table, or resize an
+//! image.
+//!
+//! Editing a table's shape means moving the data that follows it in the file,
+//! rewriting the affected `NAXISn`, `TFORMn` and `TBCOLn` keywords, and
+//! shifting the heap of any variable length array columns. Row and column
+//! numbers are one-based throughout, as in the FITS standard.
+//!
+//! Ported from CFITSIO's `editcol.c`, written by William Pence at the High
+//! Energy Astrophysics Science Archive Research Center (HEASARC), NASA Goddard
+//! Space Flight Center.
+#![warn(missing_docs)]
 
 use core::ffi::CStr;
 use core::slice;
@@ -47,15 +53,22 @@ use crate::wrappers::*;
 use crate::{bb, cs};
 use crate::{buffers::*, raw_to_slice};
 
-/*--------------------------------------------------------------------------*/
 /// resize an existing primary array or IMAGE extension.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `bitpix` — (I) bits per pixel
+/// * `naxis`  — (I) number of axes in the array
+/// * `naxes`  — (I) size of each axis
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffrsim(
-    fptr: *mut fitsfile,  /* I - FITS file pointer           */
-    bitpix: c_int,        /* I - bits per pixel              */
-    naxis: c_int,         /* I - number of axes in the array */
-    naxes: *const c_long, /* I - size of each axis           */
-    status: *mut c_int,   /* IO - error status               */
+    fptr: *mut fitsfile,
+    bitpix: c_int,
+    naxis: c_int,
+    naxes: *const c_long,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -68,14 +81,21 @@ pub unsafe extern "C" fn ffrsim(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// resize an existing primary array or IMAGE extension.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `bitpix` — (I) bits per pixel
+/// * `naxis`  — (I) number of axes in the array
+/// * `naxes`  — (I) size of each axis
+/// * `status` — (IO) error status
 pub fn ffrsim_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer           */
-    bitpix: c_int,       /* I - bits per pixel              */
-    naxis: c_int,        /* I - number of axes in the array */
-    naxes: &[c_long],    /* I - size of each axis           */
-    status: &mut c_int,  /* IO - error status               */
+    fptr: &mut fitsfile,
+    bitpix: c_int,
+    naxis: c_int,
+    naxes: &[c_long],
+    status: &mut c_int,
 ) -> c_int {
     let mut tnaxes: [LONGLONG; 99] = [0; 99];
 
@@ -96,15 +116,22 @@ pub fn ffrsim_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// resize an existing primary array or IMAGE extension.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `bitpix` — (I) bits per pixel
+/// * `naxis`  — (I) number of axes in the array
+/// * `naxes`  — (I) size of each axis
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffrsimll(
-    fptr: *mut fitsfile,    /* I - FITS file pointer           */
-    bitpix: c_int,          /* I - bits per pixel              */
-    naxis: c_int,           /* I - number of axes in the array */
-    naxes: *const LONGLONG, /* I - size of each axis           */
-    status: *mut c_int,     /* IO - error status               */
+    fptr: *mut fitsfile,
+    bitpix: c_int,
+    naxis: c_int,
+    naxes: *const LONGLONG,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -117,14 +144,21 @@ pub unsafe extern "C" fn ffrsimll(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// resize an existing primary array or IMAGE extension.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `bitpix` — (I) bits per pixel
+/// * `naxis`  — (I) number of axes in the array
+/// * `naxes`  — (I) size of each axis
+/// * `status` — (IO) error status
 pub fn ffrsimll_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer           */
-    bitpix: c_int,       /* I - bits per pixel              */
-    naxis: c_int,        /* I - number of axes in the array */
-    naxes: &[LONGLONG],  /* I - size of each axis           */
-    status: &mut c_int,  /* IO - error status               */
+    fptr: &mut fitsfile,
+    bitpix: c_int,
+    naxis: c_int,
+    naxes: &[LONGLONG],
+    status: &mut c_int,
 ) -> c_int {
     let mut simple: c_int = 0;
     let mut obitpix: c_int = 0;
@@ -378,15 +412,21 @@ pub fn ffrsimll_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// insert NROWS blank rows immediated after row firstrow (1 = first row).
 /// Set firstrow = 0 to insert space at the beginning of the table.
+///
+/// # Parameters
+///
+/// * `fptr`     — (I) FITS file pointer
+/// * `firstrow` — (I) insert space AFTER this row, 0 = insert space at beginning of table
+/// * `nrows`    — (I) number of rows to insert
+/// * `status`   — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffirow(
-    fptr: *mut fitsfile, /* I - FITS file pointer                        */
-    firstrow: LONGLONG, /* I - insert space AFTER this row, 0 = insert space at beginning of table              */
-    nrows: LONGLONG,    /* I - number of rows to insert                 */
-    status: *mut c_int, /* IO - error status                            */
+    fptr: *mut fitsfile,
+    firstrow: LONGLONG,
+    nrows: LONGLONG,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -397,14 +437,20 @@ pub unsafe extern "C" fn ffirow(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// insert NROWS blank rows immediated after row firstrow (1 = first row).
 /// Set firstrow = 0 to insert space at the beginning of the table.
+///
+/// # Parameters
+///
+/// * `fptr`     — (I) FITS file pointer
+/// * `firstrow` — (I) insert space AFTER this row, 0 = insert space at beginning of table
+/// * `nrows`    — (I) number of rows to insert
+/// * `status`   — (IO) error status
 pub fn ffirow_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                        */
-    firstrow: LONGLONG, /* I - insert space AFTER this row, 0 = insert space at beginning of table              */
-    nrows: LONGLONG,    /* I - number of rows to insert                 */
-    status: &mut c_int, /* IO - error status                            */
+    fptr: &mut fitsfile,
+    firstrow: LONGLONG,
+    nrows: LONGLONG,
+    status: &mut c_int,
 ) -> c_int {
     let mut naxis1: LONGLONG = 0;
     let mut naxis2: LONGLONG = 0;
@@ -504,14 +550,20 @@ pub fn ffirow_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// delete NROWS rows from table starting with firstrow (1 = first row of table).
+///
+/// # Parameters
+///
+/// * `fptr`     — (I) FITS file pointer
+/// * `firstrow` — (I) first row to delete (1 = first)
+/// * `nrows`    — (I) number of rows to delete
+/// * `status`   — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffdrow(
-    fptr: *mut fitsfile, /* I - FITS file pointer                        */
-    firstrow: LONGLONG,  /* I - first row to delete (1 = first)          */
-    nrows: LONGLONG,     /* I - number of rows to delete                 */
-    status: *mut c_int,  /* IO - error status                            */
+    fptr: *mut fitsfile,
+    firstrow: LONGLONG,
+    nrows: LONGLONG,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -522,13 +574,19 @@ pub unsafe extern "C" fn ffdrow(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// delete NROWS rows from table starting with firstrow (1 = first row of table).
+///
+/// # Parameters
+///
+/// * `fptr`     — (I) FITS file pointer
+/// * `firstrow` — (I) first row to delete (1 = first)
+/// * `nrows`    — (I) number of rows to delete
+/// * `status`   — (IO) error status
 pub fn ffdrow_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                        */
-    firstrow: LONGLONG,  /* I - first row to delete (1 = first)          */
-    nrows: LONGLONG,     /* I - number of rows to delete                 */
-    status: &mut c_int,  /* IO - error status                            */
+    fptr: &mut fitsfile,
+    firstrow: LONGLONG,
+    nrows: LONGLONG,
+    status: &mut c_int,
 ) -> c_int {
     let mut naxis1: LONGLONG = 0;
     let mut naxis2: LONGLONG = 0;
@@ -635,17 +693,22 @@ pub fn ffdrow_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Delete the ranges of rows from the table (1 = first row of table).
 ///
 /// The 'ranges' parameter typically looks like:
 /// '10-20, 30 - 40, 55' or '50-'
 /// and gives a list of rows or row ranges separated by commas.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer to table
+/// * `ranges` — (I) ranges of rows to delete (1 = first)
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffdrrg(
-    fptr: *mut fitsfile,   /* I - FITS file pointer to table               */
-    ranges: *const c_char, /* I - ranges of rows to delete (1 = first)     */
-    status: *mut c_int,    /* IO - error status                            */
+    fptr: *mut fitsfile,
+    ranges: *const c_char,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -658,17 +721,18 @@ pub unsafe extern "C" fn ffdrrg(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Delete the ranges of rows from the table (1 = first row of table).
 ///
 /// The 'ranges' parameter typically looks like:
 /// '10-20, 30 - 40, 55' or '50-'
 /// and gives a list of rows or row ranges separated by commas.
-pub fn ffdrrg_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer to table               */
-    ranges: &[c_char],   /* I - ranges of rows to delete (1 = first)     */
-    status: &mut c_int,  /* IO - error status                            */
-) -> c_int {
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer to table
+/// * `ranges` — (I) ranges of rows to delete (1 = first)
+/// * `status` — (IO) error status
+pub fn ffdrrg_safe(fptr: &mut fitsfile, ranges: &[c_char], status: &mut c_int) -> c_int {
     let mut nranges2: c_int = 0;
     let mut nrows: c_long = 0;
     let mut naxis2: LONGLONG = 0;
@@ -762,14 +826,20 @@ pub fn ffdrrg_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// delete the list of rows from the table (1 = first row of table).
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `rownum` — (I) list of rows to delete (1 = first)
+/// * `nrows`  — (I) number of rows to delete
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffdrws(
-    fptr: *mut fitsfile,   /* I - FITS file pointer                        */
-    rownum: *const c_long, /* I - list of rows to delete (1 = first)       */
-    nrows: c_long,         /* I - number of rows to delete                 */
-    status: *mut c_int,    /* IO - error status                            */
+    fptr: *mut fitsfile,
+    rownum: *const c_long,
+    nrows: c_long,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -782,13 +852,19 @@ pub unsafe extern "C" fn ffdrws(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// delete the list of rows from the table (1 = first row of table).
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `rownum` — (I) list of rows to delete (1 = first)
+/// * `nrows`  — (I) number of rows to delete
+/// * `status` — (IO) error status
 pub fn ffdrws_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                        */
-    rownum: &[c_long],   /* I - list of rows to delete (1 = first)       */
-    nrows: c_long,       /* I - number of rows to delete                 */
-    status: &mut c_int,  /* IO - error status                            */
+    fptr: &mut fitsfile,
+    rownum: &[c_long],
+    nrows: c_long,
+    status: &mut c_int,
 ) -> c_int {
     let mut naxis1: LONGLONG = 0;
     let mut naxis2: LONGLONG = 0;
@@ -919,14 +995,20 @@ pub fn ffdrws_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// delete the list of rows from the table (1 = first row of table).
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `rownum` — (I) list of rows to delete (1 = first)
+/// * `nrows`  — (I) number of rows to delete
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffdrwsll(
-    fptr: *mut fitsfile,     /* I - FITS file pointer                        */
-    rownum: *const LONGLONG, /* I - list of rows to delete (1 = first)       */
-    nrows: LONGLONG,         /* I - number of rows to delete                 */
-    status: *mut c_int,      /* IO - error status                            */
+    fptr: *mut fitsfile,
+    rownum: *const LONGLONG,
+    nrows: LONGLONG,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -939,13 +1021,19 @@ pub unsafe extern "C" fn ffdrwsll(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// delete the list of rows from the table (1 = first row of table).
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `rownum` — (I) list of rows to delete (1 = first)
+/// * `nrows`  — (I) number of rows to delete
+/// * `status` — (IO) error status
 pub fn ffdrwsll_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                        */
-    rownum: &[LONGLONG], /* I - list of rows to delete (1 = first)       */
-    nrows: LONGLONG,     /* I - number of rows to delete                 */
-    status: &mut c_int,  /* IO - error status                            */
+    fptr: &mut fitsfile,
+    rownum: &[LONGLONG],
+    nrows: LONGLONG,
+    status: &mut c_int,
 ) -> c_int {
     let mut insertpos: LONGLONG = 0;
     let mut nextrowpos: LONGLONG = 0;
@@ -1070,7 +1158,6 @@ pub fn ffdrwsll_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// parse the input list of row ranges, returning the number of ranges,
 /// and the min and max row value in each range.
 ///
@@ -1085,15 +1172,25 @@ pub fn ffdrwsll_safe(
 ///
 /// error is returned if min value of range is > max value of range or if the
 /// ranges are not monotonically increasing.
+///
+/// # Parameters
+///
+/// * `rowlist`   — (I) list of rows and row ranges
+/// * `maxrows`   — (I) number of rows in the table
+/// * `maxranges` — (I) max number of ranges to be returned
+/// * `numranges` — (O) number ranges returned
+/// * `minrow`    — (O) first row in each range
+/// * `maxrow`    — (O) last row in each range
+/// * `status`    — (IO) status value
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffrwrg(
-    rowlist: *const c_char, /* I - list of rows and row ranges */
-    maxrows: LONGLONG,      /* I - number of rows in the table */
-    maxranges: c_int,       /* I - max number of ranges to be returned */
-    numranges: *mut c_int,  /* O - number ranges returned */
-    minrow: *mut c_long,    /* O - first row in each range */
-    maxrow: *mut c_long,    /* O - last row in each range */
-    status: *mut c_int,     /* IO - status value */
+    rowlist: *const c_char,
+    maxrows: LONGLONG,
+    maxranges: c_int,
+    numranges: *mut c_int,
+    minrow: *mut c_long,
+    maxrow: *mut c_long,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -1110,7 +1207,6 @@ pub unsafe extern "C" fn ffrwrg(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// parse the input list of row ranges, returning the number of ranges,
 /// and the min and max row value in each range.
 ///
@@ -1125,14 +1221,24 @@ pub unsafe extern "C" fn ffrwrg(
 ///
 /// error is returned if min value of range is > max value of range or if the
 /// ranges are not monotonically increasing.
+///
+/// # Parameters
+///
+/// * `rowlist`   — (I) list of rows and row ranges
+/// * `maxrows`   — (I) number of rows in the table
+/// * `maxranges` — (I) max number of ranges to be returned
+/// * `numranges` — (O) number ranges returned
+/// * `minrow`    — (O) first row in each range
+/// * `maxrow`    — (O) last row in each range
+/// * `status`    — (IO) status value
 pub fn ffrwrg_safe(
-    rowlist: &[c_char],    /* I - list of rows and row ranges */
-    maxrows: LONGLONG,     /* I - number of rows in the table */
-    maxranges: c_int,      /* I - max number of ranges to be returned */
-    numranges: &mut c_int, /* O - number ranges returned */
-    minrow: &mut [c_long], /* O - first row in each range */
-    maxrow: &mut [c_long], /* O - last row in each range */
-    status: &mut c_int,    /* IO - status value */
+    rowlist: &[c_char],
+    maxrows: LONGLONG,
+    maxranges: c_int,
+    numranges: &mut c_int,
+    minrow: &mut [c_long],
+    maxrow: &mut [c_long],
+    status: &mut c_int,
 ) -> c_int {
     let mut minval: c_long = 0;
     let mut maxval: c_long = 0;
@@ -1266,7 +1372,6 @@ pub fn ffrwrg_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 // parse the input list of row ranges, returning the number of ranges,
 // and the min and max row value in each range.
 //
@@ -1282,14 +1387,23 @@ pub fn ffrwrg_safe(
 // error is returned if min value of range is > max value of range or if the
 // ranges are not monotonically increasing.
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
+/// # Parameters
+///
+/// * `rowlist`   — (I) list of rows and row ranges
+/// * `maxrows`   — (I) number of rows in the list
+/// * `maxranges` — (I) max number of ranges to be returned
+/// * `numranges` — (O) number ranges returned
+/// * `minrow`    — (O) first row in each range
+/// * `maxrow`    — (O) last row in each range
+/// * `status`    — (IO) status value
 pub unsafe extern "C" fn ffrwrgll(
-    rowlist: *const c_char, /* I - list of rows and row ranges */
-    maxrows: LONGLONG,      /* I - number of rows in the list */
-    maxranges: c_int,       /* I - max number of ranges to be returned */
-    numranges: *mut c_int,  /* O - number ranges returned */
-    minrow: *mut LONGLONG,  /* O - first row in each range */
-    maxrow: *mut LONGLONG,  /* O - last row in each range */
-    status: *mut c_int,     /* IO - status value */
+    rowlist: *const c_char,
+    maxrows: LONGLONG,
+    maxranges: c_int,
+    numranges: *mut c_int,
+    minrow: *mut LONGLONG,
+    maxrow: *mut LONGLONG,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -1306,7 +1420,6 @@ pub unsafe extern "C" fn ffrwrgll(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 // parse the input list of row ranges, returning the number of ranges,
 // and the min and max row value in each range.
 //
@@ -1321,14 +1434,23 @@ pub unsafe extern "C" fn ffrwrgll(
 //
 // error is returned if min value of range is > max value of range or if the
 // ranges are not monotonically increasing.
+/// # Parameters
+///
+/// * `rowlist`   — (I) list of rows and row ranges
+/// * `maxrows`   — (I) number of rows in the list
+/// * `maxranges` — (I) max number of ranges to be returned
+/// * `numranges` — (O) number ranges returned
+/// * `minrow`    — (O) first row in each range
+/// * `maxrow`    — (O) last row in each range
+/// * `status`    — (IO) status value
 pub fn ffrwrgll_safe(
-    rowlist: &[c_char],      /* I - list of rows and row ranges */
-    maxrows: LONGLONG,       /* I - number of rows in the list */
-    maxranges: c_int,        /* I - max number of ranges to be returned */
-    numranges: &mut c_int,   /* O - number ranges returned */
-    minrow: &mut [LONGLONG], /* O - first row in each range */
-    maxrow: &mut [LONGLONG], /* O - last row in each range */
-    status: &mut c_int,      /* IO - status value */
+    rowlist: &[c_char],
+    maxrows: LONGLONG,
+    maxranges: c_int,
+    numranges: &mut c_int,
+    minrow: &mut [LONGLONG],
+    maxrow: &mut [LONGLONG],
+    status: &mut c_int,
 ) -> c_int {
     let mut minval: LONGLONG = 0;
     let mut maxval: LONGLONG = 0;
@@ -1468,17 +1590,24 @@ pub fn ffrwrgll_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Insert a new column into an existing table at position numcol.  If
 /// numcol is greater than the number of existing columns in the table
 /// then the new column will be appended as the last column in the table.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `numcol` — (I) position for new col. (1 = 1st)
+/// * `ttype`  — (I) name of column (TTYPE keyword)
+/// * `tform`  — (I) format of column (TFORM keyword)
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn fficol(
-    fptr: *mut fitsfile,  /* I - FITS file pointer                        */
-    numcol: c_int,        /* I - position for new col. (1 = 1st)          */
-    ttype: *const c_char, /* I - name of column (TTYPE keyword)           */
-    tform: *const c_char, /* I - format of column (TFORM keyword)         */
-    status: *mut c_int,   /* IO - error status                            */
+    fptr: *mut fitsfile,
+    numcol: c_int,
+    ttype: *const c_char,
+    tform: *const c_char,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -1492,16 +1621,23 @@ pub unsafe extern "C" fn fficol(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Insert a new column into an existing table at position numcol.  If
 /// numcol is greater than the number of existing columns in the table
 /// then the new column will be appended as the last column in the table.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `numcol` — (I) position for new col. (1 = 1st)
+/// * `ttype`  — (I) name of column (TTYPE keyword)
+/// * `tform`  — (I) format of column (TFORM keyword)
+/// * `status` — (IO) error status
 pub fn fficol_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                        */
-    numcol: c_int,       /* I - position for new col. (1 = 1st)          */
-    ttype: &[c_char],    /* I - name of column (TTYPE keyword)           */
-    tform: &[c_char],    /* I - format of column (TFORM keyword)         */
-    status: &mut c_int,  /* IO - error status                            */
+    fptr: &mut fitsfile,
+    numcol: c_int,
+    ttype: &[c_char],
+    tform: &[c_char],
+    status: &mut c_int,
 ) -> c_int {
     let name = ttype;
     let format = tform;
@@ -1510,18 +1646,26 @@ pub fn fficol_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Insert 1 or more new columns into an existing table at position numcol.  If
 /// fstcol is greater than the number of existing columns in the table
 /// then the new column will be appended as the last column in the table.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `fstcol` — (I) position for first new col. (1 = 1st)
+/// * `ncols`  — (I) number of columns to insert
+/// * `ttype`  — (I) array of column names(TTYPE keywords)
+/// * `tform`  — (I) array of formats of column (TFORM)
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn fficls(
-    fptr: *mut fitsfile,         /* I - FITS file pointer                        */
-    fstcol: c_int,               /* I - position for first new col. (1 = 1st)    */
-    ncols: c_int,                /* I - number of columns to insert              */
-    ttype: *const *const c_char, /* I - array of column names(TTYPE keywords)    */
-    tform: *const *const c_char, /* I - array of formats of column (TFORM)       */
-    status: *mut c_int,          /* IO - error status                            */
+    fptr: *mut fitsfile,
+    fstcol: c_int,
+    ncols: c_int,
+    ttype: *const *const c_char,
+    tform: *const *const c_char,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -1549,17 +1693,25 @@ pub unsafe extern "C" fn fficls(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Insert 1 or more new columns into an existing table at position numcol.  If
 /// fstcol is greater than the number of existing columns in the table
 /// then the new column will be appended as the last column in the table.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `fstcol` — (I) position for first new col. (1 = 1st)
+/// * `ncols`  — (I) number of columns to insert
+/// * `ttype`  — (I) array of column names(TTYPE keywords)
+/// * `tform`  — (I) array of formats of column (TFORM)
+/// * `status` — (IO) error status
 pub fn fficls_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                        */
-    fstcol: c_int,       /* I - position for first new col. (1 = 1st)    */
-    ncols: c_int,        /* I - number of columns to insert              */
-    ttype: &[&[c_char]], /* I - array of column names(TTYPE keywords)    */
-    tform: &[&[c_char]], /* I - array of formats of column (TFORM)       */
-    status: &mut c_int,  /* IO - error status                            */
+    fptr: &mut fitsfile,
+    fstcol: c_int,
+    ncols: c_int,
+    ttype: &[&[c_char]],
+    tform: &[&[c_char]],
+    status: &mut c_int,
 ) -> c_int {
     let mut colnum: c_int = 0;
     let mut datacode: c_int = 0;
@@ -1890,15 +2042,21 @@ pub fn fficls_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Modify the vector length of a column in a binary table, larger or smaller.
 /// E.g., change a column from TFORMn = '1E' to '20E'.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) position of col to be modified
+/// * `newveclen` — (I) new vector length of column (TFORM)
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffmvec(
-    fptr: *mut fitsfile, /* I - FITS file pointer                        */
-    colnum: c_int,       /* I - position of col to be modified           */
-    newveclen: LONGLONG, /* I - new vector length of column (TFORM)       */
-    status: *mut c_int,  /* IO - error status                            */
+    fptr: *mut fitsfile,
+    colnum: c_int,
+    newveclen: LONGLONG,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -1909,14 +2067,20 @@ pub unsafe extern "C" fn ffmvec(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Modify the vector length of a column in a binary table, larger or smaller.
 /// E.g., change a column from TFORMn = '1E' to '20E'.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) position of col to be modified
+/// * `newveclen` — (I) new vector length of column (TFORM)
+/// * `status`    — (IO) error status
 pub fn ffmvec_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                        */
-    colnum: c_int,       /* I - position of col to be modified           */
-    newveclen: LONGLONG, /* I - new vector length of column (TFORM)       */
-    status: &mut c_int,  /* IO - error status                            */
+    fptr: &mut fitsfile,
+    colnum: c_int,
+    newveclen: LONGLONG,
+    status: &mut c_int,
 ) -> c_int {
     let mut datacode: c_int = 0;
     let mut tfields: c_int = 0;
@@ -2143,16 +2307,24 @@ pub fn ffmvec_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// copy a column from infptr and insert it in the outfptr table.
+///
+/// # Parameters
+///
+/// * `infptr`     — (I) FITS file pointer to input file
+/// * `outfptr`    — (I) FITS file pointer to output file
+/// * `incol`      — (I) number of input column
+/// * `outcol`     — (I) number for output column
+/// * `create_col` — (I) create new col if TRUE, else overwrite
+/// * `status`     — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffcpcl(
-    infptr: *mut fitsfile,  /* I - FITS file pointer to input file  */
-    outfptr: *mut fitsfile, /* I - FITS file pointer to output file */
-    incol: c_int,           /* I - number of input column   */
-    outcol: c_int,          /* I - number for output column  */
-    create_col: c_int,      /* I - create new col if TRUE, else overwrite */
-    status: *mut c_int,     /* IO - error status     */
+    infptr: *mut fitsfile,
+    outfptr: *mut fitsfile,
+    incol: c_int,
+    outcol: c_int,
+    create_col: c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -2183,17 +2355,23 @@ pub unsafe extern "C" fn ffcpcl(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// copy a column from infptr and insert it in the outfptr table.
-/// NOTE: [`ffcpcl_inplace_safe`] is a copy of this body for the case where the
-/// caller passes one file as both input and output.  Any fix here belongs there too.
+///
+/// # Parameters
+///
+/// * `infptr`     — (I) FITS file pointer to input file
+/// * `outfptr`    — (I) FITS file pointer to output file
+/// * `incol`      — (I) number of input column
+/// * `outcol`     — (I) number for output column
+/// * `create_col` — (I) create new col if TRUE, else overwrite
+/// * `status`     — (IO) error status
 pub fn ffcpcl_safe(
-    infptr: &mut fitsfile,  /* I - FITS file pointer to input file  */
-    outfptr: &mut fitsfile, /* I - FITS file pointer to output file */
-    incol: c_int,           /* I - number of input column   */
-    outcol: c_int,          /* I - number for output column  */
-    create_col: c_int,      /* I - create new col if TRUE, else overwrite */
-    status: &mut c_int,     /* IO - error status     */
+    infptr: &mut fitsfile,
+    outfptr: &mut fitsfile,
+    incol: c_int,
+    outcol: c_int,
+    create_col: c_int,
+    status: &mut c_int,
 ) -> c_int {
     let mut tstatus: c_int = 0;
     let mut colnum: c_int = 0;
@@ -2740,7 +2918,6 @@ pub fn ffcpcl_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// In-place twin of [`ffcpcl_safe`]: copy a column within one file.
 ///
 /// This is the C's `fits_copy_col(fptr, fptr, ...)` case.  The C API allows the
@@ -2750,12 +2927,20 @@ pub fn ffcpcl_safe(
 ///
 /// NOTE: this body is a copy of [`ffcpcl_safe`] with `infptr`/`outfptr`
 /// collapsed to one handle.  Any fix to one belongs in the other.
+///
+/// # Parameters
+///
+/// * `fptr`       — I/O - FITS file, used as both input and output
+/// * `incol`      — (I) number of input column
+/// * `outcol`     — (I) number for output column
+/// * `create_col` — (I) create new col if TRUE, else overwrite
+/// * `status`     — (IO) error status
 pub fn ffcpcl_inplace_safe(
-    fptr: &mut fitsfile, /* I/O - FITS file, used as both input and output */
-    incol: c_int,        /* I - number of input column   */
-    outcol: c_int,       /* I - number for output column  */
-    create_col: c_int,   /* I - create new col if TRUE, else overwrite */
-    status: &mut c_int,  /* IO - error status     */
+    fptr: &mut fitsfile,
+    incol: c_int,
+    outcol: c_int,
+    create_col: c_int,
+    status: &mut c_int,
 ) -> c_int {
     let mut tstatus: c_int = 0;
     let mut colnum: c_int = 0;
@@ -3295,20 +3480,29 @@ pub fn ffcpcl_inplace_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy multiple columns from infptr and insert them in the outfptr
 /// table.  Optimized for multiple-column case since it only expands the
 /// output file once using fits_insert_cols() instead of calling
 /// fits_insert_col() multiple times.
+///
+/// # Parameters
+///
+/// * `infptr`     — (I) FITS file pointer to input file
+/// * `outfptr`    — (I) FITS file pointer to output file
+/// * `incol`      — (I) number of first input column
+/// * `outcol`     — (I) number for first output column
+/// * `ncols`      — (I) number of columns to copy from input to output
+/// * `create_col` — (I) create new col if TRUE, else overwrite
+/// * `status`     — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffccls(
-    infptr: *mut fitsfile,  /* I - FITS file pointer to input file  */
-    outfptr: *mut fitsfile, /* I - FITS file pointer to output file */
-    incol: c_int,           /* I - number of first input column   */
-    outcol: c_int,          /* I - number for first output column  */
-    ncols: c_int,           /* I - number of columns to copy from input to output */
-    create_col: c_int,      /* I - create new col if TRUE, else overwrite */
-    status: *mut c_int,     /* IO - error status     */
+    infptr: *mut fitsfile,
+    outfptr: *mut fitsfile,
+    incol: c_int,
+    outcol: c_int,
+    ncols: c_int,
+    create_col: c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -3320,19 +3514,28 @@ pub unsafe extern "C" fn ffccls(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy multiple columns from infptr and insert them in the outfptr
 /// table.  Optimized for multiple-column case since it only expands the
 /// output file once using fits_insert_cols() instead of calling
 /// fits_insert_col() multiple times.
+///
+/// # Parameters
+///
+/// * `infptr`     — (I) FITS file pointer to input file
+/// * `outfptr`    — (I) FITS file pointer to output file
+/// * `incol`      — (I) number of first input column
+/// * `outcol`     — (I) number for first output column
+/// * `ncols`      — (I) number of columns to copy from input to output
+/// * `create_col` — (I) create new col if TRUE, else overwrite
+/// * `status`     — (IO) error status
 pub fn ffccls_safe(
-    infptr: &mut fitsfile,  /* I - FITS file pointer to input file  */
-    outfptr: &mut fitsfile, /* I - FITS file pointer to output file */
-    incol: c_int,           /* I - number of first input column   */
-    outcol: c_int,          /* I - number for first output column  */
-    ncols: c_int,           /* I - number of columns to copy from input to output */
-    create_col: c_int,      /* I - create new col if TRUE, else overwrite */
-    status: &mut c_int,     /* IO - error status     */
+    infptr: &mut fitsfile,
+    outfptr: &mut fitsfile,
+    incol: c_int,
+    outcol: c_int,
+    ncols: c_int,
+    create_col: c_int,
+    status: &mut c_int,
 ) -> c_int {
     let mut tstatus: c_int;
 
@@ -3564,15 +3767,22 @@ pub fn ffccls_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// copy consecutive set of rows from infptr and append it in the outfptr table.
+///
+/// # Parameters
+///
+/// * `infptr`   — (I) FITS file pointer to input file
+/// * `outfptr`  — (I) FITS file pointer to output file
+/// * `firstrow` — (I) number of first row to copy (1 based)
+/// * `nrows`    — (I) number of rows to copy
+/// * `status`   — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffcprw(
-    infptr: *mut fitsfile,  /* I - FITS file pointer to input file  */
-    outfptr: *mut fitsfile, /* I - FITS file pointer to output file */
-    firstrow: LONGLONG,     /* I - number of first row to copy (1 based)  */
-    nrows: LONGLONG,        /* I - number of rows to copy  */
-    status: *mut c_int,     /* IO - error status     */
+    infptr: *mut fitsfile,
+    outfptr: *mut fitsfile,
+    firstrow: LONGLONG,
+    nrows: LONGLONG,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -3584,14 +3794,21 @@ pub unsafe extern "C" fn ffcprw(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// copy consecutive set of rows from infptr and append it in the outfptr table.
+///
+/// # Parameters
+///
+/// * `infptr`   — (I) FITS file pointer to input file
+/// * `outfptr`  — (I) FITS file pointer to output file
+/// * `firstrow` — (I) number of first row to copy (1 based)
+/// * `nrows`    — (I) number of rows to copy
+/// * `status`   — (IO) error status
 pub fn ffcprw_safe(
-    infptr: &mut fitsfile,  /* I - FITS file pointer to input file  */
-    outfptr: &mut fitsfile, /* I - FITS file pointer to output file */
-    firstrow: LONGLONG,     /* I - number of first row to copy (1 based)  */
-    nrows: LONGLONG,        /* I - number of rows to copy  */
-    status: &mut c_int,     /* IO - error status     */
+    infptr: &mut fitsfile,
+    outfptr: &mut fitsfile,
+    firstrow: LONGLONG,
+    nrows: LONGLONG,
+    status: &mut c_int,
 ) -> c_int {
     let mut innaxis1: LONGLONG = 0;
     let mut innaxis2: LONGLONG = 0;
@@ -3837,16 +4054,24 @@ pub fn ffcprw_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// copy consecutive set of rows from infptr and append it in the outfptr table.
+///
+/// # Parameters
+///
+/// * `infptr`     — (I) FITS file pointer to input file
+/// * `outfptr`    — (I) FITS file pointer to output file
+/// * `firstrow`   — (I) number of first row to copy (1 based)
+/// * `nrows`      — (I) number of rows to copy
+/// * `row_status` — (I) quality list of rows to keep (1) or not keep (0)
+/// * `status`     — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffcpsr(
-    infptr: *mut fitsfile,     /* I - FITS file pointer to input file  */
-    outfptr: *mut fitsfile,    /* I - FITS file pointer to output file */
-    firstrow: LONGLONG,        /* I - number of first row to copy (1 based)  */
-    nrows: LONGLONG,           /* I - number of rows to copy  */
-    row_status: *const c_char, /* I - quality list of rows to keep (1) or not keep (0) */
-    status: *mut c_int,        /* IO - error status     */
+    infptr: *mut fitsfile,
+    outfptr: *mut fitsfile,
+    firstrow: LONGLONG,
+    nrows: LONGLONG,
+    row_status: *const c_char,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -3863,15 +4088,23 @@ pub unsafe extern "C" fn ffcpsr(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// copy consecutive set of rows from infptr and append it in the outfptr table.
+///
+/// # Parameters
+///
+/// * `infptr`     — (I) FITS file pointer to input file
+/// * `outfptr`    — (I) FITS file pointer to output file
+/// * `firstrow`   — (I) number of first row to copy (1 based)
+/// * `nrows`      — (I) number of rows to copy
+/// * `row_status` — (I) quality list of rows to keep (1) or not keep (0)
+/// * `status`     — (IO) error status
 pub fn ffcpsr_safe(
-    infptr: &mut fitsfile,         /* I - FITS file pointer to input file  */
-    outfptr: &mut fitsfile,        /* I - FITS file pointer to output file */
-    firstrow: LONGLONG,            /* I - number of first row to copy (1 based)  */
-    nrows: LONGLONG,               /* I - number of rows to copy  */
-    row_status: Option<&[c_char]>, /* I - quality list of rows to keep (1) or not keep (0) */
-    status: &mut c_int,            /* IO - error status     */
+    infptr: &mut fitsfile,
+    outfptr: &mut fitsfile,
+    firstrow: LONGLONG,
+    nrows: LONGLONG,
+    row_status: Option<&[c_char]>,
+    status: &mut c_int,
 ) -> c_int {
     let mut innaxis1: LONGLONG = 0;
     let mut innaxis2: LONGLONG = 0;
@@ -4149,16 +4382,24 @@ pub fn ffcpsr_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// copy an indexed keyword from infptr to outfptr.
+///
+/// # Parameters
+///
+/// * `infptr`   — (I) FITS file pointer to input file
+/// * `outfptr`  — (I) FITS file pointer to output file
+/// * `incol`    — (I) input index number
+/// * `outcol`   — (I) output index number
+/// * `rootname` — (I) root name of the keyword to be copied
+/// * `status`   — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffcpky(
-    infptr: *mut fitsfile,   /* I - FITS file pointer to input file  */
-    outfptr: *mut fitsfile,  /* I - FITS file pointer to output file */
-    incol: c_int,            /* I - input index number   */
-    outcol: c_int,           /* I - output index number  */
-    rootname: *const c_char, /* I - root name of the keyword to be copied */
-    status: *mut c_int,      /* IO - error status     */
+    infptr: *mut fitsfile,
+    outfptr: *mut fitsfile,
+    incol: c_int,
+    outcol: c_int,
+    rootname: *const c_char,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -4172,15 +4413,23 @@ pub unsafe extern "C" fn ffcpky(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// copy an indexed keyword from infptr to outfptr.
+///
+/// # Parameters
+///
+/// * `infptr`   — (I) FITS file pointer to input file
+/// * `outfptr`  — (I) FITS file pointer to output file
+/// * `incol`    — (I) input index number
+/// * `outcol`   — (I) output index number
+/// * `rootname` — (I) root name of the keyword to be copied
+/// * `status`   — (IO) error status
 pub fn ffcpky_safe(
-    infptr: &mut fitsfile,  /* I - FITS file pointer to input file  */
-    outfptr: &mut fitsfile, /* I - FITS file pointer to output file */
-    incol: c_int,           /* I - input index number   */
-    outcol: c_int,          /* I - output index number  */
-    rootname: &[c_char],    /* I - root name of the keyword to be copied */
-    status: &mut c_int,     /* IO - error status     */
+    infptr: &mut fitsfile,
+    outfptr: &mut fitsfile,
+    incol: c_int,
+    outcol: c_int,
+    rootname: &[c_char],
+    status: &mut c_int,
 ) -> c_int {
     let mut tstatus: c_int = 0;
 
@@ -4205,16 +4454,23 @@ pub fn ffcpky_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// In-place twin of [`ffcpky_safe`]: copy an indexed keyword within one file.
 ///
 /// The read and the write are separate statements, so one handle serves both.
+///
+/// # Parameters
+///
+/// * `fptr`     — I/O - FITS file, used as both input and output
+/// * `incol`    — (I) input index number
+/// * `outcol`   — (I) output index number
+/// * `rootname` — (I) root name of the keyword to be copied
+/// * `status`   — (IO) error status
 pub fn ffcpky_inplace_safe(
-    fptr: &mut fitsfile, /* I/O - FITS file, used as both input and output */
-    incol: c_int,        /* I - input index number   */
-    outcol: c_int,       /* I - output index number  */
-    rootname: &[c_char], /* I - root name of the keyword to be copied */
-    status: &mut c_int,  /* IO - error status     */
+    fptr: &mut fitsfile,
+    incol: c_int,
+    outcol: c_int,
+    rootname: &[c_char],
+    status: &mut c_int,
 ) -> c_int {
     let mut tstatus: c_int = 0;
 
@@ -4232,14 +4488,15 @@ pub fn ffcpky_inplace_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Delete a column from a table.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `colnum` — (I) column to delete (1 = 1st)
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
-pub unsafe extern "C" fn ffdcol(
-    fptr: *mut fitsfile, /* I - FITS file pointer                        */
-    colnum: c_int,       /* I - column to delete (1 = 1st)               */
-    status: *mut c_int,  /* IO - error status                            */
-) -> c_int {
+pub unsafe extern "C" fn ffdcol(fptr: *mut fitsfile, colnum: c_int, status: *mut c_int) -> c_int {
     // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
@@ -4249,13 +4506,14 @@ pub unsafe extern "C" fn ffdcol(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Delete a column from a table.
-pub fn ffdcol_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                        */
-    colnum: c_int,       /* I - column to delete (1 = 1st)               */
-    status: &mut c_int,  /* IO - error status                            */
-) -> c_int {
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `colnum` — (I) column to delete (1 = 1st)
+/// * `status` — (IO) error status
+pub fn ffdcol_safe(fptr: &mut fitsfile, colnum: c_int, status: &mut c_int) -> c_int {
     let mut tstatus: c_int = 0;
 
     let nbytes: LONGLONG;
@@ -4411,16 +4669,24 @@ pub fn ffdcol_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Insert 'ninsert' bytes into each row of the table at position 'bytepos'.
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `naxis1`  — (I) width of the table, in bytes
+/// * `naxis2`  — (I) number of rows in the table
+/// * `ninsert` — (I) number of bytes to insert in each row
+/// * `bytepos` — (I) rel. position in row to insert bytes
+/// * `status`  — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffcins(
-    fptr: *mut fitsfile, /* I - FITS file pointer                        */
-    naxis1: LONGLONG,    /* I - width of the table, in bytes             */
-    naxis2: LONGLONG,    /* I - number of rows in the table              */
-    ninsert: LONGLONG,   /* I - number of bytes to insert in each row    */
-    bytepos: LONGLONG,   /* I - rel. position in row to insert bytes     */
-    status: *mut c_int,  /* IO - error status                            */
+    fptr: *mut fitsfile,
+    naxis1: LONGLONG,
+    naxis2: LONGLONG,
+    ninsert: LONGLONG,
+    bytepos: LONGLONG,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -4431,15 +4697,23 @@ pub unsafe extern "C" fn ffcins(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Insert 'ninsert' bytes into each row of the table at position 'bytepos'.
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `naxis1`  — (I) width of the table, in bytes
+/// * `naxis2`  — (I) number of rows in the table
+/// * `ninsert` — (I) number of bytes to insert in each row
+/// * `bytepos` — (I) rel. position in row to insert bytes
+/// * `status`  — (IO) error status
 pub fn ffcins_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                        */
-    naxis1: LONGLONG,    /* I - width of the table, in bytes             */
-    naxis2: LONGLONG,    /* I - number of rows in the table              */
-    ninsert: LONGLONG,   /* I - number of bytes to insert in each row    */
-    bytepos: LONGLONG,   /* I - rel. position in row to insert bytes     */
-    status: &mut c_int,  /* IO - error status                            */
+    fptr: &mut fitsfile,
+    naxis1: LONGLONG,
+    naxis2: LONGLONG,
+    ninsert: LONGLONG,
+    bytepos: LONGLONG,
+    status: &mut c_int,
 ) -> c_int {
     let mut buffer: [u8; 10000] = [0; 10000];
     let mut cfill: u8 = 0;
@@ -4590,16 +4864,24 @@ pub fn ffcins_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// delete 'ndelete' bytes from each row of the table at position 'bytepos'.
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `naxis1`  — (I) width of the table, in bytes
+/// * `naxis2`  — (I) number of rows in the table
+/// * `ndelete` — (I) number of bytes to delete in each row
+/// * `bytepos` — (I) rel. position in row to delete bytes
+/// * `status`  — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffcdel(
-    fptr: *mut fitsfile, /* I - FITS file pointer                        */
-    naxis1: LONGLONG,    /* I - width of the table, in bytes             */
-    naxis2: LONGLONG,    /* I - number of rows in the table              */
-    ndelete: LONGLONG,   /* I - number of bytes to delete in each row    */
-    bytepos: LONGLONG,   /* I - rel. position in row to delete bytes     */
-    status: *mut c_int,  /* IO - error status                            */
+    fptr: *mut fitsfile,
+    naxis1: LONGLONG,
+    naxis2: LONGLONG,
+    ndelete: LONGLONG,
+    bytepos: LONGLONG,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -4610,15 +4892,23 @@ pub unsafe extern "C" fn ffcdel(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// delete 'ndelete' bytes from each row of the table at position 'bytepos'.
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `naxis1`  — (I) width of the table, in bytes
+/// * `naxis2`  — (I) number of rows in the table
+/// * `ndelete` — (I) number of bytes to delete in each row
+/// * `bytepos` — (I) rel. position in row to delete bytes
+/// * `status`  — (IO) error status
 pub fn ffcdel_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                        */
-    naxis1: LONGLONG,    /* I - width of the table, in bytes             */
-    naxis2: LONGLONG,    /* I - number of rows in the table              */
-    ndelete: LONGLONG,   /* I - number of bytes to delete in each row    */
-    bytepos: LONGLONG,   /* I - rel. position in row to delete bytes     */
-    status: &mut c_int,  /* IO - error status                            */
+    fptr: &mut fitsfile,
+    naxis1: LONGLONG,
+    naxis2: LONGLONG,
+    ndelete: LONGLONG,
+    bytepos: LONGLONG,
+    status: &mut c_int,
 ) -> c_int {
     let mut buffer: [u8; 10000] = [0; 10000];
     let mut i1: LONGLONG = 0;
@@ -4711,7 +5001,6 @@ pub fn ffcdel_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// shift the index value on any existing column keywords
 /// This routine will modify the name of any keyword that begins with 'T'
 /// and has an index number in the range COLMIN - COLMAX, inclusive.
@@ -4720,13 +5009,21 @@ pub fn ffcdel_safe(
 /// if incre is negative, then the kewords with index = COLMIN
 /// will be deleted and the index of higher numbered keywords will
 /// be decremented.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `colmin` — (I) starting col. to be incremented; 1 = 1st
+/// * `colmax` — (I) last column to be incremented
+/// * `incre`  — (I) shift index number by this amount
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffkshf(
-    fptr: *mut fitsfile, /* I - FITS file pointer                        */
-    colmin: c_int,       /* I - starting col. to be incremented; 1 = 1st */
-    colmax: c_int,       /* I - last column to be incremented            */
-    incre: c_int,        /* I - shift index number by this amount        */
-    status: *mut c_int,  /* IO - error status                            */
+    fptr: *mut fitsfile,
+    colmin: c_int,
+    colmax: c_int,
+    incre: c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -4737,7 +5034,6 @@ pub unsafe extern "C" fn ffkshf(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// shift the index value on any existing column keywords
 /// This routine will modify the name of any keyword that begins with 'T'
 /// and has an index number in the range COLMIN - COLMAX, inclusive.
@@ -4746,12 +5042,20 @@ pub unsafe extern "C" fn ffkshf(
 /// if incre is negative, then the kewords with index = COLMIN
 /// will be deleted and the index of higher numbered keywords will
 /// be decremented.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `colmin` — (I) starting col. to be incremented; 1 = 1st
+/// * `colmax` — (I) last column to be incremented
+/// * `incre`  — (I) shift index number by this amount
+/// * `status` — (IO) error status
 pub fn ffkshf_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                        */
-    colmin: c_int,       /* I - starting col. to be incremented; 1 = 1st */
-    colmax: c_int,       /* I - last column to be incremented            */
-    incre: c_int,        /* I - shift index number by this amount        */
-    status: &mut c_int,  /* IO - error status                            */
+    fptr: &mut fitsfile,
+    colmin: c_int,
+    colmax: c_int,
+    incre: c_int,
+    status: &mut c_int,
 ) -> c_int {
     let mut nkeys: c_int = 0;
     let mut nmore: c_int = 0;
@@ -4832,19 +5136,25 @@ pub fn ffkshf_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Internal function to identify which columns in a binary table are variable length.
 ///
 /// The colnums array will be filled with nvarcols elements - the 1-based numbers
 /// of all variable length columns in the table.  This ASSUMES calling function
 /// has passed in a colnums array large enough to hold these (colnums==NULL also
 /// allowed).
+///
+/// # Parameters
+///
+/// * `fptr`     — (I) FITS file pointer
+/// * `nvarcols` — (O) Number of variable length columns found
+/// * `colnums`  — (O) 1-based variable column positions
+/// * `status`   — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn fffvcl(
-    fptr: *mut fitsfile,  /* I - FITS file pointer                       */
-    nvarcols: *mut c_int, /* O - Number of variable length columns found */
-    colnums: *mut c_int,  /* O - 1-based variable column positions       */
-    status: *mut c_int,   /* IO - error status                           */
+    fptr: *mut fitsfile,
+    nvarcols: *mut c_int,
+    colnums: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -4867,17 +5177,23 @@ pub unsafe extern "C" fn fffvcl(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Internal function to identify which columns in a binary table are variable length.
 /// The colnums array will be filled with nvarcols elements - the 1-based numbers
 /// of all variable length columns in the table.  This ASSUMES calling function
 /// has passed in a colnums array large enough to hold these (colnums==NULL also
 /// allowed).
+///
+/// # Parameters
+///
+/// * `fptr`     — (I) FITS file pointer
+/// * `nvarcols` — (O) Number of variable length columns found
+/// * `colnums`  — (O) 1-based variable column positions
+/// * `status`   — (IO) error status
 pub fn fffvcl_safe(
-    fptr: &mut fitsfile,  /* I - FITS file pointer                       */
-    nvarcols: &mut c_int, /* O - Number of variable length columns found */
-    mut colnums: Option<&mut [c_int]>, /* O - 1-based variable column positions       */
-    status: &mut c_int,   /* IO - error status                           */
+    fptr: &mut fitsfile,
+    nvarcols: &mut c_int,
+    mut colnums: Option<&mut [c_int]>,
+    status: &mut c_int,
 ) -> c_int {
     let mut tfields: c_int = 0;
 
@@ -4911,18 +5227,25 @@ pub fn fffvcl_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Shift block of bytes by nshift bytes (positive or negative).
 ///
 /// A positive nshift value moves the block down further in the file, while a
 /// negative value shifts the block towards the beginning of the file.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `firstbyte` — (I) position of first byte in block to shift
+/// * `nbytes`    — (I) size of block of bytes to shift
+/// * `nshift`    — (I) size of shift in bytes (+ or -)
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffshft(
-    fptr: *mut fitsfile, /* I - FITS file pointer                        */
-    firstbyte: LONGLONG, /* I - position of first byte in block to shift */
-    nbytes: LONGLONG,    /* I - size of block of bytes to shift          */
-    nshift: LONGLONG,    /* I - size of shift in bytes (+ or -)          */
-    status: *mut c_int,  /* IO - error status                            */
+    fptr: *mut fitsfile,
+    firstbyte: LONGLONG,
+    nbytes: LONGLONG,
+    nshift: LONGLONG,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -4933,17 +5256,24 @@ pub unsafe extern "C" fn ffshft(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Shift block of bytes by nshift bytes (positive or negative).
 ///
 /// A positive nshift value moves the block down further in the file, while a
 /// negative value shifts the block towards the beginning of the file.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `firstbyte` — (I) position of first byte in block to shift
+/// * `nbytes`    — (I) size of block of bytes to shift
+/// * `nshift`    — (I) size of shift in bytes (+ or -)
+/// * `status`    — (IO) error status
 pub fn ffshft_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                        */
-    firstbyte: LONGLONG, /* I - position of first byte in block to shift */
-    nbytes: LONGLONG,    /* I - size of block of bytes to shift          */
-    nshift: LONGLONG,    /* I - size of shift in bytes (+ or -)          */
-    status: &mut c_int,  /* IO - error status                            */
+    fptr: &mut fitsfile,
+    firstbyte: LONGLONG,
+    nbytes: LONGLONG,
+    nshift: LONGLONG,
+    status: &mut c_int,
 ) -> c_int {
     const SHFTBUFFSIZE: usize = 100000;
     let mut ntomov: LONGLONG = 0;

--- a/src/edithdu.rs
+++ b/src/edithdu.rs
@@ -1,3 +1,15 @@
+//! Routines that create, copy, insert and delete whole HDUs.
+//!
+//! Inserting or deleting an HDU shifts every following HDU in the file, which
+//! is why these routines rewrite the file's HDU offsets as they go. Creating an
+//! image or table extension here writes only the required keywords; the data
+//! unit is filled in by the column and image I/O routines.
+//!
+//! Ported from CFITSIO's `edithdu.c`, written by William Pence at the High
+//! Energy Astrophysics Science Archive Research Center (HEASARC), NASA Goddard
+//! Space Flight Center.
+#![warn(missing_docs)]
+
 use crate::c_types::{FILE, c_char, c_int, c_long};
 use crate::helpers::cfile::CFile;
 use crate::{
@@ -28,15 +40,24 @@ use std::io::Write;
 
 use core::{cmp, ffi::CStr};
 
-/*--------------------------------------------------------------------------*/
-/// copy the CHDU from infptr to the CHDU of outfptr.
-/// This will also allocate space in the output header for MOREKY keywords
+/// Copy the current HDU from `infptr` and append it to the end of the file
+/// associated with `outfptr`.
+///
+/// Space may be reserved in the output header for `morekeys` additional
+/// keywords.
+///
+/// # Parameters
+///
+/// * `infptr`   — (I) FITS file pointer to input file
+/// * `outfptr`  — (I) FITS file pointer to output file
+/// * `morekeys` — (I) reserve space in output header
+/// * `status`   — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffcopy(
-    infptr: *mut fitsfile,  /* I - FITS file pointer to input file  */
-    outfptr: *mut fitsfile, /* I - FITS file pointer to output file */
-    morekeys: c_int,        /* I - reserve space in output header   */
-    status: *mut c_int,     /* IO - error status     */
+    infptr: *mut fitsfile,
+    outfptr: *mut fitsfile,
+    morekeys: c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -58,14 +79,23 @@ pub unsafe extern "C" fn ffcopy(
     }
 }
 
-/*--------------------------------------------------------------------------*/
-/// copy the CHDU from infptr to the CHDU of outfptr.
-/// This will also allocate space in the output header for MOREKY keywords
+/// Copy the current HDU from `infptr` and append it to the end of the file
+/// associated with `outfptr`.
+///
+/// Space may be reserved in the output header for `morekeys` additional
+/// keywords.
+///
+/// # Parameters
+///
+/// * `infptr`   — (I) FITS file pointer to input file
+/// * `outfptr`  — (I) FITS file pointer to output file
+/// * `morekeys` — (I) reserve space in output header
+/// * `status`   — (IO) error status
 pub fn ffcopy_safe(
-    infptr: &mut fitsfile,  /* I - FITS file pointer to input file  */
-    outfptr: &mut fitsfile, /* I - FITS file pointer to output file */
-    morekeys: c_int,        /* I - reserve space in output header   */
-    status: &mut c_int,     /* IO - error status     */
+    infptr: &mut fitsfile,
+    outfptr: &mut fitsfile,
+    morekeys: c_int,
+    status: &mut c_int,
 ) -> c_int {
     let mut nspace: c_int = 0;
 
@@ -104,16 +134,24 @@ pub fn ffcopy_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
-/// copy all or part of the input file to the output file.
+/// Copy all or part of the input file to the output file.
+///
+/// # Parameters
+///
+/// * `infptr`    — (I) FITS file pointer to input file
+/// * `outfptr`   — (I) FITS file pointer to output file
+/// * `previous`  — (I) copy any previous HDUs?
+/// * `current`   — (I) copy the current HDU?
+/// * `following` — (I) copy any following HDUs?
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffcpfl(
-    infptr: *mut fitsfile,  /* I - FITS file pointer to input file  */
-    outfptr: *mut fitsfile, /* I - FITS file pointer to output file */
-    previous: c_int,        /* I - copy any previous HDUs?   */
-    current: c_int,         /* I - copy the current HDU?     */
-    following: c_int,       /* I - copy any following HDUs?   */
-    status: *mut c_int,     /* IO - error status     */
+    infptr: *mut fitsfile,
+    outfptr: *mut fitsfile,
+    previous: c_int,
+    current: c_int,
+    following: c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -135,15 +173,23 @@ pub unsafe extern "C" fn ffcpfl(
     }
 }
 
-/*--------------------------------------------------------------------------*/
-/// copy all or part of the input file to the output file.
+/// Copy all or part of the input file to the output file.
+///
+/// # Parameters
+///
+/// * `infptr`    — (I) FITS file pointer to input file
+/// * `outfptr`   — (I) FITS file pointer to output file
+/// * `previous`  — (I) copy any previous HDUs?
+/// * `current`   — (I) copy the current HDU?
+/// * `following` — (I) copy any following HDUs?
+/// * `status`    — (IO) error status
 pub fn ffcpfl_safe(
-    infptr: &mut fitsfile,  /* I - FITS file pointer to input file  */
-    outfptr: &mut fitsfile, /* I - FITS file pointer to output file */
-    previous: c_int,        /* I - copy any previous HDUs?   */
-    current: c_int,         /* I - copy the current HDU?     */
-    following: c_int,       /* I - copy any following HDUs?   */
-    status: &mut c_int,     /* IO - error status     */
+    infptr: &mut fitsfile,
+    outfptr: &mut fitsfile,
+    previous: c_int,
+    current: c_int,
+    following: c_int,
+    status: &mut c_int,
 ) -> c_int {
     let mut hdunum = 0;
 
@@ -191,13 +237,18 @@ pub fn ffcpfl_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
-/// copy the header keywords from infptr to outfptr.
+/// Copy the header keywords from `infptr` to `outfptr`.
+///
+/// # Parameters
+///
+/// * `infptr`  — (I) FITS file pointer to input file
+/// * `outfptr` — (I) FITS file pointer to output file
+/// * `status`  — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffcphd(
-    infptr: *mut fitsfile,  /* I - FITS file pointer to input file  */
-    outfptr: *mut fitsfile, /* I - FITS file pointer to output file */
-    status: *mut c_int,     /* IO - error status     */
+    infptr: *mut fitsfile,
+    outfptr: *mut fitsfile,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -219,13 +270,14 @@ pub unsafe extern "C" fn ffcphd(
     }
 }
 
-/*--------------------------------------------------------------------------*/
-/// copy the header keywords from infptr to outfptr.
-pub fn ffcphd_safe(
-    infptr: &mut fitsfile,  /* I - FITS file pointer to input file  */
-    outfptr: &mut fitsfile, /* I - FITS file pointer to output file */
-    status: &mut c_int,     /* IO - error status     */
-) -> c_int {
+/// Copy the header keywords from `infptr` to `outfptr`.
+///
+/// # Parameters
+///
+/// * `infptr`  — (I) FITS file pointer to input file
+/// * `outfptr` — (I) FITS file pointer to output file
+/// * `status`  — (IO) error status
+pub fn ffcphd_safe(infptr: &mut fitsfile, outfptr: &mut fitsfile, status: &mut c_int) -> c_int {
     let mut nkeys: c_int = 0;
     let mut inPrim: c_int = 0;
     let mut outPrim: c_int = 0;
@@ -398,18 +450,30 @@ pub fn ffcphd_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy the table structure from an existing table HDU, but only
-/// copy a limited row range.  All header keywords from the input
-/// table are copied directly, but NAXSI2 and PCOUNT are set to their
-/// correct values.
+/// Copy the structure of an open table to a new table, optionally copying a
+/// limited range of rows.
+///
+/// All header keywords from the input table are copied directly, but `NAXIS2`
+/// and `PCOUNT` are set to their correct values. Useful when a task will filter
+/// rows before transferring them, so that a pristine output table with zero
+/// rows is wanted to start with. `nrows` may be 0. The first row of a table is
+/// row 1.
+///
+/// # Parameters
+///
+/// * `infptr`   — (I) FITS file pointer to input file
+/// * `outfptr`  — (I) FITS file pointer to output file
+/// * `firstrow` — (I) number of first row to copy (1 based)
+/// * `nrows`    — (I) number of rows to copy
+/// * `status`   — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffcpht(
-    infptr: *mut fitsfile,  /* I - FITS file pointer to input file  */
-    outfptr: *mut fitsfile, /* I - FITS file pointer to output file */
-    firstrow: LONGLONG,     /* I - number of first row to copy (1 based)  */
-    nrows: LONGLONG,        /* I - number of rows to copy  */
-    status: *mut c_int,     /* IO - error status     */
+    infptr: *mut fitsfile,
+    outfptr: *mut fitsfile,
+    firstrow: LONGLONG,
+    nrows: LONGLONG,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -421,17 +485,29 @@ pub unsafe extern "C" fn ffcpht(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy the table structure from an existing table HDU, but only
-/// copy a limited row range.  All header keywords from the input
-/// table are copied directly, but NAXSI2 and PCOUNT are set to their
-/// correct values.
+/// Copy the structure of an open table to a new table, optionally copying a
+/// limited range of rows.
+///
+/// All header keywords from the input table are copied directly, but `NAXIS2`
+/// and `PCOUNT` are set to their correct values. Useful when a task will filter
+/// rows before transferring them, so that a pristine output table with zero
+/// rows is wanted to start with. `nrows` may be 0. The first row of a table is
+/// row 1.
+///
+/// # Parameters
+///
+/// * `infptr`   — (I) FITS file pointer to input file
+/// * `outfptr`  — (I) FITS file pointer to output file
+/// * `firstrow` — (I) number of first row to copy (1 based)
+/// * `nrows`    — (I) number of rows to copy
+/// * `status`   — (IO) error status
 pub fn ffcpht_safe(
-    infptr: &mut fitsfile,  /* I - FITS file pointer to input file  */
-    outfptr: &mut fitsfile, /* I - FITS file pointer to output file */
-    firstrow: LONGLONG,     /* I - number of first row to copy (1 based)  */
-    nrows: LONGLONG,        /* I - number of rows to copy  */
-    status: &mut c_int,     /* IO - error status     */
+    infptr: &mut fitsfile,
+    outfptr: &mut fitsfile,
+    firstrow: LONGLONG,
+    nrows: LONGLONG,
+    status: &mut c_int,
 ) -> c_int {
     if *status > 0 {
         return *status;
@@ -460,14 +536,24 @@ pub fn ffcpht_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
-/// copy the data unit from the CHDU of infptr to the CHDU of outfptr.
+/// Copy the data unit, and not the header, from the current HDU of `infptr` to
+/// the current HDU of `outfptr`.
+///
+/// This overwrites any data previously in the output HDU. A low level routine
+/// used by [`ffcopy_safe`], but also useful to an application that wants to copy
+/// the data from one file to another while modifying the header itself.
 /// This will overwrite any data already in the outfptr CHDU.
+///
+/// # Parameters
+///
+/// * `infptr`  — (I) FITS file pointer to input file
+/// * `outfptr` — (I) FITS file pointer to output file
+/// * `status`  — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffcpdt(
-    infptr: *mut fitsfile,  /* I - FITS file pointer to input file  */
-    outfptr: *mut fitsfile, /* I - FITS file pointer to output file */
-    status: *mut c_int,     /* IO - error status     */
+    infptr: *mut fitsfile,
+    outfptr: *mut fitsfile,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -489,14 +575,20 @@ pub unsafe extern "C" fn ffcpdt(
     }
 }
 
-/*--------------------------------------------------------------------------*/
-/// copy the data unit from the CHDU of infptr to the CHDU of outfptr.
+/// Copy the data unit, and not the header, from the current HDU of `infptr` to
+/// the current HDU of `outfptr`.
+///
+/// This overwrites any data previously in the output HDU. A low level routine
+/// used by [`ffcopy_safe`], but also useful to an application that wants to copy
+/// the data from one file to another while modifying the header itself.
 /// This will overwrite any data already in the outfptr CHDU.
-pub fn ffcpdt_safe(
-    infptr: &mut fitsfile,  /* I - FITS file pointer to input file  */
-    outfptr: &mut fitsfile, /* I - FITS file pointer to output file */
-    status: &mut c_int,     /* IO - error status     */
-) -> c_int {
+///
+/// # Parameters
+///
+/// * `infptr`  — (I) FITS file pointer to input file
+/// * `outfptr` — (I) FITS file pointer to output file
+/// * `status`  — (IO) error status
+pub fn ffcpdt_safe(infptr: &mut fitsfile, outfptr: &mut fitsfile, status: &mut c_int) -> c_int {
     let mut nb: c_long = 0;
     let mut indatastart: LONGLONG = 0;
     let mut indataend: LONGLONG = 0;
@@ -548,13 +640,19 @@ pub fn ffcpdt_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
-/// write the data unit from the CHDU of infptr to the output file stream
+/// Write the data unit from the current HDU of `infptr` to the output file
+/// stream.
+///
+/// # Parameters
+///
+/// * `infptr`    — (I) FITS file pointer to input file
+/// * `outstream` — (I) stream to write HDU to
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffwrhdu(
-    infptr: *mut fitsfile, /* I - FITS file pointer to input file  */
-    outstream: *mut FILE,  /* I - stream to write HDU to */
-    status: *mut c_int,    /* IO - error status     */
+    infptr: *mut fitsfile,
+    outstream: *mut FILE,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -565,13 +663,14 @@ pub unsafe extern "C" fn ffwrhdu(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write the current HDU to the output stream.
-pub fn ffwrhdu_safe(
-    infptr: &mut fitsfile, /* I - FITS file pointer to input file  */
-    outstream: *mut FILE,  /* I - stream to write HDU to */
-    status: &mut c_int,    /* IO - error status     */
-) -> c_int {
+///
+/// # Parameters
+///
+/// * `infptr`    — (I) FITS file pointer to input file
+/// * `outstream` — (I) stream to write HDU to
+/// * `status`    — (IO) error status
+pub fn ffwrhdu_safe(infptr: &mut fitsfile, outstream: *mut FILE, status: &mut c_int) -> c_int {
     let mut hdustart: LONGLONG = 0;
     let mut hduend: LONGLONG = 0;
     let mut buffer: [c_char; IOBUFLEN as usize] = [0; IOBUFLEN as usize];
@@ -598,15 +697,22 @@ pub fn ffwrhdu_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
-/// insert an IMAGE extension following the current HDU
+/// Insert an IMAGE extension following the current HDU.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `bitpix` — (I) bits per pixel
+/// * `naxis`  — (I) number of axes in the array
+/// * `naxes`  — (I) size of each axis
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffiimg(
-    fptr: *mut fitsfile,  /* I - FITS file pointer           */
-    bitpix: c_int,        /* I - bits per pixel              */
-    naxis: c_int,         /* I - number of axes in the array */
-    naxes: *const c_long, /* I - size of each axis           */
-    status: *mut c_int,   /* IO - error status               */
+    fptr: *mut fitsfile,
+    bitpix: c_int,
+    naxis: c_int,
+    naxes: *const c_long,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -619,14 +725,21 @@ pub unsafe extern "C" fn ffiimg(
     }
 }
 
-/*--------------------------------------------------------------------------*/
-/// insert an IMAGE extension following the current HDU
+/// Insert an IMAGE extension following the current HDU.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `bitpix` — (I) bits per pixel
+/// * `naxis`  — (I) number of axes in the array
+/// * `naxes`  — (I) size of each axis
+/// * `status` — (IO) error status
 pub fn ffiimg_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer           */
-    bitpix: c_int,       /* I - bits per pixel              */
-    naxis: c_int,        /* I - number of axes in the array */
-    naxes: &[c_long],    /* I - size of each axis           */
-    status: &mut c_int,  /* IO - error status               */
+    fptr: &mut fitsfile,
+    bitpix: c_int,
+    naxis: c_int,
+    naxes: &[c_long],
+    status: &mut c_int,
 ) -> c_int {
     let mut tnaxes: [LONGLONG; 99] = [0; 99];
 
@@ -651,15 +764,22 @@ pub fn ffiimg_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
-/// insert an IMAGE extension following the current HDU
+/// Insert an IMAGE extension following the current HDU.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `bitpix` — (I) bits per pixel
+/// * `naxis`  — (I) number of axes in the array
+/// * `naxes`  — (I) size of each axis
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffiimgll(
-    fptr: *mut fitsfile,    /* I - FITS file pointer           */
-    bitpix: c_int,          /* I - bits per pixel              */
-    naxis: c_int,           /* I - number of axes in the array */
-    naxes: *const LONGLONG, /* I - size of each axis           */
-    status: *mut c_int,     /* IO - error status               */
+    fptr: *mut fitsfile,
+    bitpix: c_int,
+    naxis: c_int,
+    naxes: *const LONGLONG,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -672,14 +792,21 @@ pub unsafe extern "C" fn ffiimgll(
     }
 }
 
-/*--------------------------------------------------------------------------*/
-/// insert an IMAGE extension following the current HDU
+/// Insert an IMAGE extension following the current HDU.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `bitpix` — (I) bits per pixel
+/// * `naxis`  — (I) number of axes in the array
+/// * `naxes`  — (I) size of each axis
+/// * `status` — (IO) error status
 pub fn ffiimgll_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer           */
-    bitpix: c_int,       /* I - bits per pixel              */
-    naxis: c_int,        /* I - number of axes in the array */
-    naxes: &[LONGLONG],  /* I - size of each axis           */
-    status: &mut c_int,  /* IO - error status               */
+    fptr: &mut fitsfile,
+    bitpix: c_int,
+    naxis: c_int,
+    naxes: &[LONGLONG],
+    status: &mut c_int,
 ) -> c_int {
     let mut bytlen: c_int = 0;
     let mut nexthdu: c_int = 0;
@@ -900,20 +1027,32 @@ pub fn ffiimgll_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
-/// insert an ASCII table extension following the current HDU
+/// Insert an ASCII table extension following the current HDU.
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `naxis1`  — (I) width of row in the table
+/// * `naxis2`  — (I) number of rows in the table
+/// * `tfields` — (I) number of columns in the table
+/// * `ttype`   — (I) name of each column
+/// * `tbcol`   — (I) byte offset in row to each column
+/// * `tform`   — (I) value of TFORMn keyword for each column
+/// * `tunit`   — (I) value of TUNITn keyword for each column
+/// * `extnmx`  — (I) value of EXTNAME keyword, if any
+/// * `status`  — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffitab(
-    fptr: *mut fitsfile,         /* I - FITS file pointer                        */
-    naxis1: LONGLONG,            /* I - width of row in the table                */
-    naxis2: LONGLONG,            /* I - number of rows in the table              */
-    tfields: c_int,              /* I - number of columns in the table           */
-    ttype: *const *const c_char, /* I - name of each column                      */
-    tbcol: *const c_long,        /* I - byte offset in row to each column        */
-    tform: *const *const c_char, /* I - value of TFORMn keyword for each column  */
-    tunit: *const *const c_char, /* I - value of TUNITn keyword for each column  */
-    extnmx: *const c_char,       /* I - value of EXTNAME keyword, if any         */
-    status: *mut c_int,          /* IO - error status                            */
+    fptr: *mut fitsfile,
+    naxis1: LONGLONG,
+    naxis2: LONGLONG,
+    tfields: c_int,
+    ttype: *const *const c_char,
+    tbcol: *const c_long,
+    tform: *const *const c_char,
+    tunit: *const *const c_char,
+    extnmx: *const c_char,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -946,19 +1085,31 @@ pub unsafe extern "C" fn ffitab(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Insert an ASCII table extension following the current HDU.
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `naxis1`  — (I) width of row in the table
+/// * `naxis2`  — (I) number of rows in the table
+/// * `tfields` — (I) number of columns in the table
+/// * `v_ttype` — (I) name of each column
+/// * `tbcol`   — (I) byte offset in row to each column
+/// * `v_tform` — (I) value of TFORMn keyword for each column
+/// * `v_tunit` — (I) value of TUNITn keyword for each column
+/// * `extnmx`  — (I) value of EXTNAME keyword, if any
+/// * `status`  — (IO) error status
 pub fn ffitab_safe(
-    fptr: &mut fitsfile,           /* I - FITS file pointer                        */
-    naxis1: LONGLONG,              /* I - width of row in the table                */
-    naxis2: LONGLONG,              /* I - number of rows in the table              */
-    tfields: c_int,                /* I - number of columns in the table           */
-    v_ttype: &[Option<&[c_char]>], /* I - name of each column                      */
-    tbcol: Option<&[c_long]>,      /* I - byte offset in row to each column        */
-    v_tform: &[&[c_char]],         /* I - value of TFORMn keyword for each column  */
-    v_tunit: Option<&[Option<&[c_char]>]>, /* I - value of TUNITn keyword for each column  */
-    extnmx: Option<&[c_char]>,     /* I - value of EXTNAME keyword, if any         */
-    status: &mut c_int,            /* IO - error status                            */
+    fptr: &mut fitsfile,
+    naxis1: LONGLONG,
+    naxis2: LONGLONG,
+    tfields: c_int,
+    v_ttype: &[Option<&[c_char]>],
+    tbcol: Option<&[c_long]>,
+    v_tform: &[&[c_char]],
+    v_tunit: Option<&[Option<&[c_char]>]>,
+    extnmx: Option<&[c_char]>,
+    status: &mut c_int,
 ) -> c_int {
     let mut nunit: c_int = 0;
 
@@ -1133,19 +1284,30 @@ pub fn ffitab_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
-/// insert a Binary table extension following the current HDU
+/// Insert a binary table extension following the current HDU.
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `naxis2`  — (I) number of rows in the table
+/// * `tfields` — (I) number of columns in the table
+/// * `ttype`   — (I) name of each column
+/// * `tform`   — (I) value of TFORMn keyword for each column
+/// * `tunit`   — (I) value of TUNITn keyword for each column
+/// * `extnmx`  — (I) value of EXTNAME keyword, if any
+/// * `pcount`  — (I) size of special data area (heap)
+/// * `status`  — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffibin(
-    fptr: *mut fitsfile,         /* I - FITS file pointer                        */
-    naxis2: LONGLONG,            /* I - number of rows in the table              */
-    tfields: c_int,              /* I - number of columns in the table           */
-    ttype: *const *const c_char, /* I - name of each column                      */
-    tform: *const *const c_char, /* I - value of TFORMn keyword for each column  */
-    tunit: *const *const c_char, /* I - value of TUNITn keyword for each column  */
-    extnmx: *const c_char,       /* I - value of EXTNAME keyword, if any         */
-    pcount: LONGLONG,            /* I - size of special data area (heap)         */
-    status: *mut c_int,          /* IO - error status                            */
+    fptr: *mut fitsfile,
+    naxis2: LONGLONG,
+    tfields: c_int,
+    ttype: *const *const c_char,
+    tform: *const *const c_char,
+    tunit: *const *const c_char,
+    extnmx: *const c_char,
+    pcount: LONGLONG,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -1171,18 +1333,29 @@ pub unsafe extern "C" fn ffibin(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Insert a Binary table extension following the current HDU.
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `naxis2`  — (I) number of rows in the table
+/// * `tfields` — (I) number of columns in the table
+/// * `ttype`   — (I) name of each column
+/// * `tform`   — (I) value of TFORMn keyword for each column
+/// * `tunit`   — (I) value of TUNITn keyword for each column
+/// * `extnmx`  — (I) value of EXTNAME keyword, if any
+/// * `pcount`  — (I) size of special data area (heap)
+/// * `status`  — (IO) error status
 pub fn ffibin_safe(
-    fptr: &mut fitsfile,         /* I - FITS file pointer                        */
-    naxis2: LONGLONG,            /* I - number of rows in the table              */
-    tfields: c_int,              /* I - number of columns in the table           */
-    ttype: &[Option<&[c_char]>], /* I - name of each column                      */
-    tform: &[&[c_char]],         /* I - value of TFORMn keyword for each column  */
-    tunit: Option<&[Option<&[c_char]>]>, /* I - value of TUNITn keyword for each column  */
-    extnmx: Option<&[c_char]>,   /* I - value of EXTNAME keyword, if any         */
-    pcount: LONGLONG,            /* I - size of special data area (heap)         */
-    status: &mut c_int,          /* IO - error status                            */
+    fptr: &mut fitsfile,
+    naxis2: LONGLONG,
+    tfields: c_int,
+    ttype: &[Option<&[c_char]>],
+    tform: &[&[c_char]],
+    tunit: Option<&[Option<&[c_char]>]>,
+    extnmx: Option<&[c_char]>,
+    pcount: LONGLONG,
+    status: &mut c_int,
 ) -> c_int {
     let mut nunit: c_int = 0;
 
@@ -1353,15 +1526,20 @@ pub fn ffibin_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Delete the CHDU.  If the CHDU is the primary array, then replace the HDU
 /// with an empty primary array with no data.   Return the
 /// type of the new CHDU after the old CHDU is deleted.
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `hdutype` — (O) type of the new CHDU after deletion
+/// * `status`  — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffdhdu(
-    fptr: *mut fitsfile, /* I - FITS file pointer                   */
-    hdutype: *mut c_int, /* O - type of the new CHDU after deletion */
-    status: *mut c_int,  /* IO - error status                       */
+    fptr: *mut fitsfile,
+    hdutype: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -1373,15 +1551,16 @@ pub unsafe extern "C" fn ffdhdu(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Delete the CHDU.  If the CHDU is the primary array, then replace the HDU
 /// with an empty primary array with no data.   Return the
 /// type of the new CHDU after the old CHDU is deleted.
-pub fn ffdhdu_safe(
-    fptr: &mut fitsfile,         /* I - FITS file pointer                   */
-    hdutype: Option<&mut c_int>, /* O - type of the new CHDU after deletion */
-    status: &mut c_int,          /* IO - error status                       */
-) -> c_int {
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `hdutype` — (O) type of the new CHDU after deletion
+/// * `status`  — (IO) error status
+pub fn ffdhdu_safe(fptr: &mut fitsfile, hdutype: Option<&mut c_int>, status: &mut c_int) -> c_int {
     let mut tmptype = 0;
     let mut nblocks: c_long = 0;
     let naxes: [c_long; 1] = [0; 1];

--- a/src/eval_defs.rs
+++ b/src/eval_defs.rs
@@ -1,3 +1,13 @@
+//! Shared definitions for the expression parser.
+//!
+//! The types the three parser files agree on: the evaluation tree's `Node` and
+//! `NodeValue`, the `ParseData` state the parse builds up, and the column and
+//! keyword descriptions it collects. All are crate-private. Corresponds to
+//! CFITSIO's `eval_defs.h`.
+//!
+//! See [`crate::eval_f`] for how the three files fit together.
+#![warn(missing_docs)]
+
 use alloc::rc::Rc;
 use core::ffi::c_void;
 
@@ -9,15 +19,24 @@ use crate::eval_tab::FITS_PARSER_YYSTYPE;
 use crate::fitsio::{LONGLONG, PixelFilter, fitsfile, iteratorCol};
 use crate::region::SAORegion;
 
+/// Maximum number of dimensions a parsed vector column may have.
 pub const MAXDIMS: c_int = 5;
+/// Maximum number of subscripts in a column reference.
 pub const MAXSUBS: c_int = 10;
+/// Maximum length of a variable name in an expression.
 pub const MAXVARNAME: usize = 80;
+/// Operation code marking a node as a constant rather than a computation.
 pub const CONST_OP: c_int = -1000;
+/// Parser error indicator.
 pub const P_ERROR: c_int = -1;
+/// Maximum length of a string value in an expression, including the
+/// terminator.
 pub const MAX_STRLEN: c_int = 256;
+/// [`MAX_STRLEN`] less the terminator, as a string, for building format
+/// specifiers.
 pub const MAX_STRLEN_S: &str = "255";
 
-/* An opaque pointer. */
+/// The lexer's scanner state. An opaque pointer in the C.
 pub(crate) type yyscan_t<'a> = &'a mut yyguts_t;
 
 /// The sort of a parser value: which of `eval.y`'s four nonterminals a node
@@ -48,6 +67,7 @@ impl ValueSort {
         self as c_int
     }
 
+    /// The sort for a token number, or `None` if it names no sort.
     pub(crate) fn from_code(v: c_int) -> Option<ValueSort> {
         Some(match v {
             258 => ValueSort::Boolean,

--- a/src/eval_f.rs
+++ b/src/eval_f.rs
@@ -1,54 +1,28 @@
-/************************************************************************/
-/*                                                                      */
-/*                       CFITSIO Lexical Parser                         */
-/*                                                                      */
-/* This file is one of 3 files containing code which parses an          */
-/* arithmetic expression and evaluates it in the context of an input    */
-/* FITS file table extension.  The CFITSIO lexical parser is divided    */
-/* into the following 3 parts/files: the CFITSIO "front-end",           */
-/* eval_f.c, contains the interface between the user/CFITSIO and the    */
-/* real core of the parser; the FLEX interpreter, eval_l.c, takes the   */
-/* input string and parses it into tokens and identifies the FITS       */
-/* information required to evaluate the expression (ie, keywords and    */
-/* columns); and, the BISON grammar and evaluation routines, eval_y.c,  */
-/* receives the FLEX output and determines and performs the actual      */
-/* operations.  The files eval_l.c and eval_y.c are produced from       */
-/* running flex and bison on the files eval.l and eval.y, respectively. */
-/* (flex and bison are available from any GNU archive: see www.gnu.org) */
-/*                                                                      */
-/* The grammar rules, rather than evaluating the expression in situ,    */
-/* builds a tree, or Nodal, structure mapping out the order of          */
-/* operations and expression dependencies.  This "compilation" process  */
-/* allows for much faster processing of multiple rows.  This technique  */
-/* was developed by Uwe Lammers of the XMM Science Analysis System,     */
-/* although the CFITSIO implementation is entirely code original.       */
-/*                                                                      */
-/*                                                                      */
-/* Modification History:                                                */
-/*                                                                      */
-/*   Kent Blackburn      c1992  Original parser code developed for the  */
-/*                              FTOOLS software package, in particular, */
-/*                              the fselect task.                       */
-/*   Kent Blackburn      c1995  BIT column support added                */
-/*   Peter D Wilson   Feb 1998  Vector column support added             */
-/*   Peter D Wilson   May 1998  Ported to CFITSIO library.  User        */
-/*                              interface routines written, in essence  */
-/*                              making fselect, fcalc, and maketime     */
-/*                              capabilities available to all tools     */
-/*                              via single function calls.              */
-/*   Peter D Wilson   Jun 1998  Major rewrite of parser core, so as to  */
-/*                              create a run-time evaluation tree,      */
-/*                              inspired by the work of Uwe Lammers,    */
-/*                              resulting in a speed increase of        */
-/*                              10-100 times.                           */
-/*   Peter D Wilson   Jul 1998  gtifilter(a,b,c,d) function added       */
-/*   Peter D Wilson   Aug 1998  regfilter(a,b,c,d) function added       */
-/*   Peter D Wilson   Jul 1999  Make parser fitsfile-independent,       */
-/*                              allowing a purely vector-based usage    */
-/*   Peter D Wilson   Aug 1999  Add row-offset capability               */
-/*   Peter D Wilson   Sep 1999  Add row-range capability to ffcalc_rng  */
-/*                                                                      */
-/************************************************************************/
+//! The CFITSIO expression parser's front end: the interface between the
+//! library and the parser core.
+//!
+//! The expression parser is three files: this front end, the FLEX lexer in
+//! [`crate::eval_l`], and the BISON grammar and evaluation routines in
+//! [`crate::eval_y`]. `eval_l` turns the input string into tokens and works out
+//! which keywords and columns the expression needs; `eval_y` receives those
+//! tokens and performs the operations.
+//!
+//! Rather than evaluating in place, the grammar rules build a tree of nodes
+//! mapping out the order of operations and the dependencies between them. That
+//! "compilation" step is what makes evaluating the same expression over many
+//! rows fast. The technique was developed by Uwe Lammers of the XMM Science
+//! Analysis System, although the CFITSIO implementation is entirely original
+//! code.
+//!
+//! History: the parser began as Kent Blackburn's code for the FTOOLS `fselect`
+//! task around 1992, gained BIT column support in 1995 and vector column
+//! support from Peter D Wilson in 1998. Wilson ported it to CFITSIO the same
+//! year, rewrote the core around the evaluation tree for a 10-100x speed-up,
+//! added the `gtifilter` and `regfilter` functions, and in 1999 made the parser
+//! independent of a `fitsfile` so it could be used on plain vectors.
+//!
+//! Hand-written, unlike its two companions, which are generated.
+#![warn(missing_docs)]
 
 use core::slice;
 use core::{cmp, ptr};
@@ -132,18 +106,27 @@ macro_rules! FREE {
     };
 }
 
-/*---------------------------------------------------------------------------*/
 /// Evaluate a boolean expression using the indicated rows, returning an
 /// array of flags indicating which rows evaluated to TRUE/FALSE
+///
+/// # Parameters
+///
+/// * `fptr`        — (I) Input FITS file
+/// * `expr`        — (I) Boolean expression
+/// * `firstrow`    — (I) First row of table to eval
+/// * `nrows`       — (I) Number of rows to evaluate
+/// * `n_good_rows` — (O) Number of rows eval to True
+/// * `row_status`  — (O) Array of boolean results
+/// * `status`      — (O) Error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn fffrow(
-    fptr: *mut fitsfile,      /* I - Input FITS file                   */
-    expr: *mut c_char,        /* I - Boolean expression                */
-    firstrow: c_long,         /* I - First row of table to eval        */
-    nrows: c_long,            /* I - Number of rows to evaluate        */
-    n_good_rows: *mut c_long, /* O - Number of rows eval to True       */
-    row_status: *mut c_char,  /* O - Array of boolean results          */
-    status: *mut c_int,       /* O - Error status                      */
+    fptr: *mut fitsfile,
+    expr: *mut c_char,
+    firstrow: c_long,
+    nrows: c_long,
+    n_good_rows: *mut c_long,
+    row_status: *mut c_char,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -159,17 +142,26 @@ pub unsafe extern "C" fn fffrow(
     }
 }
 
-/*---------------------------------------------------------------------------*/
 /// Evaluate a boolean expression using the indicated rows, returning an
 /// array of flags indicating which rows evaluated to TRUE/FALSE
+///
+/// # Parameters
+///
+/// * `fptr`        — (I) Input FITS file
+/// * `expr`        — (I) Boolean expression
+/// * `firstrow`    — (I) First row of table to eval
+/// * `nrows`       — (I) Number of rows to evaluate
+/// * `n_good_rows` — (O) Number of rows eval to True
+/// * `row_status`  — (O) Array of boolean results
+/// * `status`      — (O) Error status
 pub fn fffrow_safe(
-    fptr: &mut fitsfile,       /* I - Input FITS file                   */
-    expr: &[c_char],           /* I - Boolean expression                */
-    firstrow: c_long,          /* I - First row of table to eval        */
-    nrows: c_long,             /* I - Number of rows to evaluate        */
-    n_good_rows: &mut c_long,  /* O - Number of rows eval to True       */
-    row_status: &mut [c_char], /* O - Array of boolean results          */
-    status: &mut c_int,        /* O - Error status                      */
+    fptr: &mut fitsfile,
+    expr: &[c_char],
+    firstrow: c_long,
+    nrows: c_long,
+    n_good_rows: &mut c_long,
+    row_status: &mut [c_char],
+    status: &mut c_int,
 ) -> c_int {
     let mut naxis: c_int = 0;
     let constant: bool;
@@ -257,13 +249,9 @@ pub fn fffrow_safe(
 
         if *status != 0 {
 
-            /***********************/
             /* Error... Do nothing */
-            /***********************/
         } else {
-            /***********************************/
             /* Count number of good rows found */
-            /***********************************/
 
             *n_good_rows = 0;
 
@@ -279,19 +267,25 @@ pub fn fffrow_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Evaluate an expression on all rows of a table.  If the input and output
 /// files are not the same, copy the TRUE rows to the output file.  If the
 /// files are the same, delete the FALSE rows (preserve the TRUE rows).
 /// Can copy rows between extensions of the same file, *BUT* if output
 /// extension is before the input extension, the second extension *MUST* be
 /// opened using ffreopen, so that CFITSIO can handle changing file lengths.
+///
+/// # Parameters
+///
+/// * `infptr`  — (I) Input FITS file
+/// * `outfptr` — (I) Output FITS file
+/// * `expr`    — (I) Boolean expression
+/// * `status`  — (O) Error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffsrow(
-    infptr: *mut fitsfile,  /* I - Input FITS file                      */
-    outfptr: *mut fitsfile, /* I - Output FITS file                     */
-    expr: *const c_char,    /* I - Boolean expression                   */
-    status: *mut c_int,     /* O - Error status                         */
+    infptr: *mut fitsfile,
+    outfptr: *mut fitsfile,
+    expr: *const c_char,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -320,20 +314,24 @@ pub unsafe extern "C" fn ffsrow(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Evaluate an expression on all rows of a table.  If the input and output
 /// files are not the same, copy the TRUE rows to the output file.  If the
 /// files are the same, delete the FALSE rows (preserve the TRUE rows).
 /// Can copy rows between extensions of the same file, *BUT* if output
 /// extension is before the input extension, the second extension *MUST* be
 /// opened using ffreopen, so that CFITSIO can handle changing file lengths
-/// Both files must be distinct handles.  Passing one file as both input and
-/// output is the C's in-place delete; use [`ffsrow_inplace_safe`] for that.
+///
+/// # Parameters
+///
+/// * `infptr`  — (I) Input FITS file
+/// * `outfptr` — (I) Output FITS file
+/// * `expr`    — (I) Boolean expression
+/// * `status`  — (O) Error status
 pub fn ffsrow_safe(
-    infptr: &mut fitsfile,  /* I - Input FITS file                      */
-    outfptr: &mut fitsfile, /* I - Output FITS file                     */
-    expr: &[c_char],        /* I - Boolean expression                   */
-    status: &mut c_int,     /* O - Error status                         */
+    infptr: &mut fitsfile,
+    outfptr: &mut fitsfile,
+    expr: &[c_char],
+    status: &mut c_int,
 ) -> c_int {
     let mut Info: parseInfo = Default::default();
     let mut naxis: c_int = 0;
@@ -396,9 +394,7 @@ pub fn ffsrow_safe(
         constant = 0;
     }
 
-    /**********************************************************************/
     /* Make sure expression evaluates to the right type... logical scalar */
-    /**********************************************************************/
 
     if Info.datatype != TLOGICAL || nelem != 1 {
         ffcprs(&mut lParse);
@@ -407,9 +403,7 @@ pub fn ffsrow_safe(
         return *status;
     }
 
-    /***********************************************************/
     /*  Extract various table information from each extension  */
-    /***********************************************************/
 
     if infptr.HDUposition != (infptr.Fptr).curhdu {
         ffmahd_safe(infptr, (infptr.HDUposition) + 1, None, status);
@@ -451,9 +445,7 @@ pub fn ffsrow_safe(
         return *status;
     }
 
-    /***********************************/
     /*  Fill out Info data for parser  */
-    /***********************************/
 
     /* The row-selection flags are owned here and handed to the parser as a
     raw pointer, so the error returns below cannot leak them.  `Info.dataPtr`
@@ -588,9 +580,7 @@ pub fn ffsrow_safe(
         if inExt.heapSize != 0 && nGood != 0 {
             /* Copy heap, if it exists and at least one row copied */
 
-            /********************************************************/
             /*  Get location information from the output extension  */
-            /********************************************************/
 
             if outfptr.HDUposition != (outfptr.Fptr).curhdu {
                 ffmahd_safe(outfptr, (outfptr.HDUposition) + 1, None, status);
@@ -598,9 +588,7 @@ pub fn ffsrow_safe(
             outExt.dataStart = (outfptr.Fptr).datastart;
             outExt.heapStart = (outfptr.Fptr).heapstart;
 
-            /*************************************************/
             /*  Insert more space into outfptr if necessary  */
-            /*************************************************/
 
             hsize = outExt.heapStart + outExt.heapSize;
             freespace = ((((hsize + (BL!() - 1)) / BL!()) * BL!()) - hsize) as c_long;
@@ -619,9 +607,7 @@ pub fn ffsrow_safe(
                 status,
             );
 
-            /*******************************************************/
             /*  Get location information from the input extension  */
-            /*******************************************************/
 
             if infptr.HDUposition != (infptr.Fptr).curhdu {
                 ffmahd_safe(infptr, (infptr.HDUposition) + 1, None, status);
@@ -629,9 +615,7 @@ pub fn ffsrow_safe(
             inExt.dataStart = (infptr.Fptr).datastart;
             inExt.heapStart = (infptr.Fptr).heapstart;
 
-            /**********************************/
             /*  Finally copy heap to outfptr  */
-            /**********************************/
 
             ntodo = inExt.heapSize;
             inbyteloc = inExt.heapStart + inExt.dataStart;
@@ -658,10 +642,8 @@ pub fn ffsrow_safe(
                 ntodo -= rdlen as LONGLONG;
             }
 
-            /***********************************************************/
             /*  But must update DES if data is being appended to a     */
             /*  pre-existing heap space.  Edit each new entry in file  */
-            /***********************************************************/
 
             if outExt.heapSize != 0 {
                 let mut repeat: LONGLONG = 0;
@@ -692,7 +674,6 @@ pub fn ffsrow_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Evaluate an expression on all rows of a table, deleting the FALSE rows
 /// (preserving the TRUE ones) in place.
 ///
@@ -701,11 +682,13 @@ pub fn ffsrow_safe(
 /// `&mut fitsfile` to one handle, so that case gets its own function and the
 /// `extern "C"` wrapper dispatches on pointer identity.  See [`ffsrow_safe`]
 /// for the two-file form.
-pub fn ffsrow_inplace_safe(
-    fptr: &mut fitsfile, /* I/O - FITS file, used as both input and output */
-    expr: &[c_char],     /* I - Boolean expression                   */
-    status: &mut c_int,  /* O - Error status                         */
-) -> c_int {
+///
+/// # Parameters
+///
+/// * `fptr`   — I/O - FITS file, used as both input and output
+/// * `expr`   — (I) Boolean expression
+/// * `status` — (O) Error status
+pub fn ffsrow_inplace_safe(fptr: &mut fitsfile, expr: &[c_char], status: &mut c_int) -> c_int {
     let mut Info: parseInfo = Default::default();
     let mut naxis: c_int = 0;
     let mut constant: c_int = 0;
@@ -762,9 +745,7 @@ pub fn ffsrow_inplace_safe(
         constant = 0;
     }
 
-    /**********************************************************************/
     /* Make sure expression evaluates to the right type... logical scalar */
-    /**********************************************************************/
 
     if Info.datatype != TLOGICAL || nelem != 1 {
         ffcprs(&mut lParse);
@@ -773,9 +754,7 @@ pub fn ffsrow_inplace_safe(
         return *status;
     }
 
-    /***********************************************************/
     /*  Extract various table information from each extension  */
-    /***********************************************************/
 
     if fptr.HDUposition != (fptr.Fptr).curhdu {
         ffmahd_safe(fptr, (fptr.HDUposition) + 1, None, status);
@@ -817,9 +796,7 @@ pub fn ffsrow_inplace_safe(
         return *status;
     }
 
-    /***********************************/
     /*  Fill out Info data for parser  */
-    /***********************************/
 
     /* The row-selection flags are owned here and handed to the parser as a
     raw pointer, so the error returns below cannot leak them.  `Info.dataPtr`
@@ -968,24 +945,35 @@ pub fn ffsrow_inplace_safe(
     *status
 }
 
-/*---------------------------------------------------------------------------*/
 /// Calculate an expression for the indicated rows of a table, returning
 /// the results, cast as datatype (TSHORT, TDOUBLE, etc), in array.  If
 /// nulval==NULL, UNDEFs will be zeroed out.  For vector results, the number
 /// of elements returned may be less than nelements if nelements is not an
 /// even multiple of the result dimension.  Call fftexp to obtain the
 /// dimensions of the results.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) Input FITS file
+/// * `datatype`  — (I) Datatype to return results as
+/// * `expr`      — (I) Arithmetic expression
+/// * `firstrow`  — (I) First row to evaluate
+/// * `nelements` — (I) Number of elements to return
+/// * `nulval`    — (I) Ptr to value to use as UNDEF
+/// * `array`     — (O) Array of results
+/// * `anynul`    — (O) Were any UNDEFs encountered?
+/// * `status`    — (O) Error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffcrow(
-    fptr: *mut fitsfile,   /* I - Input FITS file                      */
-    datatype: c_int,       /* I - Datatype to return results as        */
-    expr: *const c_char,   /* I - Arithmetic expression                */
-    firstrow: c_long,      /* I - First row to evaluate                */
-    nelements: c_long,     /* I - Number of elements to return         */
-    nulval: *const c_void, /* I - Ptr to value to use as UNDEF         */
-    array: *mut c_void,    /* O - Array of results                     */
-    anynul: *mut c_int,    /* O - Were any UNDEFs encountered?         */
-    status: *mut c_int,    /* O - Error status                         */
+    fptr: *mut fitsfile,
+    datatype: c_int,
+    expr: *const c_char,
+    firstrow: c_long,
+    nelements: c_long,
+    nulval: *const c_void,
+    array: *mut c_void,
+    anynul: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -1003,23 +991,34 @@ pub unsafe extern "C" fn ffcrow(
     }
 }
 
-/*---------------------------------------------------------------------------*/
 /// Calculate an expression for the indicated rows of a table, returning
 /// the results, cast as datatype (TSHORT, TDOUBLE, etc), in array.  If
 /// nulval==NULL, UNDEFs will be zeroed out.  For vector results, the number
 /// of elements returned may be less than nelements if nelements is not an
 /// even multiple of the result dimension.  Call fftexp to obtain the
 /// dimensions of the results.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) Input FITS file
+/// * `datatype`  — (I) Datatype to return results as
+/// * `expr`      — (I) Arithmetic expression
+/// * `firstrow`  — (I) First row to evaluate
+/// * `nelements` — (I) Number of elements to return
+/// * `nulval`    — (I) Ptr to value to use as UNDEF
+/// * `array`     — (O) Array of results
+/// * `anynul`    — (O) Were any UNDEFs encountered?
+/// * `status`    — (O) Error status
 pub fn ffcrow_safe(
-    fptr: &mut fitsfile,   /* I - Input FITS file                      */
-    datatype: c_int,       /* I - Datatype to return results as        */
-    expr: &[c_char],       /* I - Arithmetic expression                */
-    firstrow: c_long,      /* I - First row to evaluate                */
-    nelements: c_long,     /* I - Number of elements to return         */
-    nulval: *const c_void, /* I - Ptr to value to use as UNDEF         */
-    array: &mut [u8],      /* O - Array of results                     */
-    anynul: &mut c_int,    /* O - Were any UNDEFs encountered?         */
-    status: &mut c_int,    /* O - Error status                         */
+    fptr: &mut fitsfile,
+    datatype: c_int,
+    expr: &[c_char],
+    firstrow: c_long,
+    nelements: c_long,
+    nulval: *const c_void,
+    array: &mut [u8],
+    anynul: &mut c_int,
+    status: &mut c_int,
 ) -> c_int {
     let mut Info: parseInfo = Default::default();
     let mut naxis: c_int = 0;
@@ -1094,17 +1093,25 @@ pub fn ffcrow_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Evaluate an expression for all rows of a table.  Call ffcalc_rng with
 /// a row range of 1-MAX.              
+///
+/// # Parameters
+///
+/// * `infptr`  — (I) Input FITS file
+/// * `expr`    — (I) Arithmetic expression
+/// * `outfptr` — (I) Output fits file
+/// * `parName` — (I) Name of output parameter
+/// * `parInfo` — (I) Extra information on parameter
+/// * `status`  — (O) Error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffcalc(
-    infptr: *mut fitsfile,  /* I - Input FITS file                      */
-    expr: *const c_char,    /* I - Arithmetic expression                */
-    outfptr: *mut fitsfile, /* I - Output fits file                     */
-    parName: *const c_char, /* I - Name of output parameter             */
-    parInfo: *const c_char, /* I - Extra information on parameter       */
-    status: *mut c_int,     /* O - Error status                         */
+    infptr: *mut fitsfile,
+    expr: *const c_char,
+    outfptr: *mut fitsfile,
+    parName: *const c_char,
+    parInfo: *const c_char,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -1138,16 +1145,24 @@ pub unsafe extern "C" fn ffcalc(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Evaluate an expression for all rows of a table.  Call ffcalc_rng with
 /// a row range of 1-MAX.              
+///
+/// # Parameters
+///
+/// * `infptr`  — (I) Input FITS file
+/// * `expr`    — (I) Arithmetic expression
+/// * `outfptr` — (I) Output fits file
+/// * `parName` — (I) Name of output parameter
+/// * `parInfo` — (I) Extra information on parameter
+/// * `status`  — (O) Error status
 pub fn ffcalc_safe(
-    infptr: &mut fitsfile,  /* I - Input FITS file                      */
-    expr: &[c_char],        /* I - Arithmetic expression                */
-    outfptr: &mut fitsfile, /* I - Output fits file                     */
-    parName: &[c_char],     /* I - Name of output parameter             */
-    parInfo: &[c_char],     /* I - Extra information on parameter       */
-    status: &mut c_int,     /* O - Error status                         */
+    infptr: &mut fitsfile,
+    expr: &[c_char],
+    outfptr: &mut fitsfile,
+    parName: &[c_char],
+    parInfo: &[c_char],
+    status: &mut c_int,
 ) -> c_int {
     let start: c_long = 1;
     let end: c_long = LONG_MAX;
@@ -1165,16 +1180,23 @@ pub fn ffcalc_safe(
     )
 }
 
-/*--------------------------------------------------------------------------*/
 /// In-place twin of [`ffcalc_safe`]: evaluate an expression for all rows of a
 /// table and write the result back into the *same* file.  Calls
 /// [`ffcalc_rng_inplace_safe`] with a row range of 1-MAX.
+///
+/// # Parameters
+///
+/// * `fptr`    — I/O - FITS file, used as both input and output
+/// * `expr`    — (I) Arithmetic expression
+/// * `parName` — (I) Name of output parameter
+/// * `parInfo` — (I) Extra information on parameter
+/// * `status`  — (O) Error status
 pub fn ffcalc_inplace_safe(
-    fptr: &mut fitsfile, /* I/O - FITS file, used as both input and output */
-    expr: &[c_char],     /* I - Arithmetic expression                */
-    parName: &[c_char],  /* I - Name of output parameter             */
-    parInfo: &[c_char],  /* I - Extra information on parameter       */
-    status: &mut c_int,  /* O - Error status                         */
+    fptr: &mut fitsfile,
+    expr: &[c_char],
+    parName: &[c_char],
+    parInfo: &[c_char],
+    status: &mut c_int,
 ) -> c_int {
     let start: c_long = 1;
     let end: c_long = LONG_MAX;
@@ -1182,7 +1204,6 @@ pub fn ffcalc_inplace_safe(
     ffcalc_rng_inplace_safe(fptr, expr, parName, parInfo, 1, &[start], &[end], status)
 }
 
-/*--------------------------------------------------------------------------*/
 /// Evaluate an expression using the data in the input FITS file and place  
 /// the results into either a column or keyword in the output fits file,    
 /// depending on the value of parName (keywords normally prefixed with '#')
@@ -1196,17 +1217,29 @@ pub fn ffcalc_inplace_safe(
 ///        constant, put result there, using parInfo as the new comment.    
 ///    (4) Else, create a new column with name parName and TFORM parInfo.   
 ///        If parInfo is NULL, use a default data type for the column.      
+///
+/// # Parameters
+///
+/// * `infptr`  — (I) Input FITS file
+/// * `expr`    — (I) Arithmetic expression
+/// * `outfptr` — (I) Output fits file
+/// * `parName` — (I) Name of output parameter
+/// * `parInfo` — (I) Extra information on parameter
+/// * `nRngs`   — (I) Row range info
+/// * `start`   — (I) Row range info
+/// * `end`     — (I) Row range info
+/// * `status`  — (O) Error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffcalc_rng(
-    infptr: *mut fitsfile,  /* I - Input FITS file                  */
-    expr: *const c_char,    /* I - Arithmetic expression            */
-    outfptr: *mut fitsfile, /* I - Output fits file                 */
-    parName: *const c_char, /* I - Name of output parameter         */
-    parInfo: *const c_char, /* I - Extra information on parameter   */
-    nRngs: c_int,           /* I - Row range info                   */
-    start: *const c_long,   /* I - Row range info                   */
-    end: *const c_long,     /* I - Row range info                   */
-    status: *mut c_int,     /* O - Error status                     */
+    infptr: *mut fitsfile,
+    expr: *const c_char,
+    outfptr: *mut fitsfile,
+    parName: *const c_char,
+    parInfo: *const c_char,
+    nRngs: c_int,
+    start: *const c_long,
+    end: *const c_long,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -1245,7 +1278,6 @@ pub unsafe extern "C" fn ffcalc_rng(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Evaluate an expression using the data in the input FITS file and place  
 /// the results into either a column or keyword in the output fits file,    
 /// depending on the value of parName (keywords normally prefixed with '#')
@@ -1259,18 +1291,28 @@ pub unsafe extern "C" fn ffcalc_rng(
 ///        constant, put result there, using parInfo as the new comment.    
 ///    (4) Else, create a new column with name parName and TFORM parInfo.   
 ///        If parInfo is NULL, use a default data type for the column.      
-/// NOTE: [`ffcalc_rng_inplace_safe`] is a copy of this body for the case where the
-/// caller passes one file as both input and output.  Any fix here belongs there too.
+///
+/// # Parameters
+///
+/// * `infptr`  — (I) Input FITS file
+/// * `expr`    — (I) Arithmetic expression
+/// * `outfptr` — (I) Output fits file
+/// * `parName` — (I) Name of output parameter
+/// * `parInfo` — (I) Extra information on parameter
+/// * `nRngs`   — (I) Row range info
+/// * `start`   — (I) Row range info
+/// * `end`     — (I) Row range info
+/// * `status`  — (O) Error status
 pub fn ffcalc_rng_safe(
-    infptr: &mut fitsfile,  /* I - Input FITS file                  */
-    expr: &[c_char],        /* I - Arithmetic expression            */
-    outfptr: &mut fitsfile, /* I - Output fits file                 */
-    parName: &[c_char],     /* I - Name of output parameter         */
-    parInfo: &[c_char],     /* I - Extra information on parameter   */
-    nRngs: c_int,           /* I - Row range info                   */
-    start: &[c_long],       /* I - Row range info                   */
-    end: &[c_long],         /* I - Row range info                   */
-    status: &mut c_int,     /* O - Error status                     */
+    infptr: &mut fitsfile,
+    expr: &[c_char],
+    outfptr: &mut fitsfile,
+    parName: &[c_char],
+    parInfo: &[c_char],
+    nRngs: c_int,
+    start: &[c_long],
+    end: &[c_long],
+    status: &mut c_int,
 ) -> c_int {
     let mut Info: parseInfo = Default::default();
     let mut naxis: c_int = 0;
@@ -1485,9 +1527,7 @@ pub fn ffcalc_rng_safe(
             }
         }
     } else {
-        /********************************************************/
         /*  Check if a TDIM keyword should be written/updated.  */
-        /********************************************************/
 
         ffkeyn_safe(cs!(c"TDIM"), colNo, &mut tdimKwd, status);
         ffgcrd_safe(outfptr, &tdimKwd, &mut card, status);
@@ -1521,9 +1561,7 @@ pub fn ffcalc_rng_safe(
 
         ffgkyj_safe(infptr, cs!(c"NAXIS2"), &mut totaln, None, status);
 
-        /*************************************/
         /* Create new iterator Output Column */
-        /*************************************/
 
         col_cnt = lParse.nCols;
         if fits_parser_allocateCol(&mut lParse, col_cnt, status) != 0 {
@@ -1648,7 +1686,6 @@ pub fn ffcalc_rng_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// In-place twin of [`ffcalc_rng_safe`]: evaluate an expression over the rows
 /// of a table and write the result back into the *same* file.
 ///
@@ -1659,15 +1696,26 @@ pub fn ffcalc_rng_safe(
 ///
 /// NOTE: this body is a copy of [`ffcalc_rng_safe`] with `infptr`/`outfptr`
 /// collapsed to one handle.  Any fix to one belongs in the other.
+///
+/// # Parameters
+///
+/// * `fptr`    — I/O - FITS file, used as both input and output
+/// * `expr`    — (I) Arithmetic expression
+/// * `parName` — (I) Name of output parameter
+/// * `parInfo` — (I) Extra information on parameter
+/// * `nRngs`   — (I) Row range info
+/// * `start`   — (I) Row range info
+/// * `end`     — (I) Row range info
+/// * `status`  — (O) Error status
 pub fn ffcalc_rng_inplace_safe(
-    fptr: &mut fitsfile, /* I/O - FITS file, used as both input and output */
-    expr: &[c_char],     /* I - Arithmetic expression            */
-    parName: &[c_char],  /* I - Name of output parameter         */
-    parInfo: &[c_char],  /* I - Extra information on parameter   */
-    nRngs: c_int,        /* I - Row range info                   */
-    start: &[c_long],    /* I - Row range info                   */
-    end: &[c_long],      /* I - Row range info                   */
-    status: &mut c_int,  /* O - Error status                     */
+    fptr: &mut fitsfile,
+    expr: &[c_char],
+    parName: &[c_char],
+    parInfo: &[c_char],
+    nRngs: c_int,
+    start: &[c_long],
+    end: &[c_long],
+    status: &mut c_int,
 ) -> c_int {
     let mut Info: parseInfo = Default::default();
     let mut naxis: c_int = 0;
@@ -1882,9 +1930,7 @@ pub fn ffcalc_rng_inplace_safe(
             }
         }
     } else {
-        /********************************************************/
         /*  Check if a TDIM keyword should be written/updated.  */
-        /********************************************************/
 
         ffkeyn_safe(cs!(c"TDIM"), colNo, &mut tdimKwd, status);
         ffgcrd_safe(fptr, &tdimKwd, &mut card, status);
@@ -1918,9 +1964,7 @@ pub fn ffcalc_rng_inplace_safe(
 
         ffgkyj_safe(fptr, cs!(c"NAXIS2"), &mut totaln, None, status);
 
-        /*************************************/
         /* Create new iterator Output Column */
-        /*************************************/
 
         col_cnt = lParse.nCols;
         if fits_parser_allocateCol(&mut lParse, col_cnt, status) != 0 {
@@ -2045,18 +2089,28 @@ pub fn ffcalc_rng_inplace_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Evaluate the given expression and return information on the result.      
+///
+/// # Parameters
+///
+/// * `fptr`     — (I) Input FITS file
+/// * `expr`     — (I) Arithmetic expression
+/// * `maxdim`   — (I) Max Dimension of naxes
+/// * `datatype` — (O) Data type of result
+/// * `nelem`    — (O) Vector length of result
+/// * `naxis`    — (O) # of dimensions of result
+/// * `naxes`    — (O) Size of each dimension
+/// * `status`   — (O) Error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn fftexp(
-    fptr: *mut fitsfile,  /* I - Input FITS file                     */
-    expr: *const c_char,  /* I - Arithmetic expression               */
-    maxdim: c_int,        /* I - Max Dimension of naxes              */
-    datatype: *mut c_int, /* O - Data type of result                 */
-    nelem: *mut c_long,   /* O - Vector length of result             */
-    naxis: *mut c_int,    /* O - # of dimensions of result           */
-    naxes: *mut c_long,   /* O - Size of each dimension              */
-    status: *mut c_int,   /* O - Error status                        */
+    fptr: *mut fitsfile,
+    expr: *const c_char,
+    maxdim: c_int,
+    datatype: *mut c_int,
+    nelem: *mut c_long,
+    naxis: *mut c_int,
+    naxes: *mut c_long,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -2073,17 +2127,27 @@ pub unsafe extern "C" fn fftexp(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Evaluate the given expression and return information on the (*result).
+///
+/// # Parameters
+///
+/// * `fptr`     — (I) Input FITS file
+/// * `expr`     — (I) Arithmetic expression
+/// * `maxdim`   — (I) Max Dimension of naxes
+/// * `datatype` — (O) Data type of result
+/// * `nelem`    — (O) Vector length of result
+/// * `naxis`    — (O) # of dimensions of result
+/// * `naxes`    — (O) Size of each dimension
+/// * `status`   — (O) Error status
 pub fn fftexp_safe(
-    fptr: &mut fitsfile,  /* I - Input FITS file                     */
-    expr: &[c_char],      /* I - Arithmetic expression               */
-    maxdim: c_int,        /* I - Max Dimension of naxes              */
-    datatype: &mut c_int, /* O - Data type of result                 */
-    nelem: &mut c_long,   /* O - Vector length of result             */
-    naxis: &mut c_int,    /* O - # of dimensions of result           */
-    naxes: &mut [c_long], /* O - Size of each dimension              */
-    status: &mut c_int,   /* O - Error status                        */
+    fptr: &mut fitsfile,
+    expr: &[c_char],
+    maxdim: c_int,
+    datatype: &mut c_int,
+    nelem: &mut c_long,
+    naxis: &mut c_int,
+    naxes: &mut [c_long],
+    status: &mut c_int,
 ) -> c_int {
     let mut lParse: ParseData = ParseData::default();
 
@@ -2103,7 +2167,6 @@ pub fn fftexp_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Initialize the parser and determine what type of result the expression
 /// produces.
 /// Re-establish the file pointers the parse recorded.
@@ -2129,17 +2192,32 @@ fn refresh_file_ptrs(lParse: &mut ParseData, fptr: &mut fitsfile) {
     }
 }
 
+/// Initialize the parser and determine what type of result the expression
+/// produces.
+///
+/// # Parameters
+///
+/// * `fptr`       — (I) Input FITS file
+/// * `compressed` — (I) Is FITS file hkunexpanded?
+/// * `expr`       — (I) Arithmetic expression
+/// * `maxdim`     — (I) Max Dimension of naxes
+/// * `datatype`   — (O) Data type of result
+/// * `nelem`      — (O) Vector length of result
+/// * `naxis`      — (O) # of dimensions of result
+/// * `naxes`      — (O) Size of each dimension
+/// * `lParse`     — (O) parser status
+/// * `status`     — (O) Error status
 pub(crate) fn ffiprs(
-    fptr: &mut fitsfile,    /* I - Input FITS file                     */
-    compressed: c_int,      /* I - Is FITS file hkunexpanded?          */
-    expr: &[c_char],        /* I - Arithmetic expression               */
-    maxdim: c_int,          /* I - Max Dimension of naxes              */
-    datatype: &mut c_int,   /* O - Data type of result                 */
-    nelem: &mut c_long,     /* O - Vector length of result             */
-    naxis: &mut c_int,      /* O - # of dimensions of result           */
-    naxes: &mut [c_long],   /* O - Size of each dimension              */
-    lParse: &mut ParseData, /* O - parser status                       */
-    status: &mut c_int,     /* O - Error status                        */
+    fptr: &mut fitsfile,
+    compressed: c_int,
+    expr: &[c_char],
+    maxdim: c_int,
+    datatype: &mut c_int,
+    nelem: &mut c_long,
+    naxis: &mut c_int,
+    naxes: &mut [c_long],
+    lParse: &mut ParseData,
+    status: &mut c_int,
 ) -> c_int {
     let i: c_int = 0;
     let mut lexpr: c_int = 0;
@@ -2336,7 +2414,6 @@ pub(crate) fn ffiprs(
     *status
 }
 
-/*---------------------------------------------------------------------------*/
 /// Clear the parser, making it ready to accept a new expression.
 pub(crate) fn ffcprs(lParse: &mut ParseData) {
     unsafe {
@@ -2423,23 +2500,31 @@ pub(crate) fn ffcprs(lParse: &mut ParseData) {
     }
 }
 
-/*---------------------------------------------------------------------------*/
 /// Iterator work function which calls the parser and copies the results
 /// into either an OutputCol or a data pointer supplied in the userPtr
 /// structure.
+///
+/// # Parameters
+///
+/// * `totalrows` — (I) Total rows to be processed
+/// * `offset`    — (I) Number of rows skipped at start
+/// * `firstrow`  — (I) First row of this iteration
+/// * `nrows`     — (I) Number of rows in this iter
+/// * `nCols`     — (I) Number of columns in use
+/// * `colData`   — (IO) Column information/data
+/// * `userPtr`   — (I) Data handling instructions
 pub(crate) extern "C" fn fits_parser_workfn(
-    totalrows: c_long,         /* I - Total rows to be processed     */
-    offset: c_long,            /* I - Number of rows skipped at start*/
-    firstrow: c_long,          /* I - First row of this iteration    */
-    nrows: c_long,             /* I - Number of rows in this iter    */
-    nCols: c_int,              /* I - Number of columns in use       */
-    colData: *mut iteratorCol, /* IO- Column information/data        */
-    userPtr: *mut c_void,      /* I - Data handling instructions     */
+    totalrows: c_long,
+    offset: c_long,
+    firstrow: c_long,
+    nrows: c_long,
+    nCols: c_int,
+    colData: *mut iteratorCol,
+    userPtr: *mut c_void,
 ) -> c_int {
     fits_parser_workfn_safe(totalrows, offset, firstrow, nrows, nCols, colData, userPtr)
 }
 
-/*---------------------------------------------------------------------------*/
 /// Iterator work function which calls the parser and copies the results
 /// into either an OutputCol or a data pointer supplied in the userPtr
 /// structure.
@@ -2460,14 +2545,23 @@ unsafe fn copy_str_elem(dst: *mut c_char, src: &[c_char]) {
     unsafe { core::slice::from_raw_parts_mut(dst, n) }.copy_from_slice(&src[..n]);
 }
 
+/// # Parameters
+///
+/// * `totalrows` — (I) Total rows to be processed
+/// * `offset`    — (I) Number of rows skipped at start
+/// * `firstrow`  — (I) First row of this iteration
+/// * `nrows`     — (I) Number of rows in this iter
+/// * `nCols`     — (I) Number of columns in use
+/// * `colData`   — (IO) Column information/data
+/// * `userPtr`   — (I) Data handling instructions
 pub(crate) fn fits_parser_workfn_safe(
-    totalrows: c_long,           /* I - Total rows to be processed     */
-    offset: c_long,              /* I - Number of rows skipped at start*/
-    mut firstrow: c_long,        /* I - First row of this iteration    */
-    mut nrows: c_long,           /* I - Number of rows in this iter    */
-    nCols: c_int,                /* I - Number of columns in use       */
-    colData: *mut iteratorCol,   /* IO- Column information/data        */
-    userPtr: *mut c_void,        /* I - Data handling instructions     */
+    totalrows: c_long,
+    offset: c_long,
+    mut firstrow: c_long,
+    mut nrows: c_long,
+    nCols: c_int,
+    colData: *mut iteratorCol,
+    userPtr: *mut c_void,
 ) -> c_int {
     /* `colData` is a raw pointer rather than a `&mut [iteratorCol]` because it
     may be the very same array as `lParse.colData` -- the parser's own copy,
@@ -2513,9 +2607,7 @@ pub(crate) fn fits_parser_workfn_safe(
                 totalrows, offset, firstrow, nrows, nCols
             );
         }
-        /*--------------------------------------------------------*/
         /*  Initialization procedures: execute on the first call  */
-        /*--------------------------------------------------------*/
 
         if firstrow == offset + 1 {
             (pv.userInfo) = userPtr.cast::<parseInfo>();
@@ -2661,9 +2753,7 @@ pub(crate) fn fits_parser_workfn_safe(
             }
         }
 
-        /*-------------------------------------------*/
         /*  Main loop: process all the rows of data  */
-        /*-------------------------------------------*/
 
         /*  If writing to output column, set first element to appropriate  */
         /*  null value.  If no NULLs encounter, zero out before returning. */
@@ -3114,7 +3204,11 @@ pub(crate) fn fits_parser_workfn_safe(
                     2,
                 );
             } else {
-                memcpy((*outcol_ptr).array, pv.Null, pv.datasize.try_into().unwrap());
+                memcpy(
+                    (*outcol_ptr).array,
+                    pv.Null,
+                    pv.datasize.try_into().unwrap(),
+                );
             }
         }
 
@@ -3139,9 +3233,7 @@ pub(crate) fn fits_parser_workfn_safe(
             }
         }
 
-        /*-------------------------------------------------------*/
         /*  Clean up procedures:  after processing all the rows  */
-        /*-------------------------------------------------------*/
 
         /*  if the calling routine specified that only a limited number    */
         /*  of rows in the table should be processed, return a value of -1 */
@@ -3161,7 +3253,6 @@ pub(crate) fn fits_parser_workfn_safe(
 
 /*  Internal routines needed to allow the evaluator to operate on FITS data  */
 
-/***********************************************************************/
 /// Setup the varData array in gParse to contain the fits column data.
 /// Then, allocate and initialize the necessary UNDEF arrays for each
 /// column used by the parser.
@@ -3413,19 +3504,30 @@ fn Setup_DataArrays(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Convert an array of any input data type to an array of any output
 /// data type, using an array of UNDEF flags to assign nulvals to
+///
+/// # Parameters
+///
+/// * `inputType`  — (I) Data type of input array
+/// * `input`      — (I) Input array of type inputType
+/// * `undef`      — (I) Array of flags indicating UNDEF elems
+/// * `ntodo`      — (I) Number of elements to process
+/// * `outputType` — (I) Data type of output array
+/// * `nulval`     — (I) Ptr to value to use for UNDEF elements
+/// * `output`     — (O) Output array of type outputType
+/// * `anynull`    — (O) Any nulls flagged?
+/// * `status`     — (O) Error status
 fn ffcvtn(
-    inputType: c_int,      /* I - Data type of input array               */
-    input: *const c_void,  /* I - Input array of type inputType          */
-    undef: *const c_char,  /* I - Array of flags indicating UNDEF elems  */
-    ntodo: c_long,         /* I - Number of elements to process          */
-    outputType: c_int,     /* I - Data type of output array              */
-    nulval: *const c_void, /* I - Ptr to value to use for UNDEF elements */
-    output: *mut c_void,   /* O - Output array of type outputType        */
-    anynull: &mut c_int,   /* O - Any nulls flagged?                     */
-    status: &mut c_int,    /* O - Error status                           */
+    inputType: c_int,
+    input: *const c_void,
+    undef: *const c_char,
+    ntodo: c_long,
+    outputType: c_int,
+    nulval: *const c_void,
+    output: *mut c_void,
+    anynull: &mut c_int,
+    status: &mut c_int,
 ) -> c_int {
     unsafe {
         let i: c_long = 0;
@@ -4074,20 +4176,31 @@ fn ffcvtn(
     }
 }
 
-/*---------------------------------------------------------------------------*/
 /// Evaluate a boolean expression for each time in a compressed file,
 /// returning an array of flags indicating which times evaluated to TRUE/FALSE
+///
+/// # Parameters
+///
+/// * `fptr`        — (I) Input FITS file
+/// * `expr`        — (I) Boolean expression
+/// * `timeCol`     — (I) Name of time column
+/// * `parCol`      — (I) Name of parameter column
+/// * `valCol`      — (I) Name of value column
+/// * `ntimes`      — (I) Number of distinct times in file
+/// * `times`       — (O) Array of times in file
+/// * `time_status` — (O) Array of boolean results
+/// * `status`      — (O) Error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn fffrwc(
-    fptr: *mut fitsfile,      /* I - Input FITS file                    */
-    expr: *const c_char,      /* I - Boolean expression                 */
-    timeCol: *const c_char,   /* I - Name of time column                */
-    parCol: *const c_char,    /* I - Name of parameter column           */
-    valCol: *const c_char,    /* I - Name of value column               */
-    ntimes: c_long,           /* I - Number of distinct times in file   */
-    times: *mut f64,          /* O - Array of times in file             */
-    time_status: *mut c_char, /* O - Array of boolean results           */
-    status: *mut c_int,       /* O - Error status                       */
+    fptr: *mut fitsfile,
+    expr: *const c_char,
+    timeCol: *const c_char,
+    parCol: *const c_char,
+    valCol: *const c_char,
+    ntimes: c_long,
+    times: *mut f64,
+    time_status: *mut c_char,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -4116,22 +4229,32 @@ pub unsafe extern "C" fn fffrwc(
     }
 }
 
-/*---------------------------------------------------------------------------*/
 /// Evaluate a boolean expression for each time in a compressed file,
 /// returning an array of flags indicating which times evaluated to TRUE/FALSE
 // The TSTRING arm dispatches on fits_get_coltype's result; hoisting that call
 // into a match guard would hide it. Left as the C writes it.
 #[allow(clippy::collapsible_match, clippy::collapsible_if)]
+/// # Parameters
+///
+/// * `fptr`        — (I) Input FITS file
+/// * `expr`        — (I) Boolean expression
+/// * `timeCol`     — (I) Name of time column
+/// * `parCol`      — (I) Name of parameter column
+/// * `valCol`      — (I) Name of value column
+/// * `ntimes`      — (I) Number of distinct times in file
+/// * `times`       — (O) Array of times in file
+/// * `time_status` — (O) Array of boolean results
+/// * `status`      — (O) Error status
 pub fn fffrwc_safe(
-    fptr: &mut fitsfile,        /* I - Input FITS file                    */
-    expr: &[c_char],            /* I - Boolean expression                 */
-    timeCol: &[c_char],         /* I - Name of time column                */
-    parCol: &[c_char],          /* I - Name of parameter column           */
-    valCol: &[c_char],          /* I - Name of value column               */
-    ntimes: c_long,             /* I - Number of distinct times in file   */
-    times: &mut [f64],          /* O - Array of times in file             */
-    time_status: &mut [c_char], /* O - Array of boolean results           */
-    status: &mut c_int,         /* O - Error status                       */
+    fptr: &mut fitsfile,
+    expr: &[c_char],
+    timeCol: &[c_char],
+    parCol: &[c_char],
+    valCol: &[c_char],
+    ntimes: c_long,
+    times: &mut [f64],
+    time_status: &mut [c_char],
+    status: &mut c_int,
 ) -> c_int {
     let mut Info: parseInfo = Default::default();
     let mut alen: c_long = 0;
@@ -4208,9 +4331,7 @@ pub fn fffrwc_safe(
         return *status;
     }
 
-    /*******************************************/
     /* Allocate data arrays for each parameter */
-    /*******************************************/
 
     /* The C wrote each array straight into lParse.colData[parNo].array.
     `iteratorCol` is Copy here, so pulling the descriptor out into a local
@@ -4296,9 +4417,7 @@ pub fn fffrwc_safe(
         }
     }
 
-    /**********************************************************************/
     /* Read data from columns needed for the expression and then parse it */
-    /**********************************************************************/
 
     if fits_uncompress_hkdata(&mut lParse, fptr, ntimes, times, status) == 0 {
         if constant != 0 {
@@ -4319,9 +4438,9 @@ pub fn fffrwc_safe(
             let n_cols = lParse.nCols;
             let cols_ptr = lParse.colData.as_mut_ptr();
             /* The work function's first act is
-               `userPtr.parseData.as_mut().unwrap()`, so this branch used to
-               unwrap a null: unlike every other caller, it never set the
-               field. Taken after cols_ptr, as elsewhere. */
+            `userPtr.parseData.as_mut().unwrap()`, so this branch used to
+            unwrap a null: unlike every other caller, it never set the
+            field. Taken after cols_ptr, as elsewhere. */
             Info.parseData = core::ptr::from_mut::<ParseData>(&mut lParse);
             *status = fits_parser_workfn_safe(
                 ntimes,
@@ -4335,9 +4454,7 @@ pub fn fffrwc_safe(
         }
     }
 
-    /************/
     /* Clean up */
-    /************/
 
     /* No cleanup loop: lng_arrays/dbl_arrays/str_blocks/str_ptrs own the
     column arrays and drop at the end of this function. */
@@ -4350,15 +4467,21 @@ pub fn fffrwc_safe(
     *status
 }
 
-/*---------------------------------------------------------------------------*/
 /// Evaluate a boolean expression, returning the row number of the first
 /// row which evaluates to TRUE
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) Input FITS file
+/// * `expr`   — (I) Boolean expression
+/// * `rownum` — (O) First row of table to eval to T
+/// * `status` — (O) Error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffffrw(
-    fptr: *mut fitsfile, /* I - Input FITS file                   */
-    expr: *mut c_char,   /* I - Boolean expression                */
-    rownum: *mut c_long, /* O - First row of table to eval to T   */
-    status: *mut c_int,  /* O - Error status                      */
+    fptr: *mut fitsfile,
+    expr: *mut c_char,
+    rownum: *mut c_long,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -4372,14 +4495,20 @@ pub unsafe extern "C" fn ffffrw(
     }
 }
 
-/*---------------------------------------------------------------------------*/
 /// Evaluate a boolean expression, returning the row number of the first
 /// row which evaluates to TRUE
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) Input FITS file
+/// * `expr`   — (I) Boolean expression
+/// * `rownum` — (O) First row of table to eval to T
+/// * `status` — (O) Error status
 pub fn ffffrw_safer(
-    fptr: &mut fitsfile, /* I - Input FITS file                   */
-    expr: &[c_char],     /* I - Boolean expression                */
-    rownum: &mut c_long, /* O - First row of table to eval to T   */
-    status: &mut c_int,  /* O - Error status                      */
+    fptr: &mut fitsfile,
+    expr: &[c_char],
+    rownum: &mut c_long,
+    status: &mut c_int,
 ) -> c_int {
     let mut naxis = 0; /* No need to call parser... have result from ffiprs */
     let mut constant = 0; /*  Make sure there is at least 1 row in table  */
@@ -4465,7 +4594,6 @@ pub fn ffffrw_safer(
     *status
 }
 
-/*---------------------------------------------------------------------------*/
 ///  Setup iterator column and parser information to be ready to compute temporary calculator expression
 pub(crate) fn fits_parser_set_temporary_col(
     lParse: &mut ParseData,
@@ -4505,7 +4633,6 @@ pub(crate) fn fits_parser_set_temporary_col(
     0
 }
 
-/*---------------------------------------------------------------------------*/
 /// Uncompress housekeeping data from a compressed FITS table
 fn fits_uncompress_hkdata(
     lParse: &mut ParseData,
@@ -4718,16 +4845,24 @@ fn fits_uncompress_hkdata(
     }
 }
 
-/*---------------------------------------------------------------------------*/
 /// Iterator work function which calls the parser and searches for the
 /// first row which evaluates to TRUE.
+///
+/// # Parameters
+///
+/// * `totalrows` — (I) Total rows to be processed
+/// * `offset`    — (I) Number of rows skipped at start
+/// * `firstrow`  — (I) First row of this iteration
+/// * `nrows`     — (I) Number of rows in this iter
+/// * `nCols`     — (I) Number of columns in use
+/// * `colData`   — (IO) Column information/data
 pub(crate) extern "C" fn ffffrw_work(
-    totalrows: c_long,         /* I - Total rows to be processed     */
-    offset: c_long,            /* I - Number of rows skipped at start*/
-    firstrow: c_long,          /* I - First row of this iteration    */
-    nrows: c_long,             /* I - Number of rows in this iter    */
-    nCols: c_int,              /* I - Number of columns in use       */
-    colData: *mut iteratorCol, /* IO- Column information/data        */
+    totalrows: c_long,
+    offset: c_long,
+    firstrow: c_long,
+    nrows: c_long,
+    nCols: c_int,
+    colData: *mut iteratorCol,
     userPtr: *mut c_void,
 ) -> c_int {
     let workData: &mut ffffrw_workdata =
@@ -4736,15 +4871,22 @@ pub(crate) extern "C" fn ffffrw_work(
     ffffrw_work_safe(totalrows, offset, firstrow, nrows, nCols, workData)
 }
 
-/*---------------------------------------------------------------------------*/
 /// Iterator work function which calls the parser and searches for the
 /// first row which evaluates to TRUE.
+///
+/// # Parameters
+///
+/// * `totalrows` — (I) Total rows to be processed
+/// * `offset`    — (I) Number of rows skipped at start
+/// * `firstrow`  — (I) First row of this iteration
+/// * `nrows`     — (I) Number of rows in this iter
+/// * `nCols`     — (I) Number of columns in use
 pub(crate) fn ffffrw_work_safe(
-    totalrows: c_long, /* I - Total rows to be processed     */
-    offset: c_long,    /* I - Number of rows skipped at start*/
-    firstrow: c_long,  /* I - First row of this iteration    */
-    nrows: c_long,     /* I - Number of rows in this iter    */
-    nCols: c_int,      /* I - Number of columns in use       */
+    totalrows: c_long,
+    offset: c_long,
+    firstrow: c_long,
+    nrows: c_long,
+    nCols: c_int,
     workData: &mut ffffrw_workdata,
 ) -> c_int {
     unsafe {
@@ -4787,13 +4929,14 @@ unsafe impl Sync for DefaultTags {}
 
 static DEFAULT_TAGS: DefaultTags = DefaultTags([c"X".as_ptr().cast_mut()]);
 
-/*--------------------------------------------------------------------------*/
 /// Apply pixel filtering operations
+///
+/// # Parameters
+///
+/// * `filter` — (I) pixel filter structure
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
-pub unsafe extern "C" fn fits_pixel_filter(
-    filter: *mut PixelFilter, /* I - pixel filter structure */
-    status: *mut c_int,       /* IO - error status */
-) -> c_int {
+pub unsafe extern "C" fn fits_pixel_filter(filter: *mut PixelFilter, status: *mut c_int) -> c_int {
     // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect("Null status pointer");
@@ -4803,19 +4946,13 @@ pub unsafe extern "C" fn fits_pixel_filter(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Apply pixel filtering operations (safe version)
 /* Evaluate an expression using the data in the input FITS file(s)          */
-/*--------------------------------------------------------------------------*/
-/// # Safety
-/// `PixelFilter` is a C struct of raw pointers (`tag: *mut *mut c_char`,
-/// `ifptr: *mut *mut fitsfile`, `ofptr: *mut fitsfile`, `expression`), so the body
-/// is raw-pointer work throughout and the block is genuinely function-wide.  Narrowing
-/// it means changing `PixelFilter` itself, not this function.
-pub fn fits_pixel_filter_safer(
-    filter: &mut PixelFilter, /* I - pixel filter structure */
-    status: &mut c_int,       /* IO - error status */
-) -> c_int {
+/// # Parameters
+///
+/// * `filter` — (I) pixel filter structure
+/// * `status` — (IO) error status
+pub fn fits_pixel_filter_safer(filter: &mut PixelFilter, status: &mut c_int) -> c_int {
     unsafe {
         let mut info: parseInfo = parseInfo::default();
         let mut naxis: c_int = 0;
@@ -5091,9 +5228,7 @@ pub fn fits_pixel_filter_safer(
         }
 
         if *filter.keyword.as_ptr() == 0 {
-            /*************************************/
             /* Create new iterator Output Column */
-            /*************************************/
             col_cnt = lParse.nCols;
             if fits_parser_allocateCol(&mut lParse, col_cnt, status) != 0 {
                 ffcprs(&mut lParse);
@@ -5400,7 +5535,12 @@ fn find_column(
             /* As above: the C is `pixFilter->ifptr[colnum] == NULL`, testing
             the element. The address form never fired, so a NULL ifptr[colnum]
             reached the `&mut *fptr` below. */
-            if (*lParse.pixFilter).ifptr.add(colnum as usize).read().is_null() {
+            if (*lParse.pixFilter)
+                .ifptr
+                .add(colnum as usize)
+                .read()
+                .is_null()
+            {
                 ffpmsg_str("find_column: PixelFilter missing image pointer");
                 lParse.status = COL_NOT_FOUND;
                 return P_ERROR;

--- a/src/eval_l.rs
+++ b/src/eval_l.rs
@@ -1,55 +1,19 @@
-/************************************************************************/
-/*                                                                      */
-/*                       CFITSIO Lexical Parser                         */
-/*                                                                      */
-/* This specifies a thread-safe reentrant version of lex functions */
-/* This specifies CFITSIO-unique names for lexer functions */
-/* This facilitates calling between the Bison parser and this lexer */
-/* This file is one of 3 files containing code which parses an          */
-/* arithmetic expression and evaluates it in the context of an input    */
-/* FITS file table extension.  The CFITSIO lexical parser is divided    */
-/* into the following 3 parts/files: the CFITSIO "front-end",           */
-/* eval_f.c, contains the interface between the user/CFITSIO and the    */
-/* real core of the parser; the FLEX interpreter, eval_l.c, takes the   */
-/* input string and parses it into tokens and identifies the FITS       */
-/* information required to evaluate the expression (ie, keywords and    */
-/* columns); and, the BISON grammar and evaluation routines, eval_y.c,  */
-/* receives the FLEX output and determines and performs the actual      */
-/* operations.  The files eval_l.c and eval_y.c are produced from       */
-/* running flex and bison on the files eval.l and eval.y, respectively. */
-/* (flex and bison are available from any GNU archive: see www.gnu.org) */
-/*                                                                      */
-/* The grammar rules, rather than evaluating the expression in situ,    */
-/* builds a tree, or Nodal, structure mapping out the order of          */
-/* operations and expression dependencies.  This "compilation" process  */
-/* allows for much faster processing of multiple rows.  This technique  */
-/* was developed by Uwe Lammers of the XMM Science Analysis System,     */
-/* although the CFITSIO implementation is entirely code original.       */
-/*                                                                      */
-/*                                                                      */
-/* Modification History:                                                */
-/*                                                                      */
-/*   Kent Blackburn      c1992  Original parser code developed for the  */
-/*                              FTOOLS software package, in particular, */
-/*                              the fselect task.                       */
-/*   Kent Blackburn      c1995  BIT column support added                */
-/*   Peter D Wilson   Feb 1998  Vector column support added             */
-/*   Peter D Wilson   May 1998  Ported to CFITSIO library.  User        */
-/*                              interface routines written, in essence  */
-/*                              making fselect, fcalc, and maketime     */
-/*                              capabilities available to all tools     */
-/*                              via single function calls.              */
-/*   Peter D Wilson   Jun 1998  Major rewrite of parser core, so as to  */
-/*                              create a run-time evaluation tree,      */
-/*                              inspired by the work of Uwe Lammers,    */
-/*                              resulting in a speed increase of        */
-/*                              10-100 times.                           */
-/*   Peter D Wilson   Jul 1998  gtifilter(a,b,c,d) function added       */
-/*   Peter D Wilson   Aug 1998  regfilter(a,b,c,d) function added       */
-/*   Peter D Wilson   Jul 1999  Make parser fitsfile-independent,       */
-/*                              allowing a purely vector-based usage    */
-/*                                                                      */
-/************************************************************************/
+//! The CFITSIO expression parser's lexer.
+//!
+//! **Generated code**: produced by running `flex` on `eval.l`, then transpiled.
+//! Edits belong in `eval.l` upstream, not here. It is a thread-safe reentrant
+//! lexer using CFITSIO-specific function names, which is what lets the BISON
+//! parser in [`crate::eval_y`] call into it.
+//!
+//! The lexer turns the expression string into tokens and identifies the FITS
+//! keywords and columns the expression needs. See [`crate::eval_f`] for the
+//! parser as a whole.
+// The items below are flex's own output -- its typedefs, buffer state, token
+// constants and parser tables. They carry the generator's names and have no
+// meaning outside it, so they are exempt from the documentation ratchet rather
+// than given invented descriptions; the file header above documents the module
+// as a whole. Anything hand-written added here should be documented.
+#![allow(missing_docs)]
 #![deny(dead_code)]
 
 use errno::{Errno, errno, set_errno};
@@ -77,8 +41,6 @@ use crate::{
     fitscore::{ffpmsg_slice, fits_strcasecmp, fits_strncasecmp},
     wrappers::{tolower, toupper},
 };
-
-/*****  Definitions  *****/
 
 const OCT_0: &str = "000";
 const OCT_1: &str = "001";
@@ -283,8 +245,6 @@ fn expr_read(lParse: &mut ParseData, buf: &mut [c_char], nbytes: c_int) -> c_int
     buf[n as usize] = 0;
     n
 }
-
-/*****  Internal functions  *****/
 
 pub(crate) fn fits_parser_yyGetVariable(
     lParse: &mut ParseData,
@@ -825,7 +785,7 @@ pub(crate) fn fits_parser_yylex(
                                 let mut constval: c_long = 0;
                                 let mut p: *mut c_char = core::ptr::null_mut::<c_char>();
                                 /* Plain pointer arithmetic: `&mut *ptr.offset(2)` borrows a single
-                                   byte, so the scan below immediately ran past that provenance. */
+                                byte, so the scan below immediately ran past that provenance. */
                                 p = (yyscanner.yytext_r).offset(2 as c_int as isize);
                                 while *p != 0 {
                                     constval = constval << 1
@@ -839,7 +799,7 @@ pub(crate) fn fits_parser_yylex(
                                 let mut constval_0: c_long = 0;
                                 let mut p_0: *mut c_char = core::ptr::null_mut::<c_char>();
                                 /* Plain pointer arithmetic: `&mut *ptr.offset(2)` borrows a single
-                                   byte, so the scan below immediately ran past that provenance. */
+                                byte, so the scan below immediately ran past that provenance. */
                                 p_0 = (yyscanner.yytext_r).offset(2 as c_int as isize);
                                 while *p_0 != 0 {
                                     constval_0 = constval_0 << 3 as c_int
@@ -853,7 +813,7 @@ pub(crate) fn fits_parser_yylex(
                                 let mut constval_1: c_long = 0;
                                 let mut p_1: *mut c_char = core::ptr::null_mut::<c_char>();
                                 /* Plain pointer arithmetic: `&mut *ptr.offset(2)` borrows a single
-                                   byte, so the scan below immediately ran past that provenance. */
+                                byte, so the scan below immediately ran past that provenance. */
                                 p_1 = (yyscanner.yytext_r).offset(2 as c_int as isize);
                                 while *p_1 != 0 {
                                     let v: c_int = if isdigit_safe(*p_1) {
@@ -962,11 +922,13 @@ pub(crate) fn fits_parser_yylex(
                                     }
 
                                     /* yytext_r points into the same yylval slot that is passed as
-                                       `&mut` below, so the two arguments would alias. Copy the name
-                                       out first -- owned, so an overlong name keeps its terminator
-                                       rather than being truncated out of one. */
-                                    let name_owned: Vec<c_char> =
-                                        cast_slice(CStr::from_ptr(yyscanner.yytext_r).to_bytes_with_nul()).to_vec();
+                                    `&mut` below, so the two arguments would alias. Copy the name
+                                    out first -- owned, so an overlong name keeps its terminator
+                                    rather than being truncated out of one. */
+                                    let name_owned: Vec<c_char> = cast_slice(
+                                        CStr::from_ptr(yyscanner.yytext_r).to_bytes_with_nul(),
+                                    )
+                                    .to_vec();
                                     let yytext_r_slice: &[c_char] = &name_owned;
 
                                     let get_data =
@@ -1037,11 +999,13 @@ pub(crate) fn fits_parser_yylex(
                                 }
 
                                 /* yytext_r points into the same yylval slot that is passed as
-                                   `&mut` below, so the two arguments would alias. Copy the name
-                                   out first -- owned, so an overlong name keeps its terminator
-                                   rather than being truncated out of one. */
-                                let name_owned: Vec<c_char> =
-                                    cast_slice(CStr::from_ptr(yyscanner.yytext_r).to_bytes_with_nul()).to_vec();
+                                `&mut` below, so the two arguments would alias. Copy the name
+                                out first -- owned, so an overlong name keeps its terminator
+                                rather than being truncated out of one. */
+                                let name_owned: Vec<c_char> = cast_slice(
+                                    CStr::from_ptr(yyscanner.yytext_r).to_bytes_with_nul(),
+                                )
+                                .to_vec();
                                 let yytext_r_slice: &[c_char] = &name_owned;
 
                                 dtype = fits_parser_yyGetVariable(

--- a/src/eval_tab.rs
+++ b/src/eval_tab.rs
@@ -1,3 +1,14 @@
+//! The token numbers the parser and lexer agree on.
+//!
+//! **Generated code**: `bison`'s `%token` block from `eval.y`, as
+//! `eval_tab.h`. The names carry the grammar's own spelling, which is why the
+//! crate allows `clippy::upper_case_acronyms` -- `BOOLEAN`, `BITSTR`,
+//! `GTIFILTER` and the rest must stay as the grammar writes them.
+//!
+//! See [`crate::eval_f`] for how the parser's three files fit together.
+// The token constants below are bison's own output; see the note in eval_y.rs.
+#![allow(missing_docs)]
+
 use crate::{
     c_types::{c_char, c_double, c_int, c_long},
     eval_defs::MAX_STRLEN,

--- a/src/eval_y.rs
+++ b/src/eval_y.rs
@@ -1,72 +1,18 @@
-/************************************************************************/
-/*                                                                      */
-/*                       CFITSIO Lexical Parser                         */
-/*                                                                      */
-/* This file is one of 3 files containing code which parses an          */
-/* arithmetic expression and evaluates it in the context of an input    */
-/* FITS file table extension.  The CFITSIO lexical parser is divided    */
-/* into the following 3 parts/files: the CFITSIO "front-end",           */
-/* eval_f.c, contains the interface between the user/CFITSIO and the    */
-/* real core of the parser; the FLEX interpreter, eval_l.c, takes the   */
-/* input string and parses it into tokens and identifies the FITS       */
-/* information required to evaluate the expression (ie, keywords and    */
-/* columns); and, the BISON grammar and evaluation routines, eval_y.c,  */
-/* receives the FLEX output and determines and performs the actual      */
-/* operations.  The files eval_l.c and eval_y.c are produced from       */
-/* running flex and bison on the files eval.l and eval.y, respectively. */
-/* (flex and bison are available from any GNU archive: see www.gnu.org) */
-/*                                                                      */
-/* The grammar rules, rather than evaluating the expression in situ,    */
-/* builds a tree, or Nodal, structure mapping out the order of          */
-/* operations and expression dependencies.  This "compilation" process  */
-/* allows for much faster processing of multiple rows.  This technique  */
-/* was developed by Uwe Lammers of the XMM Science Analysis System,     */
-/* although the CFITSIO implementation is entirely code original.       */
-/*                                                                      */
-/*                                                                      */
-/* Modification History:                                                */
-/*                                                                      */
-/*   Kent Blackburn      c1992  Original parser code developed for the  */
-/*                              FTOOLS software package, in particular, */
-/*                              the fselect task.                       */
-/*   Kent Blackburn      c1995  BIT column support added                */
-/*   Peter D Wilson   Feb 1998  Vector column support added             */
-/*   Peter D Wilson   May 1998  Ported to CFITSIO library.  User        */
-/*                              interface routines written, in essence  */
-/*                              making fselect, fcalc, and maketime     */
-/*                              capabilities available to all tools     */
-/*                              via single function calls.              */
-/*   Peter D Wilson   Jun 1998  Major rewrite of parser core, so as to  */
-/*                              create a run-time evaluation tree,      */
-/*                              inspired by the work of Uwe Lammers,    */
-/*                              resulting in a speed increase of        */
-/*                              10-100 times.                           */
-/*   Peter D Wilson   Jul 1998  gtifilter(a,b,c,d) function added       */
-/*   Peter D Wilson   Aug 1998  regfilter(a,b,c,d) function added       */
-/*   Peter D Wilson   Jul 1999  Make parser fitsfile-independent,       */
-/*                              allowing a purely vector-based usage    */
-/*  Craig B Markwardt Jun 2004  Add MEDIAN() function                   */
-/*  Craig B Markwardt Jun 2004  Add SUM(), and MIN/MAX() for bit arrays */
-/*  Craig B Markwardt Jun 2004  Allow subscripting of nX bit arrays     */
-/*  Craig B Markwardt Jun 2004  Implement statistical functions         */
-/*                              NVALID(), AVERAGE(), and STDDEV()       */
-/*                              for integer and floating point vectors  */
-/*  Craig B Markwardt Jun 2004  Use NULL values for range errors instead*/
-/*                              of throwing a parse error               */
-/*  Craig B Markwardt Oct 2004  Add ACCUM() and SEQDIFF() functions     */
-/*  Craig B Markwardt Feb 2005  Add ANGSEP() function                   */
-/*  Craig B Markwardt Aug 2005  CIRCLE, BOX, ELLIPSE, NEAR and REGFILTER*/
-/*                              functions now accept vector arguments   */
-/*  Craig B Markwardt Sum 2006  Add RANDOMN() and RANDOMP() functions   */
-/*  Craig B Markwardt Mar 2007  Allow arguments to RANDOM and RANDOMN to*/
-/*                              determine the output dimensions         */
-/*  Craig B Markwardt Aug 2009  Add substring STRMID() and string search*/
-/*                              STRSTR() functions; more overflow checks*/
-/*  Craig B Markwardt Dec 2019  Add bit/hex/oct literal strings and     */
-/*                              bitwise operatiosn between integers     */
-/*  Craig B Markwardt Mar 2021  Add SETNULL() function                  */
-/*                                                                      */
-/************************************************************************/
+//! The CFITSIO expression parser's grammar and evaluation routines.
+//!
+//! **Generated code**: produced by running `bison` on `eval.y`, then
+//! transpiled. Edits belong in `eval.y` upstream, not here. The bulk of this
+//! file is the parser's state tables and token constants, which carry the
+//! grammar's own spelling.
+//!
+//! It receives the tokens from [`crate::eval_l`] and builds the evaluation
+//! tree described in [`crate::eval_f`], then walks that tree once per row.
+// The items below are bison's own output -- its typedefs, buffer state, token
+// constants and parser tables. They carry the generator's names and have no
+// meaning outside it, so they are exempt from the documentation ratchet rather
+// than given invented descriptions; the file header above documents the module
+// as a whole. Anything hand-written added here should be documented.
+#![allow(missing_docs)]
 
 use alloc::rc::Rc;
 use core::ffi::CStr;
@@ -241,7 +187,7 @@ pub type yy_state_fast_t = c_int;
 /// This was `typedef enum { rnd_fct = 1001, ... } funcOp` in eval_defs.h; the
 /// transpile flattened it to a `c_uint` alias with 51 loose constants, so any
 /// integer could be passed where a function code was wanted. The values are the
-/// C's, and they are contiguous from 1001, which [`funcOp::from_operation`]
+/// C's, and they are contiguous from 1001, which `funcOp::from_operation`
 /// relies on.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[repr(u32)]
@@ -814,9 +760,7 @@ static YYR2: [yytype_int8; 136] = [
     12, 2, 3, 1, 1, 4, 1, 3, 3, 5, 5, 7,
 ];
 
-/*************************************************************************/
 /*  Start of "New" routines which build the expression Nodal structure   */
-/*************************************************************************/
 
 /* Use this for allocation to guarantee *Nodes */
 /* survives on failure, making it still valid  */
@@ -1959,10 +1903,11 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         18 => {
                             /* bits: BITSTR  */
                             /* Measure first: `text_mut()` reborrows the whole yyvs Vec, so
-                               taking the length after the pointer invalidated it and New_Const
-                               then read through a dead tag. */
+                            taking the length after the pointer invalidated it and New_Const
+                            then read through a dead tag. */
                             let text_len = (strlen_safe(yyvs[yyvsp].text_mut()))
-                                .wrapping_add((1).try_into().unwrap()) as c_long;
+                                .wrapping_add((1).try_into().unwrap())
+                                as c_long;
                             yyval = FITS_PARSER_YYSTYPE::Node(New_Const(
                                 lParse,
                                 fits_parser_yytokentype::BITSTR as c_int,
@@ -5229,9 +5174,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             let yy_v1 = yyvs[yyvsp - 3].node();
                             let yy_v2 = yyvs[yyvsp - 1].node();
                             /* Derive every slot pointer from the stack's own allocation pointer.
-                               `yyvs[i]` reborrows the whole Vec, so taking a second pointer -- or
-                               any other yyvs access -- that way invalidated the first, and this
-                               constructor is handed up to three of them at once. */
+                            `yyvs[i]` reborrows the whole Vec, so taking a second pointer -- or
+                            any other yyvs access -- that way invalidated the first, and this
+                            constructor is handed up to three of them at once. */
                             let yy_base = yyvs.as_mut_ptr();
                             let yy_p1 = (*yy_base.add(yyvsp - 5)).text_mut_ptr();
                             yyval = FITS_PARSER_YYSTYPE::Node(New_GTI(
@@ -5254,9 +5199,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             let yy_v1 = yyvs[yyvsp - 7].node();
                             let yy_v2 = yyvs[yyvsp - 5].node();
                             /* Derive every slot pointer from the stack's own allocation pointer.
-                               `yyvs[i]` reborrows the whole Vec, so taking a second pointer -- or
-                               any other yyvs access -- that way invalidated the first, and this
-                               constructor is handed up to three of them at once. */
+                            `yyvs[i]` reborrows the whole Vec, so taking a second pointer -- or
+                            any other yyvs access -- that way invalidated the first, and this
+                            constructor is handed up to three of them at once. */
                             let yy_base = yyvs.as_mut_ptr();
                             let yy_p1 = (*yy_base.add(yyvsp - 9)).text_mut_ptr();
                             let yy_p2 = (*yy_base.add(yyvsp - 3)).text_mut_ptr();
@@ -6873,9 +6818,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             /* bexpr: GTIFILTER STRING ',' expr ')'  */
                             let yy_v1 = yyvs[yyvsp - 1].node();
                             /* Derive every slot pointer from the stack's own allocation pointer.
-                               `yyvs[i]` reborrows the whole Vec, so taking a second pointer -- or
-                               any other yyvs access -- that way invalidated the first, and this
-                               constructor is handed up to three of them at once. */
+                            `yyvs[i]` reborrows the whole Vec, so taking a second pointer -- or
+                            any other yyvs access -- that way invalidated the first, and this
+                            constructor is handed up to three of them at once. */
                             let yy_base = yyvs.as_mut_ptr();
                             let yy_p1 = (*yy_base.add(yyvsp - 3)).text_mut_ptr();
                             yyval = FITS_PARSER_YYSTYPE::Node(New_GTI(
@@ -6897,9 +6842,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             /* bexpr: GTIFILTER STRING ',' expr ',' STRING ',' STRING ')'  */
                             let yy_v1 = yyvs[yyvsp - 5].node();
                             /* Derive every slot pointer from the stack's own allocation pointer.
-                               `yyvs[i]` reborrows the whole Vec, so taking a second pointer -- or
-                               any other yyvs access -- that way invalidated the first, and this
-                               constructor is handed up to three of them at once. */
+                            `yyvs[i]` reborrows the whole Vec, so taking a second pointer -- or
+                            any other yyvs access -- that way invalidated the first, and this
+                            constructor is handed up to three of them at once. */
                             let yy_base = yyvs.as_mut_ptr();
                             let yy_p1 = (*yy_base.add(yyvsp - 7)).text_mut_ptr();
                             let yy_p2 = (*yy_base.add(yyvsp - 3)).text_mut_ptr();
@@ -6959,9 +6904,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             /* bexpr: GTIFIND STRING ',' expr ')'  */
                             let yy_v1 = yyvs[yyvsp - 1].node();
                             /* Derive every slot pointer from the stack's own allocation pointer.
-                               `yyvs[i]` reborrows the whole Vec, so taking a second pointer -- or
-                               any other yyvs access -- that way invalidated the first, and this
-                               constructor is handed up to three of them at once. */
+                            `yyvs[i]` reborrows the whole Vec, so taking a second pointer -- or
+                            any other yyvs access -- that way invalidated the first, and this
+                            constructor is handed up to three of them at once. */
                             let yy_base = yyvs.as_mut_ptr();
                             let yy_p1 = (*yy_base.add(yyvsp - 3)).text_mut_ptr();
                             yyval = FITS_PARSER_YYSTYPE::Node(New_GTI(
@@ -6983,9 +6928,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             /* bexpr: GTIFIND STRING ',' expr ',' STRING ',' STRING ')'  */
                             let yy_v1 = yyvs[yyvsp - 5].node();
                             /* Derive every slot pointer from the stack's own allocation pointer.
-                               `yyvs[i]` reborrows the whole Vec, so taking a second pointer -- or
-                               any other yyvs access -- that way invalidated the first, and this
-                               constructor is handed up to three of them at once. */
+                            `yyvs[i]` reborrows the whole Vec, so taking a second pointer -- or
+                            any other yyvs access -- that way invalidated the first, and this
+                            constructor is handed up to three of them at once. */
                             let yy_base = yyvs.as_mut_ptr();
                             let yy_p1 = (*yy_base.add(yyvsp - 7)).text_mut_ptr();
                             let yy_p2 = (*yy_base.add(yyvsp - 3)).text_mut_ptr();
@@ -7027,9 +6972,9 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             let yy_v1 = yyvs[yyvsp - 3].node();
                             let yy_v2 = yyvs[yyvsp - 1].node();
                             /* Derive every slot pointer from the stack's own allocation pointer.
-                               `yyvs[i]` reborrows the whole Vec, so taking a second pointer -- or
-                               any other yyvs access -- that way invalidated the first, and this
-                               constructor is handed up to three of them at once. */
+                            `yyvs[i]` reborrows the whole Vec, so taking a second pointer -- or
+                            any other yyvs access -- that way invalidated the first, and this
+                            constructor is handed up to three of them at once. */
                             let yy_base = yyvs.as_mut_ptr();
                             let yy_p1 = (*yy_base.add(yyvsp - 5)).text_mut_ptr();
                             yyval = FITS_PARSER_YYSTYPE::Node(New_REG(
@@ -7050,18 +6995,14 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                             let yy_v1 = yyvs[yyvsp - 5].node();
                             let yy_v2 = yyvs[yyvsp - 3].node();
                             /* Derive every slot pointer from the stack's own allocation pointer.
-                               `yyvs[i]` reborrows the whole Vec, so taking a second pointer -- or
-                               any other yyvs access -- that way invalidated the first, and this
-                               constructor is handed up to three of them at once. */
+                            `yyvs[i]` reborrows the whole Vec, so taking a second pointer -- or
+                            any other yyvs access -- that way invalidated the first, and this
+                            constructor is handed up to three of them at once. */
                             let yy_base = yyvs.as_mut_ptr();
                             let yy_p1 = (*yy_base.add(yyvsp - 7)).text_mut_ptr();
                             let yy_p2 = (*yy_base.add(yyvsp - 1)).text_mut_ptr();
                             yyval = FITS_PARSER_YYSTYPE::Node(New_REG(
-                                lParse,
-                                yy_p1,
-                                yy_v1,
-                                yy_v2,
-                                yy_p2,
+                                lParse, yy_p1, yy_v1, yy_v2, yy_p2,
                             ));
                             if yyval.node() < 0 {
                                 current_block = 4830776507462815627;
@@ -7181,10 +7122,11 @@ pub(crate) fn fits_parser_yyparse(scanner: &mut yyguts_t, lParse: &mut ParseData
                         127 => {
                             /* sexpr: STRING  */
                             /* Measure first: `text_mut()` reborrows the whole yyvs Vec, so
-                               taking the length after the pointer invalidated it and New_Const
-                               then read through a dead tag. */
+                            taking the length after the pointer invalidated it and New_Const
+                            then read through a dead tag. */
                             let text_len = (strlen_safe(yyvs[yyvsp].text_mut()))
-                                .wrapping_add((1).try_into().unwrap()) as c_long;
+                                .wrapping_add((1).try_into().unwrap())
+                                as c_long;
                             yyval = FITS_PARSER_YYSTYPE::Node(New_Const(
                                 lParse,
                                 fits_parser_yytokentype::STRING as c_int,
@@ -8797,18 +8739,14 @@ fn Copy_Dims(lParse: &mut ParseData, Node1: c_int, Node2: c_int) {
     }
 }
 
-/********************************************************************/
 /*    Routines for actually evaluating the expression start here    */
-/********************************************************************/
 
-/***********************************************************************/
 /*  Reset the parser for processing another batch of data...           */
 /*    firstRow:  Row number of the first element to evaluate           */
 /*    nRows:     Number of rows to be processed                        */
 /*  Initialize each COLUMN node so that its UNDEF and DATA pointers    */
 /*  point to the appropriate column arrays.                            */
 /*  Finally, call Evaluate_Node for final node.                        */
-/***********************************************************************/
 pub(crate) fn Evaluate_Parser(lParse: &mut ParseData, firstRow: c_long, nRows: c_long) {
     unsafe {
         let mut i: c_int = 0;
@@ -8820,9 +8758,9 @@ pub(crate) fn Evaluate_Parser(lParse: &mut ParseData, firstRow: c_long, nRows: c
         /* Initialize the random number generator once and only once */
         if RAND_INITIALIZED == 0 {
             /* Seed from the wall clock, as the C's time(NULL) does. Uses
-               SystemTime rather than libc time() so the expression engine has
-               no foreign call on this path -- Miri cannot make it, and it was
-               aborting every test that reaches the evaluator. */
+            SystemTime rather than libc time() so the expression engine has
+            no foreign call on this path -- Miri cannot make it, and it was
+            aborting every test that reaches the evaluator. */
             let seed = std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)
                 .map_or(0, |d| d.as_secs() as c_uint);
@@ -8930,10 +8868,8 @@ pub(crate) fn Evaluate_Parser(lParse: &mut ParseData, firstRow: c_long, nRows: c
     }
 }
 
-/**********************************************************************/
 /*  Recursively evaluate thisNode's subNodes, then call one of the    */
 /*  Do_<Action> functions pointed to by thisNode's DoOp element.      */
-/**********************************************************************/
 fn Evaluate_Node(lParse: &mut ParseData, thisNode: c_int) {
     let mut this_node_idx: usize;
     let mut i: c_int = 0;
@@ -10492,9 +10428,8 @@ fn Do_BinOp_lng(lParse: &mut ParseData, this_node_idx: usize) {
                     result is one too, but powf need not land exactly on it --
                     5**2 comes back as 24.999999999999996 under some libm
                     implementations, and `as c_long` then yields 24. */
-                    (lParse.Nodes[this_node_idx]).value.data = NodeValue::Long(
-                        pow(val1 as c_double, val2 as c_double).round() as c_long,
-                    );
+                    (lParse.Nodes[this_node_idx]).value.data =
+                        NodeValue::Long(pow(val1 as c_double, val2 as c_double).round() as c_long);
                 }
                 Operator::Accum => {
                     (lParse.Nodes[this_node_idx]).value.data = NodeValue::Long(val1);
@@ -15555,8 +15490,7 @@ fn Do_Vector(lParse: &mut ParseData, this_node_idx: usize) {
                 .operation
                 > 0
             {
-                let sub_idx =
-                    (lParse.Nodes[this_node_idx]).SubNodes[node as usize] as usize;
+                let sub_idx = (lParse.Nodes[this_node_idx]).SubNodes[node as usize] as usize;
                 free_node_buffer(&mut ((lParse.Nodes)[sub_idx]));
             }
             node += 1;
@@ -15685,9 +15619,7 @@ fn Do_Array(lParse: &mut ParseData, this_node_idx: usize) {
 
 // One arm per comparison operator, mirroring the C's switch; match guards
 // would make the operator table harder to scan.
-/*****************************************************************************/
 /*  Utility routines which perform the calculations on bits and SAO regions  */
-/*****************************************************************************/
 
 #[allow(clippy::collapsible_match, clippy::collapsible_if)]
 /// Left-pad the shorter of two bit strings with `'0'` so the two are the same

--- a/src/fits_hcompress.rs
+++ b/src/fits_hcompress.rs
@@ -1,3 +1,11 @@
+//! Deprecated C-ABI shims for Hcompress compression.
+//!
+//! Nothing in this crate calls these: the real implementation is the published
+//! `hcompress` crate, which [`crate::imcompress`] uses directly through
+//! `HCEncoder`. They exist so that a program linking against this library by
+//! its C ABI still finds the symbols, and they delegate to the same encoder.
+#![warn(missing_docs)]
+
 /* H-compress routines */
 
 use bytemuck::cast_slice_mut;

--- a/src/fits_hdecompress.rs
+++ b/src/fits_hdecompress.rs
@@ -1,3 +1,9 @@
+//! Deprecated C-ABI shims for Hcompress decompression.
+//!
+//! The counterpart of [`crate::fits_hcompress`]: nothing in this crate calls
+//! these, and they delegate to the `hcompress` crate's `HCDecoder`.
+#![warn(missing_docs)]
+
 /* H-decompress routines */
 
 use hcompress::read::HCDecoder;

--- a/src/fitscore.rs
+++ b/src/fitscore.rs
@@ -1,8 +1,17 @@
-/*  This file, fitscore.rs, contains the core set of FITSIO routines.       */
+//! The core FITSIO routines.
+//!
+//! This is the largest module in the crate and the one the others lean on. It
+//! holds the error message stack, the HDU structure machinery -- reading an
+//! HDU's required keywords, working out the column layout of a table, moving
+//! between HDUs and rewriting the header when the structure changes -- the
+//! `TFORMn` / `TDISPn` format parsers, the column name matching, and the
+//! string-to-number conversions the keyword routines are built from.
+//!
+//! Ported from CFITSIO's `fitscore.c`, written by William Pence at the High
+//! Energy Astrophysics Science Archive Research Center (HEASARC), NASA Goddard
+//! Space Flight Center.
+#![warn(missing_docs)]
 
-/*  The FITSIO software was written by William Pence at the High Energy    */
-/*  Astrophysic Science Archive Research Center (HEASARC) at the NASA      */
-/*  Goddard Space Flight Center.                                           */
 /*
 
 Copyright (Unpublished--all rights reserved under the copyright laws of
@@ -68,15 +77,24 @@ use crate::{atoi, bb, cs, int_snprintf};
 use crate::{buffers::*, raw_to_slice};
 use crate::{slice_to_str, wrappers::*};
 
+/// Maximum number of messages the error stack holds.
 pub const ERRMSGSIZ: usize = 25;
-pub const ESMARKER: c_char = 27; /* Escape character is used as error stack marker */
+/// Escape character, used as the error stack marker.
+pub const ESMARKER: c_char = 27;
 
-pub const DEL_ALL: c_int = 1; /* delete all messages on the error stack */
-pub const DEL_MARK: c_int = 2; /* delete newest messages back to and including marker */
-pub const DEL_NEWEST: c_int = 3; /* delete the newest message from the stack */
-pub const GET_MESG: c_int = 4; /* pop and return oldest message, ignoring marks */
-pub const PUT_MESG: c_int = 5; /* add a new message to the stack */
-pub const PUT_MARK: c_int = 6; /* add a marker to the stack */
+/// `ffxmsg` action: delete all messages on the error stack.
+pub const DEL_ALL: c_int = 1;
+/// `ffxmsg` action: delete the newest messages back to and including the
+/// marker.
+pub const DEL_MARK: c_int = 2;
+/// `ffxmsg` action: delete the newest message from the stack.
+pub const DEL_NEWEST: c_int = 3;
+/// `ffxmsg` action: pop and return the oldest message, ignoring marks.
+pub const GET_MESG: c_int = 4;
+/// `ffxmsg` action: add a new message to the stack.
+pub const PUT_MESG: c_int = 5;
+/// `ffxmsg` action: add a marker to the stack.
+pub const PUT_MARK: c_int = 6;
 
 // Use this to keep track of allocations so we can deallocate with the same `Layout` used for allocation.
 pub(crate) static ALLOCATIONS: LazyLock<Mutex<HashMap<usize, (usize, usize)>>> =
@@ -84,7 +102,6 @@ pub(crate) static ALLOCATIONS: LazyLock<Mutex<HashMap<usize, (usize, usize)>>> =
 
 static ERROR_STACK: LazyLock<Mutex<ErrorStack>> = LazyLock::new(|| Mutex::new(ErrorStack::new()));
 
-/*--------------------------------------------------------------------------*/
 /// return the current version number of the FITSIO software
 ///
 ///  Note that this method of calculation limits minor/micro fields to < 100.
@@ -102,6 +119,14 @@ pub unsafe extern "C" fn ffvers(version: *mut f32 /* IO - version number */) -> 
     }
 }
 
+/// Return the current version number of the FITSIO software.
+///
+/// Note that this method of calculation limits the minor and micro fields to
+/// less than 100.
+///
+/// # Parameters
+///
+/// * `version` — (O) version number
 pub fn ffvers_safe(version: &mut f32) -> f32 {
     *version = (CFITSIO_MAJOR as f32)
         + (0.01 * (CFITSIO_MINOR as f32))
@@ -235,13 +260,18 @@ pub fn ffvers_safe(version: &mut f32) -> f32 {
     *version
 }
 
-/*--------------------------------------------------------------------------*/
 ///  return the name of the FITS file
+///
+/// # Parameters
+///
+/// * `fptr`     — (I) FITS file pointer
+/// * `filename` — (O) name of the file
+/// * `status`   — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffflnm(
-    fptr: *mut fitsfile,   /* I - FITS file pointer  */
-    filename: *mut c_char, /* O - name of the file   */
-    status: *mut c_int,    /* IO - error status      */
+    fptr: *mut fitsfile,
+    filename: *mut c_char,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -253,6 +283,13 @@ pub unsafe extern "C" fn ffflnm(
     }
 }
 
+/// Return the name of the FITS file.
+///
+/// # Parameters
+///
+/// * `fptr`     — (I) FITS file pointer
+/// * `filename` — (O) name of the file
+/// * `status`   — (IO) error status
 pub fn ffflnm_safe(fptr: &mut fitsfile, filename: &mut [c_char], status: &mut c_int) -> c_int {
     strcpy_safe(
         filename,
@@ -261,13 +298,18 @@ pub fn ffflnm_safe(fptr: &mut fitsfile, filename: &mut [c_char], status: &mut c_
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// return the access mode of the FITS file
+///
+/// # Parameters
+///
+/// * `fptr`     — (I) FITS file pointer
+/// * `filemode` — (O) open mode of the file
+/// * `status`   — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffflmd(
-    fptr: *mut fitsfile,  /* I - FITS file pointer  */
-    filemode: *mut c_int, /* O - open mode of the file  */
-    status: *mut c_int,   /* IO - error status      */
+    fptr: *mut fitsfile,
+    filemode: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -278,20 +320,28 @@ pub unsafe extern "C" fn ffflmd(
     }
 }
 
+/// Return the I/O mode of the FITS file: [`READONLY`] or [`READWRITE`].
+///
+/// # Parameters
+///
+/// * `fptr`     — (I) FITS file pointer
+/// * `filemode` — (O) file mode
+/// * `status`   — (IO) error status
 pub fn ffflmd_safe(fptr: &mut fitsfile, filemode: &mut c_int, status: &mut c_int) -> c_int {
     *filemode = fptr.Fptr.writemode;
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Return a short descriptive error message that corresponds to the input
 /// error status value.  The message may be up to 30 characters long, plus
 /// the terminating null character.
+///
+/// # Parameters
+///
+/// * `status`  — (I) error status value
+/// * `errtext` — (O) error message (max 30 char long + null)
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
-pub unsafe extern "C" fn ffgerr(
-    status: c_int,        /* I - error status value */
-    errtext: *mut c_char, /* O - error message (max 30 char long + null) */
-) {
+pub unsafe extern "C" fn ffgerr(status: c_int, errtext: *mut c_char) {
     // FFI WRAPPER
     unsafe {
         let errtext = slice::from_raw_parts_mut(errtext, 31);
@@ -300,14 +350,15 @@ pub unsafe extern "C" fn ffgerr(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Return a short descriptive error message that corresponds to the input
 /// error status value.  The message may be up to 30 characters long, plus
 /// the terminating null character.
-pub fn ffgerr_safe(
-    status: c_int,          /* I - error status value */
-    errtext: &mut [c_char], /* O - error message (max 30 char long + null) */
-) {
+///
+/// # Parameters
+///
+/// * `status`  — (I) error status value
+/// * `errtext` — (O) error message (max 30 char long + null)
+pub fn ffgerr_safe(status: c_int, errtext: &mut [c_char]) {
     errtext[0] = 0;
     let t = if status >= 0 && status < 300 {
         match status {
@@ -573,7 +624,6 @@ impl ErrorStack {
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// put message on to error stack
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffpmsg(err_message: *const c_char) {
@@ -581,13 +631,16 @@ pub unsafe extern "C" fn ffpmsg(err_message: *const c_char) {
     ffxmsg(PUT_MESG, err_message.cast_mut());
 }
 
-/*--------------------------------------------------------------------------*/
 /// put message on to error stack
 pub fn ffpmsg_safe(err_message: &[c_char]) {
     let mut stack = ERROR_STACK.lock().unwrap();
     stack.push_message(cstr_bytes(err_message));
 }
 
+/// Push a message onto the error stack, taking it as a `CStr`.
+///
+/// See `ffpmsg_str` and `ffpmsg_slice` for the other spellings; those are
+/// crate-private.
 pub fn ffpmsg_cstr(err_message: &CStr) {
     let mut stack = ERROR_STACK.lock().unwrap();
     stack.push_message(err_message.to_bytes());
@@ -610,7 +663,6 @@ pub(crate) fn ffpmsg_str(err_message: &str) {
     stack.push_message(err_message.as_bytes());
 }
 
-/*--------------------------------------------------------------------------*/
 ///  write a marker to the stack.  It is then possible to pop only those
 ///  messages following the marker off of the stack, leaving the previous
 ///  messages unaffected.
@@ -622,7 +674,6 @@ pub unsafe extern "C" fn ffpmrk() {
     ffpmrk_safe();
 }
 
-/*--------------------------------------------------------------------------*/
 ///  write a marker to the stack.  It is then possible to pop only those
 ///  messages following the marker off of the stack, leaving the previous
 ///  messages unaffected.
@@ -633,7 +684,6 @@ pub fn ffpmrk_safe() {
     stack.push_marker();
 }
 
-/*--------------------------------------------------------------------------*/
 /// get oldest message from error stack, ignoring markers
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgmsg(err_message: *mut c_char) -> c_int {
@@ -644,7 +694,6 @@ pub unsafe extern "C" fn ffgmsg(err_message: *mut c_char) -> c_int {
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// get oldest message from error stack, ignoring markers
 pub fn ffgmsg_safe(err_message: &mut [c_char; FLEN_ERRMSG]) -> c_int {
     let mut stack = ERROR_STACK.lock().unwrap();
@@ -666,7 +715,6 @@ pub fn ffgmsg_safe(err_message: &mut [c_char; FLEN_ERRMSG]) -> c_int {
     }
 }
 
-/*--------------------------------------------------------------------------*/
 ///  erase all messages in the error stack
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffcmsg() {
@@ -675,14 +723,12 @@ pub unsafe extern "C" fn ffcmsg() {
     ffxmsg(DEL_ALL, dummy);
 }
 
-/*--------------------------------------------------------------------------*/
 ///  erase all messages in the error stack
 pub fn ffcmsg_safe() {
     let mut stack = ERROR_STACK.lock().unwrap();
     stack.clear_all();
 }
 
-/*--------------------------------------------------------------------------*/
 /// erase newest messages in the error stack, stopping if a marker is found.
 /// The marker is also erased in this case.
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
@@ -691,7 +737,6 @@ pub unsafe extern "C" fn ffcmrk() {
     ffcmrk_safe();
 }
 
-/*--------------------------------------------------------------------------*/
 /// erase newest messages in the error stack, stopping if a marker is found.
 /// The marker is also erased in this case.
 pub fn ffcmrk_safe() {
@@ -699,7 +744,6 @@ pub fn ffcmrk_safe() {
     stack.clear_to_marker();
 }
 
-/*--------------------------------------------------------------------------*/
 /// general routine to get, put, or clear the error message stack.
 /// Use a static array rather than allocating memory as needed for
 /// the error messages because it is likely to be more efficient
@@ -750,7 +794,6 @@ pub fn ffxmsg_safer(action: c_int, errmsg: Option<&mut [c_char; FLEN_ERRMSG]>) {
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// general routine to get, put, or clear the error message stack.
 /// Thread-safe implementation using Mutex-protected VecDeque.
 ///
@@ -812,7 +855,6 @@ pub(crate) fn ffxmsg(action: c_int, errmsg: *mut c_char) {
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// return the number of bytes per pixel associated with the datatype
 pub(crate) fn ffpxsz(datatype: c_int) -> usize {
     if datatype == TBYTE {
@@ -840,17 +882,18 @@ pub(crate) fn ffpxsz(datatype: c_int) -> usize {
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Test that the keyword name conforms to the FITS standard.  Must contain
 /// only capital letters, digits, minus or underscore chars.  Trailing spaces
 /// are allowed.  If the input status value is less than zero, then the test
 /// is modified so that upper or lower case letters are allowed, and no
 /// error messages are printed if the keyword is not legal.
+///
+/// # Parameters
+///
+/// * `keyword` — (I) keyword name
+/// * `status`  — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
-pub unsafe extern "C" fn fftkey(
-    keyword: *const c_char, /* I -  keyword name */
-    status: *mut c_int,     /* IO - error status */
-) -> c_int {
+pub unsafe extern "C" fn fftkey(keyword: *const c_char, status: *mut c_int) -> c_int {
     // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
@@ -860,16 +903,17 @@ pub unsafe extern "C" fn fftkey(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Test that the keyword name conforms to the FITS standard.  Must contain
 /// only capital letters, digits, minus or underscore chars.  Trailing spaces
 /// are allowed.  If the input status value is less than zero, then the test
 /// is modified so that upper or lower case letters are allowed, and no
 /// error messages are printed if the keyword is not legal.
-pub fn fftkey_safe(
-    keyword: &[c_char], /* I -  keyword name */
-    status: &mut c_int, /* IO - error status */
-) -> c_int {
+///
+/// # Parameters
+///
+/// * `keyword` — (I) keyword name
+/// * `status`  — (IO) error status
+pub fn fftkey_safe(keyword: &[c_char], status: &mut c_int) -> c_int {
     let mut maxchr: usize;
     let mut spaces: c_int = 0;
     let mut msg: [c_char; FLEN_ERRMSG] = [0; FLEN_ERRMSG];
@@ -943,14 +987,15 @@ pub fn fftkey_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Test that the keyword card conforms to the FITS standard.  Must contain
 /// only printable ASCII characters;
+///
+/// # Parameters
+///
+/// * `card`   — (I) keyword card to test
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
-pub unsafe extern "C" fn fftrec(
-    card: *mut c_char,  /* I -  keyword card to test */
-    status: *mut c_int, /* IO - error status */
-) -> c_int {
+pub unsafe extern "C" fn fftrec(card: *mut c_char, status: *mut c_int) -> c_int {
     // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
@@ -960,13 +1005,14 @@ pub unsafe extern "C" fn fftrec(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Test that the keyword card conforms to the FITS standard.  Must contain
 /// only printable ASCII characters;
-pub fn fftrec_safe(
-    card: &[c_char],    /* I -  keyword card to test */
-    status: &mut c_int, /* IO - error status */
-) -> c_int {
+///
+/// # Parameters
+///
+/// * `card`   — (I) keyword card to test
+/// * `status` — (IO) error status
+pub fn fftrec_safe(card: &[c_char], status: &mut c_int) -> c_int {
     let mut msg: [c_char; FLEN_ERRMSG] = [0; FLEN_ERRMSG];
 
     if *status > 0 {
@@ -1016,7 +1062,6 @@ pub fn fftrec_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// convert string to upper case, in place.
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffupch(string: *mut c_char) {
@@ -1032,7 +1077,6 @@ pub unsafe extern "C" fn ffupch(string: *mut c_char) {
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// convert string to upper case, in place.
 pub fn ffupch_safe(string: &mut [c_char]) {
     let len = strlen_safe(string);
@@ -1041,16 +1085,23 @@ pub fn ffupch_safe(string: &mut [c_char]) {
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Make a complete FITS 80-byte keyword card from the input name, value and
 /// comment strings. Output card is null terminated without any trailing blanks.
+///
+/// # Parameters
+///
+/// * `keyname` — (I) keyword name
+/// * `value`   — (I) keyword value
+/// * `comm`    — (I) keyword comment
+/// * `card`    — (O) constructed keyword card
+/// * `status`  — (IO) status value
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffmkky(
-    keyname: *const c_char, /* I - keyword name    */
-    value: *const c_char,   /* I - keyword value   */
-    comm: *const c_char,    /* I - keyword comment */
-    card: *mut c_char,      /* O - constructed keyword card */
-    status: *mut c_int,     /* IO - status value   */
+    keyname: *const c_char,
+    value: *const c_char,
+    comm: *const c_char,
+    card: *mut c_char,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -1073,15 +1124,22 @@ pub unsafe extern "C" fn ffmkky(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Make a complete FITS 80-byte keyword card from the input name, value and
 /// comment strings. Output card is null terminated without any trailing blanks.
+///
+/// # Parameters
+///
+/// * `keyname` — (I) keyword name
+/// * `value`   — (I) keyword value
+/// * `comm`    — (I) keyword comment
+/// * `card`    — (O) constructed keyword card
+/// * `status`  — (IO) status value
 pub fn ffmkky_safe(
-    keyname: &[c_char],      /* I - keyword name    */
-    value: &[c_char],        /* I - keyword value   */
-    comm: Option<&[c_char]>, /* I - keyword comment */
-    card: &mut [c_char],     /* O - constructed keyword card */
-    status: &mut c_int,      /* IO - status value   */
+    keyname: &[c_char],
+    value: &[c_char],
+    comm: Option<&[c_char]>,
+    card: &mut [c_char],
+    status: &mut c_int,
 ) -> c_int {
     let mut namelen: usize;
     let mut len: usize;
@@ -1319,14 +1377,15 @@ pub fn ffmkky_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// replace the previously read card (i.e. starting 80 bytes before the
 /// fptr.Fptr.nextkey position) with the contents of the input card.
-pub(crate) fn ffmkey(
-    fptr: &mut fitsfile, /* I - FITS file pointer  */
-    card: &[c_char],     /* I - card string value  */
-    status: &mut c_int,  /* IO - error status      */
-) -> c_int {
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `card`   — (I) card string value
+/// * `status` — (IO) error status
+pub(crate) fn ffmkey(fptr: &mut fitsfile, card: &[c_char], status: &mut c_int) -> c_int {
     let mut tcard: [c_char; FLEN_CARD] = [0; FLEN_CARD];
     let mut keylength;
 
@@ -1390,14 +1449,20 @@ pub(crate) fn ffmkey(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Construct a keyword name string by appending the index number to the root.
 /// e.g., if root = "TTYPE" and value = 12 then keyname = "TTYPE12".
+///
+/// # Parameters
+///
+/// * `keyroot` — (I) root string for keyword name
+/// * `value`   — (I) index number to be appended to root name
+/// * `keyname` — (O) output root + index keyword name
+/// * `status`  — (IO) error status
 pub fn ffkeyn_safe(
-    keyroot: &[c_char],     /* I - root string for keyword name */
-    value: c_int,           /* I - index number to be appended to root name */
-    keyname: &mut [c_char], /* O - output root + index keyword name */
-    status: &mut c_int,     /* IO - error status  */
+    keyroot: &[c_char],
+    value: c_int,
+    keyname: &mut [c_char],
+    status: &mut c_int,
 ) -> c_int {
     let mut suffix: [c_char; 16] = [0; 16]; /* initialize output name to null */
 
@@ -1426,15 +1491,21 @@ pub fn ffkeyn_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Construct a keyword name string by appending the index number to the root.
 /// e.g., if root = "TTYPE" and value = 12 then keyname = "TTYPE12".
+///
+/// # Parameters
+///
+/// * `keyroot` — (I) root string for keyword name
+/// * `value`   — (I) index number to be appended to root name
+/// * `keyname` — (O) output root + index keyword name
+/// * `status`  — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffkeyn(
-    keyroot: *const c_char, /* I - root string for keyword name */
-    value: c_int,           /* I - index number to be appended to root name */
-    keyname: *mut c_char,   /* O - output root + index keyword name */
-    status: *mut c_int,     /* IO - error status  */
+    keyroot: *const c_char,
+    value: c_int,
+    keyname: *mut c_char,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -1447,15 +1518,21 @@ pub unsafe extern "C" fn ffkeyn(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Construct a keyword name string by appending the root string to the index
 /// number. e.g., if root = "TTYPE" and value = 12 then keyname = "12TTYPE".
+///
+/// # Parameters
+///
+/// * `value`   — (I) index number to be appended to root name
+/// * `keyroot` — (I) root string for keyword name
+/// * `keyname` — (O) output root + index keyword name
+/// * `status`  — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffnkey(
-    value: c_int,           /* I - index number to be appended to root name */
-    keyroot: *const c_char, /* I - root string for keyword name */
-    keyname: *mut c_char,   /* O - output root + index keyword name */
-    status: *mut c_int,     /* IO - error status  */
+    value: c_int,
+    keyroot: *const c_char,
+    keyname: *mut c_char,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -1467,14 +1544,20 @@ pub unsafe extern "C" fn ffnkey(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Construct a keyword name string by appending the root string to the index
 /// number. e.g., if root = "TTYPE" and value = 12 then keyname = "12TTYPE".
+///
+/// # Parameters
+///
+/// * `value`   — (I) index number to be appended to root name
+/// * `keyroot` — (I) root string for keyword name
+/// * `keyname` — (O) output root + index keyword name
+/// * `status`  — (IO) error status
 pub fn ffnkey_safe(
-    value: c_int,           /* I - index number to be appended to root name */
-    keyroot: &[c_char],     /* I - root string for keyword name */
-    keyname: &mut [c_char], /* O - output root + index keyword name */
-    status: &mut c_int,     /* IO - error status  */
+    value: c_int,
+    keyroot: &[c_char],
+    keyname: &mut [c_char],
+    status: &mut c_int,
 ) -> c_int {
     keyname[0] = 0; /* initialize output name to null */
     let rootlen = strlen_safe(keyroot);
@@ -1495,18 +1578,24 @@ pub fn ffnkey_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// ParSe the Value and Comment strings from the input header card string.
 ///
 /// If the card contains a quoted string value, the returned value string
 /// includes the enclosing quote characters.  If comm = NULL, don't return
 /// the comment string.
+///
+/// # Parameters
+///
+/// * `card`   — (I) FITS header card (nominally 80 bytes long)
+/// * `value`  — (O) value string parsed from the card
+/// * `comm`   — (O) comment string parsed from the card
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffpsvc(
-    card: *const c_char, /* I - FITS header card (nominally 80 bytes long) */
-    value: *mut c_char,  /* O - value string parsed from the card */
-    comm: *mut c_char,   /* O - comment string parsed from the card */
-    status: *mut c_int,  /* IO - error status   */
+    card: *const c_char,
+    value: *mut c_char,
+    comm: *mut c_char,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -1527,16 +1616,22 @@ pub unsafe extern "C" fn ffpsvc(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// ParSe the Value and Comment strings from the input header card string.
 /// If the card contains a quoted string value, the returned value string
 /// includes the enclosing quote characters.  If comm = NULL, don't return
 /// the comment string.
+///
+/// # Parameters
+///
+/// * `card`   — (I) FITS header card (nominally 80 bytes long)
+/// * `value`  — (O) value string parsed from the card
+/// * `comm`   — (O) comment string parsed from the card
+/// * `status` — (IO) error status
 pub fn ffpsvc_safe(
-    card: &[c_char],      /* I - FITS header card (nominally 80 bytes long) */
-    value: &mut [c_char], /* O - value string parsed from the card */
-    comm: Option<&mut [c_char; FLEN_COMMENT]>, /* O - comment string parsed from the card */
-    status: &mut c_int,   /* IO - error status   */
+    card: &[c_char],
+    value: &mut [c_char],
+    comm: Option<&mut [c_char; FLEN_COMMENT]>,
+    status: &mut c_int,
 ) -> c_int {
     let mut valpos: usize;
     let mut strbuf: [c_char; 21] = [0; 21];
@@ -1756,15 +1851,21 @@ pub fn ffpsvc_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// 'Get Template HeaDer'
 /// parse a template header line and create a formated
 /// character string which is suitable for appending to a FITS header
+///
+/// # Parameters
+///
+/// * `tmplt`  — (I) input header template string
+/// * `card`   — (O) returned FITS header record
+/// * `hdtype` — (O) how to interpreter the returned card string
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgthd(
-    tmplt: *const c_char, /* I - input header template string */
-    card: *mut c_char,    /* O - returned FITS header record */
-    hdtype: *mut c_int,   /* O - how to interpreter the returned card string */
+    tmplt: *const c_char,
+    card: *mut c_char,
+    hdtype: *mut c_int,
     /*
       -2 = modify the name of a keyword; the old keyword name
            is returned starting at address chars[0]; the new name
@@ -1777,7 +1878,7 @@ pub unsafe extern "C" fn ffgthd(
            'COMMENT', or blank keyword name)
        2  =  this is the END keyword; do not write it to the header
     */
-    status: *mut c_int, /* IO - error status   */
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -1793,14 +1894,20 @@ pub unsafe extern "C" fn ffgthd(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// 'Get Template HeaDer'
 /// parse a template header line and create a formated
 /// character string which is suitable for appending to a FITS header
+///
+/// # Parameters
+///
+/// * `tmplt`  — (I) input header template string
+/// * `card`   — (O) returned FITS header record
+/// * `hdtype` — (O) how to interpreter the returned card string
+/// * `status` — (IO) error status
 pub fn ffgthd_safe(
-    tmplt: &[c_char],               /* I - input header template string */
-    card: &mut [c_char; FLEN_CARD], /* O - returned FITS header record */
-    hdtype: &mut c_int,             /* O - how to interpreter the returned card string */
+    tmplt: &[c_char],
+    card: &mut [c_char; FLEN_CARD],
+    hdtype: &mut c_int,
     /*
       -2 = modify the name of a keyword; the old keyword name
            is returned starting at address chars[0]; the new name
@@ -1813,7 +1920,7 @@ pub fn ffgthd_safe(
            'COMMENT', or blank keyword name)
        2  =  this is the END keyword; do not write it to the header
     */
-    status: &mut c_int, /* IO - error status   */
+    status: &mut c_int,
 ) -> c_int {
     let mut keyname: [c_char; FLEN_KEYWORD] = [0; FLEN_KEYWORD];
     let mut value: [c_char; 140] = [0; 140];
@@ -2130,12 +2237,11 @@ pub fn ffgthd_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Translate a keyword name to a new name, based on a set of patterns.
 ///
 /// The user passes an array of patterns to be matched.  Input pattern
-/// number i is pattern[i][0], and output pattern number i is
-/// pattern[i][1].  Keywords are matched against the input patterns.  If a
+/// number `i` is `pattern[i][0]`, and output pattern number `i` is
+/// `pattern[i][1]`.  Keywords are matched against the input patterns.  If a
 /// match is found then the keyword is re-written according to the output
 /// pattern.
 ///
@@ -2178,27 +2284,43 @@ pub fn ffgthd_safe(
 /// then values of 'n' less than or equal to n_value will match.
 ///
 /// This routine was written by Craig Markwardt, GSFC
+///
+/// # Parameters
+///
+/// * `inrec`    — (I) input string
+/// * `outrec`   — (O) output converted string, or
+/// * `patterns` — (I) pointer to input / output string
+/// * `npat`     — (I) number of templates passed
+/// * `n_value`  — (I) base 'n' template value of interest
+/// * `n_offset` — (I) offset to be applied to the 'n'
+/// * `n_range`  — (I) controls range of 'n' template
+/// * `pat_num`  — (O) matched pattern number (0 based) or -1
+/// * `i`        — (O) value of i, if any, else 0
+/// * `j`        — (O) value of j, if any, else 0
+/// * `m`        — (O) value of m, if any, else 0
+/// * `n`        — (O) value of n, if any, else 0
+/// * `status`   — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn fits_translate_keyword(
-    inrec: *mut c_char,  /* I - input string */
-    outrec: *mut c_char, /* O - output converted string, or */
+    inrec: *mut c_char,
+    outrec: *mut c_char,
     /*     a null string if input does not  */
     /*     match any of the patterns */
-    patterns: *const [*const c_char; 2], /* I - pointer to input / output string */
+    patterns: *const [*const c_char; 2],
     /*     templates */
-    npat: c_int,     /* I - number of templates passed */
-    n_value: c_int,  /* I - base 'n' template value of interest */
-    n_offset: c_int, /* I - offset to be applied to the 'n' */
+    npat: c_int,
+    n_value: c_int,
+    n_offset: c_int,
     /*     value in the output string */
-    n_range: c_int, /* I - controls range of 'n' template */
+    n_range: c_int,
     /*     values of interest (-1,0, or +1) */
-    pat_num: *mut c_int, /* O - matched pattern number (0 based) or -1 */
-    i: *mut c_int,       /* O - value of i, if any, else 0 */
-    j: *mut c_int,       /* O - value of j, if any, else 0 */
-    m: *mut c_int,       /* O - value of m, if any, else 0 */
-    n: *mut c_int,       /* O - value of n, if any, else 0 */
+    pat_num: *mut c_int,
+    i: *mut c_int,
+    j: *mut c_int,
+    m: *mut c_int,
+    n: *mut c_int,
 
-    status: *mut c_int, /* IO - error status */
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -2245,27 +2367,41 @@ pub unsafe extern "C" fn fits_translate_keyword(
     }
 }
 
-/*--------------------------------------------------------------------------*/
+/// # Parameters
+///
+/// * `inrec`    — (I) input string
+/// * `outrec`   — (O) output converted string, or
+/// * `patterns` — (I) pointer to input / output string
+/// * `npat`     — (I) number of templates passed
+/// * `n_value`  — (I) base 'n' template value of interest
+/// * `n_offset` — (I) offset to be applied to the 'n'
+/// * `n_range`  — (I) controls range of 'n' template
+/// * `pat_num`  — (O) matched pattern number (0 based) or -1
+/// * `i`        — (O) value of i, if any, else 0
+/// * `j`        — (O) value of j, if any, else 0
+/// * `m`        — (O) value of m, if any, else 0
+/// * `n`        — (O) value of n, if any, else 0
+/// * `status`   — (IO) error status
 pub fn fits_translate_keyword_safer(
-    inrec: &mut [c_char],  /* I - input string */
-    outrec: &mut [c_char], /* O - output converted string, or */
+    inrec: &mut [c_char],
+    outrec: &mut [c_char],
     /*     a null string if input does not  */
     /*     match any of the patterns */
-    patterns: &[[&CStr; 2]], /* I - pointer to input / output string */
+    patterns: &[[&CStr; 2]],
     /*     templates */
-    npat: c_int,     /* I - number of templates passed */
-    n_value: c_int,  /* I - base 'n' template value of interest */
-    n_offset: c_int, /* I - offset to be applied to the 'n' */
+    npat: c_int,
+    n_value: c_int,
+    n_offset: c_int,
     /*     value in the output string */
-    n_range: c_int, /* I - controls range of 'n' template */
+    n_range: c_int,
     /*     values of interest (-1,0, or +1) */
-    pat_num: Option<&mut c_int>, /* O - matched pattern number (0 based) or -1 */
-    i: Option<&mut c_int>,       /* O - value of i, if any, else 0 */
-    j: Option<&mut c_int>,       /* O - value of j, if any, else 0 */
-    m: Option<&mut c_int>,       /* O - value of m, if any, else 0 */
-    n: Option<&mut c_int>,       /* O - value of n, if any, else 0 */
+    pat_num: Option<&mut c_int>,
+    i: Option<&mut c_int>,
+    j: Option<&mut c_int>,
+    m: Option<&mut c_int>,
+    n: Option<&mut c_int>,
 
-    status: &mut c_int, /* IO - error status */
+    status: &mut c_int,
 ) -> c_int {
     let mut i1: c_int = 0;
     let mut j1: c_int = 0;
@@ -2523,7 +2659,6 @@ pub fn fits_translate_keyword_safer(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy relevant keywords from the table header into the newly
 /// created primary array header.  Convert names of keywords where
 /// appropriate.  See fits_translate_keyword() for the definitions.
@@ -2532,17 +2667,29 @@ pub fn fits_translate_keyword_safer(
 /// continues to the end of the header.
 ///
 /// This routine was written by Craig Markwardt, GSFC
+///
+/// # Parameters
+///
+/// * `infptr`   — (I) pointer to input HDU
+/// * `outfptr`  — (I) pointer to output HDU
+/// * `firstkey` — (I) first HDU record number to start with
+/// * `patterns` — (I) pointer to input / output keyword templates
+/// * `npat`     — (I) number of templates passed
+/// * `n_value`  — (I) base 'n' template value of interest
+/// * `n_offset` — (I) offset to be applied to the 'n' value in the output string
+/// * `n_range`  — (I) controls range of 'n' template values of interest (-1,0, or +1)
+/// * `status`   — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn fits_translate_keywords(
-    infptr: *mut fitsfile,               /* I - pointer to input HDU */
-    outfptr: *mut fitsfile,              /* I - pointer to output HDU */
-    firstkey: c_int,                     /* I - first HDU record number to start with */
-    patterns: *const [*const c_char; 2], /* I - pointer to input / output keyword templates */
-    npat: c_int,                         /* I - number of templates passed */
-    n_value: c_int,                      /* I - base 'n' template value of interest */
-    n_offset: c_int, /* I - offset to be applied to the 'n' value in the output string */
-    n_range: c_int,  /* I - controls range of 'n' template values of interest (-1,0, or +1) */
-    status: *mut c_int, /* IO - error status */
+    infptr: *mut fitsfile,
+    outfptr: *mut fitsfile,
+    firstkey: c_int,
+    patterns: *const [*const c_char; 2],
+    npat: c_int,
+    n_value: c_int,
+    n_offset: c_int,
+    n_range: c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -2571,7 +2718,6 @@ pub unsafe extern "C" fn fits_translate_keywords(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy relevant keywords from the table header into the newly
 /// created primary array header.  Convert names of keywords where
 /// appropriate.  See fits_translate_keyword() for the definitions.
@@ -2580,16 +2726,28 @@ pub unsafe extern "C" fn fits_translate_keywords(
 /// continues to the end of the header.
 ///
 /// This routine was written by Craig Markwardt, GSFC
+///
+/// # Parameters
+///
+/// * `infptr`   — (I) pointer to input HDU
+/// * `outfptr`  — (I) pointer to output HDU
+/// * `firstkey` — (I) first HDU record number to start with
+/// * `patterns` — (I) pointer to input / output keyword templates
+/// * `npat`     — (I) number of templates passed
+/// * `n_value`  — (I) base 'n' template value of interest
+/// * `n_offset` — (I) offset to be applied to the 'n' value in the output string
+/// * `n_range`  — (I) controls range of 'n' template values of interest (-1,0, or +1)
+/// * `status`   — (IO) error status
 pub fn fits_translate_keywords_safe(
-    infptr: &mut fitsfile,   /* I - pointer to input HDU */
-    outfptr: &mut fitsfile,  /* I - pointer to output HDU */
-    firstkey: c_int,         /* I - first HDU record number to start with */
-    patterns: &[[&CStr; 2]], /* I - pointer to input / output keyword templates */
-    npat: c_int,             /* I - number of templates passed */
-    n_value: c_int,          /* I - base 'n' template value of interest */
-    n_offset: c_int,         /* I - offset to be applied to the 'n' value in the output string */
-    n_range: c_int, /* I - controls range of 'n' template values of interest (-1,0, or +1) */
-    status: &mut c_int, /* IO - error status */
+    infptr: &mut fitsfile,
+    outfptr: &mut fitsfile,
+    firstkey: c_int,
+    patterns: &[[&CStr; 2]],
+    npat: c_int,
+    n_value: c_int,
+    n_offset: c_int,
+    n_range: c_int,
+    status: &mut c_int,
 ) -> c_int {
     let mut nkeys: c_int = 0;
     let mut nmore: c_int = 0;
@@ -2679,21 +2837,29 @@ pub fn fits_translate_keywords_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy relevant keywords from the pixel list table header into a newly
 /// created primary array header.  Convert names of keywords where
 /// appropriate.  See fits_translate_pixkeyword() for the definitions.
 ///
 /// Translation begins at header record number 'firstkey', and
 /// continues to the end of the header.
+///
+/// # Parameters
+///
+/// * `infptr`   — (I) pointer to input HDU
+/// * `outfptr`  — (I) pointer to output HDU
+/// * `firstkey` — (I) first HDU record number to start with
+/// * `naxis`    — (I) number of axes in the image
+/// * `colnum`   — (I) numbers of the columns to be binned
+/// * `status`   — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn fits_copy_pixlist2image(
-    infptr: *mut fitsfile,  /* I - pointer to input HDU */
-    outfptr: *mut fitsfile, /* I - pointer to output HDU */
-    firstkey: c_int,        /* I - first HDU record number to start with */
-    naxis: c_int,           /* I - number of axes in the image */
-    colnum: *const c_int,   /* I - numbers of the columns to be binned  */
-    status: *mut c_int,     /* IO - error status */
+    infptr: *mut fitsfile,
+    outfptr: *mut fitsfile,
+    firstkey: c_int,
+    naxis: c_int,
+    colnum: *const c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -2706,20 +2872,28 @@ pub unsafe extern "C" fn fits_copy_pixlist2image(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy relevant keywords from the pixel list table header into a newly
 /// created primary array header.  Convert names of keywords where
 /// appropriate.  See fits_translate_pixkeyword() for the definitions.
 ///
 /// Translation begins at header record number 'firstkey', and
 /// continues to the end of the header.
+///
+/// # Parameters
+///
+/// * `infptr`   — (I) pointer to input HDU
+/// * `outfptr`  — (I) pointer to output HDU
+/// * `firstkey` — (I) first HDU record number to start with
+/// * `naxis`    — (I) number of axes in the image
+/// * `colnum`   — (I) numbers of the columns to be binned
+/// * `status`   — (IO) error status
 pub fn fits_copy_pixlist2image_safe(
-    infptr: &mut fitsfile,  /* I - pointer to input HDU */
-    outfptr: &mut fitsfile, /* I - pointer to output HDU */
-    firstkey: c_int,        /* I - first HDU record number to start with */
-    naxis: c_int,           /* I - number of axes in the image */
-    colnum: &[c_int],       /* I - numbers of the columns to be binned  */
-    status: &mut c_int,     /* IO - error status */
+    infptr: &mut fitsfile,
+    outfptr: &mut fitsfile,
+    firstkey: c_int,
+    naxis: c_int,
+    colnum: &[c_int],
+    status: &mut c_int,
 ) -> c_int {
     let mut nkeys: c_int = 0;
     let mut nmore: c_int = 0;
@@ -2877,11 +3051,10 @@ pub fn fits_copy_pixlist2image_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Translate a keyword name to a new name, based on a set of patterns.
 /// The user passes an array of patterns to be matched.  Input pattern
-/// number i is pattern[i][0], and output pattern number i is
-/// pattern[i][1].  Keywords are matched against the input patterns.  If a
+/// number `i` is `pattern[i][0]`, and output pattern number `i` is
+/// `pattern[i][1]`.  Keywords are matched against the input patterns.  If a
 /// match is found then the keyword is re-written according to the output
 /// pattern.
 ///
@@ -2922,23 +3095,34 @@ pub fn fits_copy_pixlist2image_safe(
 /// considered as a pattern match.  If n_range = +1, then all values of
 /// 'n' greater than or equal to n_value will be a match, and if -1,
 /// then values of 'n' less than or equal to n_value will match.
+///
+/// # Parameters
+///
+/// * `inrec`    — (I) input string
+/// * `outrec`   — (O) output converted string, or
+/// * `patterns` — (I) pointer to input / output string
+/// * `npat`     — (I) number of templates passed
+/// * `_naxis`   — (I) number of columns to be binned
+/// * `colnum`   — (I) numbers of the columns to be binned
+/// * `pat_num`  — (O) matched pattern number (0 based) or -1
+/// * `status`   — (IO) error status
 pub(crate) fn fits_translate_pixkeyword(
-    inrec: &[c_char],      /* I - input string */
-    outrec: &mut [c_char], /* O - output converted string, or */
+    inrec: &[c_char],
+    outrec: &mut [c_char],
     /*     a null string if input does not  */
     /*     match any of the patterns */
-    patterns: &[[*const c_char; 2]], /* I - pointer to input / output string */
+    patterns: &[[*const c_char; 2]],
     /*     templates */
-    npat: usize,         /* I - number of templates passed */
-    _naxis: c_int,       /* I - number of columns to be binned */
-    colnum: &[c_int],    /* I - numbers of the columns to be binned */
-    pat_num: &mut c_int, /* O - matched pattern number (0 based) or -1 */
+    npat: usize,
+    _naxis: c_int,
+    colnum: &[c_int],
+    pat_num: &mut c_int,
     i: &mut c_int,
     j: &mut c_int,
     n: &mut c_int,
     m: &mut c_int,
     l: &mut c_int,
-    status: &mut c_int, /* IO - error status */
+    status: &mut c_int,
 ) -> c_int {
     let mut i1: c_int = 0;
     let mut j1: c_int = 0;
@@ -3210,16 +3394,23 @@ pub(crate) fn fits_translate_pixkeyword(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// parse the ASCII table TFORM column format to determine the data
 /// type, the field width, and number of decimal places (if relevant)
+///
+/// # Parameters
+///
+/// * `tform`    — (I) format code from the TFORMn keyword
+/// * `dtcode`   — (O) numerical datatype code
+/// * `twidth`   — (O) width of the field, in chars
+/// * `decimals` — (O) number of decimal places (F, E, D format)
+/// * `status`   — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffasfm(
-    tform: *const c_char, /* I - format code from the TFORMn keyword */
-    dtcode: *mut c_int,   /* O - numerical datatype code */
-    twidth: *mut c_long,  /* O - width of the field, in chars */
-    decimals: *mut c_int, /* O - number of decimal places (F, E, D format) */
-    status: *mut c_int,   /* IO - error status      */
+    tform: *const c_char,
+    dtcode: *mut c_int,
+    twidth: *mut c_long,
+    decimals: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -3234,15 +3425,22 @@ pub unsafe extern "C" fn ffasfm(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// parse the ASCII table TFORM column format to determine the data
 /// type, the field width, and number of decimal places (if relevant)
+///
+/// # Parameters
+///
+/// * `tform`    — (I) format code from the TFORMn keyword
+/// * `dtcode`   — (O) numerical datatype code
+/// * `twidth`   — (O) width of the field, in chars
+/// * `decimals` — (O) number of decimal places (F, E, D format)
+/// * `status`   — (IO) error status
 pub fn ffasfm_safe(
-    tform: &[c_char],             /* I - format code from the TFORMn keyword */
-    dtcode: Option<&mut c_int>,   /* O - numerical datatype code */
-    twidth: Option<&mut c_long>,  /* O - width of the field, in chars */
-    decimals: Option<&mut c_int>, /* O - number of decimal places (F, E, D format) */
-    status: &mut c_int,           /* IO - error status      */
+    tform: &[c_char],
+    dtcode: Option<&mut c_int>,
+    twidth: Option<&mut c_long>,
+    decimals: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     let mut datacode;
     let mut longval: c_long = 0;
@@ -3294,9 +3492,7 @@ pub fn ffasfm_safe(
         return *status;
     }
 
-    /*-----------------------------------------------*/
     /*       determine default datatype code         */
-    /*-----------------------------------------------*/
     if temp[form] == bb(b'A') {
         datacode = TSTRING;
     } else if temp[form] == bb(b'I') {
@@ -3324,9 +3520,7 @@ pub fn ffasfm_safe(
     form += 1; /* point to the start of field width */
 
     if datacode == TSTRING || datacode == TLONG {
-        /*-----------------------------------------------*/
         /*              A or I data formats:             */
-        /*-----------------------------------------------*/
 
         if ffc2ii(&temp[form..], &mut width, status) <= 0 {
             /* read the width field */
@@ -3341,9 +3535,7 @@ pub fn ffasfm_safe(
             }
         }
     } else {
-        /*-----------------------------------------------*/
         /*              F, E or D data formats:          */
-        /*-----------------------------------------------*/
 
         if ffc2rr(&temp[form..], &mut fwidth, status) <= 0 {
             /* read ww.dd width field */
@@ -3407,16 +3599,23 @@ pub fn ffasfm_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// parse the binary table TFORM column format to determine the data
 /// type, repeat count, and the field width (if it is an ASCII (A) field)
+///
+/// # Parameters
+///
+/// * `tform`   — (I) format code from the TFORMn keyword
+/// * `dtcode`  — (O) numerical datatype code
+/// * `trepeat` — (O) repeat count of the field
+/// * `twidth`  — (O) width of the field, in chars
+/// * `status`  — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffbnfm(
-    tform: *const c_char, /* I - format code from the TFORMn keyword */
-    dtcode: *mut c_int,   /* O - numerical datatype code */
-    trepeat: *mut c_long, /* O - repeat count of the field  */
-    twidth: *mut c_long,  /* O - width  of the field, in chars */
-    status: *mut c_int,   /* IO - error status      */
+    tform: *const c_char,
+    dtcode: *mut c_int,
+    trepeat: *mut c_long,
+    twidth: *mut c_long,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -3431,15 +3630,22 @@ pub unsafe extern "C" fn ffbnfm(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// parse the binary table TFORM column format to determine the data
 /// type, repeat count, and the field width (if it is an ASCII (A) field)
+///
+/// # Parameters
+///
+/// * `tform`   — (I) format code from the TFORMn keyword
+/// * `dtcode`  — (O) numerical datatype code
+/// * `trepeat` — (O) repeat count of the field
+/// * `twidth`  — (O) width of the field, in chars
+/// * `status`  — (IO) error status
 pub fn ffbnfm_safe(
-    tform: &[c_char],                 /* I - format code from the TFORMn keyword */
-    mut dtcode: Option<&mut c_int>,   /* O - numerical datatype code */
-    mut trepeat: Option<&mut c_long>, /* O - repeat count of the field  */
-    mut twidth: Option<&mut c_long>,  /* O - width  of the field, in chars */
-    status: &mut c_int,               /* IO - error status      */
+    tform: &[c_char],
+    mut dtcode: Option<&mut c_int>,
+    mut trepeat: Option<&mut c_long>,
+    mut twidth: Option<&mut c_long>,
+    status: &mut c_int,
 ) -> c_int {
     let mut datacode; /* flag variable cols w/ neg type code */
     let variable;
@@ -3490,9 +3696,7 @@ pub fn ffbnfm_safe(
     strcpy_safe(&mut temp, &tform[ii..]); /* copy format string */
     ffupch_safe(&mut temp); /* make sure it is in upper case */
 
-    /*-----------------------------------------------*/
     /*       get the repeat count                    */
-    /*-----------------------------------------------*/
 
     let mut ii = 0;
     while isdigit_safe(temp[ii]) {
@@ -3530,9 +3734,7 @@ pub fn ffbnfm_safe(
         */
     }
 
-    /*-----------------------------------------------*/
     /*             determine datatype code           */
-    /*-----------------------------------------------*/
     let mut fi = ii;
     /* skip over the repeat field */
 
@@ -3656,16 +3858,23 @@ pub fn ffbnfm_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// parse the binary table TFORM column format to determine the data
 /// type, repeat count, and the field width (if it is an ASCII (A) field)
+///
+/// # Parameters
+///
+/// * `tform`   — (I) format code from the TFORMn keyword
+/// * `dtcode`  — (O) numerical datatype code
+/// * `trepeat` — (O) repeat count of the field
+/// * `twidth`  — (O) width of the field, in chars
+/// * `status`  — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffbnfmll(
-    tform: *const c_char,   /* I - format code from the TFORMn keyword */
-    dtcode: *mut c_int,     /* O - numerical datatype code */
-    trepeat: *mut LONGLONG, /* O - repeat count of the field  */
-    twidth: *mut c_long,    /* O - width of the field, in chars */
-    status: *mut c_int,     /* IO - error status      */
+    tform: *const c_char,
+    dtcode: *mut c_int,
+    trepeat: *mut LONGLONG,
+    twidth: *mut c_long,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -3679,15 +3888,22 @@ pub unsafe extern "C" fn ffbnfmll(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// parse the binary table TFORM column format to determine the data
 /// type, repeat count, and the field width (if it is an ASCII (A) field)
+///
+/// # Parameters
+///
+/// * `tform`   — (I) format code from the TFORMn keyword
+/// * `dtcode`  — (O) numerical datatype code
+/// * `trepeat` — (O) repeat count of the field
+/// * `twidth`  — (O) width of the field, in chars
+/// * `status`  — (IO) error status
 pub fn ffbnfmll_safe(
-    tform: &[c_char],                   /* I - format code from the TFORMn keyword */
-    mut dtcode: Option<&mut c_int>,     /* O - numerical datatype code */
-    mut trepeat: Option<&mut LONGLONG>, /* O - repeat count of the field  */
-    mut twidth: Option<&mut c_long>,    /* O - width of the field, in chars */
-    status: &mut c_int,                 /* IO - error status      */
+    tform: &[c_char],
+    mut dtcode: Option<&mut c_int>,
+    mut trepeat: Option<&mut LONGLONG>,
+    mut twidth: Option<&mut c_long>,
+    status: &mut c_int,
 ) -> c_int {
     let mut datacode: c_int;
     let variable: c_int;
@@ -3739,9 +3955,7 @@ pub fn ffbnfmll_safe(
     ffupch_safe(&mut temp); /* make sure it is in upper case */
     let mut fi: usize = 0; /* point to start of format string */
 
-    /*-----------------------------------------------*/
     /*       get the repeat count                    */
-    /*-----------------------------------------------*/
 
     let mut ii = 0;
     while isdigit_safe(temp[fi + ii]) {
@@ -3759,9 +3973,7 @@ pub fn ffbnfmll_safe(
         sscanf_lf(&temp[fi..], cs!(c"%lf"), &raw mut drepeat);
         repeat = (drepeat + 0.1) as LONGLONG;
     }
-    /*-----------------------------------------------*/
     /*             determine datatype code           */
-    /*-----------------------------------------------*/
 
     fi += ii; /* skip over the repeat field */
 
@@ -3876,14 +4088,15 @@ pub fn ffbnfmll_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// convert the FITS format string for an ASCII Table extension column into the
 /// equivalent C format string that can be used in a printf statement, after
 /// the values have been read as a double.
-pub(crate) fn ffcfmt(
-    tform: &[c_char],     /* value of an ASCII table TFORMn keyword */
-    cform: &mut [c_char], /* equivalent format code in C language syntax */
-) {
+///
+/// # Parameters
+///
+/// * `tform` — value of an ASCII table TFORMn keyword
+/// * `cform` — equivalent format code in C language syntax
+pub(crate) fn ffcfmt(tform: &[c_char], cform: &mut [c_char]) {
     cform[0] = 0;
     let mut ii = 0;
     while tform[ii] != 0 && tform[ii] == bb(b' ') {
@@ -3947,13 +4160,14 @@ pub(crate) fn ffcfmt(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// convert the FITS TDISPn display format into the equivalent C format
 /// suitable for use in a printf statement.
-pub(crate) fn ffcdsp(
-    tform: &[c_char],     /* value of an ASCII table TFORMn keyword */
-    cform: &mut [c_char], /* equivalent format code in C language syntax */
-) {
+///
+/// # Parameters
+///
+/// * `tform` — value of an ASCII table TFORMn keyword
+/// * `cform` — equivalent format code in C language syntax
+pub(crate) fn ffcdsp(tform: &[c_char], cform: &mut [c_char]) {
     let mut ii: usize;
 
     cform[0] = 0;
@@ -4002,17 +4216,24 @@ pub(crate) fn ffcdsp(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Determine the column number corresponding to an input column name.
 /// The first column of the table = column 1;  
 /// This supports the * and ? wild cards in the input template.
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pionter
+/// * `casesen` — (I) case sensitive string comparison? 0=no
+/// * `templt`  — (I) input name of column (w/wildcards)
+/// * `colnum`  — (O) number of the named column; 1=first col
+/// * `status`  — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgcno(
-    fptr: *mut fitsfile,   /* I - FITS file pionter                       */
-    casesen: c_int,        /* I - case sensitive string comparison? 0=no  */
-    templt: *const c_char, /* I - input name of column (w/wildcards)      */
-    colnum: *mut c_int,    /* O - number of the named column; 1=first col */
-    status: *mut c_int,    /* IO - error status                           */
+    fptr: *mut fitsfile,
+    casesen: c_int,
+    templt: *const c_char,
+    colnum: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -4025,16 +4246,23 @@ pub unsafe extern "C" fn ffgcno(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Determine the column number corresponding to an input column name.
 /// The first column of the table = column 1;  
 /// This supports the * and ? wild cards in the input template.
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pionter
+/// * `casesen` — (I) case sensitive string comparison? 0=no
+/// * `templt`  — (I) input name of column (w/wildcards)
+/// * `colnum`  — (O) number of the named column; 1=first col
+/// * `status`  — (IO) error status
 pub fn ffgcno_safe(
-    fptr: &mut fitsfile, /* I - FITS file pionter                       */
-    casesen: c_int,      /* I - case sensitive string comparison? 0=no  */
-    templt: &[c_char],   /* I - input name of column (w/wildcards)      */
-    colnum: &mut c_int,  /* O - number of the named column; 1=first col */
-    status: &mut c_int,  /* IO - error status                           */
+    fptr: &mut fitsfile,
+    casesen: c_int,
+    templt: &[c_char],
+    colnum: &mut c_int,
+    status: &mut c_int,
 ) -> c_int {
     let mut colname: [c_char; FLEN_VALUE] = [0; FLEN_VALUE]; /*  temporary string to hold column name  */
 
@@ -4043,21 +4271,29 @@ pub fn ffgcno_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Return the full column name and column number of the next column whose
 /// TTYPEn keyword value matches the input template string.
 /// The template may contain the * and ? wildcards.  Status = 237 is
 /// returned if the match is not unique.  If so, one may call this routine
 /// again with input status=237  to get the next match.  A status value of
 /// 219 is returned when there are no more matching columns.
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `casesen` — (I) case sensitive string comparison? 0=no
+/// * `templt`  — (I) input name of column (w/wildcards)
+/// * `colname` — (O) full column name up to 68 + 1 chars long
+/// * `colnum`  — (O) number of the named column; 1=first col
+/// * `status`  — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgcnn(
-    fptr: *mut fitsfile,   /* I - FITS file pointer                       */
-    casesen: c_int,        /* I - case sensitive string comparison? 0=no  */
-    templt: *const c_char, /* I - input name of column (w/wildcards)      */
-    colname: *mut c_char,  /* O - full column name up to 68 + 1 chars long*/
-    colnum: *mut c_int,    /* O - number of the named column; 1=first col */
-    status: *mut c_int,    /* IO - error status                           */
+    fptr: *mut fitsfile,
+    casesen: c_int,
+    templt: *const c_char,
+    colname: *mut c_char,
+    colnum: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -4072,20 +4308,28 @@ pub unsafe extern "C" fn ffgcnn(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Return the full column name and column number of the next column whose
 /// TTYPEn keyword value matches the input template string.
 /// The template may contain the * and ? wildcards.  Status = 237 is
 /// returned if the match is not unique.  If so, one may call this routine
 /// again with input status=237  to get the next match.  A status value of
 /// 219 is returned when there are no more matching columns.
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `casesen` — (I) case sensitive string comparison? 0=no
+/// * `templt`  — (I) input name of column (w/wildcards)
+/// * `colname` — (O) full column name up to 68 + 1 chars long
+/// * `colnum`  — (O) number of the named column; 1=first col
+/// * `status`  — (IO) error status
 pub fn ffgcnn_safe(
-    fptr: &mut fitsfile,    /* I - FITS file pointer                       */
-    casesen: c_int,         /* I - case sensitive string comparison? 0=no  */
-    templt: &[c_char],      /* I - input name of column (w/wildcards)      */
-    colname: &mut [c_char], /* O - full column name up to 68 + 1 chars long*/
-    colnum: &mut c_int,     /* O - number of the named column; 1=first col */
-    status: &mut c_int,     /* IO - error status                           */
+    fptr: &mut fitsfile,
+    casesen: c_int,
+    templt: &[c_char],
+    colname: &mut [c_char],
+    colnum: &mut c_int,
+    status: &mut c_int,
 ) -> c_int {
     let mut errmsg: [c_char; FLEN_ERRMSG] = [0; FLEN_ERRMSG];
     let mut tstatus: c_int;
@@ -4197,7 +4441,6 @@ pub fn ffgcnn_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 ///  compare the template to the string and test if they match.
 ///
 ///  The strings are limited to 68 characters or less (the max. length
@@ -4212,13 +4455,21 @@ pub fn ffgcnn_safe(
 ///  is considered to be an exact rather than a wild card match to
 ///  the string 'AB*DE'.  The '#' wild card in the template string will
 ///  match any consecutive string of decimal digits in the colname.
+///
+/// # Parameters
+///
+/// * `templt`  — (I) input template (may have wildcards)
+/// * `colname` — (I) full column name up to 68 + 1 chars long
+/// * `casesen` — (I) case sensitive string comparison? 1=yes
+/// * `matchi`  — (O) do template and colname match? 1=yes
+/// * `exact`   — (O) do strings exactly match, or wildcards
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffcmps(
-    templt: *const c_char,  /* I - input template (may have wildcards)      */
-    colname: *const c_char, /* I - full column name up to 68 + 1 chars long */
-    casesen: c_int,         /* I - case sensitive string comparison? 1=yes  */
-    matchi: *mut c_int,     /* O - do template and colname match? 1=yes     */
-    exact: *mut c_int,      /* O - do strings exactly match, or wildcards   */
+    templt: *const c_char,
+    colname: *const c_char,
+    casesen: c_int,
+    matchi: *mut c_int,
+    exact: *mut c_int,
 ) {
     // FFI WRAPPER
     unsafe {
@@ -4232,7 +4483,6 @@ pub unsafe extern "C" fn ffcmps(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 ///  compare the template to the string and test if they match.
 ///
 ///  The strings are limited to 68 characters or less (the max. length
@@ -4247,12 +4497,20 @@ pub unsafe extern "C" fn ffcmps(
 ///  is considered to be an exact rather than a wild card match to
 ///  the string 'AB*DE'.  The '#' wild card in the template string will
 ///  match any consecutive string of decimal digits in the colname.
+///
+/// # Parameters
+///
+/// * `templt`  — (I) input template (may have wildcards)
+/// * `colname` — (I) full column name up to 68 + 1 chars long
+/// * `casesen` — (I) case sensitive string comparison? 1=yes
+/// * `matchi`  — (O) do template and colname match? 1=yes
+/// * `exact`   — (O) do strings exactly match, or wildcards
 pub fn ffcmps_safe(
-    templt: &[c_char],  /* I - input template (may have wildcards)      */
-    colname: &[c_char], /* I - full column name up to 68 + 1 chars long */
-    casesen: c_int,     /* I - case sensitive string comparison? 1=yes  */
-    matchi: &mut c_int, /* O - do template and colname match? 1=yes     */
-    exact: &mut c_int,  /* O - do strings exactly match, or wildcards   */
+    templt: &[c_char],
+    colname: &[c_char],
+    casesen: c_int,
+    matchi: &mut c_int,
+    exact: &mut c_int,
 ) {
     let mut found;
     let mut t1;
@@ -4390,7 +4648,6 @@ pub fn ffcmps_safe(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Get Type of table column.
 ///
 /// Returns the datatype code of the column, as well as the vector
@@ -4398,14 +4655,23 @@ pub fn ffcmps_safe(
 /// width of the field or a unit string within the field.  This supports the
 /// TFORMn = 'rAw' syntax for specifying arrays of substrings, so
 /// if TFORMn = '60A12' then repeat = 60 and width = 12.
+///
+/// # Parameters
+///
+/// * `fptr`     — (I) FITS file pointer
+/// * `colnum`   — (I) column number
+/// * `typecode` — (O) datatype code (21 = short, etc)
+/// * `repeat`   — (O) repeat count of field
+/// * `width`    — (O) if ASCII, width of field or unit string
+/// * `status`   — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgtcl(
-    fptr: *mut fitsfile,  /* I - FITS file pointer                       */
-    colnum: c_int,        /* I - column number                           */
-    typecode: *mut c_int, /* O - datatype code (21 = short, etc)         */
-    repeat: *mut c_long,  /* O - repeat count of field                   */
-    width: *mut c_long,   /* O - if ASCII, width of field or unit string */
-    status: *mut c_int,   /* IO - error status                           */
+    fptr: *mut fitsfile,
+    colnum: c_int,
+    typecode: *mut c_int,
+    repeat: *mut c_long,
+    width: *mut c_long,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -4419,7 +4685,6 @@ pub unsafe extern "C" fn ffgtcl(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Get Type of table column.
 ///
 /// Returns the datatype code of the column, as well as the vector
@@ -4427,13 +4692,22 @@ pub unsafe extern "C" fn ffgtcl(
 /// width of the field or a unit string within the field.  This supports the
 /// TFORMn = 'rAw' syntax for specifying arrays of substrings, so
 /// if TFORMn = '60A12' then repeat = 60 and width = 12.
+///
+/// # Parameters
+///
+/// * `fptr`     — (I) FITS file pointer
+/// * `colnum`   — (I) column number
+/// * `typecode` — (O) datatype code (21 = short, etc)
+/// * `repeat`   — (O) repeat count of field
+/// * `width`    — (O) if ASCII, width of field or unit string
+/// * `status`   — (IO) error status
 pub fn ffgtcl_safe(
-    fptr: &mut fitsfile,          /* I - FITS file pointer                       */
-    colnum: c_int,                /* I - column number                           */
-    typecode: Option<&mut c_int>, /* O - datatype code (21 = short, etc)         */
-    repeat: Option<&mut c_long>,  /* O - repeat count of field                   */
-    width: Option<&mut c_long>,   /* O - if ASCII, width of field or unit string */
-    status: &mut c_int,           /* IO - error status                           */
+    fptr: &mut fitsfile,
+    colnum: c_int,
+    typecode: Option<&mut c_int>,
+    repeat: Option<&mut c_long>,
+    width: Option<&mut c_long>,
+    status: &mut c_int,
 ) -> c_int {
     let mut trepeat: LONGLONG = 0;
     let mut twidth: LONGLONG = 0;
@@ -4462,7 +4736,6 @@ pub fn ffgtcl_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Get Type of table column.
 ///
 /// Returns the datatype code of the column, as well as the vector
@@ -4470,14 +4743,23 @@ pub fn ffgtcl_safe(
 /// width of the field or a unit string within the field.  This supports the
 /// TFORMn = 'rAw' syntax for specifying arrays of substrings, so
 /// if TFORMn = '60A12' then repeat = 60 and width = 12.
+///
+/// # Parameters
+///
+/// * `fptr`     — (I) FITS file pointer
+/// * `colnum`   — (I) column number
+/// * `typecode` — (O) datatype code (21 = short, etc)
+/// * `repeat`   — (O) repeat count of field
+/// * `width`    — (O) if ASCII, width of field or unit string
+/// * `status`   — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgtclll(
-    fptr: *mut fitsfile,   /* I - FITS file pointer                       */
-    colnum: c_int,         /* I - column number                           */
-    typecode: *mut c_int,  /* O - datatype code (21 = short, etc)         */
-    repeat: *mut LONGLONG, /* O - repeat count of field                   */
-    width: *mut LONGLONG,  /* O - if ASCII, width of field or unit string */
-    status: *mut c_int,    /* IO - error status                           */
+    fptr: *mut fitsfile,
+    colnum: c_int,
+    typecode: *mut c_int,
+    repeat: *mut LONGLONG,
+    width: *mut LONGLONG,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -4492,7 +4774,6 @@ pub unsafe extern "C" fn ffgtclll(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Get Type of table column.
 ///
 /// Returns the datatype code of the column, as well as the vector
@@ -4500,13 +4781,22 @@ pub unsafe extern "C" fn ffgtclll(
 /// width of the field or a unit string within the field.  This supports the
 /// TFORMn = 'rAw' syntax for specifying arrays of substrings, so
 /// if TFORMn = '60A12' then repeat = 60 and width = 12.
+///
+/// # Parameters
+///
+/// * `fptr`     — (I) FITS file pointer
+/// * `colnum`   — (I) column number
+/// * `typecode` — (O) datatype code (21 = short, etc)
+/// * `repeat`   — (O) repeat count of field
+/// * `width`    — (O) if ASCII, width of field or unit string
+/// * `status`   — (IO) error status
 pub fn ffgtclll_safe(
-    fptr: &mut fitsfile,           /* I - FITS file pointer                       */
-    colnum: c_int,                 /* I - column number                           */
-    typecode: Option<&mut c_int>,  /* O - datatype code (21 = short, etc)         */
-    repeat: Option<&mut LONGLONG>, /* O - repeat count of field                   */
-    width: Option<&mut LONGLONG>,  /* O - if ASCII, width of field or unit string */
-    status: &mut c_int,            /* IO - error status                           */
+    fptr: &mut fitsfile,
+    colnum: c_int,
+    typecode: Option<&mut c_int>,
+    repeat: Option<&mut LONGLONG>,
+    width: Option<&mut LONGLONG>,
+    status: &mut c_int,
 ) -> c_int {
     let mut hdutype = 0;
     let mut decims = 0;
@@ -4567,7 +4857,6 @@ pub fn ffgtclll_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Get the 'equivalent' table column type.
 ///
 /// This routine is similar to the ffgtcl routine (which returns the physical
@@ -4582,14 +4871,23 @@ pub fn ffgtclll_safe(
 /// width of the field or a unit string within the field.  This supports the
 /// TFORMn = 'rAw' syntax for specifying arrays of substrings, so
 /// if TFORMn = '60A12' then repeat = 60 and width = 12.
+///
+/// # Parameters
+///
+/// * `fptr`     — (I) FITS file pointer
+/// * `colnum`   — (I) column number
+/// * `typecode` — (O) datatype code (21 = short, etc)
+/// * `repeat`   — (O) repeat count of field
+/// * `width`    — (O) if ASCII, width of field or unit string
+/// * `status`   — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffeqty(
-    fptr: *mut fitsfile,  /* I - FITS file pointer                       */
-    colnum: c_int,        /* I - column number                           */
-    typecode: *mut c_int, /* O - datatype code (21 = short, etc)         */
-    repeat: *mut c_long,  /* O - repeat count of field                   */
-    width: *mut c_long,   /* O - if ASCII, width of field or unit string */
-    status: *mut c_int,   /* IO - error status                           */
+    fptr: *mut fitsfile,
+    colnum: c_int,
+    typecode: *mut c_int,
+    repeat: *mut c_long,
+    width: *mut c_long,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -4603,7 +4901,6 @@ pub unsafe extern "C" fn ffeqty(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Get the 'equivalent' table column type.
 ///
 /// This routine is similar to the ffgtcl routine (which returns the physical
@@ -4618,13 +4915,22 @@ pub unsafe extern "C" fn ffeqty(
 /// width of the field or a unit string within the field.  This supports the
 /// TFORMn = 'rAw' syntax for specifying arrays of substrings, so
 /// if TFORMn = '60A12' then repeat = 60 and width = 12.
+///
+/// # Parameters
+///
+/// * `fptr`     — (I) FITS file pointer
+/// * `colnum`   — (I) column number
+/// * `typecode` — (O) datatype code (21 = short, etc)
+/// * `repeat`   — (O) repeat count of field
+/// * `width`    — (O) if ASCII, width of field or unit string
+/// * `status`   — (IO) error status
 pub fn ffeqty_safe(
-    fptr: &mut fitsfile,          /* I - FITS file pointer                       */
-    colnum: c_int,                /* I - column number                           */
-    typecode: Option<&mut c_int>, /* O - datatype code (21 = short, etc)         */
-    repeat: Option<&mut c_long>,  /* O - repeat count of field                   */
-    width: Option<&mut c_long>,   /* O - if ASCII, width of field or unit string */
-    status: &mut c_int,           /* IO - error status                           */
+    fptr: &mut fitsfile,
+    colnum: c_int,
+    typecode: Option<&mut c_int>,
+    repeat: Option<&mut c_long>,
+    width: Option<&mut c_long>,
+    status: &mut c_int,
 ) -> c_int {
     let mut trepeat: LONGLONG = 0;
     let mut twidth: LONGLONG = 0;
@@ -4649,7 +4955,6 @@ pub fn ffeqty_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Get the 'equivalent' table column type.
 ///
 /// This routine is similar to the ffgtcl routine (which returns the physical
@@ -4664,14 +4969,23 @@ pub fn ffeqty_safe(
 /// width of the field or a unit string within the field.  This supports the
 /// TFORMn = 'rAw' syntax for specifying arrays of substrings, so
 /// if TFORMn = '60A12' then repeat = 60 and width = 12.
+///
+/// # Parameters
+///
+/// * `fptr`     — (I) FITS file pointer
+/// * `colnum`   — (I) column number
+/// * `typecode` — (O) datatype code (21 = short, etc)
+/// * `repeat`   — (O) repeat count of field
+/// * `width`    — (O) if ASCII, width of field or unit string
+/// * `status`   — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffeqtyll(
-    fptr: *mut fitsfile,   /* I - FITS file pointer                       */
-    colnum: c_int,         /* I - column number                           */
-    typecode: *mut c_int,  /* O - datatype code (21 = short, etc)         */
-    repeat: *mut LONGLONG, /* O - repeat count of field                   */
-    width: *mut LONGLONG,  /* O - if ASCII, width of field or unit string */
-    status: *mut c_int,    /* IO - error status                           */
+    fptr: *mut fitsfile,
+    colnum: c_int,
+    typecode: *mut c_int,
+    repeat: *mut LONGLONG,
+    width: *mut LONGLONG,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -4686,7 +5000,6 @@ pub unsafe extern "C" fn ffeqtyll(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Get the 'equivalent' table column type.
 ///
 /// This routine is similar to the ffgtcl routine (which returns the physical
@@ -4701,13 +5014,22 @@ pub unsafe extern "C" fn ffeqtyll(
 /// width of the field or a unit string within the field.  This supports the
 /// TFORMn = 'rAw' syntax for specifying arrays of substrings, so
 /// if TFORMn = '60A12' then repeat = 60 and width = 12.
+///
+/// # Parameters
+///
+/// * `fptr`     — (I) FITS file pointer
+/// * `colnum`   — (I) column number
+/// * `typecode` — (O) datatype code (21 = short, etc)
+/// * `repeat`   — (O) repeat count of field
+/// * `width`    — (O) if ASCII, width of field or unit string
+/// * `status`   — (IO) error status
 pub fn ffeqtyll_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                       */
-    colnum: c_int,       /* I - column number                           */
-    mut typecode: Option<&mut c_int>, /* O - datatype code (21 = short, etc)         */
-    repeat: Option<&mut LONGLONG>, /* O - repeat count of field                   */
-    width: Option<&mut LONGLONG>, /* O - if ASCII, width of field or unit string */
-    status: &mut c_int,  /* IO - error status                           */
+    fptr: &mut fitsfile,
+    colnum: c_int,
+    mut typecode: Option<&mut c_int>,
+    repeat: Option<&mut LONGLONG>,
+    width: Option<&mut LONGLONG>,
+    status: &mut c_int,
 ) -> c_int {
     let mut hdutype: c_int = 0;
     let mut decims: c_int = 0;
@@ -4873,13 +5195,18 @@ pub fn ffeqtyll_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Get the number of columns in the table (= TFIELDS keyword)
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `ncols`  — (O) number of columns in the table
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgncl(
-    fptr: *mut fitsfile, /* I - FITS file pointer                       */
-    ncols: *mut c_int,   /* O - number of columns in the table          */
-    status: *mut c_int,  /* IO - error status                           */
+    fptr: *mut fitsfile,
+    ncols: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -4891,13 +5218,14 @@ pub unsafe extern "C" fn ffgncl(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Get the number of columns in the table (= TFIELDS keyword)
-pub fn ffgncl_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                       */
-    ncols: &mut c_int,   /* O - number of columns in the table          */
-    status: &mut c_int,  /* IO - error status                           */
-) -> c_int {
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `ncols`  — (O) number of columns in the table
+/// * `status` — (IO) error status
+pub fn ffgncl_safe(fptr: &mut fitsfile, ncols: &mut c_int, status: &mut c_int) -> c_int {
     if *status > 0 {
         return *status;
     }
@@ -4921,13 +5249,18 @@ pub fn ffgncl_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Get the number of rows in the table (= NAXIS2 keyword)
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `nrows`  — (O) number of rows in the table
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgnrw(
-    fptr: *mut fitsfile, /* I - FITS file pointer                       */
-    nrows: *mut c_long,  /* O - number of rows in the table             */
-    status: *mut c_int,  /* IO - error status                           */
+    fptr: *mut fitsfile,
+    nrows: *mut c_long,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -4939,13 +5272,14 @@ pub unsafe extern "C" fn ffgnrw(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Get the number of rows in the table (= NAXIS2 keyword)
-pub fn ffgnrw_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                       */
-    nrows: &mut c_long,  /* O - number of rows in the table             */
-    status: &mut c_int,  /* IO - error status                           */
-) -> c_int {
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `nrows`  — (O) number of rows in the table
+/// * `status` — (IO) error status
+pub fn ffgnrw_safe(fptr: &mut fitsfile, nrows: &mut c_long, status: &mut c_int) -> c_int {
     if *status > 0 {
         return *status;
     }
@@ -4970,13 +5304,18 @@ pub fn ffgnrw_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Get the number of rows in the table (= NAXIS2 keyword)
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `nrows`  — (O) number of rows in the table
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgnrwll(
-    fptr: *mut fitsfile,  /* I - FITS file pointer                     */
-    nrows: *mut LONGLONG, /* O - number of rows in the table           */
-    status: *mut c_int,   /* IO - error status                         */
+    fptr: *mut fitsfile,
+    nrows: *mut LONGLONG,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -4988,13 +5327,14 @@ pub unsafe extern "C" fn ffgnrwll(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Get the number of rows in the table (= NAXIS2 keyword)
-pub fn ffgnrwll_safe(
-    fptr: &mut fitsfile,  /* I - FITS file pointer                     */
-    nrows: &mut LONGLONG, /* O - number of rows in the table           */
-    status: &mut c_int,   /* IO - error status                         */
-) -> c_int {
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `nrows`  — (O) number of rows in the table
+/// * `status` — (IO) error status
+pub fn ffgnrwll_safe(fptr: &mut fitsfile, nrows: &mut LONGLONG, status: &mut c_int) -> c_int {
     if *status > 0 {
         return *status;
     }
@@ -5018,21 +5358,34 @@ pub fn ffgnrwll_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// get ASCII table column keyword values
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `colnum` — (I) column number
+/// * `ttype`  — (O) TTYPEn keyword value
+/// * `tbcol`  — (O) TBCOLn keyword value
+/// * `tunit`  — (O) TUNITn keyword value
+/// * `tform`  — (O) TFORMn keyword value
+/// * `tscal`  — (O) TSCALn keyword value
+/// * `tzero`  — (O) TZEROn keyword value
+/// * `tnull`  — (O) TNULLn keyword value
+/// * `tdisp`  — (O) TDISPn keyword value
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgacl(
-    fptr: *mut fitsfile, /* I - FITS file pointer                      */
-    colnum: c_int,       /* I - column number                          */
-    ttype: *mut c_char,  /* O - TTYPEn keyword value                   */
-    tbcol: *mut c_long,  /* O - TBCOLn keyword value                   */
-    tunit: *mut c_char,  /* O - TUNITn keyword value                   */
-    tform: *mut c_char,  /* O - TFORMn keyword value                   */
-    tscal: *mut f64,     /* O - TSCALn keyword value                   */
-    tzero: *mut f64,     /* O - TZEROn keyword value                   */
-    tnull: *mut c_char,  /* O - TNULLn keyword value                   */
-    tdisp: *mut c_char,  /* O - TDISPn keyword value                   */
-    status: *mut c_int,  /* IO - error status                          */
+    fptr: *mut fitsfile,
+    colnum: c_int,
+    ttype: *mut c_char,
+    tbcol: *mut c_long,
+    tunit: *mut c_char,
+    tform: *mut c_char,
+    tscal: *mut f64,
+    tzero: *mut f64,
+    tnull: *mut c_char,
+    tdisp: *mut c_char,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -5074,20 +5427,33 @@ pub unsafe extern "C" fn ffgacl(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// get ASCII table column keyword values
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `colnum` — (I) column number
+/// * `ttype`  — (O) TTYPEn keyword value
+/// * `tbcol`  — (O) TBCOLn keyword value
+/// * `tunit`  — (O) TUNITn keyword value
+/// * `tform`  — (O) TFORMn keyword value
+/// * `tscal`  — (O) TSCALn keyword value
+/// * `tzero`  — (O) TZEROn keyword value
+/// * `tnull`  — (O) TNULLn keyword value
+/// * `tdisp`  — (O) TDISPn keyword value
+/// * `status` — (IO) error status
 pub fn ffgacl_safer(
-    fptr: &mut fitsfile,          /* I - FITS file pointer                      */
-    colnum: c_int,                /* I - column number                          */
-    ttype: Option<&mut [c_char]>, /* O - TTYPEn keyword value                   */
-    tbcol: Option<&mut c_long>,   /* O - TBCOLn keyword value                   */
-    tunit: Option<&mut [c_char]>, /* O - TUNITn keyword value                   */
-    tform: Option<&mut [c_char]>, /* O - TFORMn keyword value                   */
-    tscal: Option<&mut f64>,      /* O - TSCALn keyword value                   */
-    tzero: Option<&mut f64>,      /* O - TZEROn keyword value                   */
-    tnull: Option<&mut [c_char]>, /* O - TNULLn keyword value                   */
-    tdisp: Option<&mut [c_char]>, /* O - TDISPn keyword value                   */
-    status: &mut c_int,           /* IO - error status                          */
+    fptr: &mut fitsfile,
+    colnum: c_int,
+    ttype: Option<&mut [c_char]>,
+    tbcol: Option<&mut c_long>,
+    tunit: Option<&mut [c_char]>,
+    tform: Option<&mut [c_char]>,
+    tscal: Option<&mut f64>,
+    tzero: Option<&mut f64>,
+    tnull: Option<&mut [c_char]>,
+    tdisp: Option<&mut [c_char]>,
+    status: &mut c_int,
 ) -> c_int {
     let mut name: [c_char; FLEN_KEYWORD] = [0; FLEN_KEYWORD];
     let mut comm: [c_char; FLEN_COMMENT] = [0; FLEN_COMMENT];
@@ -5157,21 +5523,34 @@ pub fn ffgacl_safer(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// get BINTABLE column keyword values
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `colnum` — (I) column number
+/// * `ttype`  — (O) TTYPEn keyword value
+/// * `tunit`  — (O) TUNITn keyword value
+/// * `dtype`  — (O) datatype char: I, J, E, D, etc.
+/// * `repeat` — (O) vector column repeat count
+/// * `tscal`  — (O) TSCALn keyword value
+/// * `tzero`  — (O) TZEROn keyword value
+/// * `tnull`  — (O) TNULLn keyword value integer cols only
+/// * `tdisp`  — (O) TDISPn keyword value
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgbcl(
-    fptr: *mut fitsfile,     /* I - FITS file pointer                      */
-    colnum: c_int,           /* I - column number                          */
-    ttype: *mut c_char,      /* O - TTYPEn keyword value                   */
-    tunit: *mut c_char,      /* O - TUNITn keyword value                   */
-    dtype: *mut [c_char; 2], /* O - datatype char: I, J, E, D, etc.        */
-    repeat: *mut c_long,     /* O - vector column repeat count             */
-    tscal: *mut f64,         /* O - TSCALn keyword value                   */
-    tzero: *mut f64,         /* O - TZEROn keyword value                   */
-    tnull: *mut c_long,      /* O - TNULLn keyword value integer cols only */
-    tdisp: *mut c_char,      /* O - TDISPn keyword value                   */
-    status: *mut c_int,      /* IO - error status                          */
+    fptr: *mut fitsfile,
+    colnum: c_int,
+    ttype: *mut c_char,
+    tunit: *mut c_char,
+    dtype: *mut [c_char; 2],
+    repeat: *mut c_long,
+    tscal: *mut f64,
+    tzero: *mut f64,
+    tnull: *mut c_long,
+    tdisp: *mut c_char,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -5208,20 +5587,33 @@ pub unsafe extern "C" fn ffgbcl(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// get BINTABLE column keyword values
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `colnum` — (I) column number
+/// * `ttype`  — (O) TTYPEn keyword value
+/// * `tunit`  — (O) TUNITn keyword value
+/// * `dtype`  — (O) datatype char: I, J, E, D, etc.
+/// * `repeat` — (O) vector column repeat count
+/// * `tscal`  — (O) TSCALn keyword value
+/// * `tzero`  — (O) TZEROn keyword value
+/// * `tnull`  — (O) TNULLn keyword value integer cols only
+/// * `tdisp`  — (O) TDISPn keyword value
+/// * `status` — (IO) error status
 pub fn ffgbcl_safe(
-    fptr: &mut fitsfile,             /* I - FITS file pointer                      */
-    colnum: c_int,                   /* I - column number                          */
-    ttype: Option<&mut [c_char]>,    /* O - TTYPEn keyword value                   */
-    tunit: Option<&mut [c_char]>,    /* O - TUNITn keyword value                   */
-    dtype: Option<&mut [c_char; 2]>, /* O - datatype char: I, J, E, D, etc.        */
-    repeat: Option<&mut c_long>,     /* O - vector column repeat count             */
-    tscal: Option<&mut f64>,         /* O - TSCALn keyword value                   */
-    tzero: Option<&mut f64>,         /* O - TZEROn keyword value                   */
-    tnull: Option<&mut c_long>,      /* O - TNULLn keyword value integer cols only */
-    tdisp: Option<&mut [c_char]>,    /* O - TDISPn keyword value                   */
-    status: &mut c_int,              /* IO - error status                          */
+    fptr: &mut fitsfile,
+    colnum: c_int,
+    ttype: Option<&mut [c_char]>,
+    tunit: Option<&mut [c_char]>,
+    dtype: Option<&mut [c_char; 2]>,
+    repeat: Option<&mut c_long>,
+    tscal: Option<&mut f64>,
+    tzero: Option<&mut f64>,
+    tnull: Option<&mut c_long>,
+    tdisp: Option<&mut [c_char]>,
+    status: &mut c_int,
 ) -> c_int {
     let mut trepeat = 0;
     let mut ttnull = 0;
@@ -5255,21 +5647,34 @@ pub fn ffgbcl_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// get BINTABLE column keyword values
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `colnum` — (I) column number
+/// * `ttype`  — (O) TTYPEn keyword value
+/// * `tunit`  — (O) TUNITn keyword value
+/// * `dtype`  — (O) datatype char: I, J, E, D, etc.
+/// * `repeat` — (O) vector column repeat count
+/// * `tscal`  — (O) TSCALn keyword value
+/// * `tzero`  — (O) TZEROn keyword value
+/// * `tnull`  — (O) TNULLn keyword value integer cols only
+/// * `tdisp`  — (O) TDISPn keyword value
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgbclll(
-    fptr: *mut fitsfile,     /* I - FITS file pointer                      */
-    colnum: c_int,           /* I - column number                          */
-    ttype: *mut c_char,      /* O - TTYPEn keyword value                   */
-    tunit: *mut c_char,      /* O - TUNITn keyword value                   */
-    dtype: *mut [c_char; 2], /* O - datatype char: I, J, E, D, etc.        */
-    repeat: *mut LONGLONG,   /* O - vector column repeat count             */
-    tscal: *mut f64,         /* O - TSCALn keyword value                   */
-    tzero: *mut f64,         /* O - TZEROn keyword value                   */
-    tnull: *mut LONGLONG,    /* O - TNULLn keyword value integer cols only */
-    tdisp: *mut c_char,      /* O - TDISPn keyword value                   */
-    status: *mut c_int,      /* IO - error status                          */
+    fptr: *mut fitsfile,
+    colnum: c_int,
+    ttype: *mut c_char,
+    tunit: *mut c_char,
+    dtype: *mut [c_char; 2],
+    repeat: *mut LONGLONG,
+    tscal: *mut f64,
+    tzero: *mut f64,
+    tnull: *mut LONGLONG,
+    tdisp: *mut c_char,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -5306,20 +5711,33 @@ pub unsafe extern "C" fn ffgbclll(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// get BINTABLE column keyword values
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `colnum` — (I) column number
+/// * `ttype`  — (O) TTYPEn keyword value
+/// * `tunit`  — (O) TUNITn keyword value
+/// * `dtype`  — (O) datatype char: I, J, E, D, etc.
+/// * `repeat` — (O) vector column repeat count
+/// * `tscal`  — (O) TSCALn keyword value
+/// * `tzero`  — (O) TZEROn keyword value
+/// * `tnull`  — (O) TNULLn keyword value integer cols only
+/// * `tdisp`  — (O) TDISPn keyword value
+/// * `status` — (IO) error status
 pub fn ffgbclll_safe(
-    fptr: &mut fitsfile,             /* I - FITS file pointer                      */
-    colnum: c_int,                   /* I - column number                          */
-    ttype: Option<&mut [c_char]>,    /* O - TTYPEn keyword value                   */
-    tunit: Option<&mut [c_char]>,    /* O - TUNITn keyword value                   */
-    dtype: Option<&mut [c_char; 2]>, /* O - datatype char: I, J, E, D, etc.        */
-    repeat: Option<&mut LONGLONG>,   /* O - vector column repeat count             */
-    tscal: Option<&mut f64>,         /* O - TSCALn keyword value                   */
-    tzero: Option<&mut f64>,         /* O - TZEROn keyword value                   */
-    tnull: Option<&mut LONGLONG>,    /* O - TNULLn keyword value integer cols only */
-    tdisp: Option<&mut [c_char]>,    /* O - TDISPn keyword value                   */
-    status: &mut c_int,              /* IO - error status                          */
+    fptr: &mut fitsfile,
+    colnum: c_int,
+    ttype: Option<&mut [c_char]>,
+    tunit: Option<&mut [c_char]>,
+    dtype: Option<&mut [c_char; 2]>,
+    repeat: Option<&mut LONGLONG>,
+    tscal: Option<&mut f64>,
+    tzero: Option<&mut f64>,
+    tnull: Option<&mut LONGLONG>,
+    tdisp: Option<&mut [c_char]>,
+    status: &mut c_int,
 ) -> c_int {
     let mut name: [c_char; FLEN_KEYWORD] = [0; FLEN_KEYWORD];
     let mut comm: [c_char; FLEN_COMMENT] = [0; FLEN_COMMENT];
@@ -5424,15 +5842,16 @@ pub fn ffgbclll_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Return the number of the Current HDU in the FITS file.  The primary array
 /// is HDU number 1.  Note that this is one of the few cfitsio routines that
 /// does not return the error status value as the value of the function.
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `chdunum` — (O) number of the CHDU; 1 = primary array
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
-pub unsafe extern "C" fn ffghdn(
-    fptr: *mut fitsfile, /* I - FITS file pointer                      */
-    chdunum: *mut c_int, /* O - number of the CHDU; 1 = primary array  */
-) -> c_int {
+pub unsafe extern "C" fn ffghdn(fptr: *mut fitsfile, chdunum: *mut c_int) -> c_int {
     // FFI WRAPPER
     unsafe {
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -5442,28 +5861,36 @@ pub unsafe extern "C" fn ffghdn(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Return the number of the Current HDU in the FITS file.  The primary array
 /// is HDU number 1.  Note that this is one of the few cfitsio routines that
 /// does not return the error status value as the value of the function.
-pub fn ffghdn_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                      */
-    chdunum: &mut c_int, /* O - number of the CHDU; 1 = primary array  */
-) -> c_int {
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `chdunum` — (O) number of the CHDU; 1 = primary array
+pub fn ffghdn_safe(fptr: &mut fitsfile, chdunum: &mut c_int) -> c_int {
     *chdunum = (fptr.HDUposition) + 1;
     *chdunum
 }
 
-/*--------------------------------------------------------------------------*/
 /// Return the address (= byte offset) in the FITS file to the beginning of
 /// the current HDU, the beginning of the data unit, and the end of the data unit.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `headstart` — (O) byte offset to beginning of CHDU
+/// * `datastart` — (O) byte offset to beginning of next HDU
+/// * `dataend`   — (O) byte offset to beginning of next HDU
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffghadll(
-    fptr: *mut fitsfile,      /* I - FITS file pointer                     */
-    headstart: *mut LONGLONG, /* O - byte offset to beginning of CHDU      */
-    datastart: *mut LONGLONG, /* O - byte offset to beginning of next HDU  */
-    dataend: *mut LONGLONG,   /* O - byte offset to beginning of next HDU  */
-    status: *mut c_int,       /* IO - error status     */
+    fptr: *mut fitsfile,
+    headstart: *mut LONGLONG,
+    datastart: *mut LONGLONG,
+    dataend: *mut LONGLONG,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -5477,15 +5904,22 @@ pub unsafe extern "C" fn ffghadll(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Return the address (= byte offset) in the FITS file to the beginning of
 /// the current HDU, the beginning of the data unit, and the end of the data unit.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `headstart` — (O) byte offset to beginning of CHDU
+/// * `datastart` — (O) byte offset to beginning of next HDU
+/// * `dataend`   — (O) byte offset to beginning of next HDU
+/// * `status`    — (IO) error status
 pub fn ffghadll_safe(
-    fptr: &mut fitsfile,              /* I - FITS file pointer                     */
-    headstart: Option<&mut LONGLONG>, /* O - byte offset to beginning of CHDU      */
-    datastart: Option<&mut LONGLONG>, /* O - byte offset to beginning of next HDU  */
-    dataend: Option<&mut LONGLONG>,   /* O - byte offset to beginning of next HDU  */
-    status: &mut c_int,               /* IO - error status     */
+    fptr: &mut fitsfile,
+    headstart: Option<&mut LONGLONG>,
+    datastart: Option<&mut LONGLONG>,
+    dataend: Option<&mut LONGLONG>,
+    status: &mut c_int,
 ) -> c_int {
     if *status > 0 {
         return *status;
@@ -5514,16 +5948,23 @@ pub fn ffghadll_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Return the address (= byte offset) in the FITS file to the beginning of
 /// the current HDU, the beginning of the data unit, and the end of the data unit.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `headstart` — (O) byte offset to beginning of CHDU
+/// * `datastart` — (O) byte offset to beginning of next HDU
+/// * `dataend`   — (O) byte offset to beginning of next HDU
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffghof(
-    fptr: *mut fitsfile,   /* I - FITS file pointer                     */
-    headstart: *mut off_t, /* O - byte offset to beginning of CHDU      */
-    datastart: *mut off_t, /* O - byte offset to beginning of next HDU  */
-    dataend: *mut off_t,   /* O - byte offset to beginning of next HDU  */
-    status: *mut c_int,    /* IO - error status     */
+    fptr: *mut fitsfile,
+    headstart: *mut off_t,
+    datastart: *mut off_t,
+    dataend: *mut off_t,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -5537,15 +5978,22 @@ pub unsafe extern "C" fn ffghof(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Return the address (= byte offset) in the FITS file to the beginning of
 /// the current HDU, the beginning of the data unit, and the end of the data unit.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `headstart` — (O) byte offset to beginning of CHDU
+/// * `datastart` — (O) byte offset to beginning of next HDU
+/// * `dataend`   — (O) byte offset to beginning of next HDU
+/// * `status`    — (IO) error status
 pub fn ffghof_safe(
-    fptr: &mut fitsfile,           /* I - FITS file pointer                     */
-    headstart: Option<&mut off_t>, /* O - byte offset to beginning of CHDU      */
-    datastart: Option<&mut off_t>, /* O - byte offset to beginning of next HDU  */
-    dataend: Option<&mut off_t>,   /* O - byte offset to beginning of next HDU  */
-    status: &mut c_int,            /* IO - error status     */
+    fptr: &mut fitsfile,
+    headstart: Option<&mut off_t>,
+    datastart: Option<&mut off_t>,
+    dataend: Option<&mut off_t>,
+    status: &mut c_int,
 ) -> c_int {
     if *status > 0 {
         return *status;
@@ -5577,16 +6025,23 @@ pub fn ffghof_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Return the address (= byte offset) in the FITS file to the beginning of
 /// the current HDU, the beginning of the data unit, and the end of the data unit.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `headstart` — (O) byte offset to beginning of CHDU
+/// * `datastart` — (O) byte offset to beginning of next HDU
+/// * `dataend`   — (O) byte offset to beginning of next HDU
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffghad(
-    fptr: *mut fitsfile,    /* I - FITS file pointer                     */
-    headstart: *mut c_long, /* O - byte offset to beginning of CHDU      */
-    datastart: *mut c_long, /* O - byte offset to beginning of next HDU  */
-    dataend: *mut c_long,   /* O - byte offset to beginning of next HDU  */
-    status: *mut c_int,     /* IO - error status     */
+    fptr: *mut fitsfile,
+    headstart: *mut c_long,
+    datastart: *mut c_long,
+    dataend: *mut c_long,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -5600,15 +6055,22 @@ pub unsafe extern "C" fn ffghad(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Return the address (= byte offset) in the FITS file to the beginning of
 /// the current HDU, the beginning of the data unit, and the end of the data unit.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `headstart` — (O) byte offset to beginning of CHDU
+/// * `datastart` — (O) byte offset to beginning of next HDU
+/// * `dataend`   — (O) byte offset to beginning of next HDU
+/// * `status`    — (IO) error status
 pub fn ffghad_safe(
-    fptr: &mut fitsfile,            /* I - FITS file pointer                     */
-    headstart: Option<&mut c_long>, /* O - byte offset to beginning of CHDU      */
-    datastart: Option<&mut c_long>, /* O - byte offset to beginning of next HDU  */
-    dataend: Option<&mut c_long>,   /* O - byte offset to beginning of next HDU  */
-    status: &mut c_int,             /* IO - error status     */
+    fptr: &mut fitsfile,
+    headstart: Option<&mut c_long>,
+    datastart: Option<&mut c_long>,
+    dataend: Option<&mut c_long>,
+    status: &mut c_int,
 ) -> c_int {
     if *status > 0 {
         return *status;
@@ -5653,14 +6115,19 @@ pub fn ffghad_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// read the required keywords of the CHDU and initialize the corresponding
 /// structure elements that describe the format of the HDU
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `hdutype` — (O) type of HDU
+/// * `status`  — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffrhdu(
-    fptr: *mut fitsfile, /* I - FITS file pointer */
-    hdutype: *mut c_int, /* O - type of HDU       */
-    status: *mut c_int,  /* IO - error status     */
+    fptr: *mut fitsfile,
+    hdutype: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -5671,14 +6138,15 @@ pub unsafe extern "C" fn ffrhdu(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// read the required keywords of the CHDU and initialize the corresponding
 /// structure elements that describe the format of the HDU
-pub fn ffrhdu_safe(
-    fptr: &mut fitsfile,         /* I - FITS file pointer */
-    hdutype: Option<&mut c_int>, /* O - type of HDU       */
-    status: &mut c_int,          /* IO - error status     */
-) -> c_int {
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `hdutype` — (O) type of HDU
+/// * `status`  — (IO) error status
+pub fn ffrhdu_safe(fptr: &mut fitsfile, hdutype: Option<&mut c_int>, status: &mut c_int) -> c_int {
     let mut tstatus;
     let mut card: [c_char; FLEN_CARD] = [0; FLEN_CARD];
     let mut name: [c_char; FLEN_KEYWORD] = [0; FLEN_KEYWORD];
@@ -5812,13 +6280,14 @@ pub fn ffrhdu_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// initialize the parameters defining the structure of the primary array
 /// or an Image extension
-pub(crate) fn ffpinit(
-    fptr: &mut fitsfile, /* I - FITS file pointer */
-    status: &mut c_int,  /* IO - error status     */
-) -> c_int {
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `status` — (IO) error status
+pub(crate) fn ffpinit(fptr: &mut fitsfile, status: &mut c_int) -> c_int {
     unsafe {
         let mut simple: c_int = 0;
         let mut bitpix: c_int = 0;
@@ -6091,12 +6560,13 @@ pub(crate) fn ffpinit(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// initialize the parameters defining the structure of an ASCII table
-pub(crate) fn ffainit(
-    fptr: &mut fitsfile, /* I - FITS file pointer */
-    status: &mut c_int,  /* IO - error status     */
-) -> c_int {
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `status` — (IO) error status
+pub(crate) fn ffainit(fptr: &mut fitsfile, status: &mut c_int) -> c_int {
     unsafe {
         let mut nspace: c_int;
         let mut tfield: c_long = 0;
@@ -6364,12 +6834,13 @@ pub(crate) fn ffainit(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// initialize the parameters defining the structure of a binary table
-pub(crate) fn ffbinit(
-    fptr: &mut fitsfile, /* I - FITS file pointer */
-    status: &mut c_int,  /* IO - error status     */
-) -> c_int {
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `status` — (IO) error status
+pub(crate) fn ffbinit(fptr: &mut fitsfile, status: &mut c_int) -> c_int {
     unsafe {
         let mut tfield: c_long = 0;
         let mut pcount: LONGLONG = 0;
@@ -6602,18 +7073,26 @@ pub(crate) fn ffbinit(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// calculate the starting byte offset of each column of an ASCII table
 /// and the total length of a row, in bytes.  The input space value determines
 /// how many blank spaces to leave between each column (1 is recommended).
+///
+/// # Parameters
+///
+/// * `tfields` — (I) number of columns in the table
+/// * `tform`   — (I) value of TFORMn keyword for each column
+/// * `space`   — (I) number of spaces to leave between cols
+/// * `rowlen`  — (O) total width of a table row
+/// * `tbcol`   — (O) starting byte in row for each column
+/// * `status`  — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgabc(
-    tfields: c_int,              /* I - number of columns in the table           */
-    tform: *const *const c_char, /* I - value of TFORMn keyword for each column  */
-    space: c_int,                /* I - number of spaces to leave between cols   */
-    rowlen: *mut c_long,         /* O - total width of a table row               */
-    tbcol: *mut c_long,          /* O - starting byte in row for each column     */
-    status: *mut c_int,          /* IO - error status                            */
+    tfields: c_int,
+    tform: *const *const c_char,
+    space: c_int,
+    rowlen: *mut c_long,
+    tbcol: *mut c_long,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -6634,17 +7113,25 @@ pub unsafe extern "C" fn ffgabc(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// calculate the starting byte offset of each column of an ASCII table
 /// and the total length of a row, in bytes.  The input space value determines
 /// how many blank spaces to leave between each column (1 is recommended).
+///
+/// # Parameters
+///
+/// * `tfields` — (I) number of columns in the table
+/// * `tform`   — (I) value of TFORMn keyword for each column
+/// * `space`   — (I) number of spaces to leave between cols
+/// * `rowlen`  — (O) total width of a table row
+/// * `tbcol`   — (O) starting byte in row for each column
+/// * `status`  — (IO) error status
 pub fn ffgabc_safe(
-    tfields: c_int,       /* I - number of columns in the table           */
-    tform: &[&[c_char]],  /* I - value of TFORMn keyword for each column  */
-    space: c_int,         /* I - number of spaces to leave between cols   */
-    rowlen: &mut c_long,  /* O - total width of a table row               */
-    tbcol: &mut [c_long], /* O - starting byte in row for each column     */
-    status: &mut c_int,   /* IO - error status                            */
+    tfields: c_int,
+    tform: &[&[c_char]],
+    space: c_int,
+    rowlen: &mut c_long,
+    tbcol: &mut [c_long],
+    status: &mut c_int,
 ) -> c_int {
     let mut datacode = 0;
     let mut decims = 0;
@@ -6680,15 +7167,16 @@ pub fn ffgabc_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// calculate the starting byte offset of each column of a binary table.
 /// Use the values of the datatype code and repeat counts in the
 /// column structure. Return the total length of a row, in bytes.
-pub(crate) fn ffgtbc(
-    fptr: &mut fitsfile,       /* I - FITS file pointer          */
-    totalwidth: &mut LONGLONG, /* O - total width of a table row */
-    status: &mut c_int,        /* IO - error status              */
-) -> c_int {
+///
+/// # Parameters
+///
+/// * `fptr`       — (I) FITS file pointer
+/// * `totalwidth` — (O) total width of a table row
+/// * `status`     — (IO) error status
+pub(crate) fn ffgtbc(fptr: &mut fitsfile, totalwidth: &mut LONGLONG, status: &mut c_int) -> c_int {
     let mut nbytes: LONGLONG;
     let mut message: [c_char; FLEN_ERRMSG] = [0; FLEN_ERRMSG];
 
@@ -6754,16 +7242,22 @@ pub(crate) fn ffgtbc(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Get TaBle Parameter.  The input keyword name begins with the letter T.
 /// Test if the keyword is one of the table column definition keywords
 /// of an ASCII or binary table. If so, decode it and update the value
 /// in the structure.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `name`   — (I) name of the keyword
+/// * `value`  — (I) value string of the keyword
+/// * `status` — (IO) error status
 pub(crate) fn ffgtbp(
-    fptr: &mut fitsfile, /* I - FITS file pointer   */
-    name: &[c_char],     /* I - name of the keyword */
-    value: &[c_char],    /* I - value string of the keyword */
-    status: &mut c_int,  /* IO - error status       */
+    fptr: &mut fitsfile,
+    name: &[c_char],
+    value: &[c_char],
+    status: &mut c_int,
 ) -> c_int {
     let mut tstatus: c_int;
     let mut datacode: c_int = 0;
@@ -7076,38 +7570,61 @@ pub(crate) fn ffgtbp(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Get Column PaRameters, and test starting row and element numbers for
 /// validity.  This is a workhorse routine that is call by nearly every
 /// other routine that reads or writes to FITS files.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) column number (1 = 1st column of table)
+/// * `firstrow`  — (I) first row (1 = 1st row of table)
+/// * `firstelem` — (I) first element within vector (1 = 1st)
+/// * `nelem`     — (I) number of elements to read or write
+/// * `writemode` — (I) = 1 if writing data, = 0 if reading data
+/// * `scale`     — (O) FITS scaling factor (TSCALn keyword value)
+/// * `zero`      — (O) FITS scaling zero pt (TZEROn keyword value)
+/// * `tform`     — (O) ASCII column format: value of TFORMn keyword
+/// * `twidth`    — (O) width of ASCII column (characters)
+/// * `tcode`     — (O) abs(column datatype code): I*4=41, R*4=42, etc
+/// * `maxelem`   — (O) max number of elements that fit in buffer
+/// * `startpos`  — (O) offset in file to starting row & column
+/// * `elemnum`   — (O) starting element number ( 0 = 1st element)
+/// * `incre`     — (O) byte offset between elements within a row
+/// * `repeat`    — (O) number of elements in a row (vector column)
+/// * `rowlen`    — (O) length of a row, in bytes
+/// * `hdutype`   — (O) HDU type: 0, 1, 2 = primary, table, bintable
+/// * `tnull`     — (O) null value for integer columns
+/// * `snull`     — (O) null value for ASCII table columns
+/// * `status`    — (IO) error status
 pub(crate) fn ffgcprll(
-    fptr: &mut fitsfile, /* I - FITS file pointer                      */
-    colnum: c_int,       /* I - column number (1 = 1st column of table)      */
-    firstrow: LONGLONG,  /* I - first row (1 = 1st row of table)         */
-    firstelem: LONGLONG, /* I - first element within vector (1 = 1st)    */
-    nelem: LONGLONG,     /* I - number of elements to read or write          */
-    writemode: c_int,    /* I - = 1 if writing data, = 0 if reading data     */
+    fptr: &mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    writemode: c_int,
     /*     If = 2, then writing data, but don't modify  */
     /*     the returned values of repeat and incre.     */
     /*     If = -1, then reading data in reverse        */
     /*     direction.                                   */
     /*     If writemode has 16 added, then treat        */
     /*        TSTRING column as TBYTE vector            */
-    scale: &mut f64,         /* O - FITS scaling factor (TSCALn keyword value)   */
-    zero: &mut f64,          /* O - FITS scaling zero pt (TZEROn keyword value)  */
-    tform: &mut [c_char],    /* O - ASCII column format: value of TFORMn keyword */
-    twidth: &mut c_long,     /* O - width of ASCII column (characters)           */
-    tcode: &mut c_int,       /* O - abs(column datatype code): I*4=41, R*4=42, etc */
-    maxelem: &mut c_int,     /* O - max number of elements that fit in buffer    */
-    startpos: &mut LONGLONG, /* O - offset in file to starting row & column      */
-    elemnum: &mut LONGLONG,  /* O - starting element number ( 0 = 1st element)   */
-    incre: &mut c_long,      /* O - byte offset between elements within a row    */
-    repeat: &mut LONGLONG,   /* O - number of elements in a row (vector column)  */
-    rowlen: &mut LONGLONG,   /* O - length of a row, in bytes                    */
-    hdutype: &mut c_int,     /* O - HDU type: 0, 1, 2 = primary, table, bintable */
-    tnull: &mut LONGLONG,    /* O - null value for integer columns               */
-    snull: &mut [c_char],    /* O - null value for ASCII table columns           */
-    status: &mut c_int,      /* IO - error status                                */
+    scale: &mut f64,
+    zero: &mut f64,
+    tform: &mut [c_char],
+    twidth: &mut c_long,
+    tcode: &mut c_int,
+    maxelem: &mut c_int,
+    startpos: &mut LONGLONG,
+    elemnum: &mut LONGLONG,
+    incre: &mut c_long,
+    repeat: &mut LONGLONG,
+    rowlen: &mut LONGLONG,
+    hdutype: &mut c_int,
+    tnull: &mut LONGLONG,
+    snull: &mut [c_char],
+    status: &mut c_int,
 ) -> c_int {
     let mut writemode = writemode;
 
@@ -7683,7 +8200,6 @@ pub(crate) fn ffgcprll(
     *status
 }
 
-/*---------------------------------------------------------------------------*/
 /// Tests the contents of the binary table variable length array heap.
 ///
 /// Returns the number of bytes that are currently not pointed to by any
@@ -7691,14 +8207,23 @@ pub(crate) fn ffgcprll(
 /// by more than one descriptor.  It returns valid = FALSE if any of the
 /// descriptors point to addresses that are out of the bounds of the
 /// heap.
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `heapsz`  — (O) current size of the heap
+/// * `unused`  — (O) no. of unused bytes in the heap
+/// * `overlap` — (O) no. of bytes shared by > 1 descriptors
+/// * `valid`   — (O) are all the heap addresses valid?
+/// * `status`  — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn fftheap(
-    fptr: *mut fitsfile,    /* I - FITS file pointer                         */
-    heapsz: *mut LONGLONG,  /* O - current size of the heap               */
-    unused: *mut LONGLONG,  /* O - no. of unused bytes in the heap        */
-    overlap: *mut LONGLONG, /* O - no. of bytes shared by > 1 descriptors */
-    valid: *mut c_int,      /* O - are all the heap addresses valid?         */
-    status: *mut c_int,     /* IO - error status                             */
+    fptr: *mut fitsfile,
+    heapsz: *mut LONGLONG,
+    unused: *mut LONGLONG,
+    overlap: *mut LONGLONG,
+    valid: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -7714,7 +8239,6 @@ pub unsafe extern "C" fn fftheap(
     }
 }
 
-/*---------------------------------------------------------------------------*/
 /// Tests the contents of the binary table variable length array heap.
 ///
 /// Returns the number of bytes that are currently not pointed to by any
@@ -7722,13 +8246,22 @@ pub unsafe extern "C" fn fftheap(
 /// by more than one descriptor.  It returns valid = FALSE if any of the
 /// descriptors point to addresses that are out of the bounds of the
 /// heap.
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `heapsz`  — (O) current size of the heap
+/// * `unused`  — (O) no. of unused bytes in the heap
+/// * `overlap` — (O) no. of bytes shared by > 1 descriptors
+/// * `valid`   — (O) are all the heap addresses valid?
+/// * `status`  — (IO) error status
 pub fn fftheap_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                         */
-    mut heapsz: Option<&mut LONGLONG>, /* O - current size of the heap               */
-    mut unused: Option<&mut LONGLONG>, /* O - no. of unused bytes in the heap        */
-    mut overlap: Option<&mut LONGLONG>, /* O - no. of bytes shared by > 1 descriptors */
-    mut valid: Option<&mut c_int>, /* O - are all the heap addresses valid?         */
-    status: &mut c_int,  /* IO - error status                             */
+    fptr: &mut fitsfile,
+    mut heapsz: Option<&mut LONGLONG>,
+    mut unused: Option<&mut LONGLONG>,
+    mut overlap: Option<&mut LONGLONG>,
+    mut valid: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     let mut typecode = 0;
     let mut pixsize;
@@ -7865,14 +8398,15 @@ pub fn fftheap_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// compress the binary table heap by reordering the contents heap and
 /// recovering any unused space
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
-pub unsafe extern "C" fn ffcmph(
-    fptr: *mut fitsfile, /* I -FITS file pointer                         */
-    status: *mut c_int,  /* IO - error status                            */
-) -> c_int {
+pub unsafe extern "C" fn ffcmph(fptr: *mut fitsfile, status: *mut c_int) -> c_int {
     // FFI WRAPPER
     unsafe {
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -7882,13 +8416,14 @@ pub unsafe extern "C" fn ffcmph(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// compress the binary table heap by reordering the contents heap and
 /// recovering any unused space
-pub fn ffcmph_safe(
-    fptr: &mut fitsfile, /* I -FITS file pointer                         */
-    status: &mut c_int,  /* IO - error status                            */
-) -> c_int {
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `status` — (IO) error status
+pub fn ffcmph_safe(fptr: &mut fitsfile, status: &mut c_int) -> c_int {
     let mut typecode = 0;
     let mut pixsize;
     let mut valid = 0;
@@ -8120,16 +8655,24 @@ pub fn ffcmph_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// get (read) the variable length vector descriptor from the table.
+///
+/// # Parameters
+///
+/// * `fptr`     — (I) FITS file pointer
+/// * `colnum`   — (I) column number (1 = 1st column of table)
+/// * `rownum`   — (I) row number (1 = 1st row of table)
+/// * `length`   — (O) number of elements in the row
+/// * `heapaddr` — (O) heap pointer to the data
+/// * `status`   — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgdes(
-    fptr: *mut fitsfile,   /* I - FITS file pointer                         */
-    colnum: c_int,         /* I - column number (1 = 1st column of table)   */
-    rownum: LONGLONG,      /* I - row number (1 = 1st row of table)         */
-    length: *mut c_long,   /* O - number of elements in the row             */
-    heapaddr: *mut c_long, /* O - heap pointer to the data                  */
-    status: *mut c_int,    /* IO - error status                             */
+    fptr: *mut fitsfile,
+    colnum: c_int,
+    rownum: LONGLONG,
+    length: *mut c_long,
+    heapaddr: *mut c_long,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -8142,15 +8685,23 @@ pub unsafe extern "C" fn ffgdes(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// get (read) the variable length vector descriptor from the table.
+///
+/// # Parameters
+///
+/// * `fptr`     — (I) FITS file pointer
+/// * `colnum`   — (I) column number (1 = 1st column of table)
+/// * `rownum`   — (I) row number (1 = 1st row of table)
+/// * `length`   — (O) number of elements in the row
+/// * `heapaddr` — (O) heap pointer to the data
+/// * `status`   — (IO) error status
 pub fn ffgdes_safe(
-    fptr: &mut fitsfile,           /* I - FITS file pointer                         */
-    colnum: c_int,                 /* I - column number (1 = 1st column of table)   */
-    rownum: LONGLONG,              /* I - row number (1 = 1st row of table)         */
-    length: Option<&mut c_long>,   /* O - number of elements in the row             */
-    heapaddr: Option<&mut c_long>, /* O - heap pointer to the data                  */
-    status: &mut c_int,            /* IO - error status                             */
+    fptr: &mut fitsfile,
+    colnum: c_int,
+    rownum: LONGLONG,
+    length: Option<&mut c_long>,
+    heapaddr: Option<&mut c_long>,
+    status: &mut c_int,
 ) -> c_int {
     let mut lengthjj: LONGLONG = 0; /* convert the temporary 8-byte values to 4-byte values */
     let mut heapaddrjj: LONGLONG = 0; /* check for overflow */
@@ -8187,19 +8738,27 @@ pub fn ffgdes_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// get (read) the variable length vector descriptor from the binary table.
 ///
 /// This is similar to ffgdes, except it supports the full 8-byte range of the
 /// length and offset values in 'Q' columns, as well as 'P' columns.
+///
+/// # Parameters
+///
+/// * `fptr`     — (I) FITS file pointer
+/// * `colnum`   — (I) column number (1 = 1st column of table)
+/// * `rownum`   — (I) row number (1 = 1st row of table)
+/// * `length`   — (O) number of elements in the row
+/// * `heapaddr` — (O) heap pointer to the data
+/// * `status`   — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgdesll(
-    fptr: *mut fitsfile,     /* I - FITS file pointer                       */
-    colnum: c_int,           /* I - column number (1 = 1st column of table) */
-    rownum: LONGLONG,        /* I - row number (1 = 1st row of table)       */
-    length: *mut LONGLONG,   /* O - number of elements in the row           */
-    heapaddr: *mut LONGLONG, /* O - heap pointer to the data                */
-    status: *mut c_int,      /* IO - error status                           */
+    fptr: *mut fitsfile,
+    colnum: c_int,
+    rownum: LONGLONG,
+    length: *mut LONGLONG,
+    heapaddr: *mut LONGLONG,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -8212,18 +8771,26 @@ pub unsafe extern "C" fn ffgdesll(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// get (read) the variable length vector descriptor from the binary table.
 ///
 /// This is similar to ffgdes, except it supports the full 8-byte range of the
 /// length and offset values in 'Q' columns, as well as 'P' columns.
+///
+/// # Parameters
+///
+/// * `fptr`     — (I) FITS file pointer
+/// * `colnum`   — (I) column number (1 = 1st column of table)
+/// * `rownum`   — (I) row number (1 = 1st row of table)
+/// * `length`   — (O) number of elements in the row
+/// * `heapaddr` — (O) heap pointer to the data
+/// * `status`   — (IO) error status
 pub fn ffgdesll_safe(
-    fptr: &mut fitsfile,             /* I - FITS file pointer                       */
-    colnum: c_int,                   /* I - column number (1 = 1st column of table) */
-    rownum: LONGLONG,                /* I - row number (1 = 1st row of table)       */
-    length: Option<&mut LONGLONG>,   /* O - number of elements in the row           */
-    heapaddr: Option<&mut LONGLONG>, /* O - heap pointer to the data                */
-    status: &mut c_int,              /* IO - error status                           */
+    fptr: &mut fitsfile,
+    colnum: c_int,
+    rownum: LONGLONG,
+    length: Option<&mut LONGLONG>,
+    heapaddr: Option<&mut LONGLONG>,
+    status: &mut c_int,
 ) -> c_int {
     let mut descript4: [c_uint; 2] = [0, 0];
     let mut descript8: [LONGLONG; 2] = [0, 0];
@@ -8275,17 +8842,26 @@ pub fn ffgdesll_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 ///  get (read) a range of variable length vector descriptors from the table.
+///
+/// # Parameters
+///
+/// * `fptr`     — (I) FITS file pointer
+/// * `colnum`   — (I) column number (1 = 1st column of table)
+/// * `firstrow` — (I) first row (1 = 1st row of table)
+/// * `nrows`    — (I) number or rows to read
+/// * `length`   — (O) number of elements in the row
+/// * `heapaddr` — (O) heap pointer to the data
+/// * `status`   — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgdess(
-    fptr: *mut fitsfile,   /* I - FITS file pointer                        */
-    colnum: c_int,         /* I - column number (1 = 1st column of table)   */
-    firstrow: LONGLONG,    /* I - first row  (1 = 1st row of table)         */
-    nrows: LONGLONG,       /* I - number or rows to read                    */
-    length: *mut c_long,   /* O - number of elements in the row             */
-    heapaddr: *mut c_long, /* O - heap pointer to the data                  */
-    status: *mut c_int,    /* IO - error status                             */
+    fptr: *mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    nrows: LONGLONG,
+    length: *mut c_long,
+    heapaddr: *mut c_long,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -8306,16 +8882,25 @@ pub unsafe extern "C" fn ffgdess(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 ///  get (read) a range of variable length vector descriptors from the table.
+///
+/// # Parameters
+///
+/// * `fptr`     — (I) FITS file pointer
+/// * `colnum`   — (I) column number (1 = 1st column of table)
+/// * `firstrow` — (I) first row (1 = 1st row of table)
+/// * `nrows`    — (I) number or rows to read
+/// * `length`   — (O) number of elements in the row
+/// * `heapaddr` — (O) heap pointer to the data
+/// * `status`   — (IO) error status
 pub fn ffgdess_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                        */
-    colnum: c_int,       /* I - column number (1 = 1st column of table)   */
-    firstrow: LONGLONG,  /* I - first row  (1 = 1st row of table)         */
-    nrows: LONGLONG,     /* I - number or rows to read                    */
-    mut length: Option<&mut [c_long]>, /* O - number of elements in the row             */
-    mut heapaddr: Option<&mut [c_long]>, /* O - heap pointer to the data                  */
-    status: &mut c_int,  /* IO - error status                             */
+    fptr: &mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    nrows: LONGLONG,
+    mut length: Option<&mut [c_long]>,
+    mut heapaddr: Option<&mut [c_long]>,
+    status: &mut c_int,
 ) -> c_int {
     let mut ii: c_long;
     let mut descript4: [INT32BIT; 2] = [0, 0];
@@ -8409,17 +8994,26 @@ pub fn ffgdess_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// get (read) a range of variable length vector descriptors from the table.
+///
+/// # Parameters
+///
+/// * `fptr`     — (I) FITS file pointer
+/// * `colnum`   — (I) column number (1 = 1st column of table)
+/// * `firstrow` — (I) first row (1 = 1st row of table)
+/// * `nrows`    — (I) number or rows to read
+/// * `length`   — (O) number of elements in the row
+/// * `heapaddr` — (O) heap pointer to the data
+/// * `status`   — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgdessll(
-    fptr: *mut fitsfile,     /* I - FITS file pointer                      */
-    colnum: c_int,           /* I - column number (1 = 1st column of table)   */
-    firstrow: LONGLONG,      /* I - first row  (1 = 1st row of table)         */
-    nrows: LONGLONG,         /* I - number or rows to read                    */
-    length: *mut LONGLONG,   /* O - number of elements in the row         */
-    heapaddr: *mut LONGLONG, /* O - heap pointer to the data              */
-    status: *mut c_int,      /* IO - error status                             */
+    fptr: *mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    nrows: LONGLONG,
+    length: *mut LONGLONG,
+    heapaddr: *mut LONGLONG,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -8444,6 +9038,18 @@ pub unsafe extern "C" fn ffgdessll(
     }
 }
 
+/// Get the descriptors -- element count and heap offset -- for a range of rows
+/// of a variable length array column, as 64-bit values.
+///
+/// # Parameters
+///
+/// * `fptr`     — (I) FITS file pointer
+/// * `colnum`   — (I) column number, the first column is 1
+/// * `firstrow` — (I) first row, the first row is 1
+/// * `nrows`    — (I) number of rows to read
+/// * `length`   — (O) number of elements in each row's array
+/// * `heapaddr` — (O) heap offset of each row's array
+/// * `status`   — (IO) error status
 pub fn ffgdessll_safe(
     fptr: &mut fitsfile,
     colnum: c_int,
@@ -8537,16 +9143,24 @@ pub fn ffgdessll_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 ///  put (write) the variable length vector descriptor to the table.
+///
+/// # Parameters
+///
+/// * `fptr`     — (I) FITS file pointer
+/// * `colnum`   — (I) column number (1 = 1st column of table)
+/// * `rownum`   — (I) row number (1 = 1st row of table)
+/// * `length`   — (I) number of elements in the row
+/// * `heapaddr` — (I) heap pointer to the data
+/// * `status`   — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffpdes(
-    fptr: *mut fitsfile, /* I - FITS file pointer                         */
-    colnum: c_int,       /* I - column number (1 = 1st column of table)   */
-    rownum: LONGLONG,    /* I - row number (1 = 1st row of table)         */
-    length: LONGLONG,    /* I - number of elements in the row             */
-    heapaddr: LONGLONG,  /* I - heap pointer to the data                  */
-    status: *mut c_int,  /* IO - error status                             */
+    fptr: *mut fitsfile,
+    colnum: c_int,
+    rownum: LONGLONG,
+    length: LONGLONG,
+    heapaddr: LONGLONG,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -8557,15 +9171,23 @@ pub unsafe extern "C" fn ffpdes(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 ///  put (write) the variable length vector descriptor to the table.
+///
+/// # Parameters
+///
+/// * `fptr`     — (I) FITS file pointer
+/// * `colnum`   — (I) column number (1 = 1st column of table)
+/// * `rownum`   — (I) row number (1 = 1st row of table)
+/// * `length`   — (I) number of elements in the row
+/// * `heapaddr` — (I) heap pointer to the data
+/// * `status`   — (IO) error status
 pub fn ffpdes_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                         */
-    colnum: c_int,       /* I - column number (1 = 1st column of table)   */
-    rownum: LONGLONG,    /* I - row number (1 = 1st row of table)         */
-    length: LONGLONG,    /* I - number of elements in the row             */
-    heapaddr: LONGLONG,  /* I - heap pointer to the data                  */
-    status: &mut c_int,  /* IO - error status                             */
+    fptr: &mut fitsfile,
+    colnum: c_int,
+    rownum: LONGLONG,
+    length: LONGLONG,
+    heapaddr: LONGLONG,
+    status: &mut c_int,
 ) -> c_int {
     let mut descript4: [c_uint; 2] = [0; 2];
     let mut descript8: [LONGLONG; 2] = [0; 2];
@@ -8624,14 +9246,15 @@ pub fn ffpdes_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// close the current HDU.  If we have write access to the file, then:
 /// - write the END keyword and pad header with blanks if necessary
 /// - check the data fill values, and rewrite them if not correct
-pub(crate) fn ffchdu(
-    fptr: &mut fitsfile, /* I - FITS file pointer */
-    status: &mut c_int,  /* IO - error status     */
-) -> c_int {
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `status` — (IO) error status
+pub(crate) fn ffchdu(fptr: &mut fitsfile, status: &mut c_int) -> c_int {
     let mut message: [c_char; FLEN_ERRMSG] = [0; FLEN_ERRMSG];
     let mut stdriver = -1; // -1 so that if stream driver not found, it doesn't default
 
@@ -8703,14 +9326,15 @@ pub(crate) fn ffchdu(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Update the value of the TFORM keywords for the variable length array
 /// columns to make sure they all have the form 1Px(len) or Px(len) where
 /// 'len' is the maximum length of the vector in the table (e.g., '1PE(400)')
-pub(crate) fn ffuptf(
-    fptr: &mut fitsfile, /* I - FITS file pointer */
-    status: &mut c_int,  /* IO - error status     */
-) -> c_int {
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `status` — (IO) error status
+pub(crate) fn ffuptf(fptr: &mut fitsfile, status: &mut c_int) -> c_int {
     let mut tflds: c_long = 0;
     let mut length: LONGLONG = 0;
     let mut addr: LONGLONG = 0;
@@ -8812,15 +9436,16 @@ pub(crate) fn ffuptf(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// ReDEFine the structure of a data unit.  This routine re-reads
 /// the CHDU header keywords to determine the structure and length of the
 /// current data unit.  This redefines the start of the next HDU.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
-pub unsafe extern "C" fn ffrdef(
-    fptr: *mut fitsfile, /* I - FITS file pointer */
-    status: *mut c_int,  /* IO - error status     */
-) -> c_int {
+pub unsafe extern "C" fn ffrdef(fptr: *mut fitsfile, status: *mut c_int) -> c_int {
     // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
@@ -8830,14 +9455,15 @@ pub unsafe extern "C" fn ffrdef(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// ReDEFine the structure of a data unit.  This routine re-reads
 /// the CHDU header keywords to determine the structure and length of the
 /// current data unit.  This redefines the start of the next HDU.
-pub fn ffrdef_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer */
-    status: &mut c_int,  /* IO - error status     */
-) -> c_int {
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `status` — (IO) error status
+pub fn ffrdef_safe(fptr: &mut fitsfile, status: &mut c_int) -> c_int {
     let mut dummy: c_int = 0;
     let mut tstatus = 0;
     let mut naxis2: LONGLONG = 0;
@@ -8920,7 +9546,6 @@ pub fn ffrdef_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// based on the number of keywords which have already been written,
 /// plus the number of keywords to reserve space for, we then can
 /// define where the data unit should start (it must start at the
@@ -8931,12 +9556,14 @@ pub fn ffrdef_safe(
 /// it is always possible to add more keywords to the header even if the
 /// data has already been written.  It is just more efficient to reserve
 /// the space in advance.
+///
+/// # Parameters
+///
+/// * `fptr`     — (I) FITS file pointer
+/// * `morekeys` — (I) reserve space for this many keywords
+/// * `status`   — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
-pub unsafe extern "C" fn ffhdef(
-    fptr: *mut fitsfile, /* I - FITS file pointer                    */
-    morekeys: c_int,     /* I - reserve space for this many keywords */
-    status: *mut c_int,  /* IO - error status                        */
-) -> c_int {
+pub unsafe extern "C" fn ffhdef(fptr: *mut fitsfile, morekeys: c_int, status: *mut c_int) -> c_int {
     // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
@@ -8946,7 +9573,6 @@ pub unsafe extern "C" fn ffhdef(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// based on the number of keywords which have already been written,
 /// plus the number of keywords to reserve space for, we then can
 /// define where the data unit should start (it must start at the
@@ -8957,11 +9583,13 @@ pub unsafe extern "C" fn ffhdef(
 /// it is always possible to add more keywords to the header even if the
 /// data has already been written.  It is just more efficient to reserve
 /// the space in advance.
-pub fn ffhdef_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                    */
-    morekeys: c_int,     /* I - reserve space for this many keywords */
-    status: &mut c_int,  /* IO - error status                        */
-) -> c_int {
+///
+/// # Parameters
+///
+/// * `fptr`     — (I) FITS file pointer
+/// * `morekeys` — (I) reserve space for this many keywords
+/// * `status`   — (IO) error status
+pub fn ffhdef_safe(fptr: &mut fitsfile, morekeys: c_int, status: &mut c_int) -> c_int {
     let delta: LONGLONG;
 
     if *status > 0 || morekeys < 1 {
@@ -8990,12 +9618,13 @@ pub fn ffhdef_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// write the END card and following fill (space chars) in the current header
-pub(crate) fn ffwend(
-    fptr: &mut fitsfile, /* I - FITS file pointer */
-    status: &mut c_int,  /* IO - error status     */
-) -> c_int {
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `status` — (IO) error status
+pub(crate) fn ffwend(fptr: &mut fitsfile, status: &mut c_int) -> c_int {
     let mut blankkey: [c_char; FLEN_CARD] = [0; FLEN_CARD];
     let mut endkey: [c_char; FLEN_CARD] = [0; FLEN_CARD];
     let mut keyrec: [c_char; FLEN_CARD] = [0; FLEN_CARD];
@@ -9089,15 +9718,16 @@ pub(crate) fn ffwend(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write the Data Unit Fill values if they are not already correct.
 /// The fill values are used to fill out the last 2880 byte block of the HDU.
 /// Fill the data unit with zeros or blanks depending on the type of HDU
 /// from the end of the data to the end of the current FITS 2880 byte block
-pub(crate) fn ffpdfl(
-    fptr: &mut fitsfile, /* I - FITS file pointer */
-    status: &mut c_int,  /* IO - error status     */
-) -> c_int {
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `status` — (IO) error status
+pub(crate) fn ffpdfl(fptr: &mut fitsfile, status: &mut c_int) -> c_int {
     let chfill: u8;
     let mut fill: [u8; IOBUFLEN as usize] = [0; IOBUFLEN as usize];
     let mut fillstart: LONGLONG;
@@ -9178,18 +9808,17 @@ pub(crate) fn ffpdfl(
     *status
 }
 
-/**********************************************************************
-   ffchfl : Check Header Fill values
-
-      Check that the header unit is correctly filled with blanks from
-      the END card to the end of the current FITS 2880-byte block
-
-         Function parameters:
-            fptr     Fits file pointer
-            status   output error status
-
-    Translated ftchfl into C by Peter Wilson, Oct. 1997
-**********************************************************************/
+/// Check the header fill values.
+///
+/// Checks that the header unit is correctly filled with blanks from the END
+/// card to the end of the current FITS 2880-byte block.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `status` — (O) error status
+///
+/// Translated from `ftchfl` into C by Peter Wilson, Oct. 1997.
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffchfl(fptr: *mut fitsfile, status: *mut c_int) -> c_int {
     if fptr.is_null() || status.is_null() {
@@ -9199,6 +9828,15 @@ pub unsafe extern "C" fn ffchfl(fptr: *mut fitsfile, status: *mut c_int) -> c_in
     unsafe { ffchfl_safe(&mut *fptr, &mut *status) }
 }
 
+/// Check the header fill values.
+///
+/// Checks that the header unit is correctly filled with blanks from the END
+/// card to the end of the current FITS 2880-byte block.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `status` — (O) error status
 pub fn ffchfl_safe(fptr: &mut fitsfile, status: &mut c_int) -> c_int {
     let mut rec: [c_char; FLEN_CARD] = [0; FLEN_CARD];
     let blanks = [bb(b' '); 80]; /*  80 spaces  */
@@ -9252,19 +9890,17 @@ pub fn ffchfl_safe(fptr: &mut fitsfile, status: &mut c_int) -> c_int {
     *status
 }
 
-/**********************************************************************
-   ffcdfl : Check Data Unit Fill values
-
-      Check that the data unit is correctly filled with zeros or
-      blanks from the end of the data to the end of the current
-      FITS 2880 byte block
-
-         Function parameters:
-            fptr     Fits file pointer
-            status   output error status
-
-    Translated ftcdfl into C by Peter Wilson, Oct. 1997
-**********************************************************************/
+/// Check the data unit fill values.
+///
+/// Checks that the data unit is correctly filled with zeros or blanks from the
+/// end of the data to the end of the current FITS 2880-byte block.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `status` — (O) error status
+///
+/// Translated from `ftcdfl` into C by Peter Wilson, Oct. 1997.
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffcdfl(fptr: *mut fitsfile, status: *mut c_int) -> c_int {
     // FFI WRAPPER
@@ -9276,6 +9912,15 @@ pub unsafe extern "C" fn ffcdfl(fptr: *mut fitsfile, status: *mut c_int) -> c_in
     }
 }
 
+/// Check the data unit fill values.
+///
+/// Checks that the data unit is correctly filled with zeros or blanks from the
+/// end of the data to the end of the current FITS 2880-byte block.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `status` — (O) error status
 pub fn ffcdfl_safe(fptr: &mut fitsfile, status: &mut c_int) -> c_int {
     let mut chbuff: [c_char; BL!()] = [0; BL!()];
 
@@ -9335,7 +9980,6 @@ pub fn ffcdfl_safe(fptr: &mut fitsfile, status: &mut c_int) -> c_int {
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Grow the headstart array by 1000 entries.
 ///
 /// `headstart` is a raw pointer owned by `FITSfile`, so growing it means
@@ -9380,14 +10024,15 @@ fn grow_headstart(fptr: &mut fitsfile) -> Result<(), c_int> {
     Ok(())
 }
 
-/*--------------------------------------------------------------------------*/
 /// Create Header Data unit:  Create, initialize, and move the i/o pointer
 /// to a new extension appended to the end of the FITS file.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
-pub unsafe extern "C" fn ffcrhd(
-    fptr: *mut fitsfile, /* I - FITS file pointer */
-    status: *mut c_int,  /* IO - error status     */
-) -> c_int {
+pub unsafe extern "C" fn ffcrhd(fptr: *mut fitsfile, status: *mut c_int) -> c_int {
     // FFI WRAPPER
     unsafe {
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -9397,13 +10042,14 @@ pub unsafe extern "C" fn ffcrhd(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Create Header Data unit:  Create, initialize, and move the i/o pointer
 /// to a new extension appended to the end of the FITS file.
-pub fn ffcrhd_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer */
-    status: &mut c_int,  /* IO - error status     */
-) -> c_int {
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `status` — (IO) error status
+pub fn ffcrhd_safe(fptr: &mut fitsfile, status: &mut c_int) -> c_int {
     let mut tstatus: c_int = 0;
     let bytepos: LONGLONG;
 
@@ -9455,15 +10101,16 @@ pub fn ffcrhd_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Delete the specified number of 2880-byte blocks from the end
 /// of the CHDU by shifting all following extensions up this
 /// number of blocks.
-pub(crate) fn ffdblk(
-    fptr: &mut fitsfile, /* I - FITS file pointer                    */
-    nblocks: c_long,     /* I - number of 2880-byte blocks to delete */
-    status: &mut c_int,  /* IO - error status                        */
-) -> c_int {
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `nblocks` — (I) number of 2880-byte blocks to delete
+/// * `status`  — (IO) error status
+pub(crate) fn ffdblk(fptr: &mut fitsfile, nblocks: c_long, status: &mut c_int) -> c_int {
     let mut buffer: [c_char; BL!()] = [0; BL!()];
 
     if *status > 0 || nblocks <= 0 {
@@ -9525,17 +10172,22 @@ pub(crate) fn ffdblk(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Return the type of the CHDU. This returns the 'logical' type of the HDU,
 /// not necessarily the physical type, so in the case of a compressed image
 /// stored in a binary table, this will return the type as an Image, not a
 /// binary table.
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `exttype` — (O) type of extension, 0, 1, or 2
+/// * `status`  — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffghdt(
-    fptr: *mut fitsfile, /* I - FITS file pointer             */
-    exttype: *mut c_int, /* O - type of extension, 0, 1, or 2 */
+    fptr: *mut fitsfile,
+    exttype: *mut c_int,
     /*  for IMAGE_HDU, ASCII_TBL, or BINARY_TBL */
-    status: *mut c_int, /* IO - error status                 */
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -9547,16 +10199,21 @@ pub unsafe extern "C" fn ffghdt(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Return the type of the CHDU. This returns the 'logical' type of the HDU,
 /// not necessarily the physical type, so in the case of a compressed image
 /// stored in a binary table, this will return the type as an Image, not a
 /// binary table.
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `exttype` — (O) type of extension, 0, 1, or 2
+/// * `status`  — (IO) error status
 pub fn ffghdt_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer             */
-    exttype: &mut c_int, /* O - type of extension, 0, 1, or 2 */
+    fptr: &mut fitsfile,
+    exttype: &mut c_int,
     /*  for IMAGE_HDU, ASCII_TBL, or BINARY_TBL */
-    status: &mut c_int, /* IO - error status                 */
+    status: &mut c_int,
 ) -> c_int {
     if *status > 0 {
         return *status;
@@ -9586,7 +10243,6 @@ pub fn ffghdt_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Was CFITSIO compiled with the -D_REENTRANT flag?  1 = yes, 0 = no.
 ///
 /// Note that specifying the -D_REENTRANT flag is required, but may not be
@@ -9598,6 +10254,12 @@ pub unsafe extern "C" fn fits_is_reentrant() -> c_int {
     fits_is_reentrant_safe()
 }
 
+/// Whether this build of the library is reentrant.
+///
+/// # Returns
+///
+/// Always 1: unlike the C, which compiles the thread-safe paths only under
+/// `-D_REENTRANT`, this port is always built that way.
 pub fn fits_is_reentrant_safe() -> c_int {
     /*
     #ifdef _REENTRANT
@@ -9610,12 +10272,16 @@ pub fn fits_is_reentrant_safe() -> c_int {
     1
 }
 
-/*--------------------------------------------------------------------------*/
 /// Returns TRUE if the CHDU is a compressed image, else returns zero.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn fits_is_compressed_image(
-    fptr: *mut fitsfile, /* I - FITS file pointer  */
-    status: *mut c_int,  /* IO - error status      */
+    fptr: *mut fitsfile,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -9626,7 +10292,6 @@ pub unsafe extern "C" fn fits_is_compressed_image(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Returns TRUE if the CHDU is a compressed image, else returns zero.
 pub fn fits_is_compressed_image_safe(fptr: &mut fitsfile, status: &mut c_int) -> c_int {
     if *status > 0 {
@@ -9646,16 +10311,24 @@ pub fn fits_is_compressed_image_safe(fptr: &mut fitsfile, status: &mut c_int) ->
     0
 }
 
-/*--------------------------------------------------------------------------*/
 /// get the datatype and size of the input image
+///
+/// # Parameters
+///
+/// * `infptr`  — (I) FITS file pointer
+/// * `maxaxis` — (I) max number of axes to return
+/// * `bitpix`  — (O) image data type
+/// * `naxis`   — (O) image dimension (NAXIS value)
+/// * `naxes`   — (O) size of image dimensions
+/// * `status`  — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgipr(
-    infptr: *mut fitsfile, /* I - FITS file pointer                     */
-    maxaxis: c_int,        /* I - max number of axes to return          */
-    bitpix: *mut c_int,    /* O - image data type                       */
-    naxis: *mut c_int,     /* O - image dimension (NAXIS value)         */
-    naxes: *mut c_long,    /* O - size of image dimensions              */
-    status: *mut c_int,    /* IO - error status      */
+    infptr: *mut fitsfile,
+    maxaxis: c_int,
+    bitpix: *mut c_int,
+    naxis: *mut c_int,
+    naxes: *mut c_long,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -9673,15 +10346,23 @@ pub unsafe extern "C" fn ffgipr(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// get the datatype and size of the input image
+///
+/// # Parameters
+///
+/// * `infptr`  — (I) FITS file pointer
+/// * `maxaxis` — (I) max number of axes to return
+/// * `bitpix`  — (O) image data type
+/// * `naxis`   — (O) image dimension (NAXIS value)
+/// * `naxes`   — (O) size of image dimensions
+/// * `status`  — (IO) error status
 pub fn ffgipr_safe(
-    infptr: &mut fitsfile,        /* I - FITS file pointer                     */
-    maxaxis: c_int,               /* I - max number of axes to return          */
-    bitpix: Option<&mut c_int>,   /* O - image data type                       */
-    naxis: Option<&mut c_int>,    /* O - image dimension (NAXIS value)         */
-    naxes: Option<&mut [c_long]>, /* O - size of image dimensions              */
-    status: &mut c_int,           /* IO - error status      */
+    infptr: &mut fitsfile,
+    maxaxis: c_int,
+    bitpix: Option<&mut c_int>,
+    naxis: Option<&mut c_int>,
+    naxes: Option<&mut [c_long]>,
+    status: &mut c_int,
 ) -> c_int {
     if *status > 0 {
         return *status;
@@ -9704,16 +10385,24 @@ pub fn ffgipr_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Get the datatype and size of the input image
+///
+/// # Parameters
+///
+/// * `infptr`  — (I) FITS file pointer
+/// * `maxaxis` — (I) max number of axes to return
+/// * `bitpix`  — (O) image data type
+/// * `naxis`   — (O) image dimension (NAXIS value)
+/// * `naxes`   — (O) size of image dimensions
+/// * `status`  — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgiprll(
-    infptr: *mut fitsfile, /* I - FITS file pointer                   */
-    maxaxis: c_int,        /* I - max number of axes to return          */
-    bitpix: *mut c_int,    /* O - image data type                       */
-    naxis: *mut c_int,     /* O - image dimension (NAXIS value)         */
-    naxes: *mut LONGLONG,  /* O - size of image dimensions              */
-    status: *mut c_int,    /* IO - error status      */
+    infptr: *mut fitsfile,
+    maxaxis: c_int,
+    bitpix: *mut c_int,
+    naxis: *mut c_int,
+    naxes: *mut LONGLONG,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -9731,14 +10420,21 @@ pub unsafe extern "C" fn ffgiprll(
     }
 }
 
-/*--------------------------------------------------------------------------*/
+/// # Parameters
+///
+/// * `infptr`  — (I) FITS file pointer
+/// * `maxaxis` — (I) max number of axes to return
+/// * `bitpix`  — (O) image data type
+/// * `naxis`   — (O) image dimension (NAXIS value)
+/// * `naxes`   — (O) size of image dimensions
+/// * `status`  — (IO) error status
 pub fn ffgiprll_safe(
-    infptr: &mut fitsfile,          /* I - FITS file pointer                   */
-    maxaxis: c_int,                 /* I - max number of axes to return          */
-    bitpix: Option<&mut c_int>,     /* O - image data type                       */
-    naxis: Option<&mut c_int>,      /* O - image dimension (NAXIS value)         */
-    naxes: Option<&mut [LONGLONG]>, /* O - size of image dimensions              */
-    status: &mut c_int,             /* IO - error status      */
+    infptr: &mut fitsfile,
+    maxaxis: c_int,
+    bitpix: Option<&mut c_int>,
+    naxis: Option<&mut c_int>,
+    naxes: Option<&mut [LONGLONG]>,
+    status: &mut c_int,
 ) -> c_int {
     if *status > 0 {
         return *status; /* get NAXISn values */
@@ -9761,14 +10457,19 @@ pub fn ffgiprll_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Get the datatype of the image (= BITPIX keyword for normal image, or
 /// ZBITPIX for a compressed image)
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `imgtype` — (O) image data type
+/// * `status`  — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgidt(
-    fptr: *mut fitsfile, /* I - FITS file pointer                       */
-    imgtype: *mut c_int, /* O - image data type                         */
-    status: *mut c_int,  /* IO - error status                           */
+    fptr: *mut fitsfile,
+    imgtype: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -9780,14 +10481,15 @@ pub unsafe extern "C" fn ffgidt(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Get the datatype of the image (= BITPIX keyword for normal image, or
 /// ZBITPIX for a compressed image)
-pub fn ffgidt_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                       */
-    imgtype: &mut c_int, /* O - image data type                         */
-    status: &mut c_int,  /* IO - error status                           */
-) -> c_int {
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `imgtype` — (O) image data type
+/// * `status`  — (IO) error status
+pub fn ffgidt_safe(fptr: &mut fitsfile, imgtype: &mut c_int, status: &mut c_int) -> c_int {
     if *status > 0 {
         return *status;
     }
@@ -9826,14 +10528,19 @@ pub fn ffgidt_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Get the effective datatype of the image (= BITPIX keyword for normal image,
 /// or ZBITPIX for a compressed image)
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `imgtype` — (O) image data type
+/// * `status`  — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgiet(
-    fptr: *mut fitsfile, /* I - FITS file pointer                       */
-    imgtype: *mut c_int, /* O - image data type                         */
-    status: *mut c_int,  /* IO - error status                           */
+    fptr: *mut fitsfile,
+    imgtype: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -9845,14 +10552,15 @@ pub unsafe extern "C" fn ffgiet(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Get the effective datatype of the image (= BITPIX keyword for normal image,
 /// or ZBITPIX for a compressed image)
-pub fn ffgiet_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                       */
-    imgtype: &mut c_int, /* O - image data type                         */
-    status: &mut c_int,  /* IO - error status                           */
-) -> c_int {
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `imgtype` — (O) image data type
+/// * `status`  — (IO) error status
+pub fn ffgiet_safe(fptr: &mut fitsfile, imgtype: &mut c_int, status: &mut c_int) -> c_int {
     let mut tstatus: c_int;
 
     let mut lngzero: c_long = 0;
@@ -9986,15 +10694,20 @@ pub fn ffgiet_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Get the dimension of the image (= NAXIS keyword for normal image, or
 /// ZNAXIS for a compressed image)
 /// These values are cached for faster access.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `naxis`  — (O) image dimension (NAXIS value)
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgidm(
-    fptr: *mut fitsfile, /* I - FITS file pointer                       */
-    naxis: *mut c_int,   /* O - image dimension (NAXIS value)           */
-    status: *mut c_int,  /* IO - error status                           */
+    fptr: *mut fitsfile,
+    naxis: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -10007,15 +10720,16 @@ pub unsafe extern "C" fn ffgidm(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Get the dimension of the image (= NAXIS keyword for normal image, or
 /// ZNAXIS for a compressed image)
 /// These values are cached for faster access.
-pub fn ffgidm_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                       */
-    naxis: &mut c_int,   /* O - image dimension (NAXIS value)           */
-    status: &mut c_int,  /* IO - error status                           */
-) -> c_int {
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `naxis`  — (O) image dimension (NAXIS value)
+/// * `status` — (IO) error status
+pub fn ffgidm_safe(fptr: &mut fitsfile, naxis: &mut c_int, status: &mut c_int) -> c_int {
     if *status > 0 {
         return *status;
     }
@@ -10038,16 +10752,22 @@ pub fn ffgidm_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Get the size of the image dimensions (= NAXISn keywords for normal image, or
 /// ZNAXISn for a compressed image)
 /// These values are cached for faster access.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `nlen`   — (I) number of axes to return
+/// * `naxes`  — (O) size of image dimensions
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgisz(
-    fptr: *mut fitsfile, /* I - FITS file pointer                       */
-    nlen: c_int,         /* I - number of axes to return                */
-    naxes: *mut c_long,  /* O - size of image dimensions                */
-    status: *mut c_int,  /* IO - error status                           */
+    fptr: *mut fitsfile,
+    nlen: c_int,
+    naxes: *mut c_long,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -10086,15 +10806,21 @@ pub unsafe extern "C" fn ffgisz(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Get the size of the image dimensions (= NAXISn keywords for normal image, or
 /// ZNAXISn for a compressed image)
 /// These values are cached for faster access.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `nlen`   — (I) number of axes to return
+/// * `naxes`  — (O) size of image dimensions
+/// * `status` — (IO) error status
 pub fn ffgisz_safe(
-    fptr: &mut fitsfile,  /* I - FITS file pointer                       */
-    nlen: c_int,          /* I - number of axes to return                */
-    naxes: &mut [c_long], /* O - size of image dimensions                */
-    status: &mut c_int,   /* IO - error status                           */
+    fptr: &mut fitsfile,
+    nlen: c_int,
+    naxes: &mut [c_long],
+    status: &mut c_int,
 ) -> c_int {
     if *status > 0 {
         return *status;
@@ -10126,14 +10852,19 @@ pub fn ffgisz_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Get the size of the image dimensions (= NAXISn keywords for normal image, or
 /// ZNAXISn for a compressed image)
+///
+/// # Parameters
+///
+/// * `fptr`  — (I) FITS file pointer
+/// * `nlen`  — (I) number of axes to return
+/// * `naxes` — (O) size of image dimensions
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgiszll(
-    fptr: *mut fitsfile,  /* I - FITS file pointer                     */
-    nlen: c_int,          /* I - number of axes to return              */
-    naxes: *mut LONGLONG, /* O - size of image dimensions              */
+    fptr: *mut fitsfile,
+    nlen: c_int,
+    naxes: *mut LONGLONG,
     status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
@@ -10147,13 +10878,18 @@ pub unsafe extern "C" fn ffgiszll(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Get the size of the image dimensions (= NAXISn keywords for normal image, or
 /// ZNAXISn for a compressed image)
+///
+/// # Parameters
+///
+/// * `fptr`  — (I) FITS file pointer
+/// * `nlen`  — (I) number of axes to return
+/// * `naxes` — (O) size of image dimensions
 pub fn ffgiszll_safe(
-    fptr: &mut fitsfile,    /* I - FITS file pointer                     */
-    nlen: c_int,            /* I - number of axes to return              */
-    naxes: &mut [LONGLONG], /* O - size of image dimensions              */
+    fptr: &mut fitsfile,
+    nlen: c_int,
+    naxes: &mut [LONGLONG],
     status: &mut c_int,
 ) -> c_int {
     if *status > 0 {
@@ -10191,16 +10927,22 @@ pub fn ffgiszll_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Move to Absolute Header Data unit.  Move to the specified HDU
 /// and read the header to initialize the table structure.  Note that extnum
 /// is one based, so the primary array is extnum = 1.
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `hdunum`  — (I) number of the HDU to move to
+/// * `exttype` — (O) type of extension, 0, 1, or 2
+/// * `status`  — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffmahd(
-    fptr: *mut fitsfile, /* I - FITS file pointer             */
-    hdunum: c_int,       /* I - number of the HDU to move to  */
-    exttype: *mut c_int, /* O - type of extension, 0, 1, or 2 */
-    status: *mut c_int,  /* IO - error status                 */
+    fptr: *mut fitsfile,
+    hdunum: c_int,
+    exttype: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -10212,15 +10954,21 @@ pub unsafe extern "C" fn ffmahd(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Move to Absolute Header Data unit.  Move to the specified HDU
 /// and read the header to initialize the table structure.  Note that extnum
 /// is one based, so the primary array is extnum = 1.
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `hdunum`  — (I) number of the HDU to move to
+/// * `exttype` — (O) type of extension, 0, 1, or 2
+/// * `status`  — (IO) error status
 pub fn ffmahd_safe(
-    fptr: &mut fitsfile,         /* I - FITS file pointer             */
-    hdunum: c_int,               /* I - number of the HDU to move to  */
-    exttype: Option<&mut c_int>, /* O - type of extension, 0, 1, or 2 */
-    status: &mut c_int,          /* IO - error status                 */
+    fptr: &mut fitsfile,
+    hdunum: c_int,
+    exttype: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     let mut moveto;
     let mut tstatus;
@@ -10294,15 +11042,21 @@ pub fn ffmahd_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Move a Relative number of Header Data units.  Offset to the specified
 /// extension and read the header to initialize the HDU structure.
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `hdumov`  — (I) rel. no. of HDUs to move by (+ or -)
+/// * `exttype` — (O) type of extension, 0, 1, or 2
+/// * `status`  — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffmrhd(
-    fptr: *mut fitsfile, /* I - FITS file pointer                    */
-    hdumov: c_int,       /* I - rel. no. of HDUs to move by (+ or -) */
-    exttype: *mut c_int, /* O - type of extension, 0, 1, or 2        */
-    status: *mut c_int,  /* IO - error status                        */
+    fptr: *mut fitsfile,
+    hdumov: c_int,
+    exttype: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -10314,14 +11068,20 @@ pub unsafe extern "C" fn ffmrhd(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Move a Relative number of Header Data units.  Offset to the specified
 /// extension and read the header to initialize the HDU structure.
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `hdumov`  — (I) rel. no. of HDUs to move by (+ or -)
+/// * `exttype` — (O) type of extension, 0, 1, or 2
+/// * `status`  — (IO) error status
 pub fn ffmrhd_safe(
-    fptr: &mut fitsfile,         /* I - FITS file pointer                    */
-    hdumov: c_int,               /* I - rel. no. of HDUs to move by (+ or -) */
-    exttype: Option<&mut c_int>, /* O - type of extension, 0, 1, or 2        */
-    status: &mut c_int,          /* IO - error status                        */
+    fptr: &mut fitsfile,
+    hdumov: c_int,
+    exttype: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     if *status > 0 {
         return *status;
@@ -10333,7 +11093,6 @@ pub fn ffmrhd_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Move to the next HDU with a given extension type (IMAGE_HDU, ASCII_TBL,
 /// BINARY_TBL, or ANY_HDU), extension name (EXTNAME or HDUNAME keyword),
 /// and EXTVERS keyword values.  If hduvers = 0, then move to the first HDU
@@ -10358,7 +11117,6 @@ pub unsafe extern "C" fn ffmnhd(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Move to the next HDU with a given extension type (IMAGE_HDU, ASCII_TBL,
 /// BINARY_TBL, or ANY_HDU), extension name (EXTNAME or HDUNAME keyword),
 /// and EXTVERS keyword values.  If hduvers = 0, then move to the first HDU
@@ -10512,13 +11270,18 @@ pub fn ffmnhd_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 ///  Return the number of HDUs that currently exist in the file.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `nhdu`   — (O) number of HDUs in the file
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffthdu(
-    fptr: *mut fitsfile, /* I - FITS file pointer                    */
-    nhdu: *mut c_int,    /* O - number of HDUs in the file           */
-    status: *mut c_int,  /* IO - error status                        */
+    fptr: *mut fitsfile,
+    nhdu: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -10530,13 +11293,14 @@ pub unsafe extern "C" fn ffthdu(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Count the total number of HDUs in the file.
-pub fn ffthdu_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                    */
-    nhdu: &mut c_int,    /* O - number of HDUs in the file           */
-    status: &mut c_int,  /* IO - error status                        */
-) -> c_int {
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `nhdu`   — (O) number of HDUs in the file
+/// * `status` — (IO) error status
+pub fn ffthdu_safe(fptr: &mut fitsfile, nhdu: &mut c_int, status: &mut c_int) -> c_int {
     if *status > 0 {
         return *status;
     }
@@ -10560,14 +11324,20 @@ pub fn ffthdu_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Get Extension.  Move to the specified extension and initialize the
 /// HDU structure.
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `hdunum`  — (I) no. of HDU to move get (0 based)
+/// * `exttype` — (O) type of extension, 0, 1, or 2
+/// * `status`  — (IO) error status
 pub(crate) fn ffgext(
-    fptr: &mut fitsfile,         /* I - FITS file pointer                */
-    hdunum: c_int,               /* I - no. of HDU to move get (0 based) */
-    exttype: Option<&mut c_int>, /* O - type of extension, 0, 1, or 2    */
-    status: &mut c_int,          /* IO - error status                    */
+    fptr: &mut fitsfile,
+    hdunum: c_int,
+    exttype: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     let xcurhdu: c_int;
     let xmaxhdu: c_int;
@@ -10602,14 +11372,20 @@ pub(crate) fn ffgext(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Insert 2880-byte blocks at the end of the current header or data unit
+///
+/// # Parameters
+///
+/// * `fptr`     — (I) FITS file pointer
+/// * `nblock`   — (I) no. of blocks to insert
+/// * `headdata` — (I) insert where? 0=header, 1=data
+/// * `status`   — (IO) error status
 pub(crate) fn ffiblk(
-    fptr: &mut fitsfile, /* I - FITS file pointer               */
-    nblock: c_long,      /* I - no. of blocks to insert         */
-    headdata: c_int,     /* I - insert where? 0=header, 1=data  */
+    fptr: &mut fitsfile,
+    nblock: c_long,
+    headdata: c_int,
     /*     -1=beginning of file            */
-    status: &mut c_int, /* IO - error status                   */
+    status: &mut c_int,
 ) -> c_int {
     let mut typhdu: c_int = 0;
     let mut insertpt: LONGLONG;
@@ -10756,7 +11532,6 @@ pub(crate) fn ffiblk(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Return the type classification of the input header record
 /// ```text
 /// TYP_STRUC_KEY: SIMPLE, BITPIX, NAXIS, NAXISn, EXTEND, BLOCKED,
@@ -10821,9 +11596,19 @@ pub unsafe extern "C" fn ffgkcl(tcard: *mut c_char) -> c_int {
     }
 }
 
-/*--------------------------------------------------------------------------*/
 #[allow(clippy::if_same_then_else)]
 // C dispatch chain: distinct conditions deliberately share an action.
+/// Return the classification code of a header keyword, given its 80-character
+/// card image.
+///
+/// # Parameters
+///
+/// * `tcard` — (I) the keyword card to classify
+///
+/// # Returns
+///
+/// One of the `TYP_*_KEY` codes, e.g. [`TYP_STRUC_KEY`] for `SIMPLE` or
+/// [`TYP_USER_KEY`] for anything unrecognized.
 pub fn ffgkcl_safe(tcard: &[c_char]) -> c_int {
     let mut card: [c_char; 20] = [0; 20];
 
@@ -11351,15 +12136,20 @@ pub fn ffgkcl_safe(tcard: &[c_char]) -> c_int {
     TYP_USER_KEY /* by default all others are user keywords */
 }
 
-/*--------------------------------------------------------------------------*/
 /// determine implicit datatype of input string.
 /// This assumes that the string conforms to the FITS standard
 /// for keyword values, so may not detect all invalid formats.
+///
+/// # Parameters
+///
+/// * `cval`   — (I) formatted string representation of the value
+/// * `dtype`  — (O) datatype code: C, L, F, I, or X
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffdtyp(
-    cval: *const c_char, /* I - formatted string representation of the value */
-    dtype: *mut c_char,  /* O - datatype code: C, L, F, I, or X */
-    status: *mut c_int,  /* IO - error status */
+    cval: *const c_char,
+    dtype: *mut c_char,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -11371,15 +12161,16 @@ pub unsafe extern "C" fn ffdtyp(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// determine implicit datatype of input string.
 /// This assumes that the string conforms to the FITS standard
 /// for keyword values, so may not detect all invalid formats.
-pub fn ffdtyp_safe(
-    cval: &[c_char],    /* I - formatted string representation of the value */
-    dtype: &mut c_char, /* O - datatype code: C, L, F, I, or X */
-    status: &mut c_int, /* IO - error status */
-) -> c_int {
+///
+/// # Parameters
+///
+/// * `cval`   — (I) formatted string representation of the value
+/// * `dtype`  — (O) datatype code: C, L, F, I, or X
+/// * `status` — (IO) error status
+pub fn ffdtyp_safe(cval: &[c_char], dtype: &mut c_char, status: &mut c_int) -> c_int {
     if *status > 0 {
         /* inherit input status value if > 0 */
         return *status;
@@ -11404,16 +12195,22 @@ pub fn ffdtyp_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// determine implicit datatype of input integer string.
 /// This assumes that the string conforms to the FITS standard
 /// for integer keyword value, so may not detect all invalid formats.
+///
+/// # Parameters
+///
+/// * `cval`     — (I) formatted string representation of the integer
+/// * `dtype`    — (O) datatype code: TBYTE, TSHORT, TUSHORT, etc
+/// * `negative` — (O) is cval negative?
+/// * `status`   — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffinttyp(
-    cval: *const c_char,  /* I - formatted string representation of the integer */
-    dtype: *mut c_int,    /* O - datatype code: TBYTE, TSHORT, TUSHORT, etc */
-    negative: *mut c_int, /* O - is cval negative? */
-    status: *mut c_int,   /* IO - error status */
+    cval: *const c_char,
+    dtype: *mut c_int,
+    negative: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -11425,11 +12222,17 @@ pub unsafe extern "C" fn ffinttyp(
     }
 }
 
+/// # Parameters
+///
+/// * `cval`     — (I) formatted string representation of the integer
+/// * `dtype`    — (O) datatype code: TBYTE, TSHORT, TUSHORT, etc
+/// * `negative` — (O) is cval negative?
+/// * `status`   — (IO) error status
 pub fn ffinttyp_safe(
-    cval: &[c_char],      /* I - formatted string representation of the integer */
-    dtype: &mut c_int,    /* O - datatype code: TBYTE, TSHORT, TUSHORT, etc */
-    negative: &mut c_int, /* O - is cval negative? */
-    status: &mut c_int,   /* IO - error status */
+    cval: &[c_char],
+    dtype: &mut c_int,
+    negative: &mut c_int,
+    status: &mut c_int,
 ) -> c_int {
     if *status > 0 {
         return *status; /* inherit input status value if > 0 */
@@ -11549,18 +12352,27 @@ pub fn ffinttyp_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// high level routine to convert formatted character string to its
 /// intrinsic data type
+///
+/// # Parameters
+///
+/// * `cval`   — (I) formatted string representation of the value
+/// * `dtype`  — (O) datatype code: C, L, F, I or X
+/// * `ival`   — (O) integer value
+/// * `lval`   — (O) logical value
+/// * `sval`   — (O) string value
+/// * `dval`   — (O) double value
+/// * `status` — (IO) error status
 pub(crate) fn ffc2x(
-    cval: &[c_char],    /* I - formatted string representation of the value */
-    dtype: &mut c_char, /* O - datatype code: C, L, F, I or X  */
+    cval: &[c_char],
+    dtype: &mut c_char,
     /* Only one of the following will be defined, depending on datatype */
-    ival: &mut c_long,   /* O - integer value       */
-    lval: &mut c_int,    /* O - logical value       */
-    sval: &mut [c_char], /* O - string value        */
-    dval: &mut f64,      /* O - double value        */
-    status: &mut c_int,  /* IO - error status */
+    ival: &mut c_long,
+    lval: &mut c_int,
+    sval: &mut [c_char],
+    dval: &mut f64,
+    status: &mut c_int,
 ) -> c_int {
     ffdtyp_safe(cval, dtype, status); /* determine the datatype */
 
@@ -11577,19 +12389,28 @@ pub(crate) fn ffc2x(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// high level routine to convert formatted character string to its
 /// intrinsic data type
+///
+/// # Parameters
+///
+/// * `cval`   — (I) formatted string representation of the value
+/// * `dtype`  — (O) datatype code: C, L, F, I or X
+/// * `ival`   — (O) integer value
+/// * `lval`   — (O) logical value
+/// * `sval`   — (O) string value
+/// * `dval`   — (O) double value
+/// * `status` — (IO) error status
 pub(crate) fn ffc2xx(
-    cval: &[c_char],    /* I - formatted string representation of the value */
-    dtype: &mut c_char, /* O - datatype code: C, L, F, I or X  */
+    cval: &[c_char],
+    dtype: &mut c_char,
 
     /* Only one of the following will be defined, depending on datatype */
-    ival: &mut LONGLONG, /* O - integer value       */
-    lval: &mut c_int,    /* O - logical value       */
-    sval: &mut [c_char], /* O - string value        */
-    dval: &mut f64,      /* O - double value        */
-    status: &mut c_int,  /* IO - error status */
+    ival: &mut LONGLONG,
+    lval: &mut c_int,
+    sval: &mut [c_char],
+    dval: &mut f64,
+    status: &mut c_int,
 ) -> c_int {
     ffdtyp_safe(cval, dtype, status); /* determine the datatype */
 
@@ -11605,18 +12426,27 @@ pub(crate) fn ffc2xx(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// High level routine to convert formatted character string to its
 /// intrinsic data type
+///
+/// # Parameters
+///
+/// * `cval`   — (I) formatted string representation of the value
+/// * `dtype`  — (O) datatype code: C, L, F, I or X
+/// * `ival`   — (O) integer value
+/// * `lval`   — (O) logical value
+/// * `sval`   — (O) string value
+/// * `dval`   — (O) double value
+/// * `status` — (IO) error status
 pub(crate) fn ffc2uxx(
-    cval: &[c_char],    /* I - formatted string representation of the value */
-    dtype: &mut c_char, /* O - datatype code: C, L, F, I or X  */
+    cval: &[c_char],
+    dtype: &mut c_char,
     /* Only one of the following will be defined, depending on datatype */
-    ival: &mut ULONGLONG, /* O - integer value       */
-    lval: &mut c_int,     /* O - logical value       */
-    sval: &mut [c_char],  /* O - string value        */
-    dval: &mut f64,       /* O - double value        */
-    status: &mut c_int,   /* IO - error status */
+    ival: &mut ULONGLONG,
+    lval: &mut c_int,
+    sval: &mut [c_char],
+    dval: &mut f64,
+    status: &mut c_int,
 ) -> c_int {
     ffdtyp_safe(cval, dtype, status); /* determine the datatype */
 
@@ -11632,14 +12462,15 @@ pub(crate) fn ffc2uxx(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// convert formatted string to an integer value, doing implicit
 /// datatype conversion if necessary.
-pub(crate) fn ffc2i(
-    cval: &[c_char],    /* I - string representation of the value */
-    ival: &mut c_long,  /* O - numerical value of the input string */
-    status: &mut c_int, /* IO - error status */
-) -> c_int {
+///
+/// # Parameters
+///
+/// * `cval`   — (I) string representation of the value
+/// * `ival`   — (O) numerical value of the input string
+/// * `status` — (IO) error status
+pub(crate) fn ffc2i(cval: &[c_char], ival: &mut c_long, status: &mut c_int) -> c_int {
     let mut dtype: c_char = 0;
     let mut sval: [c_char; 81] = [0; 81];
 
@@ -11699,14 +12530,15 @@ pub(crate) fn ffc2i(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// convert formatted string to a LONGLONG integer value, doing implicit
 /// datatype conversion if necessary.
-pub(crate) fn ffc2j(
-    cval: &[c_char],     /* I - string representation of the value */
-    ival: &mut LONGLONG, /* O - numerical value of the input string */
-    status: &mut c_int,  /* IO - error status */
-) -> c_int {
+///
+/// # Parameters
+///
+/// * `cval`   — (I) string representation of the value
+/// * `ival`   — (O) numerical value of the input string
+/// * `status` — (IO) error status
+pub(crate) fn ffc2j(cval: &[c_char], ival: &mut LONGLONG, status: &mut c_int) -> c_int {
     let mut dtype: c_char = 0;
     let mut sval: [c_char; 81] = [0; 81];
     let mut msg: [c_char; 81] = [0; 81];
@@ -11763,14 +12595,15 @@ pub(crate) fn ffc2j(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Convert formatted string to a ULONGLONG integer value, doing implicit
 /// datatype conversion if necessary.
-pub(crate) fn ffc2uj(
-    cval: &[c_char],      /* I - string representation of the value */
-    ival: &mut ULONGLONG, /* O - numerical value of the input string */
-    status: &mut c_int,   /* IO - error status */
-) -> c_int {
+///
+/// # Parameters
+///
+/// * `cval`   — (I) string representation of the value
+/// * `ival`   — (O) numerical value of the input string
+/// * `status` — (IO) error status
+pub(crate) fn ffc2uj(cval: &[c_char], ival: &mut ULONGLONG, status: &mut c_int) -> c_int {
     let mut dtype: c_char = 0;
     let mut sval: [c_char; FLEN_CARD] = [0; FLEN_CARD];
     let mut msg: [c_char; FLEN_ERRMSG] = [0; FLEN_ERRMSG];
@@ -11828,14 +12661,15 @@ pub(crate) fn ffc2uj(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Convert formatted string to a logical value, doing implicit
 /// datatype conversion if necessary
-pub(crate) fn ffc2l(
-    cval: &[c_char],    /* I - string representation of the value */
-    lval: &mut c_int,   /* O - numerical value of the input string */
-    status: &mut c_int, /* IO - error status */
-) -> c_int {
+///
+/// # Parameters
+///
+/// * `cval`   — (I) string representation of the value
+/// * `lval`   — (O) numerical value of the input string
+/// * `status` — (IO) error status
+pub(crate) fn ffc2l(cval: &[c_char], lval: &mut c_int, status: &mut c_int) -> c_int {
     let mut dtype: c_char = 0;
     let mut sval: [c_char; FLEN_CARD] = [0; FLEN_CARD];
     let mut msg: [c_char; FLEN_ERRMSG] = [0; FLEN_ERRMSG];
@@ -11890,14 +12724,15 @@ pub(crate) fn ffc2l(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Convert formatted string to a real float value, doing implicit
 /// datatype conversion if necessary
-pub(crate) fn ffc2r(
-    cval: &[c_char],    /* I - string representation of the value */
-    fval: &mut f32,     /* O - numerical value of the input string */
-    status: &mut c_int, /* IO - error status */
-) -> c_int {
+///
+/// # Parameters
+///
+/// * `cval`   — (I) string representation of the value
+/// * `fval`   — (O) numerical value of the input string
+/// * `status` — (IO) error status
+pub(crate) fn ffc2r(cval: &[c_char], fval: &mut f32, status: &mut c_int) -> c_int {
     let mut dtype: c_char = 0;
     let mut sval: [c_char; FLEN_CARD] = [0; FLEN_CARD];
     let mut msg: [c_char; FLEN_ERRMSG] = [0; FLEN_ERRMSG];
@@ -11942,14 +12777,15 @@ pub(crate) fn ffc2r(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Convert formatted string to a double value, doing implicit
 /// datatype conversion if necessary
-pub(crate) fn ffc2d(
-    cval: &[c_char],    /* I - string representation of the value */
-    dval: &mut f64,     /* O - numerical value of the input string */
-    status: &mut c_int, /* IO - error status */
-) -> c_int {
+///
+/// # Parameters
+///
+/// * `cval`   — (I) string representation of the value
+/// * `dval`   — (O) numerical value of the input string
+/// * `status` — (IO) error status
+pub(crate) fn ffc2d(cval: &[c_char], dval: &mut f64, status: &mut c_int) -> c_int {
     let mut dtype: c_char = 0;
     let mut sval: [c_char; FLEN_CARD] = [0; FLEN_CARD];
     let mut msg: [c_char; FLEN_ERRMSG] = [0; FLEN_ERRMSG];
@@ -11996,13 +12832,14 @@ pub(crate) fn ffc2d(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// convert null-terminated formatted string to an integer value
-pub(crate) fn ffc2ii(
-    cval: &[c_char],    /* I - string representation of the value */
-    ival: &mut c_long,  /* O - numerical value of the input string */
-    status: &mut c_int, /* IO - error status */
-) -> c_int {
+///
+/// # Parameters
+///
+/// * `cval`   — (I) string representation of the value
+/// * `ival`   — (O) numerical value of the input string
+/// * `status` — (IO) error status
+pub(crate) fn ffc2ii(cval: &[c_char], ival: &mut c_long, status: &mut c_int) -> c_int {
     if *status > 0 {
         /* inherit input status value if > 0 */
         return *status;
@@ -12045,13 +12882,14 @@ pub(crate) fn ffc2ii(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// convert null-terminated formatted string to an long long integer value
-pub(crate) fn ffc2jj(
-    cval: &[c_char],     /* I - string representation of the value */
-    ival: &mut LONGLONG, /* O - numerical value of the input string */
-    status: &mut c_int,  /* IO - error status */
-) -> c_int {
+///
+/// # Parameters
+///
+/// * `cval`   — (I) string representation of the value
+/// * `ival`   — (O) numerical value of the input string
+/// * `status` — (IO) error status
+pub(crate) fn ffc2jj(cval: &[c_char], ival: &mut LONGLONG, status: &mut c_int) -> c_int {
     if *status > 0 {
         /* inherit input status value if > 0 */
         return *status;
@@ -12094,13 +12932,14 @@ pub(crate) fn ffc2jj(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Convert null-terminated formatted string to an unsigned long long integer value
-pub(crate) fn ffc2ujj(
-    cval: &[c_char],      /* I - string representation of the value */
-    ival: &mut ULONGLONG, /* O - numerical value of the input string */
-    status: &mut c_int,   /* IO - error status */
-) -> c_int {
+///
+/// # Parameters
+///
+/// * `cval`   — (I) string representation of the value
+/// * `ival`   — (O) numerical value of the input string
+/// * `status` — (IO) error status
+pub(crate) fn ffc2ujj(cval: &[c_char], ival: &mut ULONGLONG, status: &mut c_int) -> c_int {
     if *status > 0 {
         /* inherit input status value if > 0 */
         return *status;
@@ -12144,13 +12983,14 @@ pub(crate) fn ffc2ujj(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// convert null-terminated formatted string to a logical value
-pub(crate) fn ffc2ll(
-    cval: &[c_char],    /* I - string representation of the value: T or F */
-    lval: &mut c_int,   /* O - numerical value of the input string: 1 or 0 */
-    status: &mut c_int, /* IO - error status */
-) -> c_int {
+///
+/// # Parameters
+///
+/// * `cval`   — (I) string representation of the value: T or F
+/// * `lval`   — (O) numerical value of the input string: 1 or 0
+/// * `status` — (IO) error status
+pub(crate) fn ffc2ll(cval: &[c_char], lval: &mut c_int, status: &mut c_int) -> c_int {
     if *status > 0 {
         /* inherit input status value if > 0 */
         return *status;
@@ -12165,17 +13005,18 @@ pub(crate) fn ffc2ll(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// convert an input quoted string to an unquoted string by removing
 /// the leading and trailing quote character.  Also, replace any
 /// pairs of single quote characters with just a single quote
 /// character (FITS used a pair of single quotes to represent
 /// a literal quote character within the string).
-pub(crate) fn ffc2s(
-    instr: &[c_char],      /* I - null terminated quoted input string */
-    outstr: &mut [c_char], /* O - null terminated output string without quotes */
-    status: &mut c_int,    /* IO - error status */
-) -> c_int {
+///
+/// # Parameters
+///
+/// * `instr`  — (I) null terminated quoted input string
+/// * `outstr` — (O) null terminated output string without quotes
+/// * `status` — (IO) error status
+pub(crate) fn ffc2s(instr: &[c_char], outstr: &mut [c_char], status: &mut c_int) -> c_int {
     if *status > 0 {
         /* inherit input status value if > 0 */
         return *status;
@@ -12233,13 +13074,14 @@ pub(crate) fn ffc2s(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// convert null-terminated formatted string to a float value
-pub(crate) fn ffc2rr(
-    cval: &[c_char],    /* I - string representation of the value */
-    fval: &mut f32,     /* O - numerical value of the input string */
-    status: &mut c_int, /* IO - error status */
-) -> c_int {
+///
+/// # Parameters
+///
+/// * `cval`   — (I) string representation of the value
+/// * `fval`   — (O) numerical value of the input string
+/// * `status` — (IO) error status
+pub(crate) fn ffc2rr(cval: &[c_char], fval: &mut f32, status: &mut c_int) -> c_int {
     let mut msg: [c_char; FLEN_ERRMSG] = [0; FLEN_ERRMSG];
     let mut tval: [c_char; 73] = [0; 73];
     let decimalpt: c_char = 0;
@@ -12337,13 +13179,14 @@ pub(crate) fn ffc2rr(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// convert null-terminated formatted string to a double value
-pub(crate) fn ffc2dd(
-    cval: &[c_char],    /* I - string representation of the value */
-    dval: &mut f64,     /* O - numerical value of the input string */
-    status: &mut c_int, /* IO - error status */
-) -> c_int {
+///
+/// # Parameters
+///
+/// * `cval`   — (I) string representation of the value
+/// * `dval`   — (O) numerical value of the input string
+/// * `status` — (IO) error status
+pub(crate) fn ffc2dd(cval: &[c_char], dval: &mut f64, status: &mut c_int) -> c_int {
     let mut msg: [c_char; FLEN_ERRMSG] = [0; FLEN_ERRMSG];
     let mut tval: [c_char; 73] = [0; 73];
     let decimalpt: c_char = 0;

--- a/src/fitsio.rs
+++ b/src/fitsio.rs
@@ -1,3 +1,16 @@
+//! The public CFITSIO datatypes, symbolic constants and error status codes.
+//!
+//! Ported from CFITSIO's `fitsio.h`, written by William Pence at the High
+//! Energy Astrophysics Science Archive Research Center (HEASARC), NASA Goddard
+//! Space Flight Center. The descriptions of the error status codes are taken
+//! from the "CFITSIO Error Status Codes" appendix of the CFITSIO User's
+//! Reference Guide.
+//!
+//! Every routine in this crate returns an error status code as its `c_int`
+//! return value and through its `status` parameter; `0` means success. Prefer
+//! the symbolic names here over the integer values.
+#![warn(missing_docs)]
+
 use crate::{
     c_types::c_ulonglong,
     helpers::{boxed::box_try_new, vec_raw_parts::vec_into_raw_parts},
@@ -19,8 +32,12 @@ use crate::{
 
 use crate::cfileio::fitsdriver;
 
+/// Whether the platform provides `ftruncate()`, so a file can be shortened in
+/// place.
 pub const HAVE_FTRUNCATE: bool = true;
 
+/// The FITS block length, 2880 bytes, as a literal usable in a constant
+/// expression such as an array length.
 #[macro_export]
 macro_rules! BL {
     () => {
@@ -28,366 +45,672 @@ macro_rules! BL {
     };
 }
 
+/// Panic message used when an `extern "C"` wrapper is handed a null pointer it
+/// is not allowed to receive.
 pub const NULL_MSG: &str = "Null Pointer";
 
+/// Length of a FITS block, in bytes. A FITS file is an integral number of
+/// these.
 pub const BLOCK_LEN: usize = 2880;
 
+/// The CFITSIO version this crate is a port of, as a nul-terminated string.
 pub const CFITSIO_VERSION: [u8; 6] = *b"4.7.0\0";
 
 /* Minor and micro numbers must not exceed 99 under current method of version representataion in ffvers(). */
+/// Micro part of the CFITSIO version. Must not exceed 99, given how `ffvers`
+/// packs the version number.
 pub const CFITSIO_MICRO: u64 = 0;
+/// Minor part of the CFITSIO version. Must not exceed 99, given how `ffvers`
+/// packs the version number.
 pub const CFITSIO_MINOR: u64 = 7;
+/// Major part of the CFITSIO version.
 pub const CFITSIO_MAJOR: u64 = 4;
-pub const CFITSIO_SONAME: u64 = 10;
-
 /* the SONAME is incremented in a new release if the binary shared */
 /* library (on linux and Mac systems) is not backward compatible */
 /* with the previous release of CFITSIO */
+/// Shared library version. Incremented in a new release when the binary shared
+/// library (on Linux and macOS) is not backward compatible with the previous
+/// release of CFITSIO.
+pub const CFITSIO_SONAME: u64 = 10;
 
+/// Whether 64-bit integer literals need an `LL` suffix on this platform.
 pub const USE_LL_SUFFIX: u64 = 1;
 
+/// The 64-bit signed integer datatype. CFITSIO spells it `LONGLONG` because C
+/// has no portable name for it.
 pub type LONGLONG = c_longlong;
+/// The 64-bit unsigned integer datatype.
 pub type ULONGLONG = c_ulonglong;
 
 /*  define a default value, even if it is never used */
+/// Largest value a [`LONGLONG`] can hold.
 pub const LONGLONG_MAX: c_longlong = c_longlong::MAX;
+/// Smallest value a [`LONGLONG`] can hold.
 pub const LONGLONG_MIN: c_longlong = c_longlong::MIN;
 
+/// Largest value a `c_long` can hold. Target-dependent: 64-bit on Linux and
+/// macOS, 32-bit on Windows.
 pub const LONG_MAX: c_long = c_long::MAX;
+/// Smallest value a `c_long` can hold. Target-dependent: 64-bit on Linux and
+/// macOS, 32-bit on Windows.
 pub const LONG_MIN: c_long = c_long::MIN;
 
-pub const NIOBUF: u64 = 40; /* number of IO buffers to create (default = 40) */
-/* !! Significantly increasing NIOBUF may degrade performance !! */
+/// Number of I/O buffers to create. Significantly increasing this may *degrade*
+/// performance.
+pub const NIOBUF: u64 = 40;
 
-pub const IOBUFLEN: i64 = 2880; /* size in bytes of each IO buffer (DONT CHANGE!) */
+/// Size in bytes of each I/O buffer. Do not change: it is one FITS block.
+pub const IOBUFLEN: i64 = 2880;
 
-/* global variables */
+/// Maximum length of a filename.
+pub const FLEN_FILENAME: usize = 1025;
+/// Maximum length of a keyword name, allowing for the HIERARCH convention.
+pub const FLEN_KEYWORD: usize = 75;
+/// Length of a FITS header card, plus the nul terminator.
+pub const FLEN_CARD: usize = 81;
+/// Maximum length of a keyword value string.
+pub const FLEN_VALUE: usize = 71;
+/// Maximum length of a keyword comment string.
+pub const FLEN_COMMENT: usize = 73;
+/// Maximum length of a FITSIO error message.
+pub const FLEN_ERRMSG: usize = 81;
+/// Maximum length of a FITSIO status text string.
+pub const FLEN_STATUS: usize = 31;
 
-pub const FLEN_FILENAME: usize = 1025; /* max length of a filename  */
-pub const FLEN_KEYWORD: usize = 75; /* max length of a keyword (HIERARCH convention) */
-pub const FLEN_CARD: usize = 81; /* length of a FITS header card */
-pub const FLEN_VALUE: usize = 71; /* max length of a keyword value string */
-pub const FLEN_COMMENT: usize = 73; /* max length of a keyword comment string */
-pub const FLEN_ERRMSG: usize = 81; /* max length of a FITSIO error message */
-pub const FLEN_STATUS: usize = 31; /* max length of a FITSIO status text string */
-
-pub const TBIT: c_int = 1; /* codes for FITS table data types */
+/// Datatype code for a bit column in a FITS table.
+pub const TBIT: c_int = 1;
+/// Datatype code for an unsigned byte (`unsigned char`).
 pub const TBYTE: c_int = 11;
+/// Datatype code for a signed byte (`signed char`).
 pub const TSBYTE: c_int = 12;
+/// Datatype code for a logical value (`int`).
 pub const TLOGICAL: c_int = 14;
+/// Datatype code for a character string.
 pub const TSTRING: c_int = 16;
+/// Datatype code for an `unsigned short`.
 pub const TUSHORT: c_int = 20;
+/// Datatype code for a `short`.
 pub const TSHORT: c_int = 21;
+/// Datatype code for an `unsigned int`.
 pub const TUINT: c_int = 30;
+/// Datatype code for an `int`.
 pub const TINT: c_int = 31;
+/// Datatype code for an `unsigned long`.
 pub const TULONG: c_int = 40;
+/// Datatype code for a `long`.
 pub const TLONG: c_int = 41;
-pub const TINT32BIT: c_int = 41; /* used when returning datatype of a column */
+/// Datatype code for a 32-bit integer. Used when returning the datatype of a
+/// column; the same value as [`TLONG`].
+pub const TINT32BIT: c_int = 41;
+/// Datatype code for a `float`.
 pub const TFLOAT: c_int = 42;
+/// Datatype code for an unsigned 64-bit integer.
 pub const TULONGLONG: c_int = 80;
+/// Datatype code for a signed 64-bit integer.
 pub const TLONGLONG: c_int = 81;
+/// Datatype code for a `double`.
 pub const TDOUBLE: c_int = 82;
+/// Datatype code for a single-precision complex value.
 pub const TCOMPLEX: c_int = 83;
+/// Datatype code for a double-precision complex value.
 pub const TDBLCOMPLEX: c_int = 163;
 
+/// Keyword class: a structural keyword (`SIMPLE`, `BITPIX`, `NAXIS`, `END`, …).
 pub const TYP_STRUC_KEY: c_int = 10;
+/// Keyword class: a tile-compression keyword (`ZIMAGE`, `ZCMPTYPE`, …).
 pub const TYP_CMPRS_KEY: c_int = 20;
+/// Keyword class: a scaling keyword (`BSCALE`, `BZERO`, `TSCALn`, `TZEROn`).
 pub const TYP_SCAL_KEY: c_int = 30;
+/// Keyword class: a null-value keyword (`BLANK`, `TNULLn`).
 pub const TYP_NULL_KEY: c_int = 40;
+/// Keyword class: a dimension keyword (`TDIMn`).
 pub const TYP_DIM_KEY: c_int = 50;
+/// Keyword class: a range keyword (`TLMINn`, `TLMAXn`, `TDMINn`, `TDMAXn`).
 pub const TYP_RANG_KEY: c_int = 60;
+/// Keyword class: a units keyword (`TUNITn`).
 pub const TYP_UNIT_KEY: c_int = 70;
+/// Keyword class: a display-format keyword (`TDISPn`).
 pub const TYP_DISP_KEY: c_int = 80;
+/// Keyword class: an HDU identification keyword (`EXTNAME`, `EXTVER`, …).
 pub const TYP_HDUID_KEY: c_int = 90;
+/// Keyword class: a checksum keyword (`CHECKSUM`, `DATASUM`).
 pub const TYP_CKSUM_KEY: c_int = 100;
+/// Keyword class: a world coordinate system keyword.
 pub const TYP_WCS_KEY: c_int = 110;
+/// Keyword class: a reference system keyword (`EQUINOX`, `RADESYS`, …).
 pub const TYP_REFSYS_KEY: c_int = 120;
+/// Keyword class: a commentary keyword (`COMMENT`, `HISTORY`, blank).
 pub const TYP_COMM_KEY: c_int = 130;
+/// Keyword class: a `CONTINUE` keyword of the long-string convention.
 pub const TYP_CONT_KEY: c_int = 140;
+/// Keyword class: any other, user-defined keyword.
 pub const TYP_USER_KEY: c_int = 150;
 
-pub type INT32BIT = c_int; /* 32-bit integer datatype.  Currently this       */
+/* 32-bit integer datatype.  Currently this       */
 /* datatype is an 'int' on all useful platforms   */
 /* however, it is possible that that are cases    */
 /* where 'int' is a 2-byte integer, in which case */
 /* INT32BIT would need to be defined as 'long'.   */
+/// A 32-bit integer datatype.
+///
+/// This is an `int` on every useful platform, but there could be cases where
+/// `int` is a 2-byte integer, in which case it would have to be a `long`.
+pub type INT32BIT = c_int;
 
-pub const BYTE_IMG: c_int = 8; /* BITPIX code values for FITS image types */
+/// `BITPIX` code for an 8-bit unsigned integer image.
+pub const BYTE_IMG: c_int = 8;
+/// `BITPIX` code for a 16-bit signed integer image.
 pub const SHORT_IMG: c_int = 16;
+/// `BITPIX` code for a 32-bit signed integer image.
 pub const LONG_IMG: c_int = 32;
+/// `BITPIX` code for a 64-bit signed integer image.
 pub const LONGLONG_IMG: c_int = 64;
+/// `BITPIX` code for a single-precision floating point image.
 pub const FLOAT_IMG: c_int = -32;
+/// `BITPIX` code for a double-precision floating point image.
 pub const DOUBLE_IMG: c_int = -64;
 /* The following 2 codes are not true FITS         */
 /* datatypes; these codes are only used internally */
 /* within cfitsio to make it easier for users      */
 /* to deal with unsigned integers.                 */
+/// `BITPIX` code for a signed-byte image.
+///
+/// Not a true FITS datatype: used only internally, to make signed bytes easier
+/// to deal with. Equivalent to [`BYTE_IMG`] with a `BZERO` of -128.
 pub const SBYTE_IMG: c_int = 10;
+/// `BITPIX` code for an unsigned 16-bit integer image.
+///
+/// Not a true FITS datatype: equivalent to [`SHORT_IMG`] with a `BZERO` of
+/// 32768, which is how FITS stores unsigned integers.
 pub const USHORT_IMG: c_int = 20;
+/// `BITPIX` code for an unsigned 32-bit integer image.
+///
+/// Not a true FITS datatype: equivalent to [`LONG_IMG`] with a `BZERO` of
+/// 2147483648.
 pub const ULONG_IMG: c_int = 40;
+/// `BITPIX` code for an unsigned 64-bit integer image.
+///
+/// Not a true FITS datatype: equivalent to [`LONGLONG_IMG`] with a `BZERO` of
+/// 9223372036854775808.
 pub const ULONGLONG_IMG: c_int = 80;
 
-pub const IMAGE_HDU: c_int = 0; /* Primary Array or IMAGE HDU */
-pub const ASCII_TBL: c_int = 1; /* ASCII table HDU  */
-pub const BINARY_TBL: c_int = 2; /* Binary table HDU */
-pub const ANY_HDU: c_int = -1; /* matches any HDU type */
+/// HDU type code for a primary array or IMAGE extension.
+pub const IMAGE_HDU: c_int = 0;
+/// HDU type code for an ASCII table extension.
+pub const ASCII_TBL: c_int = 1;
+/// HDU type code for a binary table extension.
+pub const BINARY_TBL: c_int = 2;
+/// HDU type code matching any HDU type.
+pub const ANY_HDU: c_int = -1;
 
-pub const READONLY: c_int = 0; /* options when opening a file */
+/// File access mode: open for reading only.
+pub const READONLY: c_int = 0;
+/// File access mode: open for reading and writing.
 pub const READWRITE: c_int = 1;
 
 /* adopt a hopefully obscure number to use as a null value flag */
+/// Sentinel `float` meaning "this pixel is undefined".
+///
+/// A hopefully obscure value, so that it does not collide with real data.
 pub const FLOATNULLVALUE: f32 = -9.11912E-36;
+/// Sentinel `double` meaning "this pixel is undefined".
+///
+/// A hopefully obscure value, so that it does not collide with real data.
 pub const DOUBLENULLVALUE: f64 = -9.1191291391491E-36;
 
-/* compression algorithm codes */
+/// Quantization dithering: do not dither.
 pub const NO_DITHER: c_int = -1;
+/// Quantization dithering: subtractive dither, starting from a fixed offset.
 pub const SUBTRACTIVE_DITHER_1: c_int = 1;
+/// Quantization dithering: as [`SUBTRACTIVE_DITHER_1`], but zero-valued pixels
+/// are preserved exactly.
 pub const SUBTRACTIVE_DITHER_2: c_int = 2;
 
+/// Maximum number of image dimensions the tile-compression code supports.
 pub const MAX_COMPRESS_DIM: usize = 6;
+/// Compression algorithm code for Rice.
 pub const RICE_1: c_int = 11;
+/// Compression algorithm code for GZIP.
 pub const GZIP_1: c_int = 21;
+/// Compression algorithm code for GZIP applied to byte-shuffled data.
 pub const GZIP_2: c_int = 22;
+/// Compression algorithm code for PLIO, for bit-mask images.
 pub const PLIO_1: c_int = 31;
+/// Compression algorithm code for Hcompress.
 pub const HCOMPRESS_1: c_int = 41;
-pub const BZIP2_1: c_int = 51; /* not publicly supported; only for test purposes */
+/// Compression algorithm code for BZIP2. Not publicly supported; for test
+/// purposes only.
+pub const BZIP2_1: c_int = 51;
+/// Compression algorithm code meaning "do not compress".
 pub const NOCOMPRESS: c_int = -1;
 
+/// Boolean true, as CFITSIO spells it.
 pub const TRUE: u64 = 1;
 
+/// Boolean false, as CFITSIO spells it.
 pub const FALSE: u64 = 0;
 
-pub const CASESEN: u64 = 1; /* do case-sensitive string match */
-pub const CASEINSEN: u64 = 0; /* do case-insensitive string match */
+/// Do a case-sensitive string match.
+pub const CASESEN: u64 = 1;
+/// Do a case-insensitive string match.
+pub const CASEINSEN: u64 = 0;
 
-pub const GT_ID_ALL_URI: u64 = 0; /* hierarchical grouping parameters */
+/// Grouping table member identification: by all of URI, position and reference.
+pub const GT_ID_ALL_URI: u64 = 0;
+/// Grouping table member identification: by reference.
 pub const GT_ID_REF: u64 = 1;
+/// Grouping table member identification: by position.
 pub const GT_ID_POS: u64 = 2;
+/// Grouping table member identification: by both reference and position.
 pub const GT_ID_ALL: u64 = 3;
+/// Grouping table member identification: by reference and URI.
 pub const GT_ID_REF_URI: u64 = 11;
+/// Grouping table member identification: by position and URI.
 pub const GT_ID_POS_URI: u64 = 12;
 
+/// Grouping table removal option: remove the grouping table itself.
 pub const OPT_RM_GPT: u64 = 0;
+/// Grouping table removal option: remove the member's entry only.
 pub const OPT_RM_ENTRY: u64 = 1;
+/// Grouping table removal option: remove the member HDU.
 pub const OPT_RM_MBR: u64 = 2;
+/// Grouping table removal option: remove the grouping table and all members.
 pub const OPT_RM_ALL: u64 = 3;
 
+/// Grouping table copy option: copy the grouping table only.
 pub const OPT_GCP_GPT: u64 = 0;
+/// Grouping table copy option: copy the member HDUs.
 pub const OPT_GCP_MBR: u64 = 1;
+/// Grouping table copy option: copy the grouping table and all its members.
 pub const OPT_GCP_ALL: u64 = 2;
 
+/// Group member copy option: add the copy to the same grouping table.
 pub const OPT_MCP_ADD: u64 = 0;
+/// Group member copy option: do not add the copy to a grouping table.
 pub const OPT_MCP_NADD: u64 = 1;
+/// Group member copy option: replace the original member with the copy.
 pub const OPT_MCP_REPL: u64 = 2;
+/// Group member copy option: move the member rather than copying it.
 pub const OPT_MCP_MOV: u64 = 3;
 
+/// Grouping table merge option: copy the members into the target table.
 pub const OPT_MRG_COPY: u64 = 0;
+/// Grouping table merge option: move the members into the target table.
 pub const OPT_MRG_MOV: u64 = 1;
 
+/// Grouping table compact option: compact member grouping tables.
 pub const OPT_CMT_MBR: u64 = 1;
+/// Grouping table compact option: compact member grouping tables and delete
+/// them afterwards.
 pub const OPT_CMT_MBR_DEL: u64 = 11;
 
-pub const VALIDSTRUC: c_int = 555; /* magic value used to identify if structure is valid */
+/// Magic value stored in [`FITSfile::validcode`] to identify a valid structure.
+pub const VALIDSTRUC: c_int = 555;
 
-pub const INPUT_COL: c_int = 0; /* flag for input only iterator column       */
-pub const INPUT_OUTPUT_COL: c_int = 1; /* flag for input and output iterator column */
-pub const OUTPUT_COL: c_int = 2; /* flag for output only iterator column      */
-pub const TEMPORARY_COL: c_int = 3; /* flag for temporary iterator column INTERNAL */
+/// Iterator column flag: the column is read but not written.
+pub const INPUT_COL: c_int = 0;
+/// Iterator column flag: the column is both read and written.
+pub const INPUT_OUTPUT_COL: c_int = 1;
+/// Iterator column flag: the column is written but not read.
+pub const OUTPUT_COL: c_int = 2;
+/// Iterator column flag: a temporary column, used internally.
+pub const TEMPORARY_COL: c_int = 3;
 
 /* error status codes */
 
-pub const CREATE_DISK_FILE: c_int = -106; /* create disk file, without extended filename syntax */
-pub const OPEN_DISK_FILE: c_int = -105; /* open disk file, without extended filename syntax */
-pub const SKIP_TABLE: c_int = -104; /* move to 1st image when opening file */
-pub const SKIP_IMAGE: c_int = -103; /* move to 1st table when opening file */
-pub const SKIP_NULL_PRIMARY: c_int = -102; /* skip null primary array when opening file */
-pub const USE_MEM_BUFF: c_int = -101; /* use memory buffer when opening file */
-pub const OVERFLOW_ERR: c_int = -11; /* overflow during datatype conversion */
-pub const PREPEND_PRIMARY: c_int = -9; /* used in ffiimg to insert new primary array */
-pub const SAME_FILE: c_int = 101; /* input and output files are the same */
-pub const TOO_MANY_FILES: c_int = 103; /* tried to open too many FITS files */
-pub const FILE_NOT_OPENED: c_int = 104; /* could not open the named file */
-pub const FILE_NOT_CREATED: c_int = 105; /* could not create the named file */
-pub const WRITE_ERROR: c_int = 106; /* error writing to FITS file */
-pub const END_OF_FILE: c_int = 107; /* tried to move past end of file */
-pub const READ_ERROR: c_int = 108; /* error reading from FITS file */
-pub const FILE_NOT_CLOSED: c_int = 110; /* could not close the file */
-pub const ARRAY_TOO_BIG: c_int = 111; /* array dimensions exceed internal limit */
-pub const READONLY_FILE: c_int = 112; /* Cannot write to readonly file */
-pub const MEMORY_ALLOCATION: c_int = 113; /* Could not allocate memory */
-pub const BAD_FILEPTR: c_int = 114; /* invalid fitsfile pointer */
-pub const NULL_INPUT_PTR: c_int = 115; /* NULL input pointer to routine */
-pub const SEEK_ERROR: c_int = 116; /* error seeking position in file */
-pub const BAD_NETTIMEOUT: c_int = 117; /* bad value for file download timeout setting */
+/// Create a disk file, without applying the extended filename syntax.
+pub const CREATE_DISK_FILE: c_int = -106;
+/// Open a disk file, without applying the extended filename syntax.
+pub const OPEN_DISK_FILE: c_int = -105;
+/// Move to the first image when opening the file.
+pub const SKIP_TABLE: c_int = -104;
+/// Move to the first table when opening the file.
+pub const SKIP_IMAGE: c_int = -103;
+/// Skip a null primary array when opening the file.
+pub const SKIP_NULL_PRIMARY: c_int = -102;
+/// Use a memory buffer when opening the file.
+pub const USE_MEM_BUFF: c_int = -101;
+/// Overflow during datatype conversion.
+pub const OVERFLOW_ERR: c_int = -11;
+/// Used in `ffiimg` to insert a new primary array.
+pub const PREPEND_PRIMARY: c_int = -9;
+/// Input and output files are the same.
+pub const SAME_FILE: c_int = 101;
+/// Tried to open too many FITS files at once.
+pub const TOO_MANY_FILES: c_int = 103;
+/// Could not open the named file.
+pub const FILE_NOT_OPENED: c_int = 104;
+/// Could not create the named file.
+pub const FILE_NOT_CREATED: c_int = 105;
+/// Error writing to the FITS file.
+pub const WRITE_ERROR: c_int = 106;
+/// Tried to move past the end of the file.
+pub const END_OF_FILE: c_int = 107;
+/// Error reading from the FITS file.
+pub const READ_ERROR: c_int = 108;
+/// Could not close the file.
+pub const FILE_NOT_CLOSED: c_int = 110;
+/// Array dimensions exceed an internal limit.
+pub const ARRAY_TOO_BIG: c_int = 111;
+/// Cannot write to a readonly file.
+pub const READONLY_FILE: c_int = 112;
+/// Could not allocate memory.
+pub const MEMORY_ALLOCATION: c_int = 113;
+/// Invalid [`fitsfile`] pointer.
+pub const BAD_FILEPTR: c_int = 114;
+/// Null input pointer to a routine.
+pub const NULL_INPUT_PTR: c_int = 115;
+/// Error seeking to a position in the file.
+pub const SEEK_ERROR: c_int = 116;
+/// Bad value for the file download timeout setting.
+pub const BAD_NETTIMEOUT: c_int = 117;
 
-pub const BAD_URL_PREFIX: c_int = 121; /* invalid URL prefix on file name */
-pub const TOO_MANY_DRIVERS: c_int = 122; /* tried to register too many IO drivers */
-pub const DRIVER_INIT_FAILED: c_int = 123; /* driver initialization failed */
-pub const NO_MATCHING_DRIVER: c_int = 124; /* matching driver is not registered */
-pub const URL_PARSE_ERROR: c_int = 125; /* failed to parse input file URL */
-pub const RANGE_PARSE_ERROR: c_int = 126; /* failed to parse input file URL */
+/// Invalid URL prefix on the file name.
+pub const BAD_URL_PREFIX: c_int = 121;
+/// Tried to register too many I/O drivers.
+pub const TOO_MANY_DRIVERS: c_int = 122;
+/// Driver initialization failed.
+pub const DRIVER_INIT_FAILED: c_int = 123;
+/// The matching driver is not registered.
+pub const NO_MATCHING_DRIVER: c_int = 124;
+/// Failed to parse the input file URL.
+pub const URL_PARSE_ERROR: c_int = 125;
+/// Parse error in a range list.
+pub const RANGE_PARSE_ERROR: c_int = 126;
 
+/// Base value the shared memory driver's error codes are offset from.
 pub const SHARED_ERRBASE: c_int = 150;
+/// Bad argument in the shared memory driver.
 pub const SHARED_BADARG: c_int = SHARED_ERRBASE + 1;
+/// Null pointer passed as an argument to the shared memory driver.
 pub const SHARED_NULPTR: c_int = SHARED_ERRBASE + 2;
+/// No more free shared memory handles.
 pub const SHARED_TABFULL: c_int = SHARED_ERRBASE + 3;
+/// The shared memory driver is not initialized.
 pub const SHARED_NOTINIT: c_int = SHARED_ERRBASE + 4;
+/// IPC error returned by a system call.
 pub const SHARED_IPCERR: c_int = SHARED_ERRBASE + 5;
+/// No memory in the shared memory driver.
 pub const SHARED_NOMEM: c_int = SHARED_ERRBASE + 6;
+/// Resource deadlock would occur.
 pub const SHARED_AGAIN: c_int = SHARED_ERRBASE + 7;
+/// Attempt to open or create the lock file failed.
 pub const SHARED_NOFILE: c_int = SHARED_ERRBASE + 8;
+/// The shared memory block cannot be resized at the moment.
 pub const SHARED_NORESIZE: c_int = SHARED_ERRBASE + 9;
 
-pub const HEADER_NOT_EMPTY: c_int = 201; /* header already contains keywords */
-pub const KEY_NO_EXIST: c_int = 202; /* keyword not found in header */
-pub const KEY_OUT_BOUNDS: c_int = 203; /* keyword record number is out of bounds */
-pub const VALUE_UNDEFINED: c_int = 204; /* keyword value field is blank */
-pub const NO_QUOTE: c_int = 205; /* string is missing the closing quote */
-pub const BAD_INDEX_KEY: c_int = 206; /* illegal indexed keyword name */
-pub const BAD_KEYCHAR: c_int = 207; /* illegal character in keyword name or card */
-pub const BAD_ORDER: c_int = 208; /* required keywords out of order */
-pub const NOT_POS_INT: c_int = 209; /* keyword value is not a positive integer */
-pub const NO_END: c_int = 210; /* couldn't find END keyword */
-pub const BAD_BITPIX: c_int = 211; /* illegal BITPIX keyword value*/
-pub const BAD_NAXIS: c_int = 212; /* illegal NAXIS keyword value */
-pub const BAD_NAXES: c_int = 213; /* illegal NAXISn keyword value */
-pub const BAD_PCOUNT: c_int = 214; /* illegal PCOUNT keyword value */
-pub const BAD_GCOUNT: c_int = 215; /* illegal GCOUNT keyword value */
-pub const BAD_TFIELDS: c_int = 216; /* illegal TFIELDS keyword value */
-pub const NEG_WIDTH: c_int = 217; /* negative table row size */
-pub const NEG_ROWS: c_int = 218; /* negative number of rows in table */
-pub const COL_NOT_FOUND: c_int = 219; /* column with this name not found in table */
-pub const BAD_SIMPLE: c_int = 220; /* illegal value of SIMPLE keyword  */
-pub const NO_SIMPLE: c_int = 221; /* Primary array doesn't start with SIMPLE */
-pub const NO_BITPIX: c_int = 222; /* Second keyword not BITPIX */
-pub const NO_NAXIS: c_int = 223; /* Third keyword not NAXIS */
-pub const NO_NAXES: c_int = 224; /* Couldn't find all the NAXISn keywords */
-pub const NO_XTENSION: c_int = 225; /* HDU doesn't start with XTENSION keyword */
-pub const NOT_ATABLE: c_int = 226; /* the CHDU is not an ASCII table extension */
-pub const NOT_BTABLE: c_int = 227; /* the CHDU is not a binary table extension */
-pub const NO_PCOUNT: c_int = 228; /* couldn't find PCOUNT keyword */
-pub const NO_GCOUNT: c_int = 229; /* couldn't find GCOUNT keyword */
-pub const NO_TFIELDS: c_int = 230; /* couldn't find TFIELDS keyword */
-pub const NO_TBCOL: c_int = 231; /* couldn't find TBCOLn keyword */
-pub const NO_TFORM: c_int = 232; /* couldn't find TFORMn keyword */
-pub const NOT_IMAGE: c_int = 233; /* the CHDU is not an IMAGE extension */
-pub const BAD_TBCOL: c_int = 234; /* TBCOLn keyword value < 0 or > rowlength */
-pub const NOT_TABLE: c_int = 235; /* the CHDU is not a table */
-pub const COL_TOO_WIDE: c_int = 236; /* column is too wide to fit in table */
-pub const COL_NOT_UNIQUE: c_int = 237; /* more than 1 column name matches template */
-pub const BAD_ROW_WIDTH: c_int = 241; /* sum of column widths not = NAXIS1 */
-pub const UNKNOWN_EXT: c_int = 251; /* unrecognizable FITS extension type */
-pub const UNKNOWN_REC: c_int = 252; /* unrecognizable FITS record */
-pub const END_JUNK: c_int = 253; /* END keyword is not blank */
-pub const BAD_HEADER_FILL: c_int = 254; /* Header fill area not blank */
-pub const BAD_DATA_FILL: c_int = 255; /* Data fill area not blank or zero */
-pub const BAD_TFORM: c_int = 261; /* illegal TFORM format code */
-pub const BAD_TFORM_DTYPE: c_int = 262; /* unrecognizable TFORM datatype code */
-pub const BAD_TDIM: c_int = 263; /* illegal TDIMn keyword value */
-pub const BAD_HEAP_PTR: c_int = 264; /* invalid BINTABLE heap address */
+/// The header already contains keywords.
+pub const HEADER_NOT_EMPTY: c_int = 201;
+/// The keyword was not found in the header.
+pub const KEY_NO_EXIST: c_int = 202;
+/// The keyword record number is out of bounds.
+pub const KEY_OUT_BOUNDS: c_int = 203;
+/// The keyword value field is blank.
+pub const VALUE_UNDEFINED: c_int = 204;
+/// The string is missing its closing quote.
+pub const NO_QUOTE: c_int = 205;
+/// Illegal indexed keyword name, e.g. `TFORM1000`.
+pub const BAD_INDEX_KEY: c_int = 206;
+/// Illegal character in a keyword name or card.
+pub const BAD_KEYCHAR: c_int = 207;
+/// Required keywords are out of order.
+pub const BAD_ORDER: c_int = 208;
+/// The keyword value is not a positive integer.
+pub const NOT_POS_INT: c_int = 209;
+/// Could not find the `END` keyword.
+pub const NO_END: c_int = 210;
+/// Illegal `BITPIX` keyword value.
+pub const BAD_BITPIX: c_int = 211;
+/// Illegal `NAXIS` keyword value.
+pub const BAD_NAXIS: c_int = 212;
+/// Illegal `NAXISn` keyword value.
+pub const BAD_NAXES: c_int = 213;
+/// Illegal `PCOUNT` keyword value.
+pub const BAD_PCOUNT: c_int = 214;
+/// Illegal `GCOUNT` keyword value.
+pub const BAD_GCOUNT: c_int = 215;
+/// Illegal `TFIELDS` keyword value.
+pub const BAD_TFIELDS: c_int = 216;
+/// Negative table row size.
+pub const NEG_WIDTH: c_int = 217;
+/// Negative number of rows in the table.
+pub const NEG_ROWS: c_int = 218;
+/// No column with this name was found in the table.
+pub const COL_NOT_FOUND: c_int = 219;
+/// Illegal value of the `SIMPLE` keyword.
+pub const BAD_SIMPLE: c_int = 220;
+/// The primary array does not start with `SIMPLE`.
+pub const NO_SIMPLE: c_int = 221;
+/// The second keyword is not `BITPIX`.
+pub const NO_BITPIX: c_int = 222;
+/// The third keyword is not `NAXIS`.
+pub const NO_NAXIS: c_int = 223;
+/// Could not find all the `NAXISn` keywords.
+pub const NO_NAXES: c_int = 224;
+/// The HDU does not start with the `XTENSION` keyword.
+pub const NO_XTENSION: c_int = 225;
+/// The current HDU is not an ASCII table extension.
+pub const NOT_ATABLE: c_int = 226;
+/// The current HDU is not a binary table extension.
+pub const NOT_BTABLE: c_int = 227;
+/// Could not find the `PCOUNT` keyword.
+pub const NO_PCOUNT: c_int = 228;
+/// Could not find the `GCOUNT` keyword.
+pub const NO_GCOUNT: c_int = 229;
+/// Could not find the `TFIELDS` keyword.
+pub const NO_TFIELDS: c_int = 230;
+/// Could not find the `TBCOLn` keyword.
+pub const NO_TBCOL: c_int = 231;
+/// Could not find the `TFORMn` keyword.
+pub const NO_TFORM: c_int = 232;
+/// The current HDU is not an IMAGE extension.
+pub const NOT_IMAGE: c_int = 233;
+/// `TBCOLn` keyword value is < 0 or > the row length.
+pub const BAD_TBCOL: c_int = 234;
+/// The current HDU is not a table.
+pub const NOT_TABLE: c_int = 235;
+/// The column is too wide to fit in the table.
+pub const COL_TOO_WIDE: c_int = 236;
+/// More than one column name matches the template.
+pub const COL_NOT_UNIQUE: c_int = 237;
+/// The sum of the column widths does not equal `NAXIS1`.
+pub const BAD_ROW_WIDTH: c_int = 241;
+/// Unrecognizable FITS extension type.
+pub const UNKNOWN_EXT: c_int = 251;
+/// Unknown record: the first keyword is neither `SIMPLE` nor `XTENSION`.
+pub const UNKNOWN_REC: c_int = 252;
+/// The `END` keyword record is not blank.
+pub const END_JUNK: c_int = 253;
+/// The header fill area contains non-blank characters.
+pub const BAD_HEADER_FILL: c_int = 254;
+/// Illegal data fill bytes: neither zero nor blank.
+pub const BAD_DATA_FILL: c_int = 255;
+/// Illegal `TFORM` format code.
+pub const BAD_TFORM: c_int = 261;
+/// Unrecognizable `TFORM` datatype code.
+pub const BAD_TFORM_DTYPE: c_int = 262;
+/// Illegal `TDIMn` keyword value.
+pub const BAD_TDIM: c_int = 263;
+/// The binary table heap pointer is out of range.
+pub const BAD_HEAP_PTR: c_int = 264;
 
-pub const BAD_HDU_NUM: c_int = 301; /* HDU number < 1 or > MAXHDU */
-pub const BAD_COL_NUM: c_int = 302; /* column number < 1 or > tfields */
-pub const NEG_FILE_POS: c_int = 304; /* tried to move before beginning of file  */
-pub const NEG_BYTES: c_int = 306; /* tried to read or write negative bytes */
-pub const BAD_ROW_NUM: c_int = 307; /* illegal starting row number in table */
-pub const BAD_ELEM_NUM: c_int = 308; /* illegal starting element number in vector */
-pub const NOT_ASCII_COL: c_int = 309; /* this is not an ASCII string column */
-pub const NOT_LOGICAL_COL: c_int = 310; /* this is not a logical datatype column */
-pub const BAD_ATABLE_FORMAT: c_int = 311; /* ASCII table column has wrong format */
-pub const BAD_BTABLE_FORMAT: c_int = 312; /* Binary table column has wrong format */
-pub const NO_NULL: c_int = 314; /* null value has not been defined */
-pub const NOT_VARI_LEN: c_int = 317; /* this is not a variable length column */
-pub const BAD_DIMEN: c_int = 320; /* illegal number of dimensions in array */
-pub const BAD_PIX_NUM: c_int = 321; /* first pixel number greater than last pixel */
-pub const ZERO_SCALE: c_int = 322; /* illegal BSCALE or TSCALn keyword = 0 */
-pub const NEG_AXIS: c_int = 323; /* illegal axis length < 1 */
+/// HDU number < 1 or > `MAXHDU`.
+pub const BAD_HDU_NUM: c_int = 301;
+/// Column number < 1 or > `tfields`.
+pub const BAD_COL_NUM: c_int = 302;
+/// Tried to move to a negative byte location in the file.
+pub const NEG_FILE_POS: c_int = 304;
+/// Tried to read or write a negative number of bytes.
+pub const NEG_BYTES: c_int = 306;
+/// Illegal starting row number in the table.
+pub const BAD_ROW_NUM: c_int = 307;
+/// Illegal starting element number in the vector.
+pub const BAD_ELEM_NUM: c_int = 308;
+/// This is not an ASCII string column.
+pub const NOT_ASCII_COL: c_int = 309;
+/// This is not a logical datatype column.
+pub const NOT_LOGICAL_COL: c_int = 310;
+/// The ASCII table column has the wrong format.
+pub const BAD_ATABLE_FORMAT: c_int = 311;
+/// The binary table column has the wrong format.
+pub const BAD_BTABLE_FORMAT: c_int = 312;
+/// The null value has not been defined.
+pub const NO_NULL: c_int = 314;
+/// This is not a variable length column.
+pub const NOT_VARI_LEN: c_int = 317;
+/// Illegal number of dimensions in the array.
+pub const BAD_DIMEN: c_int = 320;
+/// The first pixel number is greater than the last pixel.
+pub const BAD_PIX_NUM: c_int = 321;
+/// Illegal `BSCALE` or `TSCALn` keyword value of 0.
+pub const ZERO_SCALE: c_int = 322;
+/// Illegal axis length < 1.
+pub const NEG_AXIS: c_int = 323;
 
+/// Grouping function error: the HDU is not a grouping table.
 pub const NOT_GROUP_TABLE: c_int = 340;
+/// Grouping function error: the HDU is already a member of the group.
 pub const HDU_ALREADY_MEMBER: c_int = 341;
+/// Grouping function error: the group member was not found.
 pub const MEMBER_NOT_FOUND: c_int = 342;
+/// Grouping function error: the grouping table was not found.
 pub const GROUP_NOT_FOUND: c_int = 343;
+/// Grouping function error: bad group identifier.
 pub const BAD_GROUP_ID: c_int = 344;
+/// Grouping function error: too many HDUs are being tracked.
 pub const TOO_MANY_HDUS_TRACKED: c_int = 345;
+/// Grouping function error: the HDU is already being tracked.
 pub const HDU_ALREADY_TRACKED: c_int = 346;
+/// Grouping function error: bad option value.
 pub const BAD_OPTION: c_int = 347;
+/// Grouping function error: the two file pointers are identical.
 pub const IDENTICAL_POINTERS: c_int = 348;
+/// Grouping function error: could not attach the HDU to the group.
 pub const BAD_GROUP_ATTACH: c_int = 349;
+/// Grouping function error: could not detach the HDU from the group.
 pub const BAD_GROUP_DETACH: c_int = 350;
 
-pub const BAD_I2C: c_int = 401; /* bad int to formatted string conversion */
-pub const BAD_F2C: c_int = 402; /* bad float to formatted string conversion */
-pub const BAD_INTKEY: c_int = 403; /* can't interprete keyword value as integer */
-pub const BAD_LOGICALKEY: c_int = 404; /* can't interprete keyword value as logical */
-pub const BAD_FLOATKEY: c_int = 405; /* can't interprete keyword value as float */
-pub const BAD_DOUBLEKEY: c_int = 406; /* can't interprete keyword value as double */
-pub const BAD_C2I: c_int = 407; /* bad formatted string to int conversion */
-pub const BAD_C2F: c_int = 408; /* bad formatted string to float conversion */
-pub const BAD_C2D: c_int = 409; /* bad formatted string to double conversion */
-pub const BAD_DATATYPE: c_int = 410; /* bad keyword datatype code */
-pub const BAD_DECIM: c_int = 411; /* bad number of decimal places specified */
-pub const NUM_OVERFLOW: c_int = 412; /* overflow during datatype conversion */
+/// Bad `int` to formatted string conversion.
+pub const BAD_I2C: c_int = 401;
+/// Bad `float` to formatted string conversion.
+pub const BAD_F2C: c_int = 402;
+/// Cannot interpret the keyword value as an integer.
+pub const BAD_INTKEY: c_int = 403;
+/// Cannot interpret the keyword value as a logical.
+pub const BAD_LOGICALKEY: c_int = 404;
+/// Cannot interpret the keyword value as a float.
+pub const BAD_FLOATKEY: c_int = 405;
+/// Cannot interpret the keyword value as a double.
+pub const BAD_DOUBLEKEY: c_int = 406;
+/// Bad formatted string to `int` conversion.
+pub const BAD_C2I: c_int = 407;
+/// Bad formatted string to `float` conversion.
+pub const BAD_C2F: c_int = 408;
+/// Bad formatted string to `double` conversion.
+pub const BAD_C2D: c_int = 409;
+/// Illegal datatype code value.
+pub const BAD_DATATYPE: c_int = 410;
+/// Bad number of decimal places specified.
+pub const BAD_DECIM: c_int = 411;
+/// Overflow during datatype conversion.
+pub const NUM_OVERFLOW: c_int = 412;
 
-pub const DATA_COMPRESSION_ERR: c_int = 413; /* error in imcompress routines */
-pub const DATA_DECOMPRESSION_ERR: c_int = 414; /* error in imcompress routines */
-pub const NO_COMPRESSED_TILE: c_int = 415; /* compressed tile doesn't exist */
+/// Error compressing the image.
+pub const DATA_COMPRESSION_ERR: c_int = 413;
+/// Error uncompressing the image.
+pub const DATA_DECOMPRESSION_ERR: c_int = 414;
+/// The compressed tile does not exist.
+pub const NO_COMPRESSED_TILE: c_int = 415;
 
-pub const BAD_DATE: c_int = 420; /* error in date or time conversion */
+/// Error in a date or time conversion.
+pub const BAD_DATE: c_int = 420;
 
-pub const PARSE_SYNTAX_ERR: c_int = 431; /* syntax error in parser expression */
-pub const PARSE_BAD_TYPE: c_int = 432; /* expression did not evaluate to desired type */
-pub const PARSE_LRG_VECTOR: c_int = 433; /* vector result too large to return in array */
-pub const PARSE_NO_OUTPUT: c_int = 434; /* data parser failed not sent an out column */
-pub const PARSE_BAD_COL: c_int = 435; /* bad data encounter while parsing column */
-pub const PARSE_BAD_OUTPUT: c_int = 436; /* Output file not of proper type          */
+/// Syntax error in a parser expression.
+pub const PARSE_SYNTAX_ERR: c_int = 431;
+/// The expression did not evaluate to the desired type.
+pub const PARSE_BAD_TYPE: c_int = 432;
+/// The vector result is too large to return in the array.
+pub const PARSE_LRG_VECTOR: c_int = 433;
+/// The data parser was not sent an output column.
+pub const PARSE_NO_OUTPUT: c_int = 434;
+/// Bad data encountered while parsing a column.
+pub const PARSE_BAD_COL: c_int = 435;
+/// The output file is not of the proper type.
+pub const PARSE_BAD_OUTPUT: c_int = 436;
 
-pub const ANGLE_TOO_BIG: c_int = 501; /* celestial angle too large for projection */
-pub const BAD_WCS_VAL: c_int = 502; /* bad celestial coordinate or pixel value */
-pub const WCS_ERROR: c_int = 503; /* error in celestial coordinate calculation */
-pub const BAD_WCS_PROJ: c_int = 504; /* unsupported type of celestial projection */
-pub const NO_WCS_KEY: c_int = 505; /* celestial coordinate keywords not found */
-pub const APPROX_WCS_KEY: c_int = 506; /* approximate WCS keywords were calculated */
+/// Celestial angle too large for the projection.
+pub const ANGLE_TOO_BIG: c_int = 501;
+/// Bad celestial coordinate or pixel value.
+pub const BAD_WCS_VAL: c_int = 502;
+/// Error in a celestial coordinate calculation.
+pub const WCS_ERROR: c_int = 503;
+/// Unsupported type of celestial projection.
+pub const BAD_WCS_PROJ: c_int = 504;
+/// The celestial coordinate keywords were not found.
+pub const NO_WCS_KEY: c_int = 505;
+/// Approximate WCS keyword values were returned.
+pub const APPROX_WCS_KEY: c_int = 506;
 
-pub const NO_CLOSE_ERROR: c_int = 999; /* special value used internally to switch off */
-/* the error message from ffclos and ffchdu */
+/// Special value used internally to switch off the error message from `ffclos`
+/// and `ffchdu`.
+pub const NO_CLOSE_ERROR: c_int = 999;
 
-/*------- following error codes are used in the grparser.c file -----------*/
-pub const NGP_ERRBASE: c_int = 360; /* base chosen so not to interfere with CFITSIO */
+// The following error codes are used by the header template parser in
+// grparser.rs.
+/// Base value the template parser's error codes are offset from. Chosen so as
+/// not to interfere with the CFITSIO codes.
+pub const NGP_ERRBASE: c_int = 360;
+/// Template parser: no error.
 pub const NGP_OK: c_int = 0;
-pub const NGP_NO_MEMORY: c_int = NGP_ERRBASE; /* malloc failed */
-pub const NGP_READ_ERR: c_int = NGP_ERRBASE + 1; /* read error from file */
-pub const NGP_NUL_PTR: c_int = NGP_ERRBASE + 2; /* null pointer passed as argument */
-pub const NGP_EMPTY_CURLINE: c_int = NGP_ERRBASE + 3; /* line read seems to be empty */
-pub const NGP_UNREAD_QUEUE_FULL: c_int = NGP_ERRBASE + 4; /* cannot unread more then 1 line (or single line twice) */
-pub const NGP_INC_NESTING: c_int = NGP_ERRBASE + 5; /* too deep include file nesting (inf. loop ?) */
-pub const NGP_ERR_FOPEN: c_int = NGP_ERRBASE + 6; /* fopen() failed, cannot open file */
-pub const NGP_EOF: c_int = NGP_ERRBASE + 7; /* end of file encountered */
-pub const NGP_BAD_ARG: c_int = NGP_ERRBASE + 8; /* bad arguments passed */
-pub const NGP_TOKEN_NOT_EXPECT: c_int = NGP_ERRBASE + 9; /* token not expected here */
+/// Template parser: memory allocation failed.
+pub const NGP_NO_MEMORY: c_int = NGP_ERRBASE;
+/// Template parser: read error from the file.
+pub const NGP_READ_ERR: c_int = NGP_ERRBASE + 1;
+/// Template parser: null pointer passed as an argument. Usually means a null
+/// pointer was passed as the name of the template file.
+pub const NGP_NUL_PTR: c_int = NGP_ERRBASE + 2;
+/// Template parser: the line read seems to be empty. Used internally.
+pub const NGP_EMPTY_CURLINE: c_int = NGP_ERRBASE + 3;
+/// Template parser: cannot unread more than one line, or unread a single line
+/// twice.
+pub const NGP_UNREAD_QUEUE_FULL: c_int = NGP_ERRBASE + 4;
+/// Template parser: include file nesting is too deep — an infinite loop, or a
+/// template that includes itself.
+pub const NGP_INC_NESTING: c_int = NGP_ERRBASE + 5;
+/// Template parser: `fopen()` failed, cannot open the template file.
+pub const NGP_ERR_FOPEN: c_int = NGP_ERRBASE + 6;
+/// Template parser: end of file encountered where it was not expected.
+pub const NGP_EOF: c_int = NGP_ERRBASE + 7;
+/// Template parser: bad arguments passed. Usually an internal parser error that
+/// should not happen.
+pub const NGP_BAD_ARG: c_int = NGP_ERRBASE + 8;
+/// Template parser: token not expected here.
+pub const NGP_TOKEN_NOT_EXPECT: c_int = NGP_ERRBASE + 9;
 
+/// Stores table column information.
 #[repr(C)]
 #[derive(Debug, Clone, Copy)]
 pub struct tcolumn {
-    /* structure used to store table column information */
+    /// Column name — the FITS `TTYPEn` keyword.
     pub ttype: [c_char; 70],
-    /* column name = FITS TTYPEn keyword; */
+    /// Offset in the row to the first byte of the column.
     pub tbcol: LONGLONG,
-    /* offset in row to first byte of each column */
+    /// Datatype code of the column.
     pub tdatatype: c_int,
-    /* datatype code of each column */
+    /// Repeat count of the column: the number of elements.
     pub trepeat: LONGLONG,
-    /* repeat count of column; number of elements */
+    /// FITS `TSCALn` linear scaling factor.
     pub tscale: f64,
-    /* FITS TSCALn linear scaling factor */
+    /// FITS `TZEROn` linear scaling zero point.
     pub tzero: f64,
-    /* FITS TZEROn linear scaling zero point */
+    /// FITS null value, for an integer image or binary table column.
     pub tnull: LONGLONG,
-    /* FITS null value for int image or binary table cols */
+    /// FITS null value string, for an ASCII table column.
     pub strnull: [c_char; 20],
-    /* FITS null value string for ASCII table columns */
+    /// FITS `TFORMn` keyword value.
     pub tform: [c_char; 10],
-    /* FITS tform keyword value  */
-    pub twidth: c_long, /* width of each ASCII table column */
+    /// Width of the column, for an ASCII table.
+    pub twidth: c_long,
 }
 
 impl Default for tcolumn {
@@ -673,6 +996,21 @@ impl Default for FITSfile {
 }
 
 impl FITSfile {
+    /// Allocates a `FITSfile` for an already-opened file, with its filename,
+    /// `headstart` array and I/O buffers reserved.
+    ///
+    /// # Parameters
+    ///
+    /// * `driver` — (I) the I/O driver the file was opened with
+    /// * `handle` — (I) the driver's handle for the open file
+    /// * `url`    — (I) the file name, used for the error message
+    /// * `caller` — (I) name of the calling routine, used for the error message
+    /// * `status` — (IO) error status
+    ///
+    /// # Errors
+    ///
+    /// Closes `handle` and returns [`MEMORY_ALLOCATION`] if any of the three
+    /// allocations fails.
     pub fn new(
         driver: &fitsdriver,
         handle: c_int,
@@ -782,26 +1120,36 @@ impl FITSfile {
         Ok(b.unwrap())
     }
 
+    /// The byte offset of the start of each HDU, as a slice of `MAXHDU + 1`
+    /// entries.
     pub fn get_headstart_as_slice(&self) -> &[LONGLONG] {
         unsafe { core::slice::from_raw_parts(self.headstart, self.MAXHDU as usize + 1) }
     }
 
+    /// The byte offset of the start of each HDU, mutably.
     pub fn get_headstart_as_mut_slice(&mut self) -> &mut [LONGLONG] {
         unsafe { core::slice::from_raw_parts_mut(self.headstart, self.MAXHDU as usize + 1) }
     }
 
+    /// The [`NIOBUF`] I/O buffers of [`IOBUFLEN`] bytes each, as one flat
+    /// slice, reached through a raw pointer rather than through `self`.
     pub fn get_iobuffer(iobuffer: &mut *mut c_char) -> &[c_char] {
         unsafe { core::slice::from_raw_parts(*iobuffer, NIOBUF as usize * IOBUFLEN as usize) }
     }
 
+    /// The I/O buffers as one flat slice, mutably.
     pub fn get_iobuffer_mut(iobuffer: &mut *mut c_char) -> &mut [c_char] {
         unsafe { core::slice::from_raw_parts_mut(*iobuffer, NIOBUF as usize * IOBUFLEN as usize) }
     }
 
+    /// The table's column descriptions, one per field.
     pub fn get_tableptr_as_slice(&self) -> &[tcolumn] {
         unsafe { core::slice::from_raw_parts(self.tableptr, self.tfield as usize) }
     }
 
+    /// The table's column descriptions, reached through a raw pointer and a
+    /// caller-supplied length rather than through `self`, so the returned
+    /// slice does not borrow the `FITSfile`.
     pub fn get_tableptr_as_slice_unlinked<'a>(
         tableptr: &*mut tcolumn,
         len: usize,
@@ -809,50 +1157,63 @@ impl FITSfile {
         unsafe { core::slice::from_raw_parts(*tableptr, len) }
     }
 
+    /// The table's column descriptions, mutably.
     pub fn get_tableptr_as_mut_slice(&mut self) -> &mut [tcolumn] {
         unsafe { core::slice::from_raw_parts_mut(self.tableptr, self.tfield as usize) }
     }
 
+    /// Number of tiles along the first axis of a compressed image, which is
+    /// the length every per-tile array below is allocated to.
     pub fn get_tile_alloc_len(&self) -> usize {
         ((((self).znaxis[0] - 1) / ((self).tilesize[0])) + 1) as usize
     }
 
+    /// The row number of each cached uncompressed tile.
     pub fn get_tilerow_as_slice(&self) -> &[c_int] {
         unsafe { core::slice::from_raw_parts(self.tilerow, self.get_tile_alloc_len()) }
     }
 
+    /// The row number of each cached uncompressed tile, mutably.
     pub fn get_tilerow_as_mut_slice(&mut self) -> &mut [c_int] {
         unsafe { core::slice::from_raw_parts_mut(self.tilerow, self.get_tile_alloc_len()) }
     }
 
+    /// The length in bytes of each cached tile's data.
     pub fn get_tiledatasize_as_slice(&self) -> &[c_long] {
         unsafe { core::slice::from_raw_parts(self.tiledatasize, self.get_tile_alloc_len()) }
     }
 
+    /// The length in bytes of each cached tile's data, mutably.
     pub fn get_tiledatasize_as_mut_slice(&mut self) -> &mut [c_long] {
         unsafe { core::slice::from_raw_parts_mut(self.tiledatasize, self.get_tile_alloc_len()) }
     }
 
+    /// The datatype code ([`TINT`], [`TSHORT`], …) of each cached tile.
     pub fn get_tiletype_as_slice(&self) -> &[c_int] {
         unsafe { core::slice::from_raw_parts(self.tiletype, self.get_tile_alloc_len()) }
     }
 
+    /// The datatype code of each cached tile, mutably.
     pub fn get_tiletype_as_mut_slice(&mut self) -> &mut [c_int] {
         unsafe { core::slice::from_raw_parts_mut(self.tiletype, self.get_tile_alloc_len()) }
     }
 
+    /// The uncompressed data of each cached tile.
     pub fn get_tiledata_as_slice(&self) -> &[*mut c_void] {
         unsafe { core::slice::from_raw_parts(self.tiledata, self.get_tile_alloc_len()) }
     }
 
+    /// The uncompressed data of each cached tile, mutably.
     pub fn get_tiledata_as_mut_slice(&mut self) -> &mut [*mut c_void] {
         unsafe { core::slice::from_raw_parts_mut(self.tiledata, self.get_tile_alloc_len()) }
     }
 
+    /// The optional null-value flags of each cached tile.
     pub fn get_tilenullarray_as_slice(&self) -> &[*mut c_void] {
         unsafe { core::slice::from_raw_parts(self.tilenullarray, self.get_tile_alloc_len()) }
     }
 
+    /// The optional null-value flags of each cached tile, mutably.
     pub fn get_tilenullarray_as_mut_slice(&mut self) -> &mut [*mut c_void] {
         unsafe { core::slice::from_raw_parts_mut(self.tilenullarray, self.get_tile_alloc_len()) }
     }
@@ -905,14 +1266,17 @@ impl FITSfile {
     }
     */
 
+    /// Whether each cached tile contains any null values.
     pub fn get_tileanynull_as_slice(&self) -> &[c_int] {
         unsafe { core::slice::from_raw_parts(self.tileanynull, self.get_tile_alloc_len()) }
     }
 
+    /// Whether each cached tile contains any null values, mutably.
     pub fn get_tileanynull_as_mut_slice(&mut self) -> &mut [c_int] {
         unsafe { core::slice::from_raw_parts_mut(self.tileanynull, self.get_tile_alloc_len()) }
     }
 
+    /// The file name as a borrowed C string.
     pub fn get_filename_as_cstr(&self) -> &CStr {
         unsafe { CStr::from_ptr(self.filename) }
     }
@@ -1153,19 +1517,21 @@ impl DerefMut for FptrRef {
 // interior mutability of its own.
 unsafe impl Send for FptrRef {}
 
+/// Stores basic HDU information. This is the handle every routine in the API
+/// takes.
 #[repr(C)]
-/// Structure used to store basic HDU information
 pub struct fitsfile {
-    /// HDU position in file; 0 = first HDU
+    /// HDU position in the file; 0 = the first HDU.
     pub HDUposition: c_int,
 
-    /// Pointer to FITS file structure
+    /// The file this HDU belongs to.
     pub Fptr: FptrRef,
 }
 
-/// Do not change this as it is part of the public API
-/// structure for the iterator function column information
-/// elements required as input to fits_iterate_data:
+/// Describes one column to the iterator function, as input to
+/// `fits_iterate_data`.
+///
+/// Do not change the layout: it is part of the public API.
 #[derive(Debug, Clone, Copy)]
 #[repr(C)]
 pub struct iteratorCol {
@@ -1211,60 +1577,46 @@ impl Default for iteratorCol {
     }
 }
 
-/*=============================================================================
-*
-*       The following wtbarr typedef is used in the fits_read_wcstab() routine,
-*       which is intended for use with the WCSLIB library written by Mark
-*       Calabretta, http://www.atnf.csiro.au/~mcalabre/index.html
-*
-*       In order to maintain WCSLIB and CFITSIO as independent libraries it
-*       was not permissible for any CFITSIO library code to include WCSLIB
-*       header files, or vice versa.  However, the CFITSIO function
-*       fits_read_wcstab() accepts an array of structs defined by wcs.h within
-*       WCSLIB.  The problem then was to define this struct within fitsio.h
-*       without including wcs.h, especially noting that wcs.h will often (but
-*       not always) be included together with fitsio.h in an applications
-*       program that uses fits_read_wcstab().
-*
-*       Of the various possibilities, the solution adopted was for WCSLIB to
-*       define "struct wtbarr" while fitsio.h defines "typedef wtbarr", a
-*       untagged struct with identical members.  This allows both wcs.h and
-*       fitsio.h to define a wtbarr data type without conflict by virtue of
-*       the fact that structure tags and typedef names share different
-*       namespaces in C. Therefore, declarations within WCSLIB look like
-*
-*          struct wtbarr *w;
-*
-*       while within CFITSIO they are simply
-*
-*          wtbarr *w;
-*
-*       but as suggested by the commonality of the names, these are really the
-*       same aggregate data type.  However, in passing a (struct wtbarr *) to
-*       fits_read_wcstab() a cast to (wtbarr *) is formally required.
-*===========================================================================*/
+/// Describes an array to be extracted from a binary table by
+/// `fits_read_wcstab()`, for use with Mark Calabretta's WCSLIB.
+///
+/// In order to keep WCSLIB and CFITSIO independent of one another, neither
+/// library's headers may include the other's. WCSLIB therefore defines
+/// `struct wtbarr` while `fitsio.h` defines an untagged `typedef wtbarr` with
+/// identical members — legal in C because structure tags and typedef names live
+/// in different namespaces. Despite the two spellings these are the same
+/// aggregate type, though passing a `struct wtbarr *` to `fits_read_wcstab()`
+/// formally requires a cast.
+///
+/// See <http://www.atnf.csiro.au/~mcalabre/index.html>.
 #[repr(C)]
 pub struct wtbarr {
-    pub i: c_int,             /* Image axis number.                       */
-    pub m: c_int,             /* Array axis number for index vectors.     */
-    pub kind: c_int,          /* Array type, 'c' (coord) or 'i' (index).  */
-    pub extnam: [c_char; 72], /* EXTNAME of binary table extension.       */
-    pub extver: c_int,        /* EXTVER  of binary table extension.       */
-    pub extlev: c_int,        /* EXTLEV  of binary table extension.       */
-    pub ttype: [c_char; 72],  /* TTYPEn of column containing the array.   */
-    pub row: c_long,          /* Table row number.                        */
-    pub ndim: c_int,          /* Expected array dimensionality.           */
-    pub dimlen: *mut c_int,   /* Where to write the array axis lengths.   */
-    pub arrayp: *mut *mut f64, /* Where to write the address of the array  */
-                              /* allocated to store the array.            */
+    /// Image axis number.
+    pub i: c_int,
+    /// Array axis number for index vectors.
+    pub m: c_int,
+    /// Array type: `'c'` (coord) or `'i'` (index).
+    pub kind: c_int,
+    /// `EXTNAME` of the binary table extension.
+    pub extnam: [c_char; 72],
+    /// `EXTVER` of the binary table extension.
+    pub extver: c_int,
+    /// `EXTLEV` of the binary table extension.
+    pub extlev: c_int,
+    /// `TTYPEn` of the column containing the array.
+    pub ttype: [c_char; 72],
+    /// Table row number.
+    pub row: c_long,
+    /// Expected array dimensionality.
+    pub ndim: c_int,
+    /// Where to write the array axis lengths.
+    pub dimlen: *mut c_int,
+    /// Where to write the address of the array allocated to store the array.
+    pub arrayp: *mut *mut f64,
 }
 
-/// We need to implement the Drop trait for wtbarr to ensure that the memory
-/// allocated for the dimlen and arrayp fields is properly freed when the
-/// wtbarr struct is dropped. This is necessary because these fields are
-/// pointers to dynamically allocated memory, and Rust's default behavior
-/// does not automatically free memory allocated with malloc or similar
-/// functions.
+// `dimlen` and `arrayp` point at dynamically allocated memory, which Rust will
+// not free on its own, so `wtbarr` frees them itself.
 impl Drop for wtbarr {
     fn drop(&mut self) {
         unsafe {
@@ -1278,19 +1630,30 @@ impl Drop for wtbarr {
     }
 }
 
-// Do not change this as it is exposed via extern functions
+/// Inputs to, and output control for, the pixel filtering routines.
+///
+/// Do not change the layout: it is exposed through the `extern "C"` entry
+/// points.
 #[repr(C)]
 pub struct PixelFilter {
-    /* input(s) */
+    /// Number of input files.
     pub count: c_int,
+    /// Paths of the input files.
     pub path: *mut *mut c_char,
+    /// Tag naming each input file within the expression.
     pub tag: *mut *mut c_char,
+    /// Open file pointer for each input file.
     pub ifptr: *mut *mut fitsfile,
+    /// The filtering expression to evaluate.
     pub expression: *mut c_char,
-    /* output control */
+    /// `BITPIX` of the output image.
     pub bitpix: c_int,
+    /// `BLANK` value of the output image.
     pub blank: c_long,
+    /// Open file pointer for the output file.
     pub ofptr: *mut fitsfile,
+    /// Keyword to record the expression under in the output header.
     pub keyword: [c_char; FLEN_KEYWORD],
+    /// Comment for that keyword.
     pub comment: [c_char; FLEN_COMMENT],
 }

--- a/src/fitsio2.rs
+++ b/src/fitsio2.rs
@@ -1,3 +1,10 @@
+//! Internal constants and helpers shared across the library.
+//!
+//! Ported from CFITSIO's `fitsio2.h`, the private companion to `fitsio.h`. It
+//! holds the buffer sizes, machine-type flags, IEEE special-value tests and
+//! the floating-point bounds used by the datatype conversion routines.
+#![warn(missing_docs)]
+
 use core::ffi::c_char;
 use core::mem;
 
@@ -5,23 +12,32 @@ use crate::c_types::{c_int, c_long, c_short, size_t};
 
 use crate::wrappers::{strcmp_safe, strncmp_safe};
 
-pub const USE_LARGE_VALUE: c_int = -99; /* flag used when writing images */
+/// Flag used when writing images, meaning the value is too large for the
+/// narrower parameter it would otherwise be passed in.
+pub const USE_LARGE_VALUE: c_int = -99;
 
-pub const DBUFFSIZE: u64 = 28800; /* size of data buffer in bytes */
+/// Size of the data buffer, in bytes.
+pub const DBUFFSIZE: u64 = 28800;
 
-pub const NMAXFILES: usize = 10000; /* maximum number of FITS files that can be opened */
-/* CFITSIO will allocate (NMAXFILES * 80) bytes of memory */
-/* plus each file that is opened will use NIOBUF * 2880 bytes of memeory */
-/* where NIOBUF is defined in fitio.h and has a default value of 40 */
+/// Maximum number of FITS files that can be open at once.
+///
+/// CFITSIO allocates `NMAXFILES * 80` bytes up front, and each file that is
+/// opened uses a further [`NIOBUF`](crate::fitsio::NIOBUF) × 2880 bytes.
+pub const NMAXFILES: usize = 10000;
 
-pub const MINDIRECT: i64 = 8640; /* minimum size for direct reads and writes */
-/* MINDIRECT must have a value >= 8640 */
+/// Minimum transfer size for direct reads and writes, bypassing the I/O
+/// buffers. Must be at least 8640.
+pub const MINDIRECT: i64 = 8640;
 
 /*   it is useful to identify certain specific types of machines   */
-pub const NATIVE: u64 = 0; /* machine that uses non-byteswapped IEEE formats */
-pub const OTHERTYPE: u64 = 1; /* any other type of machine */
-pub const IBMPC: u64 = 5; /* used in drvrfile.c to work around a bug on PCs */
-pub const CRAY: u64 = 6; /* requires a special NaN test algorithm */
+/// Machine type: uses non-byteswapped IEEE formats.
+pub const NATIVE: u64 = 0;
+/// Machine type: any other type of machine.
+pub const OTHERTYPE: u64 = 1;
+/// Machine type: IBM PC. Used in `drvrfile.rs` to work around a bug on PCs.
+pub const IBMPC: u64 = 5;
+/// Machine type: Cray, which requires a special NaN test algorithm.
+pub const CRAY: u64 = 6;
 
 // VAXVMS (3) and ALPHAVMS (4) are deliberately absent, as are FLOATTYPE,
 // GFLOAT and IEEEFLOAT. rustc has no VMS target and dropped VAX and Alpha
@@ -45,21 +61,39 @@ pub const CRAY: u64 = 6; /* requires a special NaN test algorithm */
 /*  assume all other machine uses the same IEEE formats as used in FITS files */
 /*  e.g., Macs fall into this category  */
 
+/// The machine type this build targets. Every supported target uses the same
+/// IEEE formats as FITS files do.
 pub const CFITSIO_MACHINE: u64 = NATIVE;
+/// Whether this machine's byte order differs from the big-endian order FITS
+/// stores numbers in, so values must be swapped on the way in and out.
 pub const BYTESWAPPED: bool = true;
 
-/*  assume longs are 8 bytes long, unless previously set otherwise */
+/// Width of a C `long` in bits: 64 on LP64 targets such as Linux and macOS, 32
+/// on Windows.
 pub const LONGSIZE: u64 = c_long::BITS as u64;
 
-/*       end of block that determine long size and byte swapping        */
-/* ==================================================================== */
-
+/// Reaching the end of the file is not an error.
 pub const IGNORE_EOF: c_int = 1;
+/// Reaching the end of the file should be reported as an error.
 pub const REPORT_EOF: c_int = 0;
+/// Marks a data value as undefined.
 pub const DATA_UNDEFINED: i64 = -1;
+/// Marks the null value of a column as not having been defined.
 pub const NULL_UNDEFINED: c_int = 1234554321;
-pub const ASCII_NULL_UNDEFINED: c_char = 1; /* indicate no defined null value */
+/// Marks an ASCII table column as having no defined null value.
+pub const ASCII_NULL_UNDEFINED: c_char = 1;
 
+/// Compares two nul-terminated strings, testing the first character inline
+/// before falling back to a full comparison.
+///
+/// # Parameters
+///
+/// * `a` — (I) first string
+/// * `b` — (I) second string
+///
+/// # Returns
+///
+/// Negative, zero or positive as `a` sorts before, equal to, or after `b`.
 pub fn FSTRCMP(a: &[c_char], b: &[c_char]) -> c_int {
     if a[0] < b[0] {
         -1
@@ -70,6 +104,18 @@ pub fn FSTRCMP(a: &[c_char], b: &[c_char]) -> c_int {
     }
 }
 
+/// Compares the first `n` characters of two nul-terminated strings, testing the
+/// first character inline before falling back to a full comparison.
+///
+/// # Parameters
+///
+/// * `a` — (I) first string
+/// * `b` — (I) second string
+/// * `n` — (I) maximum number of characters to compare
+///
+/// # Returns
+///
+/// Negative, zero or positive as `a` sorts before, equal to, or after `b`.
 pub fn FSTRNCMP(a: &[c_char], b: &[c_char], n: size_t) -> c_int {
     if a[0] < b[0] {
         -1
@@ -80,11 +126,13 @@ pub fn FSTRNCMP(a: &[c_char], b: &[c_char], n: size_t) -> c_int {
     }
 }
 
-pub const FNANMASK: u64 = 0x7F80; /* mask bits 1 - 8; all set on NaNs */
-/* all 0 on underflow  or 0. */
+/// Mask over bits 1–8 of a `float`: all set on a NaN, all clear on an
+/// underflow or zero.
+pub const FNANMASK: u64 = 0x7F80;
 
-pub const DNANMASK: u64 = 0x7FF0; /* mask bits 1 - 11; all set on NaNs */
-/* all 0 on underflow  or 0. */
+/// Mask over bits 1–11 of a `double`: all set on a NaN, all clear on an
+/// underflow or zero.
+pub const DNANMASK: u64 = 0x7FF0;
 
 /* these functions work for both big and little endian machines */
 /* that use the IEEE floating point format for internal numbers */
@@ -102,6 +150,19 @@ pub const dnan: u64 =(L) \
       ( (L & DNANMASK) == DNANMASK ?  1 : (L & DNANMASK) == 0 ? 2 : 0)
  */
 
+/// Tests whether a `float` is a reserved IEEE value.
+///
+/// Works on both big- and little-endian machines that use the IEEE floating
+/// point format internally.
+///
+/// # Parameters
+///
+/// * `L` — (I) the high-order 16 bits of the float
+///
+/// # Returns
+///
+/// `1` for a NaN, overflow or infinity, `2` for a denormalized underflow value,
+/// `0` otherwise.
 pub fn fnan(L: c_short) -> c_int {
     if (L & FNANMASK as c_short) == FNANMASK as c_short {
         1
@@ -112,6 +173,19 @@ pub fn fnan(L: c_short) -> c_int {
     }
 }
 
+/// Tests whether a `double` is a reserved IEEE value.
+///
+/// Works on both big- and little-endian machines that use the IEEE floating
+/// point format internally.
+///
+/// # Parameters
+///
+/// * `L` — (I) the high-order 16 bits of the double
+///
+/// # Returns
+///
+/// `1` for a NaN, overflow or infinity, `2` for a denormalized underflow value,
+/// `0` otherwise.
 pub fn dnan(L: c_short) -> c_int {
     if (L & DNANMASK as c_short) == DNANMASK as c_short {
         1
@@ -122,50 +196,78 @@ pub fn dnan(L: c_short) -> c_int {
     }
 }
 
-pub const DSCHAR_MAX: f64 = 127.49; /* max double value that fits in an signed char */
-pub const DSCHAR_MIN: f64 = -128.49; /* min double value that fits in an signed char */
-pub const DUCHAR_MAX: f64 = 255.49; /* max double value that fits in an unsigned char */
-pub const DUCHAR_MIN: f64 = -0.49; /* min double value that fits in an unsigned char */
-pub const DUSHRT_MAX: f64 = 65535.49; /* max double value that fits in a unsigned short*/
-pub const DUSHRT_MIN: f64 = -0.49; /* min double value that fits in an unsigned short */
-pub const DSHRT_MAX: f64 = 32767.49; /* max double value that fits in a short */
-pub const DSHRT_MIN: f64 = -32768.49; /* min double value that fits in a short */
+/// Largest `double` that fits in a `signed char`.
+pub const DSCHAR_MAX: f64 = 127.49;
+/// Smallest `double` that fits in a `signed char`.
+pub const DSCHAR_MIN: f64 = -128.49;
+/// Largest `double` that fits in an `unsigned char`.
+pub const DUCHAR_MAX: f64 = 255.49;
+/// Smallest `double` that fits in an `unsigned char`.
+pub const DUCHAR_MIN: f64 = -0.49;
+/// Largest `double` that fits in an `unsigned short`.
+pub const DUSHRT_MAX: f64 = 65535.49;
+/// Smallest `double` that fits in an `unsigned short`.
+pub const DUSHRT_MIN: f64 = -0.49;
+/// Largest `double` that fits in a `short`.
+pub const DSHRT_MAX: f64 = 32767.49;
+/// Smallest `double` that fits in a `short`.
+pub const DSHRT_MIN: f64 = -32768.49;
 
 /* These bounds depend on the width of a C `long`, which is 32 bits on Windows
  * (LLP64) and 64 bits on most Unix targets (LP64).  CFITSIO selects them via
  * `#if LONGSIZE == 32` in fitsio2.h; we mirror that by branching on the size of
  * `c_long` at const-eval time so the overflow checks stay correct on Windows. */
+/// Largest `double` that fits in a `long`. Depends on the width of a C `long`.
 pub const DLONG_MAX: f64 = if mem::size_of::<c_long>() == 4 {
     2147483647.49 /* max double value that fits in a long */
 } else {
     9.223_372_036_854_775E18 /* max double value  long */
 };
+/// Smallest `double` that fits in a `long`. Depends on the width of a C `long`.
 pub const DLONG_MIN: f64 = if mem::size_of::<c_long>() == 4 {
     -2147483648.49 /* min double value that fits in a long */
 } else {
     -9.223_372_036_854_775E18 /* min double value  long */
 };
+/// Largest `double` that fits in an `unsigned long`. Depends on the width of a
+/// C `long`.
 pub const DULONG_MAX: f64 = if mem::size_of::<c_long>() == 4 {
     4294967295.49 /* max double that fits in a unsigned long */
 } else {
     1.844_674_407_370_955E19 /* max double value  ulong */
 };
 
-pub const DULONG_MIN: f64 = -0.49; /* min double value that fits in an unsigned long */
-pub const DULONGLONG_MAX: f64 = 18446744073709551615.; /* max unsigned  longlong */
+/// Smallest `double` that fits in an `unsigned long`.
+pub const DULONG_MIN: f64 = -0.49;
+/// Largest `double` that fits in an unsigned 64-bit integer.
+pub const DULONGLONG_MAX: f64 = 18446744073709551615.;
+/// Smallest `double` that fits in an unsigned 64-bit integer.
 pub const DULONGLONG_MIN: f64 = -0.49;
-pub const DLONGLONG_MAX: f64 = 9.223_372_036_854_776E18; /* max double value  longlong */
-pub const DLONGLONG_MIN: f64 = -9.223_372_036_854_776E18; /* min double value  longlong */
-pub const DUINT_MAX: f64 = 4294967295.49; /* max dbl that fits in a unsigned 4-byte int */
-pub const DUINT_MIN: f64 = -0.49; /* min dbl that fits in an unsigned 4-byte int */
-pub const DINT_MAX: f64 = 2147483647.49; /* max double value that fits in a 4-byte int */
-pub const DINT_MIN: f64 = -2147483648.49; /* min double value that fits in a 4-byte int */
+/// Largest `double` that fits in a signed 64-bit integer.
+pub const DLONGLONG_MAX: f64 = 9.223_372_036_854_776E18;
+/// Smallest `double` that fits in a signed 64-bit integer.
+pub const DLONGLONG_MIN: f64 = -9.223_372_036_854_776E18;
+/// Largest `double` that fits in an unsigned 4-byte integer.
+pub const DUINT_MAX: f64 = 4294967295.49;
+/// Smallest `double` that fits in an unsigned 4-byte integer.
+pub const DUINT_MIN: f64 = -0.49;
+/// Largest `double` that fits in a signed 4-byte integer.
+pub const DINT_MAX: f64 = 2147483647.49;
+/// Smallest `double` that fits in a signed 4-byte integer.
+pub const DINT_MIN: f64 = -2147483648.49;
 
-pub const UINT64_MAX: u64 = 18446744073709551615; /* max unsigned 64-bit integer */
+/// Largest unsigned 64-bit integer.
+pub const UINT64_MAX: u64 = 18446744073709551615;
 
-pub const UINT32_MAX: u32 = 4294967295; /* max unsigned 32-bit integer */
-pub const INT32_MAX: i32 = 2147483647; /* max 32-bit integer */
-pub const INT32_MIN: i32 = -INT32_MAX - 1; /* min 32-bit integer */
+/// Largest unsigned 32-bit integer.
+pub const UINT32_MAX: u32 = 4294967295;
+/// Largest signed 32-bit integer.
+pub const INT32_MAX: i32 = 2147483647;
+/// Smallest signed 32-bit integer.
+pub const INT32_MIN: i32 = -INT32_MAX - 1;
 
+/// Value written for a null pixel in a tile-compressed integer image.
 pub const COMPRESS_NULL_VALUE: i32 = -2147483647;
-pub const N_RANDOM: usize = 10000; /* DO NOT CHANGE THIS;  used when quantizing real numbers */
+/// Length of the random-number sequence used when quantizing real numbers. Do
+/// not change: the dithering is reproducible only for this length.
+pub const N_RANDOM: usize = 10000;

--- a/src/getcol.rs
+++ b/src/getcol.rs
@@ -1,9 +1,21 @@
-/*  This file, getcol.rs, contains routines that read data elements from    */
-/*  a FITS image or table.  There are generic datatype routines.           */
-
-/*  The FITSIO software was written by William Pence at the High Energy    */
-/*  Astrophysic Science Archive Research Center (HEASARC) at the NASA      */
-/*  Goddard Space Flight Center.                                           */
+//! Generic-datatype routines that read data elements from a FITS image or
+//! table.
+//!
+//! These take a `datatype` code at run time and dispatch to the corresponding
+//! typed module -- `getcolb` for [`TBYTE`], `getcold` for [`TDOUBLE`], and so
+//! on. The typed routines do the real work; this is the layer the `fits_read_*`
+//! entry points sit on.
+//!
+//! Reading converts: the value handed back is
+//! `(the value in the file) * TSCALn + TZEROn`, cast to the requested type, so
+//! a column stored as 16-bit integers can be read as doubles. A value equal to
+//! the column's null value is reported through `anynul` and either left alone
+//! or replaced by the caller's `nulval`, depending on which form is called.
+//!
+//! Ported from CFITSIO's `getcol.c`, written by William Pence at the High
+//! Energy Astrophysics Science Archive Research Center (HEASARC), NASA Goddard
+//! Space Flight Center.
+#![warn(missing_docs)]
 
 use core::mem;
 use core::slice;
@@ -42,7 +54,6 @@ use crate::int_snprintf;
 use crate::{NullCheckType, fitsio::*};
 use crate::{buffers::*, calculate_subsection_length};
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of values from the primary array. The datatype of the
 /// input array is defined by the 2nd argument.  Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
@@ -50,16 +61,27 @@ use crate::{buffers::*, calculate_subsection_length};
 /// Undefined elements will be set equal to NULVAL, unless NULVAL=0
 /// in which case no checking for undefined values will be performed.
 /// ANYNUL is returned with a value of .true. if any pixels are undefined.
+///
+/// # Parameters
+///
+/// * `fptr`     — (I) FITS file pointer
+/// * `datatype` — (I) datatype of the value
+/// * `firstpix` — (I) coord of first pixel to read (1s based)
+/// * `nelem`    — (I) number of values to read
+/// * `nulval`   — (I) value for undefined pixels
+/// * `array`    — (O) array of values that are returned
+/// * `anynul`   — (O) set to 1 if any values are null; else 0
+/// * `status`   — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgpxv(
-    fptr: *mut fitsfile,     /* I - FITS file pointer                       */
-    datatype: c_int,         /* I - datatype of the value                   */
-    firstpix: *const c_long, /* I - coord of first pixel to read (1s based) */
-    nelem: LONGLONG,         /* I - number of values to read                */
-    nulval: *const c_void,   /* I - value for undefined pixels              */
-    array: *mut c_void,      /* O - array of values that are returned       */
-    anynul: *mut c_int,      /* O - set to 1 if any values are null; else 0 */
-    status: *mut c_int,      /* IO - error status                           */
+    fptr: *mut fitsfile,
+    datatype: c_int,
+    firstpix: *const c_long,
+    nelem: LONGLONG,
+    nulval: *const c_void,
+    array: *mut c_void,
+    anynul: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -83,7 +105,6 @@ pub unsafe extern "C" fn ffgpxv(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of values from the primary array. The datatype of the
 /// input array is defined by the 2nd argument.  Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
@@ -91,15 +112,26 @@ pub unsafe extern "C" fn ffgpxv(
 /// Undefined elements will be set equal to NULVAL, unless NULVAL=0
 /// in which case no checking for undefined values will be performed.
 /// ANYNUL is returned with a value of .true. if any pixels are undefined.
+///
+/// # Parameters
+///
+/// * `fptr`     — (I) FITS file pointer
+/// * `datatype` — (I) datatype of the value
+/// * `firstpix` — (I) coord of first pixel to read (1s based)
+/// * `nelem`    — (I) number of values to read
+/// * `nulval`   — (I) value for undefined pixels
+/// * `array`    — (O) array of values that are returned
+/// * `anynul`   — (O) set to 1 if any values are null; else 0
+/// * `status`   — (IO) error status
 pub fn ffgpxv_safe(
-    fptr: &mut fitsfile,        /* I - FITS file pointer                       */
-    datatype: c_int,            /* I - datatype of the value                   */
-    firstpix: &[c_long],        /* I - coord of first pixel to read (1s based) */
-    nelem: LONGLONG,            /* I - number of values to read                */
-    nulval: Option<NullValue>,  /* I - value for undefined pixels              */
-    array: &mut [u8],           /* O - array of values that are returned       */
-    anynul: Option<&mut c_int>, /* O - set to 1 if any values are null; else 0 */
-    status: &mut c_int,         /* IO - error status                           */
+    fptr: &mut fitsfile,
+    datatype: c_int,
+    firstpix: &[c_long],
+    nelem: LONGLONG,
+    nulval: Option<NullValue>,
+    array: &mut [u8],
+    anynul: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     let mut tfirstpix: [LONGLONG; 99] = [0; 99];
     let mut naxis = 0;
@@ -123,7 +155,6 @@ pub fn ffgpxv_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of values from the primary array. The datatype of the
 /// input array is defined by the 2nd argument.  Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
@@ -136,16 +167,27 @@ pub fn ffgpxv_safe(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`     — (I) FITS file pointer
+/// * `datatype` — (I) datatype of the value
+/// * `firstpix` — (I) coord of first pixel to read (1s based)
+/// * `nelem`    — (I) number of values to read
+/// * `nulval`   — (I) value for undefined pixels
+/// * `array`    — (O) array of values that are returned
+/// * `anynul`   — (O) set to 1 if any values are null; else 0
+/// * `status`   — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgpxvll(
-    fptr: *mut fitsfile,       /* I - FITS file pointer                       */
-    datatype: c_int,           /* I - datatype of the value                   */
-    firstpix: *const LONGLONG, /* I - coord of first pixel to read (1s based) */
-    nelem: LONGLONG,           /* I - number of values to read                */
-    nulval: *const c_void,     /* I - value for undefined pixels              */
-    array: *mut c_void,        /* O - array of values that are returned       */
-    anynul: *mut c_int,        /* O - set to 1 if any values are null; else 0 */
-    status: *mut c_int,        /* IO - error status                           */
+    fptr: *mut fitsfile,
+    datatype: c_int,
+    firstpix: *const LONGLONG,
+    nelem: LONGLONG,
+    nulval: *const c_void,
+    array: *mut c_void,
+    anynul: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -179,7 +221,6 @@ pub unsafe extern "C" fn ffgpxvll(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of values from the primary array. The datatype of the
 /// input array is defined by the 2nd argument.  Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
@@ -192,15 +233,26 @@ pub unsafe extern "C" fn ffgpxvll(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`     — (I) FITS file pointer
+/// * `datatype` — (I) datatype of the value
+/// * `firstpix` — (I) coord of first pixel to read (1s based)
+/// * `nelem`    — (I) number of values to read
+/// * `nulval`   — (I) value for undefined pixels
+/// * `array`    — (O) array of values that are returned
+/// * `anynul`   — (O) set to 1 if any values are null; else 0
+/// * `status`   — (IO) error status
 pub fn ffgpxvll_safe(
-    fptr: &mut fitsfile,        /* I - FITS file pointer                       */
-    datatype: c_int,            /* I - datatype of the value                   */
-    firstpix: &[LONGLONG],      /* I - coord of first pixel to read (1s based) */
-    nelem: LONGLONG,            /* I - number of values to read                */
-    nulval: Option<NullValue>,  /* I - value for undefined pixels              */
-    array: &mut [u8],           /* O - array of values that are returned       */
-    anynul: Option<&mut c_int>, /* O - set to 1 if any values are null; else 0 */
-    status: &mut c_int,         /* IO - error status                           */
+    fptr: &mut fitsfile,
+    datatype: c_int,
+    firstpix: &[LONGLONG],
+    nelem: LONGLONG,
+    nulval: Option<NullValue>,
+    array: &mut [u8],
+    anynul: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     let mut naxis = 0;
 
@@ -767,23 +819,33 @@ pub fn ffgpxvll_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of values from the primary array. The datatype of the
 /// input array is defined by the 2nd argument.  Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
 /// the FITS array is not the same as the array being read).
 /// The nullarray values will = 1 if the corresponding array value is null.
 /// ANYNUL is returned with a value of .true. if any pixels are undefined.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `datatype`  — (I) datatype of the value
+/// * `firstpix`  — (I) coord of first pixel to read (1s based)
+/// * `nelem`     — (I) number of values to read
+/// * `array`     — (O) array of values that are returned
+/// * `nullarray` — (O) returned array of null value flags
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgpxf(
-    fptr: *mut fitsfile,     /* I - FITS file pointer                       */
-    datatype: c_int,         /* I - datatype of the value                   */
-    firstpix: *const c_long, /* I - coord of first pixel to read (1s based) */
-    nelem: LONGLONG,         /* I - number of values to read            */
-    array: *mut c_void,      /* O - array of values that are returned       */
-    nullarray: *mut c_char,  /* O - returned array of null value flags      */
-    anynul: *mut c_int,      /* O - set to 1 if any values are null; else 0 */
-    status: *mut c_int,      /* IO - error status                           */
+    fptr: *mut fitsfile,
+    datatype: c_int,
+    firstpix: *const c_long,
+    nelem: LONGLONG,
+    array: *mut c_void,
+    nullarray: *mut c_char,
+    anynul: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -813,22 +875,32 @@ pub unsafe extern "C" fn ffgpxf(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of values from the primary array. The datatype of the
 /// input array is defined by the 2nd argument.  Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
 /// the FITS array is not the same as the array being read).
 /// The nullarray values will = 1 if the corresponding array value is null.
 /// ANYNUL is returned with a value of .true. if any pixels are undefined.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `datatype`  — (I) datatype of the value
+/// * `firstpix`  — (I) coord of first pixel to read (1s based)
+/// * `nelem`     — (I) number of values to read
+/// * `array`     — (O) array of values that are returned
+/// * `nullarray` — (O) returned array of null value flags
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `status`    — (IO) error status
 pub fn ffgpxf_safe(
-    fptr: &mut fitsfile,        /* I - FITS file pointer                       */
-    datatype: c_int,            /* I - datatype of the value                   */
-    firstpix: &[c_long],        /* I - coord of first pixel to read (1s based) */
-    nelem: LONGLONG,            /* I - number of values to read            */
-    array: &mut [u8],           /* O - array of values that are returned       */
-    nullarray: &mut [c_char],   /* O - returned array of null value flags      */
-    anynul: Option<&mut c_int>, /* O - set to 1 if any values are null; else 0 */
-    status: &mut c_int,         /* IO - error status                           */
+    fptr: &mut fitsfile,
+    datatype: c_int,
+    firstpix: &[c_long],
+    nelem: LONGLONG,
+    array: &mut [u8],
+    nullarray: &mut [c_char],
+    anynul: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     let mut tfirstpix: [LONGLONG; 99] = [0; 99];
     let mut naxis = 0;
@@ -852,7 +924,6 @@ pub fn ffgpxf_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of values from the primary array. The datatype of the
 /// input array is defined by the 2nd argument.  Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
@@ -864,16 +935,27 @@ pub fn ffgpxf_safe(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `datatype`  — (I) datatype of the value
+/// * `firstpix`  — (I) coord of first pixel to read (1s based)
+/// * `nelem`     — (I) number of values to read
+/// * `array`     — (O) array of values that are returned
+/// * `nullarray` — (O) returned array of null value flags
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgpxfll(
-    fptr: *mut fitsfile,       /* I - FITS file pointer                       */
-    datatype: c_int,           /* I - datatype of the value                   */
-    firstpix: *const LONGLONG, /* I - coord of first pixel to read (1s based) */
-    nelem: LONGLONG,           /* I - number of values to read              */
-    array: *mut c_void,        /* O - array of values that are returned       */
-    nullarray: *mut c_char,    /* O - returned array of null value flags      */
-    anynul: *mut c_int,        /* O - set to 1 if any values are null; else 0 */
-    status: *mut c_int,        /* IO - error status                           */
+    fptr: *mut fitsfile,
+    datatype: c_int,
+    firstpix: *const LONGLONG,
+    nelem: LONGLONG,
+    array: *mut c_void,
+    nullarray: *mut c_char,
+    anynul: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -903,7 +985,6 @@ pub unsafe extern "C" fn ffgpxfll(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of values from the primary array. The datatype of the
 /// input array is defined by the 2nd argument.  Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
@@ -915,15 +996,26 @@ pub unsafe extern "C" fn ffgpxfll(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `datatype`  — (I) datatype of the value
+/// * `firstpix`  — (I) coord of first pixel to read (1s based)
+/// * `nelem`     — (I) number of values to read
+/// * `array`     — (O) array of values that are returned
+/// * `nullarray` — (O) returned array of null value flags
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `status`    — (IO) error status
 pub fn ffgpxfll_safe(
-    fptr: &mut fitsfile,        /* I - FITS file pointer                       */
-    datatype: c_int,            /* I - datatype of the value                   */
-    firstpix: &[LONGLONG],      /* I - coord of first pixel to read (1s based) */
-    nelem: LONGLONG,            /* I - number of values to read              */
-    array: &mut [u8],           /* O - array of values that are returned       */
-    nullarray: &mut [c_char],   /* O - returned array of null value flags      */
-    anynul: Option<&mut c_int>, /* O - set to 1 if any values are null; else 0 */
-    status: &mut c_int,         /* IO - error status                           */
+    fptr: &mut fitsfile,
+    datatype: c_int,
+    firstpix: &[LONGLONG],
+    nelem: LONGLONG,
+    array: &mut [u8],
+    nullarray: &mut [c_char],
+    anynul: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     let mut naxis = 0;
     let nullcheck = NullCheckType::SetNullArray;
@@ -1176,7 +1268,6 @@ pub fn ffgpxfll_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an section of values from the primary array. The datatype of the
 /// input array is defined by the 2nd argument.  Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
@@ -1184,17 +1275,29 @@ pub fn ffgpxfll_safe(
 /// Undefined elements will be set equal to NULVAL, unless NULVAL=0
 /// in which case no checking for undefined values will be performed.
 /// ANYNUL is returned with a value of .true. if any pixels are undefined.
+///
+/// # Parameters
+///
+/// * `fptr`     — (I) FITS file pointer
+/// * `datatype` — (I) datatype of the value
+/// * `blc`      — (I) 'bottom left corner' of the subsection
+/// * `trc`      — (I) 'top right corner' of the subsection
+/// * `inc`      — (I) increment to be applied in each dim.
+/// * `nulval`   — (I) value for undefined pixels
+/// * `array`    — (O) array of values that are returned
+/// * `anynul`   — (O) set to 1 if any values are null; else 0
+/// * `status`   — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgsv(
-    fptr: *mut fitsfile,   /* I - FITS file pointer                       */
-    datatype: c_int,       /* I - datatype of the value                   */
-    blc: *const c_long,    /* I - 'bottom left corner' of the subsection  */
-    trc: *const c_long,    /* I - 'top right corner' of the subsection    */
-    inc: *const c_long,    /* I - increment to be applied in each dim.    */
-    nulval: *const c_void, /* I - value for undefined pixels              */
-    array: *mut c_void,    /* O - array of values that are returned       */
-    anynul: *mut c_int,    /* O - set to 1 if any values are null; else 0 */
-    status: *mut c_int,    /* IO - error status                           */
+    fptr: *mut fitsfile,
+    datatype: c_int,
+    blc: *const c_long,
+    trc: *const c_long,
+    inc: *const c_long,
+    nulval: *const c_void,
+    array: *mut c_void,
+    anynul: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -1220,7 +1323,6 @@ pub unsafe extern "C" fn ffgsv(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an section of values from the primary array. The datatype of the
 /// input array is defined by the 2nd argument.  Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
@@ -1228,16 +1330,28 @@ pub unsafe extern "C" fn ffgsv(
 /// Undefined elements will be set equal to NULVAL, unless NULVAL=0
 /// in which case no checking for undefined values will be performed.
 /// ANYNUL is returned with a value of .true. if any pixels are undefined.
+///
+/// # Parameters
+///
+/// * `fptr`     — (I) FITS file pointer
+/// * `datatype` — (I) datatype of the value
+/// * `blc`      — (I) 'bottom left corner' of the subsection
+/// * `trc`      — (I) 'top right corner' of the subsection
+/// * `inc`      — (I) increment to be applied in each dim.
+/// * `nulval`   — (I) value for undefined pixels
+/// * `array`    — (O) array of values that are returned
+/// * `anynul`   — (O) set to 1 if any values are null; else 0
+/// * `status`   — (IO) error status
 pub fn ffgsv_safe(
-    fptr: &mut fitsfile,        /* I - FITS file pointer                       */
-    datatype: c_int,            /* I - datatype of the value                   */
-    blc: &[c_long],             /* I - 'bottom left corner' of the subsection  */
-    trc: &[c_long],             /* I - 'top right corner' of the subsection    */
-    inc: &[c_long],             /* I - increment to be applied in each dim.    */
-    nulval: Option<NullValue>,  /* I - value for undefined pixels              */
-    array: &mut [u8],           /* O - array of values that are returned       */
-    anynul: Option<&mut c_int>, /* O - set to 1 if any values are null; else 0 */
-    status: &mut c_int,         /* IO - error status                           */
+    fptr: &mut fitsfile,
+    datatype: c_int,
+    blc: &[c_long],
+    trc: &[c_long],
+    inc: &[c_long],
+    nulval: Option<NullValue>,
+    array: &mut [u8],
+    anynul: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     let mut naxis = 0;
     let mut naxes: [c_long; 9] = [0; 9];
@@ -1615,7 +1729,6 @@ pub fn ffgsv_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of values from the primary array. The datatype of the
 /// input array is defined by the 2nd argument.  Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
@@ -1630,16 +1743,27 @@ pub fn ffgsv_safe(
 /// and the second column contains the image itself.
 ///
 /// anynul can be a null pointer
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `datatype`  — (I) datatype of the value
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `nulval`    — (I) value for undefined pixels
+/// * `array`     — (O) array of values that are returned
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgpv(
-    fptr: *mut fitsfile,   /* I - FITS file pointer                       */
-    datatype: c_int,       /* I - datatype of the value                   */
-    firstelem: LONGLONG,   /* I - first vector element to read (1 = 1st)  */
-    nelem: LONGLONG,       /* I - number of values to read                */
-    nulval: *const c_void, /* I - value for undefined pixels              */
-    array: *mut c_void,    /* O - array of values that are returned       */
-    anynul: *mut c_int,    /* O - set to 1 if any values are null; else 0 */
-    status: *mut c_int,    /* IO - error status                           */
+    fptr: *mut fitsfile,
+    datatype: c_int,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    nulval: *const c_void,
+    array: *mut c_void,
+    anynul: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -1658,7 +1782,6 @@ pub unsafe extern "C" fn ffgpv(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of values from the primary array. The datatype of the
 /// input array is defined by the 2nd argument.  Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
@@ -1673,15 +1796,26 @@ pub unsafe extern "C" fn ffgpv(
 /// and the second column contains the image itself.
 ///
 /// anynul can be a null pointer
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `datatype`  — (I) datatype of the value
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `nulval`    — (I) value for undefined pixels
+/// * `array`     — (O) array of values that are returned
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `status`    — (IO) error status
 pub fn ffgpv_safe(
-    fptr: &mut fitsfile,        /* I - FITS file pointer                       */
-    datatype: c_int,            /* I - datatype of the value                   */
-    firstelem: LONGLONG,        /* I - first vector element to read (1 = 1st)  */
-    nelem: LONGLONG,            /* I - number of values to read                */
-    nulval: Option<NullValue>,  /* I - value for undefined pixels              */
-    array: &mut [u8],           /* O - array of values that are returned       */
-    anynul: Option<&mut c_int>, /* O - set to 1 if any values are null; else 0 */
-    status: &mut c_int,         /* IO - error status                           */
+    fptr: &mut fitsfile,
+    datatype: c_int,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    nulval: Option<NullValue>,
+    array: &mut [u8],
+    anynul: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     if *status > 0 || nelem == 0 {
         /* inherit input status value if > 0 */
@@ -1971,7 +2105,6 @@ pub fn ffgpv_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of values from the primary array. The datatype of the
 /// input array is defined by the 2nd argument.  Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
@@ -1983,16 +2116,27 @@ pub fn ffgpv_safe(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `datatype`  — (I) datatype of the value
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `array`     — (O) array of values that are returned
+/// * `nullarray` — (O) array of null value flags
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgpf(
-    fptr: *mut fitsfile,    /* I - FITS file pointer                       */
-    datatype: c_int,        /* I - datatype of the value                   */
-    firstelem: LONGLONG,    /* I - first vector element to read (1 = 1st)  */
-    nelem: LONGLONG,        /* I - number of values to read                */
-    array: *mut c_void,     /* O - array of values that are returned       */
-    nullarray: *mut c_char, /* O - array of null value flags               */
-    anynul: *mut c_int,     /* O - set to 1 if any values are null; else 0 */
-    status: *mut c_int,     /* IO - error status                           */
+    fptr: *mut fitsfile,
+    datatype: c_int,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: *mut c_void,
+    nullarray: *mut c_char,
+    anynul: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -2011,7 +2155,6 @@ pub unsafe extern "C" fn ffgpf(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of values from the primary array. The datatype of the
 /// input array is defined by the 2nd argument.  Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
@@ -2023,15 +2166,26 @@ pub unsafe extern "C" fn ffgpf(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `datatype`  — (I) datatype of the value
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `array`     — (O) array of values that are returned
+/// * `nullarray` — (O) array of null value flags
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `status`    — (IO) error status
 pub fn ffgpf_safe(
-    fptr: &mut fitsfile,        /* I - FITS file pointer                       */
-    datatype: c_int,            /* I - datatype of the value                   */
-    firstelem: LONGLONG,        /* I - first vector element to read (1 = 1st)  */
-    nelem: LONGLONG,            /* I - number of values to read                */
-    array: &mut [u8],           /* O - array of values that are returned       */
-    nullarray: &mut [c_char],   /* O - array of null value flags               */
-    anynul: Option<&mut c_int>, /* O - set to 1 if any values are null; else 0 */
-    status: &mut c_int,         /* IO - error status                           */
+    fptr: &mut fitsfile,
+    datatype: c_int,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: &mut [u8],
+    nullarray: &mut [c_char],
+    anynul: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     if *status > 0 || nelem == 0 {
         /* inherit input status value if > 0 */
@@ -2093,7 +2247,6 @@ pub fn ffgpf_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of values from a table column. The datatype of the
 /// input array is defined by the 2nd argument.  Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
@@ -2101,18 +2254,31 @@ pub fn ffgpf_safe(
 /// Undefined elements will be set equal to NULVAL, unless NULVAL=0
 /// in which case no checking for undefined values will be performed.
 /// ANYNUL is returned with a value of true if any pixels are undefined.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `datatype`  — (I) datatype of the value
+/// * `colnum`    — (I) number of column to read (1 = 1st col)
+/// * `firstrow`  — (I) first row to read (1 = 1st row)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `nulval`    — (I) value for undefined pixels
+/// * `array`     — (O) array of values that are returned
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgcv(
-    fptr: *mut fitsfile,   /* I - FITS file pointer                       */
-    datatype: c_int,       /* I - datatype of the value                   */
-    colnum: c_int,         /* I - number of column to read (1 = 1st col) */
-    firstrow: LONGLONG,    /* I - first row to read (1 = 1st row)        */
-    firstelem: LONGLONG,   /* I - first vector element to read (1 = 1st)  */
-    nelem: LONGLONG,       /* I - number of values to read                */
-    nulval: *const c_void, /* I - value for undefined pixels              */
-    array: *mut c_void,    /* O - array of values that are returned       */
-    anynul: *mut c_int,    /* O - set to 1 if any values are null; else 0 */
-    status: *mut c_int,    /* IO - error status                           */
+    fptr: *mut fitsfile,
+    datatype: c_int,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    nulval: *const c_void,
+    array: *mut c_void,
+    anynul: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -2139,7 +2305,6 @@ pub unsafe extern "C" fn ffgcv(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of values from a table column. The datatype of the
 /// input array is defined by the 2nd argument.  Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
@@ -2147,17 +2312,30 @@ pub unsafe extern "C" fn ffgcv(
 /// Undefined elements will be set equal to NULVAL, unless NULVAL=0
 /// in which case no checking for undefined values will be performed.
 /// ANYNUL is returned with a value of true if any pixels are undefined.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `datatype`  — (I) datatype of the value
+/// * `colnum`    — (I) number of column to read (1 = 1st col)
+/// * `firstrow`  — (I) first row to read (1 = 1st row)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `nulval`    — (I) value for undefined pixels
+/// * `array`     — (O) array of values that are returned
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `status`    — (IO) error status
 pub fn ffgcv_safe(
-    fptr: &mut fitsfile,        /* I - FITS file pointer                       */
-    datatype: c_int,            /* I - datatype of the value                   */
-    colnum: c_int,              /* I - number of column to read (1 = 1st col) */
-    firstrow: LONGLONG,         /* I - first row to read (1 = 1st row)        */
-    firstelem: LONGLONG,        /* I - first vector element to read (1 = 1st)  */
-    nelem: LONGLONG,            /* I - number of values to read                */
-    nulval: Option<NullValue>,  /* I - value for undefined pixels              */
-    array: &mut [u8],           /* O - array of values that are returned       */
-    anynul: Option<&mut c_int>, /* O - set to 1 if any values are null; else 0 */
-    status: &mut c_int,         /* IO - error status                           */
+    fptr: &mut fitsfile,
+    datatype: c_int,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    nulval: Option<NullValue>,
+    array: &mut [u8],
+    anynul: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     let mut cdummy: [c_char; 2] = [0; 2];
 
@@ -2874,27 +3052,39 @@ pub fn ffgcv_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read arrays of values from NCOLS table columns. This is an optimization
 /// to read all columns in one pass through the table.  The datatypes of the
 /// input arrays are defined by the 3rd argument.  Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
 /// the FITS array is not the same as the array being read).
-/// Undefined elements for column i will be set equal to *(nulval[i]), unless nulval[i]=0
+/// Undefined elements for column `i` will be set equal to `*(nulval[i])`, unless `nulval[i]=0`
 /// in which case no checking for undefined values will be performed.
-/// anynul[i] is returned with a value of true if any pixels in column i are undefined.
+/// `anynul[i]` is returned with a value of true if any pixels in column `i` are undefined.
+///
+/// # Parameters
+///
+/// * `fptr`     — (I) FITS file pointer
+/// * `ncols`    — (I) number of columns to read
+/// * `datatype` — (I) datatypes of the values
+/// * `colnum`   — (I) columns numbers to read (1 = 1st col)
+/// * `firstrow` — (I) first row to read (1 = 1st row)
+/// * `nrows`    — (I) number of rows to read
+/// * `nulval`   — (I) array of pointers to values for undefined pixels
+/// * `array`    — (O) array of pointers to values that are returned
+/// * `anynul`   — (O) `anynul[i]` set to 1 if any values in column i are null; else 0
+/// * `status`   — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgcvn(
-    fptr: *mut fitsfile,          /* I - FITS file pointer                       */
-    ncols: c_int,                 /* I - number of columns to read               */
-    datatype: *const c_int,       /* I - datatypes of the values                 */
-    colnum: *const c_int,         /* I - columns numbers to read (1 = 1st col)   */
-    firstrow: LONGLONG,           /* I - first row to read (1 = 1st row)     */
-    nrows: LONGLONG,              /* I - number of rows to read              */
-    nulval: *const *const c_void, /* I - array of pointers to values for undefined pixels */
-    array: *mut *mut c_void,      /* O - array of pointers to values that are returned    */
-    anynul: *mut c_int, /* O - anynul[i] set to 1 if any values in column i are null; else 0 */
-    status: *mut c_int, /* IO - error status                           */
+    fptr: *mut fitsfile,
+    ncols: c_int,
+    datatype: *const c_int,
+    colnum: *const c_int,
+    firstrow: LONGLONG,
+    nrows: LONGLONG,
+    nulval: *const *const c_void,
+    array: *mut *mut c_void,
+    anynul: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -2924,26 +3114,38 @@ pub unsafe extern "C" fn ffgcvn(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read arrays of values from NCOLS table columns. This is an optimization
 /// to read all columns in one pass through the table.  The datatypes of the
 /// input arrays are defined by the 3rd argument.  Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
 /// the FITS array is not the same as the array being read).
-/// Undefined elements for column i will be set equal to *(nulval[i]), unless nulval[i]=0
+/// Undefined elements for column `i` will be set equal to `*(nulval[i])`, unless `nulval[i]=0`
 /// in which case no checking for undefined values will be performed.
-/// anynul[i] is returned with a value of true if any pixels in column i are undefined.
+/// `anynul[i]` is returned with a value of true if any pixels in column `i` are undefined.
+///
+/// # Parameters
+///
+/// * `fptr`     — (I) FITS file pointer
+/// * `ncols`    — (I) number of columns to read
+/// * `datatype` — (I) datatypes of the values
+/// * `colnum`   — (I) columns numbers to read (1 = 1st col)
+/// * `firstrow` — (I) first row to read (1 = 1st row)
+/// * `nrows`    — (I) number of rows to read
+/// * `nulval`   — (I) array of pointers to values for undefined pixels
+/// * `array`    — (O) array of pointers to values that are returned
+/// * `anynul`   — (O) `anynul[i]` set to 1 if any values in column i are null; else 0
+/// * `status`   — (IO) error status
 pub fn ffgcvn_safe(
-    fptr: &mut fitsfile,          /* I - FITS file pointer                       */
-    ncols: c_int,                 /* I - number of columns to read               */
-    datatype: &[c_int],           /* I - datatypes of the values                 */
-    colnum: &[c_int],             /* I - columns numbers to read (1 = 1st col)   */
-    firstrow: LONGLONG,           /* I - first row to read (1 = 1st row)     */
-    nrows: LONGLONG,              /* I - number of rows to read              */
-    nulval: &[Option<NullValue>], /* I - array of pointers to values for undefined pixels */
-    array: &mut [*mut c_void],    /* O - array of pointers to values that are returned    */
-    mut anynul: Option<&mut [c_int]>, /* O - anynul[i] set to 1 if any values in column i are null; else 0 */
-    status: &mut c_int,               /* IO - error status                           */
+    fptr: &mut fitsfile,
+    ncols: c_int,
+    datatype: &[c_int],
+    colnum: &[c_int],
+    firstrow: LONGLONG,
+    nrows: LONGLONG,
+    nulval: &[Option<NullValue>],
+    array: &mut [*mut c_void],
+    mut anynul: Option<&mut [c_int]>,
+    status: &mut c_int,
 ) -> c_int {
     let mut ntotrows: LONGLONG = 0;
     let mut ndone: LONGLONG = 0;
@@ -3117,24 +3319,36 @@ pub fn ffgcvn_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of values from a table column. The datatype of the
 /// input array is defined by the 2nd argument.  Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
 /// the FITS array is not the same as the array being read).
 /// ANYNUL is returned with a value of true if any pixels are undefined.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `datatype`  — (I) datatype of the value
+/// * `colnum`    — (I) number of column to write (1 = 1st col)
+/// * `firstrow`  — (I) first row to write (1 = 1st row)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `array`     — (O) array of values that are returned
+/// * `nullarray` — (O) array of null value flags
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgcf(
-    fptr: *mut fitsfile,    /* I - FITS file pointer                       */
-    datatype: c_int,        /* I - datatype of the value                   */
-    colnum: c_int,          /* I - number of column to write (1 = 1st col) */
-    firstrow: LONGLONG,     /* I - first row to write (1 = 1st row)        */
-    firstelem: LONGLONG,    /* I - first vector element to read (1 = 1st)  */
-    nelem: LONGLONG,        /* I - number of values to read                */
-    array: *mut c_void,     /* O - array of values that are returned       */
-    nullarray: *mut c_char, /* O - array of null value flags               */
-    anynul: *mut c_int,     /* O - set to 1 if any values are null; else 0 */
-    status: *mut c_int,     /* IO - error status                           */
+    fptr: *mut fitsfile,
+    datatype: c_int,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: *mut c_void,
+    nullarray: *mut c_char,
+    anynul: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -3170,23 +3384,35 @@ pub unsafe extern "C" fn ffgcf(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of values from a table column. The datatype of the
 /// input array is defined by the 2nd argument.  Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
 /// the FITS array is not the same as the array being read).
 /// ANYNUL is returned with a value of true if any pixels are undefined.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `datatype`  — (I) datatype of the value
+/// * `colnum`    — (I) number of column to write (1 = 1st col)
+/// * `firstrow`  — (I) first row to write (1 = 1st row)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `array`     — (O) array of values that are returned
+/// * `nullarray` — (O) array of null value flags
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `status`    — (IO) error status
 pub fn ffgcf_safe(
-    fptr: &mut fitsfile,        /* I - FITS file pointer                       */
-    datatype: c_int,            /* I - datatype of the value                   */
-    colnum: c_int,              /* I - number of column to write (1 = 1st col) */
-    firstrow: LONGLONG,         /* I - first row to write (1 = 1st row)        */
-    firstelem: LONGLONG,        /* I - first vector element to read (1 = 1st)  */
-    nelem: LONGLONG,            /* I - number of values to read                */
-    array: &mut [u8],           /* O - array of values that are returned       */
-    nullarray: &mut [c_char],   /* O - array of null value flags               */
-    anynul: Option<&mut c_int>, /* O - set to 1 if any values are null; else 0 */
-    status: &mut c_int,         /* IO - error status                           */
+    fptr: &mut fitsfile,
+    datatype: c_int,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: &mut [u8],
+    nullarray: &mut [c_char],
+    anynul: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     let nulval: f64 = 0.0;
     let cnulval: [c_char; 2] = [0; 2];

--- a/src/getcolb.rs
+++ b/src/getcolb.rs
@@ -1,9 +1,14 @@
-/*  This file, getcolb.rs, contains routines that read data elements from   */
-/*  a FITS image or table, with unsigned char (unsigned byte) data type.   */
-
-/*  The FITSIO software was written by William Pence at the High Energy    */
-/*  Astrophysic Science Archive Research Center (HEASARC) at the NASA      */
-/*  Goddard Space Flight Center.                                           */
+//! Routines that read data elements from a FITS image or table, with
+//! unsigned char (unsigned byte) datatype.
+//!
+//! The [`TBYTE`] arm of the typed column I/O family. [`crate::getcol`]
+//! dispatches here when a caller asks for this datatype at run time; the
+//! write-side counterpart is [`crate::putcolb`].
+//!
+//! Ported from CFITSIO's `getcolb.c`, written by William Pence at the High
+//! Energy Astrophysics Science Archive Research Center (HEASARC), NASA Goddard
+//! Space Flight Center.
+#![warn(missing_docs)]
 
 use core::slice;
 use core::{cmp, mem};
@@ -25,7 +30,6 @@ use crate::{NullValue, bb};
 use crate::{buffers::*, calculate_subsection_length};
 use crate::{int_snprintf, slice_to_str};
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of values from the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
 /// the FITS array is not the same as the array being read).
@@ -37,16 +41,27 @@ use crate::{int_snprintf, slice_to_str};
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to read (1 = 1st group)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `nulval`    — (I) value for undefined pixels
+/// * `array`     — (O) array of values that are returned
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgpvb(
-    fptr: *mut fitsfile, /* I - FITS file pointer                       */
-    group: c_long,       /* I - group to read (1 = 1st group)           */
-    firstelem: LONGLONG, /* I - first vector element to read (1 = 1st)  */
-    nelem: LONGLONG,     /* I - number of values to read                */
-    nulval: u8,          /* I - value for undefined pixels          */
-    array: *mut u8,      /* O - array of values that are returned   */
-    anynul: *mut c_int,  /* O - set to 1 if any values are null; else 0 */
-    status: *mut c_int,  /* IO - error status                           */
+    fptr: *mut fitsfile,
+    group: c_long,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    nulval: u8,
+    array: *mut u8,
+    anynul: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -60,7 +75,6 @@ pub unsafe extern "C" fn ffgpvb(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of values from the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
 /// the FITS array is not the same as the array being read).
@@ -72,15 +86,26 @@ pub unsafe extern "C" fn ffgpvb(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to read (1 = 1st group)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `nulval`    — (I) value for undefined pixels
+/// * `array`     — (O) array of values that are returned
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `status`    — (IO) error status
 pub fn ffgpvb_safe(
-    fptr: &mut fitsfile,        /* I - FITS file pointer                       */
-    group: c_long,              /* I - group to read (1 = 1st group)           */
-    firstelem: LONGLONG,        /* I - first vector element to read (1 = 1st)  */
-    nelem: LONGLONG,            /* I - number of values to read                */
-    nulval: u8,                 /* I - value for undefined pixels          */
-    array: &mut [u8],           /* O - array of values that are returned   */
-    anynul: Option<&mut c_int>, /* O - set to 1 if any values are null; else 0 */
-    status: &mut c_int,         /* IO - error status                           */
+    fptr: &mut fitsfile,
+    group: c_long,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    nulval: u8,
+    array: &mut [u8],
+    anynul: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     let nullcheck = NullCheckType::SetPixel;
     let nullvalue: u8;
@@ -125,7 +150,6 @@ pub fn ffgpvb_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of values from the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
 /// the FITS array is not the same as the array being read).
@@ -137,16 +161,27 @@ pub fn ffgpvb_safe(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to read (1 = 1st group)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `array`     — (O) array of values that are returned
+/// * `nularray`  — (O) array of null pixel flags
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgpfb(
-    fptr: *mut fitsfile,   /* I - FITS file pointer                       */
-    group: c_long,         /* I - group to read (1 = 1st group)           */
-    firstelem: LONGLONG,   /* I - first vector element to read (1 = 1st)  */
-    nelem: LONGLONG,       /* I - number of values to read                */
-    array: *mut u8,        /* O - array of values that are returned   */
-    nularray: *mut c_char, /* O - array of null pixel flags               */
-    anynul: *mut c_int,    /* O - set to 1 if any values are null; else 0 */
-    status: *mut c_int,    /* IO - error status                           */
+    fptr: *mut fitsfile,
+    group: c_long,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: *mut u8,
+    nularray: *mut c_char,
+    anynul: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -163,7 +198,6 @@ pub unsafe extern "C" fn ffgpfb(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of values from the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
 /// the FITS array is not the same as the array being read).
@@ -175,15 +209,26 @@ pub unsafe extern "C" fn ffgpfb(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to read (1 = 1st group)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `array`     — (O) array of values that are returned
+/// * `nularray`  — (O) array of null pixel flags
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `status`    — (IO) error status
 pub fn ffgpfb_safe(
-    fptr: &mut fitsfile,        /* I - FITS file pointer                       */
-    group: c_long,              /* I - group to read (1 = 1st group)           */
-    firstelem: LONGLONG,        /* I - first vector element to read (1 = 1st)  */
-    nelem: LONGLONG,            /* I - number of values to read                */
-    array: &mut [u8],           /* O - array of values that are returned   */
-    nularray: &mut [c_char],    /* O - array of null pixel flags               */
-    anynul: Option<&mut c_int>, /* O - set to 1 if any values are null; else 0 */
-    status: &mut c_int,         /* IO - error status                           */
+    fptr: &mut fitsfile,
+    group: c_long,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: &mut [u8],
+    nularray: &mut [c_char],
+    anynul: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     let nullcheck = NullCheckType::SetNullArray;
 
@@ -224,23 +269,34 @@ pub fn ffgpfb_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an entire 2-D array of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of the
 /// FITS array is not the same as the array being read).  Any null
 /// values in the array will be set equal to the value of nulval, unless
 /// nulval = 0 in which case no null checking will be performed.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `group`  — (I) group to read (1 = 1st group)
+/// * `nulval` — set undefined pixels equal to this
+/// * `ncols`  — (I) number of pixels in each row of array
+/// * `naxis1` — (I) FITS image NAXIS1 value
+/// * `naxis2` — (I) FITS image NAXIS2 value
+/// * `array`  — (O) array to be filled and returned
+/// * `anynul` — (O) set to 1 if any values are null; else 0
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffg2db(
-    fptr: *mut fitsfile, /* I - FITS file pointer                       */
-    group: c_long,       /* I - group to read (1 = 1st group)           */
-    nulval: u8,          /* set undefined pixels equal to this     */
-    ncols: LONGLONG,     /* I - number of pixels in each row of array   */
-    naxis1: LONGLONG,    /* I - FITS image NAXIS1 value                 */
-    naxis2: LONGLONG,    /* I - FITS image NAXIS2 value                 */
-    array: *mut u8,      /* O - array to be filled and returned    */
-    anynul: *mut c_int,  /* O - set to 1 if any values are null; else 0 */
-    status: *mut c_int,  /* IO - error status                           */
+    fptr: *mut fitsfile,
+    group: c_long,
+    nulval: u8,
+    ncols: LONGLONG,
+    naxis1: LONGLONG,
+    naxis2: LONGLONG,
+    array: *mut u8,
+    anynul: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -255,22 +311,33 @@ pub unsafe extern "C" fn ffg2db(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an entire 2-D array of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of the
 /// FITS array is not the same as the array being read).  Any null
 /// values in the array will be set equal to the value of nulval, unless
 /// nulval = 0 in which case no null checking will be performed.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `group`  — (I) group to read (1 = 1st group)
+/// * `nulval` — set undefined pixels equal to this
+/// * `ncols`  — (I) number of pixels in each row of array
+/// * `naxis1` — (I) FITS image NAXIS1 value
+/// * `naxis2` — (I) FITS image NAXIS2 value
+/// * `array`  — (O) array to be filled and returned
+/// * `anynul` — (O) set to 1 if any values are null; else 0
+/// * `status` — (IO) error status
 pub fn ffg2db_safe(
-    fptr: &mut fitsfile,        /* I - FITS file pointer                       */
-    group: c_long,              /* I - group to read (1 = 1st group)           */
-    nulval: u8,                 /* set undefined pixels equal to this     */
-    ncols: LONGLONG,            /* I - number of pixels in each row of array   */
-    naxis1: LONGLONG,           /* I - FITS image NAXIS1 value                 */
-    naxis2: LONGLONG,           /* I - FITS image NAXIS2 value                 */
-    array: &mut [u8],           /* O - array to be filled and returned    */
-    anynul: Option<&mut c_int>, /* O - set to 1 if any values are null; else 0 */
-    status: &mut c_int,         /* IO - error status                           */
+    fptr: &mut fitsfile,
+    group: c_long,
+    nulval: u8,
+    ncols: LONGLONG,
+    naxis1: LONGLONG,
+    naxis2: LONGLONG,
+    array: &mut [u8],
+    anynul: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     /* call the 3D reading routine, with the 3rd dimension = 1 */
     ffg3db_safe(
@@ -280,7 +347,6 @@ pub fn ffg2db_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an entire 3-D array of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of the
 /// FITS array is not the same as the array being read).  Any null
@@ -291,19 +357,33 @@ pub fn ffg2db_safe(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `group`  — (I) group to read (1 = 1st group)
+/// * `nulval` — set undefined pixels equal to this
+/// * `ncols`  — (I) number of pixels in each row of array
+/// * `nrows`  — (I) number of rows in each plane of array
+/// * `naxis1` — (I) FITS image NAXIS1 value
+/// * `naxis2` — (I) FITS image NAXIS2 value
+/// * `naxis3` — (I) FITS image NAXIS3 value
+/// * `array`  — (O) array to be filled and returned
+/// * `anynul` — (O) set to 1 if any values are null; else 0
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffg3db(
-    fptr: *mut fitsfile, /* I - FITS file pointer                       */
-    group: c_long,       /* I - group to read (1 = 1st group)           */
-    nulval: u8,          /* set undefined pixels equal to this     */
-    ncols: LONGLONG,     /* I - number of pixels in each row of array   */
-    nrows: LONGLONG,     /* I - number of rows in each plane of array   */
-    naxis1: LONGLONG,    /* I - FITS image NAXIS1 value                 */
-    naxis2: LONGLONG,    /* I - FITS image NAXIS2 value                 */
-    naxis3: LONGLONG,    /* I - FITS image NAXIS3 value                 */
-    array: *mut u8,      /* O - array to be filled and returned    */
-    anynul: *mut c_int,  /* O - set to 1 if any values are null; else 0 */
-    status: *mut c_int,  /* IO - error status                           */
+    fptr: *mut fitsfile,
+    group: c_long,
+    nulval: u8,
+    ncols: LONGLONG,
+    nrows: LONGLONG,
+    naxis1: LONGLONG,
+    naxis2: LONGLONG,
+    naxis3: LONGLONG,
+    array: *mut u8,
+    anynul: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -318,7 +398,6 @@ pub unsafe extern "C" fn ffg3db(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an entire 3-D array of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of the
 /// FITS array is not the same as the array being read).  Any null
@@ -329,18 +408,32 @@ pub unsafe extern "C" fn ffg3db(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `group`  — (I) group to read (1 = 1st group)
+/// * `nulval` — set undefined pixels equal to this
+/// * `ncols`  — (I) number of pixels in each row of array
+/// * `nrows`  — (I) number of rows in each plane of array
+/// * `naxis1` — (I) FITS image NAXIS1 value
+/// * `naxis2` — (I) FITS image NAXIS2 value
+/// * `naxis3` — (I) FITS image NAXIS3 value
+/// * `array`  — (O) array to be filled and returned
+/// * `anynul` — (O) set to 1 if any values are null; else 0
+/// * `status` — (IO) error status
 pub fn ffg3db_safe(
-    fptr: &mut fitsfile,            /* I - FITS file pointer                       */
-    group: c_long,                  /* I - group to read (1 = 1st group)           */
-    nulval: u8,                     /* set undefined pixels equal to this     */
-    ncols: LONGLONG,                /* I - number of pixels in each row of array   */
-    nrows: LONGLONG,                /* I - number of rows in each plane of array   */
-    naxis1: LONGLONG,               /* I - FITS image NAXIS1 value                 */
-    naxis2: LONGLONG,               /* I - FITS image NAXIS2 value                 */
-    naxis3: LONGLONG,               /* I - FITS image NAXIS3 value                 */
-    array: &mut [u8],               /* O - array to be filled and returned    */
-    mut anynul: Option<&mut c_int>, /* O - set to 1 if any values are null; else 0 */
-    status: &mut c_int,             /* IO - error status                           */
+    fptr: &mut fitsfile,
+    group: c_long,
+    nulval: u8,
+    ncols: LONGLONG,
+    nrows: LONGLONG,
+    naxis1: LONGLONG,
+    naxis2: LONGLONG,
+    naxis3: LONGLONG,
+    array: &mut [u8],
+    mut anynul: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     let mut narray;
     let mut nfits: LONGLONG;
@@ -440,22 +533,35 @@ pub fn ffg3db_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read a subsection of data values from an image or a table column.
 /// This routine is set up to handle a maximum of nine dimensions.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `colnum` — (I) number of the column to read (1 = 1st)
+/// * `naxis`  — (I) number of dimensions in the FITS array
+/// * `naxes`  — (I) size of each dimension
+/// * `blc`    — (I) 'bottom left corner' of the subsection
+/// * `trc`    — (I) 'top right corner' of the subsection
+/// * `inc`    — (I) increment to be applied in each dimension
+/// * `nulval` — (I) value to set undefined pixels
+/// * `array`  — (O) array to be filled and returned
+/// * `anynul` — (O) set to 1 if any values are null; else 0
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgsvb(
-    fptr: *mut fitsfile,  /* I - FITS file pointer                         */
-    colnum: c_int,        /* I - number of the column to read (1 = 1st)    */
-    naxis: c_int,         /* I - number of dimensions in the FITS array    */
-    naxes: *const c_long, /* I - size of each dimension                    */
-    blc: *const c_long,   /* I - 'bottom left corner' of the subsection    */
-    trc: *const c_long,   /* I - 'top right corner' of the subsection      */
-    inc: *const c_long,   /* I - increment to be applied in each dimension */
-    nulval: u8,           /* I - value to set undefined pixels       */
-    array: *mut u8,       /* O - array to be filled and returned     */
-    anynul: *mut c_int,   /* O - set to 1 if any values are null; else 0   */
-    status: *mut c_int,   /* IO - error status                             */
+    fptr: *mut fitsfile,
+    colnum: c_int,
+    naxis: c_int,
+    naxes: *const c_long,
+    blc: *const c_long,
+    trc: *const c_long,
+    inc: *const c_long,
+    nulval: u8,
+    array: *mut u8,
+    anynul: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -478,21 +584,34 @@ pub unsafe extern "C" fn ffgsvb(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read a subsection of data values from an image or a table column.
 /// This routine is set up to handle a maximum of nine dimensions.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `colnum` — (I) number of the column to read (1 = 1st)
+/// * `naxis`  — (I) number of dimensions in the FITS array
+/// * `naxes`  — (I) size of each dimension
+/// * `blc`    — (I) 'bottom left corner' of the subsection
+/// * `trc`    — (I) 'top right corner' of the subsection
+/// * `inc`    — (I) increment to be applied in each dimension
+/// * `nulval` — (I) value to set undefined pixels
+/// * `array`  — (O) array to be filled and returned
+/// * `anynul` — (O) set to 1 if any values are null; else 0
+/// * `status` — (IO) error status
 pub fn ffgsvb_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                         */
-    colnum: c_int,       /* I - number of the column to read (1 = 1st)    */
-    naxis: c_int,        /* I - number of dimensions in the FITS array    */
-    naxes: &[c_long],    /* I - size of each dimension                    */
-    blc: &[c_long],      /* I - 'bottom left corner' of the subsection    */
-    trc: &[c_long],      /* I - 'top right corner' of the subsection      */
-    inc: &[c_long],      /* I - increment to be applied in each dimension */
-    nulval: u8,          /* I - value to set undefined pixels       */
-    array: &mut [u8],    /* O - array to be filled and returned     */
-    mut anynul: Option<&mut c_int>, /* O - set to 1 if any values are null; else 0   */
-    status: &mut c_int,  /* IO - error status                             */
+    fptr: &mut fitsfile,
+    colnum: c_int,
+    naxis: c_int,
+    naxes: &[c_long],
+    blc: &[c_long],
+    trc: &[c_long],
+    inc: &[c_long],
+    nulval: u8,
+    array: &mut [u8],
+    mut anynul: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     let rstr: c_long;
     let mut rstp: c_long;
@@ -697,18 +816,31 @@ pub fn ffgsvb_safe(
     *status
 }
 
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `colnum`  — (I) number of the column to read (1 = 1st)
+/// * `naxis`   — (I) number of dimensions in the FITS array
+/// * `naxes`   — (I) size of each dimension
+/// * `blc`     — (I) 'bottom left corner' of the subsection
+/// * `trc`     — (I) 'top right corner' of the subsection
+/// * `inc`     — (I) increment to be applied in each dimension
+/// * `array`   — (O) array to be filled and returned
+/// * `flagval` — (O) set to 1 if corresponding value is null
+/// * `anynul`  — (O) set to 1 if any values are null; else 0
+/// * `status`  — (IO) error status
 pub fn ffgsfb_safe(
-    fptr: &mut fitsfile,    /* I - FITS file pointer                         */
-    colnum: c_int,          /* I - number of the column to read (1 = 1st)    */
-    naxis: c_int,           /* I - number of dimensions in the FITS array    */
-    naxes: &[c_long],       /* I - size of each dimension                    */
-    blc: &[c_long],         /* I - 'bottom left corner' of the subsection    */
-    trc: &[c_long],         /* I - 'top right corner' of the subsection      */
-    inc: &[c_long],         /* I - increment to be applied in each dimension */
-    array: &mut [u8],       /* O - array to be filled and returned     */
-    flagval: &mut [c_char], /* O - set to 1 if corresponding value is null   */
-    mut anynul: Option<&mut c_int>, /* O - set to 1 if any values are null; else 0   */
-    status: &mut c_int,     /* IO - error status                             */
+    fptr: &mut fitsfile,
+    colnum: c_int,
+    naxis: c_int,
+    naxes: &[c_long],
+    blc: &[c_long],
+    trc: &[c_long],
+    inc: &[c_long],
+    array: &mut [u8],
+    flagval: &mut [c_char],
+    mut anynul: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     let rstr: c_long;
     let mut rstp: c_long;
@@ -896,22 +1028,35 @@ pub fn ffgsfb_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read a subsection of data values from an image or a table column.
 /// This routine is set up to handle a maximum of nine dimensions.
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `colnum`  — (I) number of the column to read (1 = 1st)
+/// * `naxis`   — (I) number of dimensions in the FITS array
+/// * `naxes`   — (I) size of each dimension
+/// * `blc`     — (I) 'bottom left corner' of the subsection
+/// * `trc`     — (I) 'top right corner' of the subsection
+/// * `inc`     — (I) increment to be applied in each dimension
+/// * `array`   — (O) array to be filled and returned
+/// * `flagval` — (O) set to 1 if corresponding value is null
+/// * `anynul`  — (O) set to 1 if any values are null; else 0
+/// * `status`  — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgsfb(
-    fptr: *mut fitsfile,  /* I - FITS file pointer                         */
-    colnum: c_int,        /* I - number of the column to read (1 = 1st)    */
-    naxis: c_int,         /* I - number of dimensions in the FITS array    */
-    naxes: *const c_long, /* I - size of each dimension                    */
-    blc: *const c_long,   /* I - 'bottom left corner' of the subsection    */
-    trc: *const c_long,   /* I - 'top right corner' of the subsection      */
-    inc: *const c_long,   /* I - increment to be applied in each dimension */
-    array: *mut u8,       /* O - array to be filled and returned     */
-    flagval: *mut c_char, /* O - set to 1 if corresponding value is null   */
-    anynul: *mut c_int,   /* O - set to 1 if any values are null; else 0   */
-    status: *mut c_int,   /* IO - error status                             */
+    fptr: *mut fitsfile,
+    colnum: c_int,
+    naxis: c_int,
+    naxes: *const c_long,
+    blc: *const c_long,
+    trc: *const c_long,
+    inc: *const c_long,
+    array: *mut u8,
+    flagval: *mut c_char,
+    anynul: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -935,7 +1080,6 @@ pub unsafe extern "C" fn ffgsfb(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 ///Read an array of group parameters from the primary array. Data conversion
 ///and scaling will be performed if necessary (e.g, if the datatype of
 ///the FITS array is not the same as the array being read).
@@ -944,14 +1088,23 @@ pub unsafe extern "C" fn ffgsfb(
 ///each group of the primary array is a row in the table,
 ///where the first column contains the group parameters
 ///and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to read (1 = 1st group)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `array`     — (O) array of values that are returned
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffggpb(
-    fptr: *mut fitsfile, /* I - FITS file pointer                       */
-    group: c_long,       /* I - group to read (1 = 1st group)           */
-    firstelem: c_long,   /* I - first vector element to read (1 = 1st)  */
-    nelem: c_long,       /* I - number of values to read                */
-    array: *mut u8,      /* O - array of values that are returned   */
-    status: *mut c_int,  /* IO - error status                           */
+    fptr: *mut fitsfile,
+    group: c_long,
+    firstelem: c_long,
+    nelem: c_long,
+    array: *mut u8,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -968,13 +1121,22 @@ pub unsafe extern "C" fn ffggpb(
 /// Read an array of group parameters from the primary array.
 /// The primary array is represented as a binary table where each group
 /// is a row, with the first column containing group parameters.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to read (1 = 1st group)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `array`     — (O) array of values that are returned
+/// * `status`    — (IO) error status
 pub fn ffggpb_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                       */
-    group: c_long,       /* I - group to read (1 = 1st group)           */
-    firstelem: c_long,   /* I - first vector element to read (1 = 1st)  */
-    nelem: c_long,       /* I - number of values to read                */
-    array: &mut [u8],    /* O - array of values that are returned   */
-    status: &mut c_int,  /* IO - error status                           */
+    fptr: &mut fitsfile,
+    group: c_long,
+    firstelem: c_long,
+    nelem: c_long,
+    array: &mut [u8],
+    status: &mut c_int,
 ) -> c_int {
     let cdummy = 0;
     let mut anynul = 0;
@@ -999,24 +1161,35 @@ pub fn ffggpb_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of values from a column in the current FITS HDU. Automatic
 /// datatype conversion will be performed if the datatype of the column does not
 /// match the datatype of the array parameter. The output values will be scaled
 /// by the FITS TSCALn and TZEROn values if these values have been defined.
 /// Any undefined pixels will be set equal to the value of 'nulval' unless
 /// nulval = 0 in which case no checks for undefined pixels will be made.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to read (1 = 1st col)
+/// * `firstrow`  — (I) first row to read (1 = 1st row)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `nulval`    — (I) value for null pixels
+/// * `array`     — (O) array of values that are read
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgcvb(
-    fptr: *mut fitsfile, /* I - FITS file pointer                       */
-    colnum: c_int,       /* I - number of column to read (1 = 1st col)  */
-    firstrow: LONGLONG,  /* I - first row to read (1 = 1st row)         */
-    firstelem: LONGLONG, /* I - first vector element to read (1 = 1st)  */
-    nelem: LONGLONG,     /* I - number of values to read                */
-    nulval: u8,          /* I - value for null pixels               */
-    array: *mut u8,      /* O - array of values that are read       */
-    anynul: *mut c_int,  /* O - set to 1 if any values are null; else 0 */
-    status: *mut c_int,  /* IO - error status                           */
+    fptr: *mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    nulval: u8,
+    array: *mut u8,
+    anynul: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -1039,23 +1212,34 @@ pub unsafe extern "C" fn ffgcvb(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of values from a column in the current FITS HDU. Automatic
 /// datatype conversion will be performed if the datatype of the column does not
 /// match the datatype of the array parameter. The output values will be scaled
 /// by the FITS TSCALn and TZEROn values if these values have been defined.
 /// Any undefined pixels will be set equal to the value of 'nulval' unless
 /// nulval = 0 in which case no checks for undefined pixels will be made.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to read (1 = 1st col)
+/// * `firstrow`  — (I) first row to read (1 = 1st row)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `nulval`    — (I) value for null pixels
+/// * `array`     — (O) array of values that are read
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `status`    — (IO) error status
 pub fn ffgcvb_safe(
-    fptr: &mut fitsfile,        /* I - FITS file pointer                       */
-    colnum: c_int,              /* I - number of column to read (1 = 1st col)  */
-    firstrow: LONGLONG,         /* I - first row to read (1 = 1st row)         */
-    firstelem: LONGLONG,        /* I - first vector element to read (1 = 1st)  */
-    nelem: LONGLONG,            /* I - number of values to read                */
-    nulval: u8,                 /* I - value for null pixels               */
-    array: &mut [u8],           /* O - array of values that are read       */
-    anynul: Option<&mut c_int>, /* O - set to 1 if any values are null; else 0 */
-    status: &mut c_int,         /* IO - error status                           */
+    fptr: &mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    nulval: u8,
+    array: &mut [u8],
+    anynul: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     let mut dummy_nularray = vec![0; (nelem) as usize];
 
@@ -1076,24 +1260,35 @@ pub fn ffgcvb_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of values from a column in the current FITS HDU. Automatic
 /// datatype conversion will be performed if the datatype of the column does not
 /// match the datatype of the array parameter. The output values will be scaled
 /// by the FITS TSCALn and TZEROn values if these values have been defined.
 /// Nularray will be set = 1 if the corresponding array pixel is undefined,
 /// otherwise nularray will = 0.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to read (1 = 1st col)
+/// * `firstrow`  — (I) first row to read (1 = 1st row)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `array`     — (O) array of values that are read
+/// * `nularray`  — (O) array of flags: 1 if null pixel; else 0
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgcfb(
-    fptr: *mut fitsfile,   /* I - FITS file pointer                       */
-    colnum: c_int,         /* I - number of column to read (1 = 1st col)  */
-    firstrow: LONGLONG,    /* I - first row to read (1 = 1st row)         */
-    firstelem: LONGLONG,   /* I - first vector element to read (1 = 1st)  */
-    nelem: LONGLONG,       /* I - number of values to read                */
-    array: *mut u8,        /* O - array of values that are read       */
-    nularray: *mut c_char, /* O - array of flags: 1 if null pixel; else 0 */
-    anynul: *mut c_int,    /* O - set to 1 if any values are null; else 0 */
-    status: *mut c_int,    /* IO - error status                           */
+    fptr: *mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: *mut u8,
+    nularray: *mut c_char,
+    anynul: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -1110,23 +1305,34 @@ pub unsafe extern "C" fn ffgcfb(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of values from a column in the current FITS HDU. Automatic
 /// datatype conversion will be performed if the datatype of the column does not
 /// match the datatype of the array parameter. The output values will be scaled
 /// by the FITS TSCALn and TZEROn values if these values have been defined.
 /// Nularray will be set = 1 if the corresponding array pixel is undefined,
 /// otherwise nularray will = 0.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to read (1 = 1st col)
+/// * `firstrow`  — (I) first row to read (1 = 1st row)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `array`     — (O) array of values that are read
+/// * `nularray`  — (O) array of flags: 1 if null pixel; else 0
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `status`    — (IO) error status
 pub fn ffgcfb_safe(
-    fptr: &mut fitsfile,        /* I - FITS file pointer                       */
-    colnum: c_int,              /* I - number of column to read (1 = 1st col)  */
-    firstrow: LONGLONG,         /* I - first row to read (1 = 1st row)         */
-    firstelem: LONGLONG,        /* I - first vector element to read (1 = 1st)  */
-    nelem: LONGLONG,            /* I - number of values to read                */
-    array: &mut [u8],           /* O - array of values that are read       */
-    nularray: &mut [c_char],    /* O - array of flags: 1 if null pixel; else 0 */
-    anynul: Option<&mut c_int>, /* O - set to 1 if any values are null; else 0 */
-    status: &mut c_int,         /* IO - error status                           */
+    fptr: &mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: &mut [u8],
+    nularray: &mut [c_char],
+    anynul: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     let dummy: u8 = 0;
 
@@ -1147,7 +1353,6 @@ pub fn ffgcfb_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of values from a column in the current FITS HDU.
 /// The column number may refer to a real column in an ASCII or binary table,
 /// or it may refer be a virtual column in a 1 or more grouped FITS primary
@@ -1161,21 +1366,35 @@ pub fn ffgcfb_safe(
 /// and will be scaled by the FITS TSCALn and TZEROn values if necessary.
 #[allow(clippy::if_same_then_else)]
 // C dispatch chain: distinct conditions deliberately share an action.
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to read (1 = 1st col)
+/// * `firstrow`  — (I) first row to read (1 = 1st row)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `elemincre` — (I) pixel increment; e.g., 2 = every other
+/// * `nultyp`    — (I) null value handling code:
+/// * `nulval`    — (I) value for null pixels if nultyp = 1
+/// * `array`     — (O) array of values that are read
+/// * `nularray`  — (O) array of flags = 1 if nultyp = 2
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `status`    — (IO) error status
 pub(crate) fn ffgclb(
-    fptr: &mut fitsfile,   /* I - FITS file pointer                       */
-    colnum: c_int,         /* I - number of column to read (1 = 1st col)  */
-    firstrow: LONGLONG,    /* I - first row to read (1 = 1st row)         */
-    firstelem: LONGLONG,   /* I - first vector element to read (1 = 1st)  */
-    nelem: LONGLONG,       /* I - number of values to read                */
-    elemincre: c_long,     /* I - pixel increment; e.g., 2 = every other  */
-    nultyp: NullCheckType, /* I - null value handling code:               */
+    fptr: &mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    elemincre: c_long,
+    nultyp: NullCheckType,
     /*     1: set undefined pixels = nulval        */
     /*     2: set nularray=1 for undefined pixels  */
-    nulval: u8,                     /* I - value for null pixels if nultyp = 1 */
-    array: &mut [u8],               /* O - array of values that are read       */
-    nularray: &mut [c_char],        /* O - array of flags = 1 if nultyp = 2        */
-    mut anynul: Option<&mut c_int>, /* O - set to 1 if any values are null; else 0 */
-    status: &mut c_int,             /* IO - error status                           */
+    nulval: u8,
+    array: &mut [u8],
+    nularray: &mut [c_char],
+    mut anynul: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     let mut scale: f64 = 0.0;
     let mut zero: f64 = 0.0;
@@ -1225,9 +1444,7 @@ pub(crate) fn ffgclb(
         nularray[..nelem as usize].fill(0); /* initialize nullarray */
     }
 
-    /*---------------------------------------------------*/
     /*  Check input and get parameters about the column: */
-    /*---------------------------------------------------*/
     if elemincre < 0 {
         readcheck -= 1; /* don't do range checking in this case */
     }
@@ -1308,9 +1525,7 @@ pub(crate) fn ffgclb(
             power *= 10.0;
         }
     }
-    /*------------------------------------------------------------------*/
     /*  Decide whether to check for null values in the input FITS file: */
-    /*------------------------------------------------------------------*/
     nulcheck = nultyp; /* by default, check for null values in the FITS file */
 
     if nultyp == NullCheckType::SetPixel && nulval == 0 {
@@ -1330,10 +1545,8 @@ pub(crate) fn ffgclb(
         nulcheck = NullCheckType::None;
     }
 
-    /*----------------------------------------------------------------------*/
     /*  If FITS column and output data array have same datatype, then we do */
     /*  not need to use a temporary buffer to store intermediate datatype.  */
-    /*----------------------------------------------------------------------*/
     convert = true;
     if tcode == TBYTE {
         /* Special Case:                        */
@@ -1351,7 +1564,6 @@ pub(crate) fn ffgclb(
         }
     }
 
-    /*---------------------------------------------------------------------*/
     /*  Now read the pixels from the FITS column. If the column does not   */
     /*  have the same datatype as the output array, then we have to read   */
     /*  the raw values into a temporary buffer (of limited size).  In      */
@@ -1361,7 +1573,6 @@ pub(crate) fn ffgclb(
     /*  test for undefined values, (2) convert the datatype if necessary,  */
     /*  and (3) scale the values by the FITS TSCALn and TZEROn linear      */
     /*  scaling parameters.                                                */
-    /*---------------------------------------------------------------------*/
     remain = nelem; /* remaining number of values to read */
     next = 0; /* next element in array to be read   */
     rownum = 0; /* row number, relative to firstrow   */
@@ -1613,9 +1824,7 @@ pub(crate) fn ffgclb(
             }
         } /* End of switch block */
 
-        /*-------------------------*/
         /*  Check for fatal error  */
-        /*-------------------------*/
         if *status > 0 {
             /* test for error during previous read operation */
 
@@ -1643,9 +1852,7 @@ pub(crate) fn ffgclb(
             return *status;
         }
 
-        /*--------------------------------------------*/
         /*  increment the counters for the next loop  */
-        /*--------------------------------------------*/
         remain -= ntodo as LONGLONG;
         if remain != 0 {
             next += ntodo as usize;
@@ -1667,9 +1874,7 @@ pub(crate) fn ffgclb(
         }
     } /*  End of main while Loop  */
 
-    /*--------------------------------*/
     /*  check for numerical overflow  */
-    /*--------------------------------*/
     if *status == OVERFLOW_ERR {
         ffpmsg_str("Numerical overflow during type conversion while reading FITS data.");
         *status = NUM_OVERFLOW;
@@ -1678,17 +1883,24 @@ pub(crate) fn ffgclb(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read a stream of bytes from the current FITS HDU.  This primative routine is mainly
 /// for reading non-standard "conforming" extensions and should not be used
 /// for standard IMAGE, TABLE or BINTABLE extensions.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `offset` — (I) byte offset from start of extension data
+/// * `nelem`  — (I) number of elements to read
+/// * `buffer` — (I) stream of bytes to read
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgextn(
-    fptr: *mut fitsfile, /* I - FITS file pointer                        */
-    offset: LONGLONG,    /* I - byte offset from start of extension data */
-    nelem: LONGLONG,     /* I - number of elements to read               */
-    buffer: *mut c_void, /* I - stream of bytes to read                  */
-    status: *mut c_int,  /* IO - error status                            */
+    fptr: *mut fitsfile,
+    offset: LONGLONG,
+    nelem: LONGLONG,
+    buffer: *mut c_void,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -1700,16 +1912,23 @@ pub unsafe extern "C" fn ffgextn(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read a stream of bytes from the current FITS HDU.  This primative routine is mainly
 /// for reading non-standard "conforming" extensions and should not be used
 /// for standard IMAGE, TABLE or BINTABLE extensions.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `offset` — (I) byte offset from start of extension data
+/// * `nelem`  — (I) number of elements to read
+/// * `buffer` — (I) stream of bytes to read
+/// * `status` — (IO) error status
 pub fn ffgextn_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                        */
-    offset: LONGLONG,    /* I - byte offset from start of extension data */
-    nelem: LONGLONG,     /* I - number of elements to read               */
-    buffer: &mut [u8],   /* I - stream of bytes to read                  */
-    status: &mut c_int,  /* IO - error status                            */
+    fptr: &mut fitsfile,
+    offset: LONGLONG,
+    nelem: LONGLONG,
+    buffer: &mut [u8],
+    status: &mut c_int,
 ) -> c_int {
     if *status > 0 {
         /* inherit input status value if > 0 */
@@ -1733,7 +1952,6 @@ pub fn ffgextn_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output following reading of the input from a FITS file.
 /// Check for null values and do datatype conversion and scaling if required.
 /// The nullcheck code value determines how any null values in the input array
@@ -1745,20 +1963,34 @@ pub fn ffgextn_safe(
 /// nullarray will be set to 1; the value of nullarray for non-null pixels
 /// will = 0.  The anynul parameter will be set = 1 if any of the returned
 /// pixels are null, otherwise anynul will be returned with a value = 0;
+///
+/// # Parameters
+///
+/// * `input`     — (I) array of values to be converted
+/// * `ntodo`     — (I) number of elements in the array
+/// * `scale`     — (I) FITS TSCALn or BSCALE value
+/// * `zero`      — (I) FITS TZEROn or BZERO value
+/// * `nullcheck` — (I) null checking code; 0 = don't check
+/// * `tnull`     — (I) value of FITS TNULLn keyword if any
+/// * `nullval`   — (I) set null pixels, if nullcheck = 1
+/// * `nullarray` — (O) bad pixel array, if nullcheck = 2
+/// * `anynul`    — (O) set to 1 if any pixels are null
+/// * `output`    — (O) array of converted pixels
+/// * `status`    — (IO) error status
 pub(crate) fn fffi1i1(
-    input: &[u8],             /* I - array of values to be converted     */
-    ntodo: c_long,            /* I - number of elements in the array     */
-    scale: f64,               /* I - FITS TSCALn or BSCALE value         */
-    zero: f64,                /* I - FITS TZEROn or BZERO  value         */
-    nullcheck: NullCheckType, /* I - null checking code; 0 = don't check */
+    input: &[u8],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    nullcheck: NullCheckType,
     /*     1:set null pixels = nullval         */
     /*     2: if null pixel, set nullarray = 1 */
-    tnull: u8,                  /* I - value of FITS TNULLn keyword if any */
-    nullval: u8,                /* I - set null pixels, if nullcheck = 1   */
-    nullarray: &mut [c_char],   /* O - bad pixel array, if nullcheck = 2   */
-    anynul: Option<&mut c_int>, /* O - set to 1 if any pixels are null     */
-    output: &mut [u8],          /* O - array of converted pixels           */
-    status: &mut c_int,         /* IO - error status                       */
+    tnull: u8,
+    nullval: u8,
+    nullarray: &mut [c_char],
+    anynul: Option<&mut c_int>,
+    output: &mut [u8],
+    status: &mut c_int,
 ) -> c_int {
     let mut dvalue: f64;
 
@@ -1835,7 +2067,6 @@ pub(crate) fn fffi1i1(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output following reading of the input from a FITS file.
 /// Check for null values and do datatype conversion and scaling if required.
 /// The nullcheck code value determines how any null values in the input array
@@ -1847,19 +2078,32 @@ pub(crate) fn fffi1i1(
 /// nullarray will be set to 1; the value of nullarray for non-null pixels
 /// will = 0.  The anynul parameter will be set = 1 if any of the returned
 /// pixels are null, otherwise anynul will be returned with a value = 0;
+///
+/// # Parameters
+///
+/// * `inout`     — (I) array of values to be converted
+/// * `ntodo`     — (I) number of elements in the array
+/// * `scale`     — (I) FITS TSCALn or BSCALE value
+/// * `zero`      — (I) FITS TZEROn or BZERO value
+/// * `nullcheck` — (I) null checking code; 0 = don't check
+/// * `tnull`     — (I) value of FITS TNULLn keyword if any
+/// * `nullval`   — (I) set null pixels, if nullcheck = 1
+/// * `nullarray` — (O) bad pixel array, if nullcheck = 2
+/// * `anynul`    — (O) set to 1 if any pixels are null
+/// * `status`    — (IO) error status
 pub(crate) fn fffi1i1_inplace(
-    inout: &mut [u8],         /* I - array of values to be converted     */
-    ntodo: c_long,            /* I - number of elements in the array     */
-    scale: f64,               /* I - FITS TSCALn or BSCALE value         */
-    zero: f64,                /* I - FITS TZEROn or BZERO  value         */
-    nullcheck: NullCheckType, /* I - null checking code; 0 = don't check */
+    inout: &mut [u8],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    nullcheck: NullCheckType,
     /*     1:set null pixels = nullval         */
     /*     2: if null pixel, set nullarray = 1 */
-    tnull: u8,                  /* I - value of FITS TNULLn keyword if any */
-    nullval: u8,                /* I - set null pixels, if nullcheck = 1   */
-    nullarray: &mut [c_char],   /* O - bad pixel array, if nullcheck = 2   */
-    anynul: Option<&mut c_int>, /* O - set to 1 if any pixels are null     */
-    status: &mut c_int,         /* IO - error status                       */
+    tnull: u8,
+    nullval: u8,
+    nullarray: &mut [c_char],
+    anynul: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     let mut dvalue: f64;
 
@@ -1933,7 +2177,6 @@ pub(crate) fn fffi1i1_inplace(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output following reading of the input from a FITS file.
 /// Check for null values and do datatype conversion and scaling if required.
 /// The nullcheck code value determines how any null values in the input array
@@ -1945,20 +2188,34 @@ pub(crate) fn fffi1i1_inplace(
 /// nullarray will be set to 1; the value of nullarray for non-null pixels
 /// will = 0.  The anynul parameter will be set = 1 if any of the returned
 /// pixels are null, otherwise anynul will be returned with a value = 0;
+///
+/// # Parameters
+///
+/// * `input`     — (I) array of values to be converted
+/// * `ntodo`     — (I) number of elements in the array
+/// * `scale`     — (I) FITS TSCALn or BSCALE value
+/// * `zero`      — (I) FITS TZEROn or BZERO value
+/// * `nullcheck` — (I) null checking code; 0 = don't check
+/// * `tnull`     — (I) value of FITS TNULLn keyword if any
+/// * `nullval`   — (I) set null pixels, if nullcheck = 1
+/// * `nullarray` — (O) bad pixel array, if nullcheck = 2
+/// * `anynul`    — (O) set to 1 if any pixels are null
+/// * `output`    — (O) array of converted pixels
+/// * `status`    — (IO) error status
 pub(crate) fn fffi2i1(
-    input: &[c_short],        /* I - array of values to be converted     */
-    ntodo: c_long,            /* I - number of elements in the array     */
-    scale: f64,               /* I - FITS TSCALn or BSCALE value         */
-    zero: f64,                /* I - FITS TZEROn or BZERO  value         */
-    nullcheck: NullCheckType, /* I - null checking code; 0 = don't check */
+    input: &[c_short],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    nullcheck: NullCheckType,
     /*     1:set null pixels = nullval         */
     /*     2: if null pixel, set nullarray = 1 */
-    tnull: c_short,             /* I - value of FITS TNULLn keyword if any */
-    nullval: u8,                /* I - set null pixels, if nullcheck = 1   */
-    nullarray: &mut [c_char],   /* O - bad pixel array, if nullcheck = 2   */
-    anynul: Option<&mut c_int>, /* O - set to 1 if any pixels are null     */
-    output: &mut [u8],          /* O - array of converted pixels           */
-    status: &mut c_int,         /* IO - error status                       */
+    tnull: c_short,
+    nullval: u8,
+    nullarray: &mut [c_char],
+    anynul: Option<&mut c_int>,
+    output: &mut [u8],
+    status: &mut c_int,
 ) -> c_int {
     let mut dvalue: f64;
 
@@ -2050,7 +2307,6 @@ pub(crate) fn fffi2i1(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output following reading of the input from a FITS file.
 /// Check for null values and do datatype conversion and scaling if required.
 /// The nullcheck code value determines how any null values in the input array
@@ -2062,20 +2318,34 @@ pub(crate) fn fffi2i1(
 /// nullarray will be set to 1; the value of nullarray for non-null pixels
 /// will = 0.  The anynul parameter will be set = 1 if any of the returned
 /// pixels are null, otherwise anynul will be returned with a value = 0;
+///
+/// # Parameters
+///
+/// * `input`     — (I) array of values to be converted
+/// * `ntodo`     — (I) number of elements in the array
+/// * `scale`     — (I) FITS TSCALn or BSCALE value
+/// * `zero`      — (I) FITS TZEROn or BZERO value
+/// * `nullcheck` — (I) null checking code; 0 = don't check
+/// * `tnull`     — (I) value of FITS TNULLn keyword if any
+/// * `nullval`   — (I) set null pixels, if nullcheck = 1
+/// * `nullarray` — (O) bad pixel array, if nullcheck = 2
+/// * `anynul`    — (O) set to 1 if any pixels are null
+/// * `output`    — (O) array of converted pixels
+/// * `status`    — (IO) error status
 pub(crate) fn fffi4i1(
-    input: &[INT32BIT],       /* I - array of values to be converted     */
-    ntodo: c_long,            /* I - number of elements in the array     */
-    scale: f64,               /* I - FITS TSCALn or BSCALE value         */
-    zero: f64,                /* I - FITS TZEROn or BZERO  value         */
-    nullcheck: NullCheckType, /* I - null checking code; 0 = don't check */
+    input: &[INT32BIT],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    nullcheck: NullCheckType,
     /*     1:set null pixels = nullval         */
     /*     2: if null pixel, set nullarray = 1 */
-    tnull: INT32BIT,            /* I - value of FITS TNULLn keyword if any */
-    nullval: u8,                /* I - set null pixels, if nullcheck = 1   */
-    nullarray: &mut [c_char],   /* O - bad pixel array, if nullcheck = 2   */
-    anynul: Option<&mut c_int>, /* O - set to 1 if any pixels are null     */
-    output: &mut [u8],          /* O - array of converted pixels           */
-    status: &mut c_int,         /* IO - error status                       */
+    tnull: INT32BIT,
+    nullval: u8,
+    nullarray: &mut [c_char],
+    anynul: Option<&mut c_int>,
+    output: &mut [u8],
+    status: &mut c_int,
 ) -> c_int {
     let mut dvalue: f64;
 
@@ -2168,7 +2438,6 @@ pub(crate) fn fffi4i1(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output following reading of the input from a FITS file.
 /// Check for null values and do datatype conversion and scaling if required.
 /// The nullcheck code value determines how any null values in the input array
@@ -2180,20 +2449,34 @@ pub(crate) fn fffi4i1(
 /// nullarray will be set to 1; the value of nullarray for non-null pixels
 /// will = 0.  The anynul parameter will be set = 1 if any of the returned
 /// pixels are null, otherwise anynul will be returned with a value = 0;
+///
+/// # Parameters
+///
+/// * `input`     — (I) array of values to be converted
+/// * `ntodo`     — (I) number of elements in the array
+/// * `scale`     — (I) FITS TSCALn or BSCALE value
+/// * `zero`      — (I) FITS TZEROn or BZERO value
+/// * `nullcheck` — (I) null checking code; 0 = don't check
+/// * `tnull`     — (I) value of FITS TNULLn keyword if any
+/// * `nullval`   — (I) set null pixels, if nullcheck = 1
+/// * `nullarray` — (O) bad pixel array, if nullcheck = 2
+/// * `anynul`    — (O) set to 1 if any pixels are null
+/// * `output`    — (O) array of converted pixels
+/// * `status`    — (IO) error status
 pub(crate) fn fffi8i1(
-    input: &[LONGLONG],       /* I - array of values to be converted     */
-    ntodo: c_long,            /* I - number of elements in the array     */
-    scale: f64,               /* I - FITS TSCALn or BSCALE value         */
-    zero: f64,                /* I - FITS TZEROn or BZERO  value         */
-    nullcheck: NullCheckType, /* I - null checking code; 0 = don't check */
+    input: &[LONGLONG],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    nullcheck: NullCheckType,
     /*     1:set null pixels = nullval         */
     /*     2: if null pixel, set nullarray = 1 */
-    tnull: LONGLONG,            /* I - value of FITS TNULLn keyword if any */
-    nullval: u8,                /* I - set null pixels, if nullcheck = 1   */
-    nullarray: &mut [c_char],   /* O - bad pixel array, if nullcheck = 2   */
-    anynul: Option<&mut c_int>, /* O - set to 1 if any pixels are null     */
-    output: &mut [u8],          /* O - array of converted pixels           */
-    status: &mut c_int,         /* IO - error status                       */
+    tnull: LONGLONG,
+    nullval: u8,
+    nullarray: &mut [c_char],
+    anynul: Option<&mut c_int>,
+    output: &mut [u8],
+    status: &mut c_int,
 ) -> c_int {
     let mut dvalue: f64;
     let mut ulltemp: ULONGLONG;
@@ -2326,7 +2609,6 @@ pub(crate) fn fffi8i1(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output following reading of the input from a FITS file.
 /// Check for null values and do datatype conversion and scaling if required.
 /// The nullcheck code value determines how any null values in the input array
@@ -2338,19 +2620,32 @@ pub(crate) fn fffi8i1(
 /// nullarray will be set to 1; the value of nullarray for non-null pixels
 /// will = 0.  The anynul parameter will be set = 1 if any of the returned
 /// pixels are null, otherwise anynul will be returned with a value = 0;
+///
+/// # Parameters
+///
+/// * `input`     — (I) array of values to be converted
+/// * `ntodo`     — (I) number of elements in the array
+/// * `scale`     — (I) FITS TSCALn or BSCALE value
+/// * `zero`      — (I) FITS TZEROn or BZERO value
+/// * `nullcheck` — (I) null checking code; 0 = don't check
+/// * `nullval`   — (I) set null pixels, if nullcheck = 1
+/// * `nullarray` — (O) bad pixel array, if nullcheck = 2
+/// * `anynul`    — (O) set to 1 if any pixels are null
+/// * `output`    — (O) array of converted pixels
+/// * `status`    — (IO) error status
 pub(crate) fn fffr4i1(
-    input: &[f32],            /* I - array of values to be converted     */
-    ntodo: c_long,            /* I - number of elements in the array     */
-    scale: f64,               /* I - FITS TSCALn or BSCALE value         */
-    zero: f64,                /* I - FITS TZEROn or BZERO  value         */
-    nullcheck: NullCheckType, /* I - null checking code; 0 = don't check */
+    input: &[f32],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    nullcheck: NullCheckType,
     /*     1:set null pixels = nullval         */
     /*     2: if null pixel, set nullarray = 1 */
-    nullval: u8,                /* I - set null pixels, if nullcheck = 1   */
-    nullarray: &mut [c_char],   /* O - bad pixel array, if nullcheck = 2   */
-    anynul: Option<&mut c_int>, /* O - set to 1 if any pixels are null     */
-    output: &mut [u8],          /* O - array of converted pixels           */
-    status: &mut c_int,         /* IO - error status                       */
+    nullval: u8,
+    nullarray: &mut [c_char],
+    anynul: Option<&mut c_int>,
+    output: &mut [u8],
+    status: &mut c_int,
 ) -> c_int {
     let mut dvalue: f64;
     let mut sptr = 0;
@@ -2481,7 +2776,6 @@ pub(crate) fn fffr4i1(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output following reading of the input from a FITS file.
 /// Check for null values and do datatype conversion and scaling if required.
 /// The nullcheck code value determines how any null values in the input array
@@ -2493,19 +2787,32 @@ pub(crate) fn fffr4i1(
 /// nullarray will be set to 1; the value of nullarray for non-null pixels
 /// will = 0.  The anynul parameter will be set = 1 if any of the returned
 /// pixels are null, otherwise anynul will be returned with a value = 0;
+///
+/// # Parameters
+///
+/// * `input`     — (I) array of values to be converted
+/// * `ntodo`     — (I) number of elements in the array
+/// * `scale`     — (I) FITS TSCALn or BSCALE value
+/// * `zero`      — (I) FITS TZEROn or BZERO value
+/// * `nullcheck` — (I) null checking code; 0 = don't check
+/// * `nullval`   — (I) set null pixels, if nullcheck = 1
+/// * `nullarray` — (O) bad pixel array, if nullcheck = 2
+/// * `anynul`    — (O) set to 1 if any pixels are null
+/// * `output`    — (O) array of converted pixels
+/// * `status`    — (IO) error status
 pub(crate) fn fffr8i1(
-    input: &[f64],            /* I - array of values to be converted     */
-    ntodo: c_long,            /* I - number of elements in the array     */
-    scale: f64,               /* I - FITS TSCALn or BSCALE value         */
-    zero: f64,                /* I - FITS TZEROn or BZERO  value         */
-    nullcheck: NullCheckType, /* I - null checking code; 0 = don't check */
+    input: &[f64],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    nullcheck: NullCheckType,
     /*     1:set null pixels = nullval         */
     /*     2: if null pixel, set nullarray = 1 */
-    nullval: u8,                /* I - set null pixels, if nullcheck = 1   */
-    nullarray: &mut [c_char],   /* O - bad pixel array, if nullcheck = 2   */
-    anynul: Option<&mut c_int>, /* O - set to 1 if any pixels are null     */
-    output: &mut [u8],          /* O - array of converted pixels           */
-    status: &mut c_int,         /* IO - error status                       */
+    nullval: u8,
+    nullarray: &mut [c_char],
+    anynul: Option<&mut c_int>,
+    output: &mut [u8],
+    status: &mut c_int,
 ) -> c_int {
     let mut dvalue: f64;
     let mut sptr = 0;
@@ -2637,7 +2944,6 @@ pub(crate) fn fffr8i1(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output following reading of the input from a FITS file. Check
 /// for null values and do scaling if required. The nullcheck code value
 /// determines how any null values in the input array are treated. A null
@@ -2648,22 +2954,38 @@ pub(crate) fn fffr8i1(
 /// nullarray will be set to 1; the value of nullarray for non-null pixels
 /// will = 0.  The anynul parameter will be set = 1 if any of the returned
 /// pixels are null, otherwise anynul will be returned with a value = 0;
+///
+/// # Parameters
+///
+/// * `input`      — (I) array of values to be converted
+/// * `ntodo`      — (I) number of elements in the array
+/// * `scale`      — (I) FITS TSCALn or BSCALE value
+/// * `zero`       — (I) FITS TZEROn or BZERO value
+/// * `twidth`     — (I) width of each substring of chars
+/// * `implipower` — (I) power of 10 of implied decimal
+/// * `nullcheck`  — (I) null checking code; 0 = don't check
+/// * `snull`      — (I) value of FITS null string, if any
+/// * `nullval`    — (I) set null pixels, if nullcheck = 1
+/// * `nullarray`  — (O) bad pixel array, if nullcheck = 2
+/// * `anynul`     — (O) set to 1 if any pixels are null
+/// * `output`     — (O) array of converted pixels
+/// * `status`     — (IO) error status
 pub(crate) fn fffstri1(
-    input: &mut [c_char],     /* I - array of values to be converted     */
-    ntodo: c_long,            /* I - number of elements in the array     */
-    scale: f64,               /* I - FITS TSCALn or BSCALE value         */
-    zero: f64,                /* I - FITS TZEROn or BZERO  value         */
-    twidth: c_long,           /* I - width of each substring of chars    */
-    implipower: f64,          /* I - power of 10 of implied decimal      */
-    nullcheck: NullCheckType, /* I - null checking code; 0 = don't check */
+    input: &mut [c_char],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    twidth: c_long,
+    implipower: f64,
+    nullcheck: NullCheckType,
     /*     1:set null pixels = nullval         */
     /*     2: if null pixel, set nullarray = 1 */
-    snull: &[c_char],               /* I - value of FITS null string, if any   */
-    nullval: u8,                    /* I - set null pixels, if nullcheck = 1  */
-    nullarray: &mut [c_char],       /* O - bad pixel array, if nullcheck = 2   */
-    mut anynul: Option<&mut c_int>, /* O - set to 1 if any pixels are null     */
-    output: &mut [u8],              /* O - array of converted pixels          */
-    status: &mut c_int,             /* IO - error status                       */
+    snull: &[c_char],
+    nullval: u8,
+    nullarray: &mut [c_char],
+    mut anynul: Option<&mut c_int>,
+    output: &mut [u8],
+    status: &mut c_int,
 ) -> c_int {
     let mut dvalue: f64;
     let mut message: [c_char; FLEN_ERRMSG] = [0; FLEN_ERRMSG];

--- a/src/getcold.rs
+++ b/src/getcold.rs
@@ -1,9 +1,14 @@
-/*  This file, getcold.rs, contains routines that read data elements from   */
-/*  a FITS image or table, with double datatype.                           */
-
-/*  The FITSIO software was written by William Pence at the High Energy    */
-/*  Astrophysic Science Archive Research Center (HEASARC) at the NASA      */
-/*  Goddard Space Flight Center.                                           */
+//! Routines that read data elements from a FITS image or table, with double
+//! datatype.
+//!
+//! The [`TDOUBLE`] arm of the typed column I/O family. [`crate::getcol`]
+//! dispatches here when a caller asks for this datatype at run time; the
+//! write-side counterpart is [`crate::putcold`].
+//!
+//! Ported from CFITSIO's `getcold.c`, written by William Pence at the High
+//! Energy Astrophysics Science Archive Research Center (HEASARC), NASA Goddard
+//! Space Flight Center.
+#![warn(missing_docs)]
 
 use core::slice;
 use core::{cmp, mem};
@@ -23,7 +28,6 @@ use crate::{NullValue, bb};
 use crate::{buffers::*, calculate_subsection_length};
 use crate::{int_snprintf, slice_to_str};
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of values from the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
 /// the FITS array is not the same as the array being read).
@@ -35,16 +39,27 @@ use crate::{int_snprintf, slice_to_str};
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to read (1 = 1st group)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `nulval`    — (I) value for undefined pixels
+/// * `array`     — (O) array of values that are returned
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgpvd(
-    fptr: *mut fitsfile, /* I - FITS file pointer                       */
-    group: c_long,       /* I - group to read (1 = 1st group)           */
-    firstelem: LONGLONG, /* I - first vector element to read (1 = 1st)  */
-    nelem: LONGLONG,     /* I - number of values to read                */
-    nulval: f64,         /* I - value for undefined pixels          */
-    array: *mut f64,     /* O - array of values that are returned   */
-    anynul: *mut c_int,  /* O - set to 1 if any values are null; else 0 */
-    status: *mut c_int,  /* IO - error status                           */
+    fptr: *mut fitsfile,
+    group: c_long,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    nulval: f64,
+    array: *mut f64,
+    anynul: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -58,7 +73,6 @@ pub unsafe extern "C" fn ffgpvd(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of values from the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
 /// the FITS array is not the same as the array being read).
@@ -70,15 +84,26 @@ pub unsafe extern "C" fn ffgpvd(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to read (1 = 1st group)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `nulval`    — (I) value for undefined pixels
+/// * `array`     — (O) array of values that are returned
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `status`    — (IO) error status
 pub fn ffgpvd_safe(
-    fptr: &mut fitsfile,        /* I - FITS file pointer                       */
-    group: c_long,              /* I - group to read (1 = 1st group)           */
-    firstelem: LONGLONG,        /* I - first vector element to read (1 = 1st)  */
-    nelem: LONGLONG,            /* I - number of values to read                */
-    nulval: f64,                /* I - value for undefined pixels          */
-    array: &mut [f64],          /* O - array of values that are returned   */
-    anynul: Option<&mut c_int>, /* O - set to 1 if any values are null; else 0 */
-    status: &mut c_int,         /* IO - error status                           */
+    fptr: &mut fitsfile,
+    group: c_long,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    nulval: f64,
+    array: &mut [f64],
+    anynul: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     let nullcheck = NullCheckType::SetPixel;
     let mut nullvalue: f64 = 0.0;
@@ -123,7 +148,6 @@ pub fn ffgpvd_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of values from the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
 /// the FITS array is not the same as the array being read).
@@ -135,16 +159,27 @@ pub fn ffgpvd_safe(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to read (1 = 1st group)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `array`     — (O) array of values that are returned
+/// * `nularray`  — (O) array of null pixel flags
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgpfd(
-    fptr: *mut fitsfile,   /* I - FITS file pointer                       */
-    group: c_long,         /* I - group to read (1 = 1st group)           */
-    firstelem: LONGLONG,   /* I - first vector element to read (1 = 1st)  */
-    nelem: LONGLONG,       /* I - number of values to read                */
-    array: *mut f64,       /* O - array of values that are returned   */
-    nularray: *mut c_char, /* O - array of null pixel flags               */
-    anynul: *mut c_int,    /* O - set to 1 if any values are null; else 0 */
-    status: *mut c_int,    /* IO - error status                           */
+    fptr: *mut fitsfile,
+    group: c_long,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: *mut f64,
+    nularray: *mut c_char,
+    anynul: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -161,7 +196,6 @@ pub unsafe extern "C" fn ffgpfd(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of values from the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
 /// the FITS array is not the same as the array being read).
@@ -173,15 +207,26 @@ pub unsafe extern "C" fn ffgpfd(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to read (1 = 1st group)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `array`     — (O) array of values that are returned
+/// * `nularray`  — (O) array of null pixel flags
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `status`    — (IO) error status
 pub fn ffgpfd_safe(
-    fptr: &mut fitsfile,        /* I - FITS file pointer                       */
-    group: c_long,              /* I - group to read (1 = 1st group)           */
-    firstelem: LONGLONG,        /* I - first vector element to read (1 = 1st)  */
-    nelem: LONGLONG,            /* I - number of values to read                */
-    array: &mut [f64],          /* O - array of values that are returned   */
-    nularray: &mut [c_char],    /* O - array of null pixel flags               */
-    anynul: Option<&mut c_int>, /* O - set to 1 if any values are null; else 0 */
-    status: &mut c_int,         /* IO - error status                           */
+    fptr: &mut fitsfile,
+    group: c_long,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: &mut [f64],
+    nularray: &mut [c_char],
+    anynul: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     let nullcheck = NullCheckType::SetNullArray;
 
@@ -222,23 +267,34 @@ pub fn ffgpfd_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an entire 2-D array of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of the
 /// FITS array is not the same as the array being read).  Any null
 /// values in the array will be set equal to the value of nulval, unless
 /// nulval = 0 in which case no null checking will be performed.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `group`  — (I) group to read (1 = 1st group)
+/// * `nulval` — set undefined pixels equal to this
+/// * `ncols`  — (I) number of pixels in each row of array
+/// * `naxis1` — (I) FITS image NAXIS1 value
+/// * `naxis2` — (I) FITS image NAXIS2 value
+/// * `array`  — (O) array to be filled and returned
+/// * `anynul` — (O) set to 1 if any values are null; else 0
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffg2dd(
-    fptr: *mut fitsfile, /* I - FITS file pointer                       */
-    group: c_long,       /* I - group to read (1 = 1st group)           */
-    nulval: f64,         /* set undefined pixels equal to this     */
-    ncols: LONGLONG,     /* I - number of pixels in each row of array   */
-    naxis1: LONGLONG,    /* I - FITS image NAXIS1 value                 */
-    naxis2: LONGLONG,    /* I - FITS image NAXIS2 value                 */
-    array: *mut f64,     /* O - array to be filled and returned    */
-    anynul: *mut c_int,  /* O - set to 1 if any values are null; else 0 */
-    status: *mut c_int,  /* IO - error status                           */
+    fptr: *mut fitsfile,
+    group: c_long,
+    nulval: f64,
+    ncols: LONGLONG,
+    naxis1: LONGLONG,
+    naxis2: LONGLONG,
+    array: *mut f64,
+    anynul: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -254,22 +310,33 @@ pub unsafe extern "C" fn ffg2dd(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an entire 2-D array of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of the
 /// FITS array is not the same as the array being read).  Any null
 /// values in the array will be set equal to the value of nulval, unless
 /// nulval = 0 in which case no null checking will be performed.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `group`  — (I) group to read (1 = 1st group)
+/// * `nulval` — set undefined pixels equal to this
+/// * `ncols`  — (I) number of pixels in each row of array
+/// * `naxis1` — (I) FITS image NAXIS1 value
+/// * `naxis2` — (I) FITS image NAXIS2 value
+/// * `array`  — (O) array to be filled and returned
+/// * `anynul` — (O) set to 1 if any values are null; else 0
+/// * `status` — (IO) error status
 pub fn ffg2dd_safe(
-    fptr: &mut fitsfile,        /* I - FITS file pointer                       */
-    group: c_long,              /* I - group to read (1 = 1st group)           */
-    nulval: f64,                /* set undefined pixels equal to this     */
-    ncols: LONGLONG,            /* I - number of pixels in each row of array   */
-    naxis1: LONGLONG,           /* I - FITS image NAXIS1 value                 */
-    naxis2: LONGLONG,           /* I - FITS image NAXIS2 value                 */
-    array: &mut [f64],          /* O - array to be filled and returned    */
-    anynul: Option<&mut c_int>, /* O - set to 1 if any values are null; else 0 */
-    status: &mut c_int,         /* IO - error status                           */
+    fptr: &mut fitsfile,
+    group: c_long,
+    nulval: f64,
+    ncols: LONGLONG,
+    naxis1: LONGLONG,
+    naxis2: LONGLONG,
+    array: &mut [f64],
+    anynul: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     /* call the 3D reading routine, with the 3rd dimension = 1 */
     ffg3dd_safe(
@@ -279,7 +346,6 @@ pub fn ffg2dd_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an entire 3-D array of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of the
 /// FITS array is not the same as the array being read).  Any null
@@ -290,19 +356,33 @@ pub fn ffg2dd_safe(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `group`  — (I) group to read (1 = 1st group)
+/// * `nulval` — set undefined pixels equal to this
+/// * `ncols`  — (I) number of pixels in each row of array
+/// * `nrows`  — (I) number of rows in each plane of array
+/// * `naxis1` — (I) FITS image NAXIS1 value
+/// * `naxis2` — (I) FITS image NAXIS2 value
+/// * `naxis3` — (I) FITS image NAXIS3 value
+/// * `array`  — (O) array to be filled and returned
+/// * `anynul` — (O) set to 1 if any values are null; else 0
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffg3dd(
-    fptr: *mut fitsfile, /* I - FITS file pointer                       */
-    group: c_long,       /* I - group to read (1 = 1st group)           */
-    nulval: f64,         /* set undefined pixels equal to this     */
-    ncols: LONGLONG,     /* I - number of pixels in each row of array   */
-    nrows: LONGLONG,     /* I - number of rows in each plane of array   */
-    naxis1: LONGLONG,    /* I - FITS image NAXIS1 value                 */
-    naxis2: LONGLONG,    /* I - FITS image NAXIS2 value                 */
-    naxis3: LONGLONG,    /* I - FITS image NAXIS3 value                 */
-    array: *mut f64,     /* O - array to be filled and returned    */
-    anynul: *mut c_int,  /* O - set to 1 if any values are null; else 0 */
-    status: *mut c_int,  /* IO - error status                           */
+    fptr: *mut fitsfile,
+    group: c_long,
+    nulval: f64,
+    ncols: LONGLONG,
+    nrows: LONGLONG,
+    naxis1: LONGLONG,
+    naxis2: LONGLONG,
+    naxis3: LONGLONG,
+    array: *mut f64,
+    anynul: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -318,7 +398,6 @@ pub unsafe extern "C" fn ffg3dd(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an entire 3-D array of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of the
 /// FITS array is not the same as the array being read).  Any null
@@ -329,18 +408,32 @@ pub unsafe extern "C" fn ffg3dd(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `group`  — (I) group to read (1 = 1st group)
+/// * `nulval` — set undefined pixels equal to this
+/// * `ncols`  — (I) number of pixels in each row of array
+/// * `nrows`  — (I) number of rows in each plane of array
+/// * `naxis1` — (I) FITS image NAXIS1 value
+/// * `naxis2` — (I) FITS image NAXIS2 value
+/// * `naxis3` — (I) FITS image NAXIS3 value
+/// * `array`  — (O) array to be filled and returned
+/// * `anynul` — (O) set to 1 if any values are null; else 0
+/// * `status` — (IO) error status
 pub fn ffg3dd_safe(
-    fptr: &mut fitsfile,            /* I - FITS file pointer                       */
-    group: c_long,                  /* I - group to read (1 = 1st group)           */
-    nulval: f64,                    /* set undefined pixels equal to this     */
-    ncols: LONGLONG,                /* I - number of pixels in each row of array   */
-    nrows: LONGLONG,                /* I - number of rows in each plane of array   */
-    naxis1: LONGLONG,               /* I - FITS image NAXIS1 value                 */
-    naxis2: LONGLONG,               /* I - FITS image NAXIS2 value                 */
-    naxis3: LONGLONG,               /* I - FITS image NAXIS3 value                 */
-    array: &mut [f64],              /* O - array to be filled and returned    */
-    mut anynul: Option<&mut c_int>, /* O - set to 1 if any values are null; else 0 */
-    status: &mut c_int,             /* IO - error status                           */
+    fptr: &mut fitsfile,
+    group: c_long,
+    nulval: f64,
+    ncols: LONGLONG,
+    nrows: LONGLONG,
+    naxis1: LONGLONG,
+    naxis2: LONGLONG,
+    naxis3: LONGLONG,
+    array: &mut [f64],
+    mut anynul: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     let mut narray = 0;
     let mut nfits: LONGLONG = 0;
@@ -440,22 +533,35 @@ pub fn ffg3dd_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read a subsection of data values from an image or a table column.
 /// This routine is set up to handle a maximum of nine dimensions.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `colnum` — (I) number of the column to read (1 = 1st)
+/// * `naxis`  — (I) number of dimensions in the FITS array
+/// * `naxes`  — (I) size of each dimension
+/// * `blc`    — (I) 'bottom left corner' of the subsection
+/// * `trc`    — (I) 'top right corner' of the subsection
+/// * `inc`    — (I) increment to be applied in each dimension
+/// * `nulval` — (I) value to set undefined pixels
+/// * `array`  — (O) array to be filled and returned
+/// * `anynul` — (O) set to 1 if any values are null; else 0
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgsvd(
-    fptr: *mut fitsfile,  /* I - FITS file pointer                         */
-    colnum: c_int,        /* I - number of the column to read (1 = 1st)    */
-    naxis: c_int,         /* I - number of dimensions in the FITS array    */
-    naxes: *const c_long, /* I - size of each dimension                    */
-    blc: *const c_long,   /* I - 'bottom left corner' of the subsection    */
-    trc: *const c_long,   /* I - 'top right corner' of the subsection      */
-    inc: *const c_long,   /* I - increment to be applied in each dimension */
-    nulval: f64,          /* I - value to set undefined pixels       */
-    array: *mut f64,      /* O - array to be filled and returned     */
-    anynul: *mut c_int,   /* O - set to 1 if any values are null; else 0   */
-    status: *mut c_int,   /* IO - error status                             */
+    fptr: *mut fitsfile,
+    colnum: c_int,
+    naxis: c_int,
+    naxes: *const c_long,
+    blc: *const c_long,
+    trc: *const c_long,
+    inc: *const c_long,
+    nulval: f64,
+    array: *mut f64,
+    anynul: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -478,21 +584,34 @@ pub unsafe extern "C" fn ffgsvd(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read a subsection of data values from an image or a table column.
 /// This routine is set up to handle a maximum of nine dimensions.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `colnum` — (I) number of the column to read (1 = 1st)
+/// * `naxis`  — (I) number of dimensions in the FITS array
+/// * `naxes`  — (I) size of each dimension
+/// * `blc`    — (I) 'bottom left corner' of the subsection
+/// * `trc`    — (I) 'top right corner' of the subsection
+/// * `inc`    — (I) increment to be applied in each dimension
+/// * `nulval` — (I) value to set undefined pixels
+/// * `array`  — (O) array to be filled and returned
+/// * `anynul` — (O) set to 1 if any values are null; else 0
+/// * `status` — (IO) error status
 pub fn ffgsvd_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                         */
-    colnum: c_int,       /* I - number of the column to read (1 = 1st)    */
-    naxis: c_int,        /* I - number of dimensions in the FITS array    */
-    naxes: &[c_long],    /* I - size of each dimension                    */
-    blc: &[c_long],      /* I - 'bottom left corner' of the subsection    */
-    trc: &[c_long],      /* I - 'top right corner' of the subsection      */
-    inc: &[c_long],      /* I - increment to be applied in each dimension */
-    nulval: f64,         /* I - value to set undefined pixels       */
-    array: &mut [f64],   /* O - array to be filled and returned     */
-    mut anynul: Option<&mut c_int>, /* O - set to 1 if any values are null; else 0   */
-    status: &mut c_int,  /* IO - error status                             */
+    fptr: &mut fitsfile,
+    colnum: c_int,
+    naxis: c_int,
+    naxes: &[c_long],
+    blc: &[c_long],
+    trc: &[c_long],
+    inc: &[c_long],
+    nulval: f64,
+    array: &mut [f64],
+    mut anynul: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     let mut rstr: c_long = 0;
     let mut rstp: c_long = 0;
@@ -697,22 +816,35 @@ pub fn ffgsvd_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read a subsection of data values from an image or a table column.
 /// This routine is set up to handle a maximum of nine dimensions.
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `colnum`  — (I) number of the column to read (1 = 1st)
+/// * `naxis`   — (I) number of dimensions in the FITS array
+/// * `naxes`   — (I) size of each dimension
+/// * `blc`     — (I) 'bottom left corner' of the subsection
+/// * `trc`     — (I) 'top right corner' of the subsection
+/// * `inc`     — (I) increment to be applied in each dimension
+/// * `array`   — (O) array to be filled and returned
+/// * `flagval` — (O) set to 1 if corresponding value is null
+/// * `anynul`  — (O) set to 1 if any values are null; else 0
+/// * `status`  — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgsfd(
-    fptr: *mut fitsfile,  /* I - FITS file pointer                         */
-    colnum: c_int,        /* I - number of the column to read (1 = 1st)    */
-    naxis: c_int,         /* I - number of dimensions in the FITS array    */
-    naxes: *const c_long, /* I - size of each dimension                    */
-    blc: *const c_long,   /* I - 'bottom left corner' of the subsection    */
-    trc: *const c_long,   /* I - 'top right corner' of the subsection      */
-    inc: *const c_long,   /* I - increment to be applied in each dimension */
-    array: *mut f64,      /* O - array to be filled and returned     */
-    flagval: *mut c_char, /* O - set to 1 if corresponding value is null   */
-    anynul: *mut c_int,   /* O - set to 1 if any values are null; else 0   */
-    status: *mut c_int,   /* IO - error status                             */
+    fptr: *mut fitsfile,
+    colnum: c_int,
+    naxis: c_int,
+    naxes: *const c_long,
+    blc: *const c_long,
+    trc: *const c_long,
+    inc: *const c_long,
+    array: *mut f64,
+    flagval: *mut c_char,
+    anynul: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -737,21 +869,34 @@ pub unsafe extern "C" fn ffgsfd(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read a subsection of data values from an image or a table column.
 /// This routine is set up to handle a maximum of nine dimensions.
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `colnum`  — (I) number of the column to read (1 = 1st)
+/// * `naxis`   — (I) number of dimensions in the FITS array
+/// * `naxes`   — (I) size of each dimension
+/// * `blc`     — (I) 'bottom left corner' of the subsection
+/// * `trc`     — (I) 'top right corner' of the subsection
+/// * `inc`     — (I) increment to be applied in each dimension
+/// * `array`   — (O) array to be filled and returned
+/// * `flagval` — (O) set to 1 if corresponding value is null
+/// * `anynul`  — (O) set to 1 if any values are null; else 0
+/// * `status`  — (IO) error status
 pub fn ffgsfd_safe(
-    fptr: &mut fitsfile,    /* I - FITS file pointer                         */
-    colnum: c_int,          /* I - number of the column to read (1 = 1st)    */
-    naxis: c_int,           /* I - number of dimensions in the FITS array    */
-    naxes: &[c_long],       /* I - size of each dimension                    */
-    blc: &[c_long],         /* I - 'bottom left corner' of the subsection    */
-    trc: &[c_long],         /* I - 'top right corner' of the subsection      */
-    inc: &[c_long],         /* I - increment to be applied in each dimension */
-    array: &mut [f64],      /* O - array to be filled and returned     */
-    flagval: &mut [c_char], /* O - set to 1 if corresponding value is null   */
-    mut anynul: Option<&mut c_int>, /* O - set to 1 if any values are null; else 0   */
-    status: &mut c_int,     /* IO - error status                             */
+    fptr: &mut fitsfile,
+    colnum: c_int,
+    naxis: c_int,
+    naxes: &[c_long],
+    blc: &[c_long],
+    trc: &[c_long],
+    inc: &[c_long],
+    array: &mut [f64],
+    flagval: &mut [c_char],
+    mut anynul: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     let mut rstr: c_long = 0;
     let mut rstp: c_long = 0;
@@ -939,7 +1084,6 @@ pub fn ffgsfd_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 ///Read an array of group parameters from the primary array. Data conversion
 ///and scaling will be performed if necessary (e.g, if the datatype of
 ///the FITS array is not the same as the array being read).
@@ -948,14 +1092,23 @@ pub fn ffgsfd_safe(
 ///each group of the primary array is a row in the table,
 ///where the first column contains the group parameters
 ///and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to read (1 = 1st group)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `array`     — (O) array of values that are returned
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffggpd(
-    fptr: *mut fitsfile, /* I - FITS file pointer                       */
-    group: c_long,       /* I - group to read (1 = 1st group)           */
-    firstelem: c_long,   /* I - first vector element to read (1 = 1st)  */
-    nelem: c_long,       /* I - number of values to read                */
-    array: *mut f64,     /* O - array of values that are returned   */
-    status: *mut c_int,  /* IO - error status                           */
+    fptr: *mut fitsfile,
+    group: c_long,
+    firstelem: c_long,
+    nelem: c_long,
+    array: *mut f64,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -967,7 +1120,6 @@ pub unsafe extern "C" fn ffggpd(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 ///Read an array of group parameters from the primary array. Data conversion
 ///and scaling will be performed if necessary (e.g, if the datatype of
 ///the FITS array is not the same as the array being read).
@@ -976,13 +1128,22 @@ pub unsafe extern "C" fn ffggpd(
 ///each group of the primary array is a row in the table,
 ///where the first column contains the group parameters
 ///and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to read (1 = 1st group)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `array`     — (O) array of values that are returned
+/// * `status`    — (IO) error status
 pub fn ffggpd_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                       */
-    group: c_long,       /* I - group to read (1 = 1st group)           */
-    firstelem: c_long,   /* I - first vector element to read (1 = 1st)  */
-    nelem: c_long,       /* I - number of values to read                */
-    array: &mut [f64],   /* O - array of values that are returned   */
-    status: &mut c_int,  /* IO - error status                           */
+    fptr: &mut fitsfile,
+    group: c_long,
+    firstelem: c_long,
+    nelem: c_long,
+    array: &mut [f64],
+    status: &mut c_int,
 ) -> c_int {
     let mut anynul = 0;
     let mut dummy_nularray = vec![0; nelem as usize];
@@ -1006,24 +1167,35 @@ pub fn ffggpd_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of values from a column in the current FITS HDU. Automatic
 /// datatype conversion will be performed if the datatype of the column does not
 /// match the datatype of the array parameter. The output values will be scaled
 /// by the FITS TSCALn and TZEROn values if these values have been defined.
 /// Any undefined pixels will be set equal to the value of 'nulval' unless
 /// nulval = 0 in which case no checks for undefined pixels will be made.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to read (1 = 1st col)
+/// * `firstrow`  — (I) first row to read (1 = 1st row)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `nulval`    — (I) value for null pixels
+/// * `array`     — (O) array of values that are read
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgcvd(
-    fptr: *mut fitsfile, /* I - FITS file pointer                       */
-    colnum: c_int,       /* I - number of column to read (1 = 1st col)  */
-    firstrow: LONGLONG,  /* I - first row to read (1 = 1st row)         */
-    firstelem: LONGLONG, /* I - first vector element to read (1 = 1st)  */
-    nelem: LONGLONG,     /* I - number of values to read                */
-    nulval: f64,         /* I - value for null pixels               */
-    array: *mut f64,     /* O - array of values that are read       */
-    anynul: *mut c_int,  /* O - set to 1 if any values are null; else 0 */
-    status: *mut c_int,  /* IO - error status                           */
+    fptr: *mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    nulval: f64,
+    array: *mut f64,
+    anynul: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -1047,23 +1219,34 @@ pub unsafe extern "C" fn ffgcvd(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of values from a column in the current FITS HDU. Automatic
 /// datatype conversion will be performed if the datatype of the column does not
 /// match the datatype of the array parameter. The output values will be scaled
 /// by the FITS TSCALn and TZEROn values if these values have been defined.
 /// Any undefined pixels will be set equal to the value of 'nulval' unless
 /// nulval = 0 in which case no checks for undefined pixels will be made.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to read (1 = 1st col)
+/// * `firstrow`  — (I) first row to read (1 = 1st row)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `nulval`    — (I) value for null pixels
+/// * `array`     — (O) array of values that are read
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `status`    — (IO) error status
 pub fn ffgcvd_safe(
-    fptr: &mut fitsfile,        /* I - FITS file pointer                       */
-    colnum: c_int,              /* I - number of column to read (1 = 1st col)  */
-    firstrow: LONGLONG,         /* I - first row to read (1 = 1st row)         */
-    firstelem: LONGLONG,        /* I - first vector element to read (1 = 1st)  */
-    nelem: LONGLONG,            /* I - number of values to read                */
-    nulval: f64,                /* I - value for null pixels               */
-    array: &mut [f64],          /* O - array of values that are read       */
-    anynul: Option<&mut c_int>, /* O - set to 1 if any values are null; else 0 */
-    status: &mut c_int,         /* IO - error status                           */
+    fptr: &mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    nulval: f64,
+    array: &mut [f64],
+    anynul: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     let mut dummy_nularray = vec![0; nelem as usize];
 
@@ -1084,7 +1267,6 @@ pub fn ffgcvd_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of values from a column in the current FITS HDU. Automatic
 /// datatype conversion will be performed if the datatype of the column does not
 /// match the datatype of the array parameter. The output values will be scaled
@@ -1093,17 +1275,29 @@ pub fn ffgcvd_safe(
 /// nulval = 0 in which case no checks for undefined pixels will be made.
 ///
 /// TSCAL and ZERO should not be used with complex values.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to read (1 = 1st col)
+/// * `firstrow`  — (I) first row to read (1 = 1st row)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `nulval`    — (I) value for null pixels
+/// * `array`     — (O) array of values that are read
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgcvm(
-    fptr: *mut fitsfile, /* I - FITS file pointer                       */
-    colnum: c_int,       /* I - number of column to read (1 = 1st col)  */
-    firstrow: LONGLONG,  /* I - first row to read (1 = 1st row)         */
-    firstelem: LONGLONG, /* I - first vector element to read (1 = 1st)  */
-    nelem: LONGLONG,     /* I - number of values to read                */
-    nulval: f64,         /* I - value for null pixels                   */
-    array: *mut f64,     /* O - array of values that are read           */
-    anynul: *mut c_int,  /* O - set to 1 if any values are null; else 0 */
-    status: *mut c_int,  /* IO - error status                           */
+    fptr: *mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    nulval: f64,
+    array: *mut f64,
+    anynul: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -1127,7 +1321,6 @@ pub unsafe extern "C" fn ffgcvm(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of values from a column in the current FITS HDU. Automatic
 /// datatype conversion will be performed if the datatype of the column does not
 /// match the datatype of the array parameter. The output values will be scaled
@@ -1136,16 +1329,28 @@ pub unsafe extern "C" fn ffgcvm(
 /// nulval = 0 in which case no checks for undefined pixels will be made.
 ///
 /// TSCAL and ZERO should not be used with complex values.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to read (1 = 1st col)
+/// * `firstrow`  — (I) first row to read (1 = 1st row)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `nulval`    — (I) value for null pixels
+/// * `array`     — (O) array of values that are read
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `status`    — (IO) error status
 pub fn ffgcvm_safe(
-    fptr: &mut fitsfile,        /* I - FITS file pointer                       */
-    colnum: c_int,              /* I - number of column to read (1 = 1st col)  */
-    firstrow: LONGLONG,         /* I - first row to read (1 = 1st row)         */
-    firstelem: LONGLONG,        /* I - first vector element to read (1 = 1st)  */
-    nelem: LONGLONG,            /* I - number of values to read                */
-    nulval: f64,                /* I - value for null pixels                   */
-    array: &mut [f64],          /* O - array of values that are read           */
-    anynul: Option<&mut c_int>, /* O - set to 1 if any values are null; else 0 */
-    status: &mut c_int,         /* IO - error status                           */
+    fptr: &mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    nulval: f64,
+    array: &mut [f64],
+    anynul: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     let mut dummy_nularray = vec![0; 2 * nelem as usize];
 
@@ -1169,24 +1374,35 @@ pub fn ffgcvm_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of values from a column in the current FITS HDU. Automatic
 /// datatype conversion will be performed if the datatype of the column does not
 /// match the datatype of the array parameter. The output values will be scaled
 /// by the FITS TSCALn and TZEROn values if these values have been defined.
 /// Nularray will be set = 1 if the corresponding array pixel is undefined,
 /// otherwise nularray will = 0.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to read (1 = 1st col)
+/// * `firstrow`  — (I) first row to read (1 = 1st row)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `array`     — (O) array of values that are read
+/// * `nularray`  — (O) array of flags: 1 if null pixel; else 0
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgcfd(
-    fptr: *mut fitsfile,   /* I - FITS file pointer                       */
-    colnum: c_int,         /* I - number of column to read (1 = 1st col)  */
-    firstrow: LONGLONG,    /* I - first row to read (1 = 1st row)         */
-    firstelem: LONGLONG,   /* I - first vector element to read (1 = 1st)  */
-    nelem: LONGLONG,       /* I - number of values to read                */
-    array: *mut f64,       /* O - array of values that are read       */
-    nularray: *mut c_char, /* O - array of flags: 1 if null pixel; else 0 */
-    anynul: *mut c_int,    /* O - set to 1 if any values are null; else 0 */
-    status: *mut c_int,    /* IO - error status                           */
+    fptr: *mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: *mut f64,
+    nularray: *mut c_char,
+    anynul: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -1203,23 +1419,34 @@ pub unsafe extern "C" fn ffgcfd(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of values from a column in the current FITS HDU. Automatic
 /// datatype conversion will be performed if the datatype of the column does not
 /// match the datatype of the array parameter. The output values will be scaled
 /// by the FITS TSCALn and TZEROn values if these values have been defined.
 /// Nularray will be set = 1 if the corresponding array pixel is undefined,
 /// otherwise nularray will = 0.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to read (1 = 1st col)
+/// * `firstrow`  — (I) first row to read (1 = 1st row)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `array`     — (O) array of values that are read
+/// * `nularray`  — (O) array of flags: 1 if null pixel; else 0
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `status`    — (IO) error status
 pub fn ffgcfd_safe(
-    fptr: &mut fitsfile,        /* I - FITS file pointer                       */
-    colnum: c_int,              /* I - number of column to read (1 = 1st col)  */
-    firstrow: LONGLONG,         /* I - first row to read (1 = 1st row)         */
-    firstelem: LONGLONG,        /* I - first vector element to read (1 = 1st)  */
-    nelem: LONGLONG,            /* I - number of values to read                */
-    array: &mut [f64],          /* O - array of values that are read       */
-    nularray: &mut [c_char],    /* O - array of flags: 1 if null pixel; else 0 */
-    anynul: Option<&mut c_int>, /* O - set to 1 if any values are null; else 0 */
-    status: &mut c_int,         /* IO - error status                           */
+    fptr: &mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: &mut [f64],
+    nularray: &mut [c_char],
+    anynul: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     let dummy: f64 = 0.0;
 
@@ -1240,7 +1467,6 @@ pub fn ffgcfd_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of values from a column in the current FITS HDU. Automatic
 /// datatype conversion will be performed if the datatype of the column does not
 /// match the datatype of the array parameter. The output values will be scaled
@@ -1249,17 +1475,29 @@ pub fn ffgcfd_safe(
 /// otherwise nularray will = 0.
 ///
 /// TSCAL and ZERO should not be used with complex values.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to read (1 = 1st col)
+/// * `firstrow`  — (I) first row to read (1 = 1st row)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `array`     — (O) array of values that are read
+/// * `nularray`  — (O) array of flags: 1 if null pixel; else 0
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgcfm(
-    fptr: *mut fitsfile,   /* I - FITS file pointer                       */
-    colnum: c_int,         /* I - number of column to read (1 = 1st col)  */
-    firstrow: LONGLONG,    /* I - first row to read (1 = 1st row)         */
-    firstelem: LONGLONG,   /* I - first vector element to read (1 = 1st)  */
-    nelem: LONGLONG,       /* I - number of values to read                */
-    array: *mut f64,       /* O - array of values that are read           */
-    nularray: *mut c_char, /* O - array of flags: 1 if null pixel; else 0 */
-    anynul: *mut c_int,    /* O - set to 1 if any values are null; else 0 */
-    status: *mut c_int,    /* IO - error status                           */
+    fptr: *mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: *mut f64,
+    nularray: *mut c_char,
+    anynul: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -1284,7 +1522,6 @@ pub unsafe extern "C" fn ffgcfm(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of values from a column in the current FITS HDU. Automatic
 /// datatype conversion will be performed if the datatype of the column does not
 /// match the datatype of the array parameter. The output values will be scaled
@@ -1293,16 +1530,28 @@ pub unsafe extern "C" fn ffgcfm(
 /// otherwise nularray will = 0.
 ///
 /// TSCAL and ZERO should not be used with complex values.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to read (1 = 1st col)
+/// * `firstrow`  — (I) first row to read (1 = 1st row)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `array`     — (O) array of values that are read
+/// * `nularray`  — (O) array of flags: 1 if null pixel; else 0
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `status`    — (IO) error status
 pub fn ffgcfm_safe(
-    fptr: &mut fitsfile,        /* I - FITS file pointer                       */
-    colnum: c_int,              /* I - number of column to read (1 = 1st col)  */
-    firstrow: LONGLONG,         /* I - first row to read (1 = 1st row)         */
-    firstelem: LONGLONG,        /* I - first vector element to read (1 = 1st)  */
-    nelem: LONGLONG,            /* I - number of values to read                */
-    array: &mut [f64],          /* O - array of values that are read           */
-    nularray: &mut [c_char],    /* O - array of flags: 1 if null pixel; else 0 */
-    anynul: Option<&mut c_int>, /* O - set to 1 if any values are null; else 0 */
-    status: &mut c_int,         /* IO - error status                           */
+    fptr: &mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: &mut [f64],
+    nularray: &mut [c_char],
+    anynul: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     let dummy: f64 = 0.0;
 
@@ -1339,7 +1588,6 @@ pub fn ffgcfm_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of values from a column in the current FITS HDU.
 /// The column number may refer to a real column in an ASCII or binary table,
 /// or it may refer be a virtual column in a 1 or more grouped FITS primary
@@ -1353,21 +1601,35 @@ pub fn ffgcfm_safe(
 /// and will be scaled by the FITS TSCALn and TZEROn values if necessary.
 #[allow(clippy::if_same_then_else)]
 // C dispatch chain: distinct conditions deliberately share an action.
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to read (1 = 1st col)
+/// * `firstrow`  — (I) first row to read (1 = 1st row)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `elemincre` — (I) pixel increment; e.g., 2 = every other
+/// * `nultyp`    — (I) null value handling code:
+/// * `nulval`    — (I) value for null pixels if nultyp = 1
+/// * `array`     — (O) array of values that are read
+/// * `nularray`  — (O) array of flags = 1 if nultyp = 2
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `status`    — (IO) error status
 pub(crate) fn ffgcld(
-    fptr: &mut fitsfile,   /* I - FITS file pointer                       */
-    colnum: c_int,         /* I - number of column to read (1 = 1st col)  */
-    firstrow: LONGLONG,    /* I - first row to read (1 = 1st row)         */
-    firstelem: LONGLONG,   /* I - first vector element to read (1 = 1st)  */
-    nelem: LONGLONG,       /* I - number of values to read                */
-    elemincre: c_long,     /* I - pixel increment; e.g., 2 = every other  */
-    nultyp: NullCheckType, /* I - null value handling code:               */
+    fptr: &mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    elemincre: c_long,
+    nultyp: NullCheckType,
     /*     1: set undefined pixels = nulval        */
     /*     2: set nularray=1 for undefined pixels  */
-    nulval: f64,                    /* I - value for null pixels if nultyp = 1 */
-    array: &mut [f64],              /* O - array of values that are read       */
-    nularray: &mut [c_char],        /* O - array of flags = 1 if nultyp = 2        */
-    mut anynul: Option<&mut c_int>, /* O - set to 1 if any values are null; else 0 */
-    status: &mut c_int,             /* IO - error status                           */
+    nulval: f64,
+    array: &mut [f64],
+    nularray: &mut [c_char],
+    mut anynul: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     let mut scale: f64 = 0.0;
     let mut zero: f64 = 0.0;
@@ -1415,9 +1677,7 @@ pub(crate) fn ffgcld(
         nularray.fill(0); /* initialize nullarray */
     }
 
-    /*---------------------------------------------------*/
     /*  Check input and get parameters about the column: */
-    /*---------------------------------------------------*/
     if elemincre < 0 {
         readcheck -= 1; /* don't do range checking in this case */
     }
@@ -1468,9 +1728,7 @@ pub(crate) fn ffgcld(
             power *= 10.0;
         }
     }
-    /*------------------------------------------------------------------*/
     /*  Decide whether to check for null values in the input FITS file: */
-    /*------------------------------------------------------------------*/
     nulcheck = nultyp; /* by default, check for null values in the FITS file */
 
     if nultyp == NullCheckType::SetPixel && nulval == 0.0 {
@@ -1490,10 +1748,8 @@ pub(crate) fn ffgcld(
         nulcheck = NullCheckType::None;
     }
 
-    /*----------------------------------------------------------------------*/
     /*  If FITS column and output data array have same datatype, then we do */
     /*  not need to use a temporary buffer to store intermediate datatype.  */
-    /*----------------------------------------------------------------------*/
     convert = true;
     if tcode == TDOUBLE {
         /* Special Case:                        */
@@ -1511,7 +1767,6 @@ pub(crate) fn ffgcld(
         }
     }
 
-    /*---------------------------------------------------------------------*/
     /*  Now read the pixels from the FITS column. If the column does not   */
     /*  have the same datatype as the output array, then we have to read   */
     /*  the raw values into a temporary buffer (of limited size).  In      */
@@ -1521,7 +1776,6 @@ pub(crate) fn ffgcld(
     /*  test for undefined values, (2) convert the datatype if necessary,  */
     /*  and (3) scale the values by the FITS TSCALn and TZEROn linear      */
     /*  scaling parameters.                                                */
-    /*---------------------------------------------------------------------*/
 
     remain = nelem; /* remaining number of values to read */
     next = 0; /* next element in array to be read   */
@@ -1749,9 +2003,7 @@ pub(crate) fn ffgcld(
             }
         } /* End of switch block */
 
-        /*-------------------------*/
         /*  Check for fatal error  */
-        /*-------------------------*/
         if *status > 0 {
             /* test for error during previous read operation */
 
@@ -1779,9 +2031,7 @@ pub(crate) fn ffgcld(
             return *status;
         }
 
-        /*--------------------------------------------*/
         /*  increment the counters for the next loop  */
-        /*--------------------------------------------*/
         remain -= ntodo as LONGLONG;
         if remain != 0 {
             next += ntodo as usize;
@@ -1803,9 +2053,7 @@ pub(crate) fn ffgcld(
         }
     } /*  End of main while Loop  */
 
-    /*--------------------------------*/
     /*  check for numerical overflow  */
-    /*--------------------------------*/
     if *status == OVERFLOW_ERR {
         ffpmsg_str("Numerical overflow during type conversion while reading FITS data.");
         *status = NUM_OVERFLOW;
@@ -1814,7 +2062,6 @@ pub(crate) fn ffgcld(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output following reading of the input from a FITS file.
 /// Check for null values and do datatype conversion and scaling if required.
 /// The nullcheck code value determines how any null values in the input array
@@ -1826,20 +2073,34 @@ pub(crate) fn ffgcld(
 /// nullarray will be set to 1; the value of nullarray for non-null pixels
 /// will = 0.  The anynull parameter will be set = 1 if any of the returned
 /// pixels are null, otherwise anynull will be returned with a value = 0;
+///
+/// # Parameters
+///
+/// * `input`     — (I) array of values to be converted
+/// * `ntodo`     — (I) number of elements in the array
+/// * `scale`     — (I) FITS TSCALn or BSCALE value
+/// * `zero`      — (I) FITS TZEROn or BZERO value
+/// * `nullcheck` — (I) null checking code; 0 = don't check
+/// * `tnull`     — (I) value of FITS TNULLn keyword if any
+/// * `nullval`   — (I) set null pixels, if nullcheck = 1
+/// * `nullarray` — (O) bad pixel array, if nullcheck = 2
+/// * `anynull`   — (O) set to 1 if any pixels are null
+/// * `output`    — (O) array of converted pixels
+/// * `status`    — (IO) error status
 pub(crate) fn fffi1r8(
-    input: &[u8],             /* I - array of values to be converted     */
-    ntodo: c_long,            /* I - number of elements in the array     */
-    scale: f64,               /* I - FITS TSCALn or BSCALE value         */
-    zero: f64,                /* I - FITS TZEROn or BZERO  value         */
-    nullcheck: NullCheckType, /* I - null checking code; 0 = don't check */
+    input: &[u8],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    nullcheck: NullCheckType,
     /*     1:set null pixels = nullval         */
     /*     2: if null pixel, set nullarray = 1 */
-    tnull: u8,                   /* I - value of FITS TNULLn keyword if any */
-    nullval: f64,                /* I - set null pixels, if nullcheck = 1   */
-    nullarray: &mut [c_char],    /* O - bad pixel array, if nullcheck = 2   */
-    anynull: Option<&mut c_int>, /* O - set to 1 if any pixels are null     */
-    output: &mut [f64],          /* O - array of converted pixels           */
-    status: &mut c_int,          /* IO - error status                       */
+    tnull: u8,
+    nullval: f64,
+    nullarray: &mut [c_char],
+    anynull: Option<&mut c_int>,
+    output: &mut [f64],
+    status: &mut c_int,
 ) -> c_int {
     if nullcheck == NullCheckType::None {
         /* no null checking required */
@@ -1891,7 +2152,6 @@ pub(crate) fn fffi1r8(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output following reading of the input from a FITS file.
 /// Check for null values and do datatype conversion and scaling if required.
 /// The nullcheck code value determines how any null values in the input array
@@ -1903,20 +2163,34 @@ pub(crate) fn fffi1r8(
 /// nullarray will be set to 1; the value of nullarray for non-null pixels
 /// will = 0.  The anynull parameter will be set = 1 if any of the returned
 /// pixels are null, otherwise anynull will be returned with a value = 0;
+///
+/// # Parameters
+///
+/// * `input`     — (I) array of values to be converted
+/// * `ntodo`     — (I) number of elements in the array
+/// * `scale`     — (I) FITS TSCALn or BSCALE value
+/// * `zero`      — (I) FITS TZEROn or BZERO value
+/// * `nullcheck` — (I) null checking code; 0 = don't check
+/// * `tnull`     — (I) value of FITS TNULLn keyword if any
+/// * `nullval`   — (I) set null pixels, if nullcheck = 1
+/// * `nullarray` — (O) bad pixel array, if nullcheck = 2
+/// * `anynull`   — (O) set to 1 if any pixels are null
+/// * `output`    — (O) array of converted pixels
+/// * `status`    — (IO) error status
 pub(crate) fn fffi2r8(
-    input: &[c_short],        /* I - array of values to be converted     */
-    ntodo: c_long,            /* I - number of elements in the array     */
-    scale: f64,               /* I - FITS TSCALn or BSCALE value         */
-    zero: f64,                /* I - FITS TZEROn or BZERO  value         */
-    nullcheck: NullCheckType, /* I - null checking code; 0 = don't check */
+    input: &[c_short],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    nullcheck: NullCheckType,
     /*     1:set null pixels = nullval         */
     /*     2: if null pixel, set nullarray = 1 */
-    tnull: c_short,              /* I - value of FITS TNULLn keyword if any */
-    nullval: f64,                /* I - set null pixels, if nullcheck = 1   */
-    nullarray: &mut [c_char],    /* O - bad pixel array, if nullcheck = 2   */
-    anynull: Option<&mut c_int>, /* O - set to 1 if any pixels are null     */
-    output: &mut [f64],          /* O - array of converted pixels           */
-    status: &mut c_int,          /* IO - error status                       */
+    tnull: c_short,
+    nullval: f64,
+    nullarray: &mut [c_char],
+    anynull: Option<&mut c_int>,
+    output: &mut [f64],
+    status: &mut c_int,
 ) -> c_int {
     if nullcheck == NullCheckType::None {
         /* no null checking required */
@@ -1970,7 +2244,6 @@ pub(crate) fn fffi2r8(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output following reading of the input from a FITS file.
 /// Check for null values and do datatype conversion and scaling if required.
 /// The nullcheck code value determines how any null values in the input array
@@ -1982,20 +2255,34 @@ pub(crate) fn fffi2r8(
 /// nullarray will be set to 1; the value of nullarray for non-null pixels
 /// will = 0.  The anynull parameter will be set = 1 if any of the returned
 /// pixels are null, otherwise anynull will be returned with a value = 0;
+///
+/// # Parameters
+///
+/// * `input`     — (I) array of values to be converted
+/// * `ntodo`     — (I) number of elements in the array
+/// * `scale`     — (I) FITS TSCALn or BSCALE value
+/// * `zero`      — (I) FITS TZEROn or BZERO value
+/// * `nullcheck` — (I) null checking code; 0 = don't check
+/// * `tnull`     — (I) value of FITS TNULLn keyword if any
+/// * `nullval`   — (I) set null pixels, if nullcheck = 1
+/// * `nullarray` — (O) bad pixel array, if nullcheck = 2
+/// * `anynull`   — (O) set to 1 if any pixels are null
+/// * `output`    — (O) array of converted pixels
+/// * `status`    — (IO) error status
 pub(crate) fn fffi4r8(
-    input: &[INT32BIT],       /* I - array of values to be converted     */
-    ntodo: c_long,            /* I - number of elements in the array     */
-    scale: f64,               /* I - FITS TSCALn or BSCALE value         */
-    zero: f64,                /* I - FITS TZEROn or BZERO  value         */
-    nullcheck: NullCheckType, /* I - null checking code; 0 = don't check */
+    input: &[INT32BIT],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    nullcheck: NullCheckType,
     /*     1:set null pixels = nullval         */
     /*     2: if null pixel, set nullarray = 1 */
-    tnull: INT32BIT,             /* I - value of FITS TNULLn keyword if any */
-    nullval: f64,                /* I - set null pixels, if nullcheck = 1   */
-    nullarray: &mut [c_char],    /* O - bad pixel array, if nullcheck = 2   */
-    anynull: Option<&mut c_int>, /* O - set to 1 if any pixels are null     */
-    output: &mut [f64],          /* O - array of converted pixels           */
-    status: &mut c_int,          /* IO - error status                       */
+    tnull: INT32BIT,
+    nullval: f64,
+    nullarray: &mut [c_char],
+    anynull: Option<&mut c_int>,
+    output: &mut [f64],
+    status: &mut c_int,
 ) -> c_int {
     if nullcheck == NullCheckType::None {
         /* no null checking required */
@@ -2047,7 +2334,6 @@ pub(crate) fn fffi4r8(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output following reading of the input from a FITS file.
 /// Check for null values and do datatype conversion and scaling if required.
 /// The nullcheck code value determines how any null values in the input array
@@ -2059,20 +2345,34 @@ pub(crate) fn fffi4r8(
 /// nullarray will be set to 1; the value of nullarray for non-null pixels
 /// will = 0.  The anynull parameter will be set = 1 if any of the returned
 /// pixels are null, otherwise anynull will be returned with a value = 0;
+///
+/// # Parameters
+///
+/// * `input`     — (I) array of values to be converted
+/// * `ntodo`     — (I) number of elements in the array
+/// * `scale`     — (I) FITS TSCALn or BSCALE value
+/// * `zero`      — (I) FITS TZEROn or BZERO value
+/// * `nullcheck` — (I) null checking code; 0 = don't check
+/// * `tnull`     — (I) value of FITS TNULLn keyword if any
+/// * `nullval`   — (I) set null pixels, if nullcheck = 1
+/// * `nullarray` — (O) bad pixel array, if nullcheck = 2
+/// * `anynull`   — (O) set to 1 if any pixels are null
+/// * `output`    — (O) array of converted pixels
+/// * `status`    — (IO) error status
 pub(crate) fn fffi8r8(
-    input: &[LONGLONG],       /* I - array of values to be converted     */
-    ntodo: c_long,            /* I - number of elements in the array     */
-    scale: f64,               /* I - FITS TSCALn or BSCALE value         */
-    zero: f64,                /* I - FITS TZEROn or BZERO  value         */
-    nullcheck: NullCheckType, /* I - null checking code; 0 = don't check */
+    input: &[LONGLONG],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    nullcheck: NullCheckType,
     /*     1:set null pixels = nullval         */
     /*     2: if null pixel, set nullarray = 1 */
-    tnull: LONGLONG,             /* I - value of FITS TNULLn keyword if any */
-    nullval: f64,                /* I - set null pixels, if nullcheck = 1   */
-    nullarray: &mut [c_char],    /* O - bad pixel array, if nullcheck = 2   */
-    anynull: Option<&mut c_int>, /* O - set to 1 if any pixels are null     */
-    output: &mut [f64],          /* O - array of converted pixels           */
-    status: &mut c_int,          /* IO - error status                       */
+    tnull: LONGLONG,
+    nullval: f64,
+    nullarray: &mut [c_char],
+    anynull: Option<&mut c_int>,
+    output: &mut [f64],
+    status: &mut c_int,
 ) -> c_int {
     let mut ulltemp: ULONGLONG = 0;
 
@@ -2155,7 +2455,6 @@ pub(crate) fn fffi8r8(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output following reading of the input from a FITS file.
 /// Check for null values and do datatype conversion and scaling if required.
 /// The nullcheck code value determines how any null values in the input array
@@ -2167,19 +2466,32 @@ pub(crate) fn fffi8r8(
 /// nullarray will be set to 1; the value of nullarray for non-null pixels
 /// will = 0.  The anynull parameter will be set = 1 if any of the returned
 /// pixels are null, otherwise anynull will be returned with a value = 0;
+///
+/// # Parameters
+///
+/// * `input`     — (I) array of values to be converted
+/// * `ntodo`     — (I) number of elements in the array
+/// * `scale`     — (I) FITS TSCALn or BSCALE value
+/// * `zero`      — (I) FITS TZEROn or BZERO value
+/// * `nullcheck` — (I) null checking code; 0 = don't check
+/// * `nullval`   — (I) set null pixels, if nullcheck = 1
+/// * `nullarray` — (O) bad pixel array, if nullcheck = 2
+/// * `anynull`   — (O) set to 1 if any pixels are null
+/// * `output`    — (O) array of converted pixels
+/// * `status`    — (IO) error status
 pub(crate) fn fffr4r8(
-    input: &[f32],            /* I - array of values to be converted     */
-    ntodo: c_long,            /* I - number of elements in the array     */
-    scale: f64,               /* I - FITS TSCALn or BSCALE value         */
-    zero: f64,                /* I - FITS TZEROn or BZERO  value         */
-    nullcheck: NullCheckType, /* I - null checking code; 0 = don't check */
+    input: &[f32],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    nullcheck: NullCheckType,
     /*     1:set null pixels = nullval         */
     /*     2: if null pixel, set nullarray = 1 */
-    nullval: f64,                /* I - set null pixels, if nullcheck = 1   */
-    nullarray: &mut [c_char],    /* O - bad pixel array, if nullcheck = 2   */
-    anynull: Option<&mut c_int>, /* O - set to 1 if any pixels are null     */
-    output: &mut [f64],          /* O - array of converted pixels           */
-    status: &mut c_int,          /* IO - error status                       */
+    nullval: f64,
+    nullarray: &mut [c_char],
+    anynull: Option<&mut c_int>,
+    output: &mut [f64],
+    status: &mut c_int,
 ) -> c_int {
     let mut sptr = 0;
 
@@ -2259,7 +2571,6 @@ pub(crate) fn fffr4r8(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output following reading of the input from a FITS file.
 /// Check for null values and do datatype conversion and scaling if required.
 /// The nullcheck code value determines how any null values in the input array
@@ -2271,19 +2582,32 @@ pub(crate) fn fffr4r8(
 /// nullarray will be set to 1; the value of nullarray for non-null pixels
 /// will = 0.  The anynull parameter will be set = 1 if any of the returned
 /// pixels are null, otherwise anynull will be returned with a value = 0;
+///
+/// # Parameters
+///
+/// * `input`     — (I) array of values to be converted
+/// * `ntodo`     — (I) number of elements in the array
+/// * `scale`     — (I) FITS TSCALn or BSCALE value
+/// * `zero`      — (I) FITS TZEROn or BZERO value
+/// * `nullcheck` — (I) null checking code; 0 = don't check
+/// * `nullval`   — (I) set null pixels, if nullcheck = 1
+/// * `nullarray` — (O) bad pixel array, if nullcheck = 2
+/// * `anynull`   — (O) set to 1 if any pixels are null
+/// * `output`    — (O) array of converted pixels
+/// * `status`    — (IO) error status
 pub(crate) fn fffr8r8(
-    input: &[f64],            /* I - array of values to be converted     */
-    ntodo: c_long,            /* I - number of elements in the array     */
-    scale: f64,               /* I - FITS TSCALn or BSCALE value         */
-    zero: f64,                /* I - FITS TZEROn or BZERO  value         */
-    nullcheck: NullCheckType, /* I - null checking code; 0 = don't check */
+    input: &[f64],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    nullcheck: NullCheckType,
     /*     1:set null pixels = nullval         */
     /*     2: if null pixel, set nullarray = 1 */
-    nullval: f64,                /* I - set null pixels, if nullcheck = 1   */
-    nullarray: &mut [c_char],    /* O - bad pixel array, if nullcheck = 2   */
-    anynull: Option<&mut c_int>, /* O - set to 1 if any pixels are null     */
-    output: &mut [f64],          /* O - array of converted pixels           */
-    status: &mut c_int,          /* IO - error status                       */
+    nullval: f64,
+    nullarray: &mut [c_char],
+    anynull: Option<&mut c_int>,
+    output: &mut [f64],
+    status: &mut c_int,
 ) -> c_int {
     let mut sptr = 0;
     let mut iret = 0;
@@ -2366,7 +2690,6 @@ pub(crate) fn fffr8r8(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output following reading of the input from a FITS file.
 /// Check for null values and do datatype conversion and scaling if required.
 /// The nullcheck code value determines how any null values in the input array
@@ -2378,18 +2701,30 @@ pub(crate) fn fffr8r8(
 /// nullarray will be set to 1; the value of nullarray for non-null pixels
 /// will = 0.  The anynull parameter will be set = 1 if any of the returned
 /// pixels are null, otherwise anynull will be returned with a value = 0;
+///
+/// # Parameters
+///
+/// * `input`     — (I) array of values to be converted
+/// * `ntodo`     — (I) number of elements in the array
+/// * `scale`     — (I) FITS TSCALn or BSCALE value
+/// * `zero`      — (I) FITS TZEROn or BZERO value
+/// * `nullcheck` — (I) null checking code; 0 = don't check
+/// * `nullval`   — (I) set null pixels, if nullcheck = 1
+/// * `nullarray` — (O) bad pixel array, if nullcheck = 2
+/// * `anynull`   — (O) set to 1 if any pixels are null
+/// * `status`    — (IO) error status
 pub(crate) fn fffr8r8_inplace(
-    input: &mut [f64],        /* I - array of values to be converted     */
-    ntodo: c_long,            /* I - number of elements in the array     */
-    scale: f64,               /* I - FITS TSCALn or BSCALE value         */
-    zero: f64,                /* I - FITS TZEROn or BZERO  value         */
-    nullcheck: NullCheckType, /* I - null checking code; 0 = don't check */
+    input: &mut [f64],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    nullcheck: NullCheckType,
     /*     1:set null pixels = nullval         */
     /*     2: if null pixel, set nullarray = 1 */
-    nullval: f64,                /* I - set null pixels, if nullcheck = 1   */
-    nullarray: &mut [c_char],    /* O - bad pixel array, if nullcheck = 2   */
-    anynull: Option<&mut c_int>, /* O - set to 1 if any pixels are null     */
-    status: &mut c_int,          /* IO - error status                       */
+    nullval: f64,
+    nullarray: &mut [c_char],
+    anynull: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     let mut sptr = 0;
     let mut iret = 0;
@@ -2472,7 +2807,6 @@ pub(crate) fn fffr8r8_inplace(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output following reading of the input from a FITS file. Check
 /// for null values and do scaling if required. The nullcheck code value
 /// determines how any null values in the input array are treated. A null
@@ -2483,22 +2817,38 @@ pub(crate) fn fffr8r8_inplace(
 /// nullarray will be set to 1; the value of nullarray for non-null pixels
 /// will = 0.  The anynull parameter will be set = 1 if any of the returned
 /// pixels are null, otherwise anynull will be returned with a value = 0;
+///
+/// # Parameters
+///
+/// * `input`      — (I) array of values to be converted
+/// * `ntodo`      — (I) number of elements in the array
+/// * `scale`      — (I) FITS TSCALn or BSCALE value
+/// * `zero`       — (I) FITS TZEROn or BZERO value
+/// * `twidth`     — (I) width of each substring of chars
+/// * `implipower` — (I) power of 10 of implied decimal
+/// * `nullcheck`  — (I) null checking code; 0 = don't check
+/// * `snull`      — (I) value of FITS null string, if any
+/// * `nullval`    — (I) set null pixels, if nullcheck = 1
+/// * `nullarray`  — (O) bad pixel array, if nullcheck = 2
+/// * `anynull`    — (O) set to 1 if any pixels are null
+/// * `output`     — (O) array of converted pixels
+/// * `status`     — (IO) error status
 pub(crate) fn fffstrr8(
-    input: &mut [c_char],     /* I - array of values to be converted     */
-    ntodo: c_long,            /* I - number of elements in the array     */
-    scale: f64,               /* I - FITS TSCALn or BSCALE value         */
-    zero: f64,                /* I - FITS TZEROn or BZERO  value         */
-    twidth: c_long,           /* I - width of each substring of chars    */
-    implipower: f64,          /* I - power of 10 of implied decimal      */
-    nullcheck: NullCheckType, /* I - null checking code; 0 = don't check */
+    input: &mut [c_char],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    twidth: c_long,
+    implipower: f64,
+    nullcheck: NullCheckType,
     /*     1:set null pixels = nullval         */
     /*     2: if null pixel, set nullarray = 1 */
-    snull: &[c_char],                /* I - value of FITS null string, if any   */
-    nullval: f64,                    /* I - set null pixels, if nullcheck = 1  */
-    nullarray: &mut [c_char],        /* O - bad pixel array, if nullcheck = 2   */
-    mut anynull: Option<&mut c_int>, /* O - set to 1 if any pixels are null     */
-    output: &mut [f64],              /* O - array of converted pixels          */
-    status: &mut c_int,              /* IO - error status                       */
+    snull: &[c_char],
+    nullval: f64,
+    nullarray: &mut [c_char],
+    mut anynull: Option<&mut c_int>,
+    output: &mut [f64],
+    status: &mut c_int,
 ) -> c_int {
     let mut dvalue: f64 = 0.0;
     let mut message: [c_char; FLEN_ERRMSG] = [0; FLEN_ERRMSG];

--- a/src/getcole.rs
+++ b/src/getcole.rs
@@ -1,9 +1,14 @@
-/*  This file, getcole.rs, contains routines that read data elements from   */
-/*  a FITS image or table, with float datatype                             */
-
-/*  The FITSIO software was written by William Pence at the High Energy    */
-/*  Astrophysic Science Archive Research Center (HEASARC) at the NASA      */
-/*  Goddard Space Flight Center.                                           */
+//! Routines that read data elements from a FITS image or table, with float
+//! datatype.
+//!
+//! The [`TFLOAT`] arm of the typed column I/O family. [`crate::getcol`]
+//! dispatches here when a caller asks for this datatype at run time; the
+//! write-side counterpart is [`crate::putcole`].
+//!
+//! Ported from CFITSIO's `getcole.c`, written by William Pence at the High
+//! Energy Astrophysics Science Archive Research Center (HEASARC), NASA Goddard
+//! Space Flight Center.
+#![warn(missing_docs)]
 
 use core::slice;
 use core::{cmp, mem};
@@ -23,7 +28,6 @@ use crate::{NullValue, bb};
 use crate::{buffers::*, calculate_subsection_length};
 use crate::{int_snprintf, slice_to_str};
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of values from the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
 /// the FITS array is not the same as the array being read).
@@ -35,16 +39,27 @@ use crate::{int_snprintf, slice_to_str};
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to read (1 = 1st group)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `nulval`    — (I) value for undefined pixels
+/// * `array`     — (O) array of values that are returned
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgpve(
-    fptr: *mut fitsfile, /* I - FITS file pointer                       */
-    group: c_long,       /* I - group to read (1 = 1st group)           */
-    firstelem: LONGLONG, /* I - first vector element to read (1 = 1st)  */
-    nelem: LONGLONG,     /* I - number of values to read                */
-    nulval: f32,         /* I - value for undefined pixels          */
-    array: *mut f32,     /* O - array of values that are returned   */
-    anynul: *mut c_int,  /* O - set to 1 if any values are null; else 0 */
-    status: *mut c_int,  /* IO - error status                           */
+    fptr: *mut fitsfile,
+    group: c_long,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    nulval: f32,
+    array: *mut f32,
+    anynul: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -58,7 +73,6 @@ pub unsafe extern "C" fn ffgpve(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of values from the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
 /// the FITS array is not the same as the array being read).
@@ -70,15 +84,26 @@ pub unsafe extern "C" fn ffgpve(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to read (1 = 1st group)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `nulval`    — (I) value for undefined pixels
+/// * `array`     — (O) array of values that are returned
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `status`    — (IO) error status
 pub fn ffgpve_safe(
-    fptr: &mut fitsfile,        /* I - FITS file pointer                       */
-    group: c_long,              /* I - group to read (1 = 1st group)           */
-    firstelem: LONGLONG,        /* I - first vector element to read (1 = 1st)  */
-    nelem: LONGLONG,            /* I - number of values to read                */
-    nulval: f32,                /* I - value for undefined pixels          */
-    array: &mut [f32],          /* O - array of values that are returned   */
-    anynul: Option<&mut c_int>, /* O - set to 1 if any values are null; else 0 */
-    status: &mut c_int,         /* IO - error status                           */
+    fptr: &mut fitsfile,
+    group: c_long,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    nulval: f32,
+    array: &mut [f32],
+    anynul: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     let nullcheck = NullCheckType::SetPixel;
     let mut nullvalue: f32 = 0.0;
@@ -123,7 +148,6 @@ pub fn ffgpve_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of values from the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
 /// the FITS array is not the same as the array being read).
@@ -135,16 +159,27 @@ pub fn ffgpve_safe(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to read (1 = 1st group)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `array`     — (O) array of values that are returned
+/// * `nularray`  — (O) array of null pixel flags
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgpfe(
-    fptr: *mut fitsfile,   /* I - FITS file pointer                       */
-    group: c_long,         /* I - group to read (1 = 1st group)           */
-    firstelem: LONGLONG,   /* I - first vector element to read (1 = 1st)  */
-    nelem: LONGLONG,       /* I - number of values to read                */
-    array: *mut f32,       /* O - array of values that are returned   */
-    nularray: *mut c_char, /* O - array of null pixel flags               */
-    anynul: *mut c_int,    /* O - set to 1 if any values are null; else 0 */
-    status: *mut c_int,    /* IO - error status                           */
+    fptr: *mut fitsfile,
+    group: c_long,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: *mut f32,
+    nularray: *mut c_char,
+    anynul: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -161,7 +196,6 @@ pub unsafe extern "C" fn ffgpfe(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of values from the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
 /// the FITS array is not the same as the array being read).
@@ -173,15 +207,26 @@ pub unsafe extern "C" fn ffgpfe(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to read (1 = 1st group)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `array`     — (O) array of values that are returned
+/// * `nularray`  — (O) array of null pixel flags
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `status`    — (IO) error status
 pub fn ffgpfe_safe(
-    fptr: &mut fitsfile,        /* I - FITS file pointer                       */
-    group: c_long,              /* I - group to read (1 = 1st group)           */
-    firstelem: LONGLONG,        /* I - first vector element to read (1 = 1st)  */
-    nelem: LONGLONG,            /* I - number of values to read                */
-    array: &mut [f32],          /* O - array of values that are returned   */
-    nularray: &mut [c_char],    /* O - array of null pixel flags               */
-    anynul: Option<&mut c_int>, /* O - set to 1 if any values are null; else 0 */
-    status: &mut c_int,         /* IO - error status                           */
+    fptr: &mut fitsfile,
+    group: c_long,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: &mut [f32],
+    nularray: &mut [c_char],
+    anynul: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     let nullcheck = NullCheckType::SetNullArray;
 
@@ -222,23 +267,34 @@ pub fn ffgpfe_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an entire 2-D array of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of the
 /// FITS array is not the same as the array being read).  Any null
 /// values in the array will be set equal to the value of nulval, unless
 /// nulval = 0 in which case no null checking will be performed.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `group`  — (I) group to read (1 = 1st group)
+/// * `nulval` — set undefined pixels equal to this
+/// * `ncols`  — (I) number of pixels in each row of array
+/// * `naxis1` — (I) FITS image NAXIS1 value
+/// * `naxis2` — (I) FITS image NAXIS2 value
+/// * `array`  — (O) array to be filled and returned
+/// * `anynul` — (O) set to 1 if any values are null; else 0
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffg2de(
-    fptr: *mut fitsfile, /* I - FITS file pointer                       */
-    group: c_long,       /* I - group to read (1 = 1st group)           */
-    nulval: f32,         /* set undefined pixels equal to this     */
-    ncols: LONGLONG,     /* I - number of pixels in each row of array   */
-    naxis1: LONGLONG,    /* I - FITS image NAXIS1 value                 */
-    naxis2: LONGLONG,    /* I - FITS image NAXIS2 value                 */
-    array: *mut f32,     /* O - array to be filled and returned    */
-    anynul: *mut c_int,  /* O - set to 1 if any values are null; else 0 */
-    status: *mut c_int,  /* IO - error status                           */
+    fptr: *mut fitsfile,
+    group: c_long,
+    nulval: f32,
+    ncols: LONGLONG,
+    naxis1: LONGLONG,
+    naxis2: LONGLONG,
+    array: *mut f32,
+    anynul: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -254,22 +310,33 @@ pub unsafe extern "C" fn ffg2de(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an entire 2-D array of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of the
 /// FITS array is not the same as the array being read).  Any null
 /// values in the array will be set equal to the value of nulval, unless
 /// nulval = 0 in which case no null checking will be performed.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `group`  — (I) group to read (1 = 1st group)
+/// * `nulval` — set undefined pixels equal to this
+/// * `ncols`  — (I) number of pixels in each row of array
+/// * `naxis1` — (I) FITS image NAXIS1 value
+/// * `naxis2` — (I) FITS image NAXIS2 value
+/// * `array`  — (O) array to be filled and returned
+/// * `anynul` — (O) set to 1 if any values are null; else 0
+/// * `status` — (IO) error status
 pub fn ffg2de_safe(
-    fptr: &mut fitsfile,        /* I - FITS file pointer                       */
-    group: c_long,              /* I - group to read (1 = 1st group)           */
-    nulval: f32,                /* set undefined pixels equal to this     */
-    ncols: LONGLONG,            /* I - number of pixels in each row of array   */
-    naxis1: LONGLONG,           /* I - FITS image NAXIS1 value                 */
-    naxis2: LONGLONG,           /* I - FITS image NAXIS2 value                 */
-    array: &mut [f32],          /* O - array to be filled and returned    */
-    anynul: Option<&mut c_int>, /* O - set to 1 if any values are null; else 0 */
-    status: &mut c_int,         /* IO - error status                           */
+    fptr: &mut fitsfile,
+    group: c_long,
+    nulval: f32,
+    ncols: LONGLONG,
+    naxis1: LONGLONG,
+    naxis2: LONGLONG,
+    array: &mut [f32],
+    anynul: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     /* call the 3D reading routine, with the 3rd dimension = 1 */
     ffg3de_safe(
@@ -279,7 +346,6 @@ pub fn ffg2de_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an entire 3-D array of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of the
 /// FITS array is not the same as the array being read).  Any null
@@ -290,19 +356,33 @@ pub fn ffg2de_safe(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `group`  — (I) group to read (1 = 1st group)
+/// * `nulval` — set undefined pixels equal to this
+/// * `ncols`  — (I) number of pixels in each row of array
+/// * `nrows`  — (I) number of rows in each plane of array
+/// * `naxis1` — (I) FITS image NAXIS1 value
+/// * `naxis2` — (I) FITS image NAXIS2 value
+/// * `naxis3` — (I) FITS image NAXIS3 value
+/// * `array`  — (O) array to be filled and returned
+/// * `anynul` — (O) set to 1 if any values are null; else 0
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffg3de(
-    fptr: *mut fitsfile, /* I - FITS file pointer                       */
-    group: c_long,       /* I - group to read (1 = 1st group)           */
-    nulval: f32,         /* set undefined pixels equal to this     */
-    ncols: LONGLONG,     /* I - number of pixels in each row of array   */
-    nrows: LONGLONG,     /* I - number of rows in each plane of array   */
-    naxis1: LONGLONG,    /* I - FITS image NAXIS1 value                 */
-    naxis2: LONGLONG,    /* I - FITS image NAXIS2 value                 */
-    naxis3: LONGLONG,    /* I - FITS image NAXIS3 value                 */
-    array: *mut f32,     /* O - array to be filled and returned    */
-    anynul: *mut c_int,  /* O - set to 1 if any values are null; else 0 */
-    status: *mut c_int,  /* IO - error status                           */
+    fptr: *mut fitsfile,
+    group: c_long,
+    nulval: f32,
+    ncols: LONGLONG,
+    nrows: LONGLONG,
+    naxis1: LONGLONG,
+    naxis2: LONGLONG,
+    naxis3: LONGLONG,
+    array: *mut f32,
+    anynul: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -318,7 +398,6 @@ pub unsafe extern "C" fn ffg3de(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an entire 3-D array of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of the
 /// FITS array is not the same as the array being read).  Any null
@@ -329,18 +408,32 @@ pub unsafe extern "C" fn ffg3de(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `group`  — (I) group to read (1 = 1st group)
+/// * `nulval` — set undefined pixels equal to this
+/// * `ncols`  — (I) number of pixels in each row of array
+/// * `nrows`  — (I) number of rows in each plane of array
+/// * `naxis1` — (I) FITS image NAXIS1 value
+/// * `naxis2` — (I) FITS image NAXIS2 value
+/// * `naxis3` — (I) FITS image NAXIS3 value
+/// * `array`  — (O) array to be filled and returned
+/// * `anynul` — (O) set to 1 if any values are null; else 0
+/// * `status` — (IO) error status
 pub fn ffg3de_safe(
-    fptr: &mut fitsfile,            /* I - FITS file pointer                       */
-    group: c_long,                  /* I - group to read (1 = 1st group)           */
-    nulval: f32,                    /* set undefined pixels equal to this     */
-    ncols: LONGLONG,                /* I - number of pixels in each row of array   */
-    nrows: LONGLONG,                /* I - number of rows in each plane of array   */
-    naxis1: LONGLONG,               /* I - FITS image NAXIS1 value                 */
-    naxis2: LONGLONG,               /* I - FITS image NAXIS2 value                 */
-    naxis3: LONGLONG,               /* I - FITS image NAXIS3 value                 */
-    array: &mut [f32],              /* O - array to be filled and returned    */
-    mut anynul: Option<&mut c_int>, /* O - set to 1 if any values are null; else 0 */
-    status: &mut c_int,             /* IO - error status                           */
+    fptr: &mut fitsfile,
+    group: c_long,
+    nulval: f32,
+    ncols: LONGLONG,
+    nrows: LONGLONG,
+    naxis1: LONGLONG,
+    naxis2: LONGLONG,
+    naxis3: LONGLONG,
+    array: &mut [f32],
+    mut anynul: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     let mut narray = 0;
     let mut nfits: LONGLONG = 0;
@@ -440,22 +533,35 @@ pub fn ffg3de_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read a subsection of data values from an image or a table column.
 /// This routine is set up to handle a maximum of nine dimensions.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `colnum` — (I) number of the column to read (1 = 1st)
+/// * `naxis`  — (I) number of dimensions in the FITS array
+/// * `naxes`  — (I) size of each dimension
+/// * `blc`    — (I) 'bottom left corner' of the subsection
+/// * `trc`    — (I) 'top right corner' of the subsection
+/// * `inc`    — (I) increment to be applied in each dimension
+/// * `nulval` — (I) value to set undefined pixels
+/// * `array`  — (O) array to be filled and returned
+/// * `anynul` — (O) set to 1 if any values are null; else 0
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgsve(
-    fptr: *mut fitsfile,  /* I - FITS file pointer                         */
-    colnum: c_int,        /* I - number of the column to read (1 = 1st)    */
-    naxis: c_int,         /* I - number of dimensions in the FITS array    */
-    naxes: *const c_long, /* I - size of each dimension                    */
-    blc: *const c_long,   /* I - 'bottom left corner' of the subsection    */
-    trc: *const c_long,   /* I - 'top right corner' of the subsection      */
-    inc: *const c_long,   /* I - increment to be applied in each dimension */
-    nulval: f32,          /* I - value to set undefined pixels       */
-    array: *mut f32,      /* O - array to be filled and returned     */
-    anynul: *mut c_int,   /* O - set to 1 if any values are null; else 0   */
-    status: *mut c_int,   /* IO - error status                             */
+    fptr: *mut fitsfile,
+    colnum: c_int,
+    naxis: c_int,
+    naxes: *const c_long,
+    blc: *const c_long,
+    trc: *const c_long,
+    inc: *const c_long,
+    nulval: f32,
+    array: *mut f32,
+    anynul: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -478,21 +584,34 @@ pub unsafe extern "C" fn ffgsve(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read a subsection of data values from an image or a table column.
 /// This routine is set up to handle a maximum of nine dimensions.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `colnum` — (I) number of the column to read (1 = 1st)
+/// * `naxis`  — (I) number of dimensions in the FITS array
+/// * `naxes`  — (I) size of each dimension
+/// * `blc`    — (I) 'bottom left corner' of the subsection
+/// * `trc`    — (I) 'top right corner' of the subsection
+/// * `inc`    — (I) increment to be applied in each dimension
+/// * `nulval` — (I) value to set undefined pixels
+/// * `array`  — (O) array to be filled and returned
+/// * `anynul` — (O) set to 1 if any values are null; else 0
+/// * `status` — (IO) error status
 pub fn ffgsve_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                         */
-    colnum: c_int,       /* I - number of the column to read (1 = 1st)    */
-    naxis: c_int,        /* I - number of dimensions in the FITS array    */
-    naxes: &[c_long],    /* I - size of each dimension                    */
-    blc: &[c_long],      /* I - 'bottom left corner' of the subsection    */
-    trc: &[c_long],      /* I - 'top right corner' of the subsection      */
-    inc: &[c_long],      /* I - increment to be applied in each dimension */
-    nulval: f32,         /* I - value to set undefined pixels       */
-    array: &mut [f32],   /* O - array to be filled and returned     */
-    mut anynul: Option<&mut c_int>, /* O - set to 1 if any values are null; else 0   */
-    status: &mut c_int,  /* IO - error status                             */
+    fptr: &mut fitsfile,
+    colnum: c_int,
+    naxis: c_int,
+    naxes: &[c_long],
+    blc: &[c_long],
+    trc: &[c_long],
+    inc: &[c_long],
+    nulval: f32,
+    array: &mut [f32],
+    mut anynul: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     let mut rstr: c_long = 0;
     let mut rstp: c_long = 0;
@@ -699,22 +818,35 @@ pub fn ffgsve_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read a subsection of data values from an image or a table column.
 /// This routine is set up to handle a maximum of nine dimensions.
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `colnum`  — (I) number of the column to read (1 = 1st)
+/// * `naxis`   — (I) number of dimensions in the FITS array
+/// * `naxes`   — (I) size of each dimension
+/// * `blc`     — (I) 'bottom left corner' of the subsection
+/// * `trc`     — (I) 'top right corner' of the subsection
+/// * `inc`     — (I) increment to be applied in each dimension
+/// * `array`   — (O) array to be filled and returned
+/// * `flagval` — (O) set to 1 if corresponding value is null
+/// * `anynul`  — (O) set to 1 if any values are null; else 0
+/// * `status`  — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgsfe(
-    fptr: *mut fitsfile,  /* I - FITS file pointer                         */
-    colnum: c_int,        /* I - number of the column to read (1 = 1st)    */
-    naxis: c_int,         /* I - number of dimensions in the FITS array    */
-    naxes: *const c_long, /* I - size of each dimension                    */
-    blc: *const c_long,   /* I - 'bottom left corner' of the subsection    */
-    trc: *const c_long,   /* I - 'top right corner' of the subsection      */
-    inc: *const c_long,   /* I - increment to be applied in each dimension */
-    array: *mut f32,      /* O - array to be filled and returned     */
-    flagval: *mut c_char, /* O - set to 1 if corresponding value is null   */
-    anynul: *mut c_int,   /* O - set to 1 if any values are null; else 0   */
-    status: *mut c_int,   /* IO - error status                             */
+    fptr: *mut fitsfile,
+    colnum: c_int,
+    naxis: c_int,
+    naxes: *const c_long,
+    blc: *const c_long,
+    trc: *const c_long,
+    inc: *const c_long,
+    array: *mut f32,
+    flagval: *mut c_char,
+    anynul: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -739,21 +871,34 @@ pub unsafe extern "C" fn ffgsfe(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read a subsection of data values from an image or a table column.
 /// This routine is set up to handle a maximum of nine dimensions.
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `colnum`  — (I) number of the column to read (1 = 1st)
+/// * `naxis`   — (I) number of dimensions in the FITS array
+/// * `naxes`   — (I) size of each dimension
+/// * `blc`     — (I) 'bottom left corner' of the subsection
+/// * `trc`     — (I) 'top right corner' of the subsection
+/// * `inc`     — (I) increment to be applied in each dimension
+/// * `array`   — (O) array to be filled and returned
+/// * `flagval` — (O) set to 1 if corresponding value is null
+/// * `anynul`  — (O) set to 1 if any values are null; else 0
+/// * `status`  — (IO) error status
 pub fn ffgsfe_safe(
-    fptr: &mut fitsfile,    /* I - FITS file pointer                         */
-    colnum: c_int,          /* I - number of the column to read (1 = 1st)    */
-    naxis: c_int,           /* I - number of dimensions in the FITS array    */
-    naxes: &[c_long],       /* I - size of each dimension                    */
-    blc: &[c_long],         /* I - 'bottom left corner' of the subsection    */
-    trc: &[c_long],         /* I - 'top right corner' of the subsection      */
-    inc: &[c_long],         /* I - increment to be applied in each dimension */
-    array: &mut [f32],      /* O - array to be filled and returned           */
-    flagval: &mut [c_char], /* O - set to 1 if corresponding value is null   */
-    mut anynul: Option<&mut c_int>, /* O - set to 1 if any values are null; else 0   */
-    status: &mut c_int,     /* IO - error status                             */
+    fptr: &mut fitsfile,
+    colnum: c_int,
+    naxis: c_int,
+    naxes: &[c_long],
+    blc: &[c_long],
+    trc: &[c_long],
+    inc: &[c_long],
+    array: &mut [f32],
+    flagval: &mut [c_char],
+    mut anynul: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     let rstr: c_long;
     let mut rstp: c_long;
@@ -940,7 +1085,6 @@ pub fn ffgsfe_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 ///Read an array of group parameters from the primary array. Data conversion
 ///and scaling will be performed if necessary (e.g, if the datatype of
 ///the FITS array is not the same as the array being read).
@@ -949,14 +1093,23 @@ pub fn ffgsfe_safe(
 ///each group of the primary array is a row in the table,
 ///where the first column contains the group parameters
 ///and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to read (1 = 1st group)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `array`     — (O) array of values that are returned
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffggpe(
-    fptr: *mut fitsfile, /* I - FITS file pointer                       */
-    group: c_long,       /* I - group to read (1 = 1st group)           */
-    firstelem: c_long,   /* I - first vector element to read (1 = 1st)  */
-    nelem: c_long,       /* I - number of values to read                */
-    array: *mut f32,     /* O - array of values that are returned   */
-    status: *mut c_int,  /* IO - error status                           */
+    fptr: *mut fitsfile,
+    group: c_long,
+    firstelem: c_long,
+    nelem: c_long,
+    array: *mut f32,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -968,7 +1121,6 @@ pub unsafe extern "C" fn ffggpe(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 ///Read an array of group parameters from the primary array. Data conversion
 ///and scaling will be performed if necessary (e.g, if the datatype of
 ///the FITS array is not the same as the array being read).
@@ -977,13 +1129,22 @@ pub unsafe extern "C" fn ffggpe(
 ///each group of the primary array is a row in the table,
 ///where the first column contains the group parameters
 ///and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to read (1 = 1st group)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `array`     — (O) array of values that are returned
+/// * `status`    — (IO) error status
 pub fn ffggpe_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                       */
-    group: c_long,       /* I - group to read (1 = 1st group)           */
-    firstelem: c_long,   /* I - first vector element to read (1 = 1st)  */
-    nelem: c_long,       /* I - number of values to read                */
-    array: &mut [f32],   /* O - array of values that are returned   */
-    status: &mut c_int,  /* IO - error status                           */
+    fptr: &mut fitsfile,
+    group: c_long,
+    firstelem: c_long,
+    nelem: c_long,
+    array: &mut [f32],
+    status: &mut c_int,
 ) -> c_int {
     let mut anynul = 0;
     let mut dummy_nularray = vec![0; nelem as usize];
@@ -1007,24 +1168,35 @@ pub fn ffggpe_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of values from a column in the current FITS HDU. Automatic
 /// datatype conversion will be performed if the datatype of the column does not
 /// match the datatype of the array parameter. The output values will be scaled
 /// by the FITS TSCALn and TZEROn values if these values have been defined.
 /// Any undefined pixels will be set equal to the value of 'nulval' unless
 /// nulval = 0 in which case no checks for undefined pixels will be made.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to read (1 = 1st col)
+/// * `firstrow`  — (I) first row to read (1 = 1st row)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `nulval`    — (I) value for null pixels
+/// * `array`     — (O) array of values that are read
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgcve(
-    fptr: *mut fitsfile, /* I - FITS file pointer                       */
-    colnum: c_int,       /* I - number of column to read (1 = 1st col)  */
-    firstrow: LONGLONG,  /* I - first row to read (1 = 1st row)         */
-    firstelem: LONGLONG, /* I - first vector element to read (1 = 1st)  */
-    nelem: LONGLONG,     /* I - number of values to read                */
-    nulval: f32,         /* I - value for null pixels               */
-    array: *mut f32,     /* O - array of values that are read       */
-    anynul: *mut c_int,  /* O - set to 1 if any values are null; else 0 */
-    status: *mut c_int,  /* IO - error status                           */
+    fptr: *mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    nulval: f32,
+    array: *mut f32,
+    anynul: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -1041,23 +1213,34 @@ pub unsafe extern "C" fn ffgcve(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of values from a column in the current FITS HDU. Automatic
 /// datatype conversion will be performed if the datatype of the column does not
 /// match the datatype of the array parameter. The output values will be scaled
 /// by the FITS TSCALn and TZEROn values if these values have been defined.
 /// Any undefined pixels will be set equal to the value of 'nulval' unless
 /// nulval = 0 in which case no checks for undefined pixels will be made.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to read (1 = 1st col)
+/// * `firstrow`  — (I) first row to read (1 = 1st row)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `nulval`    — (I) value for null pixels
+/// * `array`     — (O) array of values that are read
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `status`    — (IO) error status
 pub fn ffgcve_safe(
-    fptr: &mut fitsfile,        /* I - FITS file pointer                       */
-    colnum: c_int,              /* I - number of column to read (1 = 1st col)  */
-    firstrow: LONGLONG,         /* I - first row to read (1 = 1st row)         */
-    firstelem: LONGLONG,        /* I - first vector element to read (1 = 1st)  */
-    nelem: LONGLONG,            /* I - number of values to read                */
-    nulval: f32,                /* I - value for null pixels               */
-    array: &mut [f32],          /* O - array of values that are read       */
-    anynul: Option<&mut c_int>, /* O - set to 1 if any values are null; else 0 */
-    status: &mut c_int,         /* IO - error status                           */
+    fptr: &mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    nulval: f32,
+    array: &mut [f32],
+    anynul: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     let mut dummy_nularray = vec![0; nelem as usize];
 
@@ -1078,7 +1261,6 @@ pub fn ffgcve_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of values from a column in the current FITS HDU. Automatic
 /// datatype conversion will be performed if the datatype of the column does not
 /// match the datatype of the array parameter. The output values will be scaled
@@ -1087,17 +1269,29 @@ pub fn ffgcve_safe(
 /// nulval = 0 in which case no checks for undefined pixels will be made.
 ///
 /// TSCAL and ZERO should not be used with complex values.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to read (1 = 1st col)
+/// * `firstrow`  — (I) first row to read (1 = 1st row)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `nulval`    — (I) value for null pixels
+/// * `array`     — (O) array of values that are read
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgcvc(
-    fptr: *mut fitsfile, /* I - FITS file pointer                       */
-    colnum: c_int,       /* I - number of column to read (1 = 1st col)  */
-    firstrow: LONGLONG,  /* I - first row to read (1 = 1st row)         */
-    firstelem: LONGLONG, /* I - first vector element to read (1 = 1st)  */
-    nelem: LONGLONG,     /* I - number of values to read                */
-    nulval: f32,         /* I - value for null pixels                   */
-    array: *mut f32,     /* O - array of values that are read           */
-    anynul: *mut c_int,  /* O - set to 1 if any values are null; else 0 */
-    status: *mut c_int,  /* IO - error status                           */
+    fptr: *mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    nulval: f32,
+    array: *mut f32,
+    anynul: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -1121,7 +1315,6 @@ pub unsafe extern "C" fn ffgcvc(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of values from a column in the current FITS HDU. Automatic
 /// datatype conversion will be performed if the datatype of the column does not
 /// match the datatype of the array parameter. The output values will be scaled
@@ -1130,16 +1323,28 @@ pub unsafe extern "C" fn ffgcvc(
 /// nulval = 0 in which case no checks for undefined pixels will be made.
 ///
 /// TSCAL and ZERO should not be used with complex values.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to read (1 = 1st col)
+/// * `firstrow`  — (I) first row to read (1 = 1st row)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `nulval`    — (I) value for null pixels
+/// * `array`     — (O) array of values that are read
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `status`    — (IO) error status
 pub fn ffgcvc_safe(
-    fptr: &mut fitsfile,        /* I - FITS file pointer                       */
-    colnum: c_int,              /* I - number of column to read (1 = 1st col)  */
-    firstrow: LONGLONG,         /* I - first row to read (1 = 1st row)         */
-    firstelem: LONGLONG,        /* I - first vector element to read (1 = 1st)  */
-    nelem: LONGLONG,            /* I - number of values to read                */
-    nulval: f32,                /* I - value for null pixels                   */
-    array: &mut [f32],          /* O - array of values that are read           */
-    anynul: Option<&mut c_int>, /* O - set to 1 if any values are null; else 0 */
-    status: &mut c_int,         /* IO - error status                           */
+    fptr: &mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    nulval: f32,
+    array: &mut [f32],
+    anynul: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     let mut dummy_nularray = vec![0; 2 * nelem as usize];
 
@@ -1163,24 +1368,35 @@ pub fn ffgcvc_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of values from a column in the current FITS HDU. Automatic
 /// datatype conversion will be performed if the datatype of the column does not
 /// match the datatype of the array parameter. The output values will be scaled
 /// by the FITS TSCALn and TZEROn values if these values have been defined.
 /// Nularray will be set = 1 if the corresponding array pixel is undefined,
 /// otherwise nularray will = 0.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to read (1 = 1st col)
+/// * `firstrow`  — (I) first row to read (1 = 1st row)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `array`     — (O) array of values that are read
+/// * `nularray`  — (O) array of flags: 1 if null pixel; else 0
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgcfe(
-    fptr: *mut fitsfile,   /* I - FITS file pointer                       */
-    colnum: c_int,         /* I - number of column to read (1 = 1st col)  */
-    firstrow: LONGLONG,    /* I - first row to read (1 = 1st row)         */
-    firstelem: LONGLONG,   /* I - first vector element to read (1 = 1st)  */
-    nelem: LONGLONG,       /* I - number of values to read                */
-    array: *mut f32,       /* O - array of values that are read       */
-    nularray: *mut c_char, /* O - array of flags: 1 if null pixel; else 0 */
-    anynul: *mut c_int,    /* O - set to 1 if any values are null; else 0 */
-    status: *mut c_int,    /* IO - error status                           */
+    fptr: *mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: *mut f32,
+    nularray: *mut c_char,
+    anynul: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -1197,23 +1413,34 @@ pub unsafe extern "C" fn ffgcfe(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of values from a column in the current FITS HDU. Automatic
 /// datatype conversion will be performed if the datatype of the column does not
 /// match the datatype of the array parameter. The output values will be scaled
 /// by the FITS TSCALn and TZEROn values if these values have been defined.
 /// Nularray will be set = 1 if the corresponding array pixel is undefined,
 /// otherwise nularray will = 0.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to read (1 = 1st col)
+/// * `firstrow`  — (I) first row to read (1 = 1st row)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `array`     — (O) array of values that are read
+/// * `nularray`  — (O) array of flags: 1 if null pixel; else 0
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `status`    — (IO) error status
 pub fn ffgcfe_safe(
-    fptr: &mut fitsfile,        /* I - FITS file pointer                       */
-    colnum: c_int,              /* I - number of column to read (1 = 1st col)  */
-    firstrow: LONGLONG,         /* I - first row to read (1 = 1st row)         */
-    firstelem: LONGLONG,        /* I - first vector element to read (1 = 1st)  */
-    nelem: LONGLONG,            /* I - number of values to read                */
-    array: &mut [f32],          /* O - array of values that are read       */
-    nularray: &mut [c_char],    /* O - array of flags: 1 if null pixel; else 0 */
-    anynul: Option<&mut c_int>, /* O - set to 1 if any values are null; else 0 */
-    status: &mut c_int,         /* IO - error status                           */
+    fptr: &mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: &mut [f32],
+    nularray: &mut [c_char],
+    anynul: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     let dummy: f32 = 0.0;
 
@@ -1234,7 +1461,6 @@ pub fn ffgcfe_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of values from a column in the current FITS HDU. Automatic
 /// datatype conversion will be performed if the datatype of the column does not
 /// match the datatype of the array parameter. The output values will be scaled
@@ -1243,17 +1469,29 @@ pub fn ffgcfe_safe(
 /// otherwise nularray will = 0.
 ///
 /// TSCAL and ZERO should not be used with complex values.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to read (1 = 1st col)
+/// * `firstrow`  — (I) first row to read (1 = 1st row)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `array`     — (O) array of values that are read
+/// * `nularray`  — (O) array of flags: 1 if null pixel; else 0
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgcfc(
-    fptr: *mut fitsfile,   /* I - FITS file pointer                       */
-    colnum: c_int,         /* I - number of column to read (1 = 1st col)  */
-    firstrow: LONGLONG,    /* I - first row to read (1 = 1st row)         */
-    firstelem: LONGLONG,   /* I - first vector element to read (1 = 1st)  */
-    nelem: LONGLONG,       /* I - number of values to read                */
-    array: *mut f32,       /* O - array of values that are read           */
-    nularray: *mut c_char, /* O - array of flags: 1 if null pixel; else 0 */
-    anynul: *mut c_int,    /* O - set to 1 if any values are null; else 0 */
-    status: *mut c_int,    /* IO - error status                           */
+    fptr: *mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: *mut f32,
+    nularray: *mut c_char,
+    anynul: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -1278,7 +1516,6 @@ pub unsafe extern "C" fn ffgcfc(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of values from a column in the current FITS HDU. Automatic
 /// datatype conversion will be performed if the datatype of the column does not
 /// match the datatype of the array parameter. The output values will be scaled
@@ -1287,16 +1524,28 @@ pub unsafe extern "C" fn ffgcfc(
 /// otherwise nularray will = 0.
 ///
 /// TSCAL and ZERO should not be used with complex values.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to read (1 = 1st col)
+/// * `firstrow`  — (I) first row to read (1 = 1st row)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `array`     — (O) array of values that are read
+/// * `nularray`  — (O) array of flags: 1 if null pixel; else 0
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `status`    — (IO) error status
 pub fn ffgcfc_safe(
-    fptr: &mut fitsfile,        /* I - FITS file pointer                       */
-    colnum: c_int,              /* I - number of column to read (1 = 1st col)  */
-    firstrow: LONGLONG,         /* I - first row to read (1 = 1st row)         */
-    firstelem: LONGLONG,        /* I - first vector element to read (1 = 1st)  */
-    nelem: LONGLONG,            /* I - number of values to read                */
-    array: &mut [f32],          /* O - array of values that are read           */
-    nularray: &mut [c_char],    /* O - array of flags: 1 if null pixel; else 0 */
-    anynul: Option<&mut c_int>, /* O - set to 1 if any values are null; else 0 */
-    status: &mut c_int,         /* IO - error status                           */
+    fptr: &mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: &mut [f32],
+    nularray: &mut [c_char],
+    anynul: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     let dummy: f32 = 0.0;
 
@@ -1333,7 +1582,6 @@ pub fn ffgcfc_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of values from a column in the current FITS HDU.
 /// The column number may refer to a real column in an ASCII or binary table,
 /// or it may refer be a virtual column in a 1 or more grouped FITS primary
@@ -1347,21 +1595,35 @@ pub fn ffgcfc_safe(
 /// and will be scaled by the FITS TSCALn and TZEROn values if necessary.
 #[allow(clippy::if_same_then_else)]
 // C dispatch chain: distinct conditions deliberately share an action.
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to read (1 = 1st col)
+/// * `firstrow`  — (I) first row to read (1 = 1st row)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `elemincre` — (I) pixel increment; e.g., 2 = every other
+/// * `nultyp`    — (I) null value handling code:
+/// * `nulval`    — (I) value for null pixels if nultyp = 1
+/// * `array`     — (O) array of values that are read
+/// * `nularray`  — (O) array of flags = 1 if nultyp = 2
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `status`    — (IO) error status
 pub(crate) fn ffgcle(
-    fptr: &mut fitsfile,   /* I - FITS file pointer                       */
-    colnum: c_int,         /* I - number of column to read (1 = 1st col)  */
-    firstrow: LONGLONG,    /* I - first row to read (1 = 1st row)         */
-    firstelem: LONGLONG,   /* I - first vector element to read (1 = 1st)  */
-    nelem: LONGLONG,       /* I - number of values to read                */
-    elemincre: c_long,     /* I - pixel increment; e.g., 2 = every other  */
-    nultyp: NullCheckType, /* I - null value handling code:               */
+    fptr: &mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    elemincre: c_long,
+    nultyp: NullCheckType,
     /*     1: set undefined pixels = nulval        */
     /*     2: set nularray=1 for undefined pixels  */
-    nulval: f32,                    /* I - value for null pixels if nultyp = 1 */
-    array: &mut [f32],              /* O - array of values that are read       */
-    nularray: &mut [c_char],        /* O - array of flags = 1 if nultyp = 2        */
-    mut anynul: Option<&mut c_int>, /* O - set to 1 if any values are null; else 0 */
-    status: &mut c_int,             /* IO - error status                           */
+    nulval: f32,
+    array: &mut [f32],
+    nularray: &mut [c_char],
+    mut anynul: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     let mut scale: f64 = 0.0;
     let mut zero: f64 = 0.0;
@@ -1409,9 +1671,7 @@ pub(crate) fn ffgcle(
         nularray.fill(0); /* initialize nullarray */
     }
 
-    /*---------------------------------------------------*/
     /*  Check input and get parameters about the column: */
-    /*---------------------------------------------------*/
     if elemincre < 0 {
         readcheck -= 1; /* don't do range checking in this case */
     }
@@ -1462,9 +1722,7 @@ pub(crate) fn ffgcle(
             power *= 10.0;
         }
     }
-    /*------------------------------------------------------------------*/
     /*  Decide whether to check for null values in the input FITS file: */
-    /*------------------------------------------------------------------*/
     nulcheck = nultyp; /* by default, check for null values in the FITS file */
 
     if nultyp == NullCheckType::SetPixel && nulval == 0.0 {
@@ -1484,10 +1742,8 @@ pub(crate) fn ffgcle(
         nulcheck = NullCheckType::None;
     }
 
-    /*----------------------------------------------------------------------*/
     /*  If FITS column and output data array have same datatype, then we do */
     /*  not need to use a temporary buffer to store intermediate datatype.  */
-    /*----------------------------------------------------------------------*/
     convert = true;
     if tcode == TFLOAT {
         /* Special Case:                        */
@@ -1505,7 +1761,6 @@ pub(crate) fn ffgcle(
         }
     }
 
-    /*---------------------------------------------------------------------*/
     /*  Now read the pixels from the FITS column. If the column does not   */
     /*  have the same datatype as the output array, then we have to read   */
     /*  the raw values into a temporary buffer (of limited size).  In      */
@@ -1515,7 +1770,6 @@ pub(crate) fn ffgcle(
     /*  test for undefined values, (2) convert the datatype if necessary,  */
     /*  and (3) scale the values by the FITS TSCALn and TZEROn linear      */
     /*  scaling parameters.                                                */
-    /*---------------------------------------------------------------------*/
 
     remain = nelem; /* remaining number of values to read */
     next = 0; /* next element in array to be read   */
@@ -1742,9 +1996,7 @@ pub(crate) fn ffgcle(
             }
         } /* End of switch block */
 
-        /*-------------------------*/
         /*  Check for fatal error  */
-        /*-------------------------*/
         if *status > 0 {
             /* test for error during previous read operation */
 
@@ -1772,9 +2024,7 @@ pub(crate) fn ffgcle(
             return *status;
         }
 
-        /*--------------------------------------------*/
         /*  increment the counters for the next loop  */
-        /*--------------------------------------------*/
         remain -= ntodo as LONGLONG;
         if remain != 0 {
             next += ntodo as usize;
@@ -1796,9 +2046,7 @@ pub(crate) fn ffgcle(
         }
     } /*  End of main while Loop  */
 
-    /*--------------------------------*/
     /*  check for numerical overflow  */
-    /*--------------------------------*/
     if *status == OVERFLOW_ERR {
         ffpmsg_str("Numerical overflow during type conversion while reading FITS data.");
         *status = NUM_OVERFLOW;
@@ -1807,7 +2055,6 @@ pub(crate) fn ffgcle(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output following reading of the input from a FITS file.
 /// Check for null values and do datatype conversion and scaling if required.
 /// The nullcheck code value determines how any null values in the input array
@@ -1819,20 +2066,34 @@ pub(crate) fn ffgcle(
 /// nullarray will be set to 1; the value of nullarray for non-null pixels
 /// will = 0.  The anynull parameter will be set = 1 if any of the returned
 /// pixels are null, otherwise anynull will be returned with a value = 0;
+///
+/// # Parameters
+///
+/// * `input`     — (I) array of values to be converted
+/// * `ntodo`     — (I) number of elements in the array
+/// * `scale`     — (I) FITS TSCALn or BSCALE value
+/// * `zero`      — (I) FITS TZEROn or BZERO value
+/// * `nullcheck` — (I) null checking code; 0 = don't check
+/// * `tnull`     — (I) value of FITS TNULLn keyword if any
+/// * `nullval`   — (I) set null pixels, if nullcheck = 1
+/// * `nullarray` — (O) bad pixel array, if nullcheck = 2
+/// * `anynull`   — (O) set to 1 if any pixels are null
+/// * `output`    — (O) array of converted pixels
+/// * `status`    — (IO) error status
 pub(crate) fn fffi1r4(
-    input: &[u8],             /* I - array of values to be converted     */
-    ntodo: c_long,            /* I - number of elements in the array     */
-    scale: f64,               /* I - FITS TSCALn or BSCALE value         */
-    zero: f64,                /* I - FITS TZEROn or BZERO  value         */
-    nullcheck: NullCheckType, /* I - null checking code; 0 = don't check */
+    input: &[u8],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    nullcheck: NullCheckType,
     /*     1:set null pixels = nullval         */
     /*     2: if null pixel, set nullarray = 1 */
-    tnull: u8,                   /* I - value of FITS TNULLn keyword if any */
-    nullval: f32,                /* I - set null pixels, if nullcheck = 1   */
-    nullarray: &mut [c_char],    /* O - bad pixel array, if nullcheck = 2   */
-    anynull: Option<&mut c_int>, /* O - set to 1 if any pixels are null     */
-    output: &mut [f32],          /* O - array of converted pixels           */
-    status: &mut c_int,          /* IO - error status                       */
+    tnull: u8,
+    nullval: f32,
+    nullarray: &mut [c_char],
+    anynull: Option<&mut c_int>,
+    output: &mut [f32],
+    status: &mut c_int,
 ) -> c_int {
     if nullcheck == NullCheckType::None {
         /* no null checking required */
@@ -1884,7 +2145,6 @@ pub(crate) fn fffi1r4(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output following reading of the input from a FITS file.
 /// Check for null values and do datatype conversion and scaling if required.
 /// The nullcheck code value determines how any null values in the input array
@@ -1896,20 +2156,34 @@ pub(crate) fn fffi1r4(
 /// nullarray will be set to 1; the value of nullarray for non-null pixels
 /// will = 0.  The anynull parameter will be set = 1 if any of the returned
 /// pixels are null, otherwise anynull will be returned with a value = 0;
+///
+/// # Parameters
+///
+/// * `input`     — (I) array of values to be converted
+/// * `ntodo`     — (I) number of elements in the array
+/// * `scale`     — (I) FITS TSCALn or BSCALE value
+/// * `zero`      — (I) FITS TZEROn or BZERO value
+/// * `nullcheck` — (I) null checking code; 0 = don't check
+/// * `tnull`     — (I) value of FITS TNULLn keyword if any
+/// * `nullval`   — (I) set null pixels, if nullcheck = 1
+/// * `nullarray` — (O) bad pixel array, if nullcheck = 2
+/// * `anynull`   — (O) set to 1 if any pixels are null
+/// * `output`    — (O) array of converted pixels
+/// * `status`    — (IO) error status
 pub(crate) fn fffi2r4(
-    input: &[c_short],        /* I - array of values to be converted     */
-    ntodo: c_long,            /* I - number of elements in the array     */
-    scale: f64,               /* I - FITS TSCALn or BSCALE value         */
-    zero: f64,                /* I - FITS TZEROn or BZERO  value         */
-    nullcheck: NullCheckType, /* I - null checking code; 0 = don't check */
+    input: &[c_short],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    nullcheck: NullCheckType,
     /*     1:set null pixels = nullval         */
     /*     2: if null pixel, set nullarray = 1 */
-    tnull: c_short,              /* I - value of FITS TNULLn keyword if any */
-    nullval: f32,                /* I - set null pixels, if nullcheck = 1   */
-    nullarray: &mut [c_char],    /* O - bad pixel array, if nullcheck = 2   */
-    anynull: Option<&mut c_int>, /* O - set to 1 if any pixels are null     */
-    output: &mut [f32],          /* O - array of converted pixels           */
-    status: &mut c_int,          /* IO - error status                       */
+    tnull: c_short,
+    nullval: f32,
+    nullarray: &mut [c_char],
+    anynull: Option<&mut c_int>,
+    output: &mut [f32],
+    status: &mut c_int,
 ) -> c_int {
     if nullcheck == NullCheckType::None {
         /* no null checking required */
@@ -1963,7 +2237,6 @@ pub(crate) fn fffi2r4(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output following reading of the input from a FITS file.
 /// Check for null values and do datatype conversion and scaling if required.
 /// The nullcheck code value determines how any null values in the input array
@@ -1975,20 +2248,34 @@ pub(crate) fn fffi2r4(
 /// nullarray will be set to 1; the value of nullarray for non-null pixels
 /// will = 0.  The anynull parameter will be set = 1 if any of the returned
 /// pixels are null, otherwise anynull will be returned with a value = 0;
+///
+/// # Parameters
+///
+/// * `input`     — (I) array of values to be converted
+/// * `ntodo`     — (I) number of elements in the array
+/// * `scale`     — (I) FITS TSCALn or BSCALE value
+/// * `zero`      — (I) FITS TZEROn or BZERO value
+/// * `nullcheck` — (I) null checking code; 0 = don't check
+/// * `tnull`     — (I) value of FITS TNULLn keyword if any
+/// * `nullval`   — (I) set null pixels, if nullcheck = 1
+/// * `nullarray` — (O) bad pixel array, if nullcheck = 2
+/// * `anynull`   — (O) set to 1 if any pixels are null
+/// * `output`    — (O) array of converted pixels
+/// * `status`    — (IO) error status
 pub(crate) fn fffi4r4(
-    input: &[INT32BIT],       /* I - array of values to be converted     */
-    ntodo: c_long,            /* I - number of elements in the array     */
-    scale: f64,               /* I - FITS TSCALn or BSCALE value         */
-    zero: f64,                /* I - FITS TZEROn or BZERO  value         */
-    nullcheck: NullCheckType, /* I - null checking code; 0 = don't check */
+    input: &[INT32BIT],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    nullcheck: NullCheckType,
     /*     1:set null pixels = nullval         */
     /*     2: if null pixel, set nullarray = 1 */
-    tnull: INT32BIT,             /* I - value of FITS TNULLn keyword if any */
-    nullval: f32,                /* I - set null pixels, if nullcheck = 1   */
-    nullarray: &mut [c_char],    /* O - bad pixel array, if nullcheck = 2   */
-    anynull: Option<&mut c_int>, /* O - set to 1 if any pixels are null     */
-    output: &mut [f32],          /* O - array of converted pixels           */
-    status: &mut c_int,          /* IO - error status                       */
+    tnull: INT32BIT,
+    nullval: f32,
+    nullarray: &mut [c_char],
+    anynull: Option<&mut c_int>,
+    output: &mut [f32],
+    status: &mut c_int,
 ) -> c_int {
     if nullcheck == NullCheckType::None {
         /* no null checking required */
@@ -2040,7 +2327,6 @@ pub(crate) fn fffi4r4(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output following reading of the input from a FITS file.
 /// Check for null values and do datatype conversion and scaling if required.
 /// The nullcheck code value determines how any null values in the input array
@@ -2052,20 +2338,34 @@ pub(crate) fn fffi4r4(
 /// nullarray will be set to 1; the value of nullarray for non-null pixels
 /// will = 0.  The anynull parameter will be set = 1 if any of the returned
 /// pixels are null, otherwise anynull will be returned with a value = 0;
+///
+/// # Parameters
+///
+/// * `input`     — (I) array of values to be converted
+/// * `ntodo`     — (I) number of elements in the array
+/// * `scale`     — (I) FITS TSCALn or BSCALE value
+/// * `zero`      — (I) FITS TZEROn or BZERO value
+/// * `nullcheck` — (I) null checking code; 0 = don't check
+/// * `tnull`     — (I) value of FITS TNULLn keyword if any
+/// * `nullval`   — (I) set null pixels, if nullcheck = 1
+/// * `nullarray` — (O) bad pixel array, if nullcheck = 2
+/// * `anynull`   — (O) set to 1 if any pixels are null
+/// * `output`    — (O) array of converted pixels
+/// * `status`    — (IO) error status
 pub(crate) fn fffi8r4(
-    input: &[LONGLONG],       /* I - array of values to be converted     */
-    ntodo: c_long,            /* I - number of elements in the array     */
-    scale: f64,               /* I - FITS TSCALn or BSCALE value         */
-    zero: f64,                /* I - FITS TZEROn or BZERO  value         */
-    nullcheck: NullCheckType, /* I - null checking code; 0 = don't check */
+    input: &[LONGLONG],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    nullcheck: NullCheckType,
     /*     1:set null pixels = nullval         */
     /*     2: if null pixel, set nullarray = 1 */
-    tnull: LONGLONG,             /* I - value of FITS TNULLn keyword if any */
-    nullval: f32,                /* I - set null pixels, if nullcheck = 1   */
-    nullarray: &mut [c_char],    /* O - bad pixel array, if nullcheck = 2   */
-    anynull: Option<&mut c_int>, /* O - set to 1 if any pixels are null     */
-    output: &mut [f32],          /* O - array of converted pixels           */
-    status: &mut c_int,          /* IO - error status                       */
+    tnull: LONGLONG,
+    nullval: f32,
+    nullarray: &mut [c_char],
+    anynull: Option<&mut c_int>,
+    output: &mut [f32],
+    status: &mut c_int,
 ) -> c_int {
     let mut ulltemp: ULONGLONG = 0;
 
@@ -2148,7 +2448,6 @@ pub(crate) fn fffi8r4(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output following reading of the input from a FITS file.
 /// Check for null values and do datatype conversion and scaling if required.
 /// The nullcheck code value determines how any null values in the input array
@@ -2160,19 +2459,32 @@ pub(crate) fn fffi8r4(
 /// nullarray will be set to 1; the value of nullarray for non-null pixels
 /// will = 0.  The anynull parameter will be set = 1 if any of the returned
 /// pixels are null, otherwise anynull will be returned with a value = 0;
+///
+/// # Parameters
+///
+/// * `input`     — (I) array of values to be converted
+/// * `ntodo`     — (I) number of elements in the array
+/// * `scale`     — (I) FITS TSCALn or BSCALE value
+/// * `zero`      — (I) FITS TZEROn or BZERO value
+/// * `nullcheck` — (I) null checking code; 0 = don't check
+/// * `nullval`   — (I) set null pixels, if nullcheck = 1
+/// * `nullarray` — (O) bad pixel array, if nullcheck = 2
+/// * `anynull`   — (O) set to 1 if any pixels are null
+/// * `output`    — (O) array of converted pixels
+/// * `status`    — (IO) error status
 pub(crate) fn fffr4r4(
-    input: &[f32],            /* I - array of values to be converted     */
-    ntodo: c_long,            /* I - number of elements in the array     */
-    scale: f64,               /* I - FITS TSCALn or BSCALE value         */
-    zero: f64,                /* I - FITS TZEROn or BZERO  value         */
-    nullcheck: NullCheckType, /* I - null checking code; 0 = don't check */
+    input: &[f32],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    nullcheck: NullCheckType,
     /*     1:set null pixels = nullval         */
     /*     2: if null pixel, set nullarray = 1 */
-    nullval: f32,                /* I - set null pixels, if nullcheck = 1   */
-    nullarray: &mut [c_char],    /* O - bad pixel array, if nullcheck = 2   */
-    anynull: Option<&mut c_int>, /* O - set to 1 if any pixels are null     */
-    output: &mut [f32],          /* O - array of converted pixels           */
-    status: &mut c_int,          /* IO - error status                       */
+    nullval: f32,
+    nullarray: &mut [c_char],
+    anynull: Option<&mut c_int>,
+    output: &mut [f32],
+    status: &mut c_int,
 ) -> c_int {
     let mut sptr = 0;
 
@@ -2256,7 +2568,6 @@ pub(crate) fn fffr4r4(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output following reading of the input from a FITS file.
 /// Check for null values and do datatype conversion and scaling if required.
 /// The nullcheck code value determines how any null values in the input array
@@ -2268,18 +2579,30 @@ pub(crate) fn fffr4r4(
 /// nullarray will be set to 1; the value of nullarray for non-null pixels
 /// will = 0.  The anynull parameter will be set = 1 if any of the returned
 /// pixels are null, otherwise anynull will be returned with a value = 0;
+///
+/// # Parameters
+///
+/// * `input`     — (I) array of values to be converted
+/// * `ntodo`     — (I) number of elements in the array
+/// * `scale`     — (I) FITS TSCALn or BSCALE value
+/// * `zero`      — (I) FITS TZEROn or BZERO value
+/// * `nullcheck` — (I) null checking code; 0 = don't check
+/// * `nullval`   — (I) set null pixels, if nullcheck = 1
+/// * `nullarray` — (O) bad pixel array, if nullcheck = 2
+/// * `anynull`   — (O) set to 1 if any pixels are null
+/// * `status`    — (IO) error status
 pub(crate) fn fffr4r4_inplace(
-    input: &mut [f32],        /* I - array of values to be converted     */
-    ntodo: c_long,            /* I - number of elements in the array     */
-    scale: f64,               /* I - FITS TSCALn or BSCALE value         */
-    zero: f64,                /* I - FITS TZEROn or BZERO  value         */
-    nullcheck: NullCheckType, /* I - null checking code; 0 = don't check */
+    input: &mut [f32],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    nullcheck: NullCheckType,
     /*     1:set null pixels = nullval         */
     /*     2: if null pixel, set nullarray = 1 */
-    nullval: f32,                /* I - set null pixels, if nullcheck = 1   */
-    nullarray: &mut [c_char],    /* O - bad pixel array, if nullcheck = 2   */
-    anynull: Option<&mut c_int>, /* O - set to 1 if any pixels are null     */
-    status: &mut c_int,          /* IO - error status                       */
+    nullval: f32,
+    nullarray: &mut [c_char],
+    anynull: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     let mut sptr = 0;
 
@@ -2363,7 +2686,6 @@ pub(crate) fn fffr4r4_inplace(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output following reading of the input from a FITS file.
 /// Check for null values and do datatype conversion and scaling if required.
 /// The nullcheck code value determines how any null values in the input array
@@ -2375,19 +2697,32 @@ pub(crate) fn fffr4r4_inplace(
 /// nullarray will be set to 1; the value of nullarray for non-null pixels
 /// will = 0.  The anynull parameter will be set = 1 if any of the returned
 /// pixels are null, otherwise anynull will be returned with a value = 0;
+///
+/// # Parameters
+///
+/// * `input`     — (I) array of values to be converted
+/// * `ntodo`     — (I) number of elements in the array
+/// * `scale`     — (I) FITS TSCALn or BSCALE value
+/// * `zero`      — (I) FITS TZEROn or BZERO value
+/// * `nullcheck` — (I) null checking code; 0 = don't check
+/// * `nullval`   — (I) set null pixels, if nullcheck = 1
+/// * `nullarray` — (O) bad pixel array, if nullcheck = 2
+/// * `anynull`   — (O) set to 1 if any pixels are null
+/// * `output`    — (O) array of converted pixels
+/// * `status`    — (IO) error status
 pub(crate) fn fffr8r4(
-    input: &[f64],            /* I - array of values to be converted     */
-    ntodo: c_long,            /* I - number of elements in the array     */
-    scale: f64,               /* I - FITS TSCALn or BSCALE value         */
-    zero: f64,                /* I - FITS TZEROn or BZERO  value         */
-    nullcheck: NullCheckType, /* I - null checking code; 0 = don't check */
+    input: &[f64],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    nullcheck: NullCheckType,
     /*     1:set null pixels = nullval         */
     /*     2: if null pixel, set nullarray = 1 */
-    nullval: f32,                /* I - set null pixels, if nullcheck = 1   */
-    nullarray: &mut [c_char],    /* O - bad pixel array, if nullcheck = 2   */
-    anynull: Option<&mut c_int>, /* O - set to 1 if any pixels are null     */
-    output: &mut [f32],          /* O - array of converted pixels           */
-    status: &mut c_int,          /* IO - error status                       */
+    nullval: f32,
+    nullarray: &mut [c_char],
+    anynull: Option<&mut c_int>,
+    output: &mut [f32],
+    status: &mut c_int,
 ) -> c_int {
     let mut dvalue: f64 = 0.0;
     let mut sptr = 0;
@@ -2507,7 +2842,6 @@ pub(crate) fn fffr8r4(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output following reading of the input from a FITS file. Check
 /// for null values and do scaling if required. The nullcheck code value
 /// determines how any null values in the input array are treated. A null
@@ -2518,22 +2852,38 @@ pub(crate) fn fffr8r4(
 /// nullarray will be set to 1; the value of nullarray for non-null pixels
 /// will = 0.  The anynull parameter will be set = 1 if any of the returned
 /// pixels are null, otherwise anynull will be returned with a value = 0;
+///
+/// # Parameters
+///
+/// * `input`      — (I) array of values to be converted
+/// * `ntodo`      — (I) number of elements in the array
+/// * `scale`      — (I) FITS TSCALn or BSCALE value
+/// * `zero`       — (I) FITS TZEROn or BZERO value
+/// * `twidth`     — (I) width of each substring of chars
+/// * `implipower` — (I) power of 10 of implied decimal
+/// * `nullcheck`  — (I) null checking code; 0 = don't check
+/// * `snull`      — (I) value of FITS null string, if any
+/// * `nullval`    — (I) set null pixels, if nullcheck = 1
+/// * `nullarray`  — (O) bad pixel array, if nullcheck = 2
+/// * `anynull`    — (O) set to 1 if any pixels are null
+/// * `output`     — (O) array of converted pixels
+/// * `status`     — (IO) error status
 pub(crate) fn fffstrr4(
-    input: &mut [c_char],     /* I - array of values to be converted     */
-    ntodo: c_long,            /* I - number of elements in the array     */
-    scale: f64,               /* I - FITS TSCALn or BSCALE value         */
-    zero: f64,                /* I - FITS TZEROn or BZERO  value         */
-    twidth: c_long,           /* I - width of each substring of chars    */
-    implipower: f64,          /* I - power of 10 of implied decimal      */
-    nullcheck: NullCheckType, /* I - null checking code; 0 = don't check */
+    input: &mut [c_char],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    twidth: c_long,
+    implipower: f64,
+    nullcheck: NullCheckType,
     /*     1:set null pixels = nullval         */
     /*     2: if null pixel, set nullarray = 1 */
-    snull: &[c_char],                /* I - value of FITS null string, if any   */
-    nullval: f32,                    /* I - set null pixels, if nullcheck = 1  */
-    nullarray: &mut [c_char],        /* O - bad pixel array, if nullcheck = 2   */
-    mut anynull: Option<&mut c_int>, /* O - set to 1 if any pixels are null     */
-    output: &mut [f32],              /* O - array of converted pixels          */
-    status: &mut c_int,              /* IO - error status                       */
+    snull: &[c_char],
+    nullval: f32,
+    nullarray: &mut [c_char],
+    mut anynull: Option<&mut c_int>,
+    output: &mut [f32],
+    status: &mut c_int,
 ) -> c_int {
     let mut dvalue: f64 = 0.0;
     let mut message: [c_char; FLEN_ERRMSG] = [0; FLEN_ERRMSG];

--- a/src/getcoli.rs
+++ b/src/getcoli.rs
@@ -1,9 +1,14 @@
-/*  This file, getcoli.rs, contains routines that read data elements from   */
-/*  a FITS image or table, with short datatype.                            */
-
-/*  The FITSIO software was written by William Pence at the High Energy    */
-/*  Astrophysic Science Archive Research Center (HEASARC) at the NASA      */
-/*  Goddard Space Flight Center.                                           */
+//! Routines that read data elements from a FITS image or table, with short
+//! datatype.
+//!
+//! The [`TSHORT`] arm of the typed column I/O family. [`crate::getcol`]
+//! dispatches here when a caller asks for this datatype at run time; the
+//! write-side counterpart is [`crate::putcoli`].
+//!
+//! Ported from CFITSIO's `getcoli.c`, written by William Pence at the High
+//! Energy Astrophysics Science Archive Research Center (HEASARC), NASA Goddard
+//! Space Flight Center.
+#![warn(missing_docs)]
 
 use core::slice;
 use core::{cmp, mem};
@@ -23,7 +28,6 @@ use crate::{NullValue, bb};
 use crate::{buffers::*, calculate_subsection_length};
 use crate::{int_snprintf, slice_to_str};
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of values from the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
 /// the FITS array is not the same as the array being read).
@@ -35,16 +39,27 @@ use crate::{int_snprintf, slice_to_str};
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to read (1 = 1st group)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `nulval`    — (I) value for undefined pixels
+/// * `array`     — (O) array of values that are returned
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgpvi(
-    fptr: *mut fitsfile, /* I - FITS file pointer                       */
-    group: c_long,       /* I - group to read (1 = 1st group)           */
-    firstelem: LONGLONG, /* I - first vector element to read (1 = 1st)  */
-    nelem: LONGLONG,     /* I - number of values to read                */
-    nulval: c_short,     /* I - value for undefined pixels          */
-    array: *mut c_short, /* O - array of values that are returned   */
-    anynul: *mut c_int,  /* O - set to 1 if any values are null; else 0 */
-    status: *mut c_int,  /* IO - error status                           */
+    fptr: *mut fitsfile,
+    group: c_long,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    nulval: c_short,
+    array: *mut c_short,
+    anynul: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -58,7 +73,6 @@ pub unsafe extern "C" fn ffgpvi(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of values from the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
 /// the FITS array is not the same as the array being read).
@@ -70,15 +84,26 @@ pub unsafe extern "C" fn ffgpvi(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to read (1 = 1st group)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `nulval`    — (I) value for undefined pixels
+/// * `array`     — (O) array of values that are returned
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `status`    — (IO) error status
 pub fn ffgpvi_safe(
-    fptr: &mut fitsfile,        /* I - FITS file pointer                       */
-    group: c_long,              /* I - group to read (1 = 1st group)           */
-    firstelem: LONGLONG,        /* I - first vector element to read (1 = 1st)  */
-    nelem: LONGLONG,            /* I - number of values to read                */
-    nulval: c_short,            /* I - value for undefined pixels          */
-    array: &mut [c_short],      /* O - array of values that are returned   */
-    anynul: Option<&mut c_int>, /* O - set to 1 if any values are null; else 0 */
-    status: &mut c_int,         /* IO - error status                           */
+    fptr: &mut fitsfile,
+    group: c_long,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    nulval: c_short,
+    array: &mut [c_short],
+    anynul: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     let cdummy = 0;
     let nullcheck = NullCheckType::SetPixel;
@@ -122,7 +147,6 @@ pub fn ffgpvi_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of values from the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
 /// the FITS array is not the same as the array being read).
@@ -134,16 +158,27 @@ pub fn ffgpvi_safe(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to read (1 = 1st group)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `array`     — (O) array of values that are returned
+/// * `nularray`  — (O) array of null pixel flags
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgpfi(
-    fptr: *mut fitsfile,   /* I - FITS file pointer                       */
-    group: c_long,         /* I - group to read (1 = 1st group)           */
-    firstelem: LONGLONG,   /* I - first vector element to read (1 = 1st)  */
-    nelem: LONGLONG,       /* I - number of values to read                */
-    array: *mut c_short,   /* O - array of values that are returned   */
-    nularray: *mut c_char, /* O - array of null pixel flags               */
-    anynul: *mut c_int,    /* O - set to 1 if any values are null; else 0 */
-    status: *mut c_int,    /* IO - error status                           */
+    fptr: *mut fitsfile,
+    group: c_long,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: *mut c_short,
+    nularray: *mut c_char,
+    anynul: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -160,7 +195,6 @@ pub unsafe extern "C" fn ffgpfi(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of values from the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
 /// the FITS array is not the same as the array being read).
@@ -172,15 +206,26 @@ pub unsafe extern "C" fn ffgpfi(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to read (1 = 1st group)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `array`     — (O) array of values that are returned
+/// * `nularray`  — (O) array of null pixel flags
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `status`    — (IO) error status
 pub fn ffgpfi_safe(
-    fptr: &mut fitsfile,        /* I - FITS file pointer                       */
-    group: c_long,              /* I - group to read (1 = 1st group)           */
-    firstelem: LONGLONG,        /* I - first vector element to read (1 = 1st)  */
-    nelem: LONGLONG,            /* I - number of values to read                */
-    array: &mut [c_short],      /* O - array of values that are returned   */
-    nularray: &mut [c_char],    /* O - array of null pixel flags               */
-    anynul: Option<&mut c_int>, /* O - set to 1 if any values are null; else 0 */
-    status: &mut c_int,         /* IO - error status                           */
+    fptr: &mut fitsfile,
+    group: c_long,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: &mut [c_short],
+    nularray: &mut [c_char],
+    anynul: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     let nullcheck = NullCheckType::SetNullArray;
 
@@ -221,23 +266,34 @@ pub fn ffgpfi_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an entire 2-D array of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of the
 /// FITS array is not the same as the array being read).  Any null
 /// values in the array will be set equal to the value of nulval, unless
 /// nulval = 0 in which case no null checking will be performed.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `group`  — (I) group to read (1 = 1st group)
+/// * `nulval` — set undefined pixels equal to this
+/// * `ncols`  — (I) number of pixels in each row of array
+/// * `naxis1` — (I) FITS image NAXIS1 value
+/// * `naxis2` — (I) FITS image NAXIS2 value
+/// * `array`  — (O) array to be filled and returned
+/// * `anynul` — (O) set to 1 if any values are null; else 0
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffg2di(
-    fptr: *mut fitsfile, /* I - FITS file pointer                       */
-    group: c_long,       /* I - group to read (1 = 1st group)           */
-    nulval: c_short,     /* set undefined pixels equal to this     */
-    ncols: LONGLONG,     /* I - number of pixels in each row of array   */
-    naxis1: LONGLONG,    /* I - FITS image NAXIS1 value                 */
-    naxis2: LONGLONG,    /* I - FITS image NAXIS2 value                 */
-    array: *mut c_short, /* O - array to be filled and returned    */
-    anynul: *mut c_int,  /* O - set to 1 if any values are null; else 0 */
-    status: *mut c_int,  /* IO - error status                           */
+    fptr: *mut fitsfile,
+    group: c_long,
+    nulval: c_short,
+    ncols: LONGLONG,
+    naxis1: LONGLONG,
+    naxis2: LONGLONG,
+    array: *mut c_short,
+    anynul: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -253,22 +309,33 @@ pub unsafe extern "C" fn ffg2di(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an entire 2-D array of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of the
 /// FITS array is not the same as the array being read).  Any null
 /// values in the array will be set equal to the value of nulval, unless
 /// nulval = 0 in which case no null checking will be performed.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `group`  — (I) group to read (1 = 1st group)
+/// * `nulval` — set undefined pixels equal to this
+/// * `ncols`  — (I) number of pixels in each row of array
+/// * `naxis1` — (I) FITS image NAXIS1 value
+/// * `naxis2` — (I) FITS image NAXIS2 value
+/// * `array`  — (O) array to be filled and returned
+/// * `anynul` — (O) set to 1 if any values are null; else 0
+/// * `status` — (IO) error status
 pub fn ffg2di_safe(
-    fptr: &mut fitsfile,        /* I - FITS file pointer                       */
-    group: c_long,              /* I - group to read (1 = 1st group)           */
-    nulval: c_short,            /* set undefined pixels equal to this     */
-    ncols: LONGLONG,            /* I - number of pixels in each row of array   */
-    naxis1: LONGLONG,           /* I - FITS image NAXIS1 value                 */
-    naxis2: LONGLONG,           /* I - FITS image NAXIS2 value                 */
-    array: &mut [c_short],      /* O - array to be filled and returned    */
-    anynul: Option<&mut c_int>, /* O - set to 1 if any values are null; else 0 */
-    status: &mut c_int,         /* IO - error status                           */
+    fptr: &mut fitsfile,
+    group: c_long,
+    nulval: c_short,
+    ncols: LONGLONG,
+    naxis1: LONGLONG,
+    naxis2: LONGLONG,
+    array: &mut [c_short],
+    anynul: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     /* call the 3D reading routine, with the 3rd dimension = 1 */
     ffg3di_safe(
@@ -278,7 +345,6 @@ pub fn ffg2di_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an entire 3-D array of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of the
 /// FITS array is not the same as the array being read).  Any null
@@ -289,19 +355,33 @@ pub fn ffg2di_safe(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `group`  — (I) group to read (1 = 1st group)
+/// * `nulval` — set undefined pixels equal to this
+/// * `ncols`  — (I) number of pixels in each row of array
+/// * `nrows`  — (I) number of rows in each plane of array
+/// * `naxis1` — (I) FITS image NAXIS1 value
+/// * `naxis2` — (I) FITS image NAXIS2 value
+/// * `naxis3` — (I) FITS image NAXIS3 value
+/// * `array`  — (O) array to be filled and returned
+/// * `anynul` — (O) set to 1 if any values are null; else 0
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffg3di(
-    fptr: *mut fitsfile, /* I - FITS file pointer                       */
-    group: c_long,       /* I - group to read (1 = 1st group)           */
-    nulval: c_short,     /* set undefined pixels equal to this     */
-    ncols: LONGLONG,     /* I - number of pixels in each row of array   */
-    nrows: LONGLONG,     /* I - number of rows in each plane of array   */
-    naxis1: LONGLONG,    /* I - FITS image NAXIS1 value                 */
-    naxis2: LONGLONG,    /* I - FITS image NAXIS2 value                 */
-    naxis3: LONGLONG,    /* I - FITS image NAXIS3 value                 */
-    array: *mut c_short, /* O - array to be filled and returned    */
-    anynul: *mut c_int,  /* O - set to 1 if any values are null; else 0 */
-    status: *mut c_int,  /* IO - error status                           */
+    fptr: *mut fitsfile,
+    group: c_long,
+    nulval: c_short,
+    ncols: LONGLONG,
+    nrows: LONGLONG,
+    naxis1: LONGLONG,
+    naxis2: LONGLONG,
+    naxis3: LONGLONG,
+    array: *mut c_short,
+    anynul: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -317,7 +397,6 @@ pub unsafe extern "C" fn ffg3di(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an entire 3-D array of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of the
 /// FITS array is not the same as the array being read).  Any null
@@ -328,18 +407,32 @@ pub unsafe extern "C" fn ffg3di(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `group`  — (I) group to read (1 = 1st group)
+/// * `nulval` — set undefined pixels equal to this
+/// * `ncols`  — (I) number of pixels in each row of array
+/// * `nrows`  — (I) number of rows in each plane of array
+/// * `naxis1` — (I) FITS image NAXIS1 value
+/// * `naxis2` — (I) FITS image NAXIS2 value
+/// * `naxis3` — (I) FITS image NAXIS3 value
+/// * `array`  — (O) array to be filled and returned
+/// * `anynul` — (O) set to 1 if any values are null; else 0
+/// * `status` — (IO) error status
 pub fn ffg3di_safe(
-    fptr: &mut fitsfile,            /* I - FITS file pointer                       */
-    group: c_long,                  /* I - group to read (1 = 1st group)           */
-    nulval: c_short,                /* set undefined pixels equal to this     */
-    ncols: LONGLONG,                /* I - number of pixels in each row of array   */
-    nrows: LONGLONG,                /* I - number of rows in each plane of array   */
-    naxis1: LONGLONG,               /* I - FITS image NAXIS1 value                 */
-    naxis2: LONGLONG,               /* I - FITS image NAXIS2 value                 */
-    naxis3: LONGLONG,               /* I - FITS image NAXIS3 value                 */
-    array: &mut [c_short],          /* O - array to be filled and returned    */
-    mut anynul: Option<&mut c_int>, /* O - set to 1 if any values are null; else 0 */
-    status: &mut c_int,             /* IO - error status                           */
+    fptr: &mut fitsfile,
+    group: c_long,
+    nulval: c_short,
+    ncols: LONGLONG,
+    nrows: LONGLONG,
+    naxis1: LONGLONG,
+    naxis2: LONGLONG,
+    naxis3: LONGLONG,
+    array: &mut [c_short],
+    mut anynul: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     let mut narray = 0;
     let mut nfits: LONGLONG = 0;
@@ -438,22 +531,35 @@ pub fn ffg3di_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read a subsection of data values from an image or a table column.
 /// This routine is set up to handle a maximum of nine dimensions.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `colnum` — (I) number of the column to read (1 = 1st)
+/// * `naxis`  — (I) number of dimensions in the FITS array
+/// * `naxes`  — (I) size of each dimension
+/// * `blc`    — (I) 'bottom left corner' of the subsection
+/// * `trc`    — (I) 'top right corner' of the subsection
+/// * `inc`    — (I) increment to be applied in each dimension
+/// * `nulval` — (I) value to set undefined pixels
+/// * `array`  — (O) array to be filled and returned
+/// * `anynul` — (O) set to 1 if any values are null; else 0
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgsvi(
-    fptr: *mut fitsfile,  /* I - FITS file pointer                         */
-    colnum: c_int,        /* I - number of the column to read (1 = 1st)    */
-    naxis: c_int,         /* I - number of dimensions in the FITS array    */
-    naxes: *const c_long, /* I - size of each dimension                    */
-    blc: *const c_long,   /* I - 'bottom left corner' of the subsection    */
-    trc: *const c_long,   /* I - 'top right corner' of the subsection      */
-    inc: *const c_long,   /* I - increment to be applied in each dimension */
-    nulval: c_short,      /* I - value to set undefined pixels       */
-    array: *mut c_short,  /* O - array to be filled and returned     */
-    anynul: *mut c_int,   /* O - set to 1 if any values are null; else 0   */
-    status: *mut c_int,   /* IO - error status                             */
+    fptr: *mut fitsfile,
+    colnum: c_int,
+    naxis: c_int,
+    naxes: *const c_long,
+    blc: *const c_long,
+    trc: *const c_long,
+    inc: *const c_long,
+    nulval: c_short,
+    array: *mut c_short,
+    anynul: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -476,21 +582,34 @@ pub unsafe extern "C" fn ffgsvi(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read a subsection of data values from an image or a table column.
 /// This routine is set up to handle a maximum of nine dimensions.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `colnum` — (I) number of the column to read (1 = 1st)
+/// * `naxis`  — (I) number of dimensions in the FITS array
+/// * `naxes`  — (I) size of each dimension
+/// * `blc`    — (I) 'bottom left corner' of the subsection
+/// * `trc`    — (I) 'top right corner' of the subsection
+/// * `inc`    — (I) increment to be applied in each dimension
+/// * `nulval` — (I) value to set undefined pixels
+/// * `array`  — (O) array to be filled and returned
+/// * `anynul` — (O) set to 1 if any values are null; else 0
+/// * `status` — (IO) error status
 pub fn ffgsvi_safe(
-    fptr: &mut fitsfile,   /* I - FITS file pointer                         */
-    colnum: c_int,         /* I - number of the column to read (1 = 1st)    */
-    naxis: c_int,          /* I - number of dimensions in the FITS array    */
-    naxes: &[c_long],      /* I - size of each dimension                    */
-    blc: &[c_long],        /* I - 'bottom left corner' of the subsection    */
-    trc: &[c_long],        /* I - 'top right corner' of the subsection      */
-    inc: &[c_long],        /* I - increment to be applied in each dimension */
-    nulval: c_short,       /* I - value to set undefined pixels       */
-    array: &mut [c_short], /* O - array to be filled and returned     */
-    mut anynul: Option<&mut c_int>, /* O - set to 1 if any values are null; else 0   */
-    status: &mut c_int,    /* IO - error status                             */
+    fptr: &mut fitsfile,
+    colnum: c_int,
+    naxis: c_int,
+    naxes: &[c_long],
+    blc: &[c_long],
+    trc: &[c_long],
+    inc: &[c_long],
+    nulval: c_short,
+    array: &mut [c_short],
+    mut anynul: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     let mut rstr: c_long = 0;
     let mut rstp: c_long = 0;
@@ -696,22 +815,35 @@ pub fn ffgsvi_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read a subsection of data values from an image or a table column.
 /// This routine is set up to handle a maximum of nine dimensions.
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `colnum`  — (I) number of the column to read (1 = 1st)
+/// * `naxis`   — (I) number of dimensions in the FITS array
+/// * `naxes`   — (I) size of each dimension
+/// * `blc`     — (I) 'bottom left corner' of the subsection
+/// * `trc`     — (I) 'top right corner' of the subsection
+/// * `inc`     — (I) increment to be applied in each dimension
+/// * `array`   — (O) array to be filled and returned
+/// * `flagval` — (O) set to 1 if corresponding value is null
+/// * `anynul`  — (O) set to 1 if any values are null; else 0
+/// * `status`  — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgsfi(
-    fptr: *mut fitsfile,  /* I - FITS file pointer                         */
-    colnum: c_int,        /* I - number of the column to read (1 = 1st)    */
-    naxis: c_int,         /* I - number of dimensions in the FITS array    */
-    naxes: *const c_long, /* I - size of each dimension                    */
-    blc: *const c_long,   /* I - 'bottom left corner' of the subsection    */
-    trc: *const c_long,   /* I - 'top right corner' of the subsection      */
-    inc: *const c_long,   /* I - increment to be applied in each dimension */
-    array: *mut c_short,  /* O - array to be filled and returned     */
-    flagval: *mut c_char, /* O - set to 1 if corresponding value is null   */
-    anynul: *mut c_int,   /* O - set to 1 if any values are null; else 0   */
-    status: *mut c_int,   /* IO - error status                             */
+    fptr: *mut fitsfile,
+    colnum: c_int,
+    naxis: c_int,
+    naxes: *const c_long,
+    blc: *const c_long,
+    trc: *const c_long,
+    inc: *const c_long,
+    array: *mut c_short,
+    flagval: *mut c_char,
+    anynul: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -736,18 +868,31 @@ pub unsafe extern "C" fn ffgsfi(
     }
 }
 
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `colnum`  — (I) number of the column to read (1 = 1st)
+/// * `naxis`   — (I) number of dimensions in the FITS array
+/// * `naxes`   — (I) size of each dimension
+/// * `blc`     — (I) 'bottom left corner' of the subsection
+/// * `trc`     — (I) 'top right corner' of the subsection
+/// * `inc`     — (I) increment to be applied in each dimension
+/// * `array`   — (O) array to be filled and returned
+/// * `flagval` — (O) set to 1 if corresponding value is null
+/// * `anynul`  — (O) set to 1 if any values are null; else 0
+/// * `status`  — (IO) error status
 pub fn ffgsfi_safe(
-    fptr: &mut fitsfile,    /* I - FITS file pointer                         */
-    colnum: c_int,          /* I - number of the column to read (1 = 1st)    */
-    naxis: c_int,           /* I - number of dimensions in the FITS array    */
-    naxes: &[c_long],       /* I - size of each dimension                    */
-    blc: &[c_long],         /* I - 'bottom left corner' of the subsection    */
-    trc: &[c_long],         /* I - 'top right corner' of the subsection      */
-    inc: &[c_long],         /* I - increment to be applied in each dimension */
-    array: &mut [c_short],  /* O - array to be filled and returned          */
-    flagval: &mut [c_char], /* O - set to 1 if corresponding value is null   */
-    mut anynul: Option<&mut c_int>, /* O - set to 1 if any values are null; else 0   */
-    status: &mut c_int,     /* IO - error status                             */
+    fptr: &mut fitsfile,
+    colnum: c_int,
+    naxis: c_int,
+    naxes: &[c_long],
+    blc: &[c_long],
+    trc: &[c_long],
+    inc: &[c_long],
+    array: &mut [c_short],
+    flagval: &mut [c_char],
+    mut anynul: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     let mut rstr: c_long = 0;
     let mut rstp: c_long = 0;
@@ -934,7 +1079,6 @@ pub fn ffgsfi_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 ///Read an array of group parameters from the primary array. Data conversion
 ///and scaling will be performed if necessary (e.g, if the datatype of
 ///the FITS array is not the same as the array being read).
@@ -943,14 +1087,23 @@ pub fn ffgsfi_safe(
 ///each group of the primary array is a row in the table,
 ///where the first column contains the group parameters
 ///and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to read (1 = 1st group)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `array`     — (O) array of values that are returned
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffggpi(
-    fptr: *mut fitsfile, /* I - FITS file pointer                       */
-    group: c_long,       /* I - group to read (1 = 1st group)           */
-    firstelem: c_long,   /* I - first vector element to read (1 = 1st)  */
-    nelem: c_long,       /* I - number of values to read                */
-    array: *mut c_short, /* O - array of values that are returned   */
-    status: *mut c_int,  /* IO - error status                           */
+    fptr: *mut fitsfile,
+    group: c_long,
+    firstelem: c_long,
+    nelem: c_long,
+    array: *mut c_short,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -962,7 +1115,6 @@ pub unsafe extern "C" fn ffggpi(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 ///Read an array of group parameters from the primary array. Data conversion
 ///and scaling will be performed if necessary (e.g, if the datatype of
 ///the FITS array is not the same as the array being read).
@@ -971,13 +1123,22 @@ pub unsafe extern "C" fn ffggpi(
 ///each group of the primary array is a row in the table,
 ///where the first column contains the group parameters
 ///and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to read (1 = 1st group)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `array`     — (O) array of values that are returned
+/// * `status`    — (IO) error status
 pub fn ffggpi_safe(
-    fptr: &mut fitsfile,   /* I - FITS file pointer                       */
-    group: c_long,         /* I - group to read (1 = 1st group)           */
-    firstelem: c_long,     /* I - first vector element to read (1 = 1st)  */
-    nelem: c_long,         /* I - number of values to read                */
-    array: &mut [c_short], /* O - array of values that are returned   */
-    status: &mut c_int,    /* IO - error status                           */
+    fptr: &mut fitsfile,
+    group: c_long,
+    firstelem: c_long,
+    nelem: c_long,
+    array: &mut [c_short],
+    status: &mut c_int,
 ) -> c_int {
     let cdummy = 0;
     let mut anynul = 0;
@@ -1001,24 +1162,35 @@ pub fn ffggpi_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of values from a column in the current FITS HDU. Automatic
 /// datatype conversion will be performed if the datatype of the column does not
 /// match the datatype of the array parameter. The output values will be scaled
 /// by the FITS TSCALn and TZEROn values if these values have been defined.
 /// Any undefined pixels will be set equal to the value of 'nulval' unless
 /// nulval = 0 in which case no checks for undefined pixels will be made.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to read (1 = 1st col)
+/// * `firstrow`  — (I) first row to read (1 = 1st row)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `nulval`    — (I) value for null pixels
+/// * `array`     — (O) array of values that are read
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgcvi(
-    fptr: *mut fitsfile, /* I - FITS file pointer                       */
-    colnum: c_int,       /* I - number of column to read (1 = 1st col)  */
-    firstrow: LONGLONG,  /* I - first row to read (1 = 1st row)         */
-    firstelem: LONGLONG, /* I - first vector element to read (1 = 1st)  */
-    nelem: LONGLONG,     /* I - number of values to read                */
-    nulval: c_short,     /* I - value for null pixels               */
-    array: *mut c_short, /* O - array of values that are read       */
-    anynul: *mut c_int,  /* O - set to 1 if any values are null; else 0 */
-    status: *mut c_int,  /* IO - error status                           */
+    fptr: *mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    nulval: c_short,
+    array: *mut c_short,
+    anynul: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -1034,23 +1206,34 @@ pub unsafe extern "C" fn ffgcvi(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of values from a column in the current FITS HDU. Automatic
 /// datatype conversion will be performed if the datatype of the column does not
 /// match the datatype of the array parameter. The output values will be scaled
 /// by the FITS TSCALn and TZEROn values if these values have been defined.
 /// Any undefined pixels will be set equal to the value of 'nulval' unless
 /// nulval = 0 in which case no checks for undefined pixels will be made.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to read (1 = 1st col)
+/// * `firstrow`  — (I) first row to read (1 = 1st row)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `nulval`    — (I) value for null pixels
+/// * `array`     — (O) array of values that are read
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `status`    — (IO) error status
 pub fn ffgcvi_safe(
-    fptr: &mut fitsfile,        /* I - FITS file pointer                       */
-    colnum: c_int,              /* I - number of column to read (1 = 1st col)  */
-    firstrow: LONGLONG,         /* I - first row to read (1 = 1st row)         */
-    firstelem: LONGLONG,        /* I - first vector element to read (1 = 1st)  */
-    nelem: LONGLONG,            /* I - number of values to read                */
-    nulval: c_short,            /* I - value for null pixels               */
-    array: &mut [c_short],      /* O - array of values that are read       */
-    anynul: Option<&mut c_int>, /* O - set to 1 if any values are null; else 0 */
-    status: &mut c_int,         /* IO - error status                           */
+    fptr: &mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    nulval: c_short,
+    array: &mut [c_short],
+    anynul: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     let mut dummy_nularray = vec![0; nelem as usize];
 
@@ -1071,24 +1254,35 @@ pub fn ffgcvi_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of values from a column in the current FITS HDU. Automatic
 /// datatype conversion will be performed if the datatype of the column does not
 /// match the datatype of the array parameter. The output values will be scaled
 /// by the FITS TSCALn and TZEROn values if these values have been defined.
 /// Nularray will be set = 1 if the corresponding array pixel is undefined,
 /// otherwise nularray will = 0.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to read (1 = 1st col)
+/// * `firstrow`  — (I) first row to read (1 = 1st row)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `array`     — (O) array of values that are read
+/// * `nularray`  — (O) array of flags: 1 if null pixel; else 0
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgcfi(
-    fptr: *mut fitsfile,   /* I - FITS file pointer                       */
-    colnum: c_int,         /* I - number of column to read (1 = 1st col)  */
-    firstrow: LONGLONG,    /* I - first row to read (1 = 1st row)         */
-    firstelem: LONGLONG,   /* I - first vector element to read (1 = 1st)  */
-    nelem: LONGLONG,       /* I - number of values to read                */
-    array: *mut c_short,   /* O - array of values that are read       */
-    nularray: *mut c_char, /* O - array of flags: 1 if null pixel; else 0 */
-    anynul: *mut c_int,    /* O - set to 1 if any values are null; else 0 */
-    status: *mut c_int,    /* IO - error status                           */
+    fptr: *mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: *mut c_short,
+    nularray: *mut c_char,
+    anynul: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -1105,23 +1299,34 @@ pub unsafe extern "C" fn ffgcfi(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of values from a column in the current FITS HDU. Automatic
 /// datatype conversion will be performed if the datatype of the column does not
 /// match the datatype of the array parameter. The output values will be scaled
 /// by the FITS TSCALn and TZEROn values if these values have been defined.
 /// Nularray will be set = 1 if the corresponding array pixel is undefined,
 /// otherwise nularray will = 0.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to read (1 = 1st col)
+/// * `firstrow`  — (I) first row to read (1 = 1st row)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `array`     — (O) array of values that are read
+/// * `nularray`  — (O) array of flags: 1 if null pixel; else 0
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `status`    — (IO) error status
 pub fn ffgcfi_safe(
-    fptr: &mut fitsfile,        /* I - FITS file pointer                       */
-    colnum: c_int,              /* I - number of column to read (1 = 1st col)  */
-    firstrow: LONGLONG,         /* I - first row to read (1 = 1st row)         */
-    firstelem: LONGLONG,        /* I - first vector element to read (1 = 1st)  */
-    nelem: LONGLONG,            /* I - number of values to read                */
-    array: &mut [c_short],      /* O - array of values that are read       */
-    nularray: &mut [c_char],    /* O - array of flags: 1 if null pixel; else 0 */
-    anynul: Option<&mut c_int>, /* O - set to 1 if any values are null; else 0 */
-    status: &mut c_int,         /* IO - error status                           */
+    fptr: &mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: &mut [c_short],
+    nularray: &mut [c_char],
+    anynul: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     let dummy: c_short = 0;
 
@@ -1142,7 +1347,6 @@ pub fn ffgcfi_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of values from a column in the current FITS HDU.
 /// The column number may refer to a real column in an ASCII or binary table,
 /// or it may refer be a virtual column in a 1 or more grouped FITS primary
@@ -1156,21 +1360,35 @@ pub fn ffgcfi_safe(
 /// and will be scaled by the FITS TSCALn and TZEROn values if necessary.
 #[allow(clippy::if_same_then_else)]
 // C dispatch chain: distinct conditions deliberately share an action.
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to read (1 = 1st col)
+/// * `firstrow`  — (I) first row to read (1 = 1st row)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `elemincre` — (I) pixel increment; e.g., 2 = every other
+/// * `nultyp`    — (I) null value handling code:
+/// * `nulval`    — (I) value for null pixels if nultyp = 1
+/// * `array`     — (O) array of values that are read
+/// * `nularray`  — (O) array of flags = 1 if nultyp = 2
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `status`    — (IO) error status
 pub(crate) fn ffgcli(
-    fptr: &mut fitsfile,   /* I - FITS file pointer                       */
-    colnum: c_int,         /* I - number of column to read (1 = 1st col)  */
-    firstrow: LONGLONG,    /* I - first row to read (1 = 1st row)         */
-    firstelem: LONGLONG,   /* I - first vector element to read (1 = 1st)  */
-    nelem: LONGLONG,       /* I - number of values to read                */
-    elemincre: c_long,     /* I - pixel increment; e.g., 2 = every other  */
-    nultyp: NullCheckType, /* I - null value handling code:               */
+    fptr: &mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    elemincre: c_long,
+    nultyp: NullCheckType,
     /*     1: set undefined pixels = nulval        */
     /*     2: set nularray=1 for undefined pixels  */
-    nulval: c_short,                /* I - value for null pixels if nultyp = 1 */
-    array: &mut [c_short],          /* O - array of values that are read       */
-    nularray: &mut [c_char],        /* O - array of flags = 1 if nultyp = 2        */
-    mut anynul: Option<&mut c_int>, /* O - set to 1 if any values are null; else 0 */
-    status: &mut c_int,             /* IO - error status                           */
+    nulval: c_short,
+    array: &mut [c_short],
+    nularray: &mut [c_char],
+    mut anynul: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     let mut scale: f64 = 0.0;
     let mut zero: f64 = 0.0;
@@ -1218,9 +1436,7 @@ pub(crate) fn ffgcli(
         nularray.fill(0); /* initialize nullarray */
     }
 
-    /*---------------------------------------------------*/
     /*  Check input and get parameters about the column: */
-    /*---------------------------------------------------*/
     if elemincre < 0 {
         readcheck -= 1; /* don't do range checking in this case */
     }
@@ -1271,9 +1487,7 @@ pub(crate) fn ffgcli(
             power *= 10.0;
         }
     }
-    /*------------------------------------------------------------------*/
     /*  Decide whether to check for null values in the input FITS file: */
-    /*------------------------------------------------------------------*/
     nulcheck = nultyp; /* by default, check for null values in the FITS file */
 
     if nultyp == NullCheckType::SetPixel && nulval == 0 {
@@ -1293,10 +1507,8 @@ pub(crate) fn ffgcli(
         nulcheck = NullCheckType::None;
     }
 
-    /*----------------------------------------------------------------------*/
     /*  If FITS column and output data array have same datatype, then we do */
     /*  not need to use a temporary buffer to store intermediate datatype.  */
-    /*----------------------------------------------------------------------*/
     convert = true;
     if tcode == TSHORT {
         /* Special Case:                        */
@@ -1314,7 +1526,6 @@ pub(crate) fn ffgcli(
         }
     }
 
-    /*---------------------------------------------------------------------*/
     /*  Now read the pixels from the FITS column. If the column does not   */
     /*  have the same datatype as the output array, then we have to read   */
     /*  the raw values into a temporary buffer (of limited size).  In      */
@@ -1324,7 +1535,6 @@ pub(crate) fn ffgcli(
     /*  test for undefined values, (2) convert the datatype if necessary,  */
     /*  and (3) scale the values by the FITS TSCALn and TZEROn linear      */
     /*  scaling parameters.                                                */
-    /*---------------------------------------------------------------------*/
 
     remain = nelem; /* remaining number of values to read */
     next = 0; /* next element in array to be read   */
@@ -1579,9 +1789,7 @@ pub(crate) fn ffgcli(
             }
         } /* End of switch block */
 
-        /*-------------------------*/
         /*  Check for fatal error  */
-        /*-------------------------*/
         if *status > 0 {
             /* test for error during previous read operation */
 
@@ -1609,9 +1817,7 @@ pub(crate) fn ffgcli(
             return *status;
         }
 
-        /*--------------------------------------------*/
         /*  increment the counters for the next loop  */
-        /*--------------------------------------------*/
         remain -= ntodo as LONGLONG;
         if remain != 0 {
             next += ntodo as usize;
@@ -1633,9 +1839,7 @@ pub(crate) fn ffgcli(
         }
     } /*  End of main while Loop  */
 
-    /*--------------------------------*/
     /*  check for numerical overflow  */
-    /*--------------------------------*/
     if *status == OVERFLOW_ERR {
         ffpmsg_str("Numerical overflow during type conversion while reading FITS data.");
         *status = NUM_OVERFLOW;
@@ -1644,7 +1848,6 @@ pub(crate) fn ffgcli(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output following reading of the input from a FITS file.
 /// Check for null values and do datatype conversion and scaling if required.
 /// The nullcheck code value determines how any null values in the input array
@@ -1656,20 +1859,34 @@ pub(crate) fn ffgcli(
 /// nullarray will be set to 1; the value of nullarray for non-null pixels
 /// will = 0.  The anynull parameter will be set = 1 if any of the returned
 /// pixels are null, otherwise anynull will be returned with a value = 0;
+///
+/// # Parameters
+///
+/// * `input`     — (I) array of values to be converted
+/// * `ntodo`     — (I) number of elements in the array
+/// * `scale`     — (I) FITS TSCALn or BSCALE value
+/// * `zero`      — (I) FITS TZEROn or BZERO value
+/// * `nullcheck` — (I) null checking code; 0 = don't check
+/// * `tnull`     — (I) value of FITS TNULLn keyword if any
+/// * `nullval`   — (I) set null pixels, if nullcheck = 1
+/// * `nullarray` — (O) bad pixel array, if nullcheck = 2
+/// * `anynull`   — (O) set to 1 if any pixels are null
+/// * `output`    — (O) array of converted pixels
+/// * `status`    — (IO) error status
 pub(crate) fn fffi1i2(
-    input: &[u8],             /* I - array of values to be converted     */
-    ntodo: c_long,            /* I - number of elements in the array     */
-    scale: f64,               /* I - FITS TSCALn or BSCALE value         */
-    zero: f64,                /* I - FITS TZEROn or BZERO  value         */
-    nullcheck: NullCheckType, /* I - null checking code; 0 = don't check */
+    input: &[u8],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    nullcheck: NullCheckType,
     /*     1:set null pixels = nullval         */
     /*     2: if null pixel, set nullarray = 1 */
-    tnull: u8,                   /* I - value of FITS TNULLn keyword if any */
-    nullval: c_short,            /* I - set null pixels, if nullcheck = 1   */
-    nullarray: &mut [c_char],    /* O - bad pixel array, if nullcheck = 2   */
-    anynull: Option<&mut c_int>, /* O - set to 1 if any pixels are null     */
-    output: &mut [c_short],      /* O - array of converted pixels           */
-    status: &mut c_int,          /* IO - error status                       */
+    tnull: u8,
+    nullval: c_short,
+    nullarray: &mut [c_char],
+    anynull: Option<&mut c_int>,
+    output: &mut [c_short],
+    status: &mut c_int,
 ) -> c_int {
     let mut dvalue: f64 = 0.0;
 
@@ -1743,7 +1960,6 @@ pub(crate) fn fffi1i2(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output following reading of the input from a FITS file.
 /// Check for null values and do datatype conversion and scaling if required.
 /// The nullcheck code value determines how any null values in the input array
@@ -1755,20 +1971,34 @@ pub(crate) fn fffi1i2(
 /// nullarray will be set to 1; the value of nullarray for non-null pixels
 /// will = 0.  The anynull parameter will be set = 1 if any of the returned
 /// pixels are null, otherwise anynull will be returned with a value = 0;
+///
+/// # Parameters
+///
+/// * `input`     — (I) array of values to be converted
+/// * `ntodo`     — (I) number of elements in the array
+/// * `scale`     — (I) FITS TSCALn or BSCALE value
+/// * `zero`      — (I) FITS TZEROn or BZERO value
+/// * `nullcheck` — (I) null checking code; 0 = don't check
+/// * `tnull`     — (I) value of FITS TNULLn keyword if any
+/// * `nullval`   — (I) set null pixels, if nullcheck = 1
+/// * `nullarray` — (O) bad pixel array, if nullcheck = 2
+/// * `anynull`   — (O) set to 1 if any pixels are null
+/// * `output`    — (O) array of converted pixels
+/// * `status`    — (IO) error status
 pub(crate) fn fffi2i2(
-    input: &[c_short],        /* I - array of values to be converted     */
-    ntodo: c_long,            /* I - number of elements in the array     */
-    scale: f64,               /* I - FITS TSCALn or BSCALE value         */
-    zero: f64,                /* I - FITS TZEROn or BZERO  value         */
-    nullcheck: NullCheckType, /* I - null checking code; 0 = don't check */
+    input: &[c_short],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    nullcheck: NullCheckType,
     /*     1:set null pixels = nullval         */
     /*     2: if null pixel, set nullarray = 1 */
-    tnull: c_short,              /* I - value of FITS TNULLn keyword if any */
-    nullval: c_short,            /* I - set null pixels, if nullcheck = 1   */
-    nullarray: &mut [c_char],    /* O - bad pixel array, if nullcheck = 2   */
-    anynull: Option<&mut c_int>, /* O - set to 1 if any pixels are null     */
-    output: &mut [c_short],      /* O - array of converted pixels           */
-    status: &mut c_int,          /* IO - error status                       */
+    tnull: c_short,
+    nullval: c_short,
+    nullarray: &mut [c_char],
+    anynull: Option<&mut c_int>,
+    output: &mut [c_short],
+    status: &mut c_int,
 ) -> c_int {
     let mut dvalue: f64 = 0.0;
 
@@ -1843,7 +2073,6 @@ pub(crate) fn fffi2i2(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output following reading of the input from a FITS file.
 /// Check for null values and do datatype conversion and scaling if required.
 /// The nullcheck code value determines how any null values in the input array
@@ -1855,19 +2084,32 @@ pub(crate) fn fffi2i2(
 /// nullarray will be set to 1; the value of nullarray for non-null pixels
 /// will = 0.  The anynull parameter will be set = 1 if any of the returned
 /// pixels are null, otherwise anynull will be returned with a value = 0;
+///
+/// # Parameters
+///
+/// * `inout`     — (IO) array of values to be converted
+/// * `ntodo`     — (I) number of elements in the array
+/// * `scale`     — (I) FITS TSCALn or BSCALE value
+/// * `zero`      — (I) FITS TZEROn or BZERO value
+/// * `nullcheck` — (I) null checking code; 0 = don't check
+/// * `tnull`     — (I) value of FITS TNULLn keyword if any
+/// * `nullval`   — (I) set null pixels, if nullcheck = 1
+/// * `nullarray` — (O) bad pixel array, if nullcheck = 2
+/// * `anynull`   — (O) set to 1 if any pixels are null
+/// * `status`    — (IO) error status
 pub(crate) fn fffi2i2_inplace(
-    inout: &mut [c_short],    /* IO - array of values to be converted     */
-    ntodo: c_long,            /* I - number of elements in the array     */
-    scale: f64,               /* I - FITS TSCALn or BSCALE value         */
-    zero: f64,                /* I - FITS TZEROn or BZERO  value         */
-    nullcheck: NullCheckType, /* I - null checking code; 0 = don't check */
+    inout: &mut [c_short],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    nullcheck: NullCheckType,
     /*     1:set null pixels = nullval         */
     /*     2: if null pixel, set nullarray = 1 */
-    tnull: c_short,              /* I - value of FITS TNULLn keyword if any */
-    nullval: c_short,            /* I - set null pixels, if nullcheck = 1   */
-    nullarray: &mut [c_char],    /* O - bad pixel array, if nullcheck = 2   */
-    anynull: Option<&mut c_int>, /* O - set to 1 if any pixels are null     */
-    status: &mut c_int,          /* IO - error status                       */
+    tnull: c_short,
+    nullval: c_short,
+    nullarray: &mut [c_char],
+    anynull: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     let mut dvalue: f64 = 0.0;
 
@@ -1942,7 +2184,6 @@ pub(crate) fn fffi2i2_inplace(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output following reading of the input from a FITS file.
 /// Check for null values and do datatype conversion and scaling if required.
 /// The nullcheck code value determines how any null values in the input array
@@ -1954,20 +2195,34 @@ pub(crate) fn fffi2i2_inplace(
 /// nullarray will be set to 1; the value of nullarray for non-null pixels
 /// will = 0.  The anynull parameter will be set = 1 if any of the returned
 /// pixels are null, otherwise anynull will be returned with a value = 0;
+///
+/// # Parameters
+///
+/// * `input`     — (I) array of values to be converted
+/// * `ntodo`     — (I) number of elements in the array
+/// * `scale`     — (I) FITS TSCALn or BSCALE value
+/// * `zero`      — (I) FITS TZEROn or BZERO value
+/// * `nullcheck` — (I) null checking code; 0 = don't check
+/// * `tnull`     — (I) value of FITS TNULLn keyword if any
+/// * `nullval`   — (I) set null pixels, if nullcheck = 1
+/// * `nullarray` — (O) bad pixel array, if nullcheck = 2
+/// * `anynull`   — (O) set to 1 if any pixels are null
+/// * `output`    — (O) array of converted pixels
+/// * `status`    — (IO) error status
 pub(crate) fn fffi4i2(
-    input: &[INT32BIT],       /* I - array of values to be converted     */
-    ntodo: c_long,            /* I - number of elements in the array     */
-    scale: f64,               /* I - FITS TSCALn or BSCALE value         */
-    zero: f64,                /* I - FITS TZEROn or BZERO  value         */
-    nullcheck: NullCheckType, /* I - null checking code; 0 = don't check */
+    input: &[INT32BIT],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    nullcheck: NullCheckType,
     /*     1:set null pixels = nullval         */
     /*     2: if null pixel, set nullarray = 1 */
-    tnull: INT32BIT,             /* I - value of FITS TNULLn keyword if any */
-    nullval: c_short,            /* I - set null pixels, if nullcheck = 1   */
-    nullarray: &mut [c_char],    /* O - bad pixel array, if nullcheck = 2   */
-    anynull: Option<&mut c_int>, /* O - set to 1 if any pixels are null     */
-    output: &mut [c_short],      /* O - array of converted pixels           */
-    status: &mut c_int,          /* IO - error status                       */
+    tnull: INT32BIT,
+    nullval: c_short,
+    nullarray: &mut [c_char],
+    anynull: Option<&mut c_int>,
+    output: &mut [c_short],
+    status: &mut c_int,
 ) -> c_int {
     let mut dvalue: f64 = 0.0;
 
@@ -2059,7 +2314,6 @@ pub(crate) fn fffi4i2(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output following reading of the input from a FITS file.
 /// Check for null values and do datatype conversion and scaling if required.
 /// The nullcheck code value determines how any null values in the input array
@@ -2071,20 +2325,34 @@ pub(crate) fn fffi4i2(
 /// nullarray will be set to 1; the value of nullarray for non-null pixels
 /// will = 0.  The anynull parameter will be set = 1 if any of the returned
 /// pixels are null, otherwise anynull will be returned with a value = 0;
+///
+/// # Parameters
+///
+/// * `input`     — (I) array of values to be converted
+/// * `ntodo`     — (I) number of elements in the array
+/// * `scale`     — (I) FITS TSCALn or BSCALE value
+/// * `zero`      — (I) FITS TZEROn or BZERO value
+/// * `nullcheck` — (I) null checking code; 0 = don't check
+/// * `tnull`     — (I) value of FITS TNULLn keyword if any
+/// * `nullval`   — (I) set null pixels, if nullcheck = 1
+/// * `nullarray` — (O) bad pixel array, if nullcheck = 2
+/// * `anynull`   — (O) set to 1 if any pixels are null
+/// * `output`    — (O) array of converted pixels
+/// * `status`    — (IO) error status
 pub(crate) fn fffi8i2(
-    input: &[LONGLONG],       /* I - array of values to be converted     */
-    ntodo: c_long,            /* I - number of elements in the array     */
-    scale: f64,               /* I - FITS TSCALn or BSCALE value         */
-    zero: f64,                /* I - FITS TZEROn or BZERO  value         */
-    nullcheck: NullCheckType, /* I - null checking code; 0 = don't check */
+    input: &[LONGLONG],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    nullcheck: NullCheckType,
     /*     1:set null pixels = nullval         */
     /*     2: if null pixel, set nullarray = 1 */
-    tnull: LONGLONG,             /* I - value of FITS TNULLn keyword if any */
-    nullval: c_short,            /* I - set null pixels, if nullcheck = 1   */
-    nullarray: &mut [c_char],    /* O - bad pixel array, if nullcheck = 2   */
-    anynull: Option<&mut c_int>, /* O - set to 1 if any pixels are null     */
-    output: &mut [c_short],      /* O - array of converted pixels           */
-    status: &mut c_int,          /* IO - error status                       */
+    tnull: LONGLONG,
+    nullval: c_short,
+    nullarray: &mut [c_char],
+    anynull: Option<&mut c_int>,
+    output: &mut [c_short],
+    status: &mut c_int,
 ) -> c_int {
     let mut dvalue: f64 = 0.0;
     let mut ulltemp: ULONGLONG = 0;
@@ -2216,7 +2484,6 @@ pub(crate) fn fffi8i2(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output following reading of the input from a FITS file.
 /// Check for null values and do datatype conversion and scaling if required.
 /// The nullcheck code value determines how any null values in the input array
@@ -2228,19 +2495,32 @@ pub(crate) fn fffi8i2(
 /// nullarray will be set to 1; the value of nullarray for non-null pixels
 /// will = 0.  The anynull parameter will be set = 1 if any of the returned
 /// pixels are null, otherwise anynull will be returned with a value = 0;
+///
+/// # Parameters
+///
+/// * `input`     — (I) array of values to be converted
+/// * `ntodo`     — (I) number of elements in the array
+/// * `scale`     — (I) FITS TSCALn or BSCALE value
+/// * `zero`      — (I) FITS TZEROn or BZERO value
+/// * `nullcheck` — (I) null checking code; 0 = don't check
+/// * `nullval`   — (I) set null pixels, if nullcheck = 1
+/// * `nullarray` — (O) bad pixel array, if nullcheck = 2
+/// * `anynull`   — (O) set to 1 if any pixels are null
+/// * `output`    — (O) array of converted pixels
+/// * `status`    — (IO) error status
 pub(crate) fn fffr4i2(
-    input: &[f32],            /* I - array of values to be converted     */
-    ntodo: c_long,            /* I - number of elements in the array     */
-    scale: f64,               /* I - FITS TSCALn or BSCALE value         */
-    zero: f64,                /* I - FITS TZEROn or BZERO  value         */
-    nullcheck: NullCheckType, /* I - null checking code; 0 = don't check */
+    input: &[f32],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    nullcheck: NullCheckType,
     /*     1:set null pixels = nullval         */
     /*     2: if null pixel, set nullarray = 1 */
-    nullval: c_short,            /* I - set null pixels, if nullcheck = 1   */
-    nullarray: &mut [c_char],    /* O - bad pixel array, if nullcheck = 2   */
-    anynull: Option<&mut c_int>, /* O - set to 1 if any pixels are null     */
-    output: &mut [c_short],      /* O - array of converted pixels           */
-    status: &mut c_int,          /* IO - error status                       */
+    nullval: c_short,
+    nullarray: &mut [c_char],
+    anynull: Option<&mut c_int>,
+    output: &mut [c_short],
+    status: &mut c_int,
 ) -> c_int {
     let mut dvalue: f64 = 0.0;
     let mut sptr = 0;
@@ -2363,7 +2643,6 @@ pub(crate) fn fffr4i2(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output following reading of the input from a FITS file.
 /// Check for null values and do datatype conversion and scaling if required.
 /// The nullcheck code value determines how any null values in the input array
@@ -2375,19 +2654,32 @@ pub(crate) fn fffr4i2(
 /// nullarray will be set to 1; the value of nullarray for non-null pixels
 /// will = 0.  The anynull parameter will be set = 1 if any of the returned
 /// pixels are null, otherwise anynull will be returned with a value = 0;
+///
+/// # Parameters
+///
+/// * `input`     — (I) array of values to be converted
+/// * `ntodo`     — (I) number of elements in the array
+/// * `scale`     — (I) FITS TSCALn or BSCALE value
+/// * `zero`      — (I) FITS TZEROn or BZERO value
+/// * `nullcheck` — (I) null checking code; 0 = don't check
+/// * `nullval`   — (I) set null pixels, if nullcheck = 1
+/// * `nullarray` — (O) bad pixel array, if nullcheck = 2
+/// * `anynull`   — (O) set to 1 if any pixels are null
+/// * `output`    — (O) array of converted pixels
+/// * `status`    — (IO) error status
 pub(crate) fn fffr8i2(
-    input: &[f64],            /* I - array of values to be converted     */
-    ntodo: c_long,            /* I - number of elements in the array     */
-    scale: f64,               /* I - FITS TSCALn or BSCALE value         */
-    zero: f64,                /* I - FITS TZEROn or BZERO  value         */
-    nullcheck: NullCheckType, /* I - null checking code; 0 = don't check */
+    input: &[f64],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    nullcheck: NullCheckType,
     /*     1:set null pixels = nullval         */
     /*     2: if null pixel, set nullarray = 1 */
-    nullval: c_short,            /* I - set null pixels, if nullcheck = 1   */
-    nullarray: &mut [c_char],    /* O - bad pixel array, if nullcheck = 2   */
-    anynull: Option<&mut c_int>, /* O - set to 1 if any pixels are null     */
-    output: &mut [c_short],      /* O - array of converted pixels           */
-    status: &mut c_int,          /* IO - error status                       */
+    nullval: c_short,
+    nullarray: &mut [c_char],
+    anynull: Option<&mut c_int>,
+    output: &mut [c_short],
+    status: &mut c_int,
 ) -> c_int {
     let mut dvalue: f64 = 0.0;
     let mut sptr = 0;
@@ -2509,7 +2801,6 @@ pub(crate) fn fffr8i2(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output following reading of the input from a FITS file. Check
 /// for null values and do scaling if required. The nullcheck code value
 /// determines how any null values in the input array are treated. A null
@@ -2520,22 +2811,38 @@ pub(crate) fn fffr8i2(
 /// nullarray will be set to 1; the value of nullarray for non-null pixels
 /// will = 0.  The anynull parameter will be set = 1 if any of the returned
 /// pixels are null, otherwise anynull will be returned with a value = 0;
+///
+/// # Parameters
+///
+/// * `input`      — (I) array of values to be converted
+/// * `ntodo`      — (I) number of elements in the array
+/// * `scale`      — (I) FITS TSCALn or BSCALE value
+/// * `zero`       — (I) FITS TZEROn or BZERO value
+/// * `twidth`     — (I) width of each substring of chars
+/// * `implipower` — (I) power of 10 of implied decimal
+/// * `nullcheck`  — (I) null checking code; 0 = don't check
+/// * `snull`      — (I) value of FITS null string, if any
+/// * `nullval`    — (I) set null pixels, if nullcheck = 1
+/// * `nullarray`  — (O) bad pixel array, if nullcheck = 2
+/// * `anynull`    — (O) set to 1 if any pixels are null
+/// * `output`     — (O) array of converted pixels
+/// * `status`     — (IO) error status
 pub(crate) fn fffstri2(
-    input: &mut [c_char],     /* I - array of values to be converted     */
-    ntodo: c_long,            /* I - number of elements in the array     */
-    scale: f64,               /* I - FITS TSCALn or BSCALE value         */
-    zero: f64,                /* I - FITS TZEROn or BZERO  value         */
-    twidth: c_long,           /* I - width of each substring of chars    */
-    implipower: f64,          /* I - power of 10 of implied decimal      */
-    nullcheck: NullCheckType, /* I - null checking code; 0 = don't check */
+    input: &mut [c_char],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    twidth: c_long,
+    implipower: f64,
+    nullcheck: NullCheckType,
     /*     1:set null pixels = nullval         */
     /*     2: if null pixel, set nullarray = 1 */
-    snull: &[c_char],                /* I - value of FITS null string, if any   */
-    nullval: c_short,                /* I - set null pixels, if nullcheck = 1  */
-    nullarray: &mut [c_char],        /* O - bad pixel array, if nullcheck = 2   */
-    mut anynull: Option<&mut c_int>, /* O - set to 1 if any pixels are null     */
-    output: &mut [c_short],          /* O - array of converted pixels          */
-    status: &mut c_int,              /* IO - error status                       */
+    snull: &[c_char],
+    nullval: c_short,
+    nullarray: &mut [c_char],
+    mut anynull: Option<&mut c_int>,
+    output: &mut [c_short],
+    status: &mut c_int,
 ) -> c_int {
     let mut dvalue: f64 = 0.0;
     let mut message: [c_char; FLEN_ERRMSG] = [0; FLEN_ERRMSG];

--- a/src/getcolj.rs
+++ b/src/getcolj.rs
@@ -1,9 +1,14 @@
-/*  This file, getcolj.rs, contains routines that read data elements from   */
-/*  a FITS image or table, with long data type.                            */
-
-/*  The FITSIO software was written by William Pence at the High Energy    */
-/*  Astrophysic Science Archive Research Center (HEASARC) at the NASA      */
-/*  Goddard Space Flight Center.                                           */
+//! Routines that read data elements from a FITS image or table, with long
+//! datatype.
+//!
+//! The [`TLONG`] arm of the typed column I/O family. [`crate::getcol`]
+//! dispatches here when a caller asks for this datatype at run time; the
+//! write-side counterpart is [`crate::putcolj`].
+//!
+//! Ported from CFITSIO's `getcolj.c`, written by William Pence at the High
+//! Energy Astrophysics Science Archive Research Center (HEASARC), NASA Goddard
+//! Space Flight Center.
+#![warn(missing_docs)]
 
 use core::slice;
 use core::{cmp, mem};
@@ -23,7 +28,6 @@ use crate::{NullValue, fitsio2::*};
 use crate::{buffers::*, calculate_subsection_length};
 use crate::{int_snprintf, slice_to_str};
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of values from the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
 /// the FITS array is not the same as the array being read).
@@ -35,16 +39,27 @@ use crate::{int_snprintf, slice_to_str};
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to read (1 = 1st group)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `nulval`    — (I) value for undefined pixels
+/// * `array`     — (O) array of values that are returned
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgpvj(
-    fptr: *mut fitsfile, /* I - FITS file pointer                       */
-    group: c_long,       /* I - group to read (1 = 1st group)           */
-    firstelem: LONGLONG, /* I - first vector element to read (1 = 1st)  */
-    nelem: LONGLONG,     /* I - number of values to read                */
-    nulval: c_long,      /* I - value for undefined pixels              */
-    array: *mut c_long,  /* O - array of values that are returned       */
-    anynul: *mut c_int,  /* O - set to 1 if any values are null; else 0 */
-    status: *mut c_int,  /* IO - error status                           */
+    fptr: *mut fitsfile,
+    group: c_long,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    nulval: c_long,
+    array: *mut c_long,
+    anynul: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -58,7 +73,6 @@ pub unsafe extern "C" fn ffgpvj(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of values from the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
 /// the FITS array is not the same as the array being read).
@@ -70,15 +84,26 @@ pub unsafe extern "C" fn ffgpvj(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to read (1 = 1st group)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `nulval`    — (I) value for undefined pixels
+/// * `array`     — (O) array of values that are returned
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `status`    — (IO) error status
 pub fn ffgpvj_safe(
-    fptr: &mut fitsfile,        /* I - FITS file pointer                       */
-    group: c_long,              /* I - group to read (1 = 1st group)           */
-    firstelem: LONGLONG,        /* I - first vector element to read (1 = 1st)  */
-    nelem: LONGLONG,            /* I - number of values to read                */
-    nulval: c_long,             /* I - value for undefined pixels              */
-    array: &mut [c_long],       /* O - array of values that are returned       */
-    anynul: Option<&mut c_int>, /* O - set to 1 if any values are null; else 0 */
-    status: &mut c_int,         /* IO - error status                           */
+    fptr: &mut fitsfile,
+    group: c_long,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    nulval: c_long,
+    array: &mut [c_long],
+    anynul: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     let mut row: c_long = 0;
     let nullcheck = NullCheckType::SetPixel;
@@ -125,7 +150,6 @@ pub fn ffgpvj_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of values from the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
 /// the FITS array is not the same as the array being read).
@@ -137,16 +161,27 @@ pub fn ffgpvj_safe(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to read (1 = 1st group)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `array`     — (O) array of values that are returned
+/// * `nularray`  — (O) array of null pixel flags
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgpfj(
-    fptr: *mut fitsfile,   /* I - FITS file pointer                       */
-    group: c_long,         /* I - group to read (1 = 1st group)           */
-    firstelem: LONGLONG,   /* I - first vector element to read (1 = 1st)  */
-    nelem: LONGLONG,       /* I - number of values to read                */
-    array: *mut c_long,    /* O - array of values that are returned       */
-    nularray: *mut c_char, /* O - array of null pixel flags               */
-    anynul: *mut c_int,    /* O - set to 1 if any values are null; else 0 */
-    status: *mut c_int,    /* IO - error status                           */
+    fptr: *mut fitsfile,
+    group: c_long,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: *mut c_long,
+    nularray: *mut c_char,
+    anynul: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -163,7 +198,6 @@ pub unsafe extern "C" fn ffgpfj(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of values from the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
 /// the FITS array is not the same as the array being read).
@@ -175,15 +209,26 @@ pub unsafe extern "C" fn ffgpfj(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to read (1 = 1st group)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `array`     — (O) array of values that are returned
+/// * `nularray`  — (O) array of null pixel flags
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `status`    — (IO) error status
 pub fn ffgpfj_safe(
-    fptr: &mut fitsfile,        /* I - FITS file pointer                       */
-    group: c_long,              /* I - group to read (1 = 1st group)           */
-    firstelem: LONGLONG,        /* I - first vector element to read (1 = 1st)  */
-    nelem: LONGLONG,            /* I - number of values to read                */
-    array: &mut [c_long],       /* O - array of values that are returned       */
-    nularray: &mut [c_char],    /* O - array of null pixel flags               */
-    anynul: Option<&mut c_int>, /* O - set to 1 if any values are null; else 0 */
-    status: &mut c_int,         /* IO - error status                           */
+    fptr: &mut fitsfile,
+    group: c_long,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: &mut [c_long],
+    nularray: &mut [c_char],
+    anynul: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     let mut row = 0;
     let nullcheck = NullCheckType::SetNullArray;
@@ -226,23 +271,34 @@ pub fn ffgpfj_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an entire 2-D array of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of the
 /// FITS array is not the same as the array being read).  Any null
 /// values in the array will be set equal to the value of nulval, unless
 /// nulval = 0 in which case no null checking will be performed.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `group`  — (I) group to read (1 = 1st group)
+/// * `nulval` — set undefined pixels equal to this
+/// * `ncols`  — (I) number of pixels in each row of array
+/// * `naxis1` — (I) FITS image NAXIS1 value
+/// * `naxis2` — (I) FITS image NAXIS2 value
+/// * `array`  — (O) array to be filled and returned
+/// * `anynul` — (O) set to 1 if any values are null; else 0
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffg2dj(
-    fptr: *mut fitsfile, /* I - FITS file pointer                       */
-    group: c_long,       /* I - group to read (1 = 1st group)           */
-    nulval: c_long,      /* set undefined pixels equal to this          */
-    ncols: LONGLONG,     /* I - number of pixels in each row of array   */
-    naxis1: LONGLONG,    /* I - FITS image NAXIS1 value                 */
-    naxis2: LONGLONG,    /* I - FITS image NAXIS2 value                 */
-    array: *mut c_long,  /* O - array to be filled and returned         */
-    anynul: *mut c_int,  /* O - set to 1 if any values are null; else 0 */
-    status: *mut c_int,  /* IO - error status                           */
+    fptr: *mut fitsfile,
+    group: c_long,
+    nulval: c_long,
+    ncols: LONGLONG,
+    naxis1: LONGLONG,
+    naxis2: LONGLONG,
+    array: *mut c_long,
+    anynul: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -260,22 +316,33 @@ pub unsafe extern "C" fn ffg2dj(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an entire 2-D array of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of the
 /// FITS array is not the same as the array being read).  Any null
 /// values in the array will be set equal to the value of nulval, unless
 /// nulval = 0 in which case no null checking will be performed.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `group`  — (I) group to read (1 = 1st group)
+/// * `nulval` — set undefined pixels equal to this
+/// * `ncols`  — (I) number of pixels in each row of array
+/// * `naxis1` — (I) FITS image NAXIS1 value
+/// * `naxis2` — (I) FITS image NAXIS2 value
+/// * `array`  — (O) array to be filled and returned
+/// * `anynul` — (O) set to 1 if any values are null; else 0
+/// * `status` — (IO) error status
 pub fn ffg2dj_safe(
-    fptr: &mut fitsfile,        /* I - FITS file pointer                       */
-    group: c_long,              /* I - group to read (1 = 1st group)           */
-    nulval: c_long,             /* set undefined pixels equal to this     */
-    ncols: LONGLONG,            /* I - number of pixels in each row of array   */
-    naxis1: LONGLONG,           /* I - FITS image NAXIS1 value                 */
-    naxis2: LONGLONG,           /* I - FITS image NAXIS2 value                 */
-    array: &mut [c_long],       /* O - array to be filled and returned    */
-    anynul: Option<&mut c_int>, /* O - set to 1 if any values are null; else 0 */
-    status: &mut c_int,         /* IO - error status                           */
+    fptr: &mut fitsfile,
+    group: c_long,
+    nulval: c_long,
+    ncols: LONGLONG,
+    naxis1: LONGLONG,
+    naxis2: LONGLONG,
+    array: &mut [c_long],
+    anynul: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     /* call the 3D reading routine, with the 3rd dimension = 1 */
     ffg3dj_safe(
@@ -285,7 +352,6 @@ pub fn ffg2dj_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an entire 3-D array of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of the
 /// FITS array is not the same as the array being read).  Any null
@@ -296,19 +362,33 @@ pub fn ffg2dj_safe(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `group`  — (I) group to read (1 = 1st group)
+/// * `nulval` — set undefined pixels equal to this
+/// * `ncols`  — (I) number of pixels in each row of array
+/// * `nrows`  — (I) number of rows in each plane of array
+/// * `naxis1` — (I) FITS image NAXIS1 value
+/// * `naxis2` — (I) FITS image NAXIS2 value
+/// * `naxis3` — (I) FITS image NAXIS3 value
+/// * `array`  — (O) array to be filled and returned
+/// * `anynul` — (O) set to 1 if any values are null; else 0
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffg3dj(
-    fptr: *mut fitsfile, /* I - FITS file pointer                       */
-    group: c_long,       /* I - group to read (1 = 1st group)           */
-    nulval: c_long,      /* set undefined pixels equal to this          */
-    ncols: LONGLONG,     /* I - number of pixels in each row of array   */
-    nrows: LONGLONG,     /* I - number of rows in each plane of array   */
-    naxis1: LONGLONG,    /* I - FITS image NAXIS1 value                 */
-    naxis2: LONGLONG,    /* I - FITS image NAXIS2 value                 */
-    naxis3: LONGLONG,    /* I - FITS image NAXIS3 value                 */
-    array: *mut c_long,  /* O - array to be filled and returned         */
-    anynul: *mut c_int,  /* O - set to 1 if any values are null; else 0 */
-    status: *mut c_int,  /* IO - error status                           */
+    fptr: *mut fitsfile,
+    group: c_long,
+    nulval: c_long,
+    ncols: LONGLONG,
+    nrows: LONGLONG,
+    naxis1: LONGLONG,
+    naxis2: LONGLONG,
+    naxis3: LONGLONG,
+    array: *mut c_long,
+    anynul: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -324,7 +404,6 @@ pub unsafe extern "C" fn ffg3dj(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an entire 3-D array of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of the
 /// FITS array is not the same as the array being read).  Any null
@@ -335,18 +414,32 @@ pub unsafe extern "C" fn ffg3dj(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `group`  — (I) group to read (1 = 1st group)
+/// * `nulval` — set undefined pixels equal to this
+/// * `ncols`  — (I) number of pixels in each row of array
+/// * `nrows`  — (I) number of rows in each plane of array
+/// * `naxis1` — (I) FITS image NAXIS1 value
+/// * `naxis2` — (I) FITS image NAXIS2 value
+/// * `naxis3` — (I) FITS image NAXIS3 value
+/// * `array`  — (O) array to be filled and returned
+/// * `anynul` — (O) set to 1 if any values are null; else 0
+/// * `status` — (IO) error status
 pub fn ffg3dj_safe(
-    fptr: &mut fitsfile,            /* I - FITS file pointer                       */
-    group: c_long,                  /* I - group to read (1 = 1st group)           */
-    nulval: c_long,                 /* set undefined pixels equal to this          */
-    ncols: LONGLONG,                /* I - number of pixels in each row of array   */
-    nrows: LONGLONG,                /* I - number of rows in each plane of array   */
-    naxis1: LONGLONG,               /* I - FITS image NAXIS1 value                 */
-    naxis2: LONGLONG,               /* I - FITS image NAXIS2 value                 */
-    naxis3: LONGLONG,               /* I - FITS image NAXIS3 value                 */
-    array: &mut [c_long],           /* O - array to be filled and returned         */
-    mut anynul: Option<&mut c_int>, /* O - set to 1 if any values are null; else 0 */
-    status: &mut c_int,             /* IO - error status                           */
+    fptr: &mut fitsfile,
+    group: c_long,
+    nulval: c_long,
+    ncols: LONGLONG,
+    nrows: LONGLONG,
+    naxis1: LONGLONG,
+    naxis2: LONGLONG,
+    naxis3: LONGLONG,
+    array: &mut [c_long],
+    mut anynul: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     let mut tablerow = 0;
 
@@ -448,22 +541,35 @@ pub fn ffg3dj_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read a subsection of data values from an image or a table column.
 /// This routine is set up to handle a maximum of nine dimensions.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `colnum` — (I) number of the column to read (1 = 1st)
+/// * `naxis`  — (I) number of dimensions in the FITS array
+/// * `naxes`  — (I) size of each dimension
+/// * `blc`    — (I) 'bottom left corner' of the subsection
+/// * `trc`    — (I) 'top right corner' of the subsection
+/// * `inc`    — (I) increment to be applied in each dimension
+/// * `nulval` — (I) value to set undefined pixels
+/// * `array`  — (O) array to be filled and returned
+/// * `anynul` — (O) set to 1 if any values are null; else 0
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgsvj(
-    fptr: *mut fitsfile,  /* I - FITS file pointer                         */
-    colnum: c_int,        /* I - number of the column to read (1 = 1st)    */
-    naxis: c_int,         /* I - number of dimensions in the FITS array    */
-    naxes: *const c_long, /* I - size of each dimension                    */
-    blc: *const c_long,   /* I - 'bottom left corner' of the subsection    */
-    trc: *const c_long,   /* I - 'top right corner' of the subsection      */
-    inc: *const c_long,   /* I - increment to be applied in each dimension */
-    nulval: c_long,       /* I - value to set undefined pixels             */
-    array: *mut c_long,   /* O - array to be filled and returned           */
-    anynul: *mut c_int,   /* O - set to 1 if any values are null; else 0   */
-    status: *mut c_int,   /* IO - error status                             */
+    fptr: *mut fitsfile,
+    colnum: c_int,
+    naxis: c_int,
+    naxes: *const c_long,
+    blc: *const c_long,
+    trc: *const c_long,
+    inc: *const c_long,
+    nulval: c_long,
+    array: *mut c_long,
+    anynul: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -485,21 +591,34 @@ pub unsafe extern "C" fn ffgsvj(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read a subsection of data values from an image or a table column.
 /// This routine is set up to handle a maximum of nine dimensions.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `colnum` — (I) number of the column to read (1 = 1st)
+/// * `naxis`  — (I) number of dimensions in the FITS array
+/// * `naxes`  — (I) size of each dimension
+/// * `blc`    — (I) 'bottom left corner' of the subsection
+/// * `trc`    — (I) 'top right corner' of the subsection
+/// * `inc`    — (I) increment to be applied in each dimension
+/// * `nulval` — (I) value to set undefined pixels
+/// * `array`  — (O) array to be filled and returned
+/// * `anynul` — (O) set to 1 if any values are null; else 0
+/// * `status` — (IO) error status
 pub fn ffgsvj_safe(
-    fptr: &mut fitsfile,  /* I - FITS file pointer                         */
-    colnum: c_int,        /* I - number of the column to read (1 = 1st)    */
-    naxis: c_int,         /* I - number of dimensions in the FITS array    */
-    naxes: &[c_long],     /* I - size of each dimension                    */
-    blc: &[c_long],       /* I - 'bottom left corner' of the subsection    */
-    trc: &[c_long],       /* I - 'top right corner' of the subsection      */
-    inc: &[c_long],       /* I - increment to be applied in each dimension */
-    nulval: c_long,       /* I - value to set undefined pixels             */
-    array: &mut [c_long], /* O - array to be filled and returned           */
-    mut anynul: Option<&mut c_int>, /* O - set to 1 if any values are null; else 0   */
-    status: &mut c_int,   /* IO - error status                             */
+    fptr: &mut fitsfile,
+    colnum: c_int,
+    naxis: c_int,
+    naxes: &[c_long],
+    blc: &[c_long],
+    trc: &[c_long],
+    inc: &[c_long],
+    nulval: c_long,
+    array: &mut [c_long],
+    mut anynul: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     let mut rstr: c_long = 0;
     let mut rstp: c_long = 0;
@@ -702,22 +821,35 @@ pub fn ffgsvj_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read a subsection of data values from an image or a table column.
 /// This routine is set up to handle a maximum of nine dimensions.
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `colnum`  — (I) number of the column to read (1 = 1st)
+/// * `naxis`   — (I) number of dimensions in the FITS array
+/// * `naxes`   — (I) size of each dimension
+/// * `blc`     — (I) 'bottom left corner' of the subsection
+/// * `trc`     — (I) 'top right corner' of the subsection
+/// * `inc`     — (I) increment to be applied in each dimension
+/// * `array`   — (O) array to be filled and returned
+/// * `flagval` — (O) set to 1 if corresponding value is null
+/// * `anynul`  — (O) set to 1 if any values are null; else 0
+/// * `status`  — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgsfj(
-    fptr: *mut fitsfile,  /* I - FITS file pointer                         */
-    colnum: c_int,        /* I - number of the column to read (1 = 1st)    */
-    naxis: c_int,         /* I - number of dimensions in the FITS array    */
-    naxes: *const c_long, /* I - size of each dimension                    */
-    blc: *const c_long,   /* I - 'bottom left corner' of the subsection    */
-    trc: *const c_long,   /* I - 'top right corner' of the subsection      */
-    inc: *const c_long,   /* I - increment to be applied in each dimension */
-    array: *mut c_long,   /* O - array to be filled and returned           */
-    flagval: *mut c_char, /* O - set to 1 if corresponding value is null   */
-    anynul: *mut c_int,   /* O - set to 1 if any values are null; else 0   */
-    status: *mut c_int,   /* IO - error status                             */
+    fptr: *mut fitsfile,
+    colnum: c_int,
+    naxis: c_int,
+    naxes: *const c_long,
+    blc: *const c_long,
+    trc: *const c_long,
+    inc: *const c_long,
+    array: *mut c_long,
+    flagval: *mut c_char,
+    anynul: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -741,18 +873,31 @@ pub unsafe extern "C" fn ffgsfj(
     }
 }
 
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `colnum`  — (I) number of the column to read (1 = 1st)
+/// * `naxis`   — (I) number of dimensions in the FITS array
+/// * `naxes`   — (I) size of each dimension
+/// * `blc`     — (I) 'bottom left corner' of the subsection
+/// * `trc`     — (I) 'top right corner' of the subsection
+/// * `inc`     — (I) increment to be applied in each dimension
+/// * `array`   — (O) array to be filled and returned
+/// * `flagval` — (O) set to 1 if corresponding value is null
+/// * `anynul`  — (O) set to 1 if any values are null; else 0
+/// * `status`  — (IO) error status
 pub fn ffgsfj_safe(
-    fptr: &mut fitsfile,    /* I - FITS file pointer                         */
-    colnum: c_int,          /* I - number of the column to read (1 = 1st)    */
-    naxis: c_int,           /* I - number of dimensions in the FITS array    */
-    naxes: &[c_long],       /* I - size of each dimension                    */
-    blc: &[c_long],         /* I - 'bottom left corner' of the subsection    */
-    trc: &[c_long],         /* I - 'top right corner' of the subsection      */
-    inc: &[c_long],         /* I - increment to be applied in each dimension */
-    array: &mut [c_long],   /* O - array to be filled and returned           */
-    flagval: &mut [c_char], /* O - set to 1 if corresponding value is null   */
-    mut anynul: Option<&mut c_int>, /* O - set to 1 if any values are null; else 0   */
-    status: &mut c_int,     /* IO - error status                             */
+    fptr: &mut fitsfile,
+    colnum: c_int,
+    naxis: c_int,
+    naxes: &[c_long],
+    blc: &[c_long],
+    trc: &[c_long],
+    inc: &[c_long],
+    array: &mut [c_long],
+    flagval: &mut [c_char],
+    mut anynul: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     let mut rstr: c_long = 0;
     let mut rstp: c_long = 0;
@@ -937,7 +1082,6 @@ pub fn ffgsfj_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of group parameters from the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
 /// the FITS array is not the same as the array being read).
@@ -946,14 +1090,23 @@ pub fn ffgsfj_safe(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to read (1 = 1st group)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `array`     — (O) array of values that are returned
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffggpj(
-    fptr: *mut fitsfile, /* I - FITS file pointer                       */
-    group: c_long,       /* I - group to read (1 = 1st group)           */
-    firstelem: c_long,   /* I - first vector element to read (1 = 1st)  */
-    nelem: c_long,       /* I - number of values to read                */
-    array: *mut c_long,  /* O - array of values that are returned       */
-    status: *mut c_int,  /* IO - error status                           */
+    fptr: *mut fitsfile,
+    group: c_long,
+    firstelem: c_long,
+    nelem: c_long,
+    array: *mut c_long,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -965,7 +1118,6 @@ pub unsafe extern "C" fn ffggpj(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of group parameters from the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
 /// the FITS array is not the same as the array being read).
@@ -974,13 +1126,22 @@ pub unsafe extern "C" fn ffggpj(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to read (1 = 1st group)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `array`     — (O) array of values that are returned
+/// * `status`    — (IO) error status
 pub fn ffggpj_safe(
-    fptr: &mut fitsfile,  /* I - FITS file pointer                       */
-    group: c_long,        /* I - group to read (1 = 1st group)           */
-    firstelem: c_long,    /* I - first vector element to read (1 = 1st)  */
-    nelem: c_long,        /* I - number of values to read                */
-    array: &mut [c_long], /* O - array of values that are returned       */
-    status: &mut c_int,   /* IO - error status                           */
+    fptr: &mut fitsfile,
+    group: c_long,
+    firstelem: c_long,
+    nelem: c_long,
+    array: &mut [c_long],
+    status: &mut c_int,
 ) -> c_int {
     let mut dummy_nularray = vec![0; nelem as usize];
     let mut anynul = 0;
@@ -1004,24 +1165,35 @@ pub fn ffggpj_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of values from a column in the current FITS HDU. Automatic
 /// datatype conversion will be performed if the datatype of the column does not
 /// match the datatype of the array parameter. The output values will be scaled
 /// by the FITS TSCALn and TZEROn values if these values have been defined.
 /// Any undefined pixels will be set equal to the value of 'nulval' unless
 /// nulval = 0 in which case no checks for undefined pixels will be made.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to read (1 = 1st col)
+/// * `firstrow`  — (I) first row to read (1 = 1st row)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `nulval`    — (I) value for null pixels
+/// * `array`     — (O) array of values that are read
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgcvj(
-    fptr: *mut fitsfile, /* I - FITS file pointer                       */
-    colnum: c_int,       /* I - number of column to read (1 = 1st col)  */
-    firstrow: LONGLONG,  /* I - first row to read (1 = 1st row)         */
-    firstelem: LONGLONG, /* I - first vector element to read (1 = 1st)  */
-    nelem: LONGLONG,     /* I - number of values to read                */
-    nulval: c_long,      /* I - value for null pixels                   */
-    array: *mut c_long,  /* O - array of values that are read           */
-    anynul: *mut c_int,  /* O - set to 1 if any values are null; else 0 */
-    status: *mut c_int,  /* IO - error status                           */
+    fptr: *mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    nulval: c_long,
+    array: *mut c_long,
+    anynul: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -1037,23 +1209,34 @@ pub unsafe extern "C" fn ffgcvj(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of values from a column in the current FITS HDU. Automatic
 /// datatype conversion will be performed if the datatype of the column does not
 /// match the datatype of the array parameter. The output values will be scaled
 /// by the FITS TSCALn and TZEROn values if these values have been defined.
 /// Any undefined pixels will be set equal to the value of 'nulval' unless
 /// nulval = 0 in which case no checks for undefined pixels will be made.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to read (1 = 1st col)
+/// * `firstrow`  — (I) first row to read (1 = 1st row)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `nulval`    — (I) value for null pixels
+/// * `array`     — (O) array of values that are read
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `status`    — (IO) error status
 pub fn ffgcvj_safe(
-    fptr: &mut fitsfile,        /* I - FITS file pointer                       */
-    colnum: c_int,              /* I - number of column to read (1 = 1st col)  */
-    firstrow: LONGLONG,         /* I - first row to read (1 = 1st row)         */
-    firstelem: LONGLONG,        /* I - first vector element to read (1 = 1st)  */
-    nelem: LONGLONG,            /* I - number of values to read                */
-    nulval: c_long,             /* I - value for null pixels                   */
-    array: &mut [c_long],       /* O - array of values that are read           */
-    anynul: Option<&mut c_int>, /* O - set to 1 if any values are null; else 0 */
-    status: &mut c_int,         /* IO - error status                           */
+    fptr: &mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    nulval: c_long,
+    array: &mut [c_long],
+    anynul: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     let mut dummy_nularray = vec![0; nelem as usize];
 
@@ -1074,24 +1257,35 @@ pub fn ffgcvj_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of values from a column in the current FITS HDU. Automatic
 /// datatype conversion will be performed if the datatype of the column does not
 /// match the datatype of the array parameter. The output values will be scaled
 /// by the FITS TSCALn and TZEROn values if these values have been defined.
 /// Nularray will be set = 1 if the corresponding array pixel is undefined,
 /// otherwise nularray will = 0.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to read (1 = 1st col)
+/// * `firstrow`  — (I) first row to read (1 = 1st row)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `array`     — (O) array of values that are read
+/// * `nularray`  — (O) array of flags: 1 if null pixel; else 0
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgcfj(
-    fptr: *mut fitsfile,   /* I - FITS file pointer                       */
-    colnum: c_int,         /* I - number of column to read (1 = 1st col)  */
-    firstrow: LONGLONG,    /* I - first row to read (1 = 1st row)         */
-    firstelem: LONGLONG,   /* I - first vector element to read (1 = 1st)  */
-    nelem: LONGLONG,       /* I - number of values to read                */
-    array: *mut c_long,    /* O - array of values that are read           */
-    nularray: *mut c_char, /* O - array of flags: 1 if null pixel; else 0 */
-    anynul: *mut c_int,    /* O - set to 1 if any values are null; else 0 */
-    status: *mut c_int,    /* IO - error status                           */
+    fptr: *mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: *mut c_long,
+    nularray: *mut c_char,
+    anynul: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -1108,23 +1302,34 @@ pub unsafe extern "C" fn ffgcfj(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of values from a column in the current FITS HDU. Automatic
 /// datatype conversion will be performed if the datatype of the column does not
 /// match the datatype of the array parameter. The output values will be scaled
 /// by the FITS TSCALn and TZEROn values if these values have been defined.
 /// Nularray will be set = 1 if the corresponding array pixel is undefined,
 /// otherwise nularray will = 0.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to read (1 = 1st col)
+/// * `firstrow`  — (I) first row to read (1 = 1st row)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `array`     — (O) array of values that are read
+/// * `nularray`  — (O) array of flags: 1 if null pixel; else 0
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `status`    — (IO) error status
 pub fn ffgcfj_safe(
-    fptr: &mut fitsfile,        /* I - FITS file pointer                       */
-    colnum: c_int,              /* I - number of column to read (1 = 1st col)  */
-    firstrow: LONGLONG,         /* I - first row to read (1 = 1st row)         */
-    firstelem: LONGLONG,        /* I - first vector element to read (1 = 1st)  */
-    nelem: LONGLONG,            /* I - number of values to read                */
-    array: &mut [c_long],       /* O - array of values that are read           */
-    nularray: &mut [c_char],    /* O - array of flags: 1 if null pixel; else 0 */
-    anynul: Option<&mut c_int>, /* O - set to 1 if any values are null; else 0 */
-    status: &mut c_int,         /* IO - error status                           */
+    fptr: &mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: &mut [c_long],
+    nularray: &mut [c_char],
+    anynul: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     let dummy = 0;
 
@@ -1145,7 +1350,6 @@ pub fn ffgcfj_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of values from a column in the current FITS HDU.
 /// The column number may refer to a real column in an ASCII or binary table,
 /// or it may refer be a virtual column in a 1 or more grouped FITS primary
@@ -1159,21 +1363,35 @@ pub fn ffgcfj_safe(
 /// and will be scaled by the FITS TSCALn and TZEROn values if necessary.
 #[allow(clippy::if_same_then_else)]
 // C dispatch chain: distinct conditions deliberately share an action.
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to read (1 = 1st col)
+/// * `firstrow`  — (I) first row to read (1 = 1st row)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `elemincre` — (I) pixel increment; e.g., 2 = every other
+/// * `nultyp`    — (I) null value handling code:
+/// * `nulval`    — (I) value for null pixels if nultyp = 1
+/// * `array`     — (O) array of values that are read
+/// * `nularray`  — (O) array of flags = 1 if nultyp = 2
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `status`    — (IO) error status
 pub(crate) fn ffgclj(
-    fptr: &mut fitsfile,   /* I - FITS file pointer                       */
-    colnum: c_int,         /* I - number of column to read (1 = 1st col)  */
-    firstrow: LONGLONG,    /* I - first row to read (1 = 1st row)         */
-    firstelem: LONGLONG,   /* I - first vector element to read (1 = 1st)  */
-    nelem: LONGLONG,       /* I - number of values to read                */
-    elemincre: c_long,     /* I - pixel increment; e.g., 2 = every other  */
-    nultyp: NullCheckType, /* I - null value handling code:               */
+    fptr: &mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    elemincre: c_long,
+    nultyp: NullCheckType,
     /*     1: set undefined pixels = nulval        */
     /*     2: set nularray=1 for undefined pixels  */
-    nulval: c_long,                 /* I - value for null pixels if nultyp = 1     */
-    array: &mut [c_long],           /* O - array of values that are read           */
-    nularray: &mut [c_char],        /* O - array of flags = 1 if nultyp = 2        */
-    mut anynul: Option<&mut c_int>, /* O - set to 1 if any values are null; else 0 */
-    status: &mut c_int,             /* IO - error status                           */
+    nulval: c_long,
+    array: &mut [c_long],
+    nularray: &mut [c_char],
+    mut anynul: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     let mut scale: f64 = 0.0;
     let mut zero: f64 = 0.0;
@@ -1220,9 +1438,7 @@ pub(crate) fn ffgclj(
     if nultyp == NullCheckType::SetNullArray {
         nularray.fill(0); /* initialize nullarray */
     }
-    /*---------------------------------------------------*/
     /*  Check input and get parameters about the column: */
-    /*---------------------------------------------------*/
     if elemincre < 0 {
         readcheck = -1; /* don't do range checking in this case */
     }
@@ -1271,9 +1487,7 @@ pub(crate) fn ffgclj(
         }
     }
 
-    /*------------------------------------------------------------------*/
     /*  Decide whether to check for null values in the input FITS file: */
-    /*------------------------------------------------------------------*/
     nulcheck = nultyp; /* by default check for null values in the FITS file */
 
     if nultyp == NullCheckType::SetPixel && nulval == 0 {
@@ -1292,10 +1506,8 @@ pub(crate) fn ffgclj(
         nulcheck = NullCheckType::None;
     }
 
-    /*----------------------------------------------------------------------*/
     /*  If FITS column and output data array have same datatype, then we do */
     /*  not need to use a temporary buffer to store intermediate datatype.  */
-    /*----------------------------------------------------------------------*/
 
     convert = true;
 
@@ -1315,7 +1527,6 @@ pub(crate) fn ffgclj(
         }
     }
 
-    /*---------------------------------------------------------------------*/
     /*  Now read the pixels from the FITS column. If the column does not   */
     /*  have the same datatype as the output array, then we have to read   */
     /*  the raw values into a temporary buffer (of limited size).  In      */
@@ -1325,7 +1536,6 @@ pub(crate) fn ffgclj(
     /*  test for undefined values, (2) convert the datatype if necessary,  */
     /*  and (3) scale the values by the FITS TSCALn and TZEROn linear      */
     /*  scaling parameters.                                                */
-    /*---------------------------------------------------------------------*/
     remain = nelem; /* remaining number of values to read */
     next = 0; /* next element in array to be read   */
     rownum = 0; /* row number, relative to firstrow   */
@@ -1551,9 +1761,7 @@ pub(crate) fn ffgclj(
             }
         } /* End of switch block */
 
-        /*-------------------------*/
         /*  Check for fatal error  */
-        /*-------------------------*/
         if *status > 0 {
             /* test for error during previous read operation */
             dtemp = next as f64;
@@ -1579,9 +1787,7 @@ pub(crate) fn ffgclj(
             return *status;
         }
 
-        /*--------------------------------------------*/
         /*  increment the counters for the next loop  */
-        /*--------------------------------------------*/
         remain -= ntodo as LONGLONG;
         if remain > 0 {
             next += ntodo as usize;
@@ -1601,9 +1807,7 @@ pub(crate) fn ffgclj(
         }
     } /*  End of main while Loop  */
 
-    /*--------------------------------*/
     /*  check for numerical overflow  */
-    /*--------------------------------*/
     if *status == OVERFLOW_ERR {
         ffpmsg_str("Numerical overflow during type conversion while reading FITS data.");
         *status = NUM_OVERFLOW;
@@ -1612,7 +1816,6 @@ pub(crate) fn ffgclj(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output following reading of the input from a FITS file.
 /// Check for null values and do datatype conversion and scaling if required.
 /// The nullcheck code value determines how any null values in the input array
@@ -1624,20 +1827,34 @@ pub(crate) fn ffgclj(
 /// nullarray will be set to 1; the value of nullarray for non-null pixels
 /// will = 0.  The anynull parameter will be set = 1 if any of the returned
 /// pixels are null, otherwise anynull will be returned with a value = 0;
+///
+/// # Parameters
+///
+/// * `input`     — (I) array of values to be converted
+/// * `ntodo`     — (I) number of elements in the array
+/// * `scale`     — (I) FITS TSCALn or BSCALE value
+/// * `zero`      — (I) FITS TZEROn or BZERO value
+/// * `nullcheck` — (I) null checking code; 0 = don't check
+/// * `tnull`     — (I) value of FITS TNULLn keyword if any
+/// * `nullval`   — (I) set null pixels, if nullcheck = 1
+/// * `nullarray` — (I) bad pixel array, if nullcheck = 2
+/// * `anynull`   — (O) set to 1 if any pixels are null
+/// * `output`    — (O) array of converted pixels
+/// * `status`    — (IO) error status
 pub(crate) fn fffi1i4(
-    input: &[u8],             /* I - array of values to be converted     */
-    ntodo: c_long,            /* I - number of elements in the array     */
-    scale: f64,               /* I - FITS TSCALn or BSCALE value         */
-    zero: f64,                /* I - FITS TZEROn or BZERO  value         */
-    nullcheck: NullCheckType, /* I - null checking code; 0 = don't check */
+    input: &[u8],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    nullcheck: NullCheckType,
     /*     1:set null pixels = nullval         */
     /*     2: if null pixel, set nullarray = 1 */
-    tnull: u8,                   /* I - value of FITS TNULLn keyword if any */
-    nullval: c_long,             /* I - set null pixels, if nullcheck = 1   */
-    nullarray: &mut [c_char],    /* I - bad pixel array, if nullcheck = 2   */
-    anynull: Option<&mut c_int>, /* O - set to 1 if any pixels are null     */
-    output: &mut [c_long],       /* O - array of converted pixels           */
-    status: &mut c_int,          /* IO - error status                       */
+    tnull: u8,
+    nullval: c_long,
+    nullarray: &mut [c_char],
+    anynull: Option<&mut c_int>,
+    output: &mut [c_long],
+    status: &mut c_int,
 ) -> c_int {
     let mut dvalue: f64 = 0.0;
 
@@ -1711,7 +1928,6 @@ pub(crate) fn fffi1i4(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output following reading of the input from a FITS file.
 /// Check for null values and do datatype conversion and scaling if required.
 /// The nullcheck code value determines how any null values in the input array
@@ -1723,20 +1939,34 @@ pub(crate) fn fffi1i4(
 /// nullarray will be set to 1; the value of nullarray for non-null pixels
 /// will = 0.  The anynull parameter will be set = 1 if any of the returned
 /// pixels are null, otherwise anynull will be returned with a value = 0;
+///
+/// # Parameters
+///
+/// * `input`     — (I) array of values to be converted
+/// * `ntodo`     — (I) number of elements in the array
+/// * `scale`     — (I) FITS TSCALn or BSCALE value
+/// * `zero`      — (I) FITS TZEROn or BZERO value
+/// * `nullcheck` — (I) null checking code; 0 = don't check
+/// * `tnull`     — (I) value of FITS TNULLn keyword if any
+/// * `nullval`   — (I) set null pixels, if nullcheck = 1
+/// * `nullarray` — (I) bad pixel array, if nullcheck = 2
+/// * `anynull`   — (O) set to 1 if any pixels are null
+/// * `output`    — (O) array of converted pixels
+/// * `status`    — (IO) error status
 pub(crate) fn fffi2i4(
-    input: &[c_short],        /* I - array of values to be converted     */
-    ntodo: c_long,            /* I - number of elements in the array     */
-    scale: f64,               /* I - FITS TSCALn or BSCALE value         */
-    zero: f64,                /* I - FITS TZEROn or BZERO  value         */
-    nullcheck: NullCheckType, /* I - null checking code; 0 = don't check */
+    input: &[c_short],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    nullcheck: NullCheckType,
     /*     1:set null pixels = nullval         */
     /*     2: if null pixel, set nullarray = 1 */
-    tnull: c_short,              /* I - value of FITS TNULLn keyword if any */
-    nullval: c_long,             /* I - set null pixels, if nullcheck = 1   */
-    nullarray: &mut [c_char],    /* I - bad pixel array, if nullcheck = 2   */
-    anynull: Option<&mut c_int>, /* O - set to 1 if any pixels are null     */
-    output: &mut [c_long],       /* O - array of converted pixels           */
-    status: &mut c_int,          /* IO - error status                       */
+    tnull: c_short,
+    nullval: c_long,
+    nullarray: &mut [c_char],
+    anynull: Option<&mut c_int>,
+    output: &mut [c_long],
+    status: &mut c_int,
 ) -> c_int {
     let mut dvalue: f64 = 0.0;
 
@@ -1810,7 +2040,6 @@ pub(crate) fn fffi2i4(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output following reading of the input from a FITS file.
 /// Check for null values and do datatype conversion and scaling if required.
 /// The nullcheck code value determines how any null values in the input array
@@ -1822,20 +2051,34 @@ pub(crate) fn fffi2i4(
 /// nullarray will be set to 1; the value of nullarray for non-null pixels
 /// will = 0.  The anynull parameter will be set = 1 if any of the returned
 /// pixels are null, otherwise anynull will be returned with a value = 0;
+///
+/// # Parameters
+///
+/// * `input`     — (I) array of values to be converted
+/// * `ntodo`     — (I) number of elements in the array
+/// * `scale`     — (I) FITS TSCALn or BSCALE value
+/// * `zero`      — (I) FITS TZEROn or BZERO value
+/// * `nullcheck` — (I) null checking code; 0 = don't check
+/// * `tnull`     — (I) value of FITS TNULLn keyword if any
+/// * `nullval`   — (I) set null pixels, if nullcheck = 1
+/// * `nullarray` — (I) bad pixel array, if nullcheck = 2
+/// * `anynull`   — (O) set to 1 if any pixels are null
+/// * `output`    — (O) array of converted pixels
+/// * `status`    — (IO) error status
 pub(crate) fn fffi4i4(
-    input: &[INT32BIT],       /* I - array of values to be converted     */
-    ntodo: c_long,            /* I - number of elements in the array     */
-    scale: f64,               /* I - FITS TSCALn or BSCALE value         */
-    zero: f64,                /* I - FITS TZEROn or BZERO  value         */
-    nullcheck: NullCheckType, /* I - null checking code; 0 = don't check */
+    input: &[INT32BIT],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    nullcheck: NullCheckType,
     /*     1:set null pixels = nullval         */
     /*     2: if null pixel, set nullarray = 1 */
-    tnull: INT32BIT,             /* I - value of FITS TNULLn keyword if any */
-    nullval: c_long,             /* I - set null pixels, if nullcheck = 1   */
-    nullarray: &mut [c_char],    /* I - bad pixel array, if nullcheck = 2   */
-    anynull: Option<&mut c_int>, /* O - set to 1 if any pixels are null     */
-    output: &mut [c_long],       /* O - array of converted pixels           */
-    status: &mut c_int,          /* IO - error status                       */
+    tnull: INT32BIT,
+    nullval: c_long,
+    nullarray: &mut [c_char],
+    anynull: Option<&mut c_int>,
+    output: &mut [c_long],
+    status: &mut c_int,
 ) -> c_int {
     let mut dvalue: f64 = 0.0;
 
@@ -1909,7 +2152,6 @@ pub(crate) fn fffi4i4(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output following reading of the input from a FITS file.
 /// Check for null values and do datatype conversion and scaling if required.
 /// The nullcheck code value determines how any null values in the input array
@@ -1921,20 +2163,34 @@ pub(crate) fn fffi4i4(
 /// nullarray will be set to 1; the value of nullarray for non-null pixels
 /// will = 0.  The anynull parameter will be set = 1 if any of the returned
 /// pixels are null, otherwise anynull will be returned with a value = 0;
+///
+/// # Parameters
+///
+/// * `input`     — (I) array of values to be converted
+/// * `ntodo`     — (I) number of elements in the array
+/// * `scale`     — (I) FITS TSCALn or BSCALE value
+/// * `zero`      — (I) FITS TZEROn or BZERO value
+/// * `nullcheck` — (I) null checking code; 0 = don't check
+/// * `tnull`     — (I) value of FITS TNULLn keyword if any
+/// * `nullval`   — (I) set null pixels, if nullcheck = 1
+/// * `nullarray` — (I) bad pixel array, if nullcheck = 2
+/// * `anynull`   — (O) set to 1 if any pixels are null
+/// * `output`    — (O) array of converted pixels
+/// * `status`    — (IO) error status
 pub(crate) fn fffi8i4(
-    input: &[LONGLONG],       /* I - array of values to be converted     */
-    ntodo: c_long,            /* I - number of elements in the array     */
-    scale: f64,               /* I - FITS TSCALn or BSCALE value         */
-    zero: f64,                /* I - FITS TZEROn or BZERO  value         */
-    nullcheck: NullCheckType, /* I - null checking code; 0 = don't check */
+    input: &[LONGLONG],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    nullcheck: NullCheckType,
     /*     1:set null pixels = nullval         */
     /*     2: if null pixel, set nullarray = 1 */
-    tnull: LONGLONG,             /* I - value of FITS TNULLn keyword if any */
-    nullval: c_long,             /* I - set null pixels, if nullcheck = 1   */
-    nullarray: &mut [c_char],    /* I - bad pixel array, if nullcheck = 2   */
-    anynull: Option<&mut c_int>, /* O - set to 1 if any pixels are null     */
-    output: &mut [c_long],       /* O - array of converted pixels           */
-    status: &mut c_int,          /* IO - error status                       */
+    tnull: LONGLONG,
+    nullval: c_long,
+    nullarray: &mut [c_char],
+    anynull: Option<&mut c_int>,
+    output: &mut [c_long],
+    status: &mut c_int,
 ) -> c_int {
     let mut dvalue: f64 = 0.0;
     let mut ulltemp: ULONGLONG = 0;
@@ -2062,7 +2318,6 @@ pub(crate) fn fffi8i4(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output following reading of the input from a FITS file.
 /// Check for null values and do datatype conversion and scaling if required.
 /// The nullcheck code value determines how any null values in the input array
@@ -2074,19 +2329,32 @@ pub(crate) fn fffi8i4(
 /// nullarray will be set to 1; the value of nullarray for non-null pixels
 /// will = 0.  The anynull parameter will be set = 1 if any of the returned
 /// pixels are null, otherwise anynull will be returned with a value = 0;
+///
+/// # Parameters
+///
+/// * `input`     — (I) array of values to be converted
+/// * `ntodo`     — (I) number of elements in the array
+/// * `scale`     — (I) FITS TSCALn or BSCALE value
+/// * `zero`      — (I) FITS TZEROn or BZERO value
+/// * `nullcheck` — (I) null checking code; 0 = don't check
+/// * `nullval`   — (I) set null pixels, if nullcheck = 1
+/// * `nullarray` — (I) bad pixel array, if nullcheck = 2
+/// * `anynull`   — (O) set to 1 if any pixels are null
+/// * `output`    — (O) array of converted pixels
+/// * `status`    — (IO) error status
 pub(crate) fn fffr4i4(
-    input: &[f32],            /* I - array of values to be converted     */
-    ntodo: c_long,            /* I - number of elements in the array     */
-    scale: f64,               /* I - FITS TSCALn or BSCALE value         */
-    zero: f64,                /* I - FITS TZEROn or BZERO  value         */
-    nullcheck: NullCheckType, /* I - null checking code; 0 = don't check */
+    input: &[f32],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    nullcheck: NullCheckType,
     /*     1:set null pixels = nullval         */
     /*     2: if null pixel, set nullarray = 1 */
-    nullval: c_long,             /* I - set null pixels, if nullcheck = 1   */
-    nullarray: &mut [c_char],    /* I - bad pixel array, if nullcheck = 2   */
-    anynull: Option<&mut c_int>, /* O - set to 1 if any pixels are null     */
-    output: &mut [c_long],       /* O - array of converted pixels           */
-    status: &mut c_int,          /* IO - error status                       */
+    nullval: c_long,
+    nullarray: &mut [c_char],
+    anynull: Option<&mut c_int>,
+    output: &mut [c_long],
+    status: &mut c_int,
 ) -> c_int {
     let mut dvalue: f64 = 0.0;
     let mut sptr = 0;
@@ -2210,7 +2478,6 @@ pub(crate) fn fffr4i4(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output following reading of the input from a FITS file.
 /// Check for null values and do datatype conversion and scaling if required.
 /// The nullcheck code value determines how any null values in the input array
@@ -2222,19 +2489,32 @@ pub(crate) fn fffr4i4(
 /// nullarray will be set to 1; the value of nullarray for non-null pixels
 /// will = 0.  The anynull parameter will be set = 1 if any of the returned
 /// pixels are null, otherwise anynull will be returned with a value = 0;
+///
+/// # Parameters
+///
+/// * `input`     — (I) array of values to be converted
+/// * `ntodo`     — (I) number of elements in the array
+/// * `scale`     — (I) FITS TSCALn or BSCALE value
+/// * `zero`      — (I) FITS TZEROn or BZERO value
+/// * `nullcheck` — (I) null checking code; 0 = don't check
+/// * `nullval`   — (I) set null pixels, if nullcheck = 1
+/// * `nullarray` — (I) bad pixel array, if nullcheck = 2
+/// * `anynull`   — (O) set to 1 if any pixels are null
+/// * `output`    — (O) array of converted pixels
+/// * `status`    — (IO) error status
 pub(crate) fn fffr8i4(
-    input: &[f64],            /* I - array of values to be converted     */
-    ntodo: c_long,            /* I - number of elements in the array     */
-    scale: f64,               /* I - FITS TSCALn or BSCALE value         */
-    zero: f64,                /* I - FITS TZEROn or BZERO  value         */
-    nullcheck: NullCheckType, /* I - null checking code; 0 = don't check */
+    input: &[f64],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    nullcheck: NullCheckType,
     /*     1:set null pixels = nullval         */
     /*     2: if null pixel, set nullarray = 1 */
-    nullval: c_long,             /* I - set null pixels, if nullcheck = 1   */
-    nullarray: &mut [c_char],    /* I - bad pixel array, if nullcheck = 2   */
-    anynull: Option<&mut c_int>, /* O - set to 1 if any pixels are null     */
-    output: &mut [c_long],       /* O - array of converted pixels           */
-    status: &mut c_int,          /* IO - error status                       */
+    nullval: c_long,
+    nullarray: &mut [c_char],
+    anynull: Option<&mut c_int>,
+    output: &mut [c_long],
+    status: &mut c_int,
 ) -> c_int {
     let mut dvalue: f64 = 0.0;
     let mut sptr = 0;
@@ -2358,7 +2638,6 @@ pub(crate) fn fffr8i4(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output following reading of the input from a FITS file. Check
 /// for null values and do scaling if required. The nullcheck code value
 /// determines how any null values in the input array are treated. A null
@@ -2369,22 +2648,38 @@ pub(crate) fn fffr8i4(
 /// nullarray will be set to 1; the value of nullarray for non-null pixels
 /// will = 0.  The anynull parameter will be set = 1 if any of the returned
 /// pixels are null, otherwise anynull will be returned with a value = 0;
+///
+/// # Parameters
+///
+/// * `input`      — (I) array of values to be converted
+/// * `ntodo`      — (I) number of elements in the array
+/// * `scale`      — (I) FITS TSCALn or BSCALE value
+/// * `zero`       — (I) FITS TZEROn or BZERO value
+/// * `twidth`     — (I) width of each substring of chars
+/// * `implipower` — (I) power of 10 of implied decimal
+/// * `nullcheck`  — (I) null checking code; 0 = don't check
+/// * `snull`      — (I) value of FITS null string, if any
+/// * `nullval`    — (I) set null pixels, if nullcheck = 1
+/// * `nullarray`  — (I) bad pixel array, if nullcheck = 2
+/// * `anynull`    — (O) set to 1 if any pixels are null
+/// * `output`     — (O) array of converted pixels
+/// * `status`     — (IO) error status
 pub(crate) fn fffstri4(
-    input: &mut [c_char],     /* I - array of values to be converted     */
-    ntodo: c_long,            /* I - number of elements in the array     */
-    scale: f64,               /* I - FITS TSCALn or BSCALE value         */
-    zero: f64,                /* I - FITS TZEROn or BZERO  value         */
-    twidth: c_long,           /* I - width of each substring of chars    */
-    implipower: f64,          /* I - power of 10 of implied decimal      */
-    nullcheck: NullCheckType, /* I - null checking code; 0 = don't check */
+    input: &mut [c_char],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    twidth: c_long,
+    implipower: f64,
+    nullcheck: NullCheckType,
     /*     1:set null pixels = nullval         */
     /*     2: if null pixel, set nullarray = 1 */
-    snull: &[c_char],                /* I - value of FITS null string, if any   */
-    nullval: c_long,                 /* I - set null pixels, if nullcheck = 1   */
-    nullarray: &mut [c_char],        /* I - bad pixel array, if nullcheck = 2   */
-    mut anynull: Option<&mut c_int>, /* O - set to 1 if any pixels are null     */
-    output: &mut [c_long],           /* O - array of converted pixels           */
-    status: &mut c_int,              /* IO - error status                       */
+    snull: &[c_char],
+    nullval: c_long,
+    nullarray: &mut [c_char],
+    mut anynull: Option<&mut c_int>,
+    output: &mut [c_long],
+    status: &mut c_int,
 ) -> c_int {
     let mut nullen = 0;
 
@@ -2567,7 +2862,6 @@ pub(crate) fn fffstri4(
 /*      the following routines support the 'long long' data type            */
 /* ======================================================================== */
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of values from the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
 /// the FITS array is not the same as the array being read).
@@ -2579,16 +2873,27 @@ pub(crate) fn fffstri4(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to read (1 = 1st group)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `nulval`    — (I) value for undefined pixels
+/// * `array`     — (O) array of values that are returned
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgpvjj(
-    fptr: *mut fitsfile,  /* I - FITS file pointer                       */
-    group: c_long,        /* I - group to read (1 = 1st group)           */
-    firstelem: LONGLONG,  /* I - first vector element to read (1 = 1st)  */
-    nelem: LONGLONG,      /* I - number of values to read                */
-    nulval: LONGLONG,     /* I - value for undefined pixels              */
-    array: *mut LONGLONG, /* O - array of values that are returned       */
-    anynul: *mut c_int,   /* O - set to 1 if any values are null; else 0 */
-    status: *mut c_int,   /* IO - error status                           */
+    fptr: *mut fitsfile,
+    group: c_long,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    nulval: LONGLONG,
+    array: *mut LONGLONG,
+    anynul: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -2602,7 +2907,6 @@ pub unsafe extern "C" fn ffgpvjj(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of values from the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
 /// the FITS array is not the same as the array being read).
@@ -2614,15 +2918,26 @@ pub unsafe extern "C" fn ffgpvjj(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to read (1 = 1st group)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `nulval`    — (I) value for undefined pixels
+/// * `array`     — (O) array of values that are returned
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `status`    — (IO) error status
 pub fn ffgpvjj_safe(
-    fptr: &mut fitsfile,        /* I - FITS file pointer                       */
-    group: c_long,              /* I - group to read (1 = 1st group)           */
-    firstelem: LONGLONG,        /* I - first vector element to read (1 = 1st)  */
-    nelem: LONGLONG,            /* I - number of values to read                */
-    nulval: LONGLONG,           /* I - value for undefined pixels              */
-    array: &mut [LONGLONG],     /* O - array of values that are returned       */
-    anynul: Option<&mut c_int>, /* O - set to 1 if any values are null; else 0 */
-    status: &mut c_int,         /* IO - error status                           */
+    fptr: &mut fitsfile,
+    group: c_long,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    nulval: LONGLONG,
+    array: &mut [LONGLONG],
+    anynul: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     let mut row = 0;
     let nullcheck = NullCheckType::SetPixel;
@@ -2669,7 +2984,6 @@ pub fn ffgpvjj_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of values from the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
 /// the FITS array is not the same as the array being read).
@@ -2681,16 +2995,27 @@ pub fn ffgpvjj_safe(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to read (1 = 1st group)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `array`     — (O) array of values that are returned
+/// * `nularray`  — (O) array of null pixel flags
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgpfjj(
-    fptr: *mut fitsfile,   /* I - FITS file pointer                       */
-    group: c_long,         /* I - group to read (1 = 1st group)           */
-    firstelem: LONGLONG,   /* I - first vector element to read (1 = 1st)  */
-    nelem: LONGLONG,       /* I - number of values to read                */
-    array: *mut LONGLONG,  /* O - array of values that are returned       */
-    nularray: *mut c_char, /* O - array of null pixel flags               */
-    anynul: *mut c_int,    /* O - set to 1 if any values are null; else 0 */
-    status: *mut c_int,    /* IO - error status                           */
+    fptr: *mut fitsfile,
+    group: c_long,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: *mut LONGLONG,
+    nularray: *mut c_char,
+    anynul: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -2707,7 +3032,6 @@ pub unsafe extern "C" fn ffgpfjj(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of values from the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
 /// the FITS array is not the same as the array being read).
@@ -2719,15 +3043,26 @@ pub unsafe extern "C" fn ffgpfjj(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to read (1 = 1st group)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `array`     — (O) array of values that are returned
+/// * `nularray`  — (O) array of null pixel flags
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `status`    — (IO) error status
 pub fn ffgpfjj_safe(
-    fptr: &mut fitsfile,        /* I - FITS file pointer                       */
-    group: c_long,              /* I - group to read (1 = 1st group)           */
-    firstelem: LONGLONG,        /* I - first vector element to read (1 = 1st)  */
-    nelem: LONGLONG,            /* I - number of values to read                */
-    array: &mut [LONGLONG],     /* O - array of values that are returned       */
-    nularray: &mut [c_char],    /* O - array of null pixel flags               */
-    anynul: Option<&mut c_int>, /* O - set to 1 if any values are null; else 0 */
-    status: &mut c_int,         /* IO - error status                           */
+    fptr: &mut fitsfile,
+    group: c_long,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: &mut [LONGLONG],
+    nularray: &mut [c_char],
+    anynul: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     let mut row = 0;
     let nullcheck = NullCheckType::SetNullArray;
@@ -2771,23 +3106,34 @@ pub fn ffgpfjj_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an entire 2-D array of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of the
 /// FITS array is not the same as the array being read).  Any null
 /// values in the array will be set equal to the value of nulval, unless
 /// nulval = 0 in which case no null checking will be performed.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `group`  — (I) group to read (1 = 1st group)
+/// * `nulval` — set undefined pixels equal to this
+/// * `ncols`  — (I) number of pixels in each row of array
+/// * `naxis1` — (I) FITS image NAXIS1 value
+/// * `naxis2` — (I) FITS image NAXIS2 value
+/// * `array`  — (O) array to be filled and returned
+/// * `anynul` — (O) set to 1 if any values are null; else 0
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffg2djj(
-    fptr: *mut fitsfile,  /* I - FITS file pointer                       */
-    group: c_long,        /* I - group to read (1 = 1st group)           */
-    nulval: LONGLONG,     /* set undefined pixels equal to this          */
-    ncols: LONGLONG,      /* I - number of pixels in each row of array   */
-    naxis1: LONGLONG,     /* I - FITS image NAXIS1 value                 */
-    naxis2: LONGLONG,     /* I - FITS image NAXIS2 value                 */
-    array: *mut LONGLONG, /* O - array to be filled and returned         */
-    anynul: *mut c_int,   /* O - set to 1 if any values are null; else 0 */
-    status: *mut c_int,   /* IO - error status                           */
+    fptr: *mut fitsfile,
+    group: c_long,
+    nulval: LONGLONG,
+    ncols: LONGLONG,
+    naxis1: LONGLONG,
+    naxis2: LONGLONG,
+    array: *mut LONGLONG,
+    anynul: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -2803,22 +3149,33 @@ pub unsafe extern "C" fn ffg2djj(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an entire 2-D array of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of the
 /// FITS array is not the same as the array being read).  Any null
 /// values in the array will be set equal to the value of nulval, unless
 /// nulval = 0 in which case no null checking will be performed.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `group`  — (I) group to read (1 = 1st group)
+/// * `nulval` — set undefined pixels equal to this
+/// * `ncols`  — (I) number of pixels in each row of array
+/// * `naxis1` — (I) FITS image NAXIS1 value
+/// * `naxis2` — (I) FITS image NAXIS2 value
+/// * `array`  — (O) array to be filled and returned
+/// * `anynul` — (O) set to 1 if any values are null; else 0
+/// * `status` — (IO) error status
 pub fn ffg2djj_safe(
-    fptr: &mut fitsfile,        /* I - FITS file pointer                       */
-    group: c_long,              /* I - group to read (1 = 1st group)           */
-    nulval: LONGLONG,           /* set undefined pixels equal to this     */
-    ncols: LONGLONG,            /* I - number of pixels in each row of array   */
-    naxis1: LONGLONG,           /* I - FITS image NAXIS1 value                 */
-    naxis2: LONGLONG,           /* I - FITS image NAXIS2 value                 */
-    array: &mut [LONGLONG],     /* O - array to be filled and returned    */
-    anynul: Option<&mut c_int>, /* O - set to 1 if any values are null; else 0 */
-    status: &mut c_int,         /* IO - error status                           */
+    fptr: &mut fitsfile,
+    group: c_long,
+    nulval: LONGLONG,
+    ncols: LONGLONG,
+    naxis1: LONGLONG,
+    naxis2: LONGLONG,
+    array: &mut [LONGLONG],
+    anynul: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     /* call the 3D reading routine, with the 3rd dimension = 1 */
     ffg3djj_safe(
@@ -2828,7 +3185,6 @@ pub fn ffg2djj_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an entire 3-D array of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of the
 /// FITS array is not the same as the array being read).  Any null
@@ -2839,19 +3195,33 @@ pub fn ffg2djj_safe(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `group`  — (I) group to read (1 = 1st group)
+/// * `nulval` — set undefined pixels equal to this
+/// * `ncols`  — (I) number of pixels in each row of array
+/// * `nrows`  — (I) number of rows in each plane of array
+/// * `naxis1` — (I) FITS image NAXIS1 value
+/// * `naxis2` — (I) FITS image NAXIS2 value
+/// * `naxis3` — (I) FITS image NAXIS3 value
+/// * `array`  — (O) array to be filled and returned
+/// * `anynul` — (O) set to 1 if any values are null; else 0
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffg3djj(
-    fptr: *mut fitsfile,  /* I - FITS file pointer                       */
-    group: c_long,        /* I - group to read (1 = 1st group)           */
-    nulval: LONGLONG,     /* set undefined pixels equal to this          */
-    ncols: LONGLONG,      /* I - number of pixels in each row of array   */
-    nrows: LONGLONG,      /* I - number of rows in each plane of array   */
-    naxis1: LONGLONG,     /* I - FITS image NAXIS1 value                 */
-    naxis2: LONGLONG,     /* I - FITS image NAXIS2 value                 */
-    naxis3: LONGLONG,     /* I - FITS image NAXIS3 value                 */
-    array: *mut LONGLONG, /* O - array to be filled and returned         */
-    anynul: *mut c_int,   /* O - set to 1 if any values are null; else 0 */
-    status: *mut c_int,   /* IO - error status                           */
+    fptr: *mut fitsfile,
+    group: c_long,
+    nulval: LONGLONG,
+    ncols: LONGLONG,
+    nrows: LONGLONG,
+    naxis1: LONGLONG,
+    naxis2: LONGLONG,
+    naxis3: LONGLONG,
+    array: *mut LONGLONG,
+    anynul: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -2867,7 +3237,6 @@ pub unsafe extern "C" fn ffg3djj(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an entire 3-D array of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of the
 /// FITS array is not the same as the array being read).  Any null
@@ -2878,18 +3247,32 @@ pub unsafe extern "C" fn ffg3djj(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `group`  — (I) group to read (1 = 1st group)
+/// * `nulval` — set undefined pixels equal to this
+/// * `ncols`  — (I) number of pixels in each row of array
+/// * `nrows`  — (I) number of rows in each plane of array
+/// * `naxis1` — (I) FITS image NAXIS1 value
+/// * `naxis2` — (I) FITS image NAXIS2 value
+/// * `naxis3` — (I) FITS image NAXIS3 value
+/// * `array`  — (O) array to be filled and returned
+/// * `anynul` — (O) set to 1 if any values are null; else 0
+/// * `status` — (IO) error status
 pub fn ffg3djj_safe(
-    fptr: &mut fitsfile,            /* I - FITS file pointer                       */
-    group: c_long,                  /* I - group to read (1 = 1st group)           */
-    nulval: LONGLONG,               /* set undefined pixels equal to this          */
-    ncols: LONGLONG,                /* I - number of pixels in each row of array   */
-    nrows: LONGLONG,                /* I - number of rows in each plane of array   */
-    naxis1: LONGLONG,               /* I - FITS image NAXIS1 value                 */
-    naxis2: LONGLONG,               /* I - FITS image NAXIS2 value                 */
-    naxis3: LONGLONG,               /* I - FITS image NAXIS3 value                 */
-    array: &mut [LONGLONG],         /* O - array to be filled and returned         */
-    mut anynul: Option<&mut c_int>, /* O - set to 1 if any values are null; else 0 */
-    status: &mut c_int,             /* IO - error status                           */
+    fptr: &mut fitsfile,
+    group: c_long,
+    nulval: LONGLONG,
+    ncols: LONGLONG,
+    nrows: LONGLONG,
+    naxis1: LONGLONG,
+    naxis2: LONGLONG,
+    naxis3: LONGLONG,
+    array: &mut [LONGLONG],
+    mut anynul: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     let mut tablerow: c_long = 0;
     let nullcheck = NullCheckType::SetPixel;
@@ -2991,22 +3374,35 @@ pub fn ffg3djj_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read a subsection of data values from an image or a table column.
 /// This routine is set up to handle a maximum of nine dimensions.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `colnum` — (I) number of the column to read (1 = 1st)
+/// * `naxis`  — (I) number of dimensions in the FITS array
+/// * `naxes`  — (I) size of each dimension
+/// * `blc`    — (I) 'bottom left corner' of the subsection
+/// * `trc`    — (I) 'top right corner' of the subsection
+/// * `inc`    — (I) increment to be applied in each dimension
+/// * `nulval` — (I) value to set undefined pixels
+/// * `array`  — (O) array to be filled and returned
+/// * `anynul` — (O) set to 1 if any values are null; else 0
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgsvjj(
-    fptr: *mut fitsfile,  /* I - FITS file pointer                         */
-    colnum: c_int,        /* I - number of the column to read (1 = 1st)    */
-    naxis: c_int,         /* I - number of dimensions in the FITS array    */
-    naxes: *const c_long, /* I - size of each dimension                    */
-    blc: *const c_long,   /* I - 'bottom left corner' of the subsection    */
-    trc: *const c_long,   /* I - 'top right corner' of the subsection      */
-    inc: *const c_long,   /* I - increment to be applied in each dimension */
-    nulval: LONGLONG,     /* I - value to set undefined pixels             */
-    array: *mut LONGLONG, /* O - array to be filled and returned           */
-    anynul: *mut c_int,   /* O - set to 1 if any values are null; else 0   */
-    status: *mut c_int,   /* IO - error status                             */
+    fptr: *mut fitsfile,
+    colnum: c_int,
+    naxis: c_int,
+    naxes: *const c_long,
+    blc: *const c_long,
+    trc: *const c_long,
+    inc: *const c_long,
+    nulval: LONGLONG,
+    array: *mut LONGLONG,
+    anynul: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -3029,21 +3425,34 @@ pub unsafe extern "C" fn ffgsvjj(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read a subsection of data values from an image or a table column.
 /// This routine is set up to handle a maximum of nine dimensions.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `colnum` — (I) number of the column to read (1 = 1st)
+/// * `naxis`  — (I) number of dimensions in the FITS array
+/// * `naxes`  — (I) size of each dimension
+/// * `blc`    — (I) 'bottom left corner' of the subsection
+/// * `trc`    — (I) 'top right corner' of the subsection
+/// * `inc`    — (I) increment to be applied in each dimension
+/// * `nulval` — (I) value to set undefined pixels
+/// * `array`  — (O) array to be filled and returned
+/// * `anynul` — (O) set to 1 if any values are null; else 0
+/// * `status` — (IO) error status
 pub fn ffgsvjj_safe(
-    fptr: &mut fitsfile,    /* I - FITS file pointer                         */
-    colnum: c_int,          /* I - number of the column to read (1 = 1st)    */
-    naxis: c_int,           /* I - number of dimensions in the FITS array    */
-    naxes: &[c_long],       /* I - size of each dimension                    */
-    blc: &[c_long],         /* I - 'bottom left corner' of the subsection    */
-    trc: &[c_long],         /* I - 'top right corner' of the subsection      */
-    inc: &[c_long],         /* I - increment to be applied in each dimension */
-    nulval: LONGLONG,       /* I - value to set undefined pixels             */
-    array: &mut [LONGLONG], /* O - array to be filled and returned           */
-    mut anynul: Option<&mut c_int>, /* O - set to 1 if any values are null; else 0   */
-    status: &mut c_int,     /* IO - error status                             */
+    fptr: &mut fitsfile,
+    colnum: c_int,
+    naxis: c_int,
+    naxes: &[c_long],
+    blc: &[c_long],
+    trc: &[c_long],
+    inc: &[c_long],
+    nulval: LONGLONG,
+    array: &mut [LONGLONG],
+    mut anynul: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     let mut rstr: c_long = 0;
     let mut rstp: c_long = 0;
@@ -3249,22 +3658,35 @@ pub fn ffgsvjj_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read a subsection of data values from an image or a table column.
 /// This routine is set up to handle a maximum of nine dimensions.
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `colnum`  — (I) number of the column to read (1 = 1st)
+/// * `naxis`   — (I) number of dimensions in the FITS array
+/// * `naxes`   — (I) size of each dimension
+/// * `blc`     — (I) 'bottom left corner' of the subsection
+/// * `trc`     — (I) 'top right corner' of the subsection
+/// * `inc`     — (I) increment to be applied in each dimension
+/// * `array`   — (O) array to be filled and returned
+/// * `flagval` — (O) set to 1 if corresponding value is null
+/// * `anynul`  — (O) set to 1 if any values are null; else 0
+/// * `status`  — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgsfjj(
-    fptr: *mut fitsfile,  /* I - FITS file pointer                         */
-    colnum: c_int,        /* I - number of the column to read (1 = 1st)    */
-    naxis: c_int,         /* I - number of dimensions in the FITS array    */
-    naxes: *const c_long, /* I - size of each dimension                    */
-    blc: *const c_long,   /* I - 'bottom left corner' of the subsection    */
-    trc: *const c_long,   /* I - 'top right corner' of the subsection      */
-    inc: *const c_long,   /* I - increment to be applied in each dimension */
-    array: *mut LONGLONG, /* O - array to be filled and returned           */
-    flagval: *mut c_char, /* O - set to 1 if corresponding value is null   */
-    anynul: *mut c_int,   /* O - set to 1 if any values are null; else 0   */
-    status: *mut c_int,   /* IO - error status                             */
+    fptr: *mut fitsfile,
+    colnum: c_int,
+    naxis: c_int,
+    naxes: *const c_long,
+    blc: *const c_long,
+    trc: *const c_long,
+    inc: *const c_long,
+    array: *mut LONGLONG,
+    flagval: *mut c_char,
+    anynul: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -3286,21 +3708,34 @@ pub unsafe extern "C" fn ffgsfjj(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read a subsection of data values from an image or a table column.
 /// This routine is set up to handle a maximum of nine dimensions.
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `colnum`  — (I) number of the column to read (1 = 1st)
+/// * `naxis`   — (I) number of dimensions in the FITS array
+/// * `naxes`   — (I) size of each dimension
+/// * `blc`     — (I) 'bottom left corner' of the subsection
+/// * `trc`     — (I) 'top right corner' of the subsection
+/// * `inc`     — (I) increment to be applied in each dimension
+/// * `array`   — (O) array to be filled and returned
+/// * `flagval` — (O) set to 1 if corresponding value is null
+/// * `anynul`  — (O) set to 1 if any values are null; else 0
+/// * `status`  — (IO) error status
 pub fn ffgsfjj_safe(
-    fptr: &mut fitsfile,    /* I - FITS file pointer                         */
-    colnum: c_int,          /* I - number of the column to read (1 = 1st)    */
-    naxis: c_int,           /* I - number of dimensions in the FITS array    */
-    naxes: &[c_long],       /* I - size of each dimension                    */
-    blc: &[c_long],         /* I - 'bottom left corner' of the subsection    */
-    trc: &[c_long],         /* I - 'top right corner' of the subsection      */
-    inc: &[c_long],         /* I - increment to be applied in each dimension */
-    array: &mut [LONGLONG], /* O - array to be filled and returned           */
-    flagval: &mut [c_char], /* O - set to 1 if corresponding value is null   */
-    mut anynul: Option<&mut c_int>, /* O - set to 1 if any values are null; else 0   */
-    status: &mut c_int,     /* IO - error status                             */
+    fptr: &mut fitsfile,
+    colnum: c_int,
+    naxis: c_int,
+    naxes: &[c_long],
+    blc: &[c_long],
+    trc: &[c_long],
+    inc: &[c_long],
+    array: &mut [LONGLONG],
+    flagval: &mut [c_char],
+    mut anynul: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     let mut rstr: c_long = 0;
     let mut rstp: c_long = 0;
@@ -3488,7 +3923,6 @@ pub fn ffgsfjj_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of group parameters from the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
 /// the FITS array is not the same as the array being read).
@@ -3497,14 +3931,23 @@ pub fn ffgsfjj_safe(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to read (1 = 1st group)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `array`     — (O) array of values that are returned
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffggpjj(
-    fptr: *mut fitsfile,  /* I - FITS file pointer                       */
-    group: c_long,        /* I - group to read (1 = 1st group)           */
-    firstelem: c_long,    /* I - first vector element to read (1 = 1st)  */
-    nelem: c_long,        /* I - number of values to read                */
-    array: *mut LONGLONG, /* O - array of values that are returned       */
-    status: *mut c_int,   /* IO - error status                           */
+    fptr: *mut fitsfile,
+    group: c_long,
+    firstelem: c_long,
+    nelem: c_long,
+    array: *mut LONGLONG,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -3516,7 +3959,6 @@ pub unsafe extern "C" fn ffggpjj(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of group parameters from the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
 /// the FITS array is not the same as the array being read).
@@ -3525,13 +3967,22 @@ pub unsafe extern "C" fn ffggpjj(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to read (1 = 1st group)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `array`     — (O) array of values that are returned
+/// * `status`    — (IO) error status
 pub fn ffggpjj_safe(
-    fptr: &mut fitsfile,    /* I - FITS file pointer                       */
-    group: c_long,          /* I - group to read (1 = 1st group)           */
-    firstelem: c_long,      /* I - first vector element to read (1 = 1st)  */
-    nelem: c_long,          /* I - number of values to read                */
-    array: &mut [LONGLONG], /* O - array of values that are returned       */
-    status: &mut c_int,     /* IO - error status                           */
+    fptr: &mut fitsfile,
+    group: c_long,
+    firstelem: c_long,
+    nelem: c_long,
+    array: &mut [LONGLONG],
+    status: &mut c_int,
 ) -> c_int {
     let mut dummy_nularray = vec![0; nelem as usize];
     let mut idummy = 0;
@@ -3556,24 +4007,35 @@ pub fn ffggpjj_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of values from a column in the current FITS HDU. Automatic
 /// datatype conversion will be performed if the datatype of the column does not
 /// match the datatype of the array parameter. The output values will be scaled
 /// by the FITS TSCALn and TZEROn values if these values have been defined.
 /// Any undefined pixels will be set equal to the value of 'nulval' unless
 /// nulval = 0 in which case no checks for undefined pixels will be made.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to read (1 = 1st col)
+/// * `firstrow`  — (I) first row to read (1 = 1st row)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `nulval`    — (I) value for null pixels
+/// * `array`     — (O) array of values that are read
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgcvjj(
-    fptr: *mut fitsfile,  /* I - FITS file pointer                       */
-    colnum: c_int,        /* I - number of column to read (1 = 1st col)  */
-    firstrow: LONGLONG,   /* I - first row to read (1 = 1st row)         */
-    firstelem: LONGLONG,  /* I - first vector element to read (1 = 1st)  */
-    nelem: LONGLONG,      /* I - number of values to read                */
-    nulval: LONGLONG,     /* I - value for null pixels                   */
-    array: *mut LONGLONG, /* O - array of values that are read           */
-    anynul: *mut c_int,   /* O - set to 1 if any values are null; else 0 */
-    status: *mut c_int,   /* IO - error status                           */
+    fptr: *mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    nulval: LONGLONG,
+    array: *mut LONGLONG,
+    anynul: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -3597,23 +4059,34 @@ pub unsafe extern "C" fn ffgcvjj(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of values from a column in the current FITS HDU. Automatic
 /// datatype conversion will be performed if the datatype of the column does not
 /// match the datatype of the array parameter. The output values will be scaled
 /// by the FITS TSCALn and TZEROn values if these values have been defined.
 /// Any undefined pixels will be set equal to the value of 'nulval' unless
 /// nulval = 0 in which case no checks for undefined pixels will be made.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to read (1 = 1st col)
+/// * `firstrow`  — (I) first row to read (1 = 1st row)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `nulval`    — (I) value for null pixels
+/// * `array`     — (O) array of values that are read
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `status`    — (IO) error status
 pub fn ffgcvjj_safe(
-    fptr: &mut fitsfile,        /* I - FITS file pointer                       */
-    colnum: c_int,              /* I - number of column to read (1 = 1st col)  */
-    firstrow: LONGLONG,         /* I - first row to read (1 = 1st row)         */
-    firstelem: LONGLONG,        /* I - first vector element to read (1 = 1st)  */
-    nelem: LONGLONG,            /* I - number of values to read                */
-    nulval: LONGLONG,           /* I - value for null pixels                   */
-    array: &mut [LONGLONG],     /* O - array of values that are read           */
-    anynul: Option<&mut c_int>, /* O - set to 1 if any values are null; else 0 */
-    status: &mut c_int,         /* IO - error status                           */
+    fptr: &mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    nulval: LONGLONG,
+    array: &mut [LONGLONG],
+    anynul: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     let mut dummy_nularray = vec![0; (nelem) as usize];
 
@@ -3634,24 +4107,35 @@ pub fn ffgcvjj_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of values from a column in the current FITS HDU. Automatic
 /// datatype conversion will be performed if the datatype of the column does not
 /// match the datatype of the array parameter. The output values will be scaled
 /// by the FITS TSCALn and TZEROn values if these values have been defined.
 /// Nularray will be set = 1 if the corresponding array pixel is undefined,
 /// otherwise nularray will = 0.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to read (1 = 1st col)
+/// * `firstrow`  — (I) first row to read (1 = 1st row)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `array`     — (O) array of values that are read
+/// * `nularray`  — (O) array of flags: 1 if null pixel; else 0
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgcfjj(
-    fptr: *mut fitsfile,   /* I - FITS file pointer                       */
-    colnum: c_int,         /* I - number of column to read (1 = 1st col)  */
-    firstrow: LONGLONG,    /* I - first row to read (1 = 1st row)         */
-    firstelem: LONGLONG,   /* I - first vector element to read (1 = 1st)  */
-    nelem: LONGLONG,       /* I - number of values to read                */
-    array: *mut LONGLONG,  /* O - array of values that are read           */
-    nularray: *mut c_char, /* O - array of flags: 1 if null pixel; else 0 */
-    anynul: *mut c_int,    /* O - set to 1 if any values are null; else 0 */
-    status: *mut c_int,    /* IO - error status                           */
+    fptr: *mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: *mut LONGLONG,
+    nularray: *mut c_char,
+    anynul: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -3676,23 +4160,34 @@ pub unsafe extern "C" fn ffgcfjj(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of values from a column in the current FITS HDU. Automatic
 /// datatype conversion will be performed if the datatype of the column does not
 /// match the datatype of the array parameter. The output values will be scaled
 /// by the FITS TSCALn and TZEROn values if these values have been defined.
 /// Nularray will be set = 1 if the corresponding array pixel is undefined,
 /// otherwise nularray will = 0.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to read (1 = 1st col)
+/// * `firstrow`  — (I) first row to read (1 = 1st row)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `array`     — (O) array of values that are read
+/// * `nularray`  — (O) array of flags: 1 if null pixel; else 0
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `status`    — (IO) error status
 pub fn ffgcfjj_safe(
-    fptr: &mut fitsfile,        /* I - FITS file pointer                       */
-    colnum: c_int,              /* I - number of column to read (1 = 1st col)  */
-    firstrow: LONGLONG,         /* I - first row to read (1 = 1st row)         */
-    firstelem: LONGLONG,        /* I - first vector element to read (1 = 1st)  */
-    nelem: LONGLONG,            /* I - number of values to read                */
-    array: &mut [LONGLONG],     /* O - array of values that are read           */
-    nularray: &mut [c_char],    /* O - array of flags: 1 if null pixel; else 0 */
-    anynul: Option<&mut c_int>, /* O - set to 1 if any values are null; else 0 */
-    status: &mut c_int,         /* IO - error status                           */
+    fptr: &mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: &mut [LONGLONG],
+    nularray: &mut [c_char],
+    anynul: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     let dummy: LONGLONG = 0;
 
@@ -3713,7 +4208,6 @@ pub fn ffgcfjj_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of values from a column in the current FITS HDU.
 /// The column number may refer to a real column in an ASCII or binary table,
 /// or it may refer be a virtual column in a 1 or more grouped FITS primary
@@ -3727,21 +4221,35 @@ pub fn ffgcfjj_safe(
 /// and will be scaled by the FITS TSCALn and TZEROn values if necessary.
 #[allow(clippy::if_same_then_else)]
 // C dispatch chain: distinct conditions deliberately share an action.
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to read (1 = 1st col)
+/// * `firstrow`  — (I) first row to read (1 = 1st row)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `elemincre` — (I) pixel increment; e.g., 2 = every other
+/// * `nultyp`    — (I) null value handling code:
+/// * `nulval`    — (I) value for null pixels if nultyp = 1
+/// * `array`     — (O) array of values that are read
+/// * `nularray`  — (O) array of flags = 1 if nultyp = 2
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `status`    — (IO) error status
 pub(crate) fn ffgcljj(
-    fptr: &mut fitsfile,   /* I - FITS file pointer                       */
-    colnum: c_int,         /* I - number of column to read (1 = 1st col)  */
-    firstrow: LONGLONG,    /* I - first row to read (1 = 1st row)         */
-    firstelem: LONGLONG,   /* I - first vector element to read (1 = 1st)  */
-    nelem: LONGLONG,       /* I - number of values to read                */
-    elemincre: c_long,     /* I - pixel increment; e.g., 2 = every other  */
-    nultyp: NullCheckType, /* I - null value handling code:               */
+    fptr: &mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    elemincre: c_long,
+    nultyp: NullCheckType,
     /*     1: set undefined pixels = nulval        */
     /*     2: set nularray=1 for undefined pixels  */
-    nulval: LONGLONG,               /* I - value for null pixels if nultyp = 1     */
-    array: &mut [LONGLONG],         /* O - array of values that are read           */
-    nularray: &mut [c_char],        /* O - array of flags = 1 if nultyp = 2        */
-    mut anynul: Option<&mut c_int>, /* O - set to 1 if any values are null; else 0 */
-    status: &mut c_int,             /* IO - error status                           */
+    nulval: LONGLONG,
+    array: &mut [LONGLONG],
+    nularray: &mut [c_char],
+    mut anynul: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     let mut scale: f64 = 0.0;
     let mut zero: f64 = 0.0;
@@ -3791,9 +4299,7 @@ pub(crate) fn ffgcljj(
         nularray.fill(0); /* initialize nullarray */
     }
 
-    /*---------------------------------------------------*/
     /*  Check input and get parameters about the column: */
-    /*---------------------------------------------------*/
     if elemincre < 0 {
         readcheck = -1; /* don't do range checking in this case */
     }
@@ -3843,9 +4349,7 @@ pub(crate) fn ffgcljj(
         }
     }
 
-    /*------------------------------------------------------------------*/
     /*  Decide whether to check for null values in the input FITS file: */
-    /*------------------------------------------------------------------*/
     nulcheck = nultyp; /* by default check for null values in the FITS file */
 
     if nultyp == NullCheckType::SetPixel && nulval == 0 {
@@ -3864,10 +4368,8 @@ pub(crate) fn ffgcljj(
         nulcheck = NullCheckType::None;
     }
 
-    /*----------------------------------------------------------------------*/
     /*  If FITS column and output data array have same datatype, then we do */
     /*  not need to use a temporary buffer to store intermediate datatype.  */
-    /*----------------------------------------------------------------------*/
     convert = true;
     if tcode == TLONGLONG {
         /* Special Case:                        */
@@ -3885,7 +4387,6 @@ pub(crate) fn ffgcljj(
         }
     }
 
-    /*---------------------------------------------------------------------*/
     /*  Now read the pixels from the FITS column. If the column does not   */
     /*  have the same datatype as the output array, then we have to read   */
     /*  the raw values into a temporary buffer (of limited size).  In      */
@@ -3895,7 +4396,6 @@ pub(crate) fn ffgcljj(
     /*  test for undefined values, (2) convert the datatype if necessary,  */
     /*  and (3) scale the values by the FITS TSCALn and TZEROn linear      */
     /*  scaling parameters.                                                */
-    /*---------------------------------------------------------------------*/
 
     remain = nelem; /* remaining number of values to read */
     next = 0; /* next element in array to be read   */
@@ -4077,9 +4577,7 @@ pub(crate) fn ffgcljj(
             }
         } /* End of switch block */
 
-        /*-------------------------*/
         /*  Check for fatal error  */
-        /*-------------------------*/
         if *status > 0 {
             /* test for error during previous read operation */
             dtemp = next as f64;
@@ -4105,9 +4603,7 @@ pub(crate) fn ffgcljj(
             return *status;
         }
 
-        /*--------------------------------------------*/
         /*  increment the counters for the next loop  */
-        /*--------------------------------------------*/
         remain -= ntodo as LONGLONG;
         if remain > 0 {
             next += ntodo as LONGLONG;
@@ -4127,9 +4623,7 @@ pub(crate) fn ffgcljj(
         }
     } /*  End of main while Loop  */
 
-    /*--------------------------------*/
     /*  check for numerical overflow  */
-    /*--------------------------------*/
     if *status == OVERFLOW_ERR {
         ffpmsg_str("Numerical overflow during type conversion while reading FITS data.");
         *status = NUM_OVERFLOW;
@@ -4138,7 +4632,6 @@ pub(crate) fn ffgcljj(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output following reading of the input from a FITS file.
 /// Check for null values and do datatype conversion and scaling if required.
 /// The nullcheck code value determines how any null values in the input array
@@ -4150,20 +4643,34 @@ pub(crate) fn ffgcljj(
 /// nullarray will be set to 1; the value of nullarray for non-null pixels
 /// will = 0.  The anynull parameter will be set = 1 if any of the returned
 /// pixels are null, otherwise anynull will be returned with a value = 0;
+///
+/// # Parameters
+///
+/// * `input`     — (I) array of values to be converted
+/// * `ntodo`     — (I) number of elements in the array
+/// * `scale`     — (I) FITS TSCALn or BSCALE value
+/// * `zero`      — (I) FITS TZEROn or BZERO value
+/// * `nullcheck` — (I) null checking code; 0 = don't check
+/// * `tnull`     — (I) value of FITS TNULLn keyword if any
+/// * `nullval`   — (I) set null pixels, if nullcheck = 1
+/// * `nullarray` — (I) bad pixel array, if nullcheck = 2
+/// * `anynull`   — (O) set to 1 if any pixels are null
+/// * `output`    — (O) array of converted pixels
+/// * `status`    — (IO) error status
 pub(crate) fn fffi1i8(
-    input: &[u8],             /* I - array of values to be converted     */
-    ntodo: c_long,            /* I - number of elements in the array     */
-    scale: f64,               /* I - FITS TSCALn or BSCALE value         */
-    zero: f64,                /* I - FITS TZEROn or BZERO  value         */
-    nullcheck: NullCheckType, /* I - null checking code; 0 = don't check */
+    input: &[u8],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    nullcheck: NullCheckType,
     /*     1:set null pixels = nullval         */
     /*     2: if null pixel, set nullarray = 1 */
-    tnull: u8,                   /* I - value of FITS TNULLn keyword if any */
-    nullval: LONGLONG,           /* I - set null pixels, if nullcheck = 1   */
-    nullarray: &mut [c_char],    /* I - bad pixel array, if nullcheck = 2   */
-    anynull: Option<&mut c_int>, /* O - set to 1 if any pixels are null     */
-    output: &mut [LONGLONG],     /* O - array of converted pixels           */
-    status: &mut c_int,          /* IO - error status                       */
+    tnull: u8,
+    nullval: LONGLONG,
+    nullarray: &mut [c_char],
+    anynull: Option<&mut c_int>,
+    output: &mut [LONGLONG],
+    status: &mut c_int,
 ) -> c_int {
     let mut dvalue: f64 = 0.0;
 
@@ -4237,7 +4744,6 @@ pub(crate) fn fffi1i8(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output following reading of the input from a FITS file.
 /// Check for null values and do datatype conversion and scaling if required.
 /// The nullcheck code value determines how any null values in the input array
@@ -4249,20 +4755,34 @@ pub(crate) fn fffi1i8(
 /// nullarray will be set to 1; the value of nullarray for non-null pixels
 /// will = 0.  The anynull parameter will be set = 1 if any of the returned
 /// pixels are null, otherwise anynull will be returned with a value = 0;
+///
+/// # Parameters
+///
+/// * `input`     — (I) array of values to be converted
+/// * `ntodo`     — (I) number of elements in the array
+/// * `scale`     — (I) FITS TSCALn or BSCALE value
+/// * `zero`      — (I) FITS TZEROn or BZERO value
+/// * `nullcheck` — (I) null checking code; 0 = don't check
+/// * `tnull`     — (I) value of FITS TNULLn keyword if any
+/// * `nullval`   — (I) set null pixels, if nullcheck = 1
+/// * `nullarray` — (I) bad pixel array, if nullcheck = 2
+/// * `anynull`   — (O) set to 1 if any pixels are null
+/// * `output`    — (O) array of converted pixels
+/// * `status`    — (IO) error status
 pub(crate) fn fffi2i8(
-    input: &[c_short],        /* I - array of values to be converted     */
-    ntodo: c_long,            /* I - number of elements in the array     */
-    scale: f64,               /* I - FITS TSCALn or BSCALE value         */
-    zero: f64,                /* I - FITS TZEROn or BZERO  value         */
-    nullcheck: NullCheckType, /* I - null checking code; 0 = don't check */
+    input: &[c_short],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    nullcheck: NullCheckType,
     /*     1:set null pixels = nullval         */
     /*     2: if null pixel, set nullarray = 1 */
-    tnull: c_short,              /* I - value of FITS TNULLn keyword if any */
-    nullval: LONGLONG,           /* I - set null pixels, if nullcheck = 1   */
-    nullarray: &mut [c_char],    /* I - bad pixel array, if nullcheck = 2   */
-    anynull: Option<&mut c_int>, /* O - set to 1 if any pixels are null     */
-    output: &mut [LONGLONG],     /* O - array of converted pixels           */
-    status: &mut c_int,          /* IO - error status                       */
+    tnull: c_short,
+    nullval: LONGLONG,
+    nullarray: &mut [c_char],
+    anynull: Option<&mut c_int>,
+    output: &mut [LONGLONG],
+    status: &mut c_int,
 ) -> c_int {
     let mut dvalue: f64 = 0.0;
 
@@ -4336,7 +4856,6 @@ pub(crate) fn fffi2i8(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output following reading of the input from a FITS file.
 /// Check for null values and do datatype conversion and scaling if required.
 /// The nullcheck code value determines how any null values in the input array
@@ -4348,20 +4867,34 @@ pub(crate) fn fffi2i8(
 /// nullarray will be set to 1; the value of nullarray for non-null pixels
 /// will = 0.  The anynull parameter will be set = 1 if any of the returned
 /// pixels are null, otherwise anynull will be returned with a value = 0;
+///
+/// # Parameters
+///
+/// * `input`     — (I) array of values to be converted
+/// * `ntodo`     — (I) number of elements in the array
+/// * `scale`     — (I) FITS TSCALn or BSCALE value
+/// * `zero`      — (I) FITS TZEROn or BZERO value
+/// * `nullcheck` — (I) null checking code; 0 = don't check
+/// * `tnull`     — (I) value of FITS TNULLn keyword if any
+/// * `nullval`   — (I) set null pixels, if nullcheck = 1
+/// * `nullarray` — (I) bad pixel array, if nullcheck = 2
+/// * `anynull`   — (O) set to 1 if any pixels are null
+/// * `output`    — (O) array of converted pixels
+/// * `status`    — (IO) error status
 pub(crate) fn fffi4i8(
-    input: &[INT32BIT],       /* I - array of values to be converted     */
-    ntodo: c_long,            /* I - number of elements in the array     */
-    scale: f64,               /* I - FITS TSCALn or BSCALE value         */
-    zero: f64,                /* I - FITS TZEROn or BZERO  value         */
-    nullcheck: NullCheckType, /* I - null checking code; 0 = don't check */
+    input: &[INT32BIT],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    nullcheck: NullCheckType,
     /*     1:set null pixels = nullval         */
     /*     2: if null pixel, set nullarray = 1 */
-    tnull: INT32BIT,             /* I - value of FITS TNULLn keyword if any */
-    nullval: LONGLONG,           /* I - set null pixels, if nullcheck = 1   */
-    nullarray: &mut [c_char],    /* I - bad pixel array, if nullcheck = 2   */
-    anynull: Option<&mut c_int>, /* O - set to 1 if any pixels are null     */
-    output: &mut [LONGLONG],     /* O - array of converted pixels           */
-    status: &mut c_int,          /* IO - error status                       */
+    tnull: INT32BIT,
+    nullval: LONGLONG,
+    nullarray: &mut [c_char],
+    anynull: Option<&mut c_int>,
+    output: &mut [LONGLONG],
+    status: &mut c_int,
 ) -> c_int {
     let mut dvalue: f64 = 0.0;
 
@@ -4435,7 +4968,6 @@ pub(crate) fn fffi4i8(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output following reading of the input from a FITS file.
 /// Check for null values and do datatype conversion and scaling if required.
 /// The nullcheck code value determines how any null values in the input array
@@ -4447,20 +4979,34 @@ pub(crate) fn fffi4i8(
 /// nullarray will be set to 1; the value of nullarray for non-null pixels
 /// will = 0.  The anynull parameter will be set = 1 if any of the returned
 /// pixels are null, otherwise anynull will be returned with a value = 0;
+///
+/// # Parameters
+///
+/// * `input`     — (I) array of values to be converted
+/// * `ntodo`     — (I) number of elements in the array
+/// * `scale`     — (I) FITS TSCALn or BSCALE value
+/// * `zero`      — (I) FITS TZEROn or BZERO value
+/// * `nullcheck` — (I) null checking code; 0 = don't check
+/// * `tnull`     — (I) value of FITS TNULLn keyword if any
+/// * `nullval`   — (I) set null pixels, if nullcheck = 1
+/// * `nullarray` — (I) bad pixel array, if nullcheck = 2
+/// * `anynull`   — (O) set to 1 if any pixels are null
+/// * `output`    — (O) array of converted pixels
+/// * `status`    — (IO) error status
 pub(crate) fn fffi8i8(
-    input: &[LONGLONG],       /* I - array of values to be converted     */
-    ntodo: c_long,            /* I - number of elements in the array     */
-    scale: f64,               /* I - FITS TSCALn or BSCALE value         */
-    zero: f64,                /* I - FITS TZEROn or BZERO  value         */
-    nullcheck: NullCheckType, /* I - null checking code; 0 = don't check */
+    input: &[LONGLONG],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    nullcheck: NullCheckType,
     /*     1:set null pixels = nullval         */
     /*     2: if null pixel, set nullarray = 1 */
-    tnull: LONGLONG,             /* I - value of FITS TNULLn keyword if any */
-    nullval: LONGLONG,           /* I - set null pixels, if nullcheck = 1   */
-    nullarray: &mut [c_char],    /* I - bad pixel array, if nullcheck = 2   */
-    anynull: Option<&mut c_int>, /* O - set to 1 if any pixels are null     */
-    output: &mut [LONGLONG],     /* O - array of converted pixels           */
-    status: &mut c_int,          /* IO - error status                       */
+    tnull: LONGLONG,
+    nullval: LONGLONG,
+    nullarray: &mut [c_char],
+    anynull: Option<&mut c_int>,
+    output: &mut [LONGLONG],
+    status: &mut c_int,
 ) -> c_int {
     let mut dvalue: f64 = 0.0;
     let mut ulltemp: ULONGLONG = 0;
@@ -4573,7 +5119,6 @@ pub(crate) fn fffi8i8(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output following reading of the input from a FITS file.
 /// Check for null values and do datatype conversion and scaling if required.
 /// The nullcheck code value determines how any null values in the input array
@@ -4585,19 +5130,32 @@ pub(crate) fn fffi8i8(
 /// nullarray will be set to 1; the value of nullarray for non-null pixels
 /// will = 0.  The anynull parameter will be set = 1 if any of the returned
 /// pixels are null, otherwise anynull will be returned with a value = 0;
+///
+/// # Parameters
+///
+/// * `input`     — (I) array of values to be converted
+/// * `ntodo`     — (I) number of elements in the array
+/// * `scale`     — (I) FITS TSCALn or BSCALE value
+/// * `zero`      — (I) FITS TZEROn or BZERO value
+/// * `nullcheck` — (I) null checking code; 0 = don't check
+/// * `nullval`   — (I) set null pixels, if nullcheck = 1
+/// * `nullarray` — (I) bad pixel array, if nullcheck = 2
+/// * `anynull`   — (O) set to 1 if any pixels are null
+/// * `output`    — (O) array of converted pixels
+/// * `status`    — (IO) error status
 pub(crate) fn fffr4i8(
-    input: &[f32],            /* I - array of values to be converted     */
-    ntodo: c_long,            /* I - number of elements in the array     */
-    scale: f64,               /* I - FITS TSCALn or BSCALE value         */
-    zero: f64,                /* I - FITS TZEROn or BZERO  value         */
-    nullcheck: NullCheckType, /* I - null checking code; 0 = don't check */
+    input: &[f32],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    nullcheck: NullCheckType,
     /*     1:set null pixels = nullval         */
     /*     2: if null pixel, set nullarray = 1 */
-    nullval: LONGLONG,           /* I - set null pixels, if nullcheck = 1   */
-    nullarray: &mut [c_char],    /* I - bad pixel array, if nullcheck = 2   */
-    anynull: Option<&mut c_int>, /* O - set to 1 if any pixels are null     */
-    output: &mut [LONGLONG],     /* O - array of converted pixels           */
-    status: &mut c_int,          /* IO - error status                       */
+    nullval: LONGLONG,
+    nullarray: &mut [c_char],
+    anynull: Option<&mut c_int>,
+    output: &mut [LONGLONG],
+    status: &mut c_int,
 ) -> c_int {
     let mut dvalue: f64 = 0.0;
     let mut sptr = 0;
@@ -4721,7 +5279,6 @@ pub(crate) fn fffr4i8(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output following reading of the input from a FITS file.
 /// Check for null values and do datatype conversion and scaling if required.
 /// The nullcheck code value determines how any null values in the input array
@@ -4733,19 +5290,32 @@ pub(crate) fn fffr4i8(
 /// nullarray will be set to 1; the value of nullarray for non-null pixels
 /// will = 0.  The anynull parameter will be set = 1 if any of the returned
 /// pixels are null, otherwise anynull will be returned with a value = 0;
+///
+/// # Parameters
+///
+/// * `input`     — (I) array of values to be converted
+/// * `ntodo`     — (I) number of elements in the array
+/// * `scale`     — (I) FITS TSCALn or BSCALE value
+/// * `zero`      — (I) FITS TZEROn or BZERO value
+/// * `nullcheck` — (I) null checking code; 0 = don't check
+/// * `nullval`   — (I) set null pixels, if nullcheck = 1
+/// * `nullarray` — (I) bad pixel array, if nullcheck = 2
+/// * `anynull`   — (O) set to 1 if any pixels are null
+/// * `output`    — (O) array of converted pixels
+/// * `status`    — (IO) error status
 pub(crate) fn fffr8i8(
-    input: &[f64],            /* I - array of values to be converted     */
-    ntodo: c_long,            /* I - number of elements in the array     */
-    scale: f64,               /* I - FITS TSCALn or BSCALE value         */
-    zero: f64,                /* I - FITS TZEROn or BZERO  value         */
-    nullcheck: NullCheckType, /* I - null checking code; 0 = don't check */
+    input: &[f64],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    nullcheck: NullCheckType,
     /*     1:set null pixels = nullval         */
     /*     2: if null pixel, set nullarray = 1 */
-    nullval: LONGLONG,           /* I - set null pixels, if nullcheck = 1   */
-    nullarray: &mut [c_char],    /* I - bad pixel array, if nullcheck = 2   */
-    anynull: Option<&mut c_int>, /* O - set to 1 if any pixels are null     */
-    output: &mut [LONGLONG],     /* O - array of converted pixels           */
-    status: &mut c_int,          /* IO - error status                       */
+    nullval: LONGLONG,
+    nullarray: &mut [c_char],
+    anynull: Option<&mut c_int>,
+    output: &mut [LONGLONG],
+    status: &mut c_int,
 ) -> c_int {
     let mut dvalue: f64 = 0.0;
     let mut sptr = 0;
@@ -4869,7 +5439,6 @@ pub(crate) fn fffr8i8(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output following reading of the input from a FITS file. Check
 /// for null values and do scaling if required. The nullcheck code value
 /// determines how any null values in the input array are treated. A null
@@ -4880,22 +5449,38 @@ pub(crate) fn fffr8i8(
 /// nullarray will be set to 1; the value of nullarray for non-null pixels
 /// will = 0.  The anynull parameter will be set = 1 if any of the returned
 /// pixels are null, otherwise anynull will be returned with a value = 0;
+///
+/// # Parameters
+///
+/// * `input`      — (I) array of values to be converted
+/// * `ntodo`      — (I) number of elements in the array
+/// * `scale`      — (I) FITS TSCALn or BSCALE value
+/// * `zero`       — (I) FITS TZEROn or BZERO value
+/// * `twidth`     — (I) width of each substring of chars
+/// * `implipower` — (I) power of 10 of implied decimal
+/// * `nullcheck`  — (I) null checking code; 0 = don't check
+/// * `snull`      — (I) value of FITS null string, if any
+/// * `nullval`    — (I) set null pixels, if nullcheck = 1
+/// * `nullarray`  — (I) bad pixel array, if nullcheck = 2
+/// * `anynull`    — (O) set to 1 if any pixels are null
+/// * `output`     — (O) array of converted pixels
+/// * `status`     — (IO) error status
 pub(crate) fn fffstri8(
-    input: &mut [c_char],     /* I - array of values to be converted     */
-    ntodo: c_long,            /* I - number of elements in the array     */
-    scale: f64,               /* I - FITS TSCALn or BSCALE value         */
-    zero: f64,                /* I - FITS TZEROn or BZERO  value         */
-    twidth: c_long,           /* I - width of each substring of chars    */
-    implipower: f64,          /* I - power of 10 of implied decimal      */
-    nullcheck: NullCheckType, /* I - null checking code; 0 = don't check */
+    input: &mut [c_char],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    twidth: c_long,
+    implipower: f64,
+    nullcheck: NullCheckType,
     /*     1:set null pixels = nullval         */
     /*     2: if null pixel, set nullarray = 1 */
-    snull: &[c_char],                /* I - value of FITS null string, if any   */
-    nullval: LONGLONG,               /* I - set null pixels, if nullcheck = 1   */
-    nullarray: &mut [c_char],        /* I - bad pixel array, if nullcheck = 2   */
-    mut anynull: Option<&mut c_int>, /* O - set to 1 if any pixels are null     */
-    output: &mut [LONGLONG],         /* O - array of converted pixels           */
-    status: &mut c_int,              /* IO - error status                       */
+    snull: &[c_char],
+    nullval: LONGLONG,
+    nullarray: &mut [c_char],
+    mut anynull: Option<&mut c_int>,
+    output: &mut [LONGLONG],
+    status: &mut c_int,
 ) -> c_int {
     let mut nullen: c_int = 0;
     let mut dvalue: f64 = 0.0;

--- a/src/getcolk.rs
+++ b/src/getcolk.rs
@@ -1,9 +1,14 @@
-/*  This file, getcolk.rs, contains routines that read data elements from   */
-/*  a FITS image or table, with 'int' data type.                           */
-
-/*  The FITSIO software was written by William Pence at the High Energy    */
-/*  Astrophysic Science Archive Research Center (HEASARC) at the NASA      */
-/*  Goddard Space Flight Center.                                           */
+//! Routines that read data elements from a FITS image or table, with `int`
+//! datatype.
+//!
+//! The [`TINT`] arm of the typed column I/O family. [`crate::getcol`]
+//! dispatches here when a caller asks for this datatype at run time; the
+//! write-side counterpart is [`crate::putcolk`].
+//!
+//! Ported from CFITSIO's `getcolk.c`, written by William Pence at the High
+//! Energy Astrophysics Science Archive Research Center (HEASARC), NASA Goddard
+//! Space Flight Center.
+#![warn(missing_docs)]
 
 use core::slice;
 use core::{cmp, mem};
@@ -25,7 +30,6 @@ use crate::{NullValue, bb};
 use crate::{buffers::*, calculate_subsection_length};
 use crate::{int_snprintf, slice_to_str};
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of values from the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
 /// the FITS array is not the same as the array being read).
@@ -39,16 +43,27 @@ use crate::{int_snprintf, slice_to_str};
 /// and the second column contains the image itself.
 ///
 /// anynull can be a null pointer
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to read (1 = 1st group)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `nulval`    — (I) value for undefined pixels
+/// * `array`     — (O) array of values that are returned
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgpvk(
-    fptr: *mut fitsfile, /* I - FITS file pointer                       */
-    group: c_long,       /* I - group to read (1 = 1st group)           */
-    firstelem: LONGLONG, /* I - first vector element to read (1 = 1st)  */
-    nelem: LONGLONG,     /* I - number of values to read                */
-    nulval: c_int,       /* I - value for undefined pixels          */
-    array: *mut c_int,   /* O - array of values that are returned   */
-    anynul: *mut c_int,  /* O - set to 1 if any values are null; else 0 */
-    status: *mut c_int,  /* IO - error status                           */
+    fptr: *mut fitsfile,
+    group: c_long,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    nulval: c_int,
+    array: *mut c_int,
+    anynul: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -62,7 +77,6 @@ pub unsafe extern "C" fn ffgpvk(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of values from the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
 /// the FITS array is not the same as the array being read).
@@ -76,15 +90,26 @@ pub unsafe extern "C" fn ffgpvk(
 /// and the second column contains the image itself.
 ///
 /// anynull can be a null pointer
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to read (1 = 1st group)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `nulval`    — (I) value for undefined pixels
+/// * `array`     — (O) array of values that are returned
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `status`    — (IO) error status
 pub fn ffgpvk_safe(
-    fptr: &mut fitsfile,        /* I - FITS file pointer                       */
-    group: c_long,              /* I - group to read (1 = 1st group)           */
-    firstelem: LONGLONG,        /* I - first vector element to read (1 = 1st)  */
-    nelem: LONGLONG,            /* I - number of values to read                */
-    nulval: c_int,              /* I - value for undefined pixels          */
-    array: &mut [c_int],        /* O - array of values that are returned   */
-    anynul: Option<&mut c_int>, /* O - set to 1 if any values are null; else 0 */
-    status: &mut c_int,         /* IO - error status                           */
+    fptr: &mut fitsfile,
+    group: c_long,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    nulval: c_int,
+    array: &mut [c_int],
+    anynul: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     let cdummy = 0;
     let nullcheck = NullCheckType::SetPixel;
@@ -128,7 +153,6 @@ pub fn ffgpvk_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of values from the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
 /// the FITS array is not the same as the array being read).
@@ -140,16 +164,27 @@ pub fn ffgpvk_safe(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to read (1 = 1st group)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `array`     — (O) array of values that are returned
+/// * `nularray`  — (O) array of null pixel flags
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgpfk(
-    fptr: *mut fitsfile,   /* I - FITS file pointer                       */
-    group: c_long,         /* I - group to read (1 = 1st group)           */
-    firstelem: LONGLONG,   /* I - first vector element to read (1 = 1st)  */
-    nelem: LONGLONG,       /* I - number of values to read                */
-    array: *mut c_int,     /* O - array of values that are returned   */
-    nularray: *mut c_char, /* O - array of null pixel flags               */
-    anynul: *mut c_int,    /* O - set to 1 if any values are null; else 0 */
-    status: *mut c_int,    /* IO - error status                           */
+    fptr: *mut fitsfile,
+    group: c_long,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: *mut c_int,
+    nularray: *mut c_char,
+    anynul: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -166,7 +201,6 @@ pub unsafe extern "C" fn ffgpfk(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of values from the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
 /// the FITS array is not the same as the array being read).
@@ -178,15 +212,26 @@ pub unsafe extern "C" fn ffgpfk(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to read (1 = 1st group)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `array`     — (O) array of values that are returned
+/// * `nularray`  — (O) array of null pixel flags
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `status`    — (IO) error status
 pub fn ffgpfk_safe(
-    fptr: &mut fitsfile,        /* I - FITS file pointer                       */
-    group: c_long,              /* I - group to read (1 = 1st group)           */
-    firstelem: LONGLONG,        /* I - first vector element to read (1 = 1st)  */
-    nelem: LONGLONG,            /* I - number of values to read                */
-    array: &mut [c_int],        /* O - array of values that are returned   */
-    nularray: &mut [c_char],    /* O - array of null pixel flags               */
-    anynul: Option<&mut c_int>, /* O - set to 1 if any values are null; else 0 */
-    status: &mut c_int,         /* IO - error status                           */
+    fptr: &mut fitsfile,
+    group: c_long,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: &mut [c_int],
+    nularray: &mut [c_char],
+    anynul: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     let nullcheck = NullCheckType::SetNullArray;
 
@@ -227,23 +272,34 @@ pub fn ffgpfk_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an entire 2-D array of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of the
 /// FITS array is not the same as the array being read).  Any null
 /// values in the array will be set equal to the value of nulval, unless
 /// nulval = 0 in which case no null checking will be performed.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `group`  — (I) group to read (1 = 1st group)
+/// * `nulval` — set undefined pixels equal to this
+/// * `ncols`  — (I) number of pixels in each row of array
+/// * `naxis1` — (I) FITS image NAXIS1 value
+/// * `naxis2` — (I) FITS image NAXIS2 value
+/// * `array`  — (O) array to be filled and returned
+/// * `anynul` — (O) set to 1 if any values are null; else 0
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffg2dk(
-    fptr: *mut fitsfile, /* I - FITS file pointer                       */
-    group: c_long,       /* I - group to read (1 = 1st group)           */
-    nulval: c_int,       /* set undefined pixels equal to this     */
-    ncols: LONGLONG,     /* I - number of pixels in each row of array   */
-    naxis1: LONGLONG,    /* I - FITS image NAXIS1 value                 */
-    naxis2: LONGLONG,    /* I - FITS image NAXIS2 value                 */
-    array: *mut c_int,   /* O - array to be filled and returned    */
-    anynul: *mut c_int,  /* O - set to 1 if any values are null; else 0 */
-    status: *mut c_int,  /* IO - error status                           */
+    fptr: *mut fitsfile,
+    group: c_long,
+    nulval: c_int,
+    ncols: LONGLONG,
+    naxis1: LONGLONG,
+    naxis2: LONGLONG,
+    array: *mut c_int,
+    anynul: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -259,22 +315,33 @@ pub unsafe extern "C" fn ffg2dk(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an entire 2-D array of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of the
 /// FITS array is not the same as the array being read).  Any null
 /// values in the array will be set equal to the value of nulval, unless
 /// nulval = 0 in which case no null checking will be performed.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `group`  — (I) group to read (1 = 1st group)
+/// * `nulval` — set undefined pixels equal to this
+/// * `ncols`  — (I) number of pixels in each row of array
+/// * `naxis1` — (I) FITS image NAXIS1 value
+/// * `naxis2` — (I) FITS image NAXIS2 value
+/// * `array`  — (O) array to be filled and returned
+/// * `anynul` — (O) set to 1 if any values are null; else 0
+/// * `status` — (IO) error status
 pub fn ffg2dk_safe(
-    fptr: &mut fitsfile,        /* I - FITS file pointer                       */
-    group: c_long,              /* I - group to read (1 = 1st group)           */
-    nulval: c_int,              /* set undefined pixels equal to this     */
-    ncols: LONGLONG,            /* I - number of pixels in each row of array   */
-    naxis1: LONGLONG,           /* I - FITS image NAXIS1 value                 */
-    naxis2: LONGLONG,           /* I - FITS image NAXIS2 value                 */
-    array: &mut [c_int],        /* O - array to be filled and returned    */
-    anynul: Option<&mut c_int>, /* O - set to 1 if any values are null; else 0 */
-    status: &mut c_int,         /* IO - error status                           */
+    fptr: &mut fitsfile,
+    group: c_long,
+    nulval: c_int,
+    ncols: LONGLONG,
+    naxis1: LONGLONG,
+    naxis2: LONGLONG,
+    array: &mut [c_int],
+    anynul: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     /* call the 3D reading routine, with the 3rd dimension = 1 */
     ffg3dk_safe(
@@ -284,7 +351,6 @@ pub fn ffg2dk_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an entire 3-D array of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of the
 /// FITS array is not the same as the array being read).  Any null
@@ -295,19 +361,33 @@ pub fn ffg2dk_safe(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `group`  — (I) group to read (1 = 1st group)
+/// * `nulval` — set undefined pixels equal to this
+/// * `ncols`  — (I) number of pixels in each row of array
+/// * `nrows`  — (I) number of rows in each plane of array
+/// * `naxis1` — (I) FITS image NAXIS1 value
+/// * `naxis2` — (I) FITS image NAXIS2 value
+/// * `naxis3` — (I) FITS image NAXIS3 value
+/// * `array`  — (O) array to be filled and returned
+/// * `anynul` — (O) set to 1 if any values are null; else 0
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffg3dk(
-    fptr: *mut fitsfile, /* I - FITS file pointer                       */
-    group: c_long,       /* I - group to read (1 = 1st group)           */
-    nulval: c_int,       /* set undefined pixels equal to this     */
-    ncols: LONGLONG,     /* I - number of pixels in each row of array   */
-    nrows: LONGLONG,     /* I - number of rows in each plane of array   */
-    naxis1: LONGLONG,    /* I - FITS image NAXIS1 value                 */
-    naxis2: LONGLONG,    /* I - FITS image NAXIS2 value                 */
-    naxis3: LONGLONG,    /* I - FITS image NAXIS3 value                 */
-    array: *mut c_int,   /* O - array to be filled and returned    */
-    anynul: *mut c_int,  /* O - set to 1 if any values are null; else 0 */
-    status: *mut c_int,  /* IO - error status                           */
+    fptr: *mut fitsfile,
+    group: c_long,
+    nulval: c_int,
+    ncols: LONGLONG,
+    nrows: LONGLONG,
+    naxis1: LONGLONG,
+    naxis2: LONGLONG,
+    naxis3: LONGLONG,
+    array: *mut c_int,
+    anynul: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -323,7 +403,6 @@ pub unsafe extern "C" fn ffg3dk(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an entire 3-D array of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of the
 /// FITS array is not the same as the array being read).  Any null
@@ -334,18 +413,32 @@ pub unsafe extern "C" fn ffg3dk(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `group`  — (I) group to read (1 = 1st group)
+/// * `nulval` — set undefined pixels equal to this
+/// * `ncols`  — (I) number of pixels in each row of array
+/// * `nrows`  — (I) number of rows in each plane of array
+/// * `naxis1` — (I) FITS image NAXIS1 value
+/// * `naxis2` — (I) FITS image NAXIS2 value
+/// * `naxis3` — (I) FITS image NAXIS3 value
+/// * `array`  — (O) array to be filled and returned
+/// * `anynul` — (O) set to 1 if any values are null; else 0
+/// * `status` — (IO) error status
 pub fn ffg3dk_safe(
-    fptr: &mut fitsfile,            /* I - FITS file pointer                       */
-    group: c_long,                  /* I - group to read (1 = 1st group)           */
-    nulval: c_int,                  /* set undefined pixels equal to this     */
-    ncols: LONGLONG,                /* I - number of pixels in each row of array   */
-    nrows: LONGLONG,                /* I - number of rows in each plane of array   */
-    naxis1: LONGLONG,               /* I - FITS image NAXIS1 value                 */
-    naxis2: LONGLONG,               /* I - FITS image NAXIS2 value                 */
-    naxis3: LONGLONG,               /* I - FITS image NAXIS3 value                 */
-    array: &mut [c_int],            /* O - array to be filled and returned    */
-    mut anynul: Option<&mut c_int>, /* O - set to 1 if any values are null; else 0 */
-    status: &mut c_int,             /* IO - error status                           */
+    fptr: &mut fitsfile,
+    group: c_long,
+    nulval: c_int,
+    ncols: LONGLONG,
+    nrows: LONGLONG,
+    naxis1: LONGLONG,
+    naxis2: LONGLONG,
+    naxis3: LONGLONG,
+    array: &mut [c_int],
+    mut anynul: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     let mut narray = 0;
     let mut nfits: LONGLONG = 0;
@@ -444,22 +537,35 @@ pub fn ffg3dk_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read a subsection of data values from an image or a table column.
 /// This routine is set up to handle a maximum of nine dimensions.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `colnum` — (I) number of the column to read (1 = 1st)
+/// * `naxis`  — (I) number of dimensions in the FITS array
+/// * `naxes`  — (I) size of each dimension
+/// * `blc`    — (I) 'bottom left corner' of the subsection
+/// * `trc`    — (I) 'top right corner' of the subsection
+/// * `inc`    — (I) increment to be applied in each dimension
+/// * `nulval` — (I) value to set undefined pixels
+/// * `array`  — (O) array to be filled and returned
+/// * `anynul` — (O) set to 1 if any values are null; else 0
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgsvk(
-    fptr: *mut fitsfile,  /* I - FITS file pointer                         */
-    colnum: c_int,        /* I - number of the column to read (1 = 1st)    */
-    naxis: c_int,         /* I - number of dimensions in the FITS array    */
-    naxes: *const c_long, /* I - size of each dimension                    */
-    blc: *const c_long,   /* I - 'bottom left corner' of the subsection    */
-    trc: *const c_long,   /* I - 'top right corner' of the subsection      */
-    inc: *const c_long,   /* I - increment to be applied in each dimension */
-    nulval: c_int,        /* I - value to set undefined pixels       */
-    array: *mut c_int,    /* O - array to be filled and returned     */
-    anynul: *mut c_int,   /* O - set to 1 if any values are null; else 0   */
-    status: *mut c_int,   /* IO - error status                             */
+    fptr: *mut fitsfile,
+    colnum: c_int,
+    naxis: c_int,
+    naxes: *const c_long,
+    blc: *const c_long,
+    trc: *const c_long,
+    inc: *const c_long,
+    nulval: c_int,
+    array: *mut c_int,
+    anynul: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -482,21 +588,34 @@ pub unsafe extern "C" fn ffgsvk(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read a subsection of data values from an image or a table column.
 /// This routine is set up to handle a maximum of nine dimensions.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `colnum` — (I) number of the column to read (1 = 1st)
+/// * `naxis`  — (I) number of dimensions in the FITS array
+/// * `naxes`  — (I) size of each dimension
+/// * `blc`    — (I) 'bottom left corner' of the subsection
+/// * `trc`    — (I) 'top right corner' of the subsection
+/// * `inc`    — (I) increment to be applied in each dimension
+/// * `nulval` — (I) value to set undefined pixels
+/// * `array`  — (O) array to be filled and returned
+/// * `anynul` — (O) set to 1 if any values are null; else 0
+/// * `status` — (IO) error status
 pub fn ffgsvk_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                         */
-    colnum: c_int,       /* I - number of the column to read (1 = 1st)    */
-    naxis: c_int,        /* I - number of dimensions in the FITS array    */
-    naxes: &[c_long],    /* I - size of each dimension                    */
-    blc: &[c_long],      /* I - 'bottom left corner' of the subsection    */
-    trc: &[c_long],      /* I - 'top right corner' of the subsection      */
-    inc: &[c_long],      /* I - increment to be applied in each dimension */
-    nulval: c_int,       /* I - value to set undefined pixels       */
-    array: &mut [c_int], /* O - array to be filled and returned     */
-    mut anynul: Option<&mut c_int>, /* O - set to 1 if any values are null; else 0   */
-    status: &mut c_int,  /* IO - error status                             */
+    fptr: &mut fitsfile,
+    colnum: c_int,
+    naxis: c_int,
+    naxes: &[c_long],
+    blc: &[c_long],
+    trc: &[c_long],
+    inc: &[c_long],
+    nulval: c_int,
+    array: &mut [c_int],
+    mut anynul: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     let mut rstr: c_long = 0;
     let mut rstp: c_long = 0;
@@ -701,22 +820,35 @@ pub fn ffgsvk_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read a subsection of data values from an image or a table column.
 /// This routine is set up to handle a maximum of nine dimensions.
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `colnum`  — (I) number of the column to read (1 = 1st)
+/// * `naxis`   — (I) number of dimensions in the FITS array
+/// * `naxes`   — (I) size of each dimension
+/// * `blc`     — (I) 'bottom left corner' of the subsection
+/// * `trc`     — (I) 'top right corner' of the subsection
+/// * `inc`     — (I) increment to be applied in each dimension
+/// * `array`   — (O) array to be filled and returned
+/// * `flagval` — (O) set to 1 if corresponding value is null
+/// * `anynul`  — (O) set to 1 if any values are null; else 0
+/// * `status`  — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgsfk(
-    fptr: *mut fitsfile,  /* I - FITS file pointer                         */
-    colnum: c_int,        /* I - number of the column to read (1 = 1st)    */
-    naxis: c_int,         /* I - number of dimensions in the FITS array    */
-    naxes: *const c_long, /* I - size of each dimension                    */
-    blc: *const c_long,   /* I - 'bottom left corner' of the subsection    */
-    trc: *const c_long,   /* I - 'top right corner' of the subsection      */
-    inc: *const c_long,   /* I - increment to be applied in each dimension */
-    array: *mut c_int,    /* O - array to be filled and returned     */
-    flagval: *mut c_char, /* O - set to 1 if corresponding value is null   */
-    anynul: *mut c_int,   /* O - set to 1 if any values are null; else 0   */
-    status: *mut c_int,   /* IO - error status                             */
+    fptr: *mut fitsfile,
+    colnum: c_int,
+    naxis: c_int,
+    naxes: *const c_long,
+    blc: *const c_long,
+    trc: *const c_long,
+    inc: *const c_long,
+    array: *mut c_int,
+    flagval: *mut c_char,
+    anynul: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -740,21 +872,34 @@ pub unsafe extern "C" fn ffgsfk(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read a subsection of data values from an image or a table column.
 /// This routine is set up to handle a maximum of nine dimensions.
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `colnum`  — (I) number of the column to read (1 = 1st)
+/// * `naxis`   — (I) number of dimensions in the FITS array
+/// * `naxes`   — (I) size of each dimension
+/// * `blc`     — (I) 'bottom left corner' of the subsection
+/// * `trc`     — (I) 'top right corner' of the subsection
+/// * `inc`     — (I) increment to be applied in each dimension
+/// * `array`   — (O) array to be filled and returned
+/// * `flagval` — (O) set to 1 if corresponding value is null
+/// * `anynul`  — (O) set to 1 if any values are null; else 0
+/// * `status`  — (IO) error status
 pub fn ffgsfk_safe(
-    fptr: &mut fitsfile,    /* I - FITS file pointer                         */
-    colnum: c_int,          /* I - number of the column to read (1 = 1st)    */
-    naxis: c_int,           /* I - number of dimensions in the FITS array    */
-    naxes: &[c_long],       /* I - size of each dimension                    */
-    blc: &[c_long],         /* I - 'bottom left corner' of the subsection    */
-    trc: &[c_long],         /* I - 'top right corner' of the subsection      */
-    inc: &[c_long],         /* I - increment to be applied in each dimension */
-    array: &mut [c_int],    /* O - array to be filled and returned           */
-    flagval: &mut [c_char], /* O - set to 1 if corresponding value is null   */
-    mut anynul: Option<&mut c_int>, /* O - set to 1 if any values are null; else 0   */
-    status: &mut c_int,     /* IO - error status                             */
+    fptr: &mut fitsfile,
+    colnum: c_int,
+    naxis: c_int,
+    naxes: &[c_long],
+    blc: &[c_long],
+    trc: &[c_long],
+    inc: &[c_long],
+    array: &mut [c_int],
+    flagval: &mut [c_char],
+    mut anynul: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     let mut rstr: c_long = 0;
     let mut rstp: c_long = 0;
@@ -942,7 +1087,6 @@ pub fn ffgsfk_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 ///Read an array of group parameters from the primary array. Data conversion
 ///and scaling will be performed if necessary (e.g, if the datatype of
 ///the FITS array is not the same as the array being read).
@@ -951,14 +1095,23 @@ pub fn ffgsfk_safe(
 ///each group of the primary array is a row in the table,
 ///where the first column contains the group parameters
 ///and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to read (1 = 1st group)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `array`     — (O) array of values that are returned
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffggpk(
-    fptr: *mut fitsfile, /* I - FITS file pointer                       */
-    group: c_long,       /* I - group to read (1 = 1st group)           */
-    firstelem: c_long,   /* I - first vector element to read (1 = 1st)  */
-    nelem: c_long,       /* I - number of values to read                */
-    array: *mut c_int,   /* O - array of values that are returned   */
-    status: *mut c_int,  /* IO - error status                           */
+    fptr: *mut fitsfile,
+    group: c_long,
+    firstelem: c_long,
+    nelem: c_long,
+    array: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -970,7 +1123,6 @@ pub unsafe extern "C" fn ffggpk(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 ///Read an array of group parameters from the primary array. Data conversion
 ///and scaling will be performed if necessary (e.g, if the datatype of
 ///the FITS array is not the same as the array being read).
@@ -979,13 +1131,22 @@ pub unsafe extern "C" fn ffggpk(
 ///each group of the primary array is a row in the table,
 ///where the first column contains the group parameters
 ///and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to read (1 = 1st group)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `array`     — (O) array of values that are returned
+/// * `status`    — (IO) error status
 pub fn ffggpk_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                       */
-    group: c_long,       /* I - group to read (1 = 1st group)           */
-    firstelem: c_long,   /* I - first vector element to read (1 = 1st)  */
-    nelem: c_long,       /* I - number of values to read                */
-    array: &mut [c_int], /* O - array of values that are returned       */
-    status: &mut c_int,  /* IO - error status                           */
+    fptr: &mut fitsfile,
+    group: c_long,
+    firstelem: c_long,
+    nelem: c_long,
+    array: &mut [c_int],
+    status: &mut c_int,
 ) -> c_int {
     let cdummy = 0;
     let mut anynul = 0;
@@ -1009,24 +1170,35 @@ pub fn ffggpk_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of values from a column in the current FITS HDU. Automatic
 /// datatype conversion will be performed if the datatype of the column does not
 /// match the datatype of the array parameter. The output values will be scaled
 /// by the FITS TSCALn and TZEROn values if these values have been defined.
 /// Any undefined pixels will be set equal to the value of 'nulval' unless
 /// nulval = 0 in which case no checks for undefined pixels will be made.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to read (1 = 1st col)
+/// * `firstrow`  — (I) first row to read (1 = 1st row)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `nulval`    — (I) value for null pixels
+/// * `array`     — (O) array of values that are read
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgcvk(
-    fptr: *mut fitsfile, /* I - FITS file pointer                       */
-    colnum: c_int,       /* I - number of column to read (1 = 1st col)  */
-    firstrow: LONGLONG,  /* I - first row to read (1 = 1st row)         */
-    firstelem: LONGLONG, /* I - first vector element to read (1 = 1st)  */
-    nelem: LONGLONG,     /* I - number of values to read                */
-    nulval: c_int,       /* I - value for null pixels               */
-    array: *mut c_int,   /* O - array of values that are read       */
-    anynul: *mut c_int,  /* O - set to 1 if any values are null; else 0 */
-    status: *mut c_int,  /* IO - error status                           */
+    fptr: *mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    nulval: c_int,
+    array: *mut c_int,
+    anynul: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -1043,23 +1215,34 @@ pub unsafe extern "C" fn ffgcvk(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of values from a column in the current FITS HDU. Automatic
 /// datatype conversion will be performed if the datatype of the column does not
 /// match the datatype of the array parameter. The output values will be scaled
 /// by the FITS TSCALn and TZEROn values if these values have been defined.
 /// Any undefined pixels will be set equal to the value of 'nulval' unless
 /// nulval = 0 in which case no checks for undefined pixels will be made.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to read (1 = 1st col)
+/// * `firstrow`  — (I) first row to read (1 = 1st row)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `nulval`    — (I) value for null pixels
+/// * `array`     — (O) array of values that are read
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `status`    — (IO) error status
 pub fn ffgcvk_safe(
-    fptr: &mut fitsfile,        /* I - FITS file pointer                       */
-    colnum: c_int,              /* I - number of column to read (1 = 1st col)  */
-    firstrow: LONGLONG,         /* I - first row to read (1 = 1st row)         */
-    firstelem: LONGLONG,        /* I - first vector element to read (1 = 1st)  */
-    nelem: LONGLONG,            /* I - number of values to read                */
-    nulval: c_int,              /* I - value for null pixels               */
-    array: &mut [c_int],        /* O - array of values that are read       */
-    anynul: Option<&mut c_int>, /* O - set to 1 if any values are null; else 0 */
-    status: &mut c_int,         /* IO - error status                           */
+    fptr: &mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    nulval: c_int,
+    array: &mut [c_int],
+    anynul: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     let cdummy = 0;
 
@@ -1080,24 +1263,35 @@ pub fn ffgcvk_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of values from a column in the current FITS HDU. Automatic
 /// datatype conversion will be performed if the datatype of the column does not
 /// match the datatype of the array parameter. The output values will be scaled
 /// by the FITS TSCALn and TZEROn values if these values have been defined.
 /// Nularray will be set = 1 if the corresponding array pixel is undefined,
 /// otherwise nularray will = 0.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to read (1 = 1st col)
+/// * `firstrow`  — (I) first row to read (1 = 1st row)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `array`     — (O) array of values that are read
+/// * `nularray`  — (O) array of flags: 1 if null pixel; else 0
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgcfk(
-    fptr: *mut fitsfile,   /* I - FITS file pointer                       */
-    colnum: c_int,         /* I - number of column to read (1 = 1st col)  */
-    firstrow: LONGLONG,    /* I - first row to read (1 = 1st row)         */
-    firstelem: LONGLONG,   /* I - first vector element to read (1 = 1st)  */
-    nelem: LONGLONG,       /* I - number of values to read                */
-    array: *mut c_int,     /* O - array of values that are read       */
-    nularray: *mut c_char, /* O - array of flags: 1 if null pixel; else 0 */
-    anynul: *mut c_int,    /* O - set to 1 if any values are null; else 0 */
-    status: *mut c_int,    /* IO - error status                           */
+    fptr: *mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: *mut c_int,
+    nularray: *mut c_char,
+    anynul: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -1114,23 +1308,34 @@ pub unsafe extern "C" fn ffgcfk(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of values from a column in the current FITS HDU. Automatic
 /// datatype conversion will be performed if the datatype of the column does not
 /// match the datatype of the array parameter. The output values will be scaled
 /// by the FITS TSCALn and TZEROn values if these values have been defined.
 /// Nularray will be set = 1 if the corresponding array pixel is undefined,
 /// otherwise nularray will = 0.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to read (1 = 1st col)
+/// * `firstrow`  — (I) first row to read (1 = 1st row)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `array`     — (O) array of values that are read
+/// * `nularray`  — (O) array of flags: 1 if null pixel; else 0
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `status`    — (IO) error status
 pub fn ffgcfk_safe(
-    fptr: &mut fitsfile,        /* I - FITS file pointer                       */
-    colnum: c_int,              /* I - number of column to read (1 = 1st col)  */
-    firstrow: LONGLONG,         /* I - first row to read (1 = 1st row)         */
-    firstelem: LONGLONG,        /* I - first vector element to read (1 = 1st)  */
-    nelem: LONGLONG,            /* I - number of values to read                */
-    array: &mut [c_int],        /* O - array of values that are read       */
-    nularray: &mut [c_char],    /* O - array of flags: 1 if null pixel; else 0 */
-    anynul: Option<&mut c_int>, /* O - set to 1 if any values are null; else 0 */
-    status: &mut c_int,         /* IO - error status                           */
+    fptr: &mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: &mut [c_int],
+    nularray: &mut [c_char],
+    anynul: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     let dummy: c_int = 0;
 
@@ -1151,7 +1356,6 @@ pub fn ffgcfk_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of values from a column in the current FITS HDU.
 /// The column number may refer to a real column in an ASCII or binary table,
 /// or it may refer be a virtual column in a 1 or more grouped FITS primary
@@ -1165,21 +1369,35 @@ pub fn ffgcfk_safe(
 /// and will be scaled by the FITS TSCALn and TZEROn values if necessary.
 #[allow(clippy::if_same_then_else)]
 // C dispatch chain: distinct conditions deliberately share an action.
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to read (1 = 1st col)
+/// * `firstrow`  — (I) first row to read (1 = 1st row)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `elemincre` — (I) pixel increment; e.g., 2 = every other
+/// * `nultyp`    — (I) null value handling code:
+/// * `nulval`    — (I) value for null pixels if nultyp = 1
+/// * `array`     — (O) array of values that are read
+/// * `nularray`  — (O) array of flags = 1 if nultyp = 2
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `status`    — (IO) error status
 pub(crate) fn ffgclk(
-    fptr: &mut fitsfile,   /* I - FITS file pointer                       */
-    colnum: c_int,         /* I - number of column to read (1 = 1st col)  */
-    firstrow: LONGLONG,    /* I - first row to read (1 = 1st row)         */
-    firstelem: LONGLONG,   /* I - first vector element to read (1 = 1st)  */
-    nelem: LONGLONG,       /* I - number of values to read                */
-    elemincre: c_long,     /* I - pixel increment; e.g., 2 = every other  */
-    nultyp: NullCheckType, /* I - null value handling code:               */
+    fptr: &mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    elemincre: c_long,
+    nultyp: NullCheckType,
     /*     1: set undefined pixels = nulval        */
     /*     2: set nularray=1 for undefined pixels  */
-    nulval: c_int,                  /* I - value for null pixels if nultyp = 1 */
-    array: &mut [c_int],            /* O - array of values that are read       */
-    nularray: &mut [c_char],        /* O - array of flags = 1 if nultyp = 2        */
-    mut anynul: Option<&mut c_int>, /* O - set to 1 if any values are null; else 0 */
-    status: &mut c_int,             /* IO - error status                           */
+    nulval: c_int,
+    array: &mut [c_int],
+    nularray: &mut [c_char],
+    mut anynul: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     let mut scale: f64 = 0.0;
     let mut zero: f64 = 0.0;
@@ -1267,9 +1485,7 @@ pub(crate) fn ffgclk(
             nularray.fill(0); /* initialize nullarray */
         }
 
-        /*---------------------------------------------------*/
         /*  Check input and get parameters about the column: */
-        /*---------------------------------------------------*/
         if elemincre < 0 {
             readcheck -= 1; /* don't do range checking in this case */
         }
@@ -1320,9 +1536,7 @@ pub(crate) fn ffgclk(
                 power *= 10.0;
             }
         }
-        /*------------------------------------------------------------------*/
         /*  Decide whether to check for null values in the input FITS file: */
-        /*------------------------------------------------------------------*/
         nulcheck = nultyp; /* by default, check for null values in the FITS file */
 
         if nultyp == NullCheckType::SetPixel && nulval == 0 {
@@ -1342,10 +1556,8 @@ pub(crate) fn ffgclk(
             nulcheck = NullCheckType::None;
         }
 
-        /*----------------------------------------------------------------------*/
         /*  If FITS column and output data array have same datatype, then we do */
         /*  not need to use a temporary buffer to store intermediate datatype.  */
-        /*----------------------------------------------------------------------*/
         convert = true;
         if tcode == TLONG {
             /* Special Case:                        */
@@ -1363,7 +1575,6 @@ pub(crate) fn ffgclk(
             }
         }
 
-        /*---------------------------------------------------------------------*/
         /*  Now read the pixels from the FITS column. If the column does not   */
         /*  have the same datatype as the output array, then we have to read   */
         /*  the raw values into a temporary buffer (of limited size).  In      */
@@ -1373,7 +1584,6 @@ pub(crate) fn ffgclk(
         /*  test for undefined values, (2) convert the datatype if necessary,  */
         /*  and (3) scale the values by the FITS TSCALn and TZEROn linear      */
         /*  scaling parameters.                                                */
-        /*---------------------------------------------------------------------*/
 
         remain = nelem; /* remaining number of values to read */
         next = 0; /* next element in array to be read   */
@@ -1601,9 +1811,7 @@ pub(crate) fn ffgclk(
                 }
             } /* End of switch block */
 
-            /*-------------------------*/
             /*  Check for fatal error  */
-            /*-------------------------*/
             if *status > 0 {
                 /* test for error during previous read operation */
                 dtemp = next as f64;
@@ -1630,9 +1838,7 @@ pub(crate) fn ffgclk(
                 return *status;
             }
 
-            /*--------------------------------------------*/
             /*  increment the counters for the next loop  */
-            /*--------------------------------------------*/
             remain -= ntodo as LONGLONG;
             if remain != 0 {
                 next += ntodo as usize;
@@ -1652,9 +1858,7 @@ pub(crate) fn ffgclk(
             }
         } /*  End of main while Loop  */
 
-        /*--------------------------------*/
         /*  check for numerical overflow  */
-        /*--------------------------------*/
         if *status == OVERFLOW_ERR {
             ffpmsg_str("Numerical overflow during type conversion while reading FITS data.");
             *status = NUM_OVERFLOW;
@@ -1664,7 +1868,6 @@ pub(crate) fn ffgclk(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output following reading of the input from a FITS file.
 /// Check for null values and do datatype conversion and scaling if required.
 /// The nullcheck code value determines how any null values in the input array
@@ -1676,20 +1879,34 @@ pub(crate) fn ffgclk(
 /// nullarray will be set to 1; the value of nullarray for non-null pixels
 /// will = 0.  The anynull parameter will be set = 1 if any of the returned
 /// pixels are null, otherwise anynull will be returned with a value = 0;
+///
+/// # Parameters
+///
+/// * `input`     — (I) array of values to be converted
+/// * `ntodo`     — (I) number of elements in the array
+/// * `scale`     — (I) FITS TSCALn or BSCALE value
+/// * `zero`      — (I) FITS TZEROn or BZERO value
+/// * `nullcheck` — (I) null checking code; 0 = don't check
+/// * `tnull`     — (I) value of FITS TNULLn keyword if any
+/// * `nullval`   — (I) set null pixels, if nullcheck = 1
+/// * `nullarray` — (O) bad pixel array, if nullcheck = 2
+/// * `anynull`   — (O) set to 1 if any pixels are null
+/// * `output`    — (O) array of converted pixels
+/// * `status`    — (IO) error status
 pub(crate) fn fffi1int(
-    input: &[u8],             /* I - array of values to be converted     */
-    ntodo: c_long,            /* I - number of elements in the array     */
-    scale: f64,               /* I - FITS TSCALn or BSCALE value         */
-    zero: f64,                /* I - FITS TZEROn or BZERO  value         */
-    nullcheck: NullCheckType, /* I - null checking code; 0 = don't check */
+    input: &[u8],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    nullcheck: NullCheckType,
     /*     1:set null pixels = nullval         */
     /*     2: if null pixel, set nullarray = 1 */
-    tnull: u8,                   /* I - value of FITS TNULLn keyword if any */
-    nullval: c_int,              /* I - set null pixels, if nullcheck = 1   */
-    nullarray: &mut [c_char],    /* O - bad pixel array, if nullcheck = 2   */
-    anynull: Option<&mut c_int>, /* O - set to 1 if any pixels are null     */
-    output: &mut [c_int],        /* O - array of converted pixels           */
-    status: &mut c_int,          /* IO - error status                       */
+    tnull: u8,
+    nullval: c_int,
+    nullarray: &mut [c_char],
+    anynull: Option<&mut c_int>,
+    output: &mut [c_int],
+    status: &mut c_int,
 ) -> c_int {
     let mut dvalue: f64 = 0.0;
 
@@ -1763,7 +1980,6 @@ pub(crate) fn fffi1int(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output following reading of the input from a FITS file.
 /// Check for null values and do datatype conversion and scaling if required.
 /// The nullcheck code value determines how any null values in the input array
@@ -1775,20 +1991,34 @@ pub(crate) fn fffi1int(
 /// nullarray will be set to 1; the value of nullarray for non-null pixels
 /// will = 0.  The anynull parameter will be set = 1 if any of the returned
 /// pixels are null, otherwise anynull will be returned with a value = 0;
+///
+/// # Parameters
+///
+/// * `input`     — (I) array of values to be converted
+/// * `ntodo`     — (I) number of elements in the array
+/// * `scale`     — (I) FITS TSCALn or BSCALE value
+/// * `zero`      — (I) FITS TZEROn or BZERO value
+/// * `nullcheck` — (I) null checking code; 0 = don't check
+/// * `tnull`     — (I) value of FITS TNULLn keyword if any
+/// * `nullval`   — (I) set null pixels, if nullcheck = 1
+/// * `nullarray` — (O) bad pixel array, if nullcheck = 2
+/// * `anynull`   — (O) set to 1 if any pixels are null
+/// * `output`    — (O) array of converted pixels
+/// * `status`    — (IO) error status
 pub(crate) fn fffi2int(
-    input: &[c_short],        /* I - array of values to be converted     */
-    ntodo: c_long,            /* I - number of elements in the array     */
-    scale: f64,               /* I - FITS TSCALn or BSCALE value         */
-    zero: f64,                /* I - FITS TZEROn or BZERO  value         */
-    nullcheck: NullCheckType, /* I - null checking code; 0 = don't check */
+    input: &[c_short],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    nullcheck: NullCheckType,
     /*     1:set null pixels = nullval         */
     /*     2: if null pixel, set nullarray = 1 */
-    tnull: c_short,              /* I - value of FITS TNULLn keyword if any */
-    nullval: c_int,              /* I - set null pixels, if nullcheck = 1   */
-    nullarray: &mut [c_char],    /* O - bad pixel array, if nullcheck = 2   */
-    anynull: Option<&mut c_int>, /* O - set to 1 if any pixels are null     */
-    output: &mut [c_int],        /* O - array of converted pixels           */
-    status: &mut c_int,          /* IO - error status                       */
+    tnull: c_short,
+    nullval: c_int,
+    nullarray: &mut [c_char],
+    anynull: Option<&mut c_int>,
+    output: &mut [c_int],
+    status: &mut c_int,
 ) -> c_int {
     let mut dvalue: f64 = 0.0;
 
@@ -1864,7 +2094,6 @@ pub(crate) fn fffi2int(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output following reading of the input from a FITS file.
 /// Check for null values and do datatype conversion and scaling if required.
 /// The nullcheck code value determines how any null values in the input array
@@ -1876,20 +2105,34 @@ pub(crate) fn fffi2int(
 /// nullarray will be set to 1; the value of nullarray for non-null pixels
 /// will = 0.  The anynull parameter will be set = 1 if any of the returned
 /// pixels are null, otherwise anynull will be returned with a value = 0;
+///
+/// # Parameters
+///
+/// * `input`     — (I) array of values to be converted
+/// * `ntodo`     — (I) number of elements in the array
+/// * `scale`     — (I) FITS TSCALn or BSCALE value
+/// * `zero`      — (I) FITS TZEROn or BZERO value
+/// * `nullcheck` — (I) null checking code; 0 = don't check
+/// * `tnull`     — (I) value of FITS TNULLn keyword if any
+/// * `nullval`   — (I) set null pixels, if nullcheck = 1
+/// * `nullarray` — (O) bad pixel array, if nullcheck = 2
+/// * `anynull`   — (O) set to 1 if any pixels are null
+/// * `output`    — (O) array of converted pixels
+/// * `status`    — (IO) error status
 pub(crate) fn fffi4int(
-    input: &[INT32BIT],       /* I - array of values to be converted     */
-    ntodo: c_long,            /* I - number of elements in the array     */
-    scale: f64,               /* I - FITS TSCALn or BSCALE value         */
-    zero: f64,                /* I - FITS TZEROn or BZERO  value         */
-    nullcheck: NullCheckType, /* I - null checking code; 0 = don't check */
+    input: &[INT32BIT],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    nullcheck: NullCheckType,
     /*     1:set null pixels = nullval         */
     /*     2: if null pixel, set nullarray = 1 */
-    tnull: INT32BIT,             /* I - value of FITS TNULLn keyword if any */
-    nullval: c_int,              /* I - set null pixels, if nullcheck = 1   */
-    nullarray: &mut [c_char],    /* O - bad pixel array, if nullcheck = 2   */
-    anynull: Option<&mut c_int>, /* O - set to 1 if any pixels are null     */
-    output: &mut [c_int],        /* O - array of converted pixels           */
-    status: &mut c_int,          /* IO - error status                       */
+    tnull: INT32BIT,
+    nullval: c_int,
+    nullarray: &mut [c_char],
+    anynull: Option<&mut c_int>,
+    output: &mut [c_int],
+    status: &mut c_int,
 ) -> c_int {
     let mut dvalue: f64 = 0.0;
 
@@ -1963,7 +2206,6 @@ pub(crate) fn fffi4int(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output following reading of the input from a FITS file.
 /// Check for null values and do datatype conversion and scaling if required.
 /// The nullcheck code value determines how any null values in the input array
@@ -1975,20 +2217,34 @@ pub(crate) fn fffi4int(
 /// nullarray will be set to 1; the value of nullarray for non-null pixels
 /// will = 0.  The anynull parameter will be set = 1 if any of the returned
 /// pixels are null, otherwise anynull will be returned with a value = 0;
+///
+/// # Parameters
+///
+/// * `input`     — (I) array of values to be converted
+/// * `ntodo`     — (I) number of elements in the array
+/// * `scale`     — (I) FITS TSCALn or BSCALE value
+/// * `zero`      — (I) FITS TZEROn or BZERO value
+/// * `nullcheck` — (I) null checking code; 0 = don't check
+/// * `tnull`     — (I) value of FITS TNULLn keyword if any
+/// * `nullval`   — (I) set null pixels, if nullcheck = 1
+/// * `nullarray` — (O) bad pixel array, if nullcheck = 2
+/// * `anynull`   — (O) set to 1 if any pixels are null
+/// * `output`    — (O) array of converted pixels
+/// * `status`    — (IO) error status
 pub(crate) fn fffi8int(
-    input: &[LONGLONG],       /* I - array of values to be converted     */
-    ntodo: c_long,            /* I - number of elements in the array     */
-    scale: f64,               /* I - FITS TSCALn or BSCALE value         */
-    zero: f64,                /* I - FITS TZEROn or BZERO  value         */
-    nullcheck: NullCheckType, /* I - null checking code; 0 = don't check */
+    input: &[LONGLONG],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    nullcheck: NullCheckType,
     /*     1:set null pixels = nullval         */
     /*     2: if null pixel, set nullarray = 1 */
-    tnull: LONGLONG,             /* I - value of FITS TNULLn keyword if any */
-    nullval: c_int,              /* I - set null pixels, if nullcheck = 1   */
-    nullarray: &mut [c_char],    /* O - bad pixel array, if nullcheck = 2   */
-    anynull: Option<&mut c_int>, /* O - set to 1 if any pixels are null     */
-    output: &mut [c_int],        /* O - array of converted pixels           */
-    status: &mut c_int,          /* IO - error status                       */
+    tnull: LONGLONG,
+    nullval: c_int,
+    nullarray: &mut [c_char],
+    anynull: Option<&mut c_int>,
+    output: &mut [c_int],
+    status: &mut c_int,
 ) -> c_int {
     let mut dvalue: f64 = 0.0;
     let mut ulltemp: ULONGLONG = 0;
@@ -2120,7 +2376,6 @@ pub(crate) fn fffi8int(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output following reading of the input from a FITS file.
 /// Check for null values and do datatype conversion and scaling if required.
 /// The nullcheck code value determines how any null values in the input array
@@ -2132,19 +2387,32 @@ pub(crate) fn fffi8int(
 /// nullarray will be set to 1; the value of nullarray for non-null pixels
 /// will = 0.  The anynull parameter will be set = 1 if any of the returned
 /// pixels are null, otherwise anynull will be returned with a value = 0;
+///
+/// # Parameters
+///
+/// * `input`     — (I) array of values to be converted
+/// * `ntodo`     — (I) number of elements in the array
+/// * `scale`     — (I) FITS TSCALn or BSCALE value
+/// * `zero`      — (I) FITS TZEROn or BZERO value
+/// * `nullcheck` — (I) null checking code; 0 = don't check
+/// * `nullval`   — (I) set null pixels, if nullcheck = 1
+/// * `nullarray` — (O) bad pixel array, if nullcheck = 2
+/// * `anynull`   — (O) set to 1 if any pixels are null
+/// * `output`    — (O) array of converted pixels
+/// * `status`    — (IO) error status
 pub(crate) fn fffr4int(
-    input: &[f32],            /* I - array of values to be converted     */
-    ntodo: c_long,            /* I - number of elements in the array     */
-    scale: f64,               /* I - FITS TSCALn or BSCALE value         */
-    zero: f64,                /* I - FITS TZEROn or BZERO  value         */
-    nullcheck: NullCheckType, /* I - null checking code; 0 = don't check */
+    input: &[f32],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    nullcheck: NullCheckType,
     /*     1:set null pixels = nullval         */
     /*     2: if null pixel, set nullarray = 1 */
-    nullval: c_int,              /* I - set null pixels, if nullcheck = 1   */
-    nullarray: &mut [c_char],    /* O - bad pixel array, if nullcheck = 2   */
-    anynull: Option<&mut c_int>, /* O - set to 1 if any pixels are null     */
-    output: &mut [c_int],        /* O - array of converted pixels           */
-    status: &mut c_int,          /* IO - error status                       */
+    nullval: c_int,
+    nullarray: &mut [c_char],
+    anynull: Option<&mut c_int>,
+    output: &mut [c_int],
+    status: &mut c_int,
 ) -> c_int {
     let mut dvalue: f64 = 0.0;
     let mut sptr = 0;
@@ -2267,7 +2535,6 @@ pub(crate) fn fffr4int(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output following reading of the input from a FITS file.
 /// Check for null values and do datatype conversion and scaling if required.
 /// The nullcheck code value determines how any null values in the input array
@@ -2279,19 +2546,32 @@ pub(crate) fn fffr4int(
 /// nullarray will be set to 1; the value of nullarray for non-null pixels
 /// will = 0.  The anynull parameter will be set = 1 if any of the returned
 /// pixels are null, otherwise anynull will be returned with a value = 0;
+///
+/// # Parameters
+///
+/// * `input`     — (I) array of values to be converted
+/// * `ntodo`     — (I) number of elements in the array
+/// * `scale`     — (I) FITS TSCALn or BSCALE value
+/// * `zero`      — (I) FITS TZEROn or BZERO value
+/// * `nullcheck` — (I) null checking code; 0 = don't check
+/// * `nullval`   — (I) set null pixels, if nullcheck = 1
+/// * `nullarray` — (O) bad pixel array, if nullcheck = 2
+/// * `anynull`   — (O) set to 1 if any pixels are null
+/// * `output`    — (O) array of converted pixels
+/// * `status`    — (IO) error status
 pub(crate) fn fffr8int(
-    input: &[f64],            /* I - array of values to be converted     */
-    ntodo: c_long,            /* I - number of elements in the array     */
-    scale: f64,               /* I - FITS TSCALn or BSCALE value         */
-    zero: f64,                /* I - FITS TZEROn or BZERO  value         */
-    nullcheck: NullCheckType, /* I - null checking code; 0 = don't check */
+    input: &[f64],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    nullcheck: NullCheckType,
     /*     1:set null pixels = nullval         */
     /*     2: if null pixel, set nullarray = 1 */
-    nullval: c_int,              /* I - set null pixels, if nullcheck = 1   */
-    nullarray: &mut [c_char],    /* O - bad pixel array, if nullcheck = 2   */
-    anynull: Option<&mut c_int>, /* O - set to 1 if any pixels are null     */
-    output: &mut [c_int],        /* O - array of converted pixels           */
-    status: &mut c_int,          /* IO - error status                       */
+    nullval: c_int,
+    nullarray: &mut [c_char],
+    anynull: Option<&mut c_int>,
+    output: &mut [c_int],
+    status: &mut c_int,
 ) -> c_int {
     let mut dvalue: f64 = 0.0;
     let mut sptr = 0;
@@ -2413,7 +2693,6 @@ pub(crate) fn fffr8int(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output following reading of the input from a FITS file. Check
 /// for null values and do scaling if required. The nullcheck code value
 /// determines how any null values in the input array are treated. A null
@@ -2424,22 +2703,38 @@ pub(crate) fn fffr8int(
 /// nullarray will be set to 1; the value of nullarray for non-null pixels
 /// will = 0.  The anynull parameter will be set = 1 if any of the returned
 /// pixels are null, otherwise anynull will be returned with a value = 0;
+///
+/// # Parameters
+///
+/// * `input`      — (I) array of values to be converted
+/// * `ntodo`      — (I) number of elements in the array
+/// * `scale`      — (I) FITS TSCALn or BSCALE value
+/// * `zero`       — (I) FITS TZEROn or BZERO value
+/// * `twidth`     — (I) width of each substring of chars
+/// * `implipower` — (I) power of 10 of implied decimal
+/// * `nullcheck`  — (I) null checking code; 0 = don't check
+/// * `snull`      — (I) value of FITS null string, if any
+/// * `nullval`    — (I) set null pixels, if nullcheck = 1
+/// * `nullarray`  — (O) bad pixel array, if nullcheck = 2
+/// * `anynull`    — (O) set to 1 if any pixels are null
+/// * `output`     — (O) array of converted pixels
+/// * `status`     — (IO) error status
 pub(crate) fn fffstrint(
-    input: &mut [c_char],     /* I - array of values to be converted     */
-    ntodo: c_long,            /* I - number of elements in the array     */
-    scale: f64,               /* I - FITS TSCALn or BSCALE value         */
-    zero: f64,                /* I - FITS TZEROn or BZERO  value         */
-    twidth: c_long,           /* I - width of each substring of chars    */
-    implipower: f64,          /* I - power of 10 of implied decimal      */
-    nullcheck: NullCheckType, /* I - null checking code; 0 = don't check */
+    input: &mut [c_char],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    twidth: c_long,
+    implipower: f64,
+    nullcheck: NullCheckType,
     /*     1:set null pixels = nullval         */
     /*     2: if null pixel, set nullarray = 1 */
-    snull: &[c_char],                /* I - value of FITS null string, if any   */
-    nullval: c_int,                  /* I - set null pixels, if nullcheck = 1  */
-    nullarray: &mut [c_char],        /* O - bad pixel array, if nullcheck = 2   */
-    mut anynull: Option<&mut c_int>, /* O - set to 1 if any pixels are null     */
-    output: &mut [c_int],            /* O - array of converted pixels          */
-    status: &mut c_int,              /* IO - error status                       */
+    snull: &[c_char],
+    nullval: c_int,
+    nullarray: &mut [c_char],
+    mut anynull: Option<&mut c_int>,
+    output: &mut [c_int],
+    status: &mut c_int,
 ) -> c_int {
     let mut dvalue: f64 = 0.0;
     let mut message: [c_char; FLEN_ERRMSG] = [0; FLEN_ERRMSG];

--- a/src/getcoll.rs
+++ b/src/getcoll.rs
@@ -1,9 +1,14 @@
-/*  This file, getcoll.rs, contains routines that read data elements from   */
-/*  a FITS image or table, with logical datatype.                          */
-
-/*  The FITSIO software was written by William Pence at the High Energy    */
-/*  Astrophysic Science Archive Research Center (HEASARC) at the NASA      */
-/*  Goddard Space Flight Center.                                           */
+//! Routines that read data elements from a FITS image or table, with
+//! logical datatype.
+//!
+//! The [`TLOGICAL`] arm of the typed column I/O family. [`crate::getcol`]
+//! dispatches here when a caller asks for this datatype at run time; the
+//! write-side counterpart is [`crate::putcoll`].
+//!
+//! Ported from CFITSIO's `getcoll.c`, written by William Pence at the High
+//! Energy Astrophysics Science Archive Research Center (HEASARC), NASA Goddard
+//! Space Flight Center.
+#![warn(missing_docs)]
 
 use core::cmp;
 use core::slice;
@@ -20,22 +25,33 @@ use crate::getcolui::ffgcvui_safe;
 use crate::getcoluk::ffgcvuk_safe;
 use crate::{buffers::*, int_snprintf};
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of logical values from a column in the current FITS HDU.
 ///
 /// Any undefined pixels will be set equal to the value of 'nulval' unless
 /// nulval = 0 in which case no checks for undefined pixels will be made.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to read (1 = 1st col)
+/// * `firstrow`  — (I) first row to read (1 = 1st row)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `nulval`    — (I) value for null pixels
+/// * `array`     — (O) array of values
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgcvl(
-    fptr: *mut fitsfile, /* I - FITS file pointer                       */
-    colnum: c_int,       /* I - number of column to read (1 = 1st col)  */
-    firstrow: LONGLONG,  /* I - first row to read (1 = 1st row)         */
-    firstelem: LONGLONG, /* I - first vector element to read (1 = 1st)  */
-    nelem: LONGLONG,     /* I - number of values to read                */
-    nulval: c_char,      /* I - value for null pixels                   */
-    array: *mut c_char,  /* O - array of values                         */
-    anynul: *mut c_int,  /* O - set to 1 if any values are null; else 0 */
-    status: *mut c_int,  /* IO - error status                           */
+    fptr: *mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    nulval: c_char,
+    array: *mut c_char,
+    anynul: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -59,21 +75,32 @@ pub unsafe extern "C" fn ffgcvl(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of logical values from a column in the current FITS HDU.
 ///
 /// Any undefined pixels will be set equal to the value of 'nulval' unless
 /// nulval = 0 in which case no checks for undefined pixels will be made.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to read (1 = 1st col)
+/// * `firstrow`  — (I) first row to read (1 = 1st row)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `nulval`    — (I) value for null pixels
+/// * `array`     — (O) array of values
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `status`    — (IO) error status
 pub fn ffgcvl_safe(
-    fptr: &mut fitsfile,        /* I - FITS file pointer                       */
-    colnum: c_int,              /* I - number of column to read (1 = 1st col)  */
-    firstrow: LONGLONG,         /* I - first row to read (1 = 1st row)         */
-    firstelem: LONGLONG,        /* I - first vector element to read (1 = 1st)  */
-    nelem: LONGLONG,            /* I - number of values to read                */
-    nulval: c_char,             /* I - value for null pixels                   */
-    array: &mut [c_char],       /* O - array of values                         */
-    anynul: Option<&mut c_int>, /* O - set to 1 if any values are null; else 0 */
-    status: &mut c_int,         /* IO - error status                           */
+    fptr: &mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    nulval: c_char,
+    array: &mut [c_char],
+    anynul: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     let mut cdummy: [c_char; 1] = [0];
 
@@ -94,7 +121,6 @@ pub fn ffgcvl_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of logical values from a column in the current FITS HDU.
 ///
 /// !!!! THIS ROUTINE IS DEPRECATED AND SHOULD NOT BE USED !!!!!!
@@ -102,14 +128,23 @@ pub fn ffgcvl_safe(
 /// No checking for null values will be performed.
 // #[deprecated]
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to read (1 = 1st col)
+/// * `firstrow`  — (I) first row to read (1 = 1st row)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `array`     — (O) array of values
+/// * `status`    — (IO) error status
 pub unsafe extern "C" fn ffgcl(
-    fptr: *mut fitsfile, /* I - FITS file pointer                       */
-    colnum: c_int,       /* I - number of column to read (1 = 1st col)  */
-    firstrow: LONGLONG,  /* I - first row to read (1 = 1st row)         */
-    firstelem: LONGLONG, /* I - first vector element to read (1 = 1st)  */
-    nelem: LONGLONG,     /* I - number of values to read                */
-    array: *mut c_char,  /* O - array of values                         */
-    status: *mut c_int,  /* IO - error status                           */
+    fptr: *mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: *mut c_char,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -131,21 +166,30 @@ pub unsafe extern "C" fn ffgcl(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of logical values from a column in the current FITS HDU.
 ///
 /// !!!! THIS ROUTINE IS DEPRECATED AND SHOULD NOT BE USED !!!!!!
 ///           !!!! USE ffgcvl INSTEAD  !!!!!!
 /// No checking for null values will be performed.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to read (1 = 1st col)
+/// * `firstrow`  — (I) first row to read (1 = 1st row)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `array`     — (O) array of values
+/// * `status`    — (IO) error status
 #[deprecated]
 pub fn ffgcl_safe(
-    fptr: &mut fitsfile,  /* I - FITS file pointer                       */
-    colnum: c_int,        /* I - number of column to read (1 = 1st col)  */
-    firstrow: LONGLONG,   /* I - first row to read (1 = 1st row)         */
-    firstelem: LONGLONG,  /* I - first vector element to read (1 = 1st)  */
-    nelem: LONGLONG,      /* I - number of values to read                */
-    array: &mut [c_char], /* O - array of values                         */
-    status: &mut c_int,   /* IO - error status                           */
+    fptr: &mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: &mut [c_char],
+    status: &mut c_int,
 ) -> c_int {
     let mut anynul: c_int = 0;
     let nulval: c_char = 0;
@@ -163,19 +207,30 @@ pub fn ffgcl_safe(
     )
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of logical values from a column in the current FITS HDU.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to read (1 = 1st col)
+/// * `firstrow`  — (I) first row to read (1 = 1st row)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `array`     — (O) array of values
+/// * `nularray`  — (O) array of flags = 1 if nultyp = 2
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgcfl(
-    fptr: *mut fitsfile,   /* I - FITS file pointer                       */
-    colnum: c_int,         /* I - number of column to read (1 = 1st col)  */
-    firstrow: LONGLONG,    /* I - first row to read (1 = 1st row)         */
-    firstelem: LONGLONG,   /* I - first vector element to read (1 = 1st)  */
-    nelem: LONGLONG,       /* I - number of values to read                */
-    array: *mut c_char,    /* O - array of values                         */
-    nularray: *mut c_char, /* O - array of flags = 1 if nultyp = 2        */
-    anynul: *mut c_int,    /* O - set to 1 if any values are null; else 0 */
-    status: *mut c_int,    /* IO - error status                           */
+    fptr: *mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: *mut c_char,
+    nularray: *mut c_char,
+    anynul: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -192,18 +247,29 @@ pub unsafe extern "C" fn ffgcfl(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of logical values from a column in the current FITS HDU.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to read (1 = 1st col)
+/// * `firstrow`  — (I) first row to read (1 = 1st row)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `array`     — (O) array of values
+/// * `nularray`  — (O) array of flags = 1 if nultyp = 2
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `status`    — (IO) error status
 pub fn ffgcfl_safe(
-    fptr: &mut fitsfile,        /* I - FITS file pointer                       */
-    colnum: c_int,              /* I - number of column to read (1 = 1st col)  */
-    firstrow: LONGLONG,         /* I - first row to read (1 = 1st row)         */
-    firstelem: LONGLONG,        /* I - first vector element to read (1 = 1st)  */
-    nelem: LONGLONG,            /* I - number of values to read                */
-    array: &mut [c_char],       /* O - array of values                         */
-    nularray: &mut [c_char],    /* O - array of flags = 1 if nultyp = 2        */
-    anynul: Option<&mut c_int>, /* O - set to 1 if any values are null; else 0 */
-    status: &mut c_int,         /* IO - error status                           */
+    fptr: &mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: &mut [c_char],
+    nularray: &mut [c_char],
+    anynul: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     let nulval: c_char = 0;
 
@@ -223,22 +289,35 @@ pub fn ffgcfl_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of logical values from a column in the current FITS HDU.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to read (1 = 1st col)
+/// * `firstrow`  — (I) first row to read (1 = 1st row)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `nultyp`    — (I) null value handling code:
+/// * `nulval`    — (I) value for null pixels if nultyp = 1
+/// * `array`     — (O) array of values
+/// * `nularray`  — (O) array of flags = 1 if nultyp = 2
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `status`    — (IO) error status
 pub(crate) fn ffgcll(
-    fptr: &mut fitsfile,   /* I - FITS file pointer                       */
-    colnum: c_int,         /* I - number of column to read (1 = 1st col)  */
-    firstrow: LONGLONG,    /* I - first row to read (1 = 1st row)         */
-    firstelem: LONGLONG,   /* I - first vector element to read (1 = 1st)  */
-    nelem: LONGLONG,       /* I - number of values to read                */
-    nultyp: NullCheckType, /* I - null value handling code:               */
+    fptr: &mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    nultyp: NullCheckType,
     /*     1: set undefined pixels = nulval        */
     /*     2: set nularray=1 for undefined pixels  */
-    nulval: c_char,                 /* I - value for null pixels if nultyp = 1     */
-    array: &mut [c_char],           /* O - array of values                         */
-    nularray: &mut [c_char],        /* O - array of flags = 1 if nultyp = 2        */
-    mut anynul: Option<&mut c_int>, /* O - set to 1 if any values are null; else 0 */
-    status: &mut c_int,             /* IO - error status                           */
+    nulval: c_char,
+    array: &mut [c_char],
+    nularray: &mut [c_char],
+    mut anynul: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     let mut dtemp: f64 = 0.0;
     let mut tcode: c_int = 0;
@@ -276,9 +355,7 @@ pub(crate) fn ffgcll(
     if nultyp == NullCheckType::SetNullArray {
         nularray.fill(0); /* initialize nullarray */
     }
-    /*---------------------------------------------------*/
     /*  Check input and get parameters about the column: */
-    /*---------------------------------------------------*/
     if ffgcprll(
         fptr,
         colnum,
@@ -309,17 +386,13 @@ pub(crate) fn ffgcll(
         *status = NOT_LOGICAL_COL;
         return *status;
     }
-    /*------------------------------------------------------------------*/
     /*  Decide whether to check for null values in the input FITS file: */
-    /*------------------------------------------------------------------*/
     nulcheck = nultyp; /* by default, check for null values in the FITS file */
 
     if nultyp == NullCheckType::SetPixel && nulval == 0 {
         nulcheck = NullCheckType::None; /* calling routine does not want to check for nulls */
     }
-    /*---------------------------------------------------------------------*/
     /*  Now read the logical values from the FITS column.                  */
-    /*---------------------------------------------------------------------*/
 
     remain = nelem; /* remaining number of values to read */
     next = 0; /* next element in array to be read   */
@@ -383,9 +456,7 @@ pub(crate) fn ffgcll(
             return *status;
         }
 
-        /*--------------------------------------------*/
         /*  increment the counters for the next loop  */
-        /*--------------------------------------------*/
         remain -= ntodo as LONGLONG;
         if remain > 0 {
             elemnum += ntodo as LONGLONG;
@@ -403,20 +474,29 @@ pub(crate) fn ffgcll(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// read an array of logical values from a specified bit or byte
 /// column of the binary table.    larray is set = TRUE, if the corresponding
 /// bit = 1, otherwise it is set to FALSE.
 /// The binary table column being read from must have datatype 'B' or 'X'.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `colnum` — (I) number of column to write (1 = 1st col)
+/// * `frow`   — (I) first row to write (1 = 1st row)
+/// * `fbit`   — (I) first bit to write (1 = 1st)
+/// * `nbit`   — (I) number of bits to write
+/// * `larray` — (O) array of logicals corresponding to bits
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgcx(
-    fptr: *mut fitsfile, /* I - FITS file pointer                       */
-    colnum: c_int,       /* I - number of column to write (1 = 1st col) */
-    frow: LONGLONG,      /* I - first row to write (1 = 1st row)        */
-    fbit: LONGLONG,      /* I - first bit to write (1 = 1st)            */
-    nbit: LONGLONG,      /* I - number of bits to write                 */
-    larray: *mut c_char, /* O - array of logicals corresponding to bits */
-    status: *mut c_int,  /* IO - error status                           */
+    fptr: *mut fitsfile,
+    colnum: c_int,
+    frow: LONGLONG,
+    fbit: LONGLONG,
+    nbit: LONGLONG,
+    larray: *mut c_char,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -429,19 +509,28 @@ pub unsafe extern "C" fn ffgcx(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// read an array of logical values from a specified bit or byte
 /// column of the binary table.    larray is set = TRUE, if the corresponding
 /// bit = 1, otherwise it is set to FALSE.
 /// The binary table column being read from must have datatype 'B' or 'X'.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `colnum` — (I) number of column to write (1 = 1st col)
+/// * `frow`   — (I) first row to write (1 = 1st row)
+/// * `fbit`   — (I) first bit to write (1 = 1st)
+/// * `nbit`   — (I) number of bits to write
+/// * `larray` — (O) array of logicals corresponding to bits
+/// * `status` — (IO) error status
 pub fn ffgcx_safe(
-    fptr: &mut fitsfile,   /* I - FITS file pointer                       */
-    colnum: c_int,         /* I - number of column to write (1 = 1st col) */
-    frow: LONGLONG,        /* I - first row to write (1 = 1st row)        */
-    fbit: LONGLONG,        /* I - first bit to write (1 = 1st)            */
-    nbit: LONGLONG,        /* I - number of bits to write                 */
-    larray: &mut [c_char], /* O - array of logicals corresponding to bits */
-    status: &mut c_int,    /* IO - error status                           */
+    fptr: &mut fitsfile,
+    colnum: c_int,
+    frow: LONGLONG,
+    fbit: LONGLONG,
+    nbit: LONGLONG,
+    larray: &mut [c_char],
+    status: &mut c_int,
 ) -> c_int {
     let mut bstart: LONGLONG = 0;
     let mut offset: c_long = 0;
@@ -585,21 +674,31 @@ pub fn ffgcx_safe(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read a consecutive string of bits from an 'X' or 'B' column and
 /// interpret them as an unsigned integer.  The number of bits must be
 /// less than or equal to 16 or the total number of bits in the column,
 /// which ever is less.
+///
+/// # Parameters
+///
+/// * `fptr`            — (I) FITS file pointer
+/// * `colnum`          — (I) number of column to read (1 = 1st col)
+/// * `firstrow`        — (I) first row to read (1 = 1st row)
+/// * `nrows`           — (I) no. of rows to read
+/// * `input_first_bit` — (I) first bit to read (1 = 1st)
+/// * `input_nbits`     — (I) number of bits to read (<= 32)
+/// * `array`           — (O) array of integer values
+/// * `status`          — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgcxui(
-    fptr: *mut fitsfile,     /* I - FITS file pointer                       */
-    colnum: c_int,           /* I - number of column to read (1 = 1st col)  */
-    firstrow: LONGLONG,      /* I - first row to read (1 = 1st row)         */
-    nrows: LONGLONG,         /* I - no. of rows to read                     */
-    input_first_bit: c_long, /* I - first bit to read (1 = 1st)        */
-    input_nbits: c_int,      /* I - number of bits to read (<= 32)     */
-    array: *mut c_ushort,    /* O - array of integer values            */
-    status: *mut c_int,      /* IO - error status                           */
+    fptr: *mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    nrows: LONGLONG,
+    input_first_bit: c_long,
+    input_nbits: c_int,
+    array: *mut c_ushort,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -621,22 +720,31 @@ pub unsafe extern "C" fn ffgcxui(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read a consecutive string of bits from an 'X' or 'B' column and
 /// interpret them as an unsigned integer.  The number of bits must be
 /// less than or equal to 16 or the total number of bits in the column,
 /// which ever is less.
 #[allow(clippy::if_same_then_else)]
 // C dispatch chain: distinct conditions deliberately share an action.
+/// # Parameters
+///
+/// * `fptr`            — (I) FITS file pointer
+/// * `colnum`          — (I) number of column to read (1 = 1st col)
+/// * `firstrow`        — (I) first row to read (1 = 1st row)
+/// * `nrows`           — (I) no. of rows to read
+/// * `input_first_bit` — (I) first bit to read (1 = 1st)
+/// * `input_nbits`     — (I) number of bits to read (<= 32)
+/// * `array`           — (O) array of integer values
+/// * `status`          — (IO) error status
 pub fn ffgcxui_safe(
-    fptr: &mut fitsfile,     /* I - FITS file pointer                       */
-    colnum: c_int,           /* I - number of column to read (1 = 1st col)  */
-    firstrow: LONGLONG,      /* I - first row to read (1 = 1st row)         */
-    nrows: LONGLONG,         /* I - no. of rows to read                     */
-    input_first_bit: c_long, /* I - first bit to read (1 = 1st)        */
-    input_nbits: c_int,      /* I - number of bits to read (<= 32)     */
-    array: &mut [c_ushort],  /* O - array of integer values            */
-    status: &mut c_int,      /* IO - error status                           */
+    fptr: &mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    nrows: LONGLONG,
+    input_first_bit: c_long,
+    input_nbits: c_int,
+    array: &mut [c_ushort],
+    status: &mut c_int,
 ) -> c_int {
     let mut colbyte: [c_ushort; 5] = [0; 5];
     let mut message: [c_char; FLEN_ERRMSG] = [0; FLEN_ERRMSG];
@@ -783,21 +891,31 @@ pub fn ffgcxui_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read a consecutive string of bits from an 'X' or 'B' column and
 /// interpret them as an unsigned integer.  The number of bits must be
 /// less than or equal to 32 or the total number of bits in the column,
 /// which ever is less.
+///
+/// # Parameters
+///
+/// * `fptr`            — (I) FITS file pointer
+/// * `colnum`          — (I) number of column to read (1 = 1st col)
+/// * `firstrow`        — (I) first row to read (1 = 1st row)
+/// * `nrows`           — (I) no. of rows to read
+/// * `input_first_bit` — (I) first bit to read (1 = 1st)
+/// * `input_nbits`     — (I) number of bits to read (<= 32)
+/// * `array`           — (O) array of integer values
+/// * `status`          — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgcxuk(
-    fptr: *mut fitsfile,     /* I - FITS file pointer                       */
-    colnum: c_int,           /* I - number of column to read (1 = 1st col)  */
-    firstrow: LONGLONG,      /* I - first row to read (1 = 1st row)         */
-    nrows: LONGLONG,         /* I - no. of rows to read                     */
-    input_first_bit: c_long, /* I - first bit to read (1 = 1st)        */
-    input_nbits: c_int,      /* I - number of bits to read (<= 32)     */
-    array: *mut c_uint,      /* O - array of integer values            */
-    status: *mut c_int,      /* IO - error status                           */
+    fptr: *mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    nrows: LONGLONG,
+    input_first_bit: c_long,
+    input_nbits: c_int,
+    array: *mut c_uint,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -819,22 +937,31 @@ pub unsafe extern "C" fn ffgcxuk(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read a consecutive string of bits from an 'X' or 'B' column and
 /// interpret them as an unsigned integer.  The number of bits must be
 /// less than or equal to 32 or the total number of bits in the column,
 /// which ever is less.
 #[allow(clippy::if_same_then_else)]
 // C dispatch chain: distinct conditions deliberately share an action.
+/// # Parameters
+///
+/// * `fptr`            — (I) FITS file pointer
+/// * `colnum`          — (I) number of column to read (1 = 1st col)
+/// * `firstrow`        — (I) first row to read (1 = 1st row)
+/// * `nrows`           — (I) no. of rows to read
+/// * `input_first_bit` — (I) first bit to read (1 = 1st)
+/// * `input_nbits`     — (I) number of bits to read (<= 32)
+/// * `array`           — (O) array of integer values
+/// * `status`          — (IO) error status
 pub fn ffgcxuk_safe(
-    fptr: &mut fitsfile,     /* I - FITS file pointer                       */
-    colnum: c_int,           /* I - number of column to read (1 = 1st col)  */
-    firstrow: LONGLONG,      /* I - first row to read (1 = 1st row)         */
-    nrows: LONGLONG,         /* I - no. of rows to read                     */
-    input_first_bit: c_long, /* I - first bit to read (1 = 1st)        */
-    input_nbits: c_int,      /* I - number of bits to read (<= 32)     */
-    array: &mut [c_uint],    /* O - array of integer values            */
-    status: &mut c_int,      /* IO - error status                           */
+    fptr: &mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    nrows: LONGLONG,
+    input_first_bit: c_long,
+    input_nbits: c_int,
+    array: &mut [c_uint],
+    status: &mut c_int,
 ) -> c_int {
     let mut colbyte: [c_uint; 5] = [0; 5];
     let mut message: [c_char; FLEN_ERRMSG] = [0; FLEN_ERRMSG];

--- a/src/getcols.rs
+++ b/src/getcols.rs
@@ -1,9 +1,14 @@
-/*  This file, getcols.rs, contains routines that read data elements from   */
-/*  a FITS image or table, with a character string datatype.               */
-
-/*  The FITSIO software was written by William Pence at the High Energy    */
-/*  Astrophysic Science Archive Research Center (HEASARC) at the NASA      */
-/*  Goddard Space Flight Center.                                           */
+//! Routines that read data elements from a FITS image or table, with
+//! character string datatype.
+//!
+//! The [`TSTRING`] arm of the typed column I/O family. [`crate::getcol`]
+//! dispatches here when a caller asks for this datatype at run time; the
+//! write-side counterpart is [`crate::putcols`].
+//!
+//! Ported from CFITSIO's `getcols.c`, written by William Pence at the High
+//! Energy Astrophysics Science Archive Research Center (HEASARC), NASA Goddard
+//! Space Flight Center.
+#![warn(missing_docs)]
 
 use core::ffi::CStr;
 use core::slice;
@@ -31,22 +36,33 @@ use crate::wrappers::*;
 use crate::{NullCheckType, fitsio::*};
 use crate::{bb, cs, parse_c_int};
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of string values from a column in the current FITS HDU.
 ///
 /// Any undefined pixels will be set equal to the value of 'nulval' unless
 /// nulval = null in which case no checks for undefined pixels will be made.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to read (1 = 1st col)
+/// * `firstrow`  — (I) first row to read (1 = 1st row)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of strings to read
+/// * `nulval`    — (I) string for null pixels
+/// * `array`     — (O) array of values that are read
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgcvs(
-    fptr: *mut fitsfile,     /* I - FITS file pointer                       */
-    colnum: c_int,           /* I - number of column to read (1 = 1st col)  */
-    firstrow: LONGLONG,      /* I - first row to read (1 = 1st row)         */
-    firstelem: LONGLONG,     /* I - first vector element to read (1 = 1st)  */
-    nelem: LONGLONG,         /* I - number of strings to read               */
-    nulval: *const c_char,   /* I - string for null pixels                  */
-    array: *mut *mut c_char, /* O - array of values that are read           */
-    anynul: *mut c_int,      /* O - set to 1 if any values are null; else 0 */
-    status: *mut c_int,      /* IO - error status                           */
+    fptr: *mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    nulval: *const c_char,
+    array: *mut *mut c_char,
+    anynul: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -83,20 +99,31 @@ pub unsafe extern "C" fn ffgcvs(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of string values from a column in the current FITS HDU.
 /// Any undefined pixels will be set equal to the value of 'nulval' unless
 /// nulval = null in which case no checks for undefined pixels will be made.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to read (1 = 1st col)
+/// * `firstrow`  — (I) first row to read (1 = 1st row)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of strings to read
+/// * `nulval`    — (I) string for null pixels
+/// * `array`     — (O) array of values that are read
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `status`    — (IO) error status
 pub fn ffgcvs_safe(
-    fptr: &mut fitsfile,         /* I - FITS file pointer                       */
-    colnum: c_int,               /* I - number of column to read (1 = 1st col)  */
-    firstrow: LONGLONG,          /* I - first row to read (1 = 1st row)         */
-    firstelem: LONGLONG,         /* I - first vector element to read (1 = 1st)  */
-    nelem: LONGLONG,             /* I - number of strings to read               */
-    nulval: Option<&[c_char]>,   /* I - string for null pixels                  */
-    array: &mut [&mut [c_char]], /* O - array of values that are read           */
-    anynul: Option<&mut c_int>,  /* O - set to 1 if any values are null; else 0 */
-    status: &mut c_int,          /* IO - error status                           */
+    fptr: &mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    nulval: Option<&[c_char]>,
+    array: &mut [&mut [c_char]],
+    anynul: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     let mut cdummy: [c_char; 2] = [0; 2];
 
@@ -117,21 +144,32 @@ pub fn ffgcvs_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of string values from a column in the current FITS HDU.
 /// Nularray will be set = 1 if the corresponding array pixel is undefined,
 /// otherwise nularray will = 0.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to read (1 = 1st col)
+/// * `firstrow`  — (I) first row to read (1 = 1st row)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of strings to read
+/// * `array`     — (O) array of values that are read
+/// * `nularray`  — (O) array of flags = 1 if nultyp = 2
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgcfs(
-    fptr: *mut fitsfile,     /* I - FITS file pointer                       */
-    colnum: c_int,           /* I - number of column to read (1 = 1st col)  */
-    firstrow: LONGLONG,      /* I - first row to read (1 = 1st row)         */
-    firstelem: LONGLONG,     /* I - first vector element to read (1 = 1st)  */
-    nelem: LONGLONG,         /* I - number of strings to read               */
-    array: *mut *mut c_char, /* O - array of values that are read           */
-    nularray: *mut c_char,   /* O - array of flags = 1 if nultyp = 2        */
-    anynul: *mut c_int,      /* O - set to 1 if any values are null; else 0 */
-    status: *mut c_int,      /* IO - error status                           */
+    fptr: *mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: *mut *mut c_char,
+    nularray: *mut c_char,
+    anynul: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -161,20 +199,31 @@ pub unsafe extern "C" fn ffgcfs(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of string values from a column in the current FITS HDU.
 /// Nularray will be set = 1 if the corresponding array pixel is undefined,
 /// otherwise nularray will = 0.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to read (1 = 1st col)
+/// * `firstrow`  — (I) first row to read (1 = 1st row)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of strings to read
+/// * `array`     — (O) array of values that are read
+/// * `nularray`  — (O) array of flags = 1 if nultyp = 2
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `status`    — (IO) error status
 pub fn ffgcfs_safe(
-    fptr: &mut fitsfile,            /* I - FITS file pointer                       */
-    colnum: c_int,                  /* I - number of column to read (1 = 1st col)  */
-    firstrow: LONGLONG,             /* I - first row to read (1 = 1st row)         */
-    firstelem: LONGLONG,            /* I - first vector element to read (1 = 1st)  */
-    nelem: LONGLONG,                /* I - number of strings to read               */
-    array: &mut Vec<&mut [c_char]>, /* O - array of values that are read           */
-    nularray: &mut [c_char],        /* O - array of flags = 1 if nultyp = 2        */
-    anynul: Option<&mut c_int>,     /* O - set to 1 if any values are null; else 0 */
-    status: &mut c_int,             /* IO - error status                           */
+    fptr: &mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: &mut Vec<&mut [c_char]>,
+    nularray: &mut [c_char],
+    anynul: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     let cdummy: [c_char; 2] = [0; 2];
 
@@ -194,23 +243,36 @@ pub fn ffgcfs_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of string values from a column in the current FITS HDU.
 /// Returns a formatted string value, regardless of the datatype of the column
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to read (1 = 1st col)
+/// * `firstrow`  — (I) first row to read (1 = 1st row)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of strings to read
+/// * `nultyp`    — (I) null value handling code:
+/// * `nulval`    — (I) value for null pixels if nultyp = 1
+/// * `array`     — (O) array of values that are read
+/// * `nularray`  — (O) array of flags = 1 if nultyp = 2
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `status`    — (IO) error status
 pub(crate) fn ffgcls(
-    fptr: &mut fitsfile,   /* I - FITS file pointer                       */
-    colnum: c_int,         /* I - number of column to read (1 = 1st col) */
-    firstrow: LONGLONG,    /* I - first row to read (1 = 1st row)        */
-    firstelem: LONGLONG,   /* I - first vector element to read (1 = 1st) */
-    nelem: LONGLONG,       /* I - number of strings to read              */
-    nultyp: NullCheckType, /* I - null value handling code:               */
+    fptr: &mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    nultyp: NullCheckType,
     /*     1: set undefined pixels = nulval        */
     /*     2: set nularray=1 for undefined pixels  */
-    nulval: Option<&[c_char]>, /* I - value for null pixels if nultyp = 1     */
-    array: &mut [&mut [c_char]], /* O - array of values that are read           */
-    nularray: &mut [c_char],   /* O - array of flags = 1 if nultyp = 2        */
-    anynul: Option<&mut c_int>, /* O - set to 1 if any values are null; else 0 */
-    status: &mut c_int,        /* IO - error status                           */
+    nulval: Option<&[c_char]>,
+    array: &mut [&mut [c_char]],
+    nularray: &mut [c_char],
+    anynul: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     let mut tcode: c_int = 0;
     let mut hdutype: c_int = 0;
@@ -787,14 +849,20 @@ pub(crate) fn ffgcls(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Get Column Display Width.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `colnum` — (I) number of column (1 = 1st col)
+/// * `width`  — (O) display width
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgcdw(
-    fptr: *mut fitsfile, /* I - FITS file pointer                       */
-    colnum: c_int,       /* I - number of column (1 = 1st col)      */
-    width: *mut c_int,   /* O - display width                       */
-    status: *mut c_int,  /* IO - error status                           */
+    fptr: *mut fitsfile,
+    colnum: c_int,
+    width: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -806,13 +874,19 @@ pub unsafe extern "C" fn ffgcdw(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Get Column Display Width.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `colnum` — (I) number of column (1 = 1st col)
+/// * `width`  — (O) display width
+/// * `status` — (IO) error status
 pub fn ffgcdw_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                       */
-    colnum: c_int,       /* I - number of column (1 = 1st col)      */
-    width: &mut c_int,   /* O - display width                       */
-    status: &mut c_int,  /* IO - error status                           */
+    fptr: &mut fitsfile,
+    colnum: c_int,
+    width: &mut c_int,
+    status: &mut c_int,
 ) -> c_int {
     let mut message: [c_char; FLEN_ERRMSG] = [0; FLEN_ERRMSG];
     let mut keyname: [c_char; FLEN_KEYWORD] = [0; FLEN_KEYWORD];
@@ -1002,24 +1076,36 @@ pub fn ffgcdw_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of string values from a column in the current FITS HDU.
 #[allow(clippy::if_same_then_else)]
 // C dispatch chain: distinct conditions deliberately share an action.
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to read (1 = 1st col)
+/// * `firstrow`  — (I) first row to read (1 = 1st row)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of strings to read
+/// * `nultyp`    — (I) null value handling code:
+/// * `nulval`    — (I) value for null pixels if nultyp = 1
+/// * `array`     — (O) array of values that are read
+/// * `nularray`  — (O) array of flags = 1 if nultyp = 2
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `status`    — (IO) error status
 pub(crate) fn ffgcls2(
-    fptr: &mut fitsfile,   /* I - FITS file pointer                       */
-    colnum: c_int,         /* I - number of column to read (1 = 1st col) */
-    firstrow: LONGLONG,    /* I - first row to read (1 = 1st row)        */
-    firstelem: LONGLONG,   /* I - first vector element to read (1 = 1st) */
-    nelem: LONGLONG,       /* I - number of strings to read              */
-    nultyp: NullCheckType, /* I - null value handling code:               */
+    fptr: &mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    nultyp: NullCheckType,
     /*     1: set undefined pixels = nulval        */
     /*     2: set nularray=1 for undefined pixels  */
-    nulval: Option<&[c_char]>, /* I - value for null pixels if nultyp = 1     */
-    array: &mut [&mut [c_char]], /* O - array of values that are read           */
-    nularray: &mut [c_char],   /* O - array of flags = 1 if nultyp = 2        */
-    mut anynul: Option<&mut c_int>, /* O - set to 1 if any values are null; else 0 */
-    status: &mut c_int,        /* IO - error status                           */
+    nulval: Option<&[c_char]>,
+    array: &mut [&mut [c_char]],
+    nularray: &mut [c_char],
+    mut anynul: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     let dtemp: f64;
     let mut nullen: c_long;
@@ -1066,9 +1152,7 @@ pub(crate) fn ffgcls2(
     if nultyp == NullCheckType::SetNullArray {
         nularray.fill(0); /* initialize nullarray */
     }
-    /*---------------------------------------------------*/
     /*  Check input and get parameters about the column: */
-    /*---------------------------------------------------*/
     if colnum < 1 || colnum > fptr.Fptr.tfield {
         int_snprintf!(
             &mut message,
@@ -1163,9 +1247,7 @@ pub(crate) fn ffgcls2(
     if nullen == 0 {
         nullen = 1;
     }
-    /*------------------------------------------------------------------*/
     /*  Decide whether to check for null values in the input FITS file: */
-    /*------------------------------------------------------------------*/
     nulcheck = nultyp; /* by default check for null values in the FITS file */
 
     if nultyp == NullCheckType::SetPixel && nulval.is_none() {
@@ -1178,9 +1260,7 @@ pub(crate) fn ffgcls2(
         nulcheck = NullCheckType::None; /* null value string is longer than width of column  */
         /* thus impossible for any column elements to = null */
     }
-    /*---------------------------------------------------------------------*/
     /*  Now read the strings one at a time from the FITS column.           */
-    /*---------------------------------------------------------------------*/
     next = 0; /* next element in array to be read  */
     rownum = 0; /* row number, relative to firstrow     */
 
@@ -1287,9 +1367,7 @@ pub(crate) fn ffgcls2(
             return *status;
         }
 
-        /*--------------------------------------------*/
         /*  increment the counters for the next loop  */
-        /*--------------------------------------------*/
         next += ntodo as LONGLONG;
         remain -= ntodo as LONGLONG;
         if remain > 0 {

--- a/src/getcolsb.rs
+++ b/src/getcolsb.rs
@@ -1,9 +1,14 @@
-/*  This file, getcolsb.rs, contains routines that read data elements from   */
-/*  a FITS image or table, with signed char (signed byte) data type.        */
-
-/*  The FITSIO software was written by William Pence at the High Energy    */
-/*  Astrophysic Science Archive Research Center (HEASARC) at the NASA      */
-/*  Goddard Space Flight Center.                                           */
+//! Routines that read data elements from a FITS image or table, with signed
+//! char (signed byte) datatype.
+//!
+//! The [`TSBYTE`] arm of the typed column I/O family. [`crate::getcol`]
+//! dispatches here when a caller asks for this datatype at run time; the
+//! write-side counterpart is [`crate::putcolsb`].
+//!
+//! Ported from CFITSIO's `getcolsb.c`, written by William Pence at the High
+//! Energy Astrophysics Science Archive Research Center (HEASARC), NASA Goddard
+//! Space Flight Center.
+#![warn(missing_docs)]
 
 use core::slice;
 use core::{cmp, mem};
@@ -25,7 +30,6 @@ use crate::{NullValue, bb};
 use crate::{buffers::*, calculate_subsection_length};
 use crate::{int_snprintf, slice_to_str};
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of values from the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
 /// the FITS array is not the same as the array being read).
@@ -37,16 +41,27 @@ use crate::{int_snprintf, slice_to_str};
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to read (1 = 1st group)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `nulval`    — (I) value for undefined pixels
+/// * `array`     — (O) array of values that are returned
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgpvsb(
-    fptr: *mut fitsfile, /* I - FITS file pointer                       */
-    group: c_long,       /* I - group to read (1 = 1st group)           */
-    firstelem: LONGLONG, /* I - first vector element to read (1 = 1st)  */
-    nelem: LONGLONG,     /* I - number of values to read                */
-    nulval: i8,          /* I - value for undefined pixels          */
-    array: *mut i8,      /* O - array of values that are returned   */
-    anynul: *mut c_int,  /* O - set to 1 if any values are null; else 0 */
-    status: *mut c_int,  /* IO - error status                           */
+    fptr: *mut fitsfile,
+    group: c_long,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    nulval: i8,
+    array: *mut i8,
+    anynul: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -60,7 +75,6 @@ pub unsafe extern "C" fn ffgpvsb(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of values from the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
 /// the FITS array is not the same as the array being read).
@@ -72,15 +86,26 @@ pub unsafe extern "C" fn ffgpvsb(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to read (1 = 1st group)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `nulval`    — (I) value for undefined pixels
+/// * `array`     — (O) array of values that are returned
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `status`    — (IO) error status
 pub fn ffgpvsb_safe(
-    fptr: &mut fitsfile,        /* I - FITS file pointer                       */
-    group: c_long,              /* I - group to read (1 = 1st group)           */
-    firstelem: LONGLONG,        /* I - first vector element to read (1 = 1st)  */
-    nelem: LONGLONG,            /* I - number of values to read                */
-    nulval: i8,                 /* I - value for undefined pixels          */
-    array: &mut [i8],           /* O - array of values that are returned   */
-    anynul: Option<&mut c_int>, /* O - set to 1 if any values are null; else 0 */
-    status: &mut c_int,         /* IO - error status                           */
+    fptr: &mut fitsfile,
+    group: c_long,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    nulval: i8,
+    array: &mut [i8],
+    anynul: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     let cdummy = 0;
     let nullcheck = NullCheckType::SetPixel;
@@ -124,7 +149,6 @@ pub fn ffgpvsb_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of values from the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
 /// the FITS array is not the same as the array being read).
@@ -136,16 +160,27 @@ pub fn ffgpvsb_safe(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to read (1 = 1st group)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `array`     — (O) array of values that are returned
+/// * `nularray`  — (O) array of null pixel flags
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgpfsb(
-    fptr: *mut fitsfile,   /* I - FITS file pointer                       */
-    group: c_long,         /* I - group to read (1 = 1st group)           */
-    firstelem: LONGLONG,   /* I - first vector element to read (1 = 1st)  */
-    nelem: LONGLONG,       /* I - number of values to read                */
-    array: *mut i8,        /* O - array of values that are returned   */
-    nularray: *mut c_char, /* O - array of null pixel flags               */
-    anynul: *mut c_int,    /* O - set to 1 if any values are null; else 0 */
-    status: *mut c_int,    /* IO - error status                           */
+    fptr: *mut fitsfile,
+    group: c_long,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: *mut i8,
+    nularray: *mut c_char,
+    anynul: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -162,7 +197,6 @@ pub unsafe extern "C" fn ffgpfsb(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of values from the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
 /// the FITS array is not the same as the array being read).
@@ -174,15 +208,26 @@ pub unsafe extern "C" fn ffgpfsb(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to read (1 = 1st group)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `array`     — (O) array of values that are returned
+/// * `nularray`  — (O) array of null pixel flags
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `status`    — (IO) error status
 pub fn ffgpfsb_safe(
-    fptr: &mut fitsfile,        /* I - FITS file pointer                       */
-    group: c_long,              /* I - group to read (1 = 1st group)           */
-    firstelem: LONGLONG,        /* I - first vector element to read (1 = 1st)  */
-    nelem: LONGLONG,            /* I - number of values to read                */
-    array: &mut [i8],           /* O - array of values that are returned   */
-    nularray: &mut [c_char],    /* O - array of null pixel flags               */
-    anynul: Option<&mut c_int>, /* O - set to 1 if any values are null; else 0 */
-    status: &mut c_int,         /* IO - error status                           */
+    fptr: &mut fitsfile,
+    group: c_long,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: &mut [i8],
+    nularray: &mut [c_char],
+    anynul: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     let nullcheck = NullCheckType::SetNullArray;
 
@@ -223,23 +268,34 @@ pub fn ffgpfsb_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an entire 2-D array of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of the
 /// FITS array is not the same as the array being read).  Any null
 /// values in the array will be set equal to the value of nulval, unless
 /// nulval = 0 in which case no null checking will be performed.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `group`  — (I) group to read (1 = 1st group)
+/// * `nulval` — set undefined pixels equal to this
+/// * `ncols`  — (I) number of pixels in each row of array
+/// * `naxis1` — (I) FITS image NAXIS1 value
+/// * `naxis2` — (I) FITS image NAXIS2 value
+/// * `array`  — (O) array to be filled and returned
+/// * `anynul` — (O) set to 1 if any values are null; else 0
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffg2dsb(
-    fptr: *mut fitsfile, /* I - FITS file pointer                       */
-    group: c_long,       /* I - group to read (1 = 1st group)           */
-    nulval: i8,          /* set undefined pixels equal to this     */
-    ncols: LONGLONG,     /* I - number of pixels in each row of array   */
-    naxis1: LONGLONG,    /* I - FITS image NAXIS1 value                 */
-    naxis2: LONGLONG,    /* I - FITS image NAXIS2 value                 */
-    array: *mut i8,      /* O - array to be filled and returned    */
-    anynul: *mut c_int,  /* O - set to 1 if any values are null; else 0 */
-    status: *mut c_int,  /* IO - error status                           */
+    fptr: *mut fitsfile,
+    group: c_long,
+    nulval: i8,
+    ncols: LONGLONG,
+    naxis1: LONGLONG,
+    naxis2: LONGLONG,
+    array: *mut i8,
+    anynul: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -255,22 +311,33 @@ pub unsafe extern "C" fn ffg2dsb(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an entire 2-D array of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of the
 /// FITS array is not the same as the array being read).  Any null
 /// values in the array will be set equal to the value of nulval, unless
 /// nulval = 0 in which case no null checking will be performed.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `group`  — (I) group to read (1 = 1st group)
+/// * `nulval` — set undefined pixels equal to this
+/// * `ncols`  — (I) number of pixels in each row of array
+/// * `naxis1` — (I) FITS image NAXIS1 value
+/// * `naxis2` — (I) FITS image NAXIS2 value
+/// * `array`  — (O) array to be filled and returned
+/// * `anynul` — (O) set to 1 if any values are null; else 0
+/// * `status` — (IO) error status
 pub fn ffg2dsb_safe(
-    fptr: &mut fitsfile,        /* I - FITS file pointer                       */
-    group: c_long,              /* I - group to read (1 = 1st group)           */
-    nulval: i8,                 /* set undefined pixels equal to this     */
-    ncols: LONGLONG,            /* I - number of pixels in each row of array   */
-    naxis1: LONGLONG,           /* I - FITS image NAXIS1 value                 */
-    naxis2: LONGLONG,           /* I - FITS image NAXIS2 value                 */
-    array: &mut [i8],           /* O - array to be filled and returned    */
-    anynul: Option<&mut c_int>, /* O - set to 1 if any values are null; else 0 */
-    status: &mut c_int,         /* IO - error status                           */
+    fptr: &mut fitsfile,
+    group: c_long,
+    nulval: i8,
+    ncols: LONGLONG,
+    naxis1: LONGLONG,
+    naxis2: LONGLONG,
+    array: &mut [i8],
+    anynul: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     /* call the 3D reading routine, with the 3rd dimension = 1 */
     ffg3dsb_safe(
@@ -280,7 +347,6 @@ pub fn ffg2dsb_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an entire 3-D array of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of the
 /// FITS array is not the same as the array being read).  Any null
@@ -291,19 +357,33 @@ pub fn ffg2dsb_safe(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `group`  — (I) group to read (1 = 1st group)
+/// * `nulval` — set undefined pixels equal to this
+/// * `ncols`  — (I) number of pixels in each row of array
+/// * `nrows`  — (I) number of rows in each plane of array
+/// * `naxis1` — (I) FITS image NAXIS1 value
+/// * `naxis2` — (I) FITS image NAXIS2 value
+/// * `naxis3` — (I) FITS image NAXIS3 value
+/// * `array`  — (O) array to be filled and returned
+/// * `anynul` — (O) set to 1 if any values are null; else 0
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffg3dsb(
-    fptr: *mut fitsfile, /* I - FITS file pointer                       */
-    group: c_long,       /* I - group to read (1 = 1st group)           */
-    nulval: i8,          /* set undefined pixels equal to this     */
-    ncols: LONGLONG,     /* I - number of pixels in each row of array   */
-    nrows: LONGLONG,     /* I - number of rows in each plane of array   */
-    naxis1: LONGLONG,    /* I - FITS image NAXIS1 value                 */
-    naxis2: LONGLONG,    /* I - FITS image NAXIS2 value                 */
-    naxis3: LONGLONG,    /* I - FITS image NAXIS3 value                 */
-    array: *mut i8,      /* O - array to be filled and returned    */
-    anynul: *mut c_int,  /* O - set to 1 if any values are null; else 0 */
-    status: *mut c_int,  /* IO - error status                           */
+    fptr: *mut fitsfile,
+    group: c_long,
+    nulval: i8,
+    ncols: LONGLONG,
+    nrows: LONGLONG,
+    naxis1: LONGLONG,
+    naxis2: LONGLONG,
+    naxis3: LONGLONG,
+    array: *mut i8,
+    anynul: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -319,7 +399,6 @@ pub unsafe extern "C" fn ffg3dsb(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an entire 3-D array of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of the
 /// FITS array is not the same as the array being read).  Any null
@@ -330,18 +409,32 @@ pub unsafe extern "C" fn ffg3dsb(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `group`  — (I) group to read (1 = 1st group)
+/// * `nulval` — set undefined pixels equal to this
+/// * `ncols`  — (I) number of pixels in each row of array
+/// * `nrows`  — (I) number of rows in each plane of array
+/// * `naxis1` — (I) FITS image NAXIS1 value
+/// * `naxis2` — (I) FITS image NAXIS2 value
+/// * `naxis3` — (I) FITS image NAXIS3 value
+/// * `array`  — (O) array to be filled and returned
+/// * `anynul` — (O) set to 1 if any values are null; else 0
+/// * `status` — (IO) error status
 pub fn ffg3dsb_safe(
-    fptr: &mut fitsfile,            /* I - FITS file pointer                       */
-    group: c_long,                  /* I - group to read (1 = 1st group)           */
-    nulval: i8,                     /* set undefined pixels equal to this     */
-    ncols: LONGLONG,                /* I - number of pixels in each row of array   */
-    nrows: LONGLONG,                /* I - number of rows in each plane of array   */
-    naxis1: LONGLONG,               /* I - FITS image NAXIS1 value                 */
-    naxis2: LONGLONG,               /* I - FITS image NAXIS2 value                 */
-    naxis3: LONGLONG,               /* I - FITS image NAXIS3 value                 */
-    array: &mut [i8],               /* O - array to be filled and returned    */
-    mut anynul: Option<&mut c_int>, /* O - set to 1 if any values are null; else 0 */
-    status: &mut c_int,             /* IO - error status                           */
+    fptr: &mut fitsfile,
+    group: c_long,
+    nulval: i8,
+    ncols: LONGLONG,
+    nrows: LONGLONG,
+    naxis1: LONGLONG,
+    naxis2: LONGLONG,
+    naxis3: LONGLONG,
+    array: &mut [i8],
+    mut anynul: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     let mut narray = 0;
     let mut nfits: LONGLONG = 0;
@@ -440,22 +533,35 @@ pub fn ffg3dsb_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read a subsection of data values from an image or a table column.
 /// This routine is set up to handle a maximum of nine dimensions.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `colnum` — (I) number of the column to read (1 = 1st)
+/// * `naxis`  — (I) number of dimensions in the FITS array
+/// * `naxes`  — (I) size of each dimension
+/// * `blc`    — (I) 'bottom left corner' of the subsection
+/// * `trc`    — (I) 'top right corner' of the subsection
+/// * `inc`    — (I) increment to be applied in each dimension
+/// * `nulval` — (I) value to set undefined pixels
+/// * `array`  — (O) array to be filled and returned
+/// * `anynul` — (O) set to 1 if any values are null; else 0
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgsvsb(
-    fptr: *mut fitsfile,  /* I - FITS file pointer                         */
-    colnum: c_int,        /* I - number of the column to read (1 = 1st)    */
-    naxis: c_int,         /* I - number of dimensions in the FITS array    */
-    naxes: *const c_long, /* I - size of each dimension                    */
-    blc: *const c_long,   /* I - 'bottom left corner' of the subsection    */
-    trc: *const c_long,   /* I - 'top right corner' of the subsection      */
-    inc: *const c_long,   /* I - increment to be applied in each dimension */
-    nulval: i8,           /* I - value to set undefined pixels       */
-    array: *mut i8,       /* O - array to be filled and returned     */
-    anynul: *mut c_int,   /* O - set to 1 if any values are null; else 0   */
-    status: *mut c_int,   /* IO - error status                             */
+    fptr: *mut fitsfile,
+    colnum: c_int,
+    naxis: c_int,
+    naxes: *const c_long,
+    blc: *const c_long,
+    trc: *const c_long,
+    inc: *const c_long,
+    nulval: i8,
+    array: *mut i8,
+    anynul: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -478,21 +584,34 @@ pub unsafe extern "C" fn ffgsvsb(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read a subsection of data values from an image or a table column.
 /// This routine is set up to handle a maximum of nine dimensions.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `colnum` — (I) number of the column to read (1 = 1st)
+/// * `naxis`  — (I) number of dimensions in the FITS array
+/// * `naxes`  — (I) size of each dimension
+/// * `blc`    — (I) 'bottom left corner' of the subsection
+/// * `trc`    — (I) 'top right corner' of the subsection
+/// * `inc`    — (I) increment to be applied in each dimension
+/// * `nulval` — (I) value to set undefined pixels
+/// * `array`  — (O) array to be filled and returned
+/// * `anynul` — (O) set to 1 if any values are null; else 0
+/// * `status` — (IO) error status
 pub fn ffgsvsb_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                         */
-    colnum: c_int,       /* I - number of the column to read (1 = 1st)    */
-    naxis: c_int,        /* I - number of dimensions in the FITS array    */
-    naxes: &[c_long],    /* I - size of each dimension                    */
-    blc: &[c_long],      /* I - 'bottom left corner' of the subsection    */
-    trc: &[c_long],      /* I - 'top right corner' of the subsection      */
-    inc: &[c_long],      /* I - increment to be applied in each dimension */
-    nulval: i8,          /* I - value to set undefined pixels       */
-    array: &mut [i8],    /* O - array to be filled and returned     */
-    mut anynul: Option<&mut c_int>, /* O - set to 1 if any values are null; else 0   */
-    status: &mut c_int,  /* IO - error status                             */
+    fptr: &mut fitsfile,
+    colnum: c_int,
+    naxis: c_int,
+    naxes: &[c_long],
+    blc: &[c_long],
+    trc: &[c_long],
+    inc: &[c_long],
+    nulval: i8,
+    array: &mut [i8],
+    mut anynul: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     let mut rstr: c_long = 0;
     let mut rstp: c_long = 0;
@@ -697,22 +816,35 @@ pub fn ffgsvsb_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read a subsection of data values from an image or a table column.
 /// This routine is set up to handle a maximum of nine dimensions.
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `colnum`  — (I) number of the column to read (1 = 1st)
+/// * `naxis`   — (I) number of dimensions in the FITS array
+/// * `naxes`   — (I) size of each dimension
+/// * `blc`     — (I) 'bottom left corner' of the subsection
+/// * `trc`     — (I) 'top right corner' of the subsection
+/// * `inc`     — (I) increment to be applied in each dimension
+/// * `array`   — (O) array to be filled and returned
+/// * `flagval` — (O) set to 1 if corresponding value is null
+/// * `anynul`  — (O) set to 1 if any values are null; else 0
+/// * `status`  — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgsfsb(
-    fptr: *mut fitsfile,  /* I - FITS file pointer                         */
-    colnum: c_int,        /* I - number of the column to read (1 = 1st)    */
-    naxis: c_int,         /* I - number of dimensions in the FITS array    */
-    naxes: *const c_long, /* I - size of each dimension                    */
-    blc: *const c_long,   /* I - 'bottom left corner' of the subsection    */
-    trc: *const c_long,   /* I - 'top right corner' of the subsection      */
-    inc: *const c_long,   /* I - increment to be applied in each dimension */
-    array: *mut i8,       /* O - array to be filled and returned     */
-    flagval: *mut c_char, /* O - set to 1 if corresponding value is null   */
-    anynul: *mut c_int,   /* O - set to 1 if any values are null; else 0   */
-    status: *mut c_int,   /* IO - error status                             */
+    fptr: *mut fitsfile,
+    colnum: c_int,
+    naxis: c_int,
+    naxes: *const c_long,
+    blc: *const c_long,
+    trc: *const c_long,
+    inc: *const c_long,
+    array: *mut i8,
+    flagval: *mut c_char,
+    anynul: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -736,21 +868,34 @@ pub unsafe extern "C" fn ffgsfsb(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read a subsection of data values from an image or a table column.
 /// This routine is set up to handle a maximum of nine dimensions.
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `colnum`  — (I) number of the column to read (1 = 1st)
+/// * `naxis`   — (I) number of dimensions in the FITS array
+/// * `naxes`   — (I) size of each dimension
+/// * `blc`     — (I) 'bottom left corner' of the subsection
+/// * `trc`     — (I) 'top right corner' of the subsection
+/// * `inc`     — (I) increment to be applied in each dimension
+/// * `array`   — (O) array to be filled and returned
+/// * `flagval` — (O) set to 1 if corresponding value is null
+/// * `anynul`  — (O) set to 1 if any values are null; else 0
+/// * `status`  — (IO) error status
 pub fn ffgsfsb_safe(
-    fptr: &mut fitsfile,    /* I - FITS file pointer                         */
-    colnum: c_int,          /* I - number of the column to read (1 = 1st)    */
-    naxis: c_int,           /* I - number of dimensions in the FITS array    */
-    naxes: &[c_long],       /* I - size of each dimension                    */
-    blc: &[c_long],         /* I - 'bottom left corner' of the subsection    */
-    trc: &[c_long],         /* I - 'top right corner' of the subsection      */
-    inc: &[c_long],         /* I - increment to be applied in each dimension */
-    array: &mut [i8],       /* O - array to be filled and returned     */
-    flagval: &mut [c_char], /* O - set to 1 if corresponding value is null   */
-    mut anynul: Option<&mut c_int>, /* O - set to 1 if any values are null; else 0   */
-    status: &mut c_int,     /* IO - error status                             */
+    fptr: &mut fitsfile,
+    colnum: c_int,
+    naxis: c_int,
+    naxes: &[c_long],
+    blc: &[c_long],
+    trc: &[c_long],
+    inc: &[c_long],
+    array: &mut [i8],
+    flagval: &mut [c_char],
+    mut anynul: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     let mut rstr: c_long = 0;
     let mut rstp: c_long = 0;
@@ -937,7 +1082,6 @@ pub fn ffgsfsb_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 ///Read an array of group parameters from the primary array. Data conversion
 ///and scaling will be performed if necessary (e.g, if the datatype of
 ///the FITS array is not the same as the array being read).
@@ -946,14 +1090,23 @@ pub fn ffgsfsb_safe(
 ///each group of the primary array is a row in the table,
 ///where the first column contains the group parameters
 ///and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to read (1 = 1st group)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `array`     — (O) array of values that are returned
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffggpsb(
-    fptr: *mut fitsfile, /* I - FITS file pointer                       */
-    group: c_long,       /* I - group to read (1 = 1st group)           */
-    firstelem: c_long,   /* I - first vector element to read (1 = 1st)  */
-    nelem: c_long,       /* I - number of values to read                */
-    array: *mut i8,      /* O - array of values that are returned   */
-    status: *mut c_int,  /* IO - error status                           */
+    fptr: *mut fitsfile,
+    group: c_long,
+    firstelem: c_long,
+    nelem: c_long,
+    array: *mut i8,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -965,7 +1118,6 @@ pub unsafe extern "C" fn ffggpsb(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 ///Read an array of group parameters from the primary array. Data conversion
 ///and scaling will be performed if necessary (e.g, if the datatype of
 ///the FITS array is not the same as the array being read).
@@ -974,13 +1126,22 @@ pub unsafe extern "C" fn ffggpsb(
 ///each group of the primary array is a row in the table,
 ///where the first column contains the group parameters
 ///and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to read (1 = 1st group)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `array`     — (O) array of values that are returned
+/// * `status`    — (IO) error status
 pub fn ffggpsb_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                       */
-    group: c_long,       /* I - group to read (1 = 1st group)           */
-    firstelem: c_long,   /* I - first vector element to read (1 = 1st)  */
-    nelem: c_long,       /* I - number of values to read                */
-    array: &mut [i8],    /* O - array of values that are returned       */
-    status: &mut c_int,  /* IO - error status                           */
+    fptr: &mut fitsfile,
+    group: c_long,
+    firstelem: c_long,
+    nelem: c_long,
+    array: &mut [i8],
+    status: &mut c_int,
 ) -> c_int {
     let cdummy = 0;
     let mut anynul = 0;
@@ -1004,24 +1165,35 @@ pub fn ffggpsb_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of values from a column in the current FITS HDU. Automatic
 /// datatype conversion will be performed if the datatype of the column does not
 /// match the datatype of the array parameter. The output values will be scaled
 /// by the FITS TSCALn and TZEROn values if these values have been defined.
 /// Any undefined pixels will be set equal to the value of 'nulval' unless
 /// nulval = 0 in which case no checks for undefined pixels will be made.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to read (1 = 1st col)
+/// * `firstrow`  — (I) first row to read (1 = 1st row)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `nulval`    — (I) value for null pixels
+/// * `array`     — (O) array of values that are read
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgcvsb(
-    fptr: *mut fitsfile, /* I - FITS file pointer                       */
-    colnum: c_int,       /* I - number of column to read (1 = 1st col)  */
-    firstrow: LONGLONG,  /* I - first row to read (1 = 1st row)         */
-    firstelem: LONGLONG, /* I - first vector element to read (1 = 1st)  */
-    nelem: LONGLONG,     /* I - number of values to read                */
-    nulval: i8,          /* I - value for null pixels               */
-    array: *mut i8,      /* O - array of values that are read       */
-    anynul: *mut c_int,  /* O - set to 1 if any values are null; else 0 */
-    status: *mut c_int,  /* IO - error status                           */
+    fptr: *mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    nulval: i8,
+    array: *mut i8,
+    anynul: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -1037,23 +1209,34 @@ pub unsafe extern "C" fn ffgcvsb(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of values from a column in the current FITS HDU. Automatic
 /// datatype conversion will be performed if the datatype of the column does not
 /// match the datatype of the array parameter. The output values will be scaled
 /// by the FITS TSCALn and TZEROn values if these values have been defined.
 /// Any undefined pixels will be set equal to the value of 'nulval' unless
 /// nulval = 0 in which case no checks for undefined pixels will be made.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to read (1 = 1st col)
+/// * `firstrow`  — (I) first row to read (1 = 1st row)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `nulval`    — (I) value for null pixels
+/// * `array`     — (O) array of values that are read
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `status`    — (IO) error status
 pub fn ffgcvsb_safe(
-    fptr: &mut fitsfile,        /* I - FITS file pointer                       */
-    colnum: c_int,              /* I - number of column to read (1 = 1st col)  */
-    firstrow: LONGLONG,         /* I - first row to read (1 = 1st row)         */
-    firstelem: LONGLONG,        /* I - first vector element to read (1 = 1st)  */
-    nelem: LONGLONG,            /* I - number of values to read                */
-    nulval: i8,                 /* I - value for null pixels               */
-    array: &mut [i8],           /* O - array of values that are read       */
-    anynul: Option<&mut c_int>, /* O - set to 1 if any values are null; else 0 */
-    status: &mut c_int,         /* IO - error status                           */
+    fptr: &mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    nulval: i8,
+    array: &mut [i8],
+    anynul: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     let mut dummy_nularray = vec![0; nelem as usize];
 
@@ -1074,24 +1257,35 @@ pub fn ffgcvsb_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of values from a column in the current FITS HDU. Automatic
 /// datatype conversion will be performed if the datatype of the column does not
 /// match the datatype of the array parameter. The output values will be scaled
 /// by the FITS TSCALn and TZEROn values if these values have been defined.
 /// Nularray will be set = 1 if the corresponding array pixel is undefined,
 /// otherwise nularray will = 0.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to read (1 = 1st col)
+/// * `firstrow`  — (I) first row to read (1 = 1st row)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `array`     — (O) array of values that are read
+/// * `nularray`  — (O) array of flags: 1 if null pixel; else 0
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgcfsb(
-    fptr: *mut fitsfile,   /* I - FITS file pointer                       */
-    colnum: c_int,         /* I - number of column to read (1 = 1st col)  */
-    firstrow: LONGLONG,    /* I - first row to read (1 = 1st row)         */
-    firstelem: LONGLONG,   /* I - first vector element to read (1 = 1st)  */
-    nelem: LONGLONG,       /* I - number of values to read                */
-    array: *mut i8,        /* O - array of values that are read       */
-    nularray: *mut c_char, /* O - array of flags: 1 if null pixel; else 0 */
-    anynul: *mut c_int,    /* O - set to 1 if any values are null; else 0 */
-    status: *mut c_int,    /* IO - error status                           */
+    fptr: *mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: *mut i8,
+    nularray: *mut c_char,
+    anynul: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -1108,23 +1302,34 @@ pub unsafe extern "C" fn ffgcfsb(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of values from a column in the current FITS HDU. Automatic
 /// datatype conversion will be performed if the datatype of the column does not
 /// match the datatype of the array parameter. The output values will be scaled
 /// by the FITS TSCALn and TZEROn values if these values have been defined.
 /// Nularray will be set = 1 if the corresponding array pixel is undefined,
 /// otherwise nularray will = 0.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to read (1 = 1st col)
+/// * `firstrow`  — (I) first row to read (1 = 1st row)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `array`     — (O) array of values that are read
+/// * `nularray`  — (O) array of flags: 1 if null pixel; else 0
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `status`    — (IO) error status
 pub fn ffgcfsb_safe(
-    fptr: &mut fitsfile,        /* I - FITS file pointer                       */
-    colnum: c_int,              /* I - number of column to read (1 = 1st col)  */
-    firstrow: LONGLONG,         /* I - first row to read (1 = 1st row)         */
-    firstelem: LONGLONG,        /* I - first vector element to read (1 = 1st)  */
-    nelem: LONGLONG,            /* I - number of values to read                */
-    array: &mut [i8],           /* O - array of values that are read       */
-    nularray: &mut [c_char],    /* O - array of flags: 1 if null pixel; else 0 */
-    anynul: Option<&mut c_int>, /* O - set to 1 if any values are null; else 0 */
-    status: &mut c_int,         /* IO - error status                           */
+    fptr: &mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: &mut [i8],
+    nularray: &mut [c_char],
+    anynul: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     let dummy: i8 = 0;
 
@@ -1145,7 +1350,6 @@ pub fn ffgcfsb_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of values from a column in the current FITS HDU.
 /// The column number may refer to a real column in an ASCII or binary table,
 /// or it may refer be a virtual column in a 1 or more grouped FITS primary
@@ -1159,21 +1363,35 @@ pub fn ffgcfsb_safe(
 /// and will be scaled by the FITS TSCALn and TZEROn values if necessary.
 #[allow(clippy::if_same_then_else)]
 // C dispatch chain: distinct conditions deliberately share an action.
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to read (1 = 1st col)
+/// * `firstrow`  — (I) first row to read (1 = 1st row)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `elemincre` — (I) pixel increment; e.g., 2 = every other
+/// * `nultyp`    — (I) null value handling code:
+/// * `nulval`    — (I) value for null pixels if nultyp = 1
+/// * `array`     — (O) array of values that are read
+/// * `nularray`  — (O) array of flags = 1 if nultyp = 2
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `status`    — (IO) error status
 pub(crate) fn ffgclsb(
-    fptr: &mut fitsfile,   /* I - FITS file pointer                       */
-    colnum: c_int,         /* I - number of column to read (1 = 1st col)  */
-    firstrow: LONGLONG,    /* I - first row to read (1 = 1st row)         */
-    firstelem: LONGLONG,   /* I - first vector element to read (1 = 1st)  */
-    nelem: LONGLONG,       /* I - number of values to read                */
-    elemincre: c_long,     /* I - pixel increment; e.g., 2 = every other  */
-    nultyp: NullCheckType, /* I - null value handling code:               */
+    fptr: &mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    elemincre: c_long,
+    nultyp: NullCheckType,
     /*     1: set undefined pixels = nulval        */
     /*     2: set nularray=1 for undefined pixels  */
-    nulval: i8,                     /* I - value for null pixels if nultyp = 1 */
-    array: &mut [i8],               /* O - array of values that are read       */
-    nularray: &mut [c_char],        /* O - array of flags = 1 if nultyp = 2        */
-    mut anynul: Option<&mut c_int>, /* O - set to 1 if any values are null; else 0 */
-    status: &mut c_int,             /* IO - error status                           */
+    nulval: i8,
+    array: &mut [i8],
+    nularray: &mut [c_char],
+    mut anynul: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     let mut scale: f64 = 0.0;
     let mut zero: f64 = 0.0;
@@ -1221,9 +1439,7 @@ pub(crate) fn ffgclsb(
         nularray.fill(0); /* initialize nullarray */
     }
 
-    /*---------------------------------------------------*/
     /*  Check input and get parameters about the column: */
-    /*---------------------------------------------------*/
     if elemincre < 0 {
         readcheck -= 1; /* don't do range checking in this case */
     }
@@ -1315,9 +1531,7 @@ pub(crate) fn ffgclsb(
             power *= 10.0;
         }
     }
-    /*------------------------------------------------------------------*/
     /*  Decide whether to check for null values in the input FITS file: */
-    /*------------------------------------------------------------------*/
     nulcheck = nultyp; /* by default, check for null values in the FITS file */
 
     if nultyp == NullCheckType::SetPixel && nulval == 0 {
@@ -1337,7 +1551,6 @@ pub(crate) fn ffgclsb(
         nulcheck = NullCheckType::None;
     }
 
-    /*---------------------------------------------------------------------*/
     /*  Now read the pixels from the FITS column. If the column does not   */
     /*  have the same datatype as the output array, then we have to read   */
     /*  the raw values into a temporary buffer (of limited size).  In      */
@@ -1347,7 +1560,6 @@ pub(crate) fn ffgclsb(
     /*  test for undefined values, (2) convert the datatype if necessary,  */
     /*  and (3) scale the values by the FITS TSCALn and TZEROn linear      */
     /*  scaling parameters.                                                */
-    /*---------------------------------------------------------------------*/
 
     remain = nelem; /* remaining number of values to read */
     next = 0; /* next element in array to be read   */
@@ -1573,9 +1785,7 @@ pub(crate) fn ffgclsb(
             }
         } /* End of switch block */
 
-        /*-------------------------*/
         /*  Check for fatal error  */
-        /*-------------------------*/
         if *status > 0 {
             /* test for error during previous read operation */
 
@@ -1603,9 +1813,7 @@ pub(crate) fn ffgclsb(
             return *status;
         }
 
-        /*--------------------------------------------*/
         /*  increment the counters for the next loop  */
-        /*--------------------------------------------*/
         remain -= ntodo as LONGLONG;
         if remain != 0 {
             next += ntodo as usize;
@@ -1627,9 +1835,7 @@ pub(crate) fn ffgclsb(
         }
     } /*  End of main while Loop  */
 
-    /*--------------------------------*/
     /*  check for numerical overflow  */
-    /*--------------------------------*/
     if *status == OVERFLOW_ERR {
         ffpmsg_str("Numerical overflow during type conversion while reading FITS data.");
         *status = NUM_OVERFLOW;
@@ -1638,7 +1844,6 @@ pub(crate) fn ffgclsb(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output following reading of the input from a FITS file.
 /// Check for null values and do datatype conversion and scaling if required.
 /// The nullcheck code value determines how any null values in the input array
@@ -1650,20 +1855,34 @@ pub(crate) fn ffgclsb(
 /// nullarray will be set to 1; the value of nullarray for non-null pixels
 /// will = 0.  The anynull parameter will be set = 1 if any of the returned
 /// pixels are null, otherwise anynull will be returned with a value = 0;
+///
+/// # Parameters
+///
+/// * `input`     — (I) array of values to be converted
+/// * `ntodo`     — (I) number of elements in the array
+/// * `scale`     — (I) FITS TSCALn or BSCALE value
+/// * `zero`      — (I) FITS TZEROn or BZERO value
+/// * `nullcheck` — (I) null checking code; 0 = don't check
+/// * `tnull`     — (I) value of FITS TNULLn keyword if any
+/// * `nullval`   — (I) set null pixels, if nullcheck = 1
+/// * `nullarray` — (O) bad pixel array, if nullcheck = 2
+/// * `anynull`   — (O) set to 1 if any pixels are null
+/// * `output`    — (O) array of converted pixels
+/// * `status`    — (IO) error status
 pub(crate) fn fffi1s1(
-    input: &[u8],             /* I - array of values to be converted     */
-    ntodo: c_long,            /* I - number of elements in the array     */
-    scale: f64,               /* I - FITS TSCALn or BSCALE value         */
-    zero: f64,                /* I - FITS TZEROn or BZERO  value         */
-    nullcheck: NullCheckType, /* I - null checking code; 0 = don't check */
+    input: &[u8],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    nullcheck: NullCheckType,
     /*     1:set null pixels = nullval         */
     /*     2: if null pixel, set nullarray = 1 */
-    tnull: u8,                   /* I - value of FITS TNULLn keyword if any */
-    nullval: i8,                 /* I - set null pixels, if nullcheck = 1   */
-    nullarray: &mut [c_char],    /* O - bad pixel array, if nullcheck = 2   */
-    anynull: Option<&mut c_int>, /* O - set to 1 if any pixels are null     */
-    output: &mut [i8],           /* O - array of converted pixels           */
-    status: &mut c_int,          /* IO - error status                       */
+    tnull: u8,
+    nullval: i8,
+    nullarray: &mut [c_char],
+    anynull: Option<&mut c_int>,
+    output: &mut [i8],
+    status: &mut c_int,
 ) -> c_int {
     let mut dvalue: f64 = 0.0;
 
@@ -1766,7 +1985,6 @@ pub(crate) fn fffi1s1(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output following reading of the input from a FITS file.
 /// Check for null values and do datatype conversion and scaling if required.
 /// The nullcheck code value determines how any null values in the input array
@@ -1778,20 +1996,34 @@ pub(crate) fn fffi1s1(
 /// nullarray will be set to 1; the value of nullarray for non-null pixels
 /// will = 0.  The anynull parameter will be set = 1 if any of the returned
 /// pixels are null, otherwise anynull will be returned with a value = 0;
+///
+/// # Parameters
+///
+/// * `input`     — (I) array of values to be converted
+/// * `ntodo`     — (I) number of elements in the array
+/// * `scale`     — (I) FITS TSCALn or BSCALE value
+/// * `zero`      — (I) FITS TZEROn or BZERO value
+/// * `nullcheck` — (I) null checking code; 0 = don't check
+/// * `tnull`     — (I) value of FITS TNULLn keyword if any
+/// * `nullval`   — (I) set null pixels, if nullcheck = 1
+/// * `nullarray` — (O) bad pixel array, if nullcheck = 2
+/// * `anynull`   — (O) set to 1 if any pixels are null
+/// * `output`    — (O) array of converted pixels
+/// * `status`    — (IO) error status
 pub(crate) fn fffi2s1(
-    input: &[c_short],        /* I - array of values to be converted     */
-    ntodo: c_long,            /* I - number of elements in the array     */
-    scale: f64,               /* I - FITS TSCALn or BSCALE value         */
-    zero: f64,                /* I - FITS TZEROn or BZERO  value         */
-    nullcheck: NullCheckType, /* I - null checking code; 0 = don't check */
+    input: &[c_short],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    nullcheck: NullCheckType,
     /*     1:set null pixels = nullval         */
     /*     2: if null pixel, set nullarray = 1 */
-    tnull: c_short,              /* I - value of FITS TNULLn keyword if any */
-    nullval: i8,                 /* I - set null pixels, if nullcheck = 1   */
-    nullarray: &mut [c_char],    /* O - bad pixel array, if nullcheck = 2   */
-    anynull: Option<&mut c_int>, /* O - set to 1 if any pixels are null     */
-    output: &mut [i8],           /* O - array of converted pixels           */
-    status: &mut c_int,          /* IO - error status                       */
+    tnull: c_short,
+    nullval: i8,
+    nullarray: &mut [c_char],
+    anynull: Option<&mut c_int>,
+    output: &mut [i8],
+    status: &mut c_int,
 ) -> c_int {
     let mut dvalue: f64 = 0.0;
 
@@ -1883,7 +2115,6 @@ pub(crate) fn fffi2s1(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output following reading of the input from a FITS file.
 /// Check for null values and do datatype conversion and scaling if required.
 /// The nullcheck code value determines how any null values in the input array
@@ -1895,20 +2126,34 @@ pub(crate) fn fffi2s1(
 /// nullarray will be set to 1; the value of nullarray for non-null pixels
 /// will = 0.  The anynull parameter will be set = 1 if any of the returned
 /// pixels are null, otherwise anynull will be returned with a value = 0;
+///
+/// # Parameters
+///
+/// * `input`     — (I) array of values to be converted
+/// * `ntodo`     — (I) number of elements in the array
+/// * `scale`     — (I) FITS TSCALn or BSCALE value
+/// * `zero`      — (I) FITS TZEROn or BZERO value
+/// * `nullcheck` — (I) null checking code; 0 = don't check
+/// * `tnull`     — (I) value of FITS TNULLn keyword if any
+/// * `nullval`   — (I) set null pixels, if nullcheck = 1
+/// * `nullarray` — (O) bad pixel array, if nullcheck = 2
+/// * `anynull`   — (O) set to 1 if any pixels are null
+/// * `output`    — (O) array of converted pixels
+/// * `status`    — (IO) error status
 pub(crate) fn fffi4s1(
-    input: &[INT32BIT],       /* I - array of values to be converted     */
-    ntodo: c_long,            /* I - number of elements in the array     */
-    scale: f64,               /* I - FITS TSCALn or BSCALE value         */
-    zero: f64,                /* I - FITS TZEROn or BZERO  value         */
-    nullcheck: NullCheckType, /* I - null checking code; 0 = don't check */
+    input: &[INT32BIT],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    nullcheck: NullCheckType,
     /*     1:set null pixels = nullval         */
     /*     2: if null pixel, set nullarray = 1 */
-    tnull: INT32BIT,             /* I - value of FITS TNULLn keyword if any */
-    nullval: i8,                 /* I - set null pixels, if nullcheck = 1   */
-    nullarray: &mut [c_char],    /* O - bad pixel array, if nullcheck = 2   */
-    anynull: Option<&mut c_int>, /* O - set to 1 if any pixels are null     */
-    output: &mut [i8],           /* O - array of converted pixels           */
-    status: &mut c_int,          /* IO - error status                       */
+    tnull: INT32BIT,
+    nullval: i8,
+    nullarray: &mut [c_char],
+    anynull: Option<&mut c_int>,
+    output: &mut [i8],
+    status: &mut c_int,
 ) -> c_int {
     let mut dvalue: f64 = 0.0;
 
@@ -2001,7 +2246,6 @@ pub(crate) fn fffi4s1(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output following reading of the input from a FITS file.
 /// Check for null values and do datatype conversion and scaling if required.
 /// The nullcheck code value determines how any null values in the input array
@@ -2013,20 +2257,34 @@ pub(crate) fn fffi4s1(
 /// nullarray will be set to 1; the value of nullarray for non-null pixels
 /// will = 0.  The anynull parameter will be set = 1 if any of the returned
 /// pixels are null, otherwise anynull will be returned with a value = 0;
+///
+/// # Parameters
+///
+/// * `input`     — (I) array of values to be converted
+/// * `ntodo`     — (I) number of elements in the array
+/// * `scale`     — (I) FITS TSCALn or BSCALE value
+/// * `zero`      — (I) FITS TZEROn or BZERO value
+/// * `nullcheck` — (I) null checking code; 0 = don't check
+/// * `tnull`     — (I) value of FITS TNULLn keyword if any
+/// * `nullval`   — (I) set null pixels, if nullcheck = 1
+/// * `nullarray` — (O) bad pixel array, if nullcheck = 2
+/// * `anynull`   — (O) set to 1 if any pixels are null
+/// * `output`    — (O) array of converted pixels
+/// * `status`    — (IO) error status
 pub(crate) fn fffi8s1(
-    input: &[LONGLONG],       /* I - array of values to be converted     */
-    ntodo: c_long,            /* I - number of elements in the array     */
-    scale: f64,               /* I - FITS TSCALn or BSCALE value         */
-    zero: f64,                /* I - FITS TZEROn or BZERO  value         */
-    nullcheck: NullCheckType, /* I - null checking code; 0 = don't check */
+    input: &[LONGLONG],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    nullcheck: NullCheckType,
     /*     1:set null pixels = nullval         */
     /*     2: if null pixel, set nullarray = 1 */
-    tnull: LONGLONG,             /* I - value of FITS TNULLn keyword if any */
-    nullval: i8,                 /* I - set null pixels, if nullcheck = 1   */
-    nullarray: &mut [c_char],    /* O - bad pixel array, if nullcheck = 2   */
-    anynull: Option<&mut c_int>, /* O - set to 1 if any pixels are null     */
-    output: &mut [i8],           /* O - array of converted pixels           */
-    status: &mut c_int,          /* IO - error status                       */
+    tnull: LONGLONG,
+    nullval: i8,
+    nullarray: &mut [c_char],
+    anynull: Option<&mut c_int>,
+    output: &mut [i8],
+    status: &mut c_int,
 ) -> c_int {
     let mut dvalue: f64 = 0.0;
     let mut ulltemp: ULONGLONG = 0;
@@ -2158,7 +2416,6 @@ pub(crate) fn fffi8s1(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output following reading of the input from a FITS file.
 /// Check for null values and do datatype conversion and scaling if required.
 /// The nullcheck code value determines how any null values in the input array
@@ -2170,19 +2427,32 @@ pub(crate) fn fffi8s1(
 /// nullarray will be set to 1; the value of nullarray for non-null pixels
 /// will = 0.  The anynull parameter will be set = 1 if any of the returned
 /// pixels are null, otherwise anynull will be returned with a value = 0;
+///
+/// # Parameters
+///
+/// * `input`     — (I) array of values to be converted
+/// * `ntodo`     — (I) number of elements in the array
+/// * `scale`     — (I) FITS TSCALn or BSCALE value
+/// * `zero`      — (I) FITS TZEROn or BZERO value
+/// * `nullcheck` — (I) null checking code; 0 = don't check
+/// * `nullval`   — (I) set null pixels, if nullcheck = 1
+/// * `nullarray` — (O) bad pixel array, if nullcheck = 2
+/// * `anynull`   — (O) set to 1 if any pixels are null
+/// * `output`    — (O) array of converted pixels
+/// * `status`    — (IO) error status
 pub(crate) fn fffr4s1(
-    input: &[f32],            /* I - array of values to be converted     */
-    ntodo: c_long,            /* I - number of elements in the array     */
-    scale: f64,               /* I - FITS TSCALn or BSCALE value         */
-    zero: f64,                /* I - FITS TZEROn or BZERO  value         */
-    nullcheck: NullCheckType, /* I - null checking code; 0 = don't check */
+    input: &[f32],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    nullcheck: NullCheckType,
     /*     1:set null pixels = nullval         */
     /*     2: if null pixel, set nullarray = 1 */
-    nullval: i8,                 /* I - set null pixels, if nullcheck = 1   */
-    nullarray: &mut [c_char],    /* O - bad pixel array, if nullcheck = 2   */
-    anynull: Option<&mut c_int>, /* O - set to 1 if any pixels are null     */
-    output: &mut [i8],           /* O - array of converted pixels           */
-    status: &mut c_int,          /* IO - error status                       */
+    nullval: i8,
+    nullarray: &mut [c_char],
+    anynull: Option<&mut c_int>,
+    output: &mut [i8],
+    status: &mut c_int,
 ) -> c_int {
     let mut dvalue: f64 = 0.0;
     let mut sptr = 0;
@@ -2305,7 +2575,6 @@ pub(crate) fn fffr4s1(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output following reading of the input from a FITS file.
 /// Check for null values and do datatype conversion and scaling if required.
 /// The nullcheck code value determines how any null values in the input array
@@ -2317,19 +2586,32 @@ pub(crate) fn fffr4s1(
 /// nullarray will be set to 1; the value of nullarray for non-null pixels
 /// will = 0.  The anynull parameter will be set = 1 if any of the returned
 /// pixels are null, otherwise anynull will be returned with a value = 0;
+///
+/// # Parameters
+///
+/// * `input`     — (I) array of values to be converted
+/// * `ntodo`     — (I) number of elements in the array
+/// * `scale`     — (I) FITS TSCALn or BSCALE value
+/// * `zero`      — (I) FITS TZEROn or BZERO value
+/// * `nullcheck` — (I) null checking code; 0 = don't check
+/// * `nullval`   — (I) set null pixels, if nullcheck = 1
+/// * `nullarray` — (O) bad pixel array, if nullcheck = 2
+/// * `anynull`   — (O) set to 1 if any pixels are null
+/// * `output`    — (O) array of converted pixels
+/// * `status`    — (IO) error status
 pub(crate) fn fffr8s1(
-    input: &[f64],            /* I - array of values to be converted     */
-    ntodo: c_long,            /* I - number of elements in the array     */
-    scale: f64,               /* I - FITS TSCALn or BSCALE value         */
-    zero: f64,                /* I - FITS TZEROn or BZERO  value         */
-    nullcheck: NullCheckType, /* I - null checking code; 0 = don't check */
+    input: &[f64],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    nullcheck: NullCheckType,
     /*     1:set null pixels = nullval         */
     /*     2: if null pixel, set nullarray = 1 */
-    nullval: i8,                 /* I - set null pixels, if nullcheck = 1   */
-    nullarray: &mut [c_char],    /* O - bad pixel array, if nullcheck = 2   */
-    anynull: Option<&mut c_int>, /* O - set to 1 if any pixels are null     */
-    output: &mut [i8],           /* O - array of converted pixels           */
-    status: &mut c_int,          /* IO - error status                       */
+    nullval: i8,
+    nullarray: &mut [c_char],
+    anynull: Option<&mut c_int>,
+    output: &mut [i8],
+    status: &mut c_int,
 ) -> c_int {
     let mut dvalue: f64 = 0.0;
     let mut sptr = 0;
@@ -2452,7 +2734,6 @@ pub(crate) fn fffr8s1(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output following reading of the input from a FITS file. Check
 /// for null values and do scaling if required. The nullcheck code value
 /// determines how any null values in the input array are treated. A null
@@ -2463,22 +2744,38 @@ pub(crate) fn fffr8s1(
 /// nullarray will be set to 1; the value of nullarray for non-null pixels
 /// will = 0.  The anynull parameter will be set = 1 if any of the returned
 /// pixels are null, otherwise anynull will be returned with a value = 0;
+///
+/// # Parameters
+///
+/// * `input`      — (I) array of values to be converted
+/// * `ntodo`      — (I) number of elements in the array
+/// * `scale`      — (I) FITS TSCALn or BSCALE value
+/// * `zero`       — (I) FITS TZEROn or BZERO value
+/// * `twidth`     — (I) width of each substring of chars
+/// * `implipower` — (I) power of 10 of implied decimal
+/// * `nullcheck`  — (I) null checking code; 0 = don't check
+/// * `snull`      — (I) value of FITS null string, if any
+/// * `nullval`    — (I) set null pixels, if nullcheck = 1
+/// * `nullarray`  — (O) bad pixel array, if nullcheck = 2
+/// * `anynull`    — (O) set to 1 if any pixels are null
+/// * `output`     — (O) array of converted pixels
+/// * `status`     — (IO) error status
 pub(crate) fn fffstrs1(
-    input: &mut [c_char],     /* I - array of values to be converted     */
-    ntodo: c_long,            /* I - number of elements in the array     */
-    scale: f64,               /* I - FITS TSCALn or BSCALE value         */
-    zero: f64,                /* I - FITS TZEROn or BZERO  value         */
-    twidth: c_long,           /* I - width of each substring of chars    */
-    implipower: f64,          /* I - power of 10 of implied decimal      */
-    nullcheck: NullCheckType, /* I - null checking code; 0 = don't check */
+    input: &mut [c_char],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    twidth: c_long,
+    implipower: f64,
+    nullcheck: NullCheckType,
     /*     1:set null pixels = nullval         */
     /*     2: if null pixel, set nullarray = 1 */
-    snull: &[c_char],                /* I - value of FITS null string, if any   */
-    nullval: i8,                     /* I - set null pixels, if nullcheck = 1  */
-    nullarray: &mut [c_char],        /* O - bad pixel array, if nullcheck = 2   */
-    mut anynull: Option<&mut c_int>, /* O - set to 1 if any pixels are null     */
-    output: &mut [i8],               /* O - array of converted pixels          */
-    status: &mut c_int,              /* IO - error status                       */
+    snull: &[c_char],
+    nullval: i8,
+    nullarray: &mut [c_char],
+    mut anynull: Option<&mut c_int>,
+    output: &mut [i8],
+    status: &mut c_int,
 ) -> c_int {
     let mut dvalue: f64 = 0.0;
     let mut message: [c_char; FLEN_ERRMSG] = [0; FLEN_ERRMSG];

--- a/src/getcolui.rs
+++ b/src/getcolui.rs
@@ -1,9 +1,14 @@
-/*  This file, getcolui.rs, contains routines that read data elements from   */
-/*  a FITS image or table, with unsigned short datatype.                    */
-
-/*  The FITSIO software was written by William Pence at the High Energy    */
-/*  Astrophysic Science Archive Research Center (HEASARC) at the NASA      */
-/*  Goddard Space Flight Center.                                           */
+//! Routines that read data elements from a FITS image or table, with
+//! unsigned short datatype.
+//!
+//! The [`TUSHORT`] arm of the typed column I/O family. [`crate::getcol`]
+//! dispatches here when a caller asks for this datatype at run time; the
+//! write-side counterpart is [`crate::putcolui`].
+//!
+//! Ported from CFITSIO's `getcolui.c`, written by William Pence at the High
+//! Energy Astrophysics Science Archive Research Center (HEASARC), NASA Goddard
+//! Space Flight Center.
+#![warn(missing_docs)]
 
 use core::slice;
 use core::{cmp, mem};
@@ -23,7 +28,6 @@ use crate::{NullValue, bb};
 use crate::{buffers::*, calculate_subsection_length};
 use crate::{int_snprintf, slice_to_str};
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of values from the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
 /// the FITS array is not the same as the array being read).
@@ -35,16 +39,27 @@ use crate::{int_snprintf, slice_to_str};
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to read (1 = 1st group)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `nulval`    — (I) value for undefined pixels
+/// * `array`     — (O) array of values that are returned
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgpvui(
-    fptr: *mut fitsfile,  /* I - FITS file pointer                       */
-    group: c_long,        /* I - group to read (1 = 1st group)           */
-    firstelem: LONGLONG,  /* I - first vector element to read (1 = 1st)  */
-    nelem: LONGLONG,      /* I - number of values to read                */
-    nulval: c_ushort,     /* I - value for undefined pixels          */
-    array: *mut c_ushort, /* O - array of values that are returned   */
-    anynul: *mut c_int,   /* O - set to 1 if any values are null; else 0 */
-    status: *mut c_int,   /* IO - error status                           */
+    fptr: *mut fitsfile,
+    group: c_long,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    nulval: c_ushort,
+    array: *mut c_ushort,
+    anynul: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -58,7 +73,6 @@ pub unsafe extern "C" fn ffgpvui(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of values from the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
 /// the FITS array is not the same as the array being read).
@@ -70,15 +84,26 @@ pub unsafe extern "C" fn ffgpvui(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to read (1 = 1st group)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `nulval`    — (I) value for undefined pixels
+/// * `array`     — (O) array of values that are returned
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `status`    — (IO) error status
 pub fn ffgpvui_safe(
-    fptr: &mut fitsfile,        /* I - FITS file pointer                       */
-    group: c_long,              /* I - group to read (1 = 1st group)           */
-    firstelem: LONGLONG,        /* I - first vector element to read (1 = 1st)  */
-    nelem: LONGLONG,            /* I - number of values to read                */
-    nulval: c_ushort,           /* I - value for undefined pixels          */
-    array: &mut [c_ushort],     /* O - array of values that are returned   */
-    anynul: Option<&mut c_int>, /* O - set to 1 if any values are null; else 0 */
-    status: &mut c_int,         /* IO - error status                           */
+    fptr: &mut fitsfile,
+    group: c_long,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    nulval: c_ushort,
+    array: &mut [c_ushort],
+    anynul: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     let cdummy = 0;
     let nullcheck = NullCheckType::SetPixel;
@@ -122,7 +147,6 @@ pub fn ffgpvui_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of values from the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
 /// the FITS array is not the same as the array being read).
@@ -134,16 +158,27 @@ pub fn ffgpvui_safe(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to read (1 = 1st group)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `array`     — (O) array of values that are returned
+/// * `nularray`  — (O) array of null pixel flags
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgpfui(
-    fptr: *mut fitsfile,   /* I - FITS file pointer                       */
-    group: c_long,         /* I - group to read (1 = 1st group)           */
-    firstelem: LONGLONG,   /* I - first vector element to read (1 = 1st)  */
-    nelem: LONGLONG,       /* I - number of values to read                */
-    array: *mut c_ushort,  /* O - array of values that are returned   */
-    nularray: *mut c_char, /* O - array of null pixel flags               */
-    anynul: *mut c_int,    /* O - set to 1 if any values are null; else 0 */
-    status: *mut c_int,    /* IO - error status                           */
+    fptr: *mut fitsfile,
+    group: c_long,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: *mut c_ushort,
+    nularray: *mut c_char,
+    anynul: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -160,7 +195,6 @@ pub unsafe extern "C" fn ffgpfui(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of values from the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
 /// the FITS array is not the same as the array being read).
@@ -172,15 +206,26 @@ pub unsafe extern "C" fn ffgpfui(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to read (1 = 1st group)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `array`     — (O) array of values that are returned
+/// * `nularray`  — (O) array of null pixel flags
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `status`    — (IO) error status
 pub fn ffgpfui_safe(
-    fptr: &mut fitsfile,        /* I - FITS file pointer                       */
-    group: c_long,              /* I - group to read (1 = 1st group)           */
-    firstelem: LONGLONG,        /* I - first vector element to read (1 = 1st)  */
-    nelem: LONGLONG,            /* I - number of values to read                */
-    array: &mut [c_ushort],     /* O - array of values that are returned   */
-    nularray: &mut [c_char],    /* O - array of null pixel flags               */
-    anynul: Option<&mut c_int>, /* O - set to 1 if any values are null; else 0 */
-    status: &mut c_int,         /* IO - error status                           */
+    fptr: &mut fitsfile,
+    group: c_long,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: &mut [c_ushort],
+    nularray: &mut [c_char],
+    anynul: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     let nullcheck = NullCheckType::SetNullArray;
 
@@ -221,23 +266,34 @@ pub fn ffgpfui_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an entire 2-D array of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of the
 /// FITS array is not the same as the array being read).  Any null
 /// values in the array will be set equal to the value of nulval, unless
 /// nulval = 0 in which case no null checking will be performed.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `group`  — (I) group to read (1 = 1st group)
+/// * `nulval` — set undefined pixels equal to this
+/// * `ncols`  — (I) number of pixels in each row of array
+/// * `naxis1` — (I) FITS image NAXIS1 value
+/// * `naxis2` — (I) FITS image NAXIS2 value
+/// * `array`  — (O) array to be filled and returned
+/// * `anynul` — (O) set to 1 if any values are null; else 0
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffg2dui(
-    fptr: *mut fitsfile,  /* I - FITS file pointer                       */
-    group: c_long,        /* I - group to read (1 = 1st group)           */
-    nulval: c_ushort,     /* set undefined pixels equal to this     */
-    ncols: LONGLONG,      /* I - number of pixels in each row of array   */
-    naxis1: LONGLONG,     /* I - FITS image NAXIS1 value                 */
-    naxis2: LONGLONG,     /* I - FITS image NAXIS2 value                 */
-    array: *mut c_ushort, /* O - array to be filled and returned    */
-    anynul: *mut c_int,   /* O - set to 1 if any values are null; else 0 */
-    status: *mut c_int,   /* IO - error status                           */
+    fptr: *mut fitsfile,
+    group: c_long,
+    nulval: c_ushort,
+    ncols: LONGLONG,
+    naxis1: LONGLONG,
+    naxis2: LONGLONG,
+    array: *mut c_ushort,
+    anynul: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -253,22 +309,33 @@ pub unsafe extern "C" fn ffg2dui(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an entire 2-D array of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of the
 /// FITS array is not the same as the array being read).  Any null
 /// values in the array will be set equal to the value of nulval, unless
 /// nulval = 0 in which case no null checking will be performed.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `group`  — (I) group to read (1 = 1st group)
+/// * `nulval` — set undefined pixels equal to this
+/// * `ncols`  — (I) number of pixels in each row of array
+/// * `naxis1` — (I) FITS image NAXIS1 value
+/// * `naxis2` — (I) FITS image NAXIS2 value
+/// * `array`  — (O) array to be filled and returned
+/// * `anynul` — (O) set to 1 if any values are null; else 0
+/// * `status` — (IO) error status
 pub fn ffg2dui_safe(
-    fptr: &mut fitsfile,        /* I - FITS file pointer                       */
-    group: c_long,              /* I - group to read (1 = 1st group)           */
-    nulval: c_ushort,           /* set undefined pixels equal to this     */
-    ncols: LONGLONG,            /* I - number of pixels in each row of array   */
-    naxis1: LONGLONG,           /* I - FITS image NAXIS1 value                 */
-    naxis2: LONGLONG,           /* I - FITS image NAXIS2 value                 */
-    array: &mut [c_ushort],     /* O - array to be filled and returned    */
-    anynul: Option<&mut c_int>, /* O - set to 1 if any values are null; else 0 */
-    status: &mut c_int,         /* IO - error status                           */
+    fptr: &mut fitsfile,
+    group: c_long,
+    nulval: c_ushort,
+    ncols: LONGLONG,
+    naxis1: LONGLONG,
+    naxis2: LONGLONG,
+    array: &mut [c_ushort],
+    anynul: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     /* call the 3D reading routine, with the 3rd dimension = 1 */
     ffg3dui_safe(
@@ -278,7 +345,6 @@ pub fn ffg2dui_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an entire 3-D array of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of the
 /// FITS array is not the same as the array being read).  Any null
@@ -289,19 +355,33 @@ pub fn ffg2dui_safe(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `group`  — (I) group to read (1 = 1st group)
+/// * `nulval` — set undefined pixels equal to this
+/// * `ncols`  — (I) number of pixels in each row of array
+/// * `nrows`  — (I) number of rows in each plane of array
+/// * `naxis1` — (I) FITS image NAXIS1 value
+/// * `naxis2` — (I) FITS image NAXIS2 value
+/// * `naxis3` — (I) FITS image NAXIS3 value
+/// * `array`  — (O) array to be filled and returned
+/// * `anynul` — (O) set to 1 if any values are null; else 0
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffg3dui(
-    fptr: *mut fitsfile,  /* I - FITS file pointer                       */
-    group: c_long,        /* I - group to read (1 = 1st group)           */
-    nulval: c_ushort,     /* set undefined pixels equal to this     */
-    ncols: LONGLONG,      /* I - number of pixels in each row of array   */
-    nrows: LONGLONG,      /* I - number of rows in each plane of array   */
-    naxis1: LONGLONG,     /* I - FITS image NAXIS1 value                 */
-    naxis2: LONGLONG,     /* I - FITS image NAXIS2 value                 */
-    naxis3: LONGLONG,     /* I - FITS image NAXIS3 value                 */
-    array: *mut c_ushort, /* O - array to be filled and returned    */
-    anynul: *mut c_int,   /* O - set to 1 if any values are null; else 0 */
-    status: *mut c_int,   /* IO - error status                           */
+    fptr: *mut fitsfile,
+    group: c_long,
+    nulval: c_ushort,
+    ncols: LONGLONG,
+    nrows: LONGLONG,
+    naxis1: LONGLONG,
+    naxis2: LONGLONG,
+    naxis3: LONGLONG,
+    array: *mut c_ushort,
+    anynul: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -317,7 +397,6 @@ pub unsafe extern "C" fn ffg3dui(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an entire 3-D array of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of the
 /// FITS array is not the same as the array being read).  Any null
@@ -328,18 +407,32 @@ pub unsafe extern "C" fn ffg3dui(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `group`  — (I) group to read (1 = 1st group)
+/// * `nulval` — set undefined pixels equal to this
+/// * `ncols`  — (I) number of pixels in each row of array
+/// * `nrows`  — (I) number of rows in each plane of array
+/// * `naxis1` — (I) FITS image NAXIS1 value
+/// * `naxis2` — (I) FITS image NAXIS2 value
+/// * `naxis3` — (I) FITS image NAXIS3 value
+/// * `array`  — (O) array to be filled and returned
+/// * `anynul` — (O) set to 1 if any values are null; else 0
+/// * `status` — (IO) error status
 pub fn ffg3dui_safe(
-    fptr: &mut fitsfile,            /* I - FITS file pointer                       */
-    group: c_long,                  /* I - group to read (1 = 1st group)           */
-    nulval: c_ushort,               /* set undefined pixels equal to this     */
-    ncols: LONGLONG,                /* I - number of pixels in each row of array   */
-    nrows: LONGLONG,                /* I - number of rows in each plane of array   */
-    naxis1: LONGLONG,               /* I - FITS image NAXIS1 value                 */
-    naxis2: LONGLONG,               /* I - FITS image NAXIS2 value                 */
-    naxis3: LONGLONG,               /* I - FITS image NAXIS3 value                 */
-    array: &mut [c_ushort],         /* O - array to be filled and returned    */
-    mut anynul: Option<&mut c_int>, /* O - set to 1 if any values are null; else 0 */
-    status: &mut c_int,             /* IO - error status                           */
+    fptr: &mut fitsfile,
+    group: c_long,
+    nulval: c_ushort,
+    ncols: LONGLONG,
+    nrows: LONGLONG,
+    naxis1: LONGLONG,
+    naxis2: LONGLONG,
+    naxis3: LONGLONG,
+    array: &mut [c_ushort],
+    mut anynul: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     let mut narray = 0;
     let mut nfits: LONGLONG = 0;
@@ -438,22 +531,35 @@ pub fn ffg3dui_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read a subsection of data values from an image or a table column.
 /// This routine is set up to handle a maximum of nine dimensions.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `colnum` — (I) number of the column to read (1 = 1st)
+/// * `naxis`  — (I) number of dimensions in the FITS array
+/// * `naxes`  — (I) size of each dimension
+/// * `blc`    — (I) 'bottom left corner' of the subsection
+/// * `trc`    — (I) 'top right corner' of the subsection
+/// * `inc`    — (I) increment to be applied in each dimension
+/// * `nulval` — (I) value to set undefined pixels
+/// * `array`  — (O) array to be filled and returned
+/// * `anynul` — (O) set to 1 if any values are null; else 0
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgsvui(
-    fptr: *mut fitsfile,  /* I - FITS file pointer                         */
-    colnum: c_int,        /* I - number of the column to read (1 = 1st)    */
-    naxis: c_int,         /* I - number of dimensions in the FITS array    */
-    naxes: *const c_long, /* I - size of each dimension                    */
-    blc: *const c_long,   /* I - 'bottom left corner' of the subsection    */
-    trc: *const c_long,   /* I - 'top right corner' of the subsection      */
-    inc: *const c_long,   /* I - increment to be applied in each dimension */
-    nulval: c_ushort,     /* I - value to set undefined pixels       */
-    array: *mut c_ushort, /* O - array to be filled and returned     */
-    anynul: *mut c_int,   /* O - set to 1 if any values are null; else 0   */
-    status: *mut c_int,   /* IO - error status                             */
+    fptr: *mut fitsfile,
+    colnum: c_int,
+    naxis: c_int,
+    naxes: *const c_long,
+    blc: *const c_long,
+    trc: *const c_long,
+    inc: *const c_long,
+    nulval: c_ushort,
+    array: *mut c_ushort,
+    anynul: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -476,21 +582,34 @@ pub unsafe extern "C" fn ffgsvui(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read a subsection of data values from an image or a table column.
 /// This routine is set up to handle a maximum of nine dimensions.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `colnum` — (I) number of the column to read (1 = 1st)
+/// * `naxis`  — (I) number of dimensions in the FITS array
+/// * `naxes`  — (I) size of each dimension
+/// * `blc`    — (I) 'bottom left corner' of the subsection
+/// * `trc`    — (I) 'top right corner' of the subsection
+/// * `inc`    — (I) increment to be applied in each dimension
+/// * `nulval` — (I) value to set undefined pixels
+/// * `array`  — (O) array to be filled and returned
+/// * `anynul` — (O) set to 1 if any values are null; else 0
+/// * `status` — (IO) error status
 pub fn ffgsvui_safe(
-    fptr: &mut fitsfile,    /* I - FITS file pointer                         */
-    colnum: c_int,          /* I - number of the column to read (1 = 1st)    */
-    naxis: c_int,           /* I - number of dimensions in the FITS array    */
-    naxes: &[c_long],       /* I - size of each dimension                    */
-    blc: &[c_long],         /* I - 'bottom left corner' of the subsection    */
-    trc: &[c_long],         /* I - 'top right corner' of the subsection      */
-    inc: &[c_long],         /* I - increment to be applied in each dimension */
-    nulval: c_ushort,       /* I - value to set undefined pixels       */
-    array: &mut [c_ushort], /* O - array to be filled and returned     */
-    mut anynul: Option<&mut c_int>, /* O - set to 1 if any values are null; else 0   */
-    status: &mut c_int,     /* IO - error status                             */
+    fptr: &mut fitsfile,
+    colnum: c_int,
+    naxis: c_int,
+    naxes: &[c_long],
+    blc: &[c_long],
+    trc: &[c_long],
+    inc: &[c_long],
+    nulval: c_ushort,
+    array: &mut [c_ushort],
+    mut anynul: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     let mut rstr: c_long = 0;
     let mut rstp: c_long = 0;
@@ -680,22 +799,35 @@ pub fn ffgsvui_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read a subsection of data values from an image or a table column.
 /// This routine is set up to handle a maximum of nine dimensions.
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `colnum`  — (I) number of the column to read (1 = 1st)
+/// * `naxis`   — (I) number of dimensions in the FITS array
+/// * `naxes`   — (I) size of each dimension
+/// * `blc`     — (I) 'bottom left corner' of the subsection
+/// * `trc`     — (I) 'top right corner' of the subsection
+/// * `inc`     — (I) increment to be applied in each dimension
+/// * `array`   — (O) array to be filled and returned
+/// * `flagval` — (O) set to 1 if corresponding value is null
+/// * `anynul`  — (O) set to 1 if any values are null; else 0
+/// * `status`  — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgsfui(
-    fptr: *mut fitsfile,  /* I - FITS file pointer                         */
-    colnum: c_int,        /* I - number of the column to read (1 = 1st)    */
-    naxis: c_int,         /* I - number of dimensions in the FITS array    */
-    naxes: *const c_long, /* I - size of each dimension                    */
-    blc: *const c_long,   /* I - 'bottom left corner' of the subsection    */
-    trc: *const c_long,   /* I - 'top right corner' of the subsection      */
-    inc: *const c_long,   /* I - increment to be applied in each dimension */
-    array: *mut c_ushort, /* O - array to be filled and returned     */
-    flagval: *mut c_char, /* O - set to 1 if corresponding value is null   */
-    anynul: *mut c_int,   /* O - set to 1 if any values are null; else 0   */
-    status: *mut c_int,   /* IO - error status                             */
+    fptr: *mut fitsfile,
+    colnum: c_int,
+    naxis: c_int,
+    naxes: *const c_long,
+    blc: *const c_long,
+    trc: *const c_long,
+    inc: *const c_long,
+    array: *mut c_ushort,
+    flagval: *mut c_char,
+    anynul: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -720,21 +852,34 @@ pub unsafe extern "C" fn ffgsfui(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read a subsection of data values from an image or a table column.
 /// This routine is set up to handle a maximum of nine dimensions.
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `colnum`  — (I) number of the column to read (1 = 1st)
+/// * `naxis`   — (I) number of dimensions in the FITS array
+/// * `naxes`   — (I) size of each dimension
+/// * `blc`     — (I) 'bottom left corner' of the subsection
+/// * `trc`     — (I) 'top right corner' of the subsection
+/// * `inc`     — (I) increment to be applied in each dimension
+/// * `array`   — (O) array to be filled and returned
+/// * `flagval` — (O) set to 1 if corresponding value is null
+/// * `anynul`  — (O) set to 1 if any values are null; else 0
+/// * `status`  — (IO) error status
 pub fn ffgsfui_safe(
-    fptr: &mut fitsfile,    /* I - FITS file pointer                         */
-    colnum: c_int,          /* I - number of the column to read (1 = 1st)    */
-    naxis: c_int,           /* I - number of dimensions in the FITS array    */
-    naxes: &[c_long],       /* I - size of each dimension                    */
-    blc: &[c_long],         /* I - 'bottom left corner' of the subsection    */
-    trc: &[c_long],         /* I - 'top right corner' of the subsection      */
-    inc: &[c_long],         /* I - increment to be applied in each dimension */
-    array: &mut [c_ushort], /* O - array to be filled and returned     */
-    flagval: &mut [c_char], /* O - set to 1 if corresponding value is null   */
-    mut anynul: Option<&mut c_int>, /* O - set to 1 if any values are null; else 0   */
-    status: &mut c_int,     /* IO - error status                             */
+    fptr: &mut fitsfile,
+    colnum: c_int,
+    naxis: c_int,
+    naxes: &[c_long],
+    blc: &[c_long],
+    trc: &[c_long],
+    inc: &[c_long],
+    array: &mut [c_ushort],
+    flagval: &mut [c_char],
+    mut anynul: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     let mut rstr: c_long = 0;
     let mut rstp: c_long = 0;
@@ -921,7 +1066,6 @@ pub fn ffgsfui_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 ///Read an array of group parameters from the primary array. Data conversion
 ///and scaling will be performed if necessary (e.g, if the datatype of
 ///the FITS array is not the same as the array being read).
@@ -930,14 +1074,23 @@ pub fn ffgsfui_safe(
 ///each group of the primary array is a row in the table,
 ///where the first column contains the group parameters
 ///and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to read (1 = 1st group)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `array`     — (O) array of values that are returned
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffggpui(
-    fptr: *mut fitsfile,  /* I - FITS file pointer                       */
-    group: c_long,        /* I - group to read (1 = 1st group)           */
-    firstelem: c_long,    /* I - first vector element to read (1 = 1st)  */
-    nelem: c_long,        /* I - number of values to read                */
-    array: *mut c_ushort, /* O - array of values that are returned   */
-    status: *mut c_int,   /* IO - error status                           */
+    fptr: *mut fitsfile,
+    group: c_long,
+    firstelem: c_long,
+    nelem: c_long,
+    array: *mut c_ushort,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -949,7 +1102,6 @@ pub unsafe extern "C" fn ffggpui(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 ///Read an array of group parameters from the primary array. Data conversion
 ///and scaling will be performed if necessary (e.g, if the datatype of
 ///the FITS array is not the same as the array being read).
@@ -958,13 +1110,22 @@ pub unsafe extern "C" fn ffggpui(
 ///each group of the primary array is a row in the table,
 ///where the first column contains the group parameters
 ///and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to read (1 = 1st group)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `array`     — (O) array of values that are returned
+/// * `status`    — (IO) error status
 pub fn ffggpui_safe(
-    fptr: &mut fitsfile,    /* I - FITS file pointer                       */
-    group: c_long,          /* I - group to read (1 = 1st group)           */
-    firstelem: c_long,      /* I - first vector element to read (1 = 1st)  */
-    nelem: c_long,          /* I - number of values to read                */
-    array: &mut [c_ushort], /* O - array of values that are returned       */
-    status: &mut c_int,     /* IO - error status                           */
+    fptr: &mut fitsfile,
+    group: c_long,
+    firstelem: c_long,
+    nelem: c_long,
+    array: &mut [c_ushort],
+    status: &mut c_int,
 ) -> c_int {
     let cdummy = 0;
     let mut anynul = 0;
@@ -988,24 +1149,35 @@ pub fn ffggpui_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of values from a column in the current FITS HDU. Automatic
 /// datatype conversion will be performed if the datatype of the column does not
 /// match the datatype of the array parameter. The output values will be scaled
 /// by the FITS TSCALn and TZEROn values if these values have been defined.
 /// Any undefined pixels will be set equal to the value of 'nulval' unless
 /// nulval = 0 in which case no checks for undefined pixels will be made.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to read (1 = 1st col)
+/// * `firstrow`  — (I) first row to read (1 = 1st row)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `nulval`    — (I) value for null pixels
+/// * `array`     — (O) array of values that are read
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgcvui(
-    fptr: *mut fitsfile,  /* I - FITS file pointer                       */
-    colnum: c_int,        /* I - number of column to read (1 = 1st col)  */
-    firstrow: LONGLONG,   /* I - first row to read (1 = 1st row)         */
-    firstelem: LONGLONG,  /* I - first vector element to read (1 = 1st)  */
-    nelem: LONGLONG,      /* I - number of values to read                */
-    nulval: c_ushort,     /* I - value for null pixels               */
-    array: *mut c_ushort, /* O - array of values that are read       */
-    anynul: *mut c_int,   /* O - set to 1 if any values are null; else 0 */
-    status: *mut c_int,   /* IO - error status                           */
+    fptr: *mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    nulval: c_ushort,
+    array: *mut c_ushort,
+    anynul: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -1030,23 +1202,34 @@ pub unsafe extern "C" fn ffgcvui(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of values from a column in the current FITS HDU. Automatic
 /// datatype conversion will be performed if the datatype of the column does not
 /// match the datatype of the array parameter. The output values will be scaled
 /// by the FITS TSCALn and TZEROn values if these values have been defined.
 /// Any undefined pixels will be set equal to the value of 'nulval' unless
 /// nulval = 0 in which case no checks for undefined pixels will be made.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to read (1 = 1st col)
+/// * `firstrow`  — (I) first row to read (1 = 1st row)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `nulval`    — (I) value for null pixels
+/// * `array`     — (O) array of values that are read
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `status`    — (IO) error status
 pub fn ffgcvui_safe(
-    fptr: &mut fitsfile,        /* I - FITS file pointer                       */
-    colnum: c_int,              /* I - number of column to read (1 = 1st col)  */
-    firstrow: LONGLONG,         /* I - first row to read (1 = 1st row)         */
-    firstelem: LONGLONG,        /* I - first vector element to read (1 = 1st)  */
-    nelem: LONGLONG,            /* I - number of values to read                */
-    nulval: c_ushort,           /* I - value for null pixels               */
-    array: &mut [c_ushort],     /* O - array of values that are read       */
-    anynul: Option<&mut c_int>, /* O - set to 1 if any values are null; else 0 */
-    status: &mut c_int,         /* IO - error status                           */
+    fptr: &mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    nulval: c_ushort,
+    array: &mut [c_ushort],
+    anynul: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     let mut dummy_nularray = vec![0; nelem as usize];
 
@@ -1067,24 +1250,35 @@ pub fn ffgcvui_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of values from a column in the current FITS HDU. Automatic
 /// datatype conversion will be performed if the datatype of the column does not
 /// match the datatype of the array parameter. The output values will be scaled
 /// by the FITS TSCALn and TZEROn values if these values have been defined.
 /// Nularray will be set = 1 if the corresponding array pixel is undefined,
 /// otherwise nularray will = 0.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to read (1 = 1st col)
+/// * `firstrow`  — (I) first row to read (1 = 1st row)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `array`     — (O) array of values that are read
+/// * `nularray`  — (O) array of flags: 1 if null pixel; else 0
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgcfui(
-    fptr: *mut fitsfile,   /* I - FITS file pointer                       */
-    colnum: c_int,         /* I - number of column to read (1 = 1st col)  */
-    firstrow: LONGLONG,    /* I - first row to read (1 = 1st row)         */
-    firstelem: LONGLONG,   /* I - first vector element to read (1 = 1st)  */
-    nelem: LONGLONG,       /* I - number of values to read                */
-    array: *mut c_ushort,  /* O - array of values that are read       */
-    nularray: *mut c_char, /* O - array of flags: 1 if null pixel; else 0 */
-    anynul: *mut c_int,    /* O - set to 1 if any values are null; else 0 */
-    status: *mut c_int,    /* IO - error status                           */
+    fptr: *mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: *mut c_ushort,
+    nularray: *mut c_char,
+    anynul: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -1111,23 +1305,34 @@ pub unsafe extern "C" fn ffgcfui(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of values from a column in the current FITS HDU. Automatic
 /// datatype conversion will be performed if the datatype of the column does not
 /// match the datatype of the array parameter. The output values will be scaled
 /// by the FITS TSCALn and TZEROn values if these values have been defined.
 /// Nularray will be set = 1 if the corresponding array pixel is undefined,
 /// otherwise nularray will = 0.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to read (1 = 1st col)
+/// * `firstrow`  — (I) first row to read (1 = 1st row)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `array`     — (O) array of values that are read
+/// * `nularray`  — (O) array of flags: 1 if null pixel; else 0
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `status`    — (IO) error status
 pub fn ffgcfui_safe(
-    fptr: &mut fitsfile,        /* I - FITS file pointer                       */
-    colnum: c_int,              /* I - number of column to read (1 = 1st col)  */
-    firstrow: LONGLONG,         /* I - first row to read (1 = 1st row)         */
-    firstelem: LONGLONG,        /* I - first vector element to read (1 = 1st)  */
-    nelem: LONGLONG,            /* I - number of values to read                */
-    array: &mut [c_ushort],     /* O - array of values that are read       */
-    nularray: &mut [c_char],    /* O - array of flags: 1 if null pixel; else 0 */
-    anynul: Option<&mut c_int>, /* O - set to 1 if any values are null; else 0 */
-    status: &mut c_int,         /* IO - error status                           */
+    fptr: &mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: &mut [c_ushort],
+    nularray: &mut [c_char],
+    anynul: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     let dummy: c_ushort = 0;
 
@@ -1148,7 +1353,6 @@ pub fn ffgcfui_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of values from a column in the current FITS HDU.
 /// The column number may refer to a real column in an ASCII or binary table,
 /// or it may refer be a virtual column in a 1 or more grouped FITS primary
@@ -1162,21 +1366,35 @@ pub fn ffgcfui_safe(
 /// and will be scaled by the FITS TSCALn and TZEROn values if necessary.
 #[allow(clippy::if_same_then_else)]
 // C dispatch chain: distinct conditions deliberately share an action.
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to read (1 = 1st col)
+/// * `firstrow`  — (I) first row to read (1 = 1st row)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `elemincre` — (I) pixel increment; e.g., 2 = every other
+/// * `nultyp`    — (I) null value handling code:
+/// * `nulval`    — (I) value for null pixels if nultyp = 1
+/// * `array`     — (O) array of values that are read
+/// * `nularray`  — (O) array of flags = 1 if nultyp = 2
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `status`    — (IO) error status
 pub(crate) fn ffgclui(
-    fptr: &mut fitsfile,   /* I - FITS file pointer                       */
-    colnum: c_int,         /* I - number of column to read (1 = 1st col)  */
-    firstrow: LONGLONG,    /* I - first row to read (1 = 1st row)         */
-    firstelem: LONGLONG,   /* I - first vector element to read (1 = 1st)  */
-    nelem: LONGLONG,       /* I - number of values to read                */
-    elemincre: c_long,     /* I - pixel increment; e.g., 2 = every other  */
-    nultyp: NullCheckType, /* I - null value handling code:               */
+    fptr: &mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    elemincre: c_long,
+    nultyp: NullCheckType,
     /*     1: set undefined pixels = nulval        */
     /*     2: set nularray=1 for undefined pixels  */
-    nulval: c_ushort,               /* I - value for null pixels if nultyp = 1 */
-    array: &mut [c_ushort],         /* O - array of values that are read       */
-    nularray: &mut [c_char],        /* O - array of flags = 1 if nultyp = 2        */
-    mut anynul: Option<&mut c_int>, /* O - set to 1 if any values are null; else 0 */
-    status: &mut c_int,             /* IO - error status                           */
+    nulval: c_ushort,
+    array: &mut [c_ushort],
+    nularray: &mut [c_char],
+    mut anynul: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     let mut scale: f64 = 0.0;
     let mut zero: f64 = 0.0;
@@ -1222,9 +1440,7 @@ pub(crate) fn ffgclui(
         nularray.fill(0); /* initialize nullarray */
     }
 
-    /*---------------------------------------------------*/
     /*  Check input and get parameters about the column: */
-    /*---------------------------------------------------*/
 
     if ffgcprll(
         fptr,
@@ -1272,9 +1488,7 @@ pub(crate) fn ffgclui(
             power *= 10.0;
         }
     }
-    /*------------------------------------------------------------------*/
     /*  Decide whether to check for null values in the input FITS file: */
-    /*------------------------------------------------------------------*/
     nulcheck = nultyp; /* by default, check for null values in the FITS file */
 
     if nultyp == NullCheckType::SetPixel && nulval == 0 {
@@ -1294,10 +1508,8 @@ pub(crate) fn ffgclui(
         nulcheck = NullCheckType::None;
     }
 
-    /*----------------------------------------------------------------------*/
     /*  If FITS column and output data array have same datatype, then we do */
     /*  not need to use a temporary buffer to store intermediate datatype.  */
-    /*----------------------------------------------------------------------*/
 
     if tcode == TSHORT {
         /* Special Case:                        */
@@ -1311,7 +1523,6 @@ pub(crate) fn ffgclui(
         }
     }
 
-    /*---------------------------------------------------------------------*/
     /*  Now read the pixels from the FITS column. If the column does not   */
     /*  have the same datatype as the output array, then we have to read   */
     /*  the raw values into a temporary buffer (of limited size).  In      */
@@ -1321,7 +1532,6 @@ pub(crate) fn ffgclui(
     /*  test for undefined values, (2) convert the datatype if necessary,  */
     /*  and (3) scale the values by the FITS TSCALn and TZEROn linear      */
     /*  scaling parameters.                                                */
-    /*---------------------------------------------------------------------*/
 
     remain = nelem; /* remaining number of values to read */
     next = 0; /* next element in array to be read   */
@@ -1547,9 +1757,7 @@ pub(crate) fn ffgclui(
             }
         } /* End of switch block */
 
-        /*-------------------------*/
         /*  Check for fatal error  */
-        /*-------------------------*/
         if *status > 0 {
             /* test for error during previous read operation */
 
@@ -1577,9 +1785,7 @@ pub(crate) fn ffgclui(
             return *status;
         }
 
-        /*--------------------------------------------*/
         /*  increment the counters for the next loop  */
-        /*--------------------------------------------*/
         remain -= ntodo as LONGLONG;
         if remain != 0 {
             next += ntodo as usize;
@@ -1595,9 +1801,7 @@ pub(crate) fn ffgclui(
         }
     } /*  End of main while Loop  */
 
-    /*--------------------------------*/
     /*  check for numerical overflow  */
-    /*--------------------------------*/
     if *status == OVERFLOW_ERR {
         ffpmsg_str("Numerical overflow during type conversion while reading FITS data.");
         *status = NUM_OVERFLOW;
@@ -1606,7 +1810,6 @@ pub(crate) fn ffgclui(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output following reading of the input from a FITS file.
 /// Check for null values and do datatype conversion and scaling if required.
 /// The nullcheck code value determines how any null values in the input array
@@ -1618,20 +1821,34 @@ pub(crate) fn ffgclui(
 /// nullarray will be set to 1; the value of nullarray for non-null pixels
 /// will = 0.  The anynull parameter will be set = 1 if any of the returned
 /// pixels are null, otherwise anynull will be returned with a value = 0;
+///
+/// # Parameters
+///
+/// * `input`     — (I) array of values to be converted
+/// * `ntodo`     — (I) number of elements in the array
+/// * `scale`     — (I) FITS TSCALn or BSCALE value
+/// * `zero`      — (I) FITS TZEROn or BZERO value
+/// * `nullcheck` — (I) null checking code; 0 = don't check
+/// * `tnull`     — (I) value of FITS TNULLn keyword if any
+/// * `nullval`   — (I) set null pixels, if nullcheck = 1
+/// * `nullarray` — (O) bad pixel array, if nullcheck = 2
+/// * `anynull`   — (O) set to 1 if any pixels are null
+/// * `output`    — (O) array of converted pixels
+/// * `status`    — (IO) error status
 pub(crate) fn fffi1u2(
-    input: &[u8],             /* I - array of values to be converted     */
-    ntodo: c_long,            /* I - number of elements in the array     */
-    scale: f64,               /* I - FITS TSCALn or BSCALE value         */
-    zero: f64,                /* I - FITS TZEROn or BZERO  value         */
-    nullcheck: NullCheckType, /* I - null checking code; 0 = don't check */
+    input: &[u8],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    nullcheck: NullCheckType,
     /*     1:set null pixels = nullval         */
     /*     2: if null pixel, set nullarray = 1 */
-    tnull: u8,                   /* I - value of FITS TNULLn keyword if any */
-    nullval: c_ushort,           /* I - set null pixels, if nullcheck = 1   */
-    nullarray: &mut [c_char],    /* O - bad pixel array, if nullcheck = 2   */
-    anynull: Option<&mut c_int>, /* O - set to 1 if any pixels are null     */
-    output: &mut [c_ushort],     /* O - array of converted pixels           */
-    status: &mut c_int,          /* IO - error status                       */
+    tnull: u8,
+    nullval: c_ushort,
+    nullarray: &mut [c_char],
+    anynull: Option<&mut c_int>,
+    output: &mut [c_ushort],
+    status: &mut c_int,
 ) -> c_int {
     let mut dvalue: f64 = 0.0;
 
@@ -1705,7 +1922,6 @@ pub(crate) fn fffi1u2(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output following reading of the input from a FITS file.
 /// Check for null values and do datatype conversion and scaling if required.
 /// The nullcheck code value determines how any null values in the input array
@@ -1717,20 +1933,34 @@ pub(crate) fn fffi1u2(
 /// nullarray will be set to 1; the value of nullarray for non-null pixels
 /// will = 0.  The anynull parameter will be set = 1 if any of the returned
 /// pixels are null, otherwise anynull will be returned with a value = 0;
+///
+/// # Parameters
+///
+/// * `input`     — (I) array of values to be converted
+/// * `ntodo`     — (I) number of elements in the array
+/// * `scale`     — (I) FITS TSCALn or BSCALE value
+/// * `zero`      — (I) FITS TZEROn or BZERO value
+/// * `nullcheck` — (I) null checking code; 0 = don't check
+/// * `tnull`     — (I) value of FITS TNULLn keyword if any
+/// * `nullval`   — (I) set null pixels, if nullcheck = 1
+/// * `nullarray` — (O) bad pixel array, if nullcheck = 2
+/// * `anynull`   — (O) set to 1 if any pixels are null
+/// * `output`    — (O) array of converted pixels
+/// * `status`    — (IO) error status
 pub(crate) fn fffi2u2(
-    input: &[c_short],        /* I - array of values to be converted     */
-    ntodo: c_long,            /* I - number of elements in the array     */
-    scale: f64,               /* I - FITS TSCALn or BSCALE value         */
-    zero: f64,                /* I - FITS TZEROn or BZERO  value         */
-    nullcheck: NullCheckType, /* I - null checking code; 0 = don't check */
+    input: &[c_short],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    nullcheck: NullCheckType,
     /*     1:set null pixels = nullval         */
     /*     2: if null pixel, set nullarray = 1 */
-    tnull: c_short,              /* I - value of FITS TNULLn keyword if any */
-    nullval: c_ushort,           /* I - set null pixels, if nullcheck = 1   */
-    nullarray: &mut [c_char],    /* O - bad pixel array, if nullcheck = 2   */
-    anynull: Option<&mut c_int>, /* O - set to 1 if any pixels are null     */
-    output: &mut [c_ushort],     /* O - array of converted pixels           */
-    status: &mut c_int,          /* IO - error status                       */
+    tnull: c_short,
+    nullval: c_ushort,
+    nullarray: &mut [c_char],
+    anynull: Option<&mut c_int>,
+    output: &mut [c_ushort],
+    status: &mut c_int,
 ) -> c_int {
     let mut dvalue: f64 = 0.0;
 
@@ -1836,7 +2066,6 @@ pub(crate) fn fffi2u2(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// In-place version of `fffi2u2`, for when the raw c_short values were read
 /// directly into the output array (the TSHORT special case in `ffgclui`,
 /// where no temporary buffer is used because the input and output are the
@@ -1845,19 +2074,32 @@ pub(crate) fn fffi2u2(
 /// write the converted value back over it.
 ///
 /// Mirrors `fffi2i2_inplace` in getcoli.rs and the other `_inplace` variants.
+///
+/// # Parameters
+///
+/// * `inout`     — (IO) array of values to be converted
+/// * `ntodo`     — (I) number of elements in the array
+/// * `scale`     — (I) FITS TSCALn or BSCALE value
+/// * `zero`      — (I) FITS TZEROn or BZERO value
+/// * `nullcheck` — (I) null checking code; 0 = don't check
+/// * `tnull`     — (I) value of FITS TNULLn keyword if any
+/// * `nullval`   — (I) set null pixels, if nullcheck = 1
+/// * `nullarray` — (O) bad pixel array, if nullcheck = 2
+/// * `anynull`   — (O) set to 1 if any pixels are null
+/// * `status`    — (IO) error status
 pub(crate) fn fffi2u2_inplace(
-    inout: &mut [c_ushort],   /* IO - array of values to be converted    */
-    ntodo: c_long,            /* I - number of elements in the array     */
-    scale: f64,               /* I - FITS TSCALn or BSCALE value         */
-    zero: f64,                /* I - FITS TZEROn or BZERO  value         */
-    nullcheck: NullCheckType, /* I - null checking code; 0 = don't check */
+    inout: &mut [c_ushort],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    nullcheck: NullCheckType,
     /*     1:set null pixels = nullval         */
     /*     2: if null pixel, set nullarray = 1 */
-    tnull: c_short,              /* I - value of FITS TNULLn keyword if any */
-    nullval: c_ushort,           /* I - set null pixels, if nullcheck = 1   */
-    nullarray: &mut [c_char],    /* O - bad pixel array, if nullcheck = 2   */
-    anynull: Option<&mut c_int>, /* O - set to 1 if any pixels are null     */
-    status: &mut c_int,          /* IO - error status                       */
+    tnull: c_short,
+    nullval: c_ushort,
+    nullarray: &mut [c_char],
+    anynull: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     let mut dvalue: f64 = 0.0;
 
@@ -1961,7 +2203,6 @@ pub(crate) fn fffi2u2_inplace(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output following reading of the input from a FITS file.
 /// Check for null values and do datatype conversion and scaling if required.
 /// The nullcheck code value determines how any null values in the input array
@@ -1973,20 +2214,34 @@ pub(crate) fn fffi2u2_inplace(
 /// nullarray will be set to 1; the value of nullarray for non-null pixels
 /// will = 0.  The anynull parameter will be set = 1 if any of the returned
 /// pixels are null, otherwise anynull will be returned with a value = 0;
+///
+/// # Parameters
+///
+/// * `input`     — (I) array of values to be converted
+/// * `ntodo`     — (I) number of elements in the array
+/// * `scale`     — (I) FITS TSCALn or BSCALE value
+/// * `zero`      — (I) FITS TZEROn or BZERO value
+/// * `nullcheck` — (I) null checking code; 0 = don't check
+/// * `tnull`     — (I) value of FITS TNULLn keyword if any
+/// * `nullval`   — (I) set null pixels, if nullcheck = 1
+/// * `nullarray` — (O) bad pixel array, if nullcheck = 2
+/// * `anynull`   — (O) set to 1 if any pixels are null
+/// * `output`    — (O) array of converted pixels
+/// * `status`    — (IO) error status
 pub(crate) fn fffi4u2(
-    input: &[INT32BIT],       /* I - array of values to be converted     */
-    ntodo: c_long,            /* I - number of elements in the array     */
-    scale: f64,               /* I - FITS TSCALn or BSCALE value         */
-    zero: f64,                /* I - FITS TZEROn or BZERO  value         */
-    nullcheck: NullCheckType, /* I - null checking code; 0 = don't check */
+    input: &[INT32BIT],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    nullcheck: NullCheckType,
     /*     1:set null pixels = nullval         */
     /*     2: if null pixel, set nullarray = 1 */
-    tnull: INT32BIT,             /* I - value of FITS TNULLn keyword if any */
-    nullval: c_ushort,           /* I - set null pixels, if nullcheck = 1   */
-    nullarray: &mut [c_char],    /* O - bad pixel array, if nullcheck = 2   */
-    anynull: Option<&mut c_int>, /* O - set to 1 if any pixels are null     */
-    output: &mut [c_ushort],     /* O - array of converted pixels           */
-    status: &mut c_int,          /* IO - error status                       */
+    tnull: INT32BIT,
+    nullval: c_ushort,
+    nullarray: &mut [c_char],
+    anynull: Option<&mut c_int>,
+    output: &mut [c_ushort],
+    status: &mut c_int,
 ) -> c_int {
     let mut dvalue: f64 = 0.0;
 
@@ -2078,7 +2333,6 @@ pub(crate) fn fffi4u2(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output following reading of the input from a FITS file.
 /// Check for null values and do datatype conversion and scaling if required.
 /// The nullcheck code value determines how any null values in the input array
@@ -2090,20 +2344,34 @@ pub(crate) fn fffi4u2(
 /// nullarray will be set to 1; the value of nullarray for non-null pixels
 /// will = 0.  The anynull parameter will be set = 1 if any of the returned
 /// pixels are null, otherwise anynull will be returned with a value = 0;
+///
+/// # Parameters
+///
+/// * `input`     — (I) array of values to be converted
+/// * `ntodo`     — (I) number of elements in the array
+/// * `scale`     — (I) FITS TSCALn or BSCALE value
+/// * `zero`      — (I) FITS TZEROn or BZERO value
+/// * `nullcheck` — (I) null checking code; 0 = don't check
+/// * `tnull`     — (I) value of FITS TNULLn keyword if any
+/// * `nullval`   — (I) set null pixels, if nullcheck = 1
+/// * `nullarray` — (O) bad pixel array, if nullcheck = 2
+/// * `anynull`   — (O) set to 1 if any pixels are null
+/// * `output`    — (O) array of converted pixels
+/// * `status`    — (IO) error status
 pub(crate) fn fffi8u2(
-    input: &[LONGLONG],       /* I - array of values to be converted     */
-    ntodo: c_long,            /* I - number of elements in the array     */
-    scale: f64,               /* I - FITS TSCALn or BSCALE value         */
-    zero: f64,                /* I - FITS TZEROn or BZERO  value         */
-    nullcheck: NullCheckType, /* I - null checking code; 0 = don't check */
+    input: &[LONGLONG],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    nullcheck: NullCheckType,
     /*     1:set null pixels = nullval         */
     /*     2: if null pixel, set nullarray = 1 */
-    tnull: LONGLONG,             /* I - value of FITS TNULLn keyword if any */
-    nullval: c_ushort,           /* I - set null pixels, if nullcheck = 1   */
-    nullarray: &mut [c_char],    /* O - bad pixel array, if nullcheck = 2   */
-    anynull: Option<&mut c_int>, /* O - set to 1 if any pixels are null     */
-    output: &mut [c_ushort],     /* O - array of converted pixels           */
-    status: &mut c_int,          /* IO - error status                       */
+    tnull: LONGLONG,
+    nullval: c_ushort,
+    nullarray: &mut [c_char],
+    anynull: Option<&mut c_int>,
+    output: &mut [c_ushort],
+    status: &mut c_int,
 ) -> c_int {
     let mut dvalue: f64 = 0.0;
     let mut ulltemp: ULONGLONG = 0;
@@ -2235,7 +2503,6 @@ pub(crate) fn fffi8u2(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output following reading of the input from a FITS file.
 /// Check for null values and do datatype conversion and scaling if required.
 /// The nullcheck code value determines how any null values in the input array
@@ -2247,19 +2514,32 @@ pub(crate) fn fffi8u2(
 /// nullarray will be set to 1; the value of nullarray for non-null pixels
 /// will = 0.  The anynull parameter will be set = 1 if any of the returned
 /// pixels are null, otherwise anynull will be returned with a value = 0;
+///
+/// # Parameters
+///
+/// * `input`     — (I) array of values to be converted
+/// * `ntodo`     — (I) number of elements in the array
+/// * `scale`     — (I) FITS TSCALn or BSCALE value
+/// * `zero`      — (I) FITS TZEROn or BZERO value
+/// * `nullcheck` — (I) null checking code; 0 = don't check
+/// * `nullval`   — (I) set null pixels, if nullcheck = 1
+/// * `nullarray` — (O) bad pixel array, if nullcheck = 2
+/// * `anynull`   — (O) set to 1 if any pixels are null
+/// * `output`    — (O) array of converted pixels
+/// * `status`    — (IO) error status
 pub(crate) fn fffr4u2(
-    input: &[f32],            /* I - array of values to be converted     */
-    ntodo: c_long,            /* I - number of elements in the array     */
-    scale: f64,               /* I - FITS TSCALn or BSCALE value         */
-    zero: f64,                /* I - FITS TZEROn or BZERO  value         */
-    nullcheck: NullCheckType, /* I - null checking code; 0 = don't check */
+    input: &[f32],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    nullcheck: NullCheckType,
     /*     1:set null pixels = nullval         */
     /*     2: if null pixel, set nullarray = 1 */
-    nullval: c_ushort,           /* I - set null pixels, if nullcheck = 1   */
-    nullarray: &mut [c_char],    /* O - bad pixel array, if nullcheck = 2   */
-    anynull: Option<&mut c_int>, /* O - set to 1 if any pixels are null     */
-    output: &mut [c_ushort],     /* O - array of converted pixels           */
-    status: &mut c_int,          /* IO - error status                       */
+    nullval: c_ushort,
+    nullarray: &mut [c_char],
+    anynull: Option<&mut c_int>,
+    output: &mut [c_ushort],
+    status: &mut c_int,
 ) -> c_int {
     let mut dvalue: f64 = 0.0;
     let mut sptr = 0;
@@ -2382,7 +2662,6 @@ pub(crate) fn fffr4u2(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output following reading of the input from a FITS file.
 /// Check for null values and do datatype conversion and scaling if required.
 /// The nullcheck code value determines how any null values in the input array
@@ -2394,19 +2673,32 @@ pub(crate) fn fffr4u2(
 /// nullarray will be set to 1; the value of nullarray for non-null pixels
 /// will = 0.  The anynull parameter will be set = 1 if any of the returned
 /// pixels are null, otherwise anynull will be returned with a value = 0;
+///
+/// # Parameters
+///
+/// * `input`     — (I) array of values to be converted
+/// * `ntodo`     — (I) number of elements in the array
+/// * `scale`     — (I) FITS TSCALn or BSCALE value
+/// * `zero`      — (I) FITS TZEROn or BZERO value
+/// * `nullcheck` — (I) null checking code; 0 = don't check
+/// * `nullval`   — (I) set null pixels, if nullcheck = 1
+/// * `nullarray` — (O) bad pixel array, if nullcheck = 2
+/// * `anynull`   — (O) set to 1 if any pixels are null
+/// * `output`    — (O) array of converted pixels
+/// * `status`    — (IO) error status
 pub(crate) fn fffr8u2(
-    input: &[f64],            /* I - array of values to be converted     */
-    ntodo: c_long,            /* I - number of elements in the array     */
-    scale: f64,               /* I - FITS TSCALn or BSCALE value         */
-    zero: f64,                /* I - FITS TZEROn or BZERO  value         */
-    nullcheck: NullCheckType, /* I - null checking code; 0 = don't check */
+    input: &[f64],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    nullcheck: NullCheckType,
     /*     1:set null pixels = nullval         */
     /*     2: if null pixel, set nullarray = 1 */
-    nullval: c_ushort,           /* I - set null pixels, if nullcheck = 1   */
-    nullarray: &mut [c_char],    /* O - bad pixel array, if nullcheck = 2   */
-    anynull: Option<&mut c_int>, /* O - set to 1 if any pixels are null     */
-    output: &mut [c_ushort],     /* O - array of converted pixels           */
-    status: &mut c_int,          /* IO - error status                       */
+    nullval: c_ushort,
+    nullarray: &mut [c_char],
+    anynull: Option<&mut c_int>,
+    output: &mut [c_ushort],
+    status: &mut c_int,
 ) -> c_int {
     let mut dvalue: f64 = 0.0;
     let mut sptr = 0;
@@ -2528,7 +2820,6 @@ pub(crate) fn fffr8u2(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output following reading of the input from a FITS file. Check
 /// for null values and do scaling if required. The nullcheck code value
 /// determines how any null values in the input array are treated. A null
@@ -2539,22 +2830,38 @@ pub(crate) fn fffr8u2(
 /// nullarray will be set to 1; the value of nullarray for non-null pixels
 /// will = 0.  The anynull parameter will be set = 1 if any of the returned
 /// pixels are null, otherwise anynull will be returned with a value = 0;
+///
+/// # Parameters
+///
+/// * `input`      — (I) array of values to be converted
+/// * `ntodo`      — (I) number of elements in the array
+/// * `scale`      — (I) FITS TSCALn or BSCALE value
+/// * `zero`       — (I) FITS TZEROn or BZERO value
+/// * `twidth`     — (I) width of each substring of chars
+/// * `implipower` — (I) power of 10 of implied decimal
+/// * `nullcheck`  — (I) null checking code; 0 = don't check
+/// * `snull`      — (I) value of FITS null string, if any
+/// * `nullval`    — (I) set null pixels, if nullcheck = 1
+/// * `nullarray`  — (O) bad pixel array, if nullcheck = 2
+/// * `anynull`    — (O) set to 1 if any pixels are null
+/// * `output`     — (O) array of converted pixels
+/// * `status`     — (IO) error status
 pub(crate) fn fffstru2(
-    input: &mut [c_char],     /* I - array of values to be converted     */
-    ntodo: c_long,            /* I - number of elements in the array     */
-    scale: f64,               /* I - FITS TSCALn or BSCALE value         */
-    zero: f64,                /* I - FITS TZEROn or BZERO  value         */
-    twidth: c_long,           /* I - width of each substring of chars    */
-    implipower: f64,          /* I - power of 10 of implied decimal      */
-    nullcheck: NullCheckType, /* I - null checking code; 0 = don't check */
+    input: &mut [c_char],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    twidth: c_long,
+    implipower: f64,
+    nullcheck: NullCheckType,
     /*     1:set null pixels = nullval         */
     /*     2: if null pixel, set nullarray = 1 */
-    snull: &[c_char],                /* I - value of FITS null string, if any   */
-    nullval: c_ushort,               /* I - set null pixels, if nullcheck = 1  */
-    nullarray: &mut [c_char],        /* O - bad pixel array, if nullcheck = 2   */
-    mut anynull: Option<&mut c_int>, /* O - set to 1 if any pixels are null     */
-    output: &mut [c_ushort],         /* O - array of converted pixels          */
-    status: &mut c_int,              /* IO - error status                       */
+    snull: &[c_char],
+    nullval: c_ushort,
+    nullarray: &mut [c_char],
+    mut anynull: Option<&mut c_int>,
+    output: &mut [c_ushort],
+    status: &mut c_int,
 ) -> c_int {
     let mut dvalue: f64 = 0.0;
     let mut message: [c_char; FLEN_ERRMSG] = [0; FLEN_ERRMSG];

--- a/src/getcoluj.rs
+++ b/src/getcoluj.rs
@@ -1,9 +1,14 @@
-/*  This file, getcoluj.rs, contains routines that read data elements from   */
-/*  a FITS image or table, with unsigned long data type.                            */
-
-/*  The FITSIO software was written by William Pence at the High Energy    */
-/*  Astrophysic Science Archive Research Center (HEASARC) at the NASA      */
-/*  Goddard Space Flight Center.                                           */
+//! Routines that read data elements from a FITS image or table, with
+//! unsigned long datatype.
+//!
+//! The [`TULONG`] arm of the typed column I/O family. [`crate::getcol`]
+//! dispatches here when a caller asks for this datatype at run time; the
+//! write-side counterpart is [`crate::putcoluj`].
+//!
+//! Ported from CFITSIO's `getcoluj.c`, written by William Pence at the High
+//! Energy Astrophysics Science Archive Research Center (HEASARC), NASA Goddard
+//! Space Flight Center.
+#![warn(missing_docs)]
 
 use core::slice;
 use core::{cmp, mem};
@@ -23,7 +28,6 @@ use crate::{NullValue, bb};
 use crate::{buffers::*, calculate_subsection_length};
 use crate::{int_snprintf, slice_to_str};
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of values from the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
 /// the FITS array is not the same as the array being read).
@@ -35,16 +39,27 @@ use crate::{int_snprintf, slice_to_str};
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to read (1 = 1st group)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `nulval`    — (I) value for undefined pixels
+/// * `array`     — (O) array of values that are returned
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgpvuj(
-    fptr: *mut fitsfile, /* I - FITS file pointer                       */
-    group: c_long,       /* I - group to read (1 = 1st group)           */
-    firstelem: LONGLONG, /* I - first vector element to read (1 = 1st)  */
-    nelem: LONGLONG,     /* I - number of values to read                */
-    nulval: c_ulong,     /* I - value for undefined pixels              */
-    array: *mut c_ulong, /* O - array of values that are returned       */
-    anynul: *mut c_int,  /* O - set to 1 if any values are null; else 0 */
-    status: *mut c_int,  /* IO - error status                           */
+    fptr: *mut fitsfile,
+    group: c_long,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    nulval: c_ulong,
+    array: *mut c_ulong,
+    anynul: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -58,7 +73,6 @@ pub unsafe extern "C" fn ffgpvuj(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of values from the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
 /// the FITS array is not the same as the array being read).
@@ -70,15 +84,26 @@ pub unsafe extern "C" fn ffgpvuj(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to read (1 = 1st group)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `nulval`    — (I) value for undefined pixels
+/// * `array`     — (O) array of values that are returned
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `status`    — (IO) error status
 pub fn ffgpvuj_safe(
-    fptr: &mut fitsfile,        /* I - FITS file pointer                       */
-    group: c_long,              /* I - group to read (1 = 1st group)           */
-    firstelem: LONGLONG,        /* I - first vector element to read (1 = 1st)  */
-    nelem: LONGLONG,            /* I - number of values to read                */
-    nulval: c_ulong,            /* I - value for undefined pixels              */
-    array: &mut [c_ulong],      /* O - array of values that are returned       */
-    anynul: Option<&mut c_int>, /* O - set to 1 if any values are null; else 0 */
-    status: &mut c_int,         /* IO - error status                           */
+    fptr: &mut fitsfile,
+    group: c_long,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    nulval: c_ulong,
+    array: &mut [c_ulong],
+    anynul: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     let mut row: c_long = 0;
     let nullcheck = NullCheckType::SetPixel;
@@ -125,7 +150,6 @@ pub fn ffgpvuj_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of values from the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
 /// the FITS array is not the same as the array being read).
@@ -137,16 +161,27 @@ pub fn ffgpvuj_safe(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to read (1 = 1st group)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `array`     — (O) array of values that are returned
+/// * `nularray`  — (O) array of null pixel flags
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgpfuj(
-    fptr: *mut fitsfile,   /* I - FITS file pointer                       */
-    group: c_long,         /* I - group to read (1 = 1st group)           */
-    firstelem: LONGLONG,   /* I - first vector element to read (1 = 1st)  */
-    nelem: LONGLONG,       /* I - number of values to read                */
-    array: *mut c_ulong,   /* O - array of values that are returned       */
-    nularray: *mut c_char, /* O - array of null pixel flags               */
-    anynul: *mut c_int,    /* O - set to 1 if any values are null; else 0 */
-    status: *mut c_int,    /* IO - error status                           */
+    fptr: *mut fitsfile,
+    group: c_long,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: *mut c_ulong,
+    nularray: *mut c_char,
+    anynul: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -163,7 +198,6 @@ pub unsafe extern "C" fn ffgpfuj(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of values from the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
 /// the FITS array is not the same as the array being read).
@@ -175,15 +209,26 @@ pub unsafe extern "C" fn ffgpfuj(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to read (1 = 1st group)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `array`     — (O) array of values that are returned
+/// * `nularray`  — (O) array of null pixel flags
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `status`    — (IO) error status
 pub fn ffgpfuj_safe(
-    fptr: &mut fitsfile,        /* I - FITS file pointer                       */
-    group: c_long,              /* I - group to read (1 = 1st group)           */
-    firstelem: LONGLONG,        /* I - first vector element to read (1 = 1st)  */
-    nelem: LONGLONG,            /* I - number of values to read                */
-    array: &mut [c_ulong],      /* O - array of values that are returned       */
-    nularray: &mut [c_char],    /* O - array of null pixel flags               */
-    anynul: Option<&mut c_int>, /* O - set to 1 if any values are null; else 0 */
-    status: &mut c_int,         /* IO - error status                           */
+    fptr: &mut fitsfile,
+    group: c_long,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: &mut [c_ulong],
+    nularray: &mut [c_char],
+    anynul: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     let mut row = 0;
     let nullcheck = NullCheckType::SetNullArray;
@@ -226,23 +271,34 @@ pub fn ffgpfuj_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an entire 2-D array of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of the
 /// FITS array is not the same as the array being read).  Any null
 /// values in the array will be set equal to the value of nulval, unless
 /// nulval = 0 in which case no null checking will be performed.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `group`  — (I) group to read (1 = 1st group)
+/// * `nulval` — set undefined pixels equal to this
+/// * `ncols`  — (I) number of pixels in each row of array
+/// * `naxis1` — (I) FITS image NAXIS1 value
+/// * `naxis2` — (I) FITS image NAXIS2 value
+/// * `array`  — (O) array to be filled and returned
+/// * `anynul` — (O) set to 1 if any values are null; else 0
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffg2duj(
-    fptr: *mut fitsfile, /* I - FITS file pointer                       */
-    group: c_long,       /* I - group to read (1 = 1st group)           */
-    nulval: c_ulong,     /* set undefined pixels equal to this          */
-    ncols: LONGLONG,     /* I - number of pixels in each row of array   */
-    naxis1: LONGLONG,    /* I - FITS image NAXIS1 value                 */
-    naxis2: LONGLONG,    /* I - FITS image NAXIS2 value                 */
-    array: *mut c_ulong, /* O - array to be filled and returned         */
-    anynul: *mut c_int,  /* O - set to 1 if any values are null; else 0 */
-    status: *mut c_int,  /* IO - error status                           */
+    fptr: *mut fitsfile,
+    group: c_long,
+    nulval: c_ulong,
+    ncols: LONGLONG,
+    naxis1: LONGLONG,
+    naxis2: LONGLONG,
+    array: *mut c_ulong,
+    anynul: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -260,22 +316,33 @@ pub unsafe extern "C" fn ffg2duj(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an entire 2-D array of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of the
 /// FITS array is not the same as the array being read).  Any null
 /// values in the array will be set equal to the value of nulval, unless
 /// nulval = 0 in which case no null checking will be performed.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `group`  — (I) group to read (1 = 1st group)
+/// * `nulval` — set undefined pixels equal to this
+/// * `ncols`  — (I) number of pixels in each row of array
+/// * `naxis1` — (I) FITS image NAXIS1 value
+/// * `naxis2` — (I) FITS image NAXIS2 value
+/// * `array`  — (O) array to be filled and returned
+/// * `anynul` — (O) set to 1 if any values are null; else 0
+/// * `status` — (IO) error status
 pub fn ffg2duj_safe(
-    fptr: &mut fitsfile,        /* I - FITS file pointer                       */
-    group: c_long,              /* I - group to read (1 = 1st group)           */
-    nulval: c_ulong,            /* set undefined pixels equal to this     */
-    ncols: LONGLONG,            /* I - number of pixels in each row of array   */
-    naxis1: LONGLONG,           /* I - FITS image NAXIS1 value                 */
-    naxis2: LONGLONG,           /* I - FITS image NAXIS2 value                 */
-    array: &mut [c_ulong],      /* O - array to be filled and returned    */
-    anynul: Option<&mut c_int>, /* O - set to 1 if any values are null; else 0 */
-    status: &mut c_int,         /* IO - error status                           */
+    fptr: &mut fitsfile,
+    group: c_long,
+    nulval: c_ulong,
+    ncols: LONGLONG,
+    naxis1: LONGLONG,
+    naxis2: LONGLONG,
+    array: &mut [c_ulong],
+    anynul: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     /* call the 3D reading routine, with the 3rd dimension = 1 */
     ffg3duj_safe(
@@ -285,7 +352,6 @@ pub fn ffg2duj_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an entire 3-D array of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of the
 /// FITS array is not the same as the array being read).  Any null
@@ -296,19 +362,33 @@ pub fn ffg2duj_safe(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `group`  — (I) group to read (1 = 1st group)
+/// * `nulval` — set undefined pixels equal to this
+/// * `ncols`  — (I) number of pixels in each row of array
+/// * `nrows`  — (I) number of rows in each plane of array
+/// * `naxis1` — (I) FITS image NAXIS1 value
+/// * `naxis2` — (I) FITS image NAXIS2 value
+/// * `naxis3` — (I) FITS image NAXIS3 value
+/// * `array`  — (O) array to be filled and returned
+/// * `anynul` — (O) set to 1 if any values are null; else 0
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffg3duj(
-    fptr: *mut fitsfile, /* I - FITS file pointer                       */
-    group: c_long,       /* I - group to read (1 = 1st group)           */
-    nulval: c_ulong,     /* set undefined pixels equal to this          */
-    ncols: LONGLONG,     /* I - number of pixels in each row of array   */
-    nrows: LONGLONG,     /* I - number of rows in each plane of array   */
-    naxis1: LONGLONG,    /* I - FITS image NAXIS1 value                 */
-    naxis2: LONGLONG,    /* I - FITS image NAXIS2 value                 */
-    naxis3: LONGLONG,    /* I - FITS image NAXIS3 value                 */
-    array: *mut c_ulong, /* O - array to be filled and returned         */
-    anynul: *mut c_int,  /* O - set to 1 if any values are null; else 0 */
-    status: *mut c_int,  /* IO - error status                           */
+    fptr: *mut fitsfile,
+    group: c_long,
+    nulval: c_ulong,
+    ncols: LONGLONG,
+    nrows: LONGLONG,
+    naxis1: LONGLONG,
+    naxis2: LONGLONG,
+    naxis3: LONGLONG,
+    array: *mut c_ulong,
+    anynul: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -324,7 +404,6 @@ pub unsafe extern "C" fn ffg3duj(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an entire 3-D array of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of the
 /// FITS array is not the same as the array being read).  Any null
@@ -335,18 +414,32 @@ pub unsafe extern "C" fn ffg3duj(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `group`  — (I) group to read (1 = 1st group)
+/// * `nulval` — set undefined pixels equal to this
+/// * `ncols`  — (I) number of pixels in each row of array
+/// * `nrows`  — (I) number of rows in each plane of array
+/// * `naxis1` — (I) FITS image NAXIS1 value
+/// * `naxis2` — (I) FITS image NAXIS2 value
+/// * `naxis3` — (I) FITS image NAXIS3 value
+/// * `array`  — (O) array to be filled and returned
+/// * `anynul` — (O) set to 1 if any values are null; else 0
+/// * `status` — (IO) error status
 pub fn ffg3duj_safe(
-    fptr: &mut fitsfile,            /* I - FITS file pointer                       */
-    group: c_long,                  /* I - group to read (1 = 1st group)           */
-    nulval: c_ulong,                /* set undefined pixels equal to this          */
-    ncols: LONGLONG,                /* I - number of pixels in each row of array   */
-    nrows: LONGLONG,                /* I - number of rows in each plane of array   */
-    naxis1: LONGLONG,               /* I - FITS image NAXIS1 value                 */
-    naxis2: LONGLONG,               /* I - FITS image NAXIS2 value                 */
-    naxis3: LONGLONG,               /* I - FITS image NAXIS3 value                 */
-    array: &mut [c_ulong],          /* O - array to be filled and returned         */
-    mut anynul: Option<&mut c_int>, /* O - set to 1 if any values are null; else 0 */
-    status: &mut c_int,             /* IO - error status                           */
+    fptr: &mut fitsfile,
+    group: c_long,
+    nulval: c_ulong,
+    ncols: LONGLONG,
+    nrows: LONGLONG,
+    naxis1: LONGLONG,
+    naxis2: LONGLONG,
+    naxis3: LONGLONG,
+    array: &mut [c_ulong],
+    mut anynul: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     let mut tablerow = 0;
     let nullcheck = NullCheckType::SetPixel;
@@ -446,22 +539,35 @@ pub fn ffg3duj_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read a subsection of data values from an image or a table column.
 /// This routine is set up to handle a maximum of nine dimensions.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `colnum` — (I) number of the column to read (1 = 1st)
+/// * `naxis`  — (I) number of dimensions in the FITS array
+/// * `naxes`  — (I) size of each dimension
+/// * `blc`    — (I) 'bottom left corner' of the subsection
+/// * `trc`    — (I) 'top right corner' of the subsection
+/// * `inc`    — (I) increment to be applied in each dimension
+/// * `nulval` — (I) value to set undefined pixels
+/// * `array`  — (O) array to be filled and returned
+/// * `anynul` — (O) set to 1 if any values are null; else 0
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgsvuj(
-    fptr: *mut fitsfile,  /* I - FITS file pointer                         */
-    colnum: c_int,        /* I - number of the column to read (1 = 1st)    */
-    naxis: c_int,         /* I - number of dimensions in the FITS array    */
-    naxes: *const c_long, /* I - size of each dimension                    */
-    blc: *const c_long,   /* I - 'bottom left corner' of the subsection    */
-    trc: *const c_long,   /* I - 'top right corner' of the subsection      */
-    inc: *const c_long,   /* I - increment to be applied in each dimension */
-    nulval: c_ulong,      /* I - value to set undefined pixels             */
-    array: *mut c_ulong,  /* O - array to be filled and returned           */
-    anynul: *mut c_int,   /* O - set to 1 if any values are null; else 0   */
-    status: *mut c_int,   /* IO - error status                             */
+    fptr: *mut fitsfile,
+    colnum: c_int,
+    naxis: c_int,
+    naxes: *const c_long,
+    blc: *const c_long,
+    trc: *const c_long,
+    inc: *const c_long,
+    nulval: c_ulong,
+    array: *mut c_ulong,
+    anynul: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -483,21 +589,34 @@ pub unsafe extern "C" fn ffgsvuj(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read a subsection of data values from an image or a table column.
 /// This routine is set up to handle a maximum of nine dimensions.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `colnum` — (I) number of the column to read (1 = 1st)
+/// * `naxis`  — (I) number of dimensions in the FITS array
+/// * `naxes`  — (I) size of each dimension
+/// * `blc`    — (I) 'bottom left corner' of the subsection
+/// * `trc`    — (I) 'top right corner' of the subsection
+/// * `inc`    — (I) increment to be applied in each dimension
+/// * `nulval` — (I) value to set undefined pixels
+/// * `array`  — (O) array to be filled and returned
+/// * `anynul` — (O) set to 1 if any values are null; else 0
+/// * `status` — (IO) error status
 pub fn ffgsvuj_safe(
-    fptr: &mut fitsfile,   /* I - FITS file pointer                         */
-    colnum: c_int,         /* I - number of the column to read (1 = 1st)    */
-    naxis: c_int,          /* I - number of dimensions in the FITS array    */
-    naxes: &[c_long],      /* I - size of each dimension                    */
-    blc: &[c_long],        /* I - 'bottom left corner' of the subsection    */
-    trc: &[c_long],        /* I - 'top right corner' of the subsection      */
-    inc: &[c_long],        /* I - increment to be applied in each dimension */
-    nulval: c_ulong,       /* I - value to set undefined pixels             */
-    array: &mut [c_ulong], /* O - array to be filled and returned           */
-    mut anynul: Option<&mut c_int>, /* O - set to 1 if any values are null; else 0   */
-    status: &mut c_int,    /* IO - error status                             */
+    fptr: &mut fitsfile,
+    colnum: c_int,
+    naxis: c_int,
+    naxes: &[c_long],
+    blc: &[c_long],
+    trc: &[c_long],
+    inc: &[c_long],
+    nulval: c_ulong,
+    array: &mut [c_ulong],
+    mut anynul: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     let mut rstr: c_long = 0;
     let mut rstp: c_long = 0;
@@ -683,22 +802,35 @@ pub fn ffgsvuj_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read a subsection of data values from an image or a table column.
 /// This routine is set up to handle a maximum of nine dimensions.
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `colnum`  — (I) number of the column to read (1 = 1st)
+/// * `naxis`   — (I) number of dimensions in the FITS array
+/// * `naxes`   — (I) size of each dimension
+/// * `blc`     — (I) 'bottom left corner' of the subsection
+/// * `trc`     — (I) 'top right corner' of the subsection
+/// * `inc`     — (I) increment to be applied in each dimension
+/// * `array`   — (O) array to be filled and returned
+/// * `flagval` — (O) set to 1 if corresponding value is null
+/// * `anynul`  — (O) set to 1 if any values are null; else 0
+/// * `status`  — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgsfuj(
-    fptr: *mut fitsfile,  /* I - FITS file pointer                         */
-    colnum: c_int,        /* I - number of the column to read (1 = 1st)    */
-    naxis: c_int,         /* I - number of dimensions in the FITS array    */
-    naxes: *const c_long, /* I - size of each dimension                    */
-    blc: *const c_long,   /* I - 'bottom left corner' of the subsection    */
-    trc: *const c_long,   /* I - 'top right corner' of the subsection      */
-    inc: *const c_long,   /* I - increment to be applied in each dimension */
-    array: *mut c_ulong,  /* O - array to be filled and returned           */
-    flagval: *mut c_char, /* O - set to 1 if corresponding value is null   */
-    anynul: *mut c_int,   /* O - set to 1 if any values are null; else 0   */
-    status: *mut c_int,   /* IO - error status                             */
+    fptr: *mut fitsfile,
+    colnum: c_int,
+    naxis: c_int,
+    naxes: *const c_long,
+    blc: *const c_long,
+    trc: *const c_long,
+    inc: *const c_long,
+    array: *mut c_ulong,
+    flagval: *mut c_char,
+    anynul: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -721,21 +853,34 @@ pub unsafe extern "C" fn ffgsfuj(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read a subsection of data values from an image or a table column.
 /// This routine is set up to handle a maximum of nine dimensions.
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `colnum`  — (I) number of the column to read (1 = 1st)
+/// * `naxis`   — (I) number of dimensions in the FITS array
+/// * `naxes`   — (I) size of each dimension
+/// * `blc`     — (I) 'bottom left corner' of the subsection
+/// * `trc`     — (I) 'top right corner' of the subsection
+/// * `inc`     — (I) increment to be applied in each dimension
+/// * `array`   — (O) array to be filled and returned
+/// * `flagval` — (O) set to 1 if corresponding value is null
+/// * `anynul`  — (O) set to 1 if any values are null; else 0
+/// * `status`  — (IO) error status
 pub fn ffgsfuj_safe(
-    fptr: &mut fitsfile,    /* I - FITS file pointer                         */
-    colnum: c_int,          /* I - number of the column to read (1 = 1st)    */
-    naxis: c_int,           /* I - number of dimensions in the FITS array    */
-    naxes: &[c_long],       /* I - size of each dimension                    */
-    blc: &[c_long],         /* I - 'bottom left corner' of the subsection    */
-    trc: &[c_long],         /* I - 'top right corner' of the subsection      */
-    inc: &[c_long],         /* I - increment to be applied in each dimension */
-    array: &mut [c_ulong],  /* O - array to be filled and returned           */
-    flagval: &mut [c_char], /* O - set to 1 if corresponding value is null   */
-    mut anynul: Option<&mut c_int>, /* O - set to 1 if any values are null; else 0   */
-    status: &mut c_int,     /* IO - error status                             */
+    fptr: &mut fitsfile,
+    colnum: c_int,
+    naxis: c_int,
+    naxes: &[c_long],
+    blc: &[c_long],
+    trc: &[c_long],
+    inc: &[c_long],
+    array: &mut [c_ulong],
+    flagval: &mut [c_char],
+    mut anynul: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     let mut rstr: c_long = 0;
     let mut rstp: c_long = 0;
@@ -921,7 +1066,6 @@ pub fn ffgsfuj_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of group parameters from the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
 /// the FITS array is not the same as the array being read).
@@ -930,14 +1074,23 @@ pub fn ffgsfuj_safe(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to read (1 = 1st group)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `array`     — (O) array of values that are returned
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffggpuj(
-    fptr: *mut fitsfile, /* I - FITS file pointer                       */
-    group: c_long,       /* I - group to read (1 = 1st group)           */
-    firstelem: c_long,   /* I - first vector element to read (1 = 1st)  */
-    nelem: c_long,       /* I - number of values to read                */
-    array: *mut c_ulong, /* O - array of values that are returned       */
-    status: *mut c_int,  /* IO - error status                           */
+    fptr: *mut fitsfile,
+    group: c_long,
+    firstelem: c_long,
+    nelem: c_long,
+    array: *mut c_ulong,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -949,7 +1102,6 @@ pub unsafe extern "C" fn ffggpuj(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of group parameters from the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
 /// the FITS array is not the same as the array being read).
@@ -958,13 +1110,22 @@ pub unsafe extern "C" fn ffggpuj(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to read (1 = 1st group)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `array`     — (O) array of values that are returned
+/// * `status`    — (IO) error status
 pub fn ffggpuj_safe(
-    fptr: &mut fitsfile,   /* I - FITS file pointer                       */
-    group: c_long,         /* I - group to read (1 = 1st group)           */
-    firstelem: c_long,     /* I - first vector element to read (1 = 1st)  */
-    nelem: c_long,         /* I - number of values to read                */
-    array: &mut [c_ulong], /* O - array of values that are returned       */
-    status: &mut c_int,    /* IO - error status                           */
+    fptr: &mut fitsfile,
+    group: c_long,
+    firstelem: c_long,
+    nelem: c_long,
+    array: &mut [c_ulong],
+    status: &mut c_int,
 ) -> c_int {
     let mut anynul = 0;
 
@@ -989,24 +1150,35 @@ pub fn ffggpuj_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of values from a column in the current FITS HDU. Automatic
 /// datatype conversion will be performed if the datatype of the column does not
 /// match the datatype of the array parameter. The output values will be scaled
 /// by the FITS TSCALn and TZEROn values if these values have been defined.
 /// Any undefined pixels will be set equal to the value of 'nulval' unless
 /// nulval = 0 in which case no checks for undefined pixels will be made.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to read (1 = 1st col)
+/// * `firstrow`  — (I) first row to read (1 = 1st row)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `nulval`    — (I) value for null pixels
+/// * `array`     — (O) array of values that are read
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgcvuj(
-    fptr: *mut fitsfile, /* I - FITS file pointer                       */
-    colnum: c_int,       /* I - number of column to read (1 = 1st col)  */
-    firstrow: LONGLONG,  /* I - first row to read (1 = 1st row)         */
-    firstelem: LONGLONG, /* I - first vector element to read (1 = 1st)  */
-    nelem: LONGLONG,     /* I - number of values to read                */
-    nulval: c_ulong,     /* I - value for null pixels                   */
-    array: *mut c_ulong, /* O - array of values that are read           */
-    anynul: *mut c_int,  /* O - set to 1 if any values are null; else 0 */
-    status: *mut c_int,  /* IO - error status                           */
+    fptr: *mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    nulval: c_ulong,
+    array: *mut c_ulong,
+    anynul: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -1022,23 +1194,34 @@ pub unsafe extern "C" fn ffgcvuj(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of values from a column in the current FITS HDU. Automatic
 /// datatype conversion will be performed if the datatype of the column does not
 /// match the datatype of the array parameter. The output values will be scaled
 /// by the FITS TSCALn and TZEROn values if these values have been defined.
 /// Any undefined pixels will be set equal to the value of 'nulval' unless
 /// nulval = 0 in which case no checks for undefined pixels will be made.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to read (1 = 1st col)
+/// * `firstrow`  — (I) first row to read (1 = 1st row)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `nulval`    — (I) value for null pixels
+/// * `array`     — (O) array of values that are read
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `status`    — (IO) error status
 pub fn ffgcvuj_safe(
-    fptr: &mut fitsfile,        /* I - FITS file pointer                       */
-    colnum: c_int,              /* I - number of column to read (1 = 1st col)  */
-    firstrow: LONGLONG,         /* I - first row to read (1 = 1st row)         */
-    firstelem: LONGLONG,        /* I - first vector element to read (1 = 1st)  */
-    nelem: LONGLONG,            /* I - number of values to read                */
-    nulval: c_ulong,            /* I - value for null pixels                   */
-    array: &mut [c_ulong],      /* O - array of values that are read           */
-    anynul: Option<&mut c_int>, /* O - set to 1 if any values are null; else 0 */
-    status: &mut c_int,         /* IO - error status                           */
+    fptr: &mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    nulval: c_ulong,
+    array: &mut [c_ulong],
+    anynul: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     let mut dummy_nularray = vec![0; nelem as usize];
 
@@ -1058,24 +1241,35 @@ pub fn ffgcvuj_safe(
     )
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of values from a column in the current FITS HDU. Automatic
 /// datatype conversion will be performed if the datatype of the column does not
 /// match the datatype of the array parameter. The output values will be scaled
 /// by the FITS TSCALn and TZEROn values if these values have been defined.
 /// Nularray will be set = 1 if the corresponding array pixel is undefined,
 /// otherwise nularray will = 0.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to read (1 = 1st col)
+/// * `firstrow`  — (I) first row to read (1 = 1st row)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `array`     — (O) array of values that are read
+/// * `nularray`  — (O) array of flags: 1 if null pixel; else 0
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgcfuj(
-    fptr: *mut fitsfile,   /* I - FITS file pointer                       */
-    colnum: c_int,         /* I - number of column to read (1 = 1st col)  */
-    firstrow: LONGLONG,    /* I - first row to read (1 = 1st row)         */
-    firstelem: LONGLONG,   /* I - first vector element to read (1 = 1st)  */
-    nelem: LONGLONG,       /* I - number of values to read                */
-    array: *mut c_ulong,   /* O - array of values that are read           */
-    nularray: *mut c_char, /* O - array of flags: 1 if null pixel; else 0 */
-    anynul: *mut c_int,    /* O - set to 1 if any values are null; else 0 */
-    status: *mut c_int,    /* IO - error status                           */
+    fptr: *mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: *mut c_ulong,
+    nularray: *mut c_char,
+    anynul: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -1092,23 +1286,34 @@ pub unsafe extern "C" fn ffgcfuj(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of values from a column in the current FITS HDU. Automatic
 /// datatype conversion will be performed if the datatype of the column does not
 /// match the datatype of the array parameter. The output values will be scaled
 /// by the FITS TSCALn and TZEROn values if these values have been defined.
 /// Nularray will be set = 1 if the corresponding array pixel is undefined,
 /// otherwise nularray will = 0.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to read (1 = 1st col)
+/// * `firstrow`  — (I) first row to read (1 = 1st row)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `array`     — (O) array of values that are read
+/// * `nularray`  — (O) array of flags: 1 if null pixel; else 0
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `status`    — (IO) error status
 pub fn ffgcfuj_safe(
-    fptr: &mut fitsfile,        /* I - FITS file pointer                       */
-    colnum: c_int,              /* I - number of column to read (1 = 1st col)  */
-    firstrow: LONGLONG,         /* I - first row to read (1 = 1st row)         */
-    firstelem: LONGLONG,        /* I - first vector element to read (1 = 1st)  */
-    nelem: LONGLONG,            /* I - number of values to read                */
-    array: &mut [c_ulong],      /* O - array of values that are read           */
-    nularray: &mut [c_char],    /* O - array of flags: 1 if null pixel; else 0 */
-    anynul: Option<&mut c_int>, /* O - set to 1 if any values are null; else 0 */
-    status: &mut c_int,         /* IO - error status                           */
+    fptr: &mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: &mut [c_ulong],
+    nularray: &mut [c_char],
+    anynul: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     let dummy = 0;
 
@@ -1128,7 +1333,6 @@ pub fn ffgcfuj_safe(
     )
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of values from a column in the current FITS HDU.
 /// The column number may refer to a real column in an ASCII or binary table,
 /// or it may refer be a virtual column in a 1 or more grouped FITS primary
@@ -1142,21 +1346,35 @@ pub fn ffgcfuj_safe(
 /// and will be scaled by the FITS TSCALn and TZEROn values if necessary.
 #[allow(clippy::if_same_then_else)]
 // C dispatch chain: distinct conditions deliberately share an action.
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to read (1 = 1st col)
+/// * `firstrow`  — (I) first row to read (1 = 1st row)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `elemincre` — (I) pixel increment; e.g., 2 = every other
+/// * `nultyp`    — (I) null value handling code:
+/// * `nulval`    — (I) value for null pixels if nultyp = 1
+/// * `array`     — (O) array of values that are read
+/// * `nularray`  — (O) array of flags = 1 if nultyp = 2
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `status`    — (IO) error status
 pub(crate) fn ffgcluj(
-    fptr: &mut fitsfile,   /* I - FITS file pointer                       */
-    colnum: c_int,         /* I - number of column to read (1 = 1st col)  */
-    firstrow: LONGLONG,    /* I - first row to read (1 = 1st row)         */
-    firstelem: LONGLONG,   /* I - first vector element to read (1 = 1st)  */
-    nelem: LONGLONG,       /* I - number of values to read                */
-    elemincre: c_long,     /* I - pixel increment; e.g., 2 = every other  */
-    nultyp: NullCheckType, /* I - null value handling code:               */
+    fptr: &mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    elemincre: c_long,
+    nultyp: NullCheckType,
     /*     1: set undefined pixels = nulval        */
     /*     2: set nularray=1 for undefined pixels  */
-    nulval: c_ulong,                /* I - value for null pixels if nultyp = 1     */
-    array: &mut [c_ulong],          /* O - array of values that are read           */
-    nularray: &mut [c_char],        /* O - array of flags = 1 if nultyp = 2        */
-    mut anynul: Option<&mut c_int>, /* O - set to 1 if any values are null; else 0 */
-    status: &mut c_int,             /* IO - error status                           */
+    nulval: c_ulong,
+    array: &mut [c_ulong],
+    nularray: &mut [c_char],
+    mut anynul: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     let mut scale: f64 = 0.0;
     let mut zero: f64 = 0.0;
@@ -1202,9 +1420,7 @@ pub(crate) fn ffgcluj(
     if nultyp == NullCheckType::SetNullArray {
         nularray.fill(0); /* initialize nullarray */
     }
-    /*---------------------------------------------------*/
     /*  Check input and get parameters about the column: */
-    /*---------------------------------------------------*/
 
     if ffgcprll(
         fptr,
@@ -1251,9 +1467,7 @@ pub(crate) fn ffgcluj(
         }
     }
 
-    /*------------------------------------------------------------------*/
     /*  Decide whether to check for null values in the input FITS file: */
-    /*------------------------------------------------------------------*/
     nulcheck = nultyp; /* by default check for null values in the FITS file */
 
     if nultyp == NullCheckType::SetPixel && nulval == 0 {
@@ -1272,10 +1486,8 @@ pub(crate) fn ffgcluj(
         nulcheck = NullCheckType::None;
     }
 
-    /*----------------------------------------------------------------------*/
     /*  If FITS column and output data array have same datatype, then we do */
     /*  not need to use a temporary buffer to store intermediate datatype.  */
-    /*----------------------------------------------------------------------*/
 
     if (tcode == TLONG) && (LONGSIZE == 32) {
         /* Special Case:                        */
@@ -1289,7 +1501,6 @@ pub(crate) fn ffgcluj(
         }
     }
 
-    /*---------------------------------------------------------------------*/
     /*  Now read the pixels from the FITS column. If the column does not   */
     /*  have the same datatype as the output array, then we have to read   */
     /*  the raw values into a temporary buffer (of limited size).  In      */
@@ -1299,7 +1510,6 @@ pub(crate) fn ffgcluj(
     /*  test for undefined values, (2) convert the datatype if necessary,  */
     /*  and (3) scale the values by the FITS TSCALn and TZEROn linear      */
     /*  scaling parameters.                                                */
-    /*---------------------------------------------------------------------*/
     remain = nelem; /* remaining number of values to read */
     next = 0; /* next element in array to be read   */
     rownum = 0; /* row number, relative to firstrow   */
@@ -1498,9 +1708,7 @@ pub(crate) fn ffgcluj(
             }
         } /* End of switch block */
 
-        /*-------------------------*/
         /*  Check for fatal error  */
-        /*-------------------------*/
         if *status > 0 {
             /* test for error during previous read operation */
             dtemp = next as f64;
@@ -1526,9 +1734,7 @@ pub(crate) fn ffgcluj(
             return *status;
         }
 
-        /*--------------------------------------------*/
         /*  increment the counters for the next loop  */
-        /*--------------------------------------------*/
         remain -= ntodo as LONGLONG;
         if remain > 0 {
             next += ntodo as usize;
@@ -1543,9 +1749,7 @@ pub(crate) fn ffgcluj(
         }
     } /*  End of main while Loop  */
 
-    /*--------------------------------*/
     /*  check for numerical overflow  */
-    /*--------------------------------*/
     if *status == OVERFLOW_ERR {
         ffpmsg_str("Numerical overflow during type conversion while reading FITS data.");
         *status = NUM_OVERFLOW;
@@ -1554,7 +1758,6 @@ pub(crate) fn ffgcluj(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output following reading of the input from a FITS file.
 /// Check for null values and do datatype conversion and scaling if required.
 /// The nullcheck code value determines how any null values in the input array
@@ -1566,20 +1769,34 @@ pub(crate) fn ffgcluj(
 /// nullarray will be set to 1; the value of nullarray for non-null pixels
 /// will = 0.  The anynull parameter will be set = 1 if any of the returned
 /// pixels are null, otherwise anynull will be returned with a value = 0;
+///
+/// # Parameters
+///
+/// * `input`     — (I) array of values to be converted
+/// * `ntodo`     — (I) number of elements in the array
+/// * `scale`     — (I) FITS TSCALn or BSCALE value
+/// * `zero`      — (I) FITS TZEROn or BZERO value
+/// * `nullcheck` — (I) null checking code; 0 = don't check
+/// * `tnull`     — (I) value of FITS TNULLn keyword if any
+/// * `nullval`   — (I) set null pixels, if nullcheck = 1
+/// * `nullarray` — (I) bad pixel array, if nullcheck = 2
+/// * `anynull`   — (O) set to 1 if any pixels are null
+/// * `output`    — (O) array of converted pixels
+/// * `status`    — (IO) error status
 pub(crate) fn fffi1u4(
-    input: &[u8],             /* I - array of values to be converted     */
-    ntodo: c_long,            /* I - number of elements in the array     */
-    scale: f64,               /* I - FITS TSCALn or BSCALE value         */
-    zero: f64,                /* I - FITS TZEROn or BZERO  value         */
-    nullcheck: NullCheckType, /* I - null checking code; 0 = don't check */
+    input: &[u8],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    nullcheck: NullCheckType,
     /*     1:set null pixels = nullval         */
     /*     2: if null pixel, set nullarray = 1 */
-    tnull: u8,                   /* I - value of FITS TNULLn keyword if any */
-    nullval: c_ulong,            /* I - set null pixels, if nullcheck = 1   */
-    nullarray: &mut [c_char],    /* I - bad pixel array, if nullcheck = 2   */
-    anynull: Option<&mut c_int>, /* O - set to 1 if any pixels are null     */
-    output: &mut [c_ulong],      /* O - array of converted pixels           */
-    status: &mut c_int,          /* IO - error status                       */
+    tnull: u8,
+    nullval: c_ulong,
+    nullarray: &mut [c_char],
+    anynull: Option<&mut c_int>,
+    output: &mut [c_ulong],
+    status: &mut c_int,
 ) -> c_int {
     let mut dvalue: f64 = 0.0;
 
@@ -1653,7 +1870,6 @@ pub(crate) fn fffi1u4(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output following reading of the input from a FITS file.
 /// Check for null values and do datatype conversion and scaling if required.
 /// The nullcheck code value determines how any null values in the input array
@@ -1665,20 +1881,34 @@ pub(crate) fn fffi1u4(
 /// nullarray will be set to 1; the value of nullarray for non-null pixels
 /// will = 0.  The anynull parameter will be set = 1 if any of the returned
 /// pixels are null, otherwise anynull will be returned with a value = 0;
+///
+/// # Parameters
+///
+/// * `input`     — (I) array of values to be converted
+/// * `ntodo`     — (I) number of elements in the array
+/// * `scale`     — (I) FITS TSCALn or BSCALE value
+/// * `zero`      — (I) FITS TZEROn or BZERO value
+/// * `nullcheck` — (I) null checking code; 0 = don't check
+/// * `tnull`     — (I) value of FITS TNULLn keyword if any
+/// * `nullval`   — (I) set null pixels, if nullcheck = 1
+/// * `nullarray` — (I) bad pixel array, if nullcheck = 2
+/// * `anynull`   — (O) set to 1 if any pixels are null
+/// * `output`    — (O) array of converted pixels
+/// * `status`    — (IO) error status
 pub(crate) fn fffi2u4(
-    input: &[c_short],        /* I - array of values to be converted     */
-    ntodo: c_long,            /* I - number of elements in the array     */
-    scale: f64,               /* I - FITS TSCALn or BSCALE value         */
-    zero: f64,                /* I - FITS TZEROn or BZERO  value         */
-    nullcheck: NullCheckType, /* I - null checking code; 0 = don't check */
+    input: &[c_short],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    nullcheck: NullCheckType,
     /*     1:set null pixels = nullval         */
     /*     2: if null pixel, set nullarray = 1 */
-    tnull: c_short,              /* I - value of FITS TNULLn keyword if any */
-    nullval: c_ulong,            /* I - set null pixels, if nullcheck = 1   */
-    nullarray: &mut [c_char],    /* I - bad pixel array, if nullcheck = 2   */
-    anynull: Option<&mut c_int>, /* O - set to 1 if any pixels are null     */
-    output: &mut [c_ulong],      /* O - array of converted pixels           */
-    status: &mut c_int,          /* IO - error status                       */
+    tnull: c_short,
+    nullval: c_ulong,
+    nullarray: &mut [c_char],
+    anynull: Option<&mut c_int>,
+    output: &mut [c_ulong],
+    status: &mut c_int,
 ) -> c_int {
     let mut dvalue: f64 = 0.0;
 
@@ -1760,7 +1990,6 @@ pub(crate) fn fffi2u4(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output following reading of the input from a FITS file.
 /// Check for null values and do datatype conversion and scaling if required.
 /// The nullcheck code value determines how any null values in the input array
@@ -1772,20 +2001,34 @@ pub(crate) fn fffi2u4(
 /// nullarray will be set to 1; the value of nullarray for non-null pixels
 /// will = 0.  The anynull parameter will be set = 1 if any of the returned
 /// pixels are null, otherwise anynull will be returned with a value = 0;
+///
+/// # Parameters
+///
+/// * `input`     — (I) array of values to be converted
+/// * `ntodo`     — (I) number of elements in the array
+/// * `scale`     — (I) FITS TSCALn or BSCALE value
+/// * `zero`      — (I) FITS TZEROn or BZERO value
+/// * `nullcheck` — (I) null checking code; 0 = don't check
+/// * `tnull`     — (I) value of FITS TNULLn keyword if any
+/// * `nullval`   — (I) set null pixels, if nullcheck = 1
+/// * `nullarray` — (I) bad pixel array, if nullcheck = 2
+/// * `anynull`   — (O) set to 1 if any pixels are null
+/// * `output`    — (O) array of converted pixels
+/// * `status`    — (IO) error status
 pub(crate) fn fffi4u4(
-    input: &[INT32BIT],       /* I - array of values to be converted     */
-    ntodo: c_long,            /* I - number of elements in the array     */
-    scale: f64,               /* I - FITS TSCALn or BSCALE value         */
-    zero: f64,                /* I - FITS TZEROn or BZERO  value         */
-    nullcheck: NullCheckType, /* I - null checking code; 0 = don't check */
+    input: &[INT32BIT],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    nullcheck: NullCheckType,
     /*     1:set null pixels = nullval         */
     /*     2: if null pixel, set nullarray = 1 */
-    tnull: INT32BIT,             /* I - value of FITS TNULLn keyword if any */
-    nullval: c_ulong,            /* I - set null pixels, if nullcheck = 1   */
-    nullarray: &mut [c_char],    /* I - bad pixel array, if nullcheck = 2   */
-    anynull: Option<&mut c_int>, /* O - set to 1 if any pixels are null     */
-    output: &mut [c_ulong],      /* O - array of converted pixels           */
-    status: &mut c_int,          /* IO - error status                       */
+    tnull: INT32BIT,
+    nullval: c_ulong,
+    nullarray: &mut [c_char],
+    anynull: Option<&mut c_int>,
+    output: &mut [c_ulong],
+    status: &mut c_int,
 ) -> c_int {
     let mut dvalue: f64 = 0.0;
 
@@ -1890,7 +2133,6 @@ pub(crate) fn fffi4u4(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output following reading of the input from a FITS file.
 /// Check for null values and do datatype conversion and scaling if required.
 /// The nullcheck code value determines how any null values in the input array
@@ -1902,20 +2144,34 @@ pub(crate) fn fffi4u4(
 /// nullarray will be set to 1; the value of nullarray for non-null pixels
 /// will = 0.  The anynull parameter will be set = 1 if any of the returned
 /// pixels are null, otherwise anynull will be returned with a value = 0;
+///
+/// # Parameters
+///
+/// * `input`     — (I) array of values to be converted
+/// * `ntodo`     — (I) number of elements in the array
+/// * `scale`     — (I) FITS TSCALn or BSCALE value
+/// * `zero`      — (I) FITS TZEROn or BZERO value
+/// * `nullcheck` — (I) null checking code; 0 = don't check
+/// * `tnull`     — (I) value of FITS TNULLn keyword if any
+/// * `nullval`   — (I) set null pixels, if nullcheck = 1
+/// * `nullarray` — (I) bad pixel array, if nullcheck = 2
+/// * `anynull`   — (O) set to 1 if any pixels are null
+/// * `output`    — (O) array of converted pixels
+/// * `status`    — (IO) error status
 pub(crate) fn fffi8u4(
-    input: &[LONGLONG],       /* I - array of values to be converted     */
-    ntodo: c_long,            /* I - number of elements in the array     */
-    scale: f64,               /* I - FITS TSCALn or BSCALE value         */
-    zero: f64,                /* I - FITS TZEROn or BZERO  value         */
-    nullcheck: NullCheckType, /* I - null checking code; 0 = don't check */
+    input: &[LONGLONG],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    nullcheck: NullCheckType,
     /*     1:set null pixels = nullval         */
     /*     2: if null pixel, set nullarray = 1 */
-    tnull: LONGLONG,             /* I - value of FITS TNULLn keyword if any */
-    nullval: c_ulong,            /* I - set null pixels, if nullcheck = 1   */
-    nullarray: &mut [c_char],    /* I - bad pixel array, if nullcheck = 2   */
-    anynull: Option<&mut c_int>, /* O - set to 1 if any pixels are null     */
-    output: &mut [c_ulong],      /* O - array of converted pixels           */
-    status: &mut c_int,          /* IO - error status                       */
+    tnull: LONGLONG,
+    nullval: c_ulong,
+    nullarray: &mut [c_char],
+    anynull: Option<&mut c_int>,
+    output: &mut [c_ulong],
+    status: &mut c_int,
 ) -> c_int {
     let mut dvalue: f64 = 0.0;
     let mut ulltemp: ULONGLONG = 0;
@@ -2043,7 +2299,6 @@ pub(crate) fn fffi8u4(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output following reading of the input from a FITS file.
 /// Check for null values and do datatype conversion and scaling if required.
 /// The nullcheck code value determines how any null values in the input array
@@ -2055,19 +2310,32 @@ pub(crate) fn fffi8u4(
 /// nullarray will be set to 1; the value of nullarray for non-null pixels
 /// will = 0.  The anynull parameter will be set = 1 if any of the returned
 /// pixels are null, otherwise anynull will be returned with a value = 0;
+///
+/// # Parameters
+///
+/// * `input`     — (I) array of values to be converted
+/// * `ntodo`     — (I) number of elements in the array
+/// * `scale`     — (I) FITS TSCALn or BSCALE value
+/// * `zero`      — (I) FITS TZEROn or BZERO value
+/// * `nullcheck` — (I) null checking code; 0 = don't check
+/// * `nullval`   — (I) set null pixels, if nullcheck = 1
+/// * `nullarray` — (I) bad pixel array, if nullcheck = 2
+/// * `anynull`   — (O) set to 1 if any pixels are null
+/// * `output`    — (O) array of converted pixels
+/// * `status`    — (IO) error status
 pub(crate) fn fffr4u4(
-    input: &[f32],            /* I - array of values to be converted     */
-    ntodo: c_long,            /* I - number of elements in the array     */
-    scale: f64,               /* I - FITS TSCALn or BSCALE value         */
-    zero: f64,                /* I - FITS TZEROn or BZERO  value         */
-    nullcheck: NullCheckType, /* I - null checking code; 0 = don't check */
+    input: &[f32],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    nullcheck: NullCheckType,
     /*     1:set null pixels = nullval         */
     /*     2: if null pixel, set nullarray = 1 */
-    nullval: c_ulong,            /* I - set null pixels, if nullcheck = 1   */
-    nullarray: &mut [c_char],    /* I - bad pixel array, if nullcheck = 2   */
-    anynull: Option<&mut c_int>, /* O - set to 1 if any pixels are null     */
-    output: &mut [c_ulong],      /* O - array of converted pixels           */
-    status: &mut c_int,          /* IO - error status                       */
+    nullval: c_ulong,
+    nullarray: &mut [c_char],
+    anynull: Option<&mut c_int>,
+    output: &mut [c_ulong],
+    status: &mut c_int,
 ) -> c_int {
     let mut dvalue: f64 = 0.0;
     let mut sptr = 0;
@@ -2190,20 +2458,31 @@ pub(crate) fn fffr4u4(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
+/// # Parameters
+///
+/// * `input`     — (I) array of values to be converted
+/// * `ntodo`     — (I) number of elements in the array
+/// * `scale`     — (I) FITS TSCALn or BSCALE value
+/// * `zero`      — (I) FITS TZEROn or BZERO value
+/// * `nullcheck` — (I) null checking code; 0 = don't check
+/// * `nullval`   — (I) set null pixels, if nullcheck = 1
+/// * `nullarray` — (I) bad pixel array, if nullcheck = 2
+/// * `anynull`   — (O) set to 1 if any pixels are null
+/// * `output`    — (O) array of converted pixels
+/// * `status`    — (IO) error status
 pub(crate) fn fffr8u4(
-    input: &[f64],            /* I - array of values to be converted     */
-    ntodo: c_long,            /* I - number of elements in the array     */
-    scale: f64,               /* I - FITS TSCALn or BSCALE value         */
-    zero: f64,                /* I - FITS TZEROn or BZERO  value         */
-    nullcheck: NullCheckType, /* I - null checking code; 0 = don't check */
+    input: &[f64],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    nullcheck: NullCheckType,
     /*     1:set null pixels = nullval         */
     /*     2: if null pixel, set nullarray = 1 */
-    nullval: c_ulong,            /* I - set null pixels, if nullcheck = 1   */
-    nullarray: &mut [c_char],    /* I - bad pixel array, if nullcheck = 2   */
-    anynull: Option<&mut c_int>, /* O - set to 1 if any pixels are null     */
-    output: &mut [c_ulong],      /* O - array of converted pixels           */
-    status: &mut c_int,          /* IO - error status                       */
+    nullval: c_ulong,
+    nullarray: &mut [c_char],
+    anynull: Option<&mut c_int>,
+    output: &mut [c_ulong],
+    status: &mut c_int,
 ) -> c_int
 /*
 Copy input to output following reading of the input from a FITS file.
@@ -2341,7 +2620,6 @@ pixels are null, otherwise anynull will be returned with a value = 0;
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output following reading of the input from a FITS file. Check
 /// for null values and do scaling if required. The nullcheck code value
 /// determines how any null values in the input array are treated. A null
@@ -2352,22 +2630,38 @@ pixels are null, otherwise anynull will be returned with a value = 0;
 /// nullarray will be set to 1; the value of nullarray for non-null pixels
 /// will = 0.  The anynull parameter will be set = 1 if any of the returned
 /// pixels are null, otherwise anynull will be returned with a value = 0;
+///
+/// # Parameters
+///
+/// * `input`      — (I) array of values to be converted
+/// * `ntodo`      — (I) number of elements in the array
+/// * `scale`      — (I) FITS TSCALn or BSCALE value
+/// * `zero`       — (I) FITS TZEROn or BZERO value
+/// * `twidth`     — (I) width of each substring of chars
+/// * `implipower` — (I) power of 10 of implied decimal
+/// * `nullcheck`  — (I) null checking code; 0 = don't check
+/// * `snull`      — (I) value of FITS null string, if any
+/// * `nullval`    — (I) set null pixels, if nullcheck = 1
+/// * `nullarray`  — (I) bad pixel array, if nullcheck = 2
+/// * `anynull`    — (O) set to 1 if any pixels are null
+/// * `output`     — (O) array of converted pixels
+/// * `status`     — (IO) error status
 pub(crate) fn fffstru4(
-    input: &mut [c_char],     /* I - array of values to be converted     */
-    ntodo: c_long,            /* I - number of elements in the array     */
-    scale: f64,               /* I - FITS TSCALn or BSCALE value         */
-    zero: f64,                /* I - FITS TZEROn or BZERO  value         */
-    twidth: c_long,           /* I - width of each substring of chars    */
-    implipower: f64,          /* I - power of 10 of implied decimal      */
-    nullcheck: NullCheckType, /* I - null checking code; 0 = don't check */
+    input: &mut [c_char],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    twidth: c_long,
+    implipower: f64,
+    nullcheck: NullCheckType,
     /*     1:set null pixels = nullval         */
     /*     2: if null pixel, set nullarray = 1 */
-    snull: &[c_char],                /* I - value of FITS null string, if any   */
-    nullval: c_ulong,                /* I - set null pixels, if nullcheck = 1   */
-    nullarray: &mut [c_char],        /* I - bad pixel array, if nullcheck = 2   */
-    mut anynull: Option<&mut c_int>, /* O - set to 1 if any pixels are null     */
-    output: &mut [c_ulong],          /* O - array of converted pixels           */
-    status: &mut c_int,              /* IO - error status                       */
+    snull: &[c_char],
+    nullval: c_ulong,
+    nullarray: &mut [c_char],
+    mut anynull: Option<&mut c_int>,
+    output: &mut [c_ulong],
+    status: &mut c_int,
 ) -> c_int {
     let mut nullen = 0;
 
@@ -2550,7 +2844,6 @@ pub(crate) fn fffstru4(
 /*      the following routines support the 'long long' data type            */
 /* ======================================================================== */
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of values from the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
 /// the FITS array is not the same as the array being read).
@@ -2562,16 +2855,27 @@ pub(crate) fn fffstru4(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to read (1 = 1st group)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `nulval`    — (I) value for undefined pixels
+/// * `array`     — (O) array of values that are returned
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgpvujj(
-    fptr: *mut fitsfile,   /* I - FITS file pointer                       */
-    group: c_long,         /* I - group to read (1 = 1st group)           */
-    firstelem: LONGLONG,   /* I - first vector element to read (1 = 1st)  */
-    nelem: LONGLONG,       /* I - number of values to read                */
-    nulval: ULONGLONG,     /* I - value for undefined pixels              */
-    array: *mut ULONGLONG, /* O - array of values that are returned       */
-    anynul: *mut c_int,    /* O - set to 1 if any values are null; else 0 */
-    status: *mut c_int,    /* IO - error status                           */
+    fptr: *mut fitsfile,
+    group: c_long,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    nulval: ULONGLONG,
+    array: *mut ULONGLONG,
+    anynul: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -2585,7 +2889,6 @@ pub unsafe extern "C" fn ffgpvujj(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of values from the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
 /// the FITS array is not the same as the array being read).
@@ -2597,15 +2900,26 @@ pub unsafe extern "C" fn ffgpvujj(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to read (1 = 1st group)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `nulval`    — (I) value for undefined pixels
+/// * `array`     — (O) array of values that are returned
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `status`    — (IO) error status
 pub fn ffgpvujj_safe(
-    fptr: &mut fitsfile,        /* I - FITS file pointer                       */
-    group: c_long,              /* I - group to read (1 = 1st group)           */
-    firstelem: LONGLONG,        /* I - first vector element to read (1 = 1st)  */
-    nelem: LONGLONG,            /* I - number of values to read                */
-    nulval: ULONGLONG,          /* I - value for undefined pixels              */
-    array: &mut [ULONGLONG],    /* O - array of values that are returned       */
-    anynul: Option<&mut c_int>, /* O - set to 1 if any values are null; else 0 */
-    status: &mut c_int,         /* IO - error status                           */
+    fptr: &mut fitsfile,
+    group: c_long,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    nulval: ULONGLONG,
+    array: &mut [ULONGLONG],
+    anynul: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     let mut row = 0;
     let nullcheck = NullCheckType::SetPixel;
@@ -2652,7 +2966,6 @@ pub fn ffgpvujj_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of values from the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
 /// the FITS array is not the same as the array being read).
@@ -2664,16 +2977,27 @@ pub fn ffgpvujj_safe(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to read (1 = 1st group)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `array`     — (O) array of values that are returned
+/// * `nularray`  — (O) array of null pixel flags
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgpfujj(
-    fptr: *mut fitsfile,   /* I - FITS file pointer                       */
-    group: c_long,         /* I - group to read (1 = 1st group)           */
-    firstelem: LONGLONG,   /* I - first vector element to read (1 = 1st)  */
-    nelem: LONGLONG,       /* I - number of values to read                */
-    array: *mut ULONGLONG, /* O - array of values that are returned       */
-    nularray: *mut c_char, /* O - array of null pixel flags               */
-    anynul: *mut c_int,    /* O - set to 1 if any values are null; else 0 */
-    status: *mut c_int,    /* IO - error status                           */
+    fptr: *mut fitsfile,
+    group: c_long,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: *mut ULONGLONG,
+    nularray: *mut c_char,
+    anynul: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -2690,7 +3014,6 @@ pub unsafe extern "C" fn ffgpfujj(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of values from the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
 /// the FITS array is not the same as the array being read).
@@ -2702,15 +3025,26 @@ pub unsafe extern "C" fn ffgpfujj(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to read (1 = 1st group)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `array`     — (O) array of values that are returned
+/// * `nularray`  — (O) array of null pixel flags
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `status`    — (IO) error status
 pub fn ffgpfujj_safe(
-    fptr: &mut fitsfile,        /* I - FITS file pointer                       */
-    group: c_long,              /* I - group to read (1 = 1st group)           */
-    firstelem: LONGLONG,        /* I - first vector element to read (1 = 1st)  */
-    nelem: LONGLONG,            /* I - number of values to read                */
-    array: &mut [ULONGLONG],    /* O - array of values that are returned       */
-    nularray: &mut [c_char],    /* O - array of null pixel flags               */
-    anynul: Option<&mut c_int>, /* O - set to 1 if any values are null; else 0 */
-    status: &mut c_int,         /* IO - error status                           */
+    fptr: &mut fitsfile,
+    group: c_long,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: &mut [ULONGLONG],
+    nularray: &mut [c_char],
+    anynul: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     let mut row = 0;
     let nullcheck = NullCheckType::SetNullArray;
@@ -2754,23 +3088,34 @@ pub fn ffgpfujj_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an entire 2-D array of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of the
 /// FITS array is not the same as the array being read).  Any null
 /// values in the array will be set equal to the value of nulval, unless
 /// nulval = 0 in which case no null checking will be performed.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `group`  — (I) group to read (1 = 1st group)
+/// * `nulval` — set undefined pixels equal to this
+/// * `ncols`  — (I) number of pixels in each row of array
+/// * `naxis1` — (I) FITS image NAXIS1 value
+/// * `naxis2` — (I) FITS image NAXIS2 value
+/// * `array`  — (O) array to be filled and returned
+/// * `anynul` — (O) set to 1 if any values are null; else 0
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffg2dujj(
-    fptr: *mut fitsfile,   /* I - FITS file pointer                       */
-    group: c_long,         /* I - group to read (1 = 1st group)           */
-    nulval: ULONGLONG,     /* set undefined pixels equal to this          */
-    ncols: LONGLONG,       /* I - number of pixels in each row of array   */
-    naxis1: LONGLONG,      /* I - FITS image NAXIS1 value                 */
-    naxis2: LONGLONG,      /* I - FITS image NAXIS2 value                 */
-    array: *mut ULONGLONG, /* O - array to be filled and returned         */
-    anynul: *mut c_int,    /* O - set to 1 if any values are null; else 0 */
-    status: *mut c_int,    /* IO - error status                           */
+    fptr: *mut fitsfile,
+    group: c_long,
+    nulval: ULONGLONG,
+    ncols: LONGLONG,
+    naxis1: LONGLONG,
+    naxis2: LONGLONG,
+    array: *mut ULONGLONG,
+    anynul: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -2786,22 +3131,33 @@ pub unsafe extern "C" fn ffg2dujj(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an entire 2-D array of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of the
 /// FITS array is not the same as the array being read).  Any null
 /// values in the array will be set equal to the value of nulval, unless
 /// nulval = 0 in which case no null checking will be performed.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `group`  — (I) group to read (1 = 1st group)
+/// * `nulval` — set undefined pixels equal to this
+/// * `ncols`  — (I) number of pixels in each row of array
+/// * `naxis1` — (I) FITS image NAXIS1 value
+/// * `naxis2` — (I) FITS image NAXIS2 value
+/// * `array`  — (O) array to be filled and returned
+/// * `anynul` — (O) set to 1 if any values are null; else 0
+/// * `status` — (IO) error status
 pub fn ffg2dujj_safe(
-    fptr: &mut fitsfile,        /* I - FITS file pointer                       */
-    group: c_long,              /* I - group to read (1 = 1st group)           */
-    nulval: ULONGLONG,          /* set undefined pixels equal to this     */
-    ncols: LONGLONG,            /* I - number of pixels in each row of array   */
-    naxis1: LONGLONG,           /* I - FITS image NAXIS1 value                 */
-    naxis2: LONGLONG,           /* I - FITS image NAXIS2 value                 */
-    array: &mut [ULONGLONG],    /* O - array to be filled and returned    */
-    anynul: Option<&mut c_int>, /* O - set to 1 if any values are null; else 0 */
-    status: &mut c_int,         /* IO - error status                           */
+    fptr: &mut fitsfile,
+    group: c_long,
+    nulval: ULONGLONG,
+    ncols: LONGLONG,
+    naxis1: LONGLONG,
+    naxis2: LONGLONG,
+    array: &mut [ULONGLONG],
+    anynul: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     /* call the 3D reading routine, with the 3rd dimension = 1 */
     ffg3dujj_safe(
@@ -2811,7 +3167,6 @@ pub fn ffg2dujj_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an entire 3-D array of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of the
 /// FITS array is not the same as the array being read).  Any null
@@ -2822,19 +3177,33 @@ pub fn ffg2dujj_safe(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `group`  — (I) group to read (1 = 1st group)
+/// * `nulval` — set undefined pixels equal to this
+/// * `ncols`  — (I) number of pixels in each row of array
+/// * `nrows`  — (I) number of rows in each plane of array
+/// * `naxis1` — (I) FITS image NAXIS1 value
+/// * `naxis2` — (I) FITS image NAXIS2 value
+/// * `naxis3` — (I) FITS image NAXIS3 value
+/// * `array`  — (O) array to be filled and returned
+/// * `anynul` — (O) set to 1 if any values are null; else 0
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffg3dujj(
-    fptr: *mut fitsfile,   /* I - FITS file pointer                       */
-    group: c_long,         /* I - group to read (1 = 1st group)           */
-    nulval: ULONGLONG,     /* set undefined pixels equal to this          */
-    ncols: LONGLONG,       /* I - number of pixels in each row of array   */
-    nrows: LONGLONG,       /* I - number of rows in each plane of array   */
-    naxis1: LONGLONG,      /* I - FITS image NAXIS1 value                 */
-    naxis2: LONGLONG,      /* I - FITS image NAXIS2 value                 */
-    naxis3: LONGLONG,      /* I - FITS image NAXIS3 value                 */
-    array: *mut ULONGLONG, /* O - array to be filled and returned         */
-    anynul: *mut c_int,    /* O - set to 1 if any values are null; else 0 */
-    status: *mut c_int,    /* IO - error status                           */
+    fptr: *mut fitsfile,
+    group: c_long,
+    nulval: ULONGLONG,
+    ncols: LONGLONG,
+    nrows: LONGLONG,
+    naxis1: LONGLONG,
+    naxis2: LONGLONG,
+    naxis3: LONGLONG,
+    array: *mut ULONGLONG,
+    anynul: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -2850,7 +3219,6 @@ pub unsafe extern "C" fn ffg3dujj(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an entire 3-D array of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of the
 /// FITS array is not the same as the array being read).  Any null
@@ -2861,18 +3229,32 @@ pub unsafe extern "C" fn ffg3dujj(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `group`  — (I) group to read (1 = 1st group)
+/// * `nulval` — set undefined pixels equal to this
+/// * `ncols`  — (I) number of pixels in each row of array
+/// * `nrows`  — (I) number of rows in each plane of array
+/// * `naxis1` — (I) FITS image NAXIS1 value
+/// * `naxis2` — (I) FITS image NAXIS2 value
+/// * `naxis3` — (I) FITS image NAXIS3 value
+/// * `array`  — (O) array to be filled and returned
+/// * `anynul` — (O) set to 1 if any values are null; else 0
+/// * `status` — (IO) error status
 pub fn ffg3dujj_safe(
-    fptr: &mut fitsfile,            /* I - FITS file pointer                       */
-    group: c_long,                  /* I - group to read (1 = 1st group)           */
-    nulval: ULONGLONG,              /* set undefined pixels equal to this          */
-    ncols: LONGLONG,                /* I - number of pixels in each row of array   */
-    nrows: LONGLONG,                /* I - number of rows in each plane of array   */
-    naxis1: LONGLONG,               /* I - FITS image NAXIS1 value                 */
-    naxis2: LONGLONG,               /* I - FITS image NAXIS2 value                 */
-    naxis3: LONGLONG,               /* I - FITS image NAXIS3 value                 */
-    array: &mut [ULONGLONG],        /* O - array to be filled and returned         */
-    mut anynul: Option<&mut c_int>, /* O - set to 1 if any values are null; else 0 */
-    status: &mut c_int,             /* IO - error status                           */
+    fptr: &mut fitsfile,
+    group: c_long,
+    nulval: ULONGLONG,
+    ncols: LONGLONG,
+    nrows: LONGLONG,
+    naxis1: LONGLONG,
+    naxis2: LONGLONG,
+    naxis3: LONGLONG,
+    array: &mut [ULONGLONG],
+    mut anynul: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     let mut tablerow: c_long = 0;
     let nullcheck = NullCheckType::SetPixel;
@@ -2974,22 +3356,35 @@ pub fn ffg3dujj_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read a subsection of data values from an image or a table column.
 /// This routine is set up to handle a maximum of nine dimensions.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `colnum` — (I) number of the column to read (1 = 1st)
+/// * `naxis`  — (I) number of dimensions in the FITS array
+/// * `naxes`  — (I) size of each dimension
+/// * `blc`    — (I) 'bottom left corner' of the subsection
+/// * `trc`    — (I) 'top right corner' of the subsection
+/// * `inc`    — (I) increment to be applied in each dimension
+/// * `nulval` — (I) value to set undefined pixels
+/// * `array`  — (O) array to be filled and returned
+/// * `anynul` — (O) set to 1 if any values are null; else 0
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgsvujj(
-    fptr: *mut fitsfile,   /* I - FITS file pointer                         */
-    colnum: c_int,         /* I - number of the column to read (1 = 1st)    */
-    naxis: c_int,          /* I - number of dimensions in the FITS array    */
-    naxes: *const c_long,  /* I - size of each dimension                    */
-    blc: *const c_long,    /* I - 'bottom left corner' of the subsection    */
-    trc: *const c_long,    /* I - 'top right corner' of the subsection      */
-    inc: *const c_long,    /* I - increment to be applied in each dimension */
-    nulval: ULONGLONG,     /* I - value to set undefined pixels             */
-    array: *mut ULONGLONG, /* O - array to be filled and returned           */
-    anynul: *mut c_int,    /* O - set to 1 if any values are null; else 0   */
-    status: *mut c_int,    /* IO - error status                             */
+    fptr: *mut fitsfile,
+    colnum: c_int,
+    naxis: c_int,
+    naxes: *const c_long,
+    blc: *const c_long,
+    trc: *const c_long,
+    inc: *const c_long,
+    nulval: ULONGLONG,
+    array: *mut ULONGLONG,
+    anynul: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -3012,21 +3407,34 @@ pub unsafe extern "C" fn ffgsvujj(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read a subsection of data values from an image or a table column.
 /// This routine is set up to handle a maximum of nine dimensions.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `colnum` — (I) number of the column to read (1 = 1st)
+/// * `naxis`  — (I) number of dimensions in the FITS array
+/// * `naxes`  — (I) size of each dimension
+/// * `blc`    — (I) 'bottom left corner' of the subsection
+/// * `trc`    — (I) 'top right corner' of the subsection
+/// * `inc`    — (I) increment to be applied in each dimension
+/// * `nulval` — (I) value to set undefined pixels
+/// * `array`  — (O) array to be filled and returned
+/// * `anynul` — (O) set to 1 if any values are null; else 0
+/// * `status` — (IO) error status
 pub fn ffgsvujj_safe(
-    fptr: &mut fitsfile,     /* I - FITS file pointer                         */
-    colnum: c_int,           /* I - number of the column to read (1 = 1st)    */
-    naxis: c_int,            /* I - number of dimensions in the FITS array    */
-    naxes: &[c_long],        /* I - size of each dimension                    */
-    blc: &[c_long],          /* I - 'bottom left corner' of the subsection    */
-    trc: &[c_long],          /* I - 'top right corner' of the subsection      */
-    inc: &[c_long],          /* I - increment to be applied in each dimension */
-    nulval: ULONGLONG,       /* I - value to set undefined pixels             */
-    array: &mut [ULONGLONG], /* O - array to be filled and returned           */
-    mut anynul: Option<&mut c_int>, /* O - set to 1 if any values are null; else 0   */
-    status: &mut c_int,      /* IO - error status                             */
+    fptr: &mut fitsfile,
+    colnum: c_int,
+    naxis: c_int,
+    naxes: &[c_long],
+    blc: &[c_long],
+    trc: &[c_long],
+    inc: &[c_long],
+    nulval: ULONGLONG,
+    array: &mut [ULONGLONG],
+    mut anynul: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     let mut rstr: c_long = 0;
     let mut rstp: c_long = 0;
@@ -3232,22 +3640,35 @@ pub fn ffgsvujj_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read a subsection of data values from an image or a table column.
 /// This routine is set up to handle a maximum of nine dimensions.
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `colnum`  — (I) number of the column to read (1 = 1st)
+/// * `naxis`   — (I) number of dimensions in the FITS array
+/// * `naxes`   — (I) size of each dimension
+/// * `blc`     — (I) 'bottom left corner' of the subsection
+/// * `trc`     — (I) 'top right corner' of the subsection
+/// * `inc`     — (I) increment to be applied in each dimension
+/// * `array`   — (O) array to be filled and returned
+/// * `flagval` — (O) set to 1 if corresponding value is null
+/// * `anynul`  — (O) set to 1 if any values are null; else 0
+/// * `status`  — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgsfujj(
-    fptr: *mut fitsfile,   /* I - FITS file pointer                         */
-    colnum: c_int,         /* I - number of the column to read (1 = 1st)    */
-    naxis: c_int,          /* I - number of dimensions in the FITS array    */
-    naxes: *const c_long,  /* I - size of each dimension                    */
-    blc: *const c_long,    /* I - 'bottom left corner' of the subsection    */
-    trc: *const c_long,    /* I - 'top right corner' of the subsection      */
-    inc: *const c_long,    /* I - increment to be applied in each dimension */
-    array: *mut ULONGLONG, /* O - array to be filled and returned           */
-    flagval: *mut c_char,  /* O - set to 1 if corresponding value is null   */
-    anynul: *mut c_int,    /* O - set to 1 if any values are null; else 0   */
-    status: *mut c_int,    /* IO - error status                             */
+    fptr: *mut fitsfile,
+    colnum: c_int,
+    naxis: c_int,
+    naxes: *const c_long,
+    blc: *const c_long,
+    trc: *const c_long,
+    inc: *const c_long,
+    array: *mut ULONGLONG,
+    flagval: *mut c_char,
+    anynul: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -3271,21 +3692,34 @@ pub unsafe extern "C" fn ffgsfujj(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read a subsection of data values from an image or a table column.
 /// This routine is set up to handle a maximum of nine dimensions.
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `colnum`  — (I) number of the column to read (1 = 1st)
+/// * `naxis`   — (I) number of dimensions in the FITS array
+/// * `naxes`   — (I) size of each dimension
+/// * `blc`     — (I) 'bottom left corner' of the subsection
+/// * `trc`     — (I) 'top right corner' of the subsection
+/// * `inc`     — (I) increment to be applied in each dimension
+/// * `array`   — (O) array to be filled and returned
+/// * `flagval` — (O) set to 1 if corresponding value is null
+/// * `anynul`  — (O) set to 1 if any values are null; else 0
+/// * `status`  — (IO) error status
 pub fn ffgsfujj_safe(
-    fptr: &mut fitsfile,     /* I - FITS file pointer                         */
-    colnum: c_int,           /* I - number of the column to read (1 = 1st)    */
-    naxis: c_int,            /* I - number of dimensions in the FITS array    */
-    naxes: &[c_long],        /* I - size of each dimension                    */
-    blc: &[c_long],          /* I - 'bottom left corner' of the subsection    */
-    trc: &[c_long],          /* I - 'top right corner' of the subsection      */
-    inc: &[c_long],          /* I - increment to be applied in each dimension */
-    array: &mut [ULONGLONG], /* O - array to be filled and returned           */
-    flagval: &mut [c_char],  /* O - set to 1 if corresponding value is null   */
-    mut anynul: Option<&mut c_int>, /* O - set to 1 if any values are null; else 0   */
-    status: &mut c_int,      /* IO - error status                             */
+    fptr: &mut fitsfile,
+    colnum: c_int,
+    naxis: c_int,
+    naxes: &[c_long],
+    blc: &[c_long],
+    trc: &[c_long],
+    inc: &[c_long],
+    array: &mut [ULONGLONG],
+    flagval: &mut [c_char],
+    mut anynul: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     let mut rstr: c_long = 0;
     let mut rstp: c_long = 0;
@@ -3473,7 +3907,6 @@ pub fn ffgsfujj_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of group parameters from the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
 /// the FITS array is not the same as the array being read).
@@ -3482,14 +3915,23 @@ pub fn ffgsfujj_safe(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to read (1 = 1st group)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `array`     — (O) array of values that are returned
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffggpujj(
-    fptr: *mut fitsfile,   /* I - FITS file pointer                       */
-    group: c_long,         /* I - group to read (1 = 1st group)           */
-    firstelem: c_long,     /* I - first vector element to read (1 = 1st)  */
-    nelem: c_long,         /* I - number of values to read                */
-    array: *mut ULONGLONG, /* O - array of values that are returned       */
-    status: *mut c_int,    /* IO - error status                           */
+    fptr: *mut fitsfile,
+    group: c_long,
+    firstelem: c_long,
+    nelem: c_long,
+    array: *mut ULONGLONG,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -3501,7 +3943,6 @@ pub unsafe extern "C" fn ffggpujj(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of group parameters from the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
 /// the FITS array is not the same as the array being read).
@@ -3510,13 +3951,22 @@ pub unsafe extern "C" fn ffggpujj(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to read (1 = 1st group)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `array`     — (O) array of values that are returned
+/// * `status`    — (IO) error status
 pub fn ffggpujj_safe(
-    fptr: &mut fitsfile,     /* I - FITS file pointer                       */
-    group: c_long,           /* I - group to read (1 = 1st group)           */
-    firstelem: c_long,       /* I - first vector element to read (1 = 1st)  */
-    nelem: c_long,           /* I - number of values to read                */
-    array: &mut [ULONGLONG], /* O - array of values that are returned       */
-    status: &mut c_int,      /* IO - error status                           */
+    fptr: &mut fitsfile,
+    group: c_long,
+    firstelem: c_long,
+    nelem: c_long,
+    array: &mut [ULONGLONG],
+    status: &mut c_int,
 ) -> c_int {
     let mut idummy = 0;
     let dummy: ULONGLONG = 0;
@@ -3542,24 +3992,35 @@ pub fn ffggpujj_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of values from a column in the current FITS HDU. Automatic
 /// datatype conversion will be performed if the datatype of the column does not
 /// match the datatype of the array parameter. The output values will be scaled
 /// by the FITS TSCALn and TZEROn values if these values have been defined.
 /// Any undefined pixels will be set equal to the value of 'nulval' unless
 /// nulval = 0 in which case no checks for undefined pixels will be made.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to read (1 = 1st col)
+/// * `firstrow`  — (I) first row to read (1 = 1st row)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `nulval`    — (I) value for null pixels
+/// * `array`     — (O) array of values that are read
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgcvujj(
-    fptr: *mut fitsfile,   /* I - FITS file pointer                       */
-    colnum: c_int,         /* I - number of column to read (1 = 1st col)  */
-    firstrow: LONGLONG,    /* I - first row to read (1 = 1st row)         */
-    firstelem: LONGLONG,   /* I - first vector element to read (1 = 1st)  */
-    nelem: LONGLONG,       /* I - number of values to read                */
-    nulval: ULONGLONG,     /* I - value for null pixels                   */
-    array: *mut ULONGLONG, /* O - array of values that are read           */
-    anynul: *mut c_int,    /* O - set to 1 if any values are null; else 0 */
-    status: *mut c_int,    /* IO - error status                           */
+    fptr: *mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    nulval: ULONGLONG,
+    array: *mut ULONGLONG,
+    anynul: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -3583,23 +4044,34 @@ pub unsafe extern "C" fn ffgcvujj(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of values from a column in the current FITS HDU. Automatic
 /// datatype conversion will be performed if the datatype of the column does not
 /// match the datatype of the array parameter. The output values will be scaled
 /// by the FITS TSCALn and TZEROn values if these values have been defined.
 /// Any undefined pixels will be set equal to the value of 'nulval' unless
 /// nulval = 0 in which case no checks for undefined pixels will be made.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to read (1 = 1st col)
+/// * `firstrow`  — (I) first row to read (1 = 1st row)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `nulval`    — (I) value for null pixels
+/// * `array`     — (O) array of values that are read
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `status`    — (IO) error status
 pub fn ffgcvujj_safe(
-    fptr: &mut fitsfile,        /* I - FITS file pointer                       */
-    colnum: c_int,              /* I - number of column to read (1 = 1st col)  */
-    firstrow: LONGLONG,         /* I - first row to read (1 = 1st row)         */
-    firstelem: LONGLONG,        /* I - first vector element to read (1 = 1st)  */
-    nelem: LONGLONG,            /* I - number of values to read                */
-    nulval: ULONGLONG,          /* I - value for null pixels                   */
-    array: &mut [ULONGLONG],    /* O - array of values that are read           */
-    anynul: Option<&mut c_int>, /* O - set to 1 if any values are null; else 0 */
-    status: &mut c_int,         /* IO - error status                           */
+    fptr: &mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    nulval: ULONGLONG,
+    array: &mut [ULONGLONG],
+    anynul: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     let mut dummy_nularray = vec![0; nelem as usize];
 
@@ -3620,24 +4092,35 @@ pub fn ffgcvujj_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of values from a column in the current FITS HDU. Automatic
 /// datatype conversion will be performed if the datatype of the column does not
 /// match the datatype of the array parameter. The output values will be scaled
 /// by the FITS TSCALn and TZEROn values if these values have been defined.
 /// Nularray will be set = 1 if the corresponding array pixel is undefined,
 /// otherwise nularray will = 0.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to read (1 = 1st col)
+/// * `firstrow`  — (I) first row to read (1 = 1st row)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `array`     — (O) array of values that are read
+/// * `nularray`  — (O) array of flags: 1 if null pixel; else 0
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgcfujj(
-    fptr: *mut fitsfile,   /* I - FITS file pointer                       */
-    colnum: c_int,         /* I - number of column to read (1 = 1st col)  */
-    firstrow: LONGLONG,    /* I - first row to read (1 = 1st row)         */
-    firstelem: LONGLONG,   /* I - first vector element to read (1 = 1st)  */
-    nelem: LONGLONG,       /* I - number of values to read                */
-    array: *mut ULONGLONG, /* O - array of values that are read           */
-    nularray: *mut c_char, /* O - array of flags: 1 if null pixel; else 0 */
-    anynul: *mut c_int,    /* O - set to 1 if any values are null; else 0 */
-    status: *mut c_int,    /* IO - error status                           */
+    fptr: *mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: *mut ULONGLONG,
+    nularray: *mut c_char,
+    anynul: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -3662,23 +4145,34 @@ pub unsafe extern "C" fn ffgcfujj(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of values from a column in the current FITS HDU. Automatic
 /// datatype conversion will be performed if the datatype of the column does not
 /// match the datatype of the array parameter. The output values will be scaled
 /// by the FITS TSCALn and TZEROn values if these values have been defined.
 /// Nularray will be set = 1 if the corresponding array pixel is undefined,
 /// otherwise nularray will = 0.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to read (1 = 1st col)
+/// * `firstrow`  — (I) first row to read (1 = 1st row)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `array`     — (O) array of values that are read
+/// * `nularray`  — (O) array of flags: 1 if null pixel; else 0
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `status`    — (IO) error status
 pub fn ffgcfujj_safe(
-    fptr: &mut fitsfile,        /* I - FITS file pointer                       */
-    colnum: c_int,              /* I - number of column to read (1 = 1st col)  */
-    firstrow: LONGLONG,         /* I - first row to read (1 = 1st row)         */
-    firstelem: LONGLONG,        /* I - first vector element to read (1 = 1st)  */
-    nelem: LONGLONG,            /* I - number of values to read                */
-    array: &mut [ULONGLONG],    /* O - array of values that are read           */
-    nularray: &mut [c_char],    /* O - array of flags: 1 if null pixel; else 0 */
-    anynul: Option<&mut c_int>, /* O - set to 1 if any values are null; else 0 */
-    status: &mut c_int,         /* IO - error status                           */
+    fptr: &mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: &mut [ULONGLONG],
+    nularray: &mut [c_char],
+    anynul: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     let dummy: ULONGLONG = 0;
 
@@ -3700,7 +4194,6 @@ pub fn ffgcfujj_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of values from a column in the current FITS HDU.
 /// The column number may refer to a real column in an ASCII or binary table,
 /// or it may refer be a virtual column in a 1 or more grouped FITS primary
@@ -3714,21 +4207,35 @@ pub fn ffgcfujj_safe(
 /// and will be scaled by the FITS TSCALn and TZEROn values if necessary.
 #[allow(clippy::if_same_then_else)]
 // C dispatch chain: distinct conditions deliberately share an action.
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to read (1 = 1st col)
+/// * `firstrow`  — (I) first row to read (1 = 1st row)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `elemincre` — (I) pixel increment; e.g., 2 = every other
+/// * `nultyp`    — (I) null value handling code:
+/// * `nulval`    — (I) value for null pixels if nultyp = 1
+/// * `array`     — (O) array of values that are read
+/// * `nularray`  — (O) array of flags = 1 if nultyp = 2
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `status`    — (IO) error status
 pub(crate) fn ffgclujj(
-    fptr: &mut fitsfile,   /* I - FITS file pointer                       */
-    colnum: c_int,         /* I - number of column to read (1 = 1st col)  */
-    firstrow: LONGLONG,    /* I - first row to read (1 = 1st row)         */
-    firstelem: LONGLONG,   /* I - first vector element to read (1 = 1st)  */
-    nelem: LONGLONG,       /* I - number of values to read                */
-    elemincre: c_long,     /* I - pixel increment; e.g., 2 = every other  */
-    nultyp: NullCheckType, /* I - null value handling code:               */
+    fptr: &mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    elemincre: c_long,
+    nultyp: NullCheckType,
     /*     1: set undefined pixels = nulval        */
     /*     2: set nularray=1 for undefined pixels  */
-    nulval: ULONGLONG,       /* I - value for null pixels if nultyp = 1     */
-    array: &mut [ULONGLONG], /* O - array of values that are read           */
-    nularray: &mut [c_char], /* O - array of flags = 1 if nultyp = 2        */
-    mut anynul: Option<&mut c_int>, /* O - set to 1 if any values are null; else 0 */
-    status: &mut c_int,      /* IO - error status                           */
+    nulval: ULONGLONG,
+    array: &mut [ULONGLONG],
+    nularray: &mut [c_char],
+    mut anynul: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     let mut scale: f64 = 0.0;
     let mut zero: f64 = 0.0;
@@ -3777,9 +4284,7 @@ pub(crate) fn ffgclujj(
         nularray.fill(0); /* initialize nullarray */
     }
 
-    /*---------------------------------------------------*/
     /*  Check input and get parameters about the column: */
-    /*---------------------------------------------------*/
     if elemincre < 0 {
         readcheck = -1; /* don't do range checking in this case */
     }
@@ -3830,9 +4335,7 @@ pub(crate) fn ffgclujj(
         }
     }
 
-    /*------------------------------------------------------------------*/
     /*  Decide whether to check for null values in the input FITS file: */
-    /*------------------------------------------------------------------*/
     nulcheck = nultyp; /* by default check for null values in the FITS file */
 
     if nultyp == NullCheckType::SetPixel && nulval == 0 {
@@ -3851,7 +4354,6 @@ pub(crate) fn ffgclujj(
         nulcheck = NullCheckType::None;
     }
 
-    /*---------------------------------------------------------------------*/
     /*  Now read the pixels from the FITS column. If the column does not   */
     /*  have the same datatype as the output array, then we have to read   */
     /*  the raw values into a temporary buffer (of limited size).  In      */
@@ -3861,7 +4363,6 @@ pub(crate) fn ffgclujj(
     /*  test for undefined values, (2) convert the datatype if necessary,  */
     /*  and (3) scale the values by the FITS TSCALn and TZEROn linear      */
     /*  scaling parameters.                                                */
-    /*---------------------------------------------------------------------*/
 
     remain = nelem; /* remaining number of values to read */
     next = 0; /* next element in array to be read   */
@@ -4036,9 +4537,7 @@ pub(crate) fn ffgclujj(
             }
         } /* End of switch block */
 
-        /*-------------------------*/
         /*  Check for fatal error  */
-        /*-------------------------*/
         if *status > 0 {
             /* test for error during previous read operation */
             dtemp = next as f64;
@@ -4064,9 +4563,7 @@ pub(crate) fn ffgclujj(
             return *status;
         }
 
-        /*--------------------------------------------*/
         /*  increment the counters for the next loop  */
-        /*--------------------------------------------*/
         remain -= ntodo as LONGLONG;
         if remain > 0 {
             next += ntodo as LONGLONG;
@@ -4086,9 +4583,7 @@ pub(crate) fn ffgclujj(
         }
     } /*  End of main while Loop  */
 
-    /*--------------------------------*/
     /*  check for numerical overflow  */
-    /*--------------------------------*/
     if *status == OVERFLOW_ERR {
         ffpmsg_str("Numerical overflow during type conversion while reading FITS data.");
         *status = NUM_OVERFLOW;
@@ -4097,7 +4592,6 @@ pub(crate) fn ffgclujj(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output following reading of the input from a FITS file.
 /// Check for null values and do datatype conversion and scaling if required.
 /// The nullcheck code value determines how any null values in the input array
@@ -4109,20 +4603,34 @@ pub(crate) fn ffgclujj(
 /// nullarray will be set to 1; the value of nullarray for non-null pixels
 /// will = 0.  The anynull parameter will be set = 1 if any of the returned
 /// pixels are null, otherwise anynull will be returned with a value = 0;
+///
+/// # Parameters
+///
+/// * `input`     — (I) array of values to be converted
+/// * `ntodo`     — (I) number of elements in the array
+/// * `scale`     — (I) FITS TSCALn or BSCALE value
+/// * `zero`      — (I) FITS TZEROn or BZERO value
+/// * `nullcheck` — (I) null checking code; 0 = don't check
+/// * `tnull`     — (I) value of FITS TNULLn keyword if any
+/// * `nullval`   — (I) set null pixels, if nullcheck = 1
+/// * `nullarray` — (I) bad pixel array, if nullcheck = 2
+/// * `anynull`   — (O) set to 1 if any pixels are null
+/// * `output`    — (O) array of converted pixels
+/// * `status`    — (IO) error status
 pub(crate) fn fffi1u8(
-    input: &[u8],             /* I - array of values to be converted     */
-    ntodo: c_long,            /* I - number of elements in the array     */
-    scale: f64,               /* I - FITS TSCALn or BSCALE value         */
-    zero: f64,                /* I - FITS TZEROn or BZERO  value         */
-    nullcheck: NullCheckType, /* I - null checking code; 0 = don't check */
+    input: &[u8],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    nullcheck: NullCheckType,
     /*     1:set null pixels = nullval         */
     /*     2: if null pixel, set nullarray = 1 */
-    tnull: u8,                   /* I - value of FITS TNULLn keyword if any */
-    nullval: ULONGLONG,          /* I - set null pixels, if nullcheck = 1   */
-    nullarray: &mut [c_char],    /* I - bad pixel array, if nullcheck = 2   */
-    anynull: Option<&mut c_int>, /* O - set to 1 if any pixels are null     */
-    output: &mut [ULONGLONG],    /* O - array of converted pixels           */
-    status: &mut c_int,          /* IO - error status                       */
+    tnull: u8,
+    nullval: ULONGLONG,
+    nullarray: &mut [c_char],
+    anynull: Option<&mut c_int>,
+    output: &mut [ULONGLONG],
+    status: &mut c_int,
 ) -> c_int {
     let mut dvalue: f64 = 0.0;
 
@@ -4196,7 +4704,6 @@ pub(crate) fn fffi1u8(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output following reading of the input from a FITS file.
 /// Check for null values and do datatype conversion and scaling if required.
 /// The nullcheck code value determines how any null values in the input array
@@ -4208,20 +4715,34 @@ pub(crate) fn fffi1u8(
 /// nullarray will be set to 1; the value of nullarray for non-null pixels
 /// will = 0.  The anynull parameter will be set = 1 if any of the returned
 /// pixels are null, otherwise anynull will be returned with a value = 0;
+///
+/// # Parameters
+///
+/// * `input`     — (I) array of values to be converted
+/// * `ntodo`     — (I) number of elements in the array
+/// * `scale`     — (I) FITS TSCALn or BSCALE value
+/// * `zero`      — (I) FITS TZEROn or BZERO value
+/// * `nullcheck` — (I) null checking code; 0 = don't check
+/// * `tnull`     — (I) value of FITS TNULLn keyword if any
+/// * `nullval`   — (I) set null pixels, if nullcheck = 1
+/// * `nullarray` — (I) bad pixel array, if nullcheck = 2
+/// * `anynull`   — (O) set to 1 if any pixels are null
+/// * `output`    — (O) array of converted pixels
+/// * `status`    — (IO) error status
 pub(crate) fn fffi2u8(
-    input: &[c_short],        /* I - array of values to be converted     */
-    ntodo: c_long,            /* I - number of elements in the array     */
-    scale: f64,               /* I - FITS TSCALn or BSCALE value         */
-    zero: f64,                /* I - FITS TZEROn or BZERO  value         */
-    nullcheck: NullCheckType, /* I - null checking code; 0 = don't check */
+    input: &[c_short],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    nullcheck: NullCheckType,
     /*     1:set null pixels = nullval         */
     /*     2: if null pixel, set nullarray = 1 */
-    tnull: c_short,              /* I - value of FITS TNULLn keyword if any */
-    nullval: ULONGLONG,          /* I - set null pixels, if nullcheck = 1   */
-    nullarray: &mut [c_char],    /* I - bad pixel array, if nullcheck = 2   */
-    anynull: Option<&mut c_int>, /* O - set to 1 if any pixels are null     */
-    output: &mut [ULONGLONG],    /* O - array of converted pixels           */
-    status: &mut c_int,          /* IO - error status                       */
+    tnull: c_short,
+    nullval: ULONGLONG,
+    nullarray: &mut [c_char],
+    anynull: Option<&mut c_int>,
+    output: &mut [ULONGLONG],
+    status: &mut c_int,
 ) -> c_int {
     let mut dvalue: f64 = 0.0;
 
@@ -4300,7 +4821,6 @@ pub(crate) fn fffi2u8(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output following reading of the input from a FITS file.
 /// Check for null values and do datatype conversion and scaling if required.
 /// The nullcheck code value determines how any null values in the input array
@@ -4312,20 +4832,34 @@ pub(crate) fn fffi2u8(
 /// nullarray will be set to 1; the value of nullarray for non-null pixels
 /// will = 0.  The anynull parameter will be set = 1 if any of the returned
 /// pixels are null, otherwise anynull will be returned with a value = 0;
+///
+/// # Parameters
+///
+/// * `input`     — (I) array of values to be converted
+/// * `ntodo`     — (I) number of elements in the array
+/// * `scale`     — (I) FITS TSCALn or BSCALE value
+/// * `zero`      — (I) FITS TZEROn or BZERO value
+/// * `nullcheck` — (I) null checking code; 0 = don't check
+/// * `tnull`     — (I) value of FITS TNULLn keyword if any
+/// * `nullval`   — (I) set null pixels, if nullcheck = 1
+/// * `nullarray` — (I) bad pixel array, if nullcheck = 2
+/// * `anynull`   — (O) set to 1 if any pixels are null
+/// * `output`    — (O) array of converted pixels
+/// * `status`    — (IO) error status
 pub(crate) fn fffi4u8(
-    input: &[INT32BIT],       /* I - array of values to be converted     */
-    ntodo: c_long,            /* I - number of elements in the array     */
-    scale: f64,               /* I - FITS TSCALn or BSCALE value         */
-    zero: f64,                /* I - FITS TZEROn or BZERO  value         */
-    nullcheck: NullCheckType, /* I - null checking code; 0 = don't check */
+    input: &[INT32BIT],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    nullcheck: NullCheckType,
     /*     1:set null pixels = nullval         */
     /*     2: if null pixel, set nullarray = 1 */
-    tnull: INT32BIT,             /* I - value of FITS TNULLn keyword if any */
-    nullval: ULONGLONG,          /* I - set null pixels, if nullcheck = 1   */
-    nullarray: &mut [c_char],    /* I - bad pixel array, if nullcheck = 2   */
-    anynull: Option<&mut c_int>, /* O - set to 1 if any pixels are null     */
-    output: &mut [ULONGLONG],    /* O - array of converted pixels           */
-    status: &mut c_int,          /* IO - error status                       */
+    tnull: INT32BIT,
+    nullval: ULONGLONG,
+    nullarray: &mut [c_char],
+    anynull: Option<&mut c_int>,
+    output: &mut [ULONGLONG],
+    status: &mut c_int,
 ) -> c_int {
     let mut dvalue: f64 = 0.0;
 
@@ -4407,7 +4941,6 @@ pub(crate) fn fffi4u8(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output following reading of the input from a FITS file.
 /// Check for null values and do datatype conversion and scaling if required.
 /// The nullcheck code value determines how any null values in the input array
@@ -4419,20 +4952,34 @@ pub(crate) fn fffi4u8(
 /// nullarray will be set to 1; the value of nullarray for non-null pixels
 /// will = 0.  The anynull parameter will be set = 1 if any of the returned
 /// pixels are null, otherwise anynull will be returned with a value = 0;
+///
+/// # Parameters
+///
+/// * `input`     — (I) array of values to be converted
+/// * `ntodo`     — (I) number of elements in the array
+/// * `scale`     — (I) FITS TSCALn or BSCALE value
+/// * `zero`      — (I) FITS TZEROn or BZERO value
+/// * `nullcheck` — (I) null checking code; 0 = don't check
+/// * `tnull`     — (I) value of FITS TNULLn keyword if any
+/// * `nullval`   — (I) set null pixels, if nullcheck = 1
+/// * `nullarray` — (I) bad pixel array, if nullcheck = 2
+/// * `anynull`   — (O) set to 1 if any pixels are null
+/// * `output`    — (O) array of converted pixels
+/// * `status`    — (IO) error status
 pub(crate) fn fffi8u8(
-    input: &[LONGLONG],       /* I - array of values to be converted     */
-    ntodo: c_long,            /* I - number of elements in the array     */
-    scale: f64,               /* I - FITS TSCALn or BSCALE value         */
-    zero: f64,                /* I - FITS TZEROn or BZERO  value         */
-    nullcheck: NullCheckType, /* I - null checking code; 0 = don't check */
+    input: &[LONGLONG],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    nullcheck: NullCheckType,
     /*     1:set null pixels = nullval         */
     /*     2: if null pixel, set nullarray = 1 */
-    tnull: LONGLONG,             /* I - value of FITS TNULLn keyword if any */
-    nullval: ULONGLONG,          /* I - set null pixels, if nullcheck = 1   */
-    nullarray: &mut [c_char],    /* I - bad pixel array, if nullcheck = 2   */
-    anynull: Option<&mut c_int>, /* O - set to 1 if any pixels are null     */
-    output: &mut [ULONGLONG],    /* O - array of converted pixels           */
-    status: &mut c_int,          /* IO - error status                       */
+    tnull: LONGLONG,
+    nullval: ULONGLONG,
+    nullarray: &mut [c_char],
+    anynull: Option<&mut c_int>,
+    output: &mut [ULONGLONG],
+    status: &mut c_int,
 ) -> c_int {
     let mut dvalue: f64 = 0.0;
 
@@ -4539,7 +5086,6 @@ pub(crate) fn fffi8u8(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output following reading of the input from a FITS file.
 /// Check for null values and do datatype conversion and scaling if required.
 /// The nullcheck code value determines how any null values in the input array
@@ -4551,19 +5097,32 @@ pub(crate) fn fffi8u8(
 /// nullarray will be set to 1; the value of nullarray for non-null pixels
 /// will = 0.  The anynull parameter will be set = 1 if any of the returned
 /// pixels are null, otherwise anynull will be returned with a value = 0;
+///
+/// # Parameters
+///
+/// * `input`     — (I) array of values to be converted
+/// * `ntodo`     — (I) number of elements in the array
+/// * `scale`     — (I) FITS TSCALn or BSCALE value
+/// * `zero`      — (I) FITS TZEROn or BZERO value
+/// * `nullcheck` — (I) null checking code; 0 = don't check
+/// * `nullval`   — (I) set null pixels, if nullcheck = 1
+/// * `nullarray` — (I) bad pixel array, if nullcheck = 2
+/// * `anynull`   — (O) set to 1 if any pixels are null
+/// * `output`    — (O) array of converted pixels
+/// * `status`    — (IO) error status
 pub(crate) fn fffr4u8(
-    input: &[f32],            /* I - array of values to be converted     */
-    ntodo: c_long,            /* I - number of elements in the array     */
-    scale: f64,               /* I - FITS TSCALn or BSCALE value         */
-    zero: f64,                /* I - FITS TZEROn or BZERO  value         */
-    nullcheck: NullCheckType, /* I - null checking code; 0 = don't check */
+    input: &[f32],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    nullcheck: NullCheckType,
     /*     1:set null pixels = nullval         */
     /*     2: if null pixel, set nullarray = 1 */
-    nullval: ULONGLONG,          /* I - set null pixels, if nullcheck = 1   */
-    nullarray: &mut [c_char],    /* I - bad pixel array, if nullcheck = 2   */
-    anynull: Option<&mut c_int>, /* O - set to 1 if any pixels are null     */
-    output: &mut [ULONGLONG],    /* O - array of converted pixels           */
-    status: &mut c_int,          /* IO - error status                       */
+    nullval: ULONGLONG,
+    nullarray: &mut [c_char],
+    anynull: Option<&mut c_int>,
+    output: &mut [ULONGLONG],
+    status: &mut c_int,
 ) -> c_int {
     let mut dvalue: f64 = 0.0;
     let mut sptr = 0;
@@ -4687,7 +5246,6 @@ pub(crate) fn fffr4u8(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output following reading of the input from a FITS file.
 /// Check for null values and do datatype conversion and scaling if required.
 /// The nullcheck code value determines how any null values in the input array
@@ -4699,19 +5257,32 @@ pub(crate) fn fffr4u8(
 /// nullarray will be set to 1; the value of nullarray for non-null pixels
 /// will = 0.  The anynull parameter will be set = 1 if any of the returned
 /// pixels are null, otherwise anynull will be returned with a value = 0;
+///
+/// # Parameters
+///
+/// * `input`     — (I) array of values to be converted
+/// * `ntodo`     — (I) number of elements in the array
+/// * `scale`     — (I) FITS TSCALn or BSCALE value
+/// * `zero`      — (I) FITS TZEROn or BZERO value
+/// * `nullcheck` — (I) null checking code; 0 = don't check
+/// * `nullval`   — (I) set null pixels, if nullcheck = 1
+/// * `nullarray` — (I) bad pixel array, if nullcheck = 2
+/// * `anynull`   — (O) set to 1 if any pixels are null
+/// * `output`    — (O) array of converted pixels
+/// * `status`    — (IO) error status
 pub(crate) fn fffr8u8(
-    input: &[f64],            /* I - array of values to be converted     */
-    ntodo: c_long,            /* I - number of elements in the array     */
-    scale: f64,               /* I - FITS TSCALn or BSCALE value         */
-    zero: f64,                /* I - FITS TZEROn or BZERO  value         */
-    nullcheck: NullCheckType, /* I - null checking code; 0 = don't check */
+    input: &[f64],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    nullcheck: NullCheckType,
     /*     1:set null pixels = nullval         */
     /*     2: if null pixel, set nullarray = 1 */
-    nullval: ULONGLONG,          /* I - set null pixels, if nullcheck = 1   */
-    nullarray: &mut [c_char],    /* I - bad pixel array, if nullcheck = 2   */
-    anynull: Option<&mut c_int>, /* O - set to 1 if any pixels are null     */
-    output: &mut [ULONGLONG],    /* O - array of converted pixels           */
-    status: &mut c_int,          /* IO - error status                       */
+    nullval: ULONGLONG,
+    nullarray: &mut [c_char],
+    anynull: Option<&mut c_int>,
+    output: &mut [ULONGLONG],
+    status: &mut c_int,
 ) -> c_int {
     let mut dvalue: f64 = 0.0;
     let mut sptr = 0;
@@ -4835,7 +5406,6 @@ pub(crate) fn fffr8u8(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output following reading of the input from a FITS file. Check
 /// for null values and do scaling if required. The nullcheck code value
 /// determines how any null values in the input array are treated. A null
@@ -4846,22 +5416,38 @@ pub(crate) fn fffr8u8(
 /// nullarray will be set to 1; the value of nullarray for non-null pixels
 /// will = 0.  The anynull parameter will be set = 1 if any of the returned
 /// pixels are null, otherwise anynull will be returned with a value = 0;
+///
+/// # Parameters
+///
+/// * `input`      — (I) array of values to be converted
+/// * `ntodo`      — (I) number of elements in the array
+/// * `scale`      — (I) FITS TSCALn or BSCALE value
+/// * `zero`       — (I) FITS TZEROn or BZERO value
+/// * `twidth`     — (I) width of each substring of chars
+/// * `implipower` — (I) power of 10 of implied decimal
+/// * `nullcheck`  — (I) null checking code; 0 = don't check
+/// * `snull`      — (I) value of FITS null string, if any
+/// * `nullval`    — (I) set null pixels, if nullcheck = 1
+/// * `nullarray`  — (I) bad pixel array, if nullcheck = 2
+/// * `anynull`    — (O) set to 1 if any pixels are null
+/// * `output`     — (O) array of converted pixels
+/// * `status`     — (IO) error status
 pub(crate) fn fffstru8(
-    input: &mut [c_char],     /* I - array of values to be converted     */
-    ntodo: c_long,            /* I - number of elements in the array     */
-    scale: f64,               /* I - FITS TSCALn or BSCALE value         */
-    zero: f64,                /* I - FITS TZEROn or BZERO  value         */
-    twidth: c_long,           /* I - width of each substring of chars    */
-    implipower: f64,          /* I - power of 10 of implied decimal      */
-    nullcheck: NullCheckType, /* I - null checking code; 0 = don't check */
+    input: &mut [c_char],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    twidth: c_long,
+    implipower: f64,
+    nullcheck: NullCheckType,
     /*     1:set null pixels = nullval         */
     /*     2: if null pixel, set nullarray = 1 */
-    snull: &[c_char],                /* I - value of FITS null string, if any   */
-    nullval: ULONGLONG,              /* I - set null pixels, if nullcheck = 1   */
-    nullarray: &mut [c_char],        /* I - bad pixel array, if nullcheck = 2   */
-    mut anynull: Option<&mut c_int>, /* O - set to 1 if any pixels are null     */
-    output: &mut [ULONGLONG],        /* O - array of converted pixels           */
-    status: &mut c_int,              /* IO - error status                       */
+    snull: &[c_char],
+    nullval: ULONGLONG,
+    nullarray: &mut [c_char],
+    mut anynull: Option<&mut c_int>,
+    output: &mut [ULONGLONG],
+    status: &mut c_int,
 ) -> c_int {
     let mut nullen: c_int = 0;
     let mut dvalue: f64 = 0.0;

--- a/src/getcoluk.rs
+++ b/src/getcoluk.rs
@@ -1,9 +1,14 @@
-/*  This file, getcoluk.rs, contains routines that read data elements from   */
-/*  a FITS image or table, with 'unsigned int' data type.                           */
-
-/*  The FITSIO software was written by William Pence at the High Energy    */
-/*  Astrophysic Science Archive Research Center (HEASARC) at the NASA      */
-/*  Goddard Space Flight Center.                                           */
+//! Routines that read data elements from a FITS image or table, with
+//! `unsigned int` datatype.
+//!
+//! The [`TUINT`] arm of the typed column I/O family. [`crate::getcol`]
+//! dispatches here when a caller asks for this datatype at run time; the
+//! write-side counterpart is [`crate::putcoluk`].
+//!
+//! Ported from CFITSIO's `getcoluk.c`, written by William Pence at the High
+//! Energy Astrophysics Science Archive Research Center (HEASARC), NASA Goddard
+//! Space Flight Center.
+#![warn(missing_docs)]
 
 use core::slice;
 use core::{cmp, mem};
@@ -25,7 +30,6 @@ use crate::{NullValue, bb};
 use crate::{buffers::*, calculate_subsection_length};
 use crate::{int_snprintf, slice_to_str};
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of values from the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
 /// the FITS array is not the same as the array being read).
@@ -37,16 +41,27 @@ use crate::{int_snprintf, slice_to_str};
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to read (1 = 1st group)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `nulval`    — (I) value for undefined pixels
+/// * `array`     — (O) array of values that are returned
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgpvuk(
-    fptr: *mut fitsfile, /* I - FITS file pointer                       */
-    group: c_long,       /* I - group to read (1 = 1st group)           */
-    firstelem: LONGLONG, /* I - first vector element to read (1 = 1st)  */
-    nelem: LONGLONG,     /* I - number of values to read                */
-    nulval: c_uint,      /* I - value for undefined pixels          */
-    array: *mut c_uint,  /* O - array of values that are returned   */
-    anynul: *mut c_int,  /* O - set to 1 if any values are null; else 0 */
-    status: *mut c_int,  /* IO - error status                           */
+    fptr: *mut fitsfile,
+    group: c_long,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    nulval: c_uint,
+    array: *mut c_uint,
+    anynul: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -60,7 +75,6 @@ pub unsafe extern "C" fn ffgpvuk(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of values from the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
 /// the FITS array is not the same as the array being read).
@@ -72,15 +86,26 @@ pub unsafe extern "C" fn ffgpvuk(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to read (1 = 1st group)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `nulval`    — (I) value for undefined pixels
+/// * `array`     — (O) array of values that are returned
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `status`    — (IO) error status
 pub fn ffgpvuk_safe(
-    fptr: &mut fitsfile,        /* I - FITS file pointer                       */
-    group: c_long,              /* I - group to read (1 = 1st group)           */
-    firstelem: LONGLONG,        /* I - first vector element to read (1 = 1st)  */
-    nelem: LONGLONG,            /* I - number of values to read                */
-    nulval: c_uint,             /* I - value for undefined pixels          */
-    array: &mut [c_uint],       /* O - array of values that are returned   */
-    anynul: Option<&mut c_int>, /* O - set to 1 if any values are null; else 0 */
-    status: &mut c_int,         /* IO - error status                           */
+    fptr: &mut fitsfile,
+    group: c_long,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    nulval: c_uint,
+    array: &mut [c_uint],
+    anynul: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     let cdummy = 0;
     let nullcheck = NullCheckType::SetPixel;
@@ -124,7 +149,6 @@ pub fn ffgpvuk_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of values from the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
 /// the FITS array is not the same as the array being read).
@@ -136,16 +160,27 @@ pub fn ffgpvuk_safe(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to read (1 = 1st group)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `array`     — (O) array of values that are returned
+/// * `nularray`  — (O) array of null pixel flags
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgpfuk(
-    fptr: *mut fitsfile,   /* I - FITS file pointer                       */
-    group: c_long,         /* I - group to read (1 = 1st group)           */
-    firstelem: LONGLONG,   /* I - first vector element to read (1 = 1st)  */
-    nelem: LONGLONG,       /* I - number of values to read                */
-    array: *mut c_uint,    /* O - array of values that are returned   */
-    nularray: *mut c_char, /* O - array of null pixel flags               */
-    anynul: *mut c_int,    /* O - set to 1 if any values are null; else 0 */
-    status: *mut c_int,    /* IO - error status                           */
+    fptr: *mut fitsfile,
+    group: c_long,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: *mut c_uint,
+    nularray: *mut c_char,
+    anynul: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -162,7 +197,6 @@ pub unsafe extern "C" fn ffgpfuk(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of values from the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
 /// the FITS array is not the same as the array being read).
@@ -174,15 +208,26 @@ pub unsafe extern "C" fn ffgpfuk(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to read (1 = 1st group)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `array`     — (O) array of values that are returned
+/// * `nularray`  — (O) array of null pixel flags
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `status`    — (IO) error status
 pub fn ffgpfuk_safe(
-    fptr: &mut fitsfile,        /* I - FITS file pointer                       */
-    group: c_long,              /* I - group to read (1 = 1st group)           */
-    firstelem: LONGLONG,        /* I - first vector element to read (1 = 1st)  */
-    nelem: LONGLONG,            /* I - number of values to read                */
-    array: &mut [c_uint],       /* O - array of values that are returned   */
-    nularray: &mut [c_char],    /* O - array of null pixel flags               */
-    anynul: Option<&mut c_int>, /* O - set to 1 if any values are null; else 0 */
-    status: &mut c_int,         /* IO - error status                           */
+    fptr: &mut fitsfile,
+    group: c_long,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: &mut [c_uint],
+    nularray: &mut [c_char],
+    anynul: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     let nullcheck = NullCheckType::SetNullArray;
 
@@ -223,23 +268,34 @@ pub fn ffgpfuk_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an entire 2-D array of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of the
 /// FITS array is not the same as the array being read).  Any null
 /// values in the array will be set equal to the value of nulval, unless
 /// nulval = 0 in which case no null checking will be performed.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `group`  — (I) group to read (1 = 1st group)
+/// * `nulval` — set undefined pixels equal to this
+/// * `ncols`  — (I) number of pixels in each row of array
+/// * `naxis1` — (I) FITS image NAXIS1 value
+/// * `naxis2` — (I) FITS image NAXIS2 value
+/// * `array`  — (O) array to be filled and returned
+/// * `anynul` — (O) set to 1 if any values are null; else 0
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffg2duk(
-    fptr: *mut fitsfile, /* I - FITS file pointer                       */
-    group: c_long,       /* I - group to read (1 = 1st group)           */
-    nulval: c_uint,      /* set undefined pixels equal to this     */
-    ncols: LONGLONG,     /* I - number of pixels in each row of array   */
-    naxis1: LONGLONG,    /* I - FITS image NAXIS1 value                 */
-    naxis2: LONGLONG,    /* I - FITS image NAXIS2 value                 */
-    array: *mut c_uint,  /* O - array to be filled and returned    */
-    anynul: *mut c_int,  /* O - set to 1 if any values are null; else 0 */
-    status: *mut c_int,  /* IO - error status                           */
+    fptr: *mut fitsfile,
+    group: c_long,
+    nulval: c_uint,
+    ncols: LONGLONG,
+    naxis1: LONGLONG,
+    naxis2: LONGLONG,
+    array: *mut c_uint,
+    anynul: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -255,22 +311,33 @@ pub unsafe extern "C" fn ffg2duk(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an entire 2-D array of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of the
 /// FITS array is not the same as the array being read).  Any null
 /// values in the array will be set equal to the value of nulval, unless
 /// nulval = 0 in which case no null checking will be performed.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `group`  — (I) group to read (1 = 1st group)
+/// * `nulval` — set undefined pixels equal to this
+/// * `ncols`  — (I) number of pixels in each row of array
+/// * `naxis1` — (I) FITS image NAXIS1 value
+/// * `naxis2` — (I) FITS image NAXIS2 value
+/// * `array`  — (O) array to be filled and returned
+/// * `anynul` — (O) set to 1 if any values are null; else 0
+/// * `status` — (IO) error status
 pub fn ffg2duk_safe(
-    fptr: &mut fitsfile,        /* I - FITS file pointer                       */
-    group: c_long,              /* I - group to read (1 = 1st group)           */
-    nulval: c_uint,             /* set undefined pixels equal to this     */
-    ncols: LONGLONG,            /* I - number of pixels in each row of array   */
-    naxis1: LONGLONG,           /* I - FITS image NAXIS1 value                 */
-    naxis2: LONGLONG,           /* I - FITS image NAXIS2 value                 */
-    array: &mut [c_uint],       /* O - array to be filled and returned    */
-    anynul: Option<&mut c_int>, /* O - set to 1 if any values are null; else 0 */
-    status: &mut c_int,         /* IO - error status                           */
+    fptr: &mut fitsfile,
+    group: c_long,
+    nulval: c_uint,
+    ncols: LONGLONG,
+    naxis1: LONGLONG,
+    naxis2: LONGLONG,
+    array: &mut [c_uint],
+    anynul: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     /* call the 3D reading routine, with the 3rd dimension = 1 */
     ffg3duk_safe(
@@ -280,7 +347,6 @@ pub fn ffg2duk_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an entire 3-D array of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of the
 /// FITS array is not the same as the array being read).  Any null
@@ -291,19 +357,33 @@ pub fn ffg2duk_safe(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `group`  — (I) group to read (1 = 1st group)
+/// * `nulval` — set undefined pixels equal to this
+/// * `ncols`  — (I) number of pixels in each row of array
+/// * `nrows`  — (I) number of rows in each plane of array
+/// * `naxis1` — (I) FITS image NAXIS1 value
+/// * `naxis2` — (I) FITS image NAXIS2 value
+/// * `naxis3` — (I) FITS image NAXIS3 value
+/// * `array`  — (O) array to be filled and returned
+/// * `anynul` — (O) set to 1 if any values are null; else 0
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffg3duk(
-    fptr: *mut fitsfile, /* I - FITS file pointer                       */
-    group: c_long,       /* I - group to read (1 = 1st group)           */
-    nulval: c_uint,      /* set undefined pixels equal to this     */
-    ncols: LONGLONG,     /* I - number of pixels in each row of array   */
-    nrows: LONGLONG,     /* I - number of rows in each plane of array   */
-    naxis1: LONGLONG,    /* I - FITS image NAXIS1 value                 */
-    naxis2: LONGLONG,    /* I - FITS image NAXIS2 value                 */
-    naxis3: LONGLONG,    /* I - FITS image NAXIS3 value                 */
-    array: *mut c_uint,  /* O - array to be filled and returned    */
-    anynul: *mut c_int,  /* O - set to 1 if any values are null; else 0 */
-    status: *mut c_int,  /* IO - error status                           */
+    fptr: *mut fitsfile,
+    group: c_long,
+    nulval: c_uint,
+    ncols: LONGLONG,
+    nrows: LONGLONG,
+    naxis1: LONGLONG,
+    naxis2: LONGLONG,
+    naxis3: LONGLONG,
+    array: *mut c_uint,
+    anynul: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -319,7 +399,6 @@ pub unsafe extern "C" fn ffg3duk(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an entire 3-D array of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of the
 /// FITS array is not the same as the array being read).  Any null
@@ -330,18 +409,32 @@ pub unsafe extern "C" fn ffg3duk(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `group`  — (I) group to read (1 = 1st group)
+/// * `nulval` — set undefined pixels equal to this
+/// * `ncols`  — (I) number of pixels in each row of array
+/// * `nrows`  — (I) number of rows in each plane of array
+/// * `naxis1` — (I) FITS image NAXIS1 value
+/// * `naxis2` — (I) FITS image NAXIS2 value
+/// * `naxis3` — (I) FITS image NAXIS3 value
+/// * `array`  — (O) array to be filled and returned
+/// * `anynul` — (O) set to 1 if any values are null; else 0
+/// * `status` — (IO) error status
 pub fn ffg3duk_safe(
-    fptr: &mut fitsfile,            /* I - FITS file pointer                       */
-    group: c_long,                  /* I - group to read (1 = 1st group)           */
-    nulval: c_uint,                 /* set undefined pixels equal to this     */
-    ncols: LONGLONG,                /* I - number of pixels in each row of array   */
-    nrows: LONGLONG,                /* I - number of rows in each plane of array   */
-    naxis1: LONGLONG,               /* I - FITS image NAXIS1 value                 */
-    naxis2: LONGLONG,               /* I - FITS image NAXIS2 value                 */
-    naxis3: LONGLONG,               /* I - FITS image NAXIS3 value                 */
-    array: &mut [c_uint],           /* O - array to be filled and returned    */
-    mut anynul: Option<&mut c_int>, /* O - set to 1 if any values are null; else 0 */
-    status: &mut c_int,             /* IO - error status                           */
+    fptr: &mut fitsfile,
+    group: c_long,
+    nulval: c_uint,
+    ncols: LONGLONG,
+    nrows: LONGLONG,
+    naxis1: LONGLONG,
+    naxis2: LONGLONG,
+    naxis3: LONGLONG,
+    array: &mut [c_uint],
+    mut anynul: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     let mut narray = 0;
     let mut nfits: LONGLONG = 0;
@@ -440,22 +533,35 @@ pub fn ffg3duk_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read a subsection of data values from an image or a table column.
 /// This routine is set up to handle a maximum of nine dimensions.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `colnum` — (I) number of the column to read (1 = 1st)
+/// * `naxis`  — (I) number of dimensions in the FITS array
+/// * `naxes`  — (I) size of each dimension
+/// * `blc`    — (I) 'bottom left corner' of the subsection
+/// * `trc`    — (I) 'top right corner' of the subsection
+/// * `inc`    — (I) increment to be applied in each dimension
+/// * `nulval` — (I) value to set undefined pixels
+/// * `array`  — (O) array to be filled and returned
+/// * `anynul` — (O) set to 1 if any values are null; else 0
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgsvuk(
-    fptr: *mut fitsfile,  /* I - FITS file pointer                         */
-    colnum: c_int,        /* I - number of the column to read (1 = 1st)    */
-    naxis: c_int,         /* I - number of dimensions in the FITS array    */
-    naxes: *const c_long, /* I - size of each dimension                    */
-    blc: *const c_long,   /* I - 'bottom left corner' of the subsection    */
-    trc: *const c_long,   /* I - 'top right corner' of the subsection      */
-    inc: *const c_long,   /* I - increment to be applied in each dimension */
-    nulval: c_uint,       /* I - value to set undefined pixels       */
-    array: *mut c_uint,   /* O - array to be filled and returned     */
-    anynul: *mut c_int,   /* O - set to 1 if any values are null; else 0   */
-    status: *mut c_int,   /* IO - error status                             */
+    fptr: *mut fitsfile,
+    colnum: c_int,
+    naxis: c_int,
+    naxes: *const c_long,
+    blc: *const c_long,
+    trc: *const c_long,
+    inc: *const c_long,
+    nulval: c_uint,
+    array: *mut c_uint,
+    anynul: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -478,21 +584,34 @@ pub unsafe extern "C" fn ffgsvuk(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read a subsection of data values from an image or a table column.
 /// This routine is set up to handle a maximum of nine dimensions.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `colnum` — (I) number of the column to read (1 = 1st)
+/// * `naxis`  — (I) number of dimensions in the FITS array
+/// * `naxes`  — (I) size of each dimension
+/// * `blc`    — (I) 'bottom left corner' of the subsection
+/// * `trc`    — (I) 'top right corner' of the subsection
+/// * `inc`    — (I) increment to be applied in each dimension
+/// * `nulval` — (I) value to set undefined pixels
+/// * `array`  — (O) array to be filled and returned
+/// * `anynul` — (O) set to 1 if any values are null; else 0
+/// * `status` — (IO) error status
 pub fn ffgsvuk_safe(
-    fptr: &mut fitsfile,  /* I - FITS file pointer                         */
-    colnum: c_int,        /* I - number of the column to read (1 = 1st)    */
-    naxis: c_int,         /* I - number of dimensions in the FITS array    */
-    naxes: &[c_long],     /* I - size of each dimension                    */
-    blc: &[c_long],       /* I - 'bottom left corner' of the subsection    */
-    trc: &[c_long],       /* I - 'top right corner' of the subsection      */
-    inc: &[c_long],       /* I - increment to be applied in each dimension */
-    nulval: c_uint,       /* I - value to set undefined pixels       */
-    array: &mut [c_uint], /* O - array to be filled and returned     */
-    mut anynul: Option<&mut c_int>, /* O - set to 1 if any values are null; else 0   */
-    status: &mut c_int,   /* IO - error status                             */
+    fptr: &mut fitsfile,
+    colnum: c_int,
+    naxis: c_int,
+    naxes: &[c_long],
+    blc: &[c_long],
+    trc: &[c_long],
+    inc: &[c_long],
+    nulval: c_uint,
+    array: &mut [c_uint],
+    mut anynul: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     let mut rstr: c_long = 0;
     let mut rstp: c_long = 0;
@@ -684,22 +803,35 @@ pub fn ffgsvuk_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read a subsection of data values from an image or a table column.
 /// This routine is set up to handle a maximum of nine dimensions.
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `colnum`  — (I) number of the column to read (1 = 1st)
+/// * `naxis`   — (I) number of dimensions in the FITS array
+/// * `naxes`   — (I) size of each dimension
+/// * `blc`     — (I) 'bottom left corner' of the subsection
+/// * `trc`     — (I) 'top right corner' of the subsection
+/// * `inc`     — (I) increment to be applied in each dimension
+/// * `array`   — (O) array to be filled and returned
+/// * `flagval` — (O) set to 1 if corresponding value is null
+/// * `anynul`  — (O) set to 1 if any values are null; else 0
+/// * `status`  — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgsfuk(
-    fptr: *mut fitsfile,  /* I - FITS file pointer                         */
-    colnum: c_int,        /* I - number of the column to read (1 = 1st)    */
-    naxis: c_int,         /* I - number of dimensions in the FITS array    */
-    naxes: *const c_long, /* I - size of each dimension                    */
-    blc: *const c_long,   /* I - 'bottom left corner' of the subsection    */
-    trc: *const c_long,   /* I - 'top right corner' of the subsection      */
-    inc: *const c_long,   /* I - increment to be applied in each dimension */
-    array: *mut c_uint,   /* O - array to be filled and returned     */
-    flagval: *mut c_char, /* O - set to 1 if corresponding value is null   */
-    anynul: *mut c_int,   /* O - set to 1 if any values are null; else 0   */
-    status: *mut c_int,   /* IO - error status                             */
+    fptr: *mut fitsfile,
+    colnum: c_int,
+    naxis: c_int,
+    naxes: *const c_long,
+    blc: *const c_long,
+    trc: *const c_long,
+    inc: *const c_long,
+    array: *mut c_uint,
+    flagval: *mut c_char,
+    anynul: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -724,21 +856,34 @@ pub unsafe extern "C" fn ffgsfuk(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read a subsection of data values from an image or a table column.
 /// This routine is set up to handle a maximum of nine dimensions.
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `colnum`  — (I) number of the column to read (1 = 1st)
+/// * `naxis`   — (I) number of dimensions in the FITS array
+/// * `naxes`   — (I) size of each dimension
+/// * `blc`     — (I) 'bottom left corner' of the subsection
+/// * `trc`     — (I) 'top right corner' of the subsection
+/// * `inc`     — (I) increment to be applied in each dimension
+/// * `array`   — (O) array to be filled and returned
+/// * `flagval` — (O) set to 1 if corresponding value is null
+/// * `anynul`  — (O) set to 1 if any values are null; else 0
+/// * `status`  — (IO) error status
 pub fn ffgsfuk_safe(
-    fptr: &mut fitsfile,    /* I - FITS file pointer                         */
-    colnum: c_int,          /* I - number of the column to read (1 = 1st)    */
-    naxis: c_int,           /* I - number of dimensions in the FITS array    */
-    naxes: &[c_long],       /* I - size of each dimension                    */
-    blc: &[c_long],         /* I - 'bottom left corner' of the subsection    */
-    trc: &[c_long],         /* I - 'top right corner' of the subsection      */
-    inc: &[c_long],         /* I - increment to be applied in each dimension */
-    array: &mut [c_uint],   /* O - array to be filled and returned           */
-    flagval: &mut [c_char], /* O - set to 1 if corresponding value is null   */
-    mut anynul: Option<&mut c_int>, /* O - set to 1 if any values are null; else 0   */
-    status: &mut c_int,     /* IO - error status                             */
+    fptr: &mut fitsfile,
+    colnum: c_int,
+    naxis: c_int,
+    naxes: &[c_long],
+    blc: &[c_long],
+    trc: &[c_long],
+    inc: &[c_long],
+    array: &mut [c_uint],
+    flagval: &mut [c_char],
+    mut anynul: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     let mut rstr: c_long = 0;
     let mut rstp: c_long = 0;
@@ -925,7 +1070,6 @@ pub fn ffgsfuk_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 ///Read an array of group parameters from the primary array. Data conversion
 ///and scaling will be performed if necessary (e.g, if the datatype of
 ///the FITS array is not the same as the array being read).
@@ -934,14 +1078,23 @@ pub fn ffgsfuk_safe(
 ///each group of the primary array is a row in the table,
 ///where the first column contains the group parameters
 ///and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to read (1 = 1st group)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `array`     — (O) array of values that are returned
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffggpuk(
-    fptr: *mut fitsfile, /* I - FITS file pointer                       */
-    group: c_long,       /* I - group to read (1 = 1st group)           */
-    firstelem: c_long,   /* I - first vector element to read (1 = 1st)  */
-    nelem: c_long,       /* I - number of values to read                */
-    array: *mut c_uint,  /* O - array of values that are returned   */
-    status: *mut c_int,  /* IO - error status                           */
+    fptr: *mut fitsfile,
+    group: c_long,
+    firstelem: c_long,
+    nelem: c_long,
+    array: *mut c_uint,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -953,7 +1106,6 @@ pub unsafe extern "C" fn ffggpuk(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 ///Read an array of group parameters from the primary array. Data conversion
 ///and scaling will be performed if necessary (e.g, if the datatype of
 ///the FITS array is not the same as the array being read).
@@ -962,13 +1114,22 @@ pub unsafe extern "C" fn ffggpuk(
 ///each group of the primary array is a row in the table,
 ///where the first column contains the group parameters
 ///and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to read (1 = 1st group)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `array`     — (O) array of values that are returned
+/// * `status`    — (IO) error status
 pub fn ffggpuk_safe(
-    fptr: &mut fitsfile,  /* I - FITS file pointer                       */
-    group: c_long,        /* I - group to read (1 = 1st group)           */
-    firstelem: c_long,    /* I - first vector element to read (1 = 1st)  */
-    nelem: c_long,        /* I - number of values to read                */
-    array: &mut [c_uint], /* O - array of values that are returned       */
-    status: &mut c_int,   /* IO - error status                           */
+    fptr: &mut fitsfile,
+    group: c_long,
+    firstelem: c_long,
+    nelem: c_long,
+    array: &mut [c_uint],
+    status: &mut c_int,
 ) -> c_int {
     let cdummy = 0;
     let mut anynul = 0;
@@ -992,24 +1153,35 @@ pub fn ffggpuk_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of values from a column in the current FITS HDU. Automatic
 /// datatype conversion will be performed if the datatype of the column does not
 /// match the datatype of the array parameter. The output values will be scaled
 /// by the FITS TSCALn and TZEROn values if these values have been defined.
 /// Any undefined pixels will be set equal to the value of 'nulval' unless
 /// nulval = 0 in which case no checks for undefined pixels will be made.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to read (1 = 1st col)
+/// * `firstrow`  — (I) first row to read (1 = 1st row)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `nulval`    — (I) value for null pixels
+/// * `array`     — (O) array of values that are read
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgcvuk(
-    fptr: *mut fitsfile, /* I - FITS file pointer                       */
-    colnum: c_int,       /* I - number of column to read (1 = 1st col)  */
-    firstrow: LONGLONG,  /* I - first row to read (1 = 1st row)         */
-    firstelem: LONGLONG, /* I - first vector element to read (1 = 1st)  */
-    nelem: LONGLONG,     /* I - number of values to read                */
-    nulval: c_uint,      /* I - value for null pixels               */
-    array: *mut c_uint,  /* O - array of values that are read       */
-    anynul: *mut c_int,  /* O - set to 1 if any values are null; else 0 */
-    status: *mut c_int,  /* IO - error status                           */
+    fptr: *mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    nulval: c_uint,
+    array: *mut c_uint,
+    anynul: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -1026,23 +1198,34 @@ pub unsafe extern "C" fn ffgcvuk(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of values from a column in the current FITS HDU. Automatic
 /// datatype conversion will be performed if the datatype of the column does not
 /// match the datatype of the array parameter. The output values will be scaled
 /// by the FITS TSCALn and TZEROn values if these values have been defined.
 /// Any undefined pixels will be set equal to the value of 'nulval' unless
 /// nulval = 0 in which case no checks for undefined pixels will be made.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to read (1 = 1st col)
+/// * `firstrow`  — (I) first row to read (1 = 1st row)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `nulval`    — (I) value for null pixels
+/// * `array`     — (O) array of values that are read
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `status`    — (IO) error status
 pub fn ffgcvuk_safe(
-    fptr: &mut fitsfile,        /* I - FITS file pointer                       */
-    colnum: c_int,              /* I - number of column to read (1 = 1st col)  */
-    firstrow: LONGLONG,         /* I - first row to read (1 = 1st row)         */
-    firstelem: LONGLONG,        /* I - first vector element to read (1 = 1st)  */
-    nelem: LONGLONG,            /* I - number of values to read                */
-    nulval: c_uint,             /* I - value for null pixels                   */
-    array: &mut [c_uint],       /* O - array of values that are read           */
-    anynul: Option<&mut c_int>, /* O - set to 1 if any values are null; else 0 */
-    status: &mut c_int,         /* IO - error status                           */
+    fptr: &mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    nulval: c_uint,
+    array: &mut [c_uint],
+    anynul: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     let mut dummy_nularray = vec![0; nelem as usize];
 
@@ -1062,24 +1245,35 @@ pub fn ffgcvuk_safe(
     )
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of values from a column in the current FITS HDU. Automatic
 /// datatype conversion will be performed if the datatype of the column does not
 /// match the datatype of the array parameter. The output values will be scaled
 /// by the FITS TSCALn and TZEROn values if these values have been defined.
 /// Nularray will be set = 1 if the corresponding array pixel is undefined,
 /// otherwise nularray will = 0.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to read (1 = 1st col)
+/// * `firstrow`  — (I) first row to read (1 = 1st row)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `array`     — (O) array of values that are read
+/// * `nularray`  — (O) array of flags: 1 if null pixel; else 0
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgcfuk(
-    fptr: *mut fitsfile,   /* I - FITS file pointer                       */
-    colnum: c_int,         /* I - number of column to read (1 = 1st col)  */
-    firstrow: LONGLONG,    /* I - first row to read (1 = 1st row)         */
-    firstelem: LONGLONG,   /* I - first vector element to read (1 = 1st)  */
-    nelem: LONGLONG,       /* I - number of values to read                */
-    array: *mut c_uint,    /* O - array of values that are read       */
-    nularray: *mut c_char, /* O - array of flags: 1 if null pixel; else 0 */
-    anynul: *mut c_int,    /* O - set to 1 if any values are null; else 0 */
-    status: *mut c_int,    /* IO - error status                           */
+    fptr: *mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: *mut c_uint,
+    nularray: *mut c_char,
+    anynul: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -1098,23 +1292,34 @@ pub unsafe extern "C" fn ffgcfuk(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of values from a column in the current FITS HDU. Automatic
 /// datatype conversion will be performed if the datatype of the column does not
 /// match the datatype of the array parameter. The output values will be scaled
 /// by the FITS TSCALn and TZEROn values if these values have been defined.
 /// Nularray will be set = 1 if the corresponding array pixel is undefined,
 /// otherwise nularray will = 0.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to read (1 = 1st col)
+/// * `firstrow`  — (I) first row to read (1 = 1st row)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `array`     — (O) array of values that are read
+/// * `nularray`  — (O) array of flags: 1 if null pixel; else 0
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `status`    — (IO) error status
 pub fn ffgcfuk_safe(
-    fptr: &mut fitsfile,        /* I - FITS file pointer                       */
-    colnum: c_int,              /* I - number of column to read (1 = 1st col)  */
-    firstrow: LONGLONG,         /* I - first row to read (1 = 1st row)         */
-    firstelem: LONGLONG,        /* I - first vector element to read (1 = 1st)  */
-    nelem: LONGLONG,            /* I - number of values to read                */
-    array: &mut [c_uint],       /* O - array of values that are read           */
-    nularray: &mut [c_char],    /* O - array of flags: 1 if null pixel; else 0 */
-    anynul: Option<&mut c_int>, /* O - set to 1 if any values are null; else 0 */
-    status: &mut c_int,         /* IO - error status                           */
+    fptr: &mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: &mut [c_uint],
+    nularray: &mut [c_char],
+    anynul: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     let dummy: c_uint = 0;
 
@@ -1134,7 +1339,6 @@ pub fn ffgcfuk_safe(
     )
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read an array of values from a column in the current FITS HDU.
 /// The column number may refer to a real column in an ASCII or binary table,
 /// or it may refer be a virtual column in a 1 or more grouped FITS primary
@@ -1148,21 +1352,35 @@ pub fn ffgcfuk_safe(
 /// and will be scaled by the FITS TSCALn and TZEROn values if necessary.
 #[allow(clippy::if_same_then_else)]
 // C dispatch chain: distinct conditions deliberately share an action.
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to read (1 = 1st col)
+/// * `firstrow`  — (I) first row to read (1 = 1st row)
+/// * `firstelem` — (I) first vector element to read (1 = 1st)
+/// * `nelem`     — (I) number of values to read
+/// * `elemincre` — (I) pixel increment; e.g., 2 = every other
+/// * `nultyp`    — (I) null value handling code:
+/// * `nulval`    — (I) value for null pixels if nultyp = 1
+/// * `array`     — (O) array of values that are read
+/// * `nularray`  — (O) array of flags = 1 if nultyp = 2
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `status`    — (IO) error status
 pub(crate) fn ffgcluk(
-    fptr: &mut fitsfile,   /* I - FITS file pointer                       */
-    colnum: c_int,         /* I - number of column to read (1 = 1st col)  */
-    firstrow: LONGLONG,    /* I - first row to read (1 = 1st row)         */
-    firstelem: LONGLONG,   /* I - first vector element to read (1 = 1st)  */
-    nelem: LONGLONG,       /* I - number of values to read                */
-    elemincre: c_long,     /* I - pixel increment; e.g., 2 = every other  */
-    nultyp: NullCheckType, /* I - null value handling code:               */
+    fptr: &mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    elemincre: c_long,
+    nultyp: NullCheckType,
     /*     1: set undefined pixels = nulval        */
     /*     2: set nularray=1 for undefined pixels  */
-    nulval: c_uint,                 /* I - value for null pixels if nultyp = 1 */
-    array: &mut [c_uint],           /* O - array of values that are read       */
-    nularray: &mut [c_char],        /* O - array of flags = 1 if nultyp = 2        */
-    mut anynul: Option<&mut c_int>, /* O - set to 1 if any values are null; else 0 */
-    status: &mut c_int,             /* IO - error status                           */
+    nulval: c_uint,
+    array: &mut [c_uint],
+    nularray: &mut [c_char],
+    mut anynul: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     let mut scale: f64 = 0.0;
     let mut zero: f64 = 0.0;
@@ -1249,9 +1467,7 @@ pub(crate) fn ffgcluk(
             nularray.fill(0); /* initialize nullarray */
         }
 
-        /*---------------------------------------------------*/
         /*  Check input and get parameters about the column: */
-        /*---------------------------------------------------*/
 
         if ffgcprll(
             fptr,
@@ -1299,9 +1515,7 @@ pub(crate) fn ffgcluk(
                 power *= 10.0;
             }
         }
-        /*------------------------------------------------------------------*/
         /*  Decide whether to check for null values in the input FITS file: */
-        /*------------------------------------------------------------------*/
         nulcheck = nultyp; /* by default, check for null values in the FITS file */
 
         if nultyp == NullCheckType::SetPixel && nulval == 0 {
@@ -1321,10 +1535,8 @@ pub(crate) fn ffgcluk(
             nulcheck = NullCheckType::None;
         }
 
-        /*----------------------------------------------------------------------*/
         /*  If FITS column and output data array have same datatype, then we do */
         /*  not need to use a temporary buffer to store intermediate datatype.  */
-        /*----------------------------------------------------------------------*/
 
         if tcode == TLONG {
             /* Special Case:                        */
@@ -1338,7 +1550,6 @@ pub(crate) fn ffgcluk(
             }
         }
 
-        /*---------------------------------------------------------------------*/
         /*  Now read the pixels from the FITS column. If the column does not   */
         /*  have the same datatype as the output array, then we have to read   */
         /*  the raw values into a temporary buffer (of limited size).  In      */
@@ -1348,7 +1559,6 @@ pub(crate) fn ffgcluk(
         /*  test for undefined values, (2) convert the datatype if necessary,  */
         /*  and (3) scale the values by the FITS TSCALn and TZEROn linear      */
         /*  scaling parameters.                                                */
-        /*---------------------------------------------------------------------*/
 
         remain = nelem; /* remaining number of values to read */
         next = 0; /* next element in array to be read   */
@@ -1567,9 +1777,7 @@ pub(crate) fn ffgcluk(
                 }
             } /* End of switch block */
 
-            /*-------------------------*/
             /*  Check for fatal error  */
-            /*-------------------------*/
             if *status > 0 {
                 /* test for error during previous read operation */
                 dtemp = next as f64;
@@ -1596,9 +1804,7 @@ pub(crate) fn ffgcluk(
                 return *status;
             }
 
-            /*--------------------------------------------*/
             /*  increment the counters for the next loop  */
-            /*--------------------------------------------*/
             remain -= ntodo as LONGLONG;
             if remain != 0 {
                 next += ntodo as usize;
@@ -1613,9 +1819,7 @@ pub(crate) fn ffgcluk(
             }
         } /*  End of main while Loop  */
 
-        /*--------------------------------*/
         /*  check for numerical overflow  */
-        /*--------------------------------*/
         if *status == OVERFLOW_ERR {
             ffpmsg_str("Numerical overflow during type conversion while reading FITS data.");
             *status = NUM_OVERFLOW;
@@ -1625,7 +1829,6 @@ pub(crate) fn ffgcluk(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output following reading of the input from a FITS file.
 /// Check for null values and do datatype conversion and scaling if required.
 /// The nullcheck code value determines how any null values in the input array
@@ -1637,20 +1840,34 @@ pub(crate) fn ffgcluk(
 /// nullarray will be set to 1; the value of nullarray for non-null pixels
 /// will = 0.  The anynull parameter will be set = 1 if any of the returned
 /// pixels are null, otherwise anynull will be returned with a value = 0;
+///
+/// # Parameters
+///
+/// * `input`     — (I) array of values to be converted
+/// * `ntodo`     — (I) number of elements in the array
+/// * `scale`     — (I) FITS TSCALn or BSCALE value
+/// * `zero`      — (I) FITS TZEROn or BZERO value
+/// * `nullcheck` — (I) null checking code; 0 = don't check
+/// * `tnull`     — (I) value of FITS TNULLn keyword if any
+/// * `nullval`   — (I) set null pixels, if nullcheck = 1
+/// * `nullarray` — (O) bad pixel array, if nullcheck = 2
+/// * `anynull`   — (O) set to 1 if any pixels are null
+/// * `output`    — (O) array of converted pixels
+/// * `status`    — (IO) error status
 pub(crate) fn fffi1uint(
-    input: &[u8],             /* I - array of values to be converted     */
-    ntodo: c_long,            /* I - number of elements in the array     */
-    scale: f64,               /* I - FITS TSCALn or BSCALE value         */
-    zero: f64,                /* I - FITS TZEROn or BZERO  value         */
-    nullcheck: NullCheckType, /* I - null checking code; 0 = don't check */
+    input: &[u8],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    nullcheck: NullCheckType,
     /*     1:set null pixels = nullval         */
     /*     2: if null pixel, set nullarray = 1 */
-    tnull: u8,                   /* I - value of FITS TNULLn keyword if any */
-    nullval: c_uint,             /* I - set null pixels, if nullcheck = 1   */
-    nullarray: &mut [c_char],    /* O - bad pixel array, if nullcheck = 2   */
-    anynull: Option<&mut c_int>, /* O - set to 1 if any pixels are null     */
-    output: &mut [c_uint],       /* O - array of converted pixels           */
-    status: &mut c_int,          /* IO - error status                       */
+    tnull: u8,
+    nullval: c_uint,
+    nullarray: &mut [c_char],
+    anynull: Option<&mut c_int>,
+    output: &mut [c_uint],
+    status: &mut c_int,
 ) -> c_int {
     let mut dvalue: f64 = 0.0;
 
@@ -1724,7 +1941,6 @@ pub(crate) fn fffi1uint(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output following reading of the input from a FITS file.
 /// Check for null values and do datatype conversion and scaling if required.
 /// The nullcheck code value determines how any null values in the input array
@@ -1736,20 +1952,34 @@ pub(crate) fn fffi1uint(
 /// nullarray will be set to 1; the value of nullarray for non-null pixels
 /// will = 0.  The anynull parameter will be set = 1 if any of the returned
 /// pixels are null, otherwise anynull will be returned with a value = 0;
+///
+/// # Parameters
+///
+/// * `input`     — (I) array of values to be converted
+/// * `ntodo`     — (I) number of elements in the array
+/// * `scale`     — (I) FITS TSCALn or BSCALE value
+/// * `zero`      — (I) FITS TZEROn or BZERO value
+/// * `nullcheck` — (I) null checking code; 0 = don't check
+/// * `tnull`     — (I) value of FITS TNULLn keyword if any
+/// * `nullval`   — (I) set null pixels, if nullcheck = 1
+/// * `nullarray` — (O) bad pixel array, if nullcheck = 2
+/// * `anynull`   — (O) set to 1 if any pixels are null
+/// * `output`    — (O) array of converted pixels
+/// * `status`    — (IO) error status
 pub(crate) fn fffi2uint(
-    input: &[c_short],        /* I - array of values to be converted     */
-    ntodo: c_long,            /* I - number of elements in the array     */
-    scale: f64,               /* I - FITS TSCALn or BSCALE value         */
-    zero: f64,                /* I - FITS TZEROn or BZERO  value         */
-    nullcheck: NullCheckType, /* I - null checking code; 0 = don't check */
+    input: &[c_short],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    nullcheck: NullCheckType,
     /*     1:set null pixels = nullval         */
     /*     2: if null pixel, set nullarray = 1 */
-    tnull: c_short,              /* I - value of FITS TNULLn keyword if any */
-    nullval: c_uint,             /* I - set null pixels, if nullcheck = 1   */
-    nullarray: &mut [c_char],    /* O - bad pixel array, if nullcheck = 2   */
-    anynull: Option<&mut c_int>, /* O - set to 1 if any pixels are null     */
-    output: &mut [c_uint],       /* O - array of converted pixels           */
-    status: &mut c_int,          /* IO - error status                       */
+    tnull: c_short,
+    nullval: c_uint,
+    nullarray: &mut [c_char],
+    anynull: Option<&mut c_int>,
+    output: &mut [c_uint],
+    status: &mut c_int,
 ) -> c_int {
     let mut dvalue: f64 = 0.0;
 
@@ -1833,7 +2063,6 @@ pub(crate) fn fffi2uint(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output following reading of the input from a FITS file.
 /// Check for null values and do datatype conversion and scaling if required.
 /// The nullcheck code value determines how any null values in the input array
@@ -1845,20 +2074,34 @@ pub(crate) fn fffi2uint(
 /// nullarray will be set to 1; the value of nullarray for non-null pixels
 /// will = 0.  The anynull parameter will be set = 1 if any of the returned
 /// pixels are null, otherwise anynull will be returned with a value = 0;
+///
+/// # Parameters
+///
+/// * `input`     — (I) array of values to be converted
+/// * `ntodo`     — (I) number of elements in the array
+/// * `scale`     — (I) FITS TSCALn or BSCALE value
+/// * `zero`      — (I) FITS TZEROn or BZERO value
+/// * `nullcheck` — (I) null checking code; 0 = don't check
+/// * `tnull`     — (I) value of FITS TNULLn keyword if any
+/// * `nullval`   — (I) set null pixels, if nullcheck = 1
+/// * `nullarray` — (O) bad pixel array, if nullcheck = 2
+/// * `anynull`   — (O) set to 1 if any pixels are null
+/// * `output`    — (O) array of converted pixels
+/// * `status`    — (IO) error status
 pub(crate) fn fffi4uint(
-    input: &[INT32BIT],       /* I - array of values to be converted     */
-    ntodo: c_long,            /* I - number of elements in the array     */
-    scale: f64,               /* I - FITS TSCALn or BSCALE value         */
-    zero: f64,                /* I - FITS TZEROn or BZERO  value         */
-    nullcheck: NullCheckType, /* I - null checking code; 0 = don't check */
+    input: &[INT32BIT],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    nullcheck: NullCheckType,
     /*     1:set null pixels = nullval         */
     /*     2: if null pixel, set nullarray = 1 */
-    tnull: INT32BIT,             /* I - value of FITS TNULLn keyword if any */
-    nullval: c_uint,             /* I - set null pixels, if nullcheck = 1   */
-    nullarray: &mut [c_char],    /* O - bad pixel array, if nullcheck = 2   */
-    anynull: Option<&mut c_int>, /* O - set to 1 if any pixels are null     */
-    output: &mut [c_uint],       /* O - array of converted pixels           */
-    status: &mut c_int,          /* IO - error status                       */
+    tnull: INT32BIT,
+    nullval: c_uint,
+    nullarray: &mut [c_char],
+    anynull: Option<&mut c_int>,
+    output: &mut [c_uint],
+    status: &mut c_int,
 ) -> c_int {
     let mut dvalue: f64 = 0.0;
 
@@ -1960,7 +2203,6 @@ pub(crate) fn fffi4uint(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output following reading of the input from a FITS file.
 /// Check for null values and do datatype conversion and scaling if required.
 /// The nullcheck code value determines how any null values in the input array
@@ -1972,20 +2214,34 @@ pub(crate) fn fffi4uint(
 /// nullarray will be set to 1; the value of nullarray for non-null pixels
 /// will = 0.  The anynull parameter will be set = 1 if any of the returned
 /// pixels are null, otherwise anynull will be returned with a value = 0;
+///
+/// # Parameters
+///
+/// * `input`     — (I) array of values to be converted
+/// * `ntodo`     — (I) number of elements in the array
+/// * `scale`     — (I) FITS TSCALn or BSCALE value
+/// * `zero`      — (I) FITS TZEROn or BZERO value
+/// * `nullcheck` — (I) null checking code; 0 = don't check
+/// * `tnull`     — (I) value of FITS TNULLn keyword if any
+/// * `nullval`   — (I) set null pixels, if nullcheck = 1
+/// * `nullarray` — (O) bad pixel array, if nullcheck = 2
+/// * `anynull`   — (O) set to 1 if any pixels are null
+/// * `output`    — (O) array of converted pixels
+/// * `status`    — (IO) error status
 pub(crate) fn fffi8uint(
-    input: &[LONGLONG],       /* I - array of values to be converted     */
-    ntodo: c_long,            /* I - number of elements in the array     */
-    scale: f64,               /* I - FITS TSCALn or BSCALE value         */
-    zero: f64,                /* I - FITS TZEROn or BZERO  value         */
-    nullcheck: NullCheckType, /* I - null checking code; 0 = don't check */
+    input: &[LONGLONG],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    nullcheck: NullCheckType,
     /*     1:set null pixels = nullval         */
     /*     2: if null pixel, set nullarray = 1 */
-    tnull: LONGLONG,             /* I - value of FITS TNULLn keyword if any */
-    nullval: c_uint,             /* I - set null pixels, if nullcheck = 1   */
-    nullarray: &mut [c_char],    /* O - bad pixel array, if nullcheck = 2   */
-    anynull: Option<&mut c_int>, /* O - set to 1 if any pixels are null     */
-    output: &mut [c_uint],       /* O - array of converted pixels           */
-    status: &mut c_int,          /* IO - error status                       */
+    tnull: LONGLONG,
+    nullval: c_uint,
+    nullarray: &mut [c_char],
+    anynull: Option<&mut c_int>,
+    output: &mut [c_uint],
+    status: &mut c_int,
 ) -> c_int {
     let mut dvalue: f64 = 0.0;
     let mut ulltemp: ULONGLONG = 0;
@@ -2116,7 +2372,6 @@ pub(crate) fn fffi8uint(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output following reading of the input from a FITS file.
 /// Check for null values and do datatype conversion and scaling if required.
 /// The nullcheck code value determines how any null values in the input array
@@ -2128,19 +2383,32 @@ pub(crate) fn fffi8uint(
 /// nullarray will be set to 1; the value of nullarray for non-null pixels
 /// will = 0.  The anynull parameter will be set = 1 if any of the returned
 /// pixels are null, otherwise anynull will be returned with a value = 0;
+///
+/// # Parameters
+///
+/// * `input`     — (I) array of values to be converted
+/// * `ntodo`     — (I) number of elements in the array
+/// * `scale`     — (I) FITS TSCALn or BSCALE value
+/// * `zero`      — (I) FITS TZEROn or BZERO value
+/// * `nullcheck` — (I) null checking code; 0 = don't check
+/// * `nullval`   — (I) set null pixels, if nullcheck = 1
+/// * `nullarray` — (O) bad pixel array, if nullcheck = 2
+/// * `anynull`   — (O) set to 1 if any pixels are null
+/// * `output`    — (O) array of converted pixels
+/// * `status`    — (IO) error status
 pub(crate) fn fffr4uint(
-    input: &[f32],            /* I - array of values to be converted     */
-    ntodo: c_long,            /* I - number of elements in the array     */
-    scale: f64,               /* I - FITS TSCALn or BSCALE value         */
-    zero: f64,                /* I - FITS TZEROn or BZERO  value         */
-    nullcheck: NullCheckType, /* I - null checking code; 0 = don't check */
+    input: &[f32],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    nullcheck: NullCheckType,
     /*     1:set null pixels = nullval         */
     /*     2: if null pixel, set nullarray = 1 */
-    nullval: c_uint,             /* I - set null pixels, if nullcheck = 1   */
-    nullarray: &mut [c_char],    /* O - bad pixel array, if nullcheck = 2   */
-    anynull: Option<&mut c_int>, /* O - set to 1 if any pixels are null     */
-    output: &mut [c_uint],       /* O - array of converted pixels           */
-    status: &mut c_int,          /* IO - error status                       */
+    nullval: c_uint,
+    nullarray: &mut [c_char],
+    anynull: Option<&mut c_int>,
+    output: &mut [c_uint],
+    status: &mut c_int,
 ) -> c_int {
     let mut dvalue: f64 = 0.0;
     let mut sptr = 0;
@@ -2263,7 +2531,6 @@ pub(crate) fn fffr4uint(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output following reading of the input from a FITS file.
 /// Check for null values and do datatype conversion and scaling if required.
 /// The nullcheck code value determines how any null values in the input array
@@ -2275,19 +2542,32 @@ pub(crate) fn fffr4uint(
 /// nullarray will be set to 1; the value of nullarray for non-null pixels
 /// will = 0.  The anynull parameter will be set = 1 if any of the returned
 /// pixels are null, otherwise anynull will be returned with a value = 0;
+///
+/// # Parameters
+///
+/// * `input`     — (I) array of values to be converted
+/// * `ntodo`     — (I) number of elements in the array
+/// * `scale`     — (I) FITS TSCALn or BSCALE value
+/// * `zero`      — (I) FITS TZEROn or BZERO value
+/// * `nullcheck` — (I) null checking code; 0 = don't check
+/// * `nullval`   — (I) set null pixels, if nullcheck = 1
+/// * `nullarray` — (O) bad pixel array, if nullcheck = 2
+/// * `anynull`   — (O) set to 1 if any pixels are null
+/// * `output`    — (O) array of converted pixels
+/// * `status`    — (IO) error status
 pub(crate) fn fffr8uint(
-    input: &[f64],            /* I - array of values to be converted     */
-    ntodo: c_long,            /* I - number of elements in the array     */
-    scale: f64,               /* I - FITS TSCALn or BSCALE value         */
-    zero: f64,                /* I - FITS TZEROn or BZERO  value         */
-    nullcheck: NullCheckType, /* I - null checking code; 0 = don't check */
+    input: &[f64],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    nullcheck: NullCheckType,
     /*     1:set null pixels = nullval         */
     /*     2: if null pixel, set nullarray = 1 */
-    nullval: c_uint,             /* I - set null pixels, if nullcheck = 1   */
-    nullarray: &mut [c_char],    /* O - bad pixel array, if nullcheck = 2   */
-    anynull: Option<&mut c_int>, /* O - set to 1 if any pixels are null     */
-    output: &mut [c_uint],       /* O - array of converted pixels           */
-    status: &mut c_int,          /* IO - error status                       */
+    nullval: c_uint,
+    nullarray: &mut [c_char],
+    anynull: Option<&mut c_int>,
+    output: &mut [c_uint],
+    status: &mut c_int,
 ) -> c_int {
     let mut dvalue: f64 = 0.0;
     let mut sptr = 0;
@@ -2409,7 +2689,6 @@ pub(crate) fn fffr8uint(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output following reading of the input from a FITS file. Check
 /// for null values and do scaling if required. The nullcheck code value
 /// determines how any null values in the input array are treated. A null
@@ -2420,22 +2699,38 @@ pub(crate) fn fffr8uint(
 /// nullarray will be set to 1; the value of nullarray for non-null pixels
 /// will = 0.  The anynull parameter will be set = 1 if any of the returned
 /// pixels are null, otherwise anynull will be returned with a value = 0;
+///
+/// # Parameters
+///
+/// * `input`      — (I) array of values to be converted
+/// * `ntodo`      — (I) number of elements in the array
+/// * `scale`      — (I) FITS TSCALn or BSCALE value
+/// * `zero`       — (I) FITS TZEROn or BZERO value
+/// * `twidth`     — (I) width of each substring of chars
+/// * `implipower` — (I) power of 10 of implied decimal
+/// * `nullcheck`  — (I) null checking code; 0 = don't check
+/// * `snull`      — (I) value of FITS null string, if any
+/// * `nullval`    — (I) set null pixels, if nullcheck = 1
+/// * `nullarray`  — (O) bad pixel array, if nullcheck = 2
+/// * `anynull`    — (O) set to 1 if any pixels are null
+/// * `output`     — (O) array of converted pixels
+/// * `status`     — (IO) error status
 pub(crate) fn fffstruint(
-    input: &mut [c_char],     /* I - array of values to be converted     */
-    ntodo: c_long,            /* I - number of elements in the array     */
-    scale: f64,               /* I - FITS TSCALn or BSCALE value         */
-    zero: f64,                /* I - FITS TZEROn or BZERO  value         */
-    twidth: c_long,           /* I - width of each substring of chars    */
-    implipower: f64,          /* I - power of 10 of implied decimal      */
-    nullcheck: NullCheckType, /* I - null checking code; 0 = don't check */
+    input: &mut [c_char],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    twidth: c_long,
+    implipower: f64,
+    nullcheck: NullCheckType,
     /*     1:set null pixels = nullval         */
     /*     2: if null pixel, set nullarray = 1 */
-    snull: &[c_char],                /* I - value of FITS null string, if any   */
-    nullval: c_uint,                 /* I - set null pixels, if nullcheck = 1  */
-    nullarray: &mut [c_char],        /* O - bad pixel array, if nullcheck = 2   */
-    mut anynull: Option<&mut c_int>, /* O - set to 1 if any pixels are null     */
-    output: &mut [c_uint],           /* O - array of converted pixels          */
-    status: &mut c_int,              /* IO - error status                       */
+    snull: &[c_char],
+    nullval: c_uint,
+    nullarray: &mut [c_char],
+    mut anynull: Option<&mut c_int>,
+    output: &mut [c_uint],
+    status: &mut c_int,
 ) -> c_int {
     let mut dvalue: f64 = 0.0;
     let mut message: [c_char; FLEN_ERRMSG] = [0; FLEN_ERRMSG];

--- a/src/getkey.rs
+++ b/src/getkey.rs
@@ -1,9 +1,20 @@
-/*  This file, getkey.rs, contains routines that read keywords from         */
-/*  a FITS header.                                                         */
-
-/*  The FITSIO software was written by William Pence at the High Energy    */
-/*  Astrophysic Science Archive Research Center (HEASARC) at the NASA      */
-/*  Goddard Space Flight Center.                                           */
+//! Routines that read keywords from a FITS header.
+//!
+//! A keyword can be reached in three ways: by name (`ffgkey` and the typed
+//! `ffgky*` family), by position in the header (`ffgrec`, `ffgcrd`), or by
+//! walking an indexed set such as `NAXISn` (the `ffgkn*` family). The typed
+//! routines convert the card's value string to the requested datatype, so a
+//! keyword written as an integer can be read back as a double.
+//!
+//! Also here are the routines that read a whole header as one string
+//! (`ffhdr2str`), the required-keyword readers for each HDU type, and the
+//! support for the long-string convention, in which a value too long for one
+//! card is continued over `CONTINUE` keywords.
+//!
+//! Ported from CFITSIO's `getkey.c`, written by William Pence at the High
+//! Energy Astrophysics Science Archive Research Center (HEASARC), NASA Goddard
+//! Space Flight Center.
+#![warn(missing_docs)]
 
 use core::ffi::CStr;
 use core::slice;
@@ -29,16 +40,22 @@ use crate::{KeywordDatatypeMut, bb, cs};
 use crate::{fitsio::*, int_snprintf};
 use crate::{fitsio2::*, slice_to_str};
 
-/*--------------------------------------------------------------------------*/
-/// returns the number of existing keywords (not counting the END keyword)
-/// and the number of more keyword that will fit in the current header
-/// without having to insert more FITS blocks.
+/// Return the number of existing keywords, not counting the END keyword, and
+/// the number of further keywords that will fit in the current header without
+/// having to insert more FITS blocks.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `nexist` — (O) number of existing keywords in header
+/// * `nmore`  — (O) how many more keywords will fit
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffghsp(
-    fptr: *mut fitsfile, /* I - FITS file pointer                     */
-    nexist: *mut c_int,  /* O - number of existing keywords in header */
-    nmore: *mut c_int,   /* O - how many more keywords will fit       */
-    status: *mut c_int,  /* IO - error status                         */
+    fptr: *mut fitsfile,
+    nexist: *mut c_int,
+    nmore: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -52,15 +69,21 @@ pub unsafe extern "C" fn ffghsp(
     }
 }
 
-/*--------------------------------------------------------------------------*/
-/// returns the number of existing keywords (not counting the END keyword)
-/// and the number of more keyword that will fit in the current header
-/// without having to insert more FITS blocks.
+/// Return the number of existing keywords, not counting the END keyword, and
+/// the number of further keywords that will fit in the current header without
+/// having to insert more FITS blocks.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `nexist` — (O) number of existing keywords in header
+/// * `nmore`  — (O) how many more keywords will fit
+/// * `status` — (IO) error status
 pub fn ffghsp_safe(
-    fptr: &mut fitsfile,        /* I - FITS file pointer                     */
-    nexist: Option<&mut c_int>, /* O - number of existing keywords in header */
-    nmore: Option<&mut c_int>,  /* O - how many more keywords will fit       */
-    status: &mut c_int,         /* IO - error status                         */
+    fptr: &mut fitsfile,
+    nexist: Option<&mut c_int>,
+    nmore: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     if *status > 0 {
         return *status;
@@ -90,15 +113,21 @@ pub fn ffghsp_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Return the number of existing keywords and the position of the next
 /// keyword that will be read.
+///
+/// # Parameters
+///
+/// * `fptr`     — (I) FITS file pointer
+/// * `nexist`   — (O) number of existing keywords in header
+/// * `position` — (O) position of next keyword to be read
+/// * `status`   — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffghps(
-    fptr: *mut fitsfile,  /* I - FITS file pointer                     */
-    nexist: *mut c_int,   /* O - number of existing keywords in header */
-    position: *mut c_int, /* O - position of next keyword to be read   */
-    status: *mut c_int,   /* IO - error status                         */
+    fptr: *mut fitsfile,
+    nexist: *mut c_int,
+    position: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -111,14 +140,20 @@ pub unsafe extern "C" fn ffghps(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Return the number of existing keywords and the position of the next
 /// keyword that will be read.
+///
+/// # Parameters
+///
+/// * `fptr`     — (I) FITS file pointer
+/// * `nexist`   — (O) number of existing keywords in header
+/// * `position` — (O) position of next keyword to be read
+/// * `status`   — (IO) error status
 pub fn ffghps_safe(
-    fptr: &mut fitsfile,          /* I - FITS file pointer                     */
-    nexist: Option<&mut c_int>,   /* O - number of existing keywords in header */
-    position: Option<&mut c_int>, /* O - position of next keyword to be read   */
-    status: &mut c_int,           /* IO - error status                         */
+    fptr: &mut fitsfile,
+    nexist: Option<&mut c_int>,
+    position: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     if *status > 0 {
         return *status;
@@ -141,16 +176,17 @@ pub fn ffghps_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Function returns the position of the first null character (ASCII 0), if
 /// any, in the current header.  Null characters are illegal, but the other
 /// CFITSIO routines that read the header will not detect this error, because
 /// the null gets interpreted as a normal end of string character.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
-pub unsafe extern "C" fn ffnchk(
-    fptr: *mut fitsfile, /* I - FITS file pointer                     */
-    status: *mut c_int,  /* IO - error status                         */
-) -> c_int {
+pub unsafe extern "C" fn ffnchk(fptr: *mut fitsfile, status: *mut c_int) -> c_int {
     // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
@@ -160,15 +196,16 @@ pub unsafe extern "C" fn ffnchk(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Function returns the position of the first null character (ASCII 0), if
 /// any, in the current header.  Null characters are illegal, but the other
 /// CFITSIO routines that read the header will not detect this error, because
 /// the null gets interpreted as a normal end of string character.
-pub fn ffnchk_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                     */
-    status: &mut c_int,  /* IO - error status                         */
-) -> c_int {
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `status` — (IO) error status
+pub fn ffnchk_safe(fptr: &mut fitsfile, status: &mut c_int) -> c_int {
     let mut bytepos: LONGLONG = 0;
     let mut length = 0;
     let mut nullpos: c_int = 0;
@@ -212,15 +249,16 @@ pub fn ffnchk_safe(
     0
 }
 
-/*--------------------------------------------------------------------------*/
 /// Move pointer to the specified absolute keyword position.  E.g. this keyword
 /// will then be read by the next call to ffgnky.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `nrec`   — (I) one-based keyword number to move to
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
-pub unsafe extern "C" fn ffmaky(
-    fptr: *mut fitsfile, /* I - FITS file pointer                    */
-    nrec: c_int,         /* I - one-based keyword number to move to  */
-    status: *mut c_int,  /* IO - error status                        */
-) -> c_int {
+pub unsafe extern "C" fn ffmaky(fptr: *mut fitsfile, nrec: c_int, status: *mut c_int) -> c_int {
     // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
@@ -230,14 +268,15 @@ pub unsafe extern "C" fn ffmaky(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Move pointer to the specified absolute keyword position.  E.g. this keyword
 /// will then be read by the next call to ffgnky.
-pub fn ffmaky_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                    */
-    nrec: c_int,         /* I - one-based keyword number to move to  */
-    status: &mut c_int,  /* IO - error status                        */
-) -> c_int {
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `nrec`   — (I) one-based keyword number to move to
+/// * `status` — (IO) error status
+pub fn ffmaky_safe(fptr: &mut fitsfile, nrec: c_int, status: &mut c_int) -> c_int {
     if fptr.HDUposition != fptr.Fptr.curhdu {
         ffmahd_safe(fptr, (fptr.HDUposition) + 1, None, status);
     }
@@ -247,15 +286,16 @@ pub fn ffmaky_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
-/// move pointer to the specified keyword position relative to the current
-/// position.  E.g. this keyword  will then be read by the next call to ffgnky.
+/// Move the pointer to the specified keyword position, relative to the current
+/// position; that keyword will then be read by the next call to `ffgnky`.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `nmove`  — (I) relative number of keywords to move
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
-pub unsafe extern "C" fn ffmrky(
-    fptr: *mut fitsfile, /* I - FITS file pointer                   */
-    nmove: c_int,        /* I - relative number of keywords to move */
-    status: *mut c_int,  /* IO - error status                       */
-) -> c_int {
+pub unsafe extern "C" fn ffmrky(fptr: *mut fitsfile, nmove: c_int, status: *mut c_int) -> c_int {
     // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
@@ -265,14 +305,15 @@ pub unsafe extern "C" fn ffmrky(
     }
 }
 
-/*--------------------------------------------------------------------------*/
-/// move pointer to the specified keyword position relative to the current
-/// position.  E.g. this keyword  will then be read by the next call to ffgnky.
-pub fn ffmrky_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                   */
-    nmove: c_int,        /* I - relative number of keywords to move */
-    status: &mut c_int,  /* IO - error status                       */
-) -> c_int {
+/// Move the pointer to the specified keyword position, relative to the current
+/// position; that keyword will then be read by the next call to `ffgnky`.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `nmove`  — (I) relative number of keywords to move
+/// * `status` — (IO) error status
+pub fn ffmrky_safe(fptr: &mut fitsfile, nmove: c_int, status: &mut c_int) -> c_int {
     if fptr.HDUposition != fptr.Fptr.curhdu {
         ffmahd_safe(fptr, (fptr.HDUposition) + 1, None, status);
     }
@@ -282,13 +323,14 @@ pub fn ffmrky_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read the next keyword from the header - used internally by cfitsio
-pub(crate) fn ffgnky(
-    fptr: &mut fitsfile, /* I - FITS file pointer     */
-    card: &mut [c_char], /* O - card string           */
-    status: &mut c_int,  /* IO - error status         */
-) -> c_int {
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `card`   — (O) card string
+/// * `status` — (IO) error status
+pub(crate) fn ffgnky(fptr: &mut fitsfile, card: &mut [c_char], status: &mut c_int) -> c_int {
     let mut message: [c_char; FLEN_ERRMSG] = [0; FLEN_ERRMSG];
 
     if *status > 0 {
@@ -345,20 +387,29 @@ pub(crate) fn ffgnky(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Return the next keyword that matches one of the names in inclist
 /// but does not match any of the names in exclist.  The search
 /// goes from the current position to the end of the header, only.
 /// Wild card characters may be used in the name lists ('*', '?' and '#').
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `inclist` — (I) list of included keyword names
+/// * `ninc`    — (I) number of names in inclist
+/// * `exclist` — (I) list of excluded keyword names
+/// * `nexc`    — (I) number of names in exclist
+/// * `card`    — (O) first matching keyword
+/// * `status`  — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgnxk(
-    fptr: *mut fitsfile,           /* I - FITS file pointer              */
-    inclist: *const *const c_char, /* I - list of included keyword names */
-    ninc: c_int,                   /* I - number of names in inclist     */
-    exclist: *const *const c_char, /* I - list of excluded keyword names */
-    nexc: c_int,                   /* I - number of names in exclist     */
-    card: *mut c_char,             /* O - first matching keyword         */
-    status: *mut c_int,            /* IO - error status                  */
+    fptr: *mut fitsfile,
+    inclist: *const *const c_char,
+    ninc: c_int,
+    exclist: *const *const c_char,
+    nexc: c_int,
+    card: *mut c_char,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -383,19 +434,28 @@ pub unsafe extern "C" fn ffgnxk(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Return the next keyword that matches one of the names in inclist
 /// but does not match any of the names in exclist.  The search
 /// goes from the current position to the end of the header, only.
 /// Wild card characters may be used in the name lists ('*', '?' and '#').
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `inclist` — (I) list of included keyword names
+/// * `ninc`    — (I) number of names in inclist
+/// * `exclist` — (I) list of excluded keyword names
+/// * `nexc`    — (I) number of names in exclist
+/// * `card`    — (O) first matching keyword
+/// * `status`  — (IO) error status
 pub fn ffgnxk_safe(
-    fptr: &mut fitsfile,   /* I - FITS file pointer              */
-    inclist: &[&[c_char]], /* I - list of included keyword names */
-    ninc: c_int,           /* I - number of names in inclist     */
-    exclist: &[&[c_char]], /* I - list of excluded keyword names */
-    nexc: c_int,           /* I - number of names in exclist     */
-    card: &mut [c_char],   /* O - first matching keyword         */
-    status: &mut c_int,    /* IO - error status                  */
+    fptr: &mut fitsfile,
+    inclist: &[&[c_char]],
+    ninc: c_int,
+    exclist: &[&[c_char]],
+    nexc: c_int,
+    card: &mut [c_char],
+    status: &mut c_int,
 ) -> c_int {
     let mut casesn: c_int = 0;
     let mut is_match: c_int = 0;
@@ -446,17 +506,25 @@ pub fn ffgnxk_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read (get) the keyword value and comment from the FITS header.
 /// Reads a keyword value with the datatype specified by the 2nd argument.
+///
+/// # Parameters
+///
+/// * `fptr`     — (I) FITS file pointer
+/// * `datatype` — (I) datatype of the value
+/// * `keyname`  — (I) name of keyword to read
+/// * `value`    — (O) keyword value
+/// * `comm`     — (O) keyword comment
+/// * `status`   — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgky(
-    fptr: *mut fitsfile,    /* I - FITS file pointer        */
-    datatype: c_int,        /* I - datatype of the value    */
-    keyname: *const c_char, /* I - name of keyword to read  */
-    value: *mut c_void,     /* O - keyword value            */
-    comm: *mut c_char,      /* O - keyword comment          */
-    status: *mut c_int,     /* IO - error status            */
+    fptr: *mut fitsfile,
+    datatype: c_int,
+    keyname: *const c_char,
+    value: *mut c_void,
+    comm: *mut c_char,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -479,17 +547,24 @@ pub unsafe extern "C" fn ffgky(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read (get) the keyword value and comment from the FITS header.
 /// Reads a keyword value with the datatype specified by the 2nd argument.
 ///
 /// This has been modified heavily from the original for safety.
+///
+/// # Parameters
+///
+/// * `fptr`     — (I) FITS file pointer
+/// * `datatype` — (I) datatype of the value
+/// * `keyname`  — (I) name of keyword to read
+/// * `comm`     — (O) keyword comment
+/// * `status`   — (IO) error status
 pub fn ffgky_safe(
-    fptr: &mut fitsfile,                           /* I - FITS file pointer        */
-    datatype: KeywordDatatypeMut,                  /* I - datatype of the value    */
-    keyname: &[c_char],                            /* I - name of keyword to read  */
-    mut comm: Option<&mut [c_char; FLEN_COMMENT]>, /* O - keyword comment          */
-    status: &mut c_int,                            /* IO - error status            */
+    fptr: &mut fitsfile,
+    datatype: KeywordDatatypeMut,
+    keyname: &[c_char],
+    mut comm: Option<&mut [c_char; FLEN_COMMENT]>,
+    status: &mut c_int,
 ) -> c_int {
     let mut longval: LONGLONG = 0;
     let mut ulongval: ULONGLONG = 0;
@@ -605,7 +680,6 @@ pub fn ffgky_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read (get) the named keyword, returning the keyword value and comment.
 ///
 /// The value is just the literal string of characters in the value field
@@ -614,13 +688,21 @@ pub fn ffgky_safe(
 /// up to 70 characters long, and the comment may be up to 72 characters long.
 /// If the keyword has no value (no equal sign in column 9) then a null value
 /// is returned.
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) name of keyword to read
+/// * `keyval`  — (O) keyword value
+/// * `comm`    — (O) keyword comment
+/// * `status`  — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgkey(
-    fptr: *mut fitsfile,    /* I - FITS file pointer        */
-    keyname: *const c_char, /* I - name of keyword to read  */
-    keyval: *mut c_char,    /* O - keyword value            */
-    comm: *mut c_char,      /* O - keyword comment          */
-    status: *mut c_int,     /* IO - error status            */
+    fptr: *mut fitsfile,
+    keyname: *const c_char,
+    keyval: *mut c_char,
+    comm: *mut c_char,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -643,7 +725,6 @@ pub unsafe extern "C" fn ffgkey(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read (get) the named keyword, returning the keyword value and comment.
 ///
 /// The value is just the literal string of characters in the value field
@@ -652,12 +733,20 @@ pub unsafe extern "C" fn ffgkey(
 /// up to 70 characters long, and the comment may be up to 72 characters long.
 /// If the keyword has no value (no equal sign in column 9) then a null value
 /// is returned.
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) name of keyword to read
+/// * `keyval`  — (O) keyword value
+/// * `comm`    — (O) keyword comment
+/// * `status`  — (IO) error status
 pub fn ffgkey_safe(
-    fptr: &mut fitsfile,                       /* I - FITS file pointer        */
-    keyname: &[c_char],                        /* I - name of keyword to read  */
-    keyval: &mut [c_char],                     /* O - keyword value            */
-    comm: Option<&mut [c_char; FLEN_COMMENT]>, /* O - keyword comment          */
-    status: &mut c_int,                        /* IO - error status            */
+    fptr: &mut fitsfile,
+    keyname: &[c_char],
+    keyval: &mut [c_char],
+    comm: Option<&mut [c_char; FLEN_COMMENT]>,
+    status: &mut c_int,
 ) -> c_int {
     let mut card: [c_char; FLEN_CARD] = [0; FLEN_CARD];
 
@@ -682,18 +771,24 @@ pub fn ffgkey_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read (get) the nrec-th keyword, returning the entire keyword card up to
 /// 80 characters long.  The first keyword in the header has nrec = 1, not 0.
 /// The returned card value is null terminated with any trailing blank
 /// characters removed.  If nrec = 0, then this routine simply moves the
 /// current header pointer to the top of the header.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `nrec`   — (I) number of keyword to read
+/// * `card`   — (O) keyword card
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgrec(
-    fptr: *mut fitsfile, /* I - FITS file pointer          */
-    nrec: c_int,         /* I - number of keyword to read  */
-    card: *mut c_char,   /* O - keyword card               */
-    status: *mut c_int,  /* IO - error status              */
+    fptr: *mut fitsfile,
+    nrec: c_int,
+    card: *mut c_char,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -714,17 +809,23 @@ pub unsafe extern "C" fn ffgrec(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read (get) the nrec-th keyword, returning the entire keyword card up to
 /// 80 characters long.  The first keyword in the header has nrec = 1, not 0.
 /// The returned card value is null terminated with any trailing blank
 /// characters removed.  If nrec = 0, then this routine simply moves the
 /// current header pointer to the top of the header.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `nrec`   — (I) number of keyword to read
+/// * `card`   — (O) keyword card
+/// * `status` — (IO) error status
 pub fn ffgrec_safe(
-    fptr: &mut fitsfile,         /* I - FITS file pointer          */
-    nrec: c_int,                 /* I - number of keyword to read  */
-    card: Option<&mut [c_char]>, /* O - keyword card               */
-    status: &mut c_int,          /* IO - error status              */
+    fptr: &mut fitsfile,
+    nrec: c_int,
+    card: Option<&mut [c_char]>,
+    status: &mut c_int,
 ) -> c_int {
     if *status > 0 {
         return *status;
@@ -743,7 +844,6 @@ pub fn ffgrec_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read (get) the named keyword, returning the entire keyword card up to
 /// 80 characters long.  
 /// The returned card value is null terminated with any trailing blank
@@ -753,12 +853,19 @@ pub fn ffgrec_safe(
 /// and '*' matches any sequence of chars, # matches any string of decimal
 /// digits) then the search ends once the end of header is reached and does
 /// not automatically resume from the top of the header.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `name`   — (I) name of keyword to read
+/// * `card`   — (O) keyword card
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgcrd(
-    fptr: *mut fitsfile, /* I - FITS file pointer        */
-    name: *const c_char, /* I - name of keyword to read  */
-    card: *mut c_char,   /* O - keyword card             */
-    status: *mut c_int,  /* IO - error status            */
+    fptr: *mut fitsfile,
+    name: *const c_char,
+    card: *mut c_char,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -773,7 +880,6 @@ pub unsafe extern "C" fn ffgcrd(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read (get) the named keyword, returning the entire keyword card up to
 /// 80 characters long.  
 /// The returned card value is null terminated with any trailing blank
@@ -783,11 +889,18 @@ pub unsafe extern "C" fn ffgcrd(
 /// and '*' matches any sequence of chars, # matches any string of decimal
 /// digits) then the search ends once the end of header is reached and does
 /// not automatically resume from the top of the header.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `name`   — (I) name of keyword to read
+/// * `card`   — (O) keyword card
+/// * `status` — (IO) error status
 pub fn ffgcrd_safe(
-    fptr: &mut fitsfile,            /* I - FITS file pointer        */
-    name: &[c_char],                /* I - name of keyword to read  */
-    card: &mut [c_char; FLEN_CARD], /* O - keyword card             */
-    status: &mut c_int,             /* IO - error status            */
+    fptr: &mut fitsfile,
+    name: &[c_char],
+    card: &mut [c_char; FLEN_CARD],
+    status: &mut c_int,
 ) -> c_int {
     let mut nkeys: isize = 0;
     let mut nextkey: isize = 0;
@@ -962,17 +1075,23 @@ pub fn ffgcrd_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read (get) the next keyword record that contains the input character string,
 /// returning the entire keyword card up to 80 characters long.
 /// The returned card value is null terminated with any trailing blank
 /// characters removed.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `string` — (I) string to match
+/// * `card`   — (O) keyword card
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgstr(
-    fptr: *mut fitsfile,   /* I - FITS file pointer        */
-    string: *const c_char, /* I - string to match  */
-    card: *mut c_char,     /* O - keyword card             */
-    status: *mut c_int,    /* IO - error status            */
+    fptr: *mut fitsfile,
+    string: *const c_char,
+    card: *mut c_char,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -986,16 +1105,22 @@ pub unsafe extern "C" fn ffgstr(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read (get) the next keyword record that contains the input character string,
 /// returning the entire keyword card up to 80 characters long.
 /// The returned card value is null terminated with any trailing blank
 /// characters removed.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `string` — (I) string to match
+/// * `card`   — (O) keyword card
+/// * `status` — (IO) error status
 pub fn ffgstr_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer        */
-    string: &[c_char],   /* I - string to match  */
-    card: &mut [c_char], /* O - keyword card             */
-    status: &mut c_int,  /* IO - error status            */
+    fptr: &mut fitsfile,
+    string: &[c_char],
+    card: &mut [c_char],
+    status: &mut c_int,
 ) -> c_int {
     let mut nkeys: c_int = 0;
     let mut nextkey: c_int = 0;
@@ -1030,15 +1155,21 @@ pub fn ffgstr_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Return the name of the keyword, and the name length.  This supports the
 /// ESO HIERARCH convention where keyword names may be > 8 characters long.
+///
+/// # Parameters
+///
+/// * `card`   — (I) keyword card
+/// * `name`   — (O) name of the keyword
+/// * `length` — (O) length of the keyword name
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgknm(
-    card: *const c_char, /* I - keyword card                   */
-    name: *mut c_char,   /* O - name of the keyword            */
-    length: *mut c_int,  /* O - length of the keyword name     */
-    status: *mut c_int,  /* IO - error status                  */
+    card: *const c_char,
+    name: *mut c_char,
+    length: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -1054,14 +1185,20 @@ pub unsafe extern "C" fn ffgknm(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Return the name of the keyword, and the name length.  This supports the
 /// ESO HIERARCH convention where keyword names may be > 8 characters long.
+///
+/// # Parameters
+///
+/// * `card`   — (I) keyword card
+/// * `name`   — (O) name of the keyword
+/// * `length` — (O) length of the keyword name
+/// * `status` — (IO) error status
 pub fn ffgknm_safe(
-    card: &[c_char; FLEN_CARD],        /* I - keyword card                   */
-    name: &mut [c_char; FLEN_KEYWORD], /* O - name of the keyword            */
-    length: &mut c_int,                /* O - length of the keyword name     */
-    status: &mut c_int,                /* IO - error status                  */
+    card: &[c_char; FLEN_CARD],
+    name: &mut [c_char; FLEN_KEYWORD],
+    length: &mut c_int,
+    status: &mut c_int,
 ) -> c_int {
     let mut ptr1: usize = 0;
 
@@ -1120,20 +1257,29 @@ pub fn ffgknm_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read (get) the units string from the comment field of the existing
 /// keyword. This routine uses a local FITS convention (not defined in the
 /// official FITS standard) in which the units are enclosed in
 /// square brackets following the '/' comment field delimiter, e.g.:
 ///
+/// ```text
 /// KEYWORD =                   12 / [kpc] comment string goes here
+/// ```
+///
 /// WARNING: No definition in spec of length of units
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) name of keyword to read
+/// * `unit`    — (O) keyword units
+/// * `status`  — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgunt(
-    fptr: *mut fitsfile,    /* I - FITS file pointer         */
-    keyname: *const c_char, /* I - name of keyword to read   */
-    unit: *mut c_char,      /* O - keyword units             */
-    status: *mut c_int,     /* IO - error status             */
+    fptr: *mut fitsfile,
+    keyname: *const c_char,
+    unit: *mut c_char,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -1149,11 +1295,18 @@ pub unsafe extern "C" fn ffgunt(
 }
 
 /// Safe wrapper for ffgunt that handles null pointer checks
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) name of keyword to read
+/// * `unit`    — (O) keyword units
+/// * `status`  — (IO) error status
 pub fn ffgunt_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer         */
-    keyname: &[c_char],  /* I - name of keyword to read   */
-    unit: &mut [c_char], /* O - keyword units             */
-    status: &mut c_int,  /* IO - error status             */
+    fptr: &mut fitsfile,
+    keyname: &[c_char],
+    unit: &mut [c_char],
+    status: &mut c_int,
 ) -> c_int {
     let mut valstring: [c_char; FLEN_VALUE] = [0; FLEN_VALUE];
     let mut comm: [c_char; FLEN_COMMENT] = [0; FLEN_COMMENT];
@@ -1178,20 +1331,27 @@ pub fn ffgunt_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Get KeYword with a String value:
 /// Read (get) a simple string valued keyword.  The returned value may be up to
 /// 68 chars long ( + 1 null terminator char).  The routine does not support the
 /// HEASARC convention for continuing long string values over multiple keywords.
 /// The ffgkls routine may be used to read long continued strings. The returned
 /// comment string may be up to 69 characters long (including null terminator).
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) name of keyword to read
+/// * `value`   — (O) keyword value
+/// * `comm`    — (O) keyword comment
+/// * `status`  — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgkys(
-    fptr: *mut fitsfile,    /* I - FITS file pointer         */
-    keyname: *const c_char, /* I - name of keyword to read   */
-    value: *mut c_char,     /* O - keyword value             */
-    comm: *mut c_char,      /* O - keyword comment           */
-    status: *mut c_int,     /* IO - error status             */
+    fptr: *mut fitsfile,
+    keyname: *const c_char,
+    value: *mut c_char,
+    comm: *mut c_char,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -1216,19 +1376,26 @@ pub unsafe extern "C" fn ffgkys(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Get KeYword with a String value:
 /// Read (get) a simple string valued keyword.  The returned value may be up to
 /// 68 chars long ( + 1 null terminator char).  The routine does not support the
 /// HEASARC convention for continuing long string values over multiple keywords.
 /// The ffgkls routine may be used to read long continued strings. The returned
 /// comment string may be up to 69 characters long (including null terminator).
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) name of keyword to read
+/// * `value`   — (O) keyword value
+/// * `comm`    — (O) keyword comment
+/// * `status`  — (IO) error status
 pub fn ffgkys_safe(
-    fptr: &mut fitsfile,                       /* I - FITS file pointer         */
-    keyname: &[c_char],                        /* I - name of keyword to read   */
-    value: &mut [c_char],                      /* O - keyword value             */
-    comm: Option<&mut [c_char; FLEN_COMMENT]>, /* O - keyword comment           */
-    status: &mut c_int,                        /* IO - error status             */
+    fptr: &mut fitsfile,
+    keyname: &[c_char],
+    value: &mut [c_char],
+    comm: Option<&mut [c_char; FLEN_COMMENT]>,
+    status: &mut c_int,
 ) -> c_int {
     let mut valstring: [c_char; FLEN_VALUE] = [0; FLEN_VALUE];
 
@@ -1243,15 +1410,21 @@ pub fn ffgkys_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Get the length of the keyword value string.
 /// This routine explicitly supports the CONTINUE convention for long string values.
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) name of keyword to read
+/// * `length`  — (O) length of the string value
+/// * `status`  — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgksl(
-    fptr: *mut fitsfile,    /* I - FITS file pointer             */
-    keyname: *const c_char, /* I - name of keyword to read       */
-    length: *mut c_int,     /* O - length of the string value    */
-    status: *mut c_int,     /* IO - error status                 */
+    fptr: *mut fitsfile,
+    keyname: *const c_char,
+    length: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -1269,14 +1442,20 @@ pub unsafe extern "C" fn ffgksl(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Get the length of the keyword value string.
 /// This routine explicitly supports the CONTINUE convention for long string values.
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) name of keyword to read
+/// * `length`  — (O) length of the string value
+/// * `status`  — (IO) error status
 pub fn ffgksl_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer             */
-    keyname: &[c_char],  /* I - name of keyword to read       */
-    length: &mut c_int,  /* O - length of the string value    */
-    status: &mut c_int,  /* IO - error status                 */
+    fptr: &mut fitsfile,
+    keyname: &[c_char],
+    length: &mut c_int,
+    status: &mut c_int,
 ) -> c_int {
     if *status > 0 {
         return *status;
@@ -1288,16 +1467,23 @@ pub fn ffgksl_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Get the length of the keyword value string and comment string.
 /// This routine explicitly supports the CONTINUE convention for long string values.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `keyname`   — (I) name of keyword to read
+/// * `length`    — (O) length of the string value
+/// * `comlength` — (O) length of comment string
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgkcsl(
-    fptr: *mut fitsfile,    /* I - FITS file pointer             */
-    keyname: *const c_char, /* I - name of keyword to read       */
-    length: *mut c_int,     /* O - length of the string value    */
-    comlength: *mut c_int,  /* O - length of comment string      */
-    status: *mut c_int,     /* IO - error status                 */
+    fptr: *mut fitsfile,
+    keyname: *const c_char,
+    length: *mut c_int,
+    comlength: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -1320,15 +1506,22 @@ pub unsafe extern "C" fn ffgkcsl(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Get the length of the keyword value string and comment string.
 /// This routine explicitly supports the CONTINUE convention for long string values.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `keyname`   — (I) name of keyword to read
+/// * `length`    — (O) length of the string value
+/// * `comlength` — (O) length of comment string
+/// * `status`    — (IO) error status
 pub fn ffgkcsl_safe(
-    fptr: &mut fitsfile,   /* I - FITS file pointer             */
-    keyname: &[c_char],    /* I - name of keyword to read       */
-    length: &mut c_int,    /* O - length of the string value    */
-    comlength: &mut c_int, /* O - length of comment string      */
-    status: &mut c_int,    /* IO - error status                 */
+    fptr: &mut fitsfile,
+    keyname: &[c_char],
+    length: &mut c_int,
+    comlength: &mut c_int,
+    status: &mut c_int,
 ) -> c_int {
     if *status > 0 {
         return *status;
@@ -1341,7 +1534,6 @@ pub fn ffgkcsl_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// This is the original routine for reading long string keywords that use
 /// the CONTINUE keyword convention.  In 2016 a new routine called
 /// ffgsky / fits_read_string_key was added, which may provide a more
@@ -1357,12 +1549,19 @@ pub fn ffgkcsl_safe(
 /// characters long.
 // #[deprecated]
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) name of keyword to read
+/// * `value`   — (O) pointer to keyword value
+/// * `comm`    — (O) keyword comment (may be NULL)
+/// * `status`  — (IO) error status
 pub unsafe extern "C" fn ffgkls(
-    fptr: *mut fitsfile,     /* I - FITS file pointer         */
-    keyname: *const c_char,  /* I - name of keyword to read       */
-    value: *mut *mut c_char, /* O - pointer to keyword value      */
-    comm: *mut c_char,       /* O - keyword comment (may be NULL) */
-    status: *mut c_int,      /* IO - error status             */
+    fptr: *mut fitsfile,
+    keyname: *const c_char,
+    value: *mut *mut c_char,
+    comm: *mut c_char,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -1386,13 +1585,25 @@ pub unsafe extern "C" fn ffgkls(
     }
 }
 
-/// Safe wrapper for ffgkls that handles null pointer checks
+/// Read a keyword value that uses the long-string convention, in which a value
+/// too long for one card is continued over `CONTINUE` keywords.
+///
+/// Unlike [`ffgsky_safe`], this allocates the returned string on the heap, so
+/// the caller must free it with `fffree` once it is no longer needed.
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) name of keyword to read
+/// * `value`   — (O) pointer to keyword value
+/// * `comm`    — (O) keyword comment (may be NULL)
+/// * `status`  — (IO) error status
 pub fn ffgkls_safe(
-    fptr: &mut fitsfile,                           /* I - FITS file pointer         */
-    keyname: &[c_char],                            /* I - name of keyword to read       */
-    value: &mut *mut c_char,                       /* O - pointer to keyword value      */
-    mut comm: Option<&mut [c_char; FLEN_COMMENT]>, /* O - keyword comment (may be NULL) */
-    status: &mut c_int,                            /* IO - error status             */
+    fptr: &mut fitsfile,
+    keyname: &[c_char],
+    value: &mut *mut c_char,
+    mut comm: Option<&mut [c_char; FLEN_COMMENT]>,
+    status: &mut c_int,
 ) -> c_int {
     let mut valstring: [c_char; FLEN_VALUE] = [0; FLEN_VALUE];
     let mut nextcomm: [c_char; FLEN_COMMENT] = [0; FLEN_COMMENT];
@@ -1512,7 +1723,6 @@ pub fn ffgkls_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read and return the value of the specified string-valued keyword.
 ///
 /// This new routine was added in 2016 to provide a more convenient user
@@ -1530,20 +1740,31 @@ pub fn ffgkls_safe(
 /// This routine differs from the ffkls routine in that it does not
 /// internally allocate memory for the returned value string, and consequently
 /// the calling routine does not need to call fffree to free the memory.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `keyname`   — (I) name of keyword to read
+/// * `firstchar` — (I) first character of string to return
+/// * `maxchar`   — (I) maximum length of string to return
+/// * `value`     — (O) pointer to keyword value
+/// * `valuelen`  — (O) total length of the keyword value string
+/// * `comm`      — (O) keyword comment (may be NULL)
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgsky(
-    fptr: *mut fitsfile,    /* I - FITS file pointer             */
-    keyname: *const c_char, /* I - name of keyword to read       */
-    firstchar: c_int,       /* I - first character of string to return */
-    maxchar: c_int,         /* I - maximum length of string to return */
+    fptr: *mut fitsfile,
+    keyname: *const c_char,
+    firstchar: c_int,
+    maxchar: c_int,
     /*    (string will be null terminated)  */
-    value: *mut c_char,   /* O - pointer to keyword value      */
-    valuelen: *mut c_int, /* O - total length of the keyword value string */
+    value: *mut c_char,
+    valuelen: *mut c_int,
     /*     The returned 'value' string may only */
     /*     contain a piece of the total string, depending */
     /*     on the value of firstchar and maxchar */
-    comm: *mut c_char,  /* O - keyword comment (may be NULL) */
-    status: *mut c_int, /* IO - error status                 */
+    comm: *mut c_char,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -1573,7 +1794,6 @@ pub unsafe extern "C" fn ffgsky(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read and return the value of the specified string-valued keyword.
 ///
 /// This new routine was added in 2016 to provide a more convenient user
@@ -1591,15 +1811,26 @@ pub unsafe extern "C" fn ffgsky(
 /// This routine differs from the ffkls routine in that it does not
 /// internally allocate memory for the returned value string, and consequently
 /// the calling routine does not need to call fffree to free the memory.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `keyname`   — (I) name of keyword to read
+/// * `firstchar` — (I) first character of string to return
+/// * `maxchar`   — (I) maximum length of string to return
+/// * `value`     — (O) pointer to keyword value
+/// * `valuelen`  — (O) total length of the keyword value string
+/// * `comm`      — (O) keyword comment (may be NULL)
+/// * `status`    — (IO) error status
 pub fn ffgsky_safe(
-    fptr: &mut fitsfile,              /* I - FITS file pointer             */
-    keyname: &[c_char],               /* I - name of keyword to read       */
-    firstchar: c_int,                 /* I - first character of string to return */
-    maxchar: c_int,                   /* I - maximum length of string to return */
-    value: &mut [c_char],             /* O - pointer to keyword value      */
-    mut valuelen: Option<&mut c_int>, /* O - total length of the keyword value string */
-    mut comm: Option<&mut [c_char; FLEN_COMMENT]>, /* O - keyword comment (may be NULL) */
-    status: &mut c_int,               /* IO - error status                 */
+    fptr: &mut fitsfile,
+    keyname: &[c_char],
+    firstchar: c_int,
+    maxchar: c_int,
+    value: &mut [c_char],
+    mut valuelen: Option<&mut c_int>,
+    mut comm: Option<&mut [c_char; FLEN_COMMENT]>,
+    status: &mut c_int,
 ) -> c_int {
     let mut valstring: [c_char; FLEN_VALUE] = [0; FLEN_VALUE];
     let mut nextcomm: [c_char; FLEN_COMMENT] = [0; FLEN_COMMENT];
@@ -1722,23 +1953,34 @@ pub fn ffgsky_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
+/// # Parameters
+///
+/// * `fptr`       — (I) FITS file pointer
+/// * `keyname`    — (I) name of keyword to read
+/// * `firstchar`  — (I) first character of string to return
+/// * `maxchar`    — (I) maximum length of string to return
+/// * `maxcomchar` — (I) maximum length of comment to return
+/// * `value`      — (O) pointer to keyword value
+/// * `valuelen`   — (O) total length of the keyword value string
+/// * `comm`       — (O) keyword comment (may be NULL)
+/// * `comlen`     — (O) total length of the comment string
+/// * `status`     — (IO) error status
 pub unsafe extern "C" fn ffgskyc(
-    fptr: *mut fitsfile,    /* I - FITS file pointer             */
-    keyname: *const c_char, /* I - name of keyword to read       */
-    firstchar: c_int,       /* I - first character of string to return */
-    maxchar: c_int,         /* I - maximum length of string to return */
+    fptr: *mut fitsfile,
+    keyname: *const c_char,
+    firstchar: c_int,
+    maxchar: c_int,
     /*    (string will be null terminated)  */
-    maxcomchar: c_int,    /* I - maximum length of comment to return */
-    value: *mut c_char,   /* O - pointer to keyword value      */
-    valuelen: *mut c_int, /* O - total length of the keyword value string */
+    maxcomchar: c_int,
+    value: *mut c_char,
+    valuelen: *mut c_int,
     /*     The returned 'value' string may only */
     /*     contain a piece of the total string, depending */
     /*     on the value of firstchar and maxchar */
-    comm: *mut c_char,  /* O - keyword comment (may be NULL) */
-    comlen: *mut c_int, /* O - total length of the comment string */
-    status: *mut c_int, /* IO - error status                 */
+    comm: *mut c_char,
+    comlen: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -1765,22 +2007,33 @@ pub unsafe extern "C" fn ffgskyc(
     }
 }
 
-/*--------------------------------------------------------------------------*/
+/// # Parameters
+///
+/// * `fptr`       — (I) FITS file pointer
+/// * `keyname`    — (I) name of keyword to read
+/// * `firstchar`  — (I) first character of string to return
+/// * `maxchar`    — (I) maximum length of string to return
+/// * `maxcomchar` — (I) maximum length of comment to return
+/// * `value`      — (O) pointer to keyword value
+/// * `valuelen`   — (O) total length of the keyword value string
+/// * `comm`       — (O) keyword comment (may be NULL)
+/// * `comlen`     — (O) total length of the comment string
+/// * `status`     — (IO) error status
 pub fn ffgskyc_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer             */
-    keyname: &[c_char],  /* I - name of keyword to read       */
-    firstchar: c_int,    /* I - first character of string to return */
-    maxchar: c_int,      /* I - maximum length of string to return */
+    fptr: &mut fitsfile,
+    keyname: &[c_char],
+    firstchar: c_int,
+    maxchar: c_int,
     /*    (string will be null terminated)  */
-    maxcomchar: c_int,            /* I - maximum length of comment to return */
-    value: Option<&mut [c_char]>, /* O - pointer to keyword value      */
-    valuelen: &mut c_int,         /* O - total length of the keyword value string */
+    maxcomchar: c_int,
+    value: Option<&mut [c_char]>,
+    valuelen: &mut c_int,
     /*     The returned 'value' string may only */
     /*     contain a piece of the total string, depending */
     /*     on the value of firstchar and maxchar */
-    comm: Option<&mut [c_char]>, /* O - keyword comment (may be NULL) */
-    comlen: &mut c_int,          /* O - total length of the comment string */
-    status: &mut c_int,          /* IO - error status                 */
+    comm: Option<&mut [c_char]>,
+    comlen: &mut c_int,
+    status: &mut c_int,
 ) -> c_int {
     if *status > 0 {
         return *status;
@@ -1793,22 +2046,33 @@ pub fn ffgskyc_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
+/// # Parameters
+///
+/// * `fptr`       — (I) FITS file pointer
+/// * `keyname`    — (I) name of keyword to read
+/// * `firstchar`  — (I) first character of string to return
+/// * `maxvalchar` — (I) maximum length of string to return
+/// * `maxcomchar` — (I) maximum length of comment to return
+/// * `value`      — (O) pointer to keyword value (may be NULL)
+/// * `valuelen`   — (O) total length of the keyword value string
+/// * `comm`       — (O) keyword comment (may be NULL)
+/// * `comlen`     — (O) total length of comment string
+/// * `status`     — (IO) error status
 pub(crate) fn ffglkut(
-    fptr: &mut fitsfile, /* I - FITS file pointer             */
-    keyname: &[c_char],  /* I - name of keyword to read       */
-    firstchar: c_int,    /* I - first character of string to return */
-    maxvalchar: c_int,   /* I - maximum length of string to return */
+    fptr: &mut fitsfile,
+    keyname: &[c_char],
+    firstchar: c_int,
+    maxvalchar: c_int,
     /*    (string will be null terminated)  */
-    maxcomchar: c_int,                /* I - maximum length of comment to return */
-    mut value: Option<&mut [c_char]>, /* O - pointer to keyword value (may be NULL) */
-    valuelen: &mut c_int,             /* O - total length of the keyword value string */
+    maxcomchar: c_int,
+    mut value: Option<&mut [c_char]>,
+    valuelen: &mut c_int,
     /*     The returned 'value' string may only */
     /*     contain a piece of the total string, depending */
     /*     on the value of firstchar and maxvalchar */
-    mut comm: Option<&mut [c_char]>, /* O - keyword comment (may be NULL) */
-    comlen: &mut c_int,              /* O - total length of comment string */
-    status: &mut c_int,              /* IO - error status                 */
+    mut comm: Option<&mut [c_char]>,
+    comlen: &mut c_int,
+    status: &mut c_int,
 ) -> c_int {
     let mut valstring: [c_char; FLEN_VALUE] = [0; FLEN_VALUE];
     let mut comstring: [c_char; FLEN_COMMENT] = [0; FLEN_COMMENT];
@@ -1959,14 +2223,15 @@ pub(crate) fn ffglkut(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Free the memory that was previously allocated by CFITSIO,
 /// such as by ffgkls or fits_hdr2str
+///
+/// # Parameters
+///
+/// * `value`  — (I) pointer to keyword value
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
-pub unsafe extern "C" fn fffree(
-    value: *mut c_void, /* I - pointer to keyword value  */
-    status: *mut c_int, /* IO - error status             */
-) -> c_int {
+pub unsafe extern "C" fn fffree(value: *mut c_void, status: *mut c_int) -> c_int {
     // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
@@ -1974,7 +2239,6 @@ pub unsafe extern "C" fn fffree(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Free memory allocated by FITS library functions.
 /// This function deallocates memory that was previously allocated by other
 /// FITS library functions and tracked in the global allocations map.
@@ -1984,10 +2248,12 @@ pub unsafe extern "C" fn fffree(
 /// `value` must either be null or a pointer previously handed out by a CFITSIO
 /// allocating function (ffgkls, fits_hdr2str, ...) and not yet freed. Passing
 /// any other pointer, or freeing the same one twice, is undefined behaviour.
-pub unsafe fn fffree_safe(
-    value: *mut c_void, /* I - pointer to keyword value  */
-    status: &mut c_int, /* IO - error status             */
-) -> c_int {
+///
+/// # Parameters
+///
+/// * `value`  — (I) pointer to keyword value
+/// * `status` — (IO) error status
+pub unsafe fn fffree_safe(value: *mut c_void, status: &mut c_int) -> c_int {
     if *status > 0 {
         return *status;
     }
@@ -2006,7 +2272,6 @@ pub unsafe fn fffree_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Attempt to read the next keyword, returning the string value
 /// if it is a continuation of the previous string keyword value.
 /// This uses the HEASARC convention for continuing long string values
@@ -2015,11 +2280,18 @@ pub unsafe fn fffree_safe(
 /// which must have the name CONTINUE without an equal sign in column 9
 /// of the card.  If the next card is not a continuation, then the returned
 /// value string will be null.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `value`  — (O) continued string value
+/// * `comm`   — (O) continued comment string
+/// * `status` — (IO) error status
 pub(crate) fn ffgcnt(
-    fptr: &mut fitsfile,                       /* I - FITS file pointer         */
-    value: &mut [c_char],                      /* O - continued string value    */
-    comm: Option<&mut [c_char; FLEN_COMMENT]>, /* O - continued comment string  */
-    status: &mut c_int,                        /* IO - error status             */
+    fptr: &mut fitsfile,
+    value: &mut [c_char],
+    comm: Option<&mut [c_char; FLEN_COMMENT]>,
+    status: &mut c_int,
 ) -> c_int {
     let mut tstatus = 0;
     let mut card: [c_char; FLEN_CARD] = [0; FLEN_CARD];
@@ -2056,17 +2328,24 @@ pub(crate) fn ffgcnt(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read (get) the named keyword, returning the value and comment.
 /// The returned value = 1 if the keyword is true, else = 0 if false.
 /// The comment may be up to 69 characters long.
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) name of keyword to read
+/// * `value`   — (O) keyword value
+/// * `comm`    — (O) keyword comment
+/// * `status`  — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgkyl(
-    fptr: *mut fitsfile,    /* I - FITS file pointer         */
-    keyname: *const c_char, /* I - name of keyword to read   */
-    value: *mut c_int,      /* O - keyword value             */
-    comm: *mut c_char,      /* O - keyword comment           */
-    status: *mut c_int,     /* IO - error status             */
+    fptr: *mut fitsfile,
+    keyname: *const c_char,
+    value: *mut c_int,
+    comm: *mut c_char,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -2091,16 +2370,23 @@ pub unsafe extern "C" fn ffgkyl(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read (get) the named keyword, returning the value and comment.
 /// The returned value = 1 if the keyword is true, else = 0 if false.
 /// The comment may be up to 69 characters long.
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) name of keyword to read
+/// * `value`   — (O) keyword value
+/// * `comm`    — (O) keyword comment
+/// * `status`  — (IO) error status
 pub fn ffgkyl_safe(
-    fptr: &mut fitsfile,                       /* I - FITS file pointer         */
-    keyname: &[c_char],                        /* I - name of keyword to read   */
-    value: &mut c_int,                         /* O - keyword value             */
-    comm: Option<&mut [c_char; FLEN_COMMENT]>, /* O - keyword comment           */
-    status: &mut c_int,                        /* IO - error status             */
+    fptr: &mut fitsfile,
+    keyname: &[c_char],
+    value: &mut c_int,
+    comm: Option<&mut [c_char; FLEN_COMMENT]>,
+    status: &mut c_int,
 ) -> c_int {
     let mut valstring: [c_char; FLEN_VALUE] = [0; FLEN_VALUE];
 
@@ -2114,18 +2400,25 @@ pub fn ffgkyl_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 ///Read (get) the named keyword, returning the value and comment.
 ///
 ///The value will be implicitly converted to a (long) integer if it not
 ///already of this datatype.  The comment may be up to 69 characters long.
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) name of keyword to read
+/// * `value`   — (O) keyword value
+/// * `comm`    — (O) keyword comment
+/// * `status`  — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgkyj(
-    fptr: *mut fitsfile,    /* I - FITS file pointer         */
-    keyname: *const c_char, /* I - name of keyword to read   */
-    value: *mut c_long,     /* O - keyword value             */
-    comm: *mut c_char,      /* O - keyword comment           */
-    status: *mut c_int,     /* IO - error status             */
+    fptr: *mut fitsfile,
+    keyname: *const c_char,
+    value: *mut c_long,
+    comm: *mut c_char,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -2150,17 +2443,24 @@ pub unsafe extern "C" fn ffgkyj(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 ///Read (get) the named keyword, returning the value and comment.
 ///
 ///The value will be implicitly converted to a (long) integer if it not
 ///already of this datatype.  The comment may be up to 69 characters long.
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) name of keyword to read
+/// * `value`   — (O) keyword value
+/// * `comm`    — (O) keyword comment
+/// * `status`  — (IO) error status
 pub fn ffgkyj_safe(
-    fptr: &mut fitsfile,                       /* I - FITS file pointer         */
-    keyname: &[c_char],                        /* I - name of keyword to read   */
-    value: &mut c_long,                        /* O - keyword value             */
-    comm: Option<&mut [c_char; FLEN_COMMENT]>, /* O - keyword comment           */
-    status: &mut c_int,                        /* IO - error status             */
+    fptr: &mut fitsfile,
+    keyname: &[c_char],
+    value: &mut c_long,
+    comm: Option<&mut [c_char; FLEN_COMMENT]>,
+    status: &mut c_int,
 ) -> c_int {
     let mut valstring: [c_char; FLEN_VALUE] = [0; FLEN_VALUE];
 
@@ -2174,18 +2474,25 @@ pub fn ffgkyj_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read (get) the named keyword, returning the value and comment.
 ///
 /// The value will be implicitly converted to a (LONGLONG) integer if it not
 /// already of this datatype.  The comment may be up to 69 characters long.
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) name of keyword to read
+/// * `value`   — (O) keyword value
+/// * `comm`    — (O) keyword comment
+/// * `status`  — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgkyjj(
-    fptr: *mut fitsfile,    /* I - FITS file pointer         */
-    keyname: *const c_char, /* I - name of keyword to read   */
-    value: *mut LONGLONG,   /* O - keyword value             */
-    comm: *mut c_char,      /* O - keyword comment           */
-    status: *mut c_int,     /* IO - error status             */
+    fptr: *mut fitsfile,
+    keyname: *const c_char,
+    value: *mut LONGLONG,
+    comm: *mut c_char,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -2210,17 +2517,24 @@ pub unsafe extern "C" fn ffgkyjj(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read (get) the named keyword, returning the value and comment.
 ///
 /// The value will be implicitly converted to a (LONGLONG) integer if it not
 /// already of this datatype.  The comment may be up to 69 characters long.
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) name of keyword to read
+/// * `value`   — (O) keyword value
+/// * `comm`    — (O) keyword comment
+/// * `status`  — (IO) error status
 pub fn ffgkyjj_safe(
-    fptr: &mut fitsfile,                       /* I - FITS file pointer         */
-    keyname: &[c_char],                        /* I - name of keyword to read   */
-    value: &mut LONGLONG,                      /* O - keyword value             */
-    comm: Option<&mut [c_char; FLEN_COMMENT]>, /* O - keyword comment           */
-    status: &mut c_int,                        /* IO - error status             */
+    fptr: &mut fitsfile,
+    keyname: &[c_char],
+    value: &mut LONGLONG,
+    comm: Option<&mut [c_char; FLEN_COMMENT]>,
+    status: &mut c_int,
 ) -> c_int {
     let mut valstring: [c_char; FLEN_VALUE] = [0; FLEN_VALUE];
 
@@ -2234,7 +2548,6 @@ pub fn ffgkyjj_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read (get) the named keyword, returning the value and comment.
 ///
 /// The value will be implicitly converted to a (ULONGLONG) integer if it not
@@ -2270,7 +2583,6 @@ pub unsafe extern "C" fn ffgkyujj(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read (get) the named keyword, returning the value and comment.
 ///
 /// The value will be implicitly converted to a (ULONGLONG) integer if it not
@@ -2294,17 +2606,24 @@ pub fn ffgkyujj_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read (get) the named keyword, returning the value and comment.
 /// The value will be implicitly converted to a float if it not
 /// already of this datatype.  The comment may be up to 69 characters long.
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) name of keyword to read
+/// * `value`   — (O) keyword value
+/// * `comm`    — (O) keyword comment
+/// * `status`  — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgkye(
-    fptr: *mut fitsfile,    /* I - FITS file pointer         */
-    keyname: *const c_char, /* I - name of keyword to read   */
-    value: *mut f32,        /* O - keyword value             */
-    comm: *mut c_char,      /* O - keyword comment           */
-    status: *mut c_int,     /* IO - error status             */
+    fptr: *mut fitsfile,
+    keyname: *const c_char,
+    value: *mut f32,
+    comm: *mut c_char,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -2329,16 +2648,23 @@ pub unsafe extern "C" fn ffgkye(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read (get) the named keyword, returning the value and comment.
 /// The value will be implicitly converted to a float if it not
 /// already of this datatype.  The comment may be up to 69 characters long.
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) name of keyword to read
+/// * `value`   — (O) keyword value
+/// * `comm`    — (O) keyword comment
+/// * `status`  — (IO) error status
 pub fn ffgkye_safe(
-    fptr: &mut fitsfile,                       /* I - FITS file pointer         */
-    keyname: &[c_char],                        /* I - name of keyword to read   */
-    value: &mut f32,                           /* O - keyword value             */
-    comm: Option<&mut [c_char; FLEN_COMMENT]>, /* O - keyword comment           */
-    status: &mut c_int,                        /* IO - error status             */
+    fptr: &mut fitsfile,
+    keyname: &[c_char],
+    value: &mut f32,
+    comm: Option<&mut [c_char; FLEN_COMMENT]>,
+    status: &mut c_int,
 ) -> c_int {
     let mut valstring: [c_char; FLEN_VALUE] = [0; FLEN_VALUE];
 
@@ -2352,17 +2678,24 @@ pub fn ffgkye_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read (get) the named keyword, returning the value and comment.
 /// The value will be implicitly converted to a double if it not
 /// already of this datatype.  The comment may be up to 69 characters long.
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) name of keyword to read
+/// * `value`   — (O) keyword value
+/// * `comm`    — (O) keyword comment
+/// * `status`  — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgkyd(
-    fptr: *mut fitsfile,    /* I - FITS file pointer         */
-    keyname: *const c_char, /* I - name of keyword to read   */
-    value: *mut f64,        /* O - keyword value             */
-    comm: *mut c_char,      /* O - keyword comment           */
-    status: *mut c_int,     /* IO - error status             */
+    fptr: *mut fitsfile,
+    keyname: *const c_char,
+    value: *mut f64,
+    comm: *mut c_char,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -2387,16 +2720,23 @@ pub unsafe extern "C" fn ffgkyd(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read (get) the named keyword, returning the value and comment.
 /// The value will be implicitly converted to a double if it not
 /// already of this datatype.  The comment may be up to 69 characters long.
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) name of keyword to read
+/// * `value`   — (O) keyword value
+/// * `comm`    — (O) keyword comment
+/// * `status`  — (IO) error status
 pub fn ffgkyd_safe(
-    fptr: &mut fitsfile,                       /* I - FITS file pointer         */
-    keyname: &[c_char],                        /* I - name of keyword to read   */
-    value: &mut f64,                           /* O - keyword value             */
-    comm: Option<&mut [c_char; FLEN_COMMENT]>, /* O - keyword comment           */
-    status: &mut c_int,                        /* IO - error status             */
+    fptr: &mut fitsfile,
+    keyname: &[c_char],
+    value: &mut f64,
+    comm: Option<&mut [c_char; FLEN_COMMENT]>,
+    status: &mut c_int,
 ) -> c_int {
     let mut valstring: [c_char; FLEN_VALUE] = [0; FLEN_VALUE];
 
@@ -2410,17 +2750,24 @@ pub fn ffgkyd_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read (get) the named keyword, returning the value and comment.
 /// The keyword must have a complex value. No implicit data conversion
 /// will be performed.
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) name of keyword to read
+/// * `value`   — (O) keyword value (real,imag)
+/// * `comm`    — (O) keyword comment
+/// * `status`  — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgkyc(
-    fptr: *mut fitsfile,    /* I - FITS file pointer         */
-    keyname: *const c_char, /* I - name of keyword to read   */
-    value: *mut [f32; 2],   /* O - keyword value (real,imag) */
-    comm: *mut c_char,      /* O - keyword comment           */
-    status: *mut c_int,     /* IO - error status             */
+    fptr: *mut fitsfile,
+    keyname: *const c_char,
+    value: *mut [f32; 2],
+    comm: *mut c_char,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -2445,16 +2792,23 @@ pub unsafe extern "C" fn ffgkyc(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read (get) the named keyword, returning the value and comment.
 /// The keyword must have a complex value. No implicit data conversion
 /// will be performed.
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) name of keyword to read
+/// * `value`   — (O) keyword value (real,imag)
+/// * `comm`    — (O) keyword comment
+/// * `status`  — (IO) error status
 pub fn ffgkyc_safe(
-    fptr: &mut fitsfile,                       /* I - FITS file pointer         */
-    keyname: &[c_char],                        /* I - name of keyword to read   */
-    value: &mut [f32; 2],                      /* O - keyword value (real,imag) */
-    comm: Option<&mut [c_char; FLEN_COMMENT]>, /* O - keyword comment           */
-    status: &mut c_int,                        /* IO - error status             */
+    fptr: &mut fitsfile,
+    keyname: &[c_char],
+    value: &mut [f32; 2],
+    comm: Option<&mut [c_char; FLEN_COMMENT]>,
+    status: &mut c_int,
 ) -> c_int {
     let mut valstring: [c_char; FLEN_VALUE] = [0; FLEN_VALUE];
     let mut message: [c_char; FLEN_ERRMSG] = [0; FLEN_ERRMSG];
@@ -2493,17 +2847,24 @@ pub fn ffgkyc_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read (get) the named keyword, returning the value and comment.
 /// The keyword must have a complex value. No implicit data conversion
 /// will be performed.
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) name of keyword to read
+/// * `value`   — (O) keyword value (real,imag)
+/// * `comm`    — (O) keyword comment
+/// * `status`  — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgkym(
-    fptr: *mut fitsfile,    /* I - FITS file pointer         */
-    keyname: *const c_char, /* I - name of keyword to read   */
-    value: *mut [f64; 2],   /* O - keyword value (real,imag) */
-    comm: *mut c_char,      /* O - keyword comment           */
-    status: *mut c_int,     /* IO - error status             */
+    fptr: *mut fitsfile,
+    keyname: *const c_char,
+    value: *mut [f64; 2],
+    comm: *mut c_char,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -2528,16 +2889,23 @@ pub unsafe extern "C" fn ffgkym(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read (get) the named keyword, returning the value and comment.
 /// The keyword must have a complex value. No implicit data conversion
 /// will be performed.
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) name of keyword to read
+/// * `value`   — (O) keyword value (real,imag)
+/// * `comm`    — (O) keyword comment
+/// * `status`  — (IO) error status
 pub fn ffgkym_safe(
-    fptr: &mut fitsfile,                       /* I - FITS file pointer         */
-    keyname: &[c_char],                        /* I - name of keyword to read   */
-    value: &mut [f64; 2],                      /* O - keyword value (real,imag) */
-    comm: Option<&mut [c_char; FLEN_COMMENT]>, /* O - keyword comment           */
-    status: &mut c_int,                        /* IO - error status             */
+    fptr: &mut fitsfile,
+    keyname: &[c_char],
+    value: &mut [f64; 2],
+    comm: Option<&mut [c_char; FLEN_COMMENT]>,
+    status: &mut c_int,
 ) -> c_int {
     let mut valstring: [c_char; FLEN_VALUE] = [0; FLEN_VALUE];
     let mut message: [c_char; FLEN_ERRMSG] = [0; FLEN_ERRMSG];
@@ -2577,21 +2945,29 @@ pub fn ffgkym_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read (get) the named keyword, returning the value and comment.
 ///
 /// The integer and fractional parts of the value are returned in separate
 /// variables, to allow more numerical precision to be passed.  This
 /// effectively passes a 'triple' precision value, with a 4-byte integer
 /// and an 8-byte fraction.  The comment may be up to 69 characters long.
+///
+/// # Parameters
+///
+/// * `fptr`     — (I) FITS file pointer
+/// * `keyname`  — (I) name of keyword to read
+/// * `ivalue`   — (O) integer part of keyword value
+/// * `fraction` — (O) fractional part of keyword value
+/// * `comm`     — (O) keyword comment
+/// * `status`   — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgkyt(
-    fptr: *mut fitsfile,    /* I - FITS file pointer         */
-    keyname: *const c_char, /* I - name of keyword to read   */
-    ivalue: *mut c_long,    /* O - integer part of keyword value     */
-    fraction: *mut f64,     /* O - fractional part of keyword value  */
-    comm: *mut c_char,      /* O - keyword comment           */
-    status: *mut c_int,     /* IO - error status             */
+    fptr: *mut fitsfile,
+    keyname: *const c_char,
+    ivalue: *mut c_long,
+    fraction: *mut f64,
+    comm: *mut c_char,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -2618,13 +2994,22 @@ pub unsafe extern "C" fn ffgkyt(
 }
 
 /// Safe wrapper for ffgkyt that handles null pointer checks
+///
+/// # Parameters
+///
+/// * `fptr`     — (I) FITS file pointer
+/// * `keyname`  — (I) name of keyword to read
+/// * `ivalue`   — (O) integer part of keyword value
+/// * `fraction` — (O) fractional part of keyword value
+/// * `comm`     — (O) keyword comment
+/// * `status`   — (IO) error status
 pub fn ffgkyt_safe(
-    fptr: &mut fitsfile,                       /* I - FITS file pointer         */
-    keyname: &[c_char],                        /* I - name of keyword to read   */
-    ivalue: &mut c_long,                       /* O - integer part of keyword value     */
-    fraction: &mut f64,                        /* O - fractional part of keyword value  */
-    comm: Option<&mut [c_char; FLEN_COMMENT]>, /* O - keyword comment           */
-    status: &mut c_int,                        /* IO - error status             */
+    fptr: &mut fitsfile,
+    keyname: &[c_char],
+    ivalue: &mut c_long,
+    fraction: &mut f64,
+    comm: Option<&mut [c_char; FLEN_COMMENT]>,
+    status: &mut c_int,
 ) -> c_int {
     let mut valstring: [c_char; FLEN_VALUE] = [0; FLEN_VALUE];
 
@@ -2655,7 +3040,6 @@ pub fn ffgkyt_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read (get) the nkey-th keyword returning the keyword name, value and comment.
 ///
 /// The value is just the literal string of characters in the value field
@@ -2664,14 +3048,23 @@ pub fn ffgkyt_safe(
 /// up to 70 characters long, and the comment may be up to 72 characters long.
 /// If the keyword has no value (no equal sign in column 9) then a null value
 /// is returned.  If comm = NULL, then do not return the comment string.
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `nkey`    — (I) number of the keyword to read
+/// * `keyname` — (O) name of the keyword
+/// * `value`   — (O) keyword value
+/// * `comm`    — (O) keyword comment
+/// * `status`  — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgkyn(
-    fptr: *mut fitsfile,  /* I - FITS file pointer             */
-    nkey: c_int,          /* I - number of the keyword to read */
-    keyname: *mut c_char, /* O - name of the keyword           */
-    value: *mut c_char,   /* O - keyword value                 */
-    comm: *mut c_char,    /* O - keyword comment               */
-    status: *mut c_int,   /* IO - error status                 */
+    fptr: *mut fitsfile,
+    nkey: c_int,
+    keyname: *mut c_char,
+    value: *mut c_char,
+    comm: *mut c_char,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -2698,7 +3091,6 @@ pub unsafe extern "C" fn ffgkyn(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read (get) the nkey-th keyword returning the keyword name, value and comment.
 ///
 /// The value is just the literal string of characters in the value field
@@ -2707,13 +3099,22 @@ pub unsafe extern "C" fn ffgkyn(
 /// up to 70 characters long, and the comment may be up to 72 characters long.
 /// If the keyword has no value (no equal sign in column 9) then a null value
 /// is returned.  If comm = NULL, then do not return the comment string.
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `nkey`    — (I) number of the keyword to read
+/// * `keyname` — (O) name of the keyword
+/// * `value`   — (O) keyword value
+/// * `comm`    — (O) keyword comment
+/// * `status`  — (IO) error status
 pub fn ffgkyn_safe(
-    fptr: &mut fitsfile,                       /* I - FITS file pointer             */
-    nkey: c_int,                               /* I - number of the keyword to read */
-    keyname: &mut [c_char; FLEN_KEYWORD],      /* O - name of the keyword           */
-    value: &mut [c_char; FLEN_VALUE],          /* O - keyword value                 */
-    comm: Option<&mut [c_char; FLEN_COMMENT]>, /* O - keyword comment               */
-    status: &mut c_int,                        /* IO - error status                 */
+    fptr: &mut fitsfile,
+    nkey: c_int,
+    keyname: &mut [c_char; FLEN_KEYWORD],
+    value: &mut [c_char; FLEN_VALUE],
+    comm: Option<&mut [c_char; FLEN_COMMENT]>,
+    status: &mut c_int,
 ) -> c_int {
     let mut card: [c_char; FLEN_CARD] = [0; FLEN_CARD];
     let mut sbuff: [c_char; FLEN_CARD] = [0; FLEN_CARD];
@@ -2759,19 +3160,28 @@ pub fn ffgkyn_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read (get) an indexed array of keywords with index numbers between
 /// NSTART and (NSTART + NMAX -1) inclusive.  
 /// This routine does NOT support the HEASARC long string convention.
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) root name of keywords to read
+/// * `nstart`  — (I) starting index number
+/// * `nmax`    — (I) maximum number of keywords to return
+/// * `value`   — (O) array of pointers to keyword values
+/// * `nfound`  — (O) number of values that were returned
+/// * `status`  — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgkns(
-    fptr: *mut fitsfile,     /* I - FITS file pointer                    */
-    keyname: *const c_char,  /* I - root name of keywords to read        */
-    nstart: c_int,           /* I - starting index number                */
-    nmax: c_int,             /* I - maximum number of keywords to return */
-    value: *mut *mut c_char, /* O - array of pointers to keyword values  */
-    nfound: *mut c_int,      /* O - number of values that were returned  */
-    status: *mut c_int,      /* IO - error status                        */
+    fptr: *mut fitsfile,
+    keyname: *const c_char,
+    nstart: c_int,
+    nmax: c_int,
+    value: *mut *mut c_char,
+    nfound: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -2792,18 +3202,27 @@ pub unsafe extern "C" fn ffgkns(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read (get) an indexed array of keywords with index numbers between
 /// NSTART and (NSTART + NMAX -1) inclusive.  
 /// This routine does NOT support the HEASARC long string convention.
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) root name of keywords to read
+/// * `nstart`  — (I) starting index number
+/// * `nmax`    — (I) maximum number of keywords to return
+/// * `value`   — (O) array of pointers to keyword values
+/// * `nfound`  — (O) number of values that were returned
+/// * `status`  — (IO) error status
 pub fn ffgkns_safe(
-    fptr: &mut fitsfile,         /* I - FITS file pointer                    */
-    keyname: &[c_char],          /* I - root name of keywords to read        */
-    nstart: c_int,               /* I - starting index number                */
-    nmax: c_int,                 /* I - maximum number of keywords to return */
-    value: &mut [&mut [c_char]], /* O - array of pointers to keyword values  */
-    nfound: &mut c_int,          /* O - number of values that were returned  */
-    status: &mut c_int,          /* IO - error status                        */
+    fptr: &mut fitsfile,
+    keyname: &[c_char],
+    nstart: c_int,
+    nmax: c_int,
+    value: &mut [&mut [c_char]],
+    nfound: &mut c_int,
+    status: &mut c_int,
 ) -> c_int {
     let mut nend: c_int = 0;
     let mut lenroot: usize = 0;
@@ -2893,19 +3312,28 @@ pub fn ffgkns_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read (get) an indexed array of keywords with index numbers between
 /// NSTART and (NSTART + NMAX -1) inclusive.  
 /// The returned value = 1 if the keyword is true, else = 0 if false.
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) root name of keywords to read
+/// * `nstart`  — (I) starting index number
+/// * `nmax`    — (I) maximum number of keywords to return
+/// * `value`   — (O) array of keyword values
+/// * `nfound`  — (O) number of values that were returned
+/// * `status`  — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgknl(
-    fptr: *mut fitsfile,    /* I - FITS file pointer                    */
-    keyname: *const c_char, /* I - root name of keywords to read        */
-    nstart: c_int,          /* I - starting index number                */
-    nmax: c_int,            /* I - maximum number of keywords to return */
-    value: *mut c_int,      /* O - array of keyword values              */
-    nfound: *mut c_int,     /* O - number of values that were returned  */
-    status: *mut c_int,     /* IO - error status                        */
+    fptr: *mut fitsfile,
+    keyname: *const c_char,
+    nstart: c_int,
+    nmax: c_int,
+    value: *mut c_int,
+    nfound: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -2921,18 +3349,27 @@ pub unsafe extern "C" fn ffgknl(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read (get) an indexed array of keywords with index numbers between
 /// NSTART and (NSTART + NMAX -1) inclusive.  
 /// The returned value = 1 if the keyword is true, else = 0 if false.
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) root name of keywords to read
+/// * `nstart`  — (I) starting index number
+/// * `nmax`    — (I) maximum number of keywords to return
+/// * `value`   — (O) array of keyword values
+/// * `nfound`  — (O) number of values that were returned
+/// * `status`  — (IO) error status
 pub fn ffgknl_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                    */
-    keyname: &[c_char],  /* I - root name of keywords to read        */
-    nstart: c_int,       /* I - starting index number                */
-    nmax: c_int,         /* I - maximum number of keywords to return */
-    value: &mut [c_int], /* O - array of keyword values              */
-    nfound: &mut c_int,  /* O - number of values that were returned  */
-    status: &mut c_int,  /* IO - error status                        */
+    fptr: &mut fitsfile,
+    keyname: &[c_char],
+    nstart: c_int,
+    nmax: c_int,
+    value: &mut [c_int],
+    nfound: &mut c_int,
+    status: &mut c_int,
 ) -> c_int {
     let mut nkeys = 0;
     let mut mkeys = 0;
@@ -3022,18 +3459,27 @@ pub fn ffgknl_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read (get) an indexed array of keywords with index numbers between
 /// NSTART and (NSTART + NMAX -1) inclusive.  
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) root name of keywords to read
+/// * `nstart`  — (I) starting index number
+/// * `nmax`    — (I) maximum number of keywords to return
+/// * `value`   — (O) array of keyword values
+/// * `nfound`  — (O) number of values that were returned
+/// * `status`  — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgknj(
-    fptr: *mut fitsfile,    /* I - FITS file pointer                    */
-    keyname: *const c_char, /* I - root name of keywords to read        */
-    nstart: c_int,          /* I - starting index number                */
-    nmax: c_int,            /* I - maximum number of keywords to return */
-    value: *mut c_long,     /* O - array of keyword values              */
-    nfound: *mut c_int,     /* O - number of values that were returned  */
-    status: *mut c_int,     /* IO - error status                        */
+    fptr: *mut fitsfile,
+    keyname: *const c_char,
+    nstart: c_int,
+    nmax: c_int,
+    value: *mut c_long,
+    nfound: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -3049,17 +3495,26 @@ pub unsafe extern "C" fn ffgknj(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read (get) an indexed array of keywords with index numbers between
 /// NSTART and (NSTART + NMAX -1) inclusive.  
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) root name of keywords to read
+/// * `nstart`  — (I) starting index number
+/// * `nmax`    — (I) maximum number of keywords to return
+/// * `value`   — (O) array of keyword values
+/// * `nfound`  — (O) number of values that were returned
+/// * `status`  — (IO) error status
 pub fn ffgknj_safe(
-    fptr: &mut fitsfile,  /* I - FITS file pointer                    */
-    keyname: &[c_char],   /* I - root name of keywords to read        */
-    nstart: c_int,        /* I - starting index number                */
-    nmax: c_int,          /* I - maximum number of keywords to return */
-    value: &mut [c_long], /* O - array of keyword values              */
-    nfound: &mut c_int,   /* O - number of values that were returned  */
-    status: &mut c_int,   /* IO - error status                        */
+    fptr: &mut fitsfile,
+    keyname: &[c_char],
+    nstart: c_int,
+    nmax: c_int,
+    value: &mut [c_long],
+    nfound: &mut c_int,
+    status: &mut c_int,
 ) -> c_int {
     let mut nkeys = 0;
     let mut mkeys = 0;
@@ -3151,18 +3606,27 @@ pub fn ffgknj_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read (get) an indexed array of keywords with index numbers between
 /// NSTART and (NSTART + NMAX -1) inclusive.  
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) root name of keywords to read
+/// * `nstart`  — (I) starting index number
+/// * `nmax`    — (I) maximum number of keywords to return
+/// * `value`   — (O) array of keyword values
+/// * `nfound`  — (O) number of values that were returned
+/// * `status`  — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgknjj(
-    fptr: *mut fitsfile,    /* I - FITS file pointer                    */
-    keyname: *const c_char, /* I - root name of keywords to read        */
-    nstart: c_int,          /* I - starting index number                */
-    nmax: c_int,            /* I - maximum number of keywords to return */
-    value: *mut LONGLONG,   /* O - array of keyword values              */
-    nfound: *mut c_int,     /* O - number of values that were returned  */
-    status: *mut c_int,     /* IO - error status                        */
+    fptr: *mut fitsfile,
+    keyname: *const c_char,
+    nstart: c_int,
+    nmax: c_int,
+    value: *mut LONGLONG,
+    nfound: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -3178,17 +3642,26 @@ pub unsafe extern "C" fn ffgknjj(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read (get) an indexed array of keywords with index numbers between
 /// NSTART and (NSTART + NMAX -1) inclusive.  
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) root name of keywords to read
+/// * `nstart`  — (I) starting index number
+/// * `nmax`    — (I) maximum number of keywords to return
+/// * `value`   — (O) array of keyword values
+/// * `nfound`  — (O) number of values that were returned
+/// * `status`  — (IO) error status
 pub fn ffgknjj_safe(
-    fptr: &mut fitsfile,    /* I - FITS file pointer                    */
-    keyname: &[c_char],     /* I - root name of keywords to read        */
-    nstart: c_int,          /* I - starting index number                */
-    nmax: c_int,            /* I - maximum number of keywords to return */
-    value: &mut [LONGLONG], /* O - array of keyword values              */
-    nfound: &mut c_int,     /* O - number of values that were returned  */
-    status: &mut c_int,     /* IO - error status                        */
+    fptr: &mut fitsfile,
+    keyname: &[c_char],
+    nstart: c_int,
+    nmax: c_int,
+    value: &mut [LONGLONG],
+    nfound: &mut c_int,
+    status: &mut c_int,
 ) -> c_int {
     let mut nkeys = 0;
     let mut mkeys = 0;
@@ -3279,18 +3752,27 @@ pub fn ffgknjj_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read (get) an indexed array of keywords with index numbers between
 /// NSTART and (NSTART + NMAX -1) inclusive.  
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) root name of keywords to read
+/// * `nstart`  — (I) starting index number
+/// * `nmax`    — (I) maximum number of keywords to return
+/// * `value`   — (O) array of keyword values
+/// * `nfound`  — (O) number of values that were returned
+/// * `status`  — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgkne(
-    fptr: *mut fitsfile,    /* I - FITS file pointer                    */
-    keyname: *const c_char, /* I - root name of keywords to read        */
-    nstart: c_int,          /* I - starting index number                */
-    nmax: c_int,            /* I - maximum number of keywords to return */
-    value: *mut f32,        /* O - array of keyword values              */
-    nfound: *mut c_int,     /* O - number of values that were returned  */
-    status: *mut c_int,     /* IO - error status                        */
+    fptr: *mut fitsfile,
+    keyname: *const c_char,
+    nstart: c_int,
+    nmax: c_int,
+    value: *mut f32,
+    nfound: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -3305,17 +3787,26 @@ pub unsafe extern "C" fn ffgkne(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read (get) an indexed array of keywords with index numbers between
 /// NSTART and (NSTART + NMAX -1) inclusive.  
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) root name of keywords to read
+/// * `nstart`  — (I) starting index number
+/// * `nmax`    — (I) maximum number of keywords to return
+/// * `value`   — (O) array of keyword values
+/// * `nfound`  — (O) number of values that were returned
+/// * `status`  — (IO) error status
 pub fn ffgkne_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                    */
-    keyname: &[c_char],  /* I - root name of keywords to read        */
-    nstart: c_int,       /* I - starting index number                */
-    nmax: c_int,         /* I - maximum number of keywords to return */
-    value: &mut [f32],   /* O - array of keyword values              */
-    nfound: &mut c_int,  /* O - number of values that were returned  */
-    status: &mut c_int,  /* IO - error status                        */
+    fptr: &mut fitsfile,
+    keyname: &[c_char],
+    nstart: c_int,
+    nmax: c_int,
+    value: &mut [f32],
+    nfound: &mut c_int,
+    status: &mut c_int,
 ) -> c_int {
     let mut nkeys = 0;
     let mut mkeys = 0;
@@ -3405,18 +3896,27 @@ pub fn ffgkne_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read (get) an indexed array of keywords with index numbers between
 /// NSTART and (NSTART + NMAX -1) inclusive.  
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) root name of keywords to read
+/// * `nstart`  — (I) starting index number
+/// * `nmax`    — (I) maximum number of keywords to return
+/// * `value`   — (O) array of keyword values
+/// * `nfound`  — (O) number of values that were returned
+/// * `status`  — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgknd(
-    fptr: *mut fitsfile,    /* I - FITS file pointer                    */
-    keyname: *const c_char, /* I - root name of keywords to read        */
-    nstart: c_int,          /* I - starting index number                */
-    nmax: c_int,            /* I - maximum number of keywords to return */
-    value: *mut f64,        /* O - array of keyword values              */
-    nfound: *mut c_int,     /* O - number of values that were returned  */
-    status: *mut c_int,     /* IO - error status                        */
+    fptr: *mut fitsfile,
+    keyname: *const c_char,
+    nstart: c_int,
+    nmax: c_int,
+    value: *mut f64,
+    nfound: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -3431,17 +3931,26 @@ pub unsafe extern "C" fn ffgknd(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read (get) an indexed array of keywords with index numbers between
 /// NSTART and (NSTART + NMAX -1) inclusive.  
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) root name of keywords to read
+/// * `nstart`  — (I) starting index number
+/// * `nmax`    — (I) maximum number of keywords to return
+/// * `value`   — (O) array of keyword values
+/// * `nfound`  — (O) number of values that were returned
+/// * `status`  — (IO) error status
 pub fn ffgknd_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                    */
-    keyname: &[c_char],  /* I - root name of keywords to read        */
-    nstart: c_int,       /* I - starting index number                */
-    nmax: c_int,         /* I - maximum number of keywords to return */
-    value: &mut [f64],   /* O - array of keyword values              */
-    nfound: &mut c_int,  /* O - number of values that were returned  */
-    status: &mut c_int,  /* IO - error status                        */
+    fptr: &mut fitsfile,
+    keyname: &[c_char],
+    nstart: c_int,
+    nmax: c_int,
+    value: &mut [f64],
+    nfound: &mut c_int,
+    status: &mut c_int,
 ) -> c_int {
     let mut nkeys = 0;
     let mut mkeys = 0;
@@ -3533,16 +4042,24 @@ pub fn ffgknd_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// read and parse the TDIMnnn keyword to get the dimensionality of a column
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `colnum` — (I) number of the column to read
+/// * `maxdim` — (I) maximum no. of dimensions to read;
+/// * `naxis`  — (O) number of axes in the data array
+/// * `naxes`  — (O) length of each data axis
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgtdm(
-    fptr: *mut fitsfile, /* I - FITS file pointer                        */
-    colnum: c_int,       /* I - number of the column to read             */
-    maxdim: c_int,       /* I - maximum no. of dimensions to read;       */
-    naxis: *mut c_int,   /* O - number of axes in the data array         */
-    naxes: *mut c_long,  /* O - length of each data axis                 */
-    status: *mut c_int,  /* IO - error status                            */
+    fptr: *mut fitsfile,
+    colnum: c_int,
+    maxdim: c_int,
+    naxis: *mut c_int,
+    naxes: *mut c_long,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -3556,15 +4073,23 @@ pub unsafe extern "C" fn ffgtdm(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// read and parse the TDIMnnn keyword to get the dimensionality of a column
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `colnum` — (I) number of the column to read
+/// * `maxdim` — (I) maximum no. of dimensions to read;
+/// * `naxis`  — (O) number of axes in the data array
+/// * `naxes`  — (O) length of each data axis
+/// * `status` — (IO) error status
 pub fn ffgtdm_safe(
-    fptr: &mut fitsfile,  /* I - FITS file pointer                        */
-    colnum: c_int,        /* I - number of the column to read             */
-    maxdim: c_int,        /* I - maximum no. of dimensions to read;       */
-    naxis: &mut c_int,    /* O - number of axes in the data array         */
-    naxes: &mut [c_long], /* O - length of each data axis                 */
-    status: &mut c_int,   /* IO - error status                            */
+    fptr: &mut fitsfile,
+    colnum: c_int,
+    maxdim: c_int,
+    naxis: &mut c_int,
+    naxes: &mut [c_long],
+    status: &mut c_int,
 ) -> c_int {
     let mut tstatus = 0;
     let mut keyname: [c_char; FLEN_KEYWORD] = [0; FLEN_KEYWORD];
@@ -3583,16 +4108,24 @@ pub fn ffgtdm_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// read and parse the TDIMnnn keyword to get the dimensionality of a column
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `colnum` — (I) number of the column to read
+/// * `maxdim` — (I) maximum no. of dimensions to read;
+/// * `naxis`  — (O) number of axes in the data array
+/// * `naxes`  — (O) length of each data axis
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgtdmll(
-    fptr: *mut fitsfile,  /* I - FITS file pointer                        */
-    colnum: c_int,        /* I - number of the column to read             */
-    maxdim: c_int,        /* I - maximum no. of dimensions to read;       */
-    naxis: *mut c_int,    /* O - number of axes in the data array         */
-    naxes: *mut LONGLONG, /* O - length of each data axis                 */
-    status: *mut c_int,   /* IO - error status                            */
+    fptr: *mut fitsfile,
+    colnum: c_int,
+    maxdim: c_int,
+    naxis: *mut c_int,
+    naxes: *mut LONGLONG,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -3606,15 +4139,23 @@ pub unsafe extern "C" fn ffgtdmll(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Get the dimensionality of a column by reading the TDIMnnn keyword.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `colnum` — (I) number of the column to read
+/// * `maxdim` — (I) maximum no. of dimensions to read;
+/// * `naxis`  — (O) number of axes in the data array
+/// * `naxes`  — (O) length of each data axis
+/// * `status` — (IO) error status
 pub fn ffgtdmll_safer(
-    fptr: &mut fitsfile,    /* I - FITS file pointer                        */
-    colnum: c_int,          /* I - number of the column to read             */
-    maxdim: c_int,          /* I - maximum no. of dimensions to read;       */
-    naxis: &mut c_int,      /* O - number of axes in the data array         */
-    naxes: &mut [LONGLONG], /* O - length of each data axis               */
-    status: &mut c_int,     /* IO - error status                            */
+    fptr: &mut fitsfile,
+    colnum: c_int,
+    maxdim: c_int,
+    naxis: &mut c_int,
+    naxes: &mut [LONGLONG],
+    status: &mut c_int,
 ) -> c_int {
     let mut tstatus = 0;
     let mut keyname: [c_char; FLEN_KEYWORD] = [0; FLEN_KEYWORD];
@@ -3633,19 +4174,28 @@ pub fn ffgtdmll_safer(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Decode the TDIMnnn keyword to get the dimensionality of a column.
 /// Check that the value is legal and consistent with the TFORM value.
 /// If colnum = 0, then the validity checking is disabled.
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `tdimstr` — (I) TDIMn keyword value string. e.g. (10,10)
+/// * `colnum`  — (I) number of the column
+/// * `maxdim`  — (I) maximum no. of dimensions to read;
+/// * `naxis`   — (O) number of axes in the data array
+/// * `naxes`   — (O) length of each data axis
+/// * `status`  — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffdtdm(
-    fptr: *mut fitsfile,    /* I - FITS file pointer                        */
-    tdimstr: *const c_char, /* I - TDIMn keyword value string. e.g. (10,10) */
-    colnum: c_int,          /* I - number of the column             */
-    maxdim: c_int,          /* I - maximum no. of dimensions to read;       */
-    naxis: *mut c_int,      /* O - number of axes in the data array         */
-    naxes: *mut c_long,     /* O - length of each data axis                 */
-    status: *mut c_int,     /* IO - error status                            */
+    fptr: *mut fitsfile,
+    tdimstr: *const c_char,
+    colnum: c_int,
+    maxdim: c_int,
+    naxis: *mut c_int,
+    naxes: *mut c_long,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -3661,18 +4211,27 @@ pub unsafe extern "C" fn ffdtdm(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Decode the TDIMnnn keyword to get the dimensionality of a column.
 /// Check that the value is legal and consistent with the TFORM value.
 /// If colnum = 0, then the validity checking is disabled.
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `tdimstr` — (I) TDIMn keyword value string. e.g. (10,10)
+/// * `colnum`  — (I) number of the column
+/// * `maxdim`  — (I) maximum no. of dimensions to read;
+/// * `naxis`   — (O) number of axes in the data array
+/// * `naxes`   — (O) length of each data axis
+/// * `status`  — (IO) error status
 pub fn ffdtdm_safe(
-    fptr: &mut fitsfile,  /* I - FITS file pointer                        */
-    tdimstr: &[c_char],   /* I - TDIMn keyword value string. e.g. (10,10) */
-    colnum: c_int,        /* I - number of the column             */
-    maxdim: c_int,        /* I - maximum no. of dimensions to read;       */
-    naxis: &mut c_int,    /* O - number of axes in the data array         */
-    naxes: &mut [c_long], /* O - length of each data axis                 */
-    status: &mut c_int,   /* IO - error status                            */
+    fptr: &mut fitsfile,
+    tdimstr: &[c_char],
+    colnum: c_int,
+    maxdim: c_int,
+    naxis: &mut c_int,
+    naxes: &mut [c_long],
+    status: &mut c_int,
 ) -> c_int {
     let mut lastloc = 0;
     let mut dimsize = 0;
@@ -3789,18 +4348,27 @@ pub fn ffdtdm_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Decode the TDIMnnn keyword to get the dimensionality of a column.
 /// Check that the value is legal and consistent with the TFORM value.
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `tdimstr` — (I) TDIMn keyword value string. e.g. (10,10)
+/// * `colnum`  — (I) number of the column
+/// * `maxdim`  — (I) maximum no. of dimensions to read;
+/// * `naxis`   — (O) number of axes in the data array
+/// * `naxes`   — (O) length of each data axis
+/// * `status`  — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffdtdmll(
-    fptr: *mut fitsfile,    /* I - FITS file pointer                        */
-    tdimstr: *const c_char, /* I - TDIMn keyword value string. e.g. (10,10) */
-    colnum: c_int,          /* I - number of the column             */
-    maxdim: c_int,          /* I - maximum no. of dimensions to read;       */
-    naxis: *mut c_int,      /* O - number of axes in the data array         */
-    naxes: *mut LONGLONG,   /* O - length of each data axis                 */
-    status: *mut c_int,     /* IO - error status                            */
+    fptr: *mut fitsfile,
+    tdimstr: *const c_char,
+    colnum: c_int,
+    maxdim: c_int,
+    naxis: *mut c_int,
+    naxes: *mut LONGLONG,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -3816,17 +4384,26 @@ pub unsafe extern "C" fn ffdtdmll(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Decode the TDIMnnn keyword to get the dimensionality of a column.
 /// Check that the value is legal and consistent with the TFORM value.
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `tdimstr` — (I) TDIMn keyword value string. e.g. (10,10)
+/// * `colnum`  — (I) number of the column
+/// * `maxdim`  — (I) maximum no. of dimensions to read;
+/// * `naxis`   — (O) number of axes in the data array
+/// * `naxes`   — (O) length of each data axis
+/// * `status`  — (IO) error status
 pub fn ffdtdmll_safe(
-    fptr: &mut fitsfile,    /* I - FITS file pointer                        */
-    tdimstr: &[c_char],     /* I - TDIMn keyword value string. e.g. (10,10) */
-    colnum: c_int,          /* I - number of the column             */
-    maxdim: c_int,          /* I - maximum no. of dimensions to read;       */
-    naxis: &mut c_int,      /* O - number of axes in the data array         */
-    naxes: &mut [LONGLONG], /* O - length of each data axis                 */
-    status: &mut c_int,     /* IO - error status                            */
+    fptr: &mut fitsfile,
+    tdimstr: &[c_char],
+    colnum: c_int,
+    maxdim: c_int,
+    naxis: &mut c_int,
+    naxes: &mut [LONGLONG],
+    status: &mut c_int,
 ) -> c_int {
     let mut lastloc = 0;
     let mut dimsize = 0;
@@ -3932,23 +4509,35 @@ pub fn ffdtdmll_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Get keywords from the Header of the Primary array:
 /// Check that the keywords conform to the FITS standard and return the
 /// parameters which determine the size and structure of the primary array
 /// or IMAGE extension.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `maxdim` — (I) maximum no. of dimensions to read;
+/// * `simple` — (O) does file conform to FITS standard? 1/0
+/// * `bitpix` — (O) number of bits per data value pixel
+/// * `naxis`  — (O) number of axes in the data array
+/// * `naxes`  — (O) length of each data axis
+/// * `pcount` — (O) number of group parameters (usually 0)
+/// * `gcount` — (O) number of random groups (usually 1 or 0)
+/// * `extend` — (O) may FITS file haave extensions?
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffghpr(
-    fptr: *mut fitsfile, /* I - FITS file pointer                        */
-    maxdim: c_int,       /* I - maximum no. of dimensions to read;       */
-    simple: *mut c_int,  /* O - does file conform to FITS standard? 1/0  */
-    bitpix: *mut c_int,  /* O - number of bits per data value pixel      */
-    naxis: *mut c_int,   /* O - number of axes in the data array         */
-    naxes: *mut c_long,  /* O - length of each data axis                 */
-    pcount: *mut c_long, /* O - number of group parameters (usually 0)   */
-    gcount: *mut c_long, /* O - number of random groups (usually 1 or 0) */
-    extend: *mut c_int,  /* O - may FITS file haave extensions?          */
-    status: *mut c_int,  /* IO - error status                            */
+    fptr: *mut fitsfile,
+    maxdim: c_int,
+    simple: *mut c_int,
+    bitpix: *mut c_int,
+    naxis: *mut c_int,
+    naxes: *mut c_long,
+    pcount: *mut c_long,
+    gcount: *mut c_long,
+    extend: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -3971,22 +4560,34 @@ pub unsafe extern "C" fn ffghpr(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Get keywords from the Header of the Primary array:
 /// Check that the keywords conform to the FITS standard and return the
 /// parameters which determine the size and structure of the primary array
 /// or IMAGE extension.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `maxdim` — (I) maximum no. of dimensions to read;
+/// * `simple` — (O) does file conform to FITS standard? 1/0
+/// * `bitpix` — (O) number of bits per data value pixel
+/// * `naxis`  — (O) number of axes in the data array
+/// * `naxes`  — (O) length of each data axis
+/// * `pcount` — (O) number of group parameters (usually 0)
+/// * `gcount` — (O) number of random groups (usually 1 or 0)
+/// * `extend` — (O) may FITS file haave extensions?
+/// * `status` — (IO) error status
 pub fn ffghpr_safe(
-    fptr: &mut fitsfile,           /* I - FITS file pointer                        */
-    maxdim: c_int,                 /* I - maximum no. of dimensions to read;       */
-    simple: &mut c_int,            /* O - does file conform to FITS standard? 1/0  */
-    bitpix: &mut c_int,            /* O - number of bits per data value pixel      */
-    mut naxis: Option<&mut c_int>, /* O - number of axes in the data array         */
-    naxes: Option<&mut [c_long]>,  /* O - length of each data axis                 */
-    pcount: &mut c_long,           /* O - number of group parameters (usually 0)   */
-    gcount: &mut c_long,           /* O - number of random groups (usually 1 or 0) */
-    extend: &mut c_int,            /* O - may FITS file haave extensions?          */
-    status: &mut c_int,            /* IO - error status                            */
+    fptr: &mut fitsfile,
+    maxdim: c_int,
+    simple: &mut c_int,
+    bitpix: &mut c_int,
+    mut naxis: Option<&mut c_int>,
+    naxes: Option<&mut [c_long]>,
+    pcount: &mut c_long,
+    gcount: &mut c_long,
+    extend: &mut c_int,
+    status: &mut c_int,
 ) -> c_int {
     let mut idummy: c_int = 0;
     let mut lldummy: LONGLONG = 0;
@@ -4028,23 +4629,35 @@ pub fn ffghpr_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Get keywords from the Header of the PRimary array:
 /// Check that the keywords conform to the FITS standard and return the
 /// parameters which determine the size and structure of the primary array
 /// or IMAGE extension.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `maxdim` — (I) maximum no. of dimensions to read;
+/// * `simple` — (O) does file conform to FITS standard? 1/0
+/// * `bitpix` — (O) number of bits per data value pixel
+/// * `naxis`  — (O) number of axes in the data array
+/// * `naxes`  — (O) length of each data axis
+/// * `pcount` — (O) number of group parameters (usually 0)
+/// * `gcount` — (O) number of random groups (usually 1 or 0)
+/// * `extend` — (O) may FITS file haave extensions?
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffghprll(
-    fptr: *mut fitsfile,  /* I - FITS file pointer                        */
-    maxdim: c_int,        /* I - maximum no. of dimensions to read;       */
-    simple: *mut c_int,   /* O - does file conform to FITS standard? 1/0  */
-    bitpix: *mut c_int,   /* O - number of bits per data value pixel      */
-    naxis: *mut c_int,    /* O - number of axes in the data array         */
-    naxes: *mut LONGLONG, /* O - length of each data axis                 */
-    pcount: *mut c_long,  /* O - number of group parameters (usually 0)   */
-    gcount: *mut c_long,  /* O - number of random groups (usually 1 or 0) */
-    extend: *mut c_int,   /* O - may FITS file haave extensions?          */
-    status: *mut c_int,   /* IO - error status                            */
+    fptr: *mut fitsfile,
+    maxdim: c_int,
+    simple: *mut c_int,
+    bitpix: *mut c_int,
+    naxis: *mut c_int,
+    naxes: *mut LONGLONG,
+    pcount: *mut c_long,
+    gcount: *mut c_long,
+    extend: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -4065,22 +4678,34 @@ pub unsafe extern "C" fn ffghprll(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Get keywords from the Header of the PRimary array:
 /// Check that the keywords conform to the FITS standard and return the
 /// parameters which determine the size and structure of the primary array
 /// or IMAGE extension.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `maxdim` — (I) maximum no. of dimensions to read;
+/// * `simple` — (O) does file conform to FITS standard? 1/0
+/// * `bitpix` — (O) number of bits per data value pixel
+/// * `naxis`  — (O) number of axes in the data array
+/// * `naxes`  — (O) length of each data axis
+/// * `pcount` — (O) number of group parameters (usually 0)
+/// * `gcount` — (O) number of random groups (usually 1 or 0)
+/// * `extend` — (O) may FITS file haave extensions?
+/// * `status` — (IO) error status
 pub fn ffghprll_safe(
-    fptr: &mut fitsfile,       /* I - FITS file pointer                        */
-    maxdim: c_int,             /* I - maximum no. of dimensions to read;       */
-    simple: &mut c_int,        /* O - does file conform to FITS standard? 1/0  */
-    bitpix: &mut c_int,        /* O - number of bits per data value pixel      */
-    naxis: Option<&mut c_int>, /* O - number of axes in the data array         */
-    naxes: &mut [LONGLONG],    /* O - length of each data axis                 */
-    pcount: &mut c_long,       /* O - number of group parameters (usually 0)   */
-    gcount: &mut c_long,       /* O - number of random groups (usually 1 or 0) */
-    extend: &mut c_int,        /* O - may FITS file haave extensions?          */
-    status: &mut c_int,        /* IO - error status                            */
+    fptr: &mut fitsfile,
+    maxdim: c_int,
+    simple: &mut c_int,
+    bitpix: &mut c_int,
+    naxis: Option<&mut c_int>,
+    naxes: &mut [LONGLONG],
+    pcount: &mut c_long,
+    gcount: &mut c_long,
+    extend: &mut c_int,
+    status: &mut c_int,
 ) -> c_int {
     let mut idummy: c_int = 0;
     let mut lldummy: LONGLONG = 0;
@@ -4107,7 +4732,6 @@ pub fn ffghprll_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Number of entries of the `char *arr[]` output arrays of ffghtb/ffghbn that
 /// the safe implementation may touch.
 ///
@@ -4155,23 +4779,36 @@ unsafe fn ffgh_str_array<'a>(arr: *mut *mut c_char, nelem: usize) -> Option<Vec<
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Get keywords from the Header of the ASCII TaBle:
 /// Check that the keywords conform to the FITS standard and return the
 /// parameters which describe the table.
+///
+/// # Parameters
+///
+/// * `fptr`     — (I) FITS file pointer
+/// * `maxfield` — (I) maximum no. of columns to read;
+/// * `naxis1`   — (O) length of table row in bytes
+/// * `naxis2`   — (O) number of rows in the table
+/// * `tfields`  — (O) number of columns in the table
+/// * `ttype`    — (O) name of each column
+/// * `tbcol`    — (O) byte offset in row to each column
+/// * `tform`    — (O) value of TFORMn keyword for each column
+/// * `tunit`    — (O) value of TUNITn keyword for each column
+/// * `extnm`    — (O) value of EXTNAME keyword, if any
+/// * `status`   — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffghtb(
-    fptr: *mut fitsfile,     /* I - FITS file pointer                        */
-    maxfield: c_int,         /* I - maximum no. of columns to read;          */
-    naxis1: *mut c_long,     /* O - length of table row in bytes             */
-    naxis2: *mut c_long,     /* O - number of rows in the table              */
-    tfields: *mut c_int,     /* O - number of columns in the table           */
-    ttype: *mut *mut c_char, /* O - name of each column                      */
-    tbcol: *mut c_long,      /* O - byte offset in row to each column        */
-    tform: *mut *mut c_char, /* O - value of TFORMn keyword for each column  */
-    tunit: *mut *mut c_char, /* O - value of TUNITn keyword for each column  */
-    extnm: *mut c_char,      /* O - value of EXTNAME keyword, if any         */
-    status: *mut c_int,      /* IO - error status                            */
+    fptr: *mut fitsfile,
+    maxfield: c_int,
+    naxis1: *mut c_long,
+    naxis2: *mut c_long,
+    tfields: *mut c_int,
+    ttype: *mut *mut c_char,
+    tbcol: *mut c_long,
+    tform: *mut *mut c_char,
+    tunit: *mut *mut c_char,
+    extnm: *mut c_char,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -4202,7 +4839,6 @@ pub unsafe extern "C" fn ffghtb(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Get keywords from the Header of the ASCII TaBle:
 /// Check that the keywords conform to the FITS standard and return the
 /// parameters which describe the table.
@@ -4210,18 +4846,32 @@ pub unsafe extern "C" fn ffghtb(
 /// `ttype`, `tform` and `tunit` are arrays of per-column string buffers; each
 /// must hold at least `min(maxfield, TFIELDS)` entries (all TFIELDS of them
 /// when `maxfield` is negative), and so must `tbcol`.
+///
+/// # Parameters
+///
+/// * `fptr`     — (I) FITS file pointer
+/// * `maxfield` — (I) maximum no. of columns to read;
+/// * `naxis1`   — (O) length of table row in bytes
+/// * `naxis2`   — (O) number of rows in the table
+/// * `tfields`  — (O) number of columns in the table
+/// * `ttype`    — (O) name of each column
+/// * `tbcol`    — (O) byte offset in row to each column
+/// * `tform`    — (O) value of TFORMn keyword for each column
+/// * `tunit`    — (O) value of TUNITn keyword for each column
+/// * `extnm`    — (O) value of EXTNAME keyword, if any
+/// * `status`   — (IO) error status
 pub fn ffghtb_safe(
-    fptr: &mut fitsfile,         /* I - FITS file pointer                        */
-    maxfield: c_int,             /* I - maximum no. of columns to read;          */
-    naxis1: Option<&mut c_long>, /* O - length of table row in bytes             */
-    naxis2: Option<&mut c_long>, /* O - number of rows in the table              */
-    tfields: Option<&mut c_int>, /* O - number of columns in the table           */
-    mut ttype: Option<&mut [&mut [c_char]]>, /* O - name of each column                   */
-    tbcol: Option<&mut [c_long]>, /* O - byte offset in row to each column        */
-    tform: Option<&mut [&mut [c_char]]>, /* O - value of TFORMn keyword for each column  */
-    mut tunit: Option<&mut [&mut [c_char]]>, /* O - value of TUNITn keyword for each column */
-    extnm: Option<&mut [c_char]>, /* O - value of EXTNAME keyword, if any         */
-    status: &mut c_int,          /* IO - error status                            */
+    fptr: &mut fitsfile,
+    maxfield: c_int,
+    naxis1: Option<&mut c_long>,
+    naxis2: Option<&mut c_long>,
+    tfields: Option<&mut c_int>,
+    mut ttype: Option<&mut [&mut [c_char]]>,
+    tbcol: Option<&mut [c_long]>,
+    tform: Option<&mut [&mut [c_char]]>,
+    mut tunit: Option<&mut [&mut [c_char]]>,
+    extnm: Option<&mut [c_char]>,
+    status: &mut c_int,
 ) -> c_int {
     let mut maxf: c_int = 0;
     let mut nfound: c_int = 0;
@@ -4414,23 +5064,36 @@ pub fn ffghtb_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Get keywords from the Header of the ASCII TaBle:
 /// Check that the keywords conform to the FITS standard and return the
 /// parameters which describe the table.
+///
+/// # Parameters
+///
+/// * `fptr`     — (I) FITS file pointer
+/// * `maxfield` — (I) maximum no. of columns to read;
+/// * `naxis1`   — (O) length of table row in bytes
+/// * `naxis2`   — (O) number of rows in the table
+/// * `tfields`  — (O) number of columns in the table
+/// * `ttype`    — (O) name of each column
+/// * `tbcol`    — (O) byte offset in row to each column
+/// * `tform`    — (O) value of TFORMn keyword for each column
+/// * `tunit`    — (O) value of TUNITn keyword for each column
+/// * `extnm`    — (O) value of EXTNAME keyword, if any
+/// * `status`   — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffghtbll(
-    fptr: *mut fitsfile,     /* I - FITS file pointer                        */
-    maxfield: c_int,         /* I - maximum no. of columns to read;          */
-    naxis1: *mut LONGLONG,   /* O - length of table row in bytes             */
-    naxis2: *mut LONGLONG,   /* O - number of rows in the table              */
-    tfields: *mut c_int,     /* O - number of columns in the table           */
-    ttype: *mut *mut c_char, /* O - name of each column                      */
-    tbcol: *mut LONGLONG,    /* O - byte offset in row to each column        */
-    tform: *mut *mut c_char, /* O - value of TFORMn keyword for each column  */
-    tunit: *mut *mut c_char, /* O - value of TUNITn keyword for each column  */
-    extnm: *mut c_char,      /* O - value of EXTNAME keyword, if any         */
-    status: *mut c_int,      /* IO - error status                            */
+    fptr: *mut fitsfile,
+    maxfield: c_int,
+    naxis1: *mut LONGLONG,
+    naxis2: *mut LONGLONG,
+    tfields: *mut c_int,
+    ttype: *mut *mut c_char,
+    tbcol: *mut LONGLONG,
+    tform: *mut *mut c_char,
+    tunit: *mut *mut c_char,
+    extnm: *mut c_char,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -4461,7 +5124,6 @@ pub unsafe extern "C" fn ffghtbll(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Get keywords from the Header of the ASCII TaBle:
 /// Check that the keywords conform to the FITS standard and return the
 /// parameters which describe the table.
@@ -4469,18 +5131,32 @@ pub unsafe extern "C" fn ffghtbll(
 /// `ttype`, `tform` and `tunit` are arrays of per-column string buffers; each
 /// must hold at least `min(maxfield, TFIELDS)` entries (all TFIELDS of them
 /// when `maxfield` is negative), and so must `tbcol`.
+///
+/// # Parameters
+///
+/// * `fptr`     — (I) FITS file pointer
+/// * `maxfield` — (I) maximum no. of columns to read;
+/// * `naxis1`   — (O) length of table row in bytes
+/// * `naxis2`   — (O) number of rows in the table
+/// * `tfields`  — (O) number of columns in the table
+/// * `ttype`    — (O) name of each column
+/// * `tbcol`    — (O) byte offset in row to each column
+/// * `tform`    — (O) value of TFORMn keyword for each column
+/// * `tunit`    — (O) value of TUNITn keyword for each column
+/// * `extnm`    — (O) value of EXTNAME keyword, if any
+/// * `status`   — (IO) error status
 pub fn ffghtbll_safe(
-    fptr: &mut fitsfile,           /* I - FITS file pointer                        */
-    maxfield: c_int,               /* I - maximum no. of columns to read;          */
-    naxis1: Option<&mut LONGLONG>, /* O - length of table row in bytes             */
-    naxis2: Option<&mut LONGLONG>, /* O - number of rows in the table              */
-    tfields: Option<&mut c_int>,   /* O - number of columns in the table           */
-    mut ttype: Option<&mut [&mut [c_char]]>, /* O - name of each column                   */
-    tbcol: Option<&mut [LONGLONG]>, /* O - byte offset in row to each column        */
-    tform: Option<&mut [&mut [c_char]]>, /* O - value of TFORMn keyword for each column  */
-    mut tunit: Option<&mut [&mut [c_char]]>, /* O - value of TUNITn keyword for each column */
-    extnm: Option<&mut [c_char]>,  /* O - value of EXTNAME keyword, if any         */
-    status: &mut c_int,            /* IO - error status                            */
+    fptr: &mut fitsfile,
+    maxfield: c_int,
+    naxis1: Option<&mut LONGLONG>,
+    naxis2: Option<&mut LONGLONG>,
+    tfields: Option<&mut c_int>,
+    mut ttype: Option<&mut [&mut [c_char]]>,
+    tbcol: Option<&mut [LONGLONG]>,
+    tform: Option<&mut [&mut [c_char]]>,
+    mut tunit: Option<&mut [&mut [c_char]]>,
+    extnm: Option<&mut [c_char]>,
+    status: &mut c_int,
 ) -> c_int {
     let mut maxf: c_int = 0;
     let mut nfound: c_int = 0;
@@ -4673,22 +5349,34 @@ pub fn ffghtbll_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Get keywords from the Header of the BiNary table:
 /// Check that the keywords conform to the FITS standard and return the
 /// parameters which describe the table.
+///
+/// # Parameters
+///
+/// * `fptr`     — (I) FITS file pointer
+/// * `maxfield` — (I) maximum no. of columns to read;
+/// * `naxis2`   — (O) number of rows in the table
+/// * `tfields`  — (O) number of columns in the table
+/// * `ttype`    — (O) name of each column
+/// * `tform`    — (O) TFORMn value for each column
+/// * `tunit`    — (O) TUNITn value for each column
+/// * `extnm`    — (O) value of EXTNAME keyword, if any
+/// * `pcount`   — (O) value of PCOUNT keyword
+/// * `status`   — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffghbn(
-    fptr: *mut fitsfile,     /* I - FITS file pointer                        */
-    maxfield: c_int,         /* I - maximum no. of columns to read;          */
-    naxis2: *mut c_long,     /* O - number of rows in the table              */
-    tfields: *mut c_int,     /* O - number of columns in the table           */
-    ttype: *mut *mut c_char, /* O - name of each column                      */
-    tform: *mut *mut c_char, /* O - TFORMn value for each column             */
-    tunit: *mut *mut c_char, /* O - TUNITn value for each column             */
-    extnm: *mut c_char,      /* O - value of EXTNAME keyword, if any         */
-    pcount: *mut c_long,     /* O - value of PCOUNT keyword                  */
-    status: *mut c_int,      /* IO - error status                            */
+    fptr: *mut fitsfile,
+    maxfield: c_int,
+    naxis2: *mut c_long,
+    tfields: *mut c_int,
+    ttype: *mut *mut c_char,
+    tform: *mut *mut c_char,
+    tunit: *mut *mut c_char,
+    extnm: *mut c_char,
+    pcount: *mut c_long,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -4717,7 +5405,6 @@ pub unsafe extern "C" fn ffghbn(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Get keywords from the Header of the BiNary table:
 /// Check that the keywords conform to the FITS standard and return the
 /// parameters which describe the table.
@@ -4725,17 +5412,30 @@ pub unsafe extern "C" fn ffghbn(
 /// `ttype`, `tform` and `tunit` are arrays of per-column string buffers; each
 /// must hold at least `min(maxfield, TFIELDS)` entries (all TFIELDS of them
 /// when `maxfield` is negative).
+///
+/// # Parameters
+///
+/// * `fptr`     — (I) FITS file pointer
+/// * `maxfield` — (I) maximum no. of columns to read;
+/// * `naxis2`   — (O) number of rows in the table
+/// * `tfields`  — (O) number of columns in the table
+/// * `ttype`    — (O) name of each column
+/// * `tform`    — (O) TFORMn value for each column
+/// * `tunit`    — (O) TUNITn value for each column
+/// * `extnm`    — (O) value of EXTNAME keyword, if any
+/// * `pcount`   — (O) value of PCOUNT keyword
+/// * `status`   — (IO) error status
 pub fn ffghbn_safe(
-    fptr: &mut fitsfile,         /* I - FITS file pointer                        */
-    maxfield: c_int,             /* I - maximum no. of columns to read;          */
-    naxis2: Option<&mut c_long>, /* O - number of rows in the table              */
-    tfields: Option<&mut c_int>, /* O - number of columns in the table           */
-    mut ttype: Option<&mut [&mut [c_char]]>, /* O - name of each column                   */
-    tform: Option<&mut [&mut [c_char]]>, /* O - TFORMn value for each column             */
-    mut tunit: Option<&mut [&mut [c_char]]>, /* O - TUNITn value for each column          */
-    extnm: Option<&mut [c_char]>, /* O - value of EXTNAME keyword, if any         */
-    pcount: Option<&mut c_long>, /* O - value of PCOUNT keyword                  */
-    status: &mut c_int,          /* IO - error status                            */
+    fptr: &mut fitsfile,
+    maxfield: c_int,
+    naxis2: Option<&mut c_long>,
+    tfields: Option<&mut c_int>,
+    mut ttype: Option<&mut [&mut [c_char]]>,
+    tform: Option<&mut [&mut [c_char]]>,
+    mut tunit: Option<&mut [&mut [c_char]]>,
+    extnm: Option<&mut [c_char]>,
+    pcount: Option<&mut c_long>,
+    status: &mut c_int,
 ) -> c_int {
     let mut maxf: c_int = 0;
     let mut nfound: c_int = 0;
@@ -4902,22 +5602,34 @@ pub fn ffghbn_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Get keywords from the Header of the BiNary table:
 /// Check that the keywords conform to the FITS standard and return the
 /// parameters which describe the table.
+///
+/// # Parameters
+///
+/// * `fptr`     — (I) FITS file pointer
+/// * `maxfield` — (I) maximum no. of columns to read;
+/// * `naxis2`   — (O) number of rows in the table
+/// * `tfields`  — (O) number of columns in the table
+/// * `ttype`    — (O) name of each column
+/// * `tform`    — (O) TFORMn value for each column
+/// * `tunit`    — (O) TUNITn value for each column
+/// * `extnm`    — (O) value of EXTNAME keyword, if any
+/// * `pcount`   — (O) value of PCOUNT keyword
+/// * `status`   — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffghbnll(
-    fptr: *mut fitsfile,     /* I - FITS file pointer                        */
-    maxfield: c_int,         /* I - maximum no. of columns to read;          */
-    naxis2: *mut LONGLONG,   /* O - number of rows in the table              */
-    tfields: *mut c_int,     /* O - number of columns in the table           */
-    ttype: *mut *mut c_char, /* O - name of each column                      */
-    tform: *mut *mut c_char, /* O - TFORMn value for each column             */
-    tunit: *mut *mut c_char, /* O - TUNITn value for each column             */
-    extnm: *mut c_char,      /* O - value of EXTNAME keyword, if any         */
-    pcount: *mut LONGLONG,   /* O - value of PCOUNT keyword                  */
-    status: *mut c_int,      /* IO - error status                            */
+    fptr: *mut fitsfile,
+    maxfield: c_int,
+    naxis2: *mut LONGLONG,
+    tfields: *mut c_int,
+    ttype: *mut *mut c_char,
+    tform: *mut *mut c_char,
+    tunit: *mut *mut c_char,
+    extnm: *mut c_char,
+    pcount: *mut LONGLONG,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -4946,7 +5658,6 @@ pub unsafe extern "C" fn ffghbnll(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Get keywords from the Header of the BiNary table:
 /// Check that the keywords conform to the FITS standard and return the
 /// parameters which describe the table.
@@ -4954,17 +5665,30 @@ pub unsafe extern "C" fn ffghbnll(
 /// `ttype`, `tform` and `tunit` are arrays of per-column string buffers; each
 /// must hold at least `min(maxfield, TFIELDS)` entries (all TFIELDS of them
 /// when `maxfield` is negative).
+///
+/// # Parameters
+///
+/// * `fptr`     — (I) FITS file pointer
+/// * `maxfield` — (I) maximum no. of columns to read;
+/// * `naxis2`   — (O) number of rows in the table
+/// * `tfields`  — (O) number of columns in the table
+/// * `ttype`    — (O) name of each column
+/// * `tform`    — (O) TFORMn value for each column
+/// * `tunit`    — (O) TUNITn value for each column
+/// * `extnm`    — (O) value of EXTNAME keyword, if any
+/// * `pcount`   — (O) value of PCOUNT keyword
+/// * `status`   — (IO) error status
 pub fn ffghbnll_safe(
-    fptr: &mut fitsfile,           /* I - FITS file pointer                        */
-    maxfield: c_int,               /* I - maximum no. of columns to read;          */
-    naxis2: Option<&mut LONGLONG>, /* O - number of rows in the table              */
-    tfields: Option<&mut c_int>,   /* O - number of columns in the table           */
-    mut ttype: Option<&mut [&mut [c_char]]>, /* O - name of each column                   */
-    tform: Option<&mut [&mut [c_char]]>, /* O - TFORMn value for each column             */
-    mut tunit: Option<&mut [&mut [c_char]]>, /* O - TUNITn value for each column          */
-    extnm: Option<&mut [c_char]>,  /* O - value of EXTNAME keyword, if any         */
-    pcount: Option<&mut LONGLONG>, /* O - value of PCOUNT keyword                  */
-    status: &mut c_int,            /* IO - error status                            */
+    fptr: &mut fitsfile,
+    maxfield: c_int,
+    naxis2: Option<&mut LONGLONG>,
+    tfields: Option<&mut c_int>,
+    mut ttype: Option<&mut [&mut [c_char]]>,
+    tform: Option<&mut [&mut [c_char]]>,
+    mut tunit: Option<&mut [&mut [c_char]]>,
+    extnm: Option<&mut [c_char]>,
+    pcount: Option<&mut LONGLONG>,
+    status: &mut c_int,
 ) -> c_int {
     let mut maxf: c_int = 0;
     let mut nfound: c_int = 0;
@@ -5132,25 +5856,41 @@ pub fn ffghbnll_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Get the Primary HeaDer parameters.  Check that the keywords conform to
 /// the FITS standard and return the parameters which determine the size and
 /// structure of the primary array or IMAGE extension.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `maxdim` — (I) maximum no. of dimensions to read;
+/// * `simple` — (O) does file conform to FITS standard? 1/0
+/// * `bitpix` — (O) number of bits per data value pixel
+/// * `naxis`  — (O) number of axes in the data array
+/// * `naxes`  — (O) length of each data axis
+/// * `pcount` — (O) number of group parameters (usually 0)
+/// * `gcount` — (O) number of random groups (usually 1 or 0)
+/// * `extend` — (O) may FITS file have extensions?
+/// * `bscale` — (O) array pixel linear scaling factor
+/// * `bzero`  — (O) array pixel linear scaling zero point
+/// * `blank`  — (O) value used to represent undefined pixels
+/// * `nspace` — (O) number of blank keywords prior to END
+/// * `status` — (IO) error status
 pub(crate) fn ffgphd(
-    fptr: &mut fitsfile,       /* I - FITS file pointer                        */
-    maxdim: c_int,             /* I - maximum no. of dimensions to read;       */
-    simple: &mut c_int,        /* O - does file conform to FITS standard? 1/0  */
-    bitpix: &mut c_int,        /* O - number of bits per data value pixel      */
-    naxis: Option<&mut c_int>, /* O - number of axes in the data array         */
-    naxes: &mut [LONGLONG],    /* O - length of each data axis                 */
-    pcount: &mut c_long,       /* O - number of group parameters (usually 0)   */
-    gcount: &mut c_long,       /* O - number of random groups (usually 1 or 0) */
-    extend: &mut c_int,        /* O - may FITS file have extensions?          */
-    bscale: &mut f64,          /* O - array pixel linear scaling factor        */
-    bzero: &mut f64,           /* O - array pixel linear scaling zero point    */
-    blank: &mut LONGLONG,      /* O - value used to represent undefined pixels */
-    nspace: &mut c_int,        /* O - number of blank keywords prior to END    */
-    status: &mut c_int,        /* IO - error status                            */
+    fptr: &mut fitsfile,
+    maxdim: c_int,
+    simple: &mut c_int,
+    bitpix: &mut c_int,
+    naxis: Option<&mut c_int>,
+    naxes: &mut [LONGLONG],
+    pcount: &mut c_long,
+    gcount: &mut c_long,
+    extend: &mut c_int,
+    bscale: &mut f64,
+    bzero: &mut f64,
+    blank: &mut LONGLONG,
+    nspace: &mut c_int,
+    status: &mut c_int,
 ) -> c_int {
     let mut ii = 0;
     let mut nextkey = 0;
@@ -5179,9 +5919,7 @@ pub(crate) fn ffgphd(
 
     let mut unknown = 0;
 
-    /*--------------------------------------------------------------------*/
     /*  Get 1st keyword of HDU and test whether it is SIMPLE or XTENSION  */
-    /*--------------------------------------------------------------------*/
 
     ffgkyn_safe(fptr, 1, &mut name, &mut value, Some(&mut comm), status);
 
@@ -5282,9 +6020,7 @@ pub(crate) fn ffgphd(
         //}
         nextkey = 9; /* skip required table keywords in the following search */
     } else {
-        /*----------------------------------------------------------------*/
         /*  Get 2nd keyword;  test whether it is BITPIX with legal value  */
-        /*----------------------------------------------------------------*/
 
         /* BITPIX = 2nd keyword */
         ffgkyn_safe(fptr, 2, &mut name, &mut value, Some(&mut comm), status);
@@ -5333,9 +6069,7 @@ pub(crate) fn ffgphd(
         *bitpix = longbitpix as c_int; /* do explicit type conversion */
         //}
 
-        /*---------------------------------------------------------------*/
         /*  Get 3rd keyword;  test whether it is NAXIS with legal value  */
-        /*---------------------------------------------------------------*/
         ffgtkn(fptr, 3, cs!(c"NAXIS"), &mut longnaxis, status);
         if *status == BAD_ORDER {
             *status = NO_NAXIS;
@@ -5355,9 +6089,7 @@ pub(crate) fn ffgphd(
             *naxis = longnaxis as c_int; /* do explicit type conversion */
         }
 
-        /*---------------------------------------------------------*/
         /*  Get the next NAXISn keywords and test for legal values */
-        /*---------------------------------------------------------*/
 
         ii = 0;
         nextkey = 4;
@@ -5382,10 +6114,8 @@ pub(crate) fn ffgphd(
         }
     }
 
-    /*---------------------------------------------------------*/
     /*  now look for other keywords of interest:               */
     /*  BSCALE, BZERO, BLANK, PCOUNT, GCOUNT, EXTEND, and END  */
-    /*---------------------------------------------------------*/
 
     /*  initialize default values in case keyword is not present */
 
@@ -5596,18 +6326,26 @@ pub(crate) fn ffgphd(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Get and Test TaBle;
 /// Test that this is a legal ASCII or binary table and get some keyword values.
 /// We assume that the calling routine has already tested the 1st keyword
 /// of the extension to ensure that this is really a table extension.
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `rowlen`  — (O) length of a table row, in bytes
+/// * `nrows`   — (O) number of rows in the table
+/// * `pcount`  — (O) value of PCOUNT keyword
+/// * `tfields` — (O) number of fields in the table
+/// * `status`  — (IO) error status
 pub(crate) fn ffgttb(
-    fptr: &mut fitsfile,   /* I - FITS file pointer*/
-    rowlen: &mut LONGLONG, /* O - length of a table row, in bytes */
-    nrows: &mut LONGLONG,  /* O - number of rows in the table */
-    pcount: &mut LONGLONG, /* O - value of PCOUNT keyword */
-    tfields: &mut c_long,  /* O - number of fields in the table */
-    status: &mut c_int,    /* IO - error status    */
+    fptr: &mut fitsfile,
+    rowlen: &mut LONGLONG,
+    nrows: &mut LONGLONG,
+    pcount: &mut LONGLONG,
+    tfields: &mut c_long,
+    status: &mut c_int,
 ) -> c_int {
     if *status > 0 {
         return *status;
@@ -5682,17 +6420,24 @@ pub(crate) fn ffgttb(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Test that keyword number NUMKEY has the expected name and get the
 /// integer value of the keyword.  Return an error if the keyword
 /// name does not match the input name, or if the value of the
 /// keyword is not a positive integer.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `numkey` — (I) number of the keyword to read
+/// * `name`   — (I) expected name of the keyword
+/// * `value`  — (O) integer value of the keyword
+/// * `status` — (IO) error status
 pub(crate) fn ffgtkn(
-    fptr: &mut fitsfile, /* I - FITS file pointer              */
-    numkey: c_int,       /* I - number of the keyword to read  */
-    name: &[c_char],     /* I - expected name of the keyword   */
-    value: &mut c_long,  /* O - integer value of the keyword   */
-    status: &mut c_int,  /* IO - error status                  */
+    fptr: &mut fitsfile,
+    numkey: c_int,
+    name: &[c_char],
+    value: &mut c_long,
+    status: &mut c_int,
 ) -> c_int {
     let mut keyname: [c_char; FLEN_KEYWORD] = [0; FLEN_KEYWORD]; /* incorrect keyword name */
     let mut valuestring: [c_char; FLEN_VALUE] = [0; FLEN_VALUE]; /* convert to integer */
@@ -5753,17 +6498,24 @@ pub(crate) fn ffgtkn(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Test that keyword number NUMKEY has the expected name and get the
 /// integer value of the keyword.  Return an error if the keyword
 /// name does not match the input name, or if the value of the
 /// keyword is not a positive integer.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `numkey` — (I) number of the keyword to read
+/// * `name`   — (I) expected name of the keyword
+/// * `value`  — (O) integer value of the keyword
+/// * `status` — (IO) error status
 pub(crate) fn ffgtknjj(
-    fptr: &mut fitsfile,  /* I - FITS file pointer              */
-    numkey: c_int,        /* I - number of the keyword to read  */
-    name: &[c_char],      /* I - expected name of the keyword   */
-    value: &mut LONGLONG, /* O - integer value of the keyword   */
-    status: &mut c_int,   /* IO - error status                  */
+    fptr: &mut fitsfile,
+    numkey: c_int,
+    name: &[c_char],
+    value: &mut LONGLONG,
+    status: &mut c_int,
 ) -> c_int {
     let mut keyname: [c_char; FLEN_KEYWORD] = [0; FLEN_KEYWORD];
     let mut valuestring: [c_char; FLEN_VALUE] = [0; FLEN_VALUE];
@@ -5826,15 +6578,22 @@ pub(crate) fn ffgtknjj(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Test that keyword number NUMKEY has the expected name and the
 /// expected value string.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `numkey` — (I) number of the keyword to read
+/// * `name`   — (I) expected name of the keyword
+/// * `value`  — (I) expected value of the keyword
+/// * `status` — (IO) error status
 pub(crate) fn fftkyn(
-    fptr: &mut fitsfile, /* I - FITS file pointer              */
-    numkey: c_int,       /* I - number of the keyword to read  */
-    name: &[c_char],     /* I - expected name of the keyword   */
-    value: &[c_char],    /* I - expected value of the keyword  */
-    status: &mut c_int,  /* IO - error status                  */
+    fptr: &mut fitsfile,
+    numkey: c_int,
+    name: &[c_char],
+    value: &[c_char],
+    status: &mut c_int,
 ) -> c_int {
     let mut keyname: [c_char; FLEN_KEYWORD] = [0; FLEN_KEYWORD];
     let mut valuestring: [c_char; FLEN_VALUE] = [0; FLEN_VALUE];
@@ -5895,15 +6654,20 @@ pub(crate) fn fftkyn(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read header keywords into a long string of chars.  This routine allocates
 /// memory for the string, so the calling routine must eventually free the
 /// memory when it is not needed any more.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `header` — (O) returned header string
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffh2st(
-    fptr: *mut fitsfile,      /* I - FITS file pointer           */
-    header: *mut *mut c_char, /* O - returned header string      */
-    status: *mut c_int,       /* IO - error status               */
+    fptr: *mut fitsfile,
+    header: *mut *mut c_char,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -5915,15 +6679,16 @@ pub unsafe extern "C" fn ffh2st(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read header keywords into a long string of chars.  This routine allocates
 /// memory for the string, so the calling routine must eventually free the
 /// memory when it is not needed any more.
-pub fn ffh2st_safe(
-    fptr: &mut fitsfile,      /* I - FITS file pointer           */
-    header: &mut *mut c_char, /* O - returned header string      */
-    status: &mut c_int,       /* IO - error status               */
-) -> c_int {
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `header` — (O) returned header string
+/// * `status` — (IO) error status
+pub fn ffh2st_safe(fptr: &mut fitsfile, header: &mut *mut c_char, status: &mut c_int) -> c_int {
     let mut nkeys: c_int = 0;
     let mut nrec: c_long = 0;
     let mut headstart: LONGLONG = 0;
@@ -5974,22 +6739,31 @@ pub fn ffh2st_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read header keywords into a long string of chars.  This routine allocates
 /// memory for the string, so the calling routine must eventually free the
 /// memory when it is not needed any more.  If exclude_comm is TRUE, then all
-/// the COMMENT, HISTORY, and <blank> keywords will be excluded from the output
+/// the COMMENT, HISTORY, and `<blank>` keywords will be excluded from the output
 /// string of keywords.  Any other list of keywords to be excluded may be
 /// specified with the exclist parameter.
+///
+/// # Parameters
+///
+/// * `fptr`         — (I) FITS file pointer
+/// * `exclude_comm` — (I) if TRUE, exclude commentary keywords
+/// * `exclist`      — (I) list of excluded keyword names
+/// * `nexc`         — (I) number of names in exclist
+/// * `header`       — (O) returned header string
+/// * `nkeys`        — (O) returned number of 80-char keywords
+/// * `status`       — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffhdr2str(
-    fptr: *mut fitsfile,           /* I - FITS file pointer                    */
-    exclude_comm: c_int,           /* I - if TRUE, exclude commentary keywords */
-    exclist: *const *const c_char, /* I - list of excluded keyword names       */
-    nexc: c_int,                   /* I - number of names in exclist           */
-    header: *mut *mut c_char,      /* O - returned header string               */
-    nkeys: *mut c_int,             /* O - returned number of 80-char keywords  */
-    status: *mut c_int,            /* IO - error status                        */
+    fptr: *mut fitsfile,
+    exclude_comm: c_int,
+    exclist: *const *const c_char,
+    nexc: c_int,
+    header: *mut *mut c_char,
+    nkeys: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -6010,21 +6784,30 @@ pub unsafe extern "C" fn ffhdr2str(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read header keywords into a long string of chars.  This routine allocates
 /// memory for the string, so the calling routine must eventually free the
 /// memory when it is not needed any more.  If exclude_comm is TRUE, then all
-/// the COMMENT, HISTORY, and <blank> keywords will be excluded from the output
+/// the COMMENT, HISTORY, and `<blank>` keywords will be excluded from the output
 /// string of keywords.  Any other list of keywords to be excluded may be
 /// specified with the exclist parameter.
+///
+/// # Parameters
+///
+/// * `fptr`         — (I) FITS file pointer
+/// * `exclude_comm` — (I) if TRUE, exclude commentary keywords
+/// * `exclist`      — (I) list of excluded keyword names
+/// * `nexc`         — (I) number of names in exclist
+/// * `header`       — (O) returned header string
+/// * `nkeys`        — (O) returned number of 80-char keywords
+/// * `status`       — (IO) error status
 pub fn ffhdr2str_safe(
-    fptr: &mut fitsfile,      /* I - FITS file pointer                    */
-    exclude_comm: c_int,      /* I - if TRUE, exclude commentary keywords */
-    exclist: &[&[c_char]],    /* I - list of excluded keyword names       */
-    nexc: c_int,              /* I - number of names in exclist           */
-    header: &mut *mut c_char, /* O - returned header string               */
-    nkeys: &mut c_int,        /* O - returned number of 80-char keywords  */
-    status: &mut c_int,       /* IO - error status                        */
+    fptr: &mut fitsfile,
+    exclude_comm: c_int,
+    exclist: &[&[c_char]],
+    nexc: c_int,
+    header: &mut *mut c_char,
+    nkeys: &mut c_int,
+    status: &mut c_int,
 ) -> c_int {
     let mut casesn: c_int = 0;
     let mut matched: c_int = 0;
@@ -6131,20 +6914,29 @@ pub fn ffhdr2str_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Same as ffhdr2str, except that if the input HDU is a tile compressed image
 /// (stored in a binary table) then it will first convert that header back
 /// to that of a normal uncompressed FITS image before concatenating the header
 /// keyword records.
+///
+/// # Parameters
+///
+/// * `fptr`         — (I) FITS file pointer
+/// * `exclude_comm` — (I) if TRUE, exclude commentary keywords
+/// * `exclist`      — (I) list of excluded keyword names
+/// * `nexc`         — (I) number of names in exclist
+/// * `header`       — (O) returned header string
+/// * `nkeys`        — (O) returned number of 80-char keywords
+/// * `status`       — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffcnvthdr2str(
-    fptr: *mut fitsfile,           /* I - FITS file pointer                    */
-    exclude_comm: c_int,           /* I - if TRUE, exclude commentary keywords */
-    exclist: *const *const c_char, /* I - list of excluded keyword names       */
-    nexc: c_int,                   /* I - number of names in exclist           */
-    header: *mut *mut c_char,      /* O - returned header string               */
-    nkeys: *mut c_int,             /* O - returned number of 80-char keywords  */
-    status: *mut c_int,            /* IO - error status                        */
+    fptr: *mut fitsfile,
+    exclude_comm: c_int,
+    exclist: *const *const c_char,
+    nexc: c_int,
+    header: *mut *mut c_char,
+    nkeys: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -6165,19 +6957,28 @@ pub unsafe extern "C" fn ffcnvthdr2str(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Same as ffhdr2str, except that if the input HDU is a tile compressed image
 /// (stored in a binary table) then it will first convert that header back
 /// to that of a normal uncompressed FITS image before concatenating the header
 /// keyword records. (safe version)
+///
+/// # Parameters
+///
+/// * `fptr`         — (I) FITS file pointer
+/// * `exclude_comm` — (I) if TRUE, exclude commentary keywords
+/// * `exclist`      — (I) list of excluded keyword names
+/// * `nexc`         — (I) number of names in exclist
+/// * `header`       — (O) returned header string
+/// * `nkeys`        — (O) returned number of 80-char keywords
+/// * `status`       — (IO) error status
 pub fn ffcnvthdr2str_safe(
-    fptr: &mut fitsfile,      /* I - FITS file pointer                    */
-    exclude_comm: c_int,      /* I - if TRUE, exclude commentary keywords */
-    exclist: &[&[c_char]],    /* I - list of excluded keyword names       */
-    nexc: c_int,              /* I - number of names in exclist           */
-    header: &mut *mut c_char, /* O - returned header string               */
-    nkeys: &mut c_int,        /* O - returned number of 80-char keywords  */
-    status: &mut c_int,       /* IO - error status                        */
+    fptr: &mut fitsfile,
+    exclude_comm: c_int,
+    exclist: &[&[c_char]],
+    nexc: c_int,
+    header: &mut *mut c_char,
+    nkeys: &mut c_int,
+    status: &mut c_int,
 ) -> c_int {
     if *status > 0 {
         return *status;

--- a/src/group.rs
+++ b/src/group.rs
@@ -1,8 +1,19 @@
-/*  This file, group.rs, contains the grouping convention support routines.  */
-
-/*  The FITSIO software was written by William Pence at the High Energy    */
-/*  Astrophysic Science Archive Research Center (HEASARC) at the NASA      */
-/*  Goddard Space Flight Center.                                           */
+//! Support for the FITS hierarchical grouping convention.
+//!
+//! A grouping table is a binary table whose rows name other HDUs -- its
+//! members -- so that a set of related HDUs, possibly spread across several
+//! files, can be treated as a unit. A member is identified by some combination
+//! of position, reference and URI; the `GT_ID_*` constants select which.
+//!
+//! Because a member may live in another file, most of the work here is
+//! resolving the URI that names it, which is why the routines below deal in
+//! partial and absolute URLs.
+//!
+//! Ported from CFITSIO's `grouping.c`, written by William Pence at the High
+//! Energy Astrophysics Science Archive Research Center (HEASARC), NASA Goddard
+//! Space Flight Center. See the "Hierarchical Grouping Routines" chapter of the
+//! CFITSIO User's Reference Guide.
+#![warn(missing_docs)]
 /*                                                                         */
 /*  The group.c module of CFITSIO was written by Donald G. Jennings of     */
 /*  the INTEGRAL Science Data Centre (ISDC) under NASA contract task       */
@@ -34,8 +45,10 @@ use crate::{
     },
 };
 
+/// The character introducing a percent-escape in a group member URI.
 pub const HEX_ESCAPE: u8 = b'%';
 
+/// Maximum number of HDUs that can be tracked while copying a group.
 pub const MAX_HDU_TRACKER: usize = 1000;
 
 // The C uses `char *filename[MAXHDU]` etc., where each entry is either NULL or a
@@ -66,7 +79,6 @@ impl Default for HDUtracker {
     }
 }
 
-/*---------------------------------------------------------------------------*/
 /// Create a grouping table at the end of the current FITS file.
 ///
 /// This function makes the last HDU in the file the CHDU, then calls the
@@ -78,12 +90,19 @@ impl Default for HDUtracker {
 ///   GT_ID_ALL      3 ==> ID by ref. and position
 ///   GT_ID_REF_URI 11 ==> (1) + URI info
 ///   GT_ID_POS_URI 12 ==> (2) + URI info  
+///
+/// # Parameters
+///
+/// * `fptr`      — FITS file pointer
+/// * `grpname`   — name of the grouping table
+/// * `grouptype` — code specifying the type of
+/// * `status`    — return status code
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgtcr(
-    fptr: *mut fitsfile,    /* FITS file pointer                         */
-    grpname: *const c_char, /* name of the grouping table                */
-    grouptype: c_int,       /* code specifying the type of  */
-    status: *mut c_int,     /* return status code                        */
+    fptr: *mut fitsfile,
+    grpname: *const c_char,
+    grouptype: c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -96,7 +115,6 @@ pub unsafe extern "C" fn ffgtcr(
     }
 }
 
-/*---------------------------------------------------------------------------*/
 /// Create a grouping table at the end of the current FITS file.
 ///
 /// This function makes the last HDU in the file the CHDU, then calls the
@@ -108,11 +126,18 @@ pub unsafe extern "C" fn ffgtcr(
 ///   GT_ID_ALL      3 ==> ID by ref. and position
 ///   GT_ID_REF_URI 11 ==> (1) + URI info
 ///   GT_ID_POS_URI 12 ==> (2) + URI info  
+///
+/// # Parameters
+///
+/// * `fptr`      — FITS file pointer
+/// * `grpname`   — name of the grouping table
+/// * `grouptype` — code specifying the type of
+/// * `status`    — return status code
 pub fn ffgtcr_safe(
-    fptr: &mut fitsfile, /* FITS file pointer                         */
-    grpname: &[c_char],  /* name of the grouping table                */
-    grouptype: c_int,    /* code specifying the type of  */
-    status: &mut c_int,  /* return status code                        */
+    fptr: &mut fitsfile,
+    grpname: &[c_char],
+    grouptype: c_int,
+    status: &mut c_int,
 ) -> c_int {
     let mut hdutype: c_int = 0;
     let mut hdunum: c_int = 0;
@@ -148,7 +173,6 @@ pub fn ffgtcr_safe(
     *status
 }
 
-/*---------------------------------------------------------------------------*/
 /// Insert a grouping table just after the current HDU of the current FITS file.
 ///
 /// This is the same as fits_create_group() only it allows the user to select
@@ -160,12 +184,19 @@ pub fn ffgtcr_safe(
 ///   GT_ID_ALL      3 ==> ID by ref. and position
 ///   GT_ID_REF_URI 11 ==> (1) + URI info
 ///   GT_ID_POS_URI 12 ==> (2) + URI info  
+///
+/// # Parameters
+///
+/// * `fptr`      — FITS file pointer
+/// * `grpname`   — name of the grouping table
+/// * `grouptype` — code specifying the type of
+/// * `status`    — return status code
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgtis(
-    fptr: *mut fitsfile,    /* FITS file pointer                         */
-    grpname: *const c_char, /* name of the grouping table                */
-    grouptype: c_int,       /* code specifying the type of  */
-    status: *mut c_int,     /* return status code                        */
+    fptr: *mut fitsfile,
+    grpname: *const c_char,
+    grouptype: c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -178,7 +209,6 @@ pub unsafe extern "C" fn ffgtis(
     }
 }
 
-/*---------------------------------------------------------------------------*/
 /// Insert a grouping table just after the current HDU of the current FITS file.
 ///
 /// This is the same as fits_create_group() only it allows the user to select
@@ -190,11 +220,18 @@ pub unsafe extern "C" fn ffgtis(
 ///   GT_ID_ALL      3 ==> ID by ref. and position
 ///   GT_ID_REF_URI 11 ==> (1) + URI info
 ///   GT_ID_POS_URI 12 ==> (2) + URI info  
+///
+/// # Parameters
+///
+/// * `fptr`      — FITS file pointer
+/// * `grpname`   — name of the grouping table
+/// * `grouptype` — code specifying the type of
+/// * `status`    — return status code
 pub fn ffgtis_safe(
-    fptr: &mut fitsfile, /* FITS file pointer                         */
-    grpname: &[c_char],  /* name of the grouping table                */
-    grouptype: c_int,    /* code specifying the type of  */
-    status: &mut c_int,  /* return status code                        */
+    fptr: &mut fitsfile,
+    grpname: &[c_char],
+    grouptype: c_int,
+    status: &mut c_int,
 ) -> c_int {
     let mut tfields: c_int = 0;
     let mut hdunum: c_int = 0;
@@ -375,7 +412,6 @@ pub fn ffgtis_safe(
     *status
 }
 
-/*---------------------------------------------------------------------------*/
 /// Change the grouping table structure of the grouping table pointed to by gfptr.
 ///
 /// The grouptype code specifies the new structure of the table. This
@@ -391,11 +427,17 @@ pub fn ffgtis_safe(
 ///   GT_ID_ALL      3 ==> ID by ref. and position
 ///   GT_ID_REF_URI 11 ==> (1) + URI info
 ///   GT_ID_POS_URI 12 ==> (2) + URI info  
+///
+/// # Parameters
+///
+/// * `gfptr`     — FITS file pointer
+/// * `grouptype` — code specifying the type of
+/// * `status`    — return status code
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgtch(
-    gfptr: *mut fitsfile, /* FITS file pointer                         */
-    grouptype: c_int,     /* code specifying the type of  */
-    status: *mut c_int,   /* return status code                        */
+    gfptr: *mut fitsfile,
+    grouptype: c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -406,7 +448,6 @@ pub unsafe extern "C" fn ffgtch(
     }
 }
 
-/*---------------------------------------------------------------------------*/
 /// Change the grouping table structure of the grouping table pointed to by gfptr.
 ///
 /// The grouptype code specifies the new structure of the table. This
@@ -422,11 +463,13 @@ pub unsafe extern "C" fn ffgtch(
 ///   GT_ID_ALL      3 ==> ID by ref. and position
 ///   GT_ID_REF_URI 11 ==> (1) + URI info
 ///   GT_ID_POS_URI 12 ==> (2) + URI info  
-pub fn ffgtch_safe(
-    gfptr: &mut fitsfile, /* FITS file pointer                         */
-    grouptype: c_int,     /* code specifying the type of  */
-    status: &mut c_int,   /* return status code                        */
-) -> c_int {
+///
+/// # Parameters
+///
+/// * `gfptr`     — FITS file pointer
+/// * `grouptype` — code specifying the type of
+/// * `status`    — return status code
+pub fn ffgtch_safe(gfptr: &mut fitsfile, grouptype: c_int, status: &mut c_int) -> c_int {
     let mut xtensionCol: c_int = 0;
     let mut extnameCol: c_int = 0;
     let mut extverCol: c_int = 0;
@@ -751,7 +794,6 @@ pub fn ffgtch_safe(
     *status
 }
 
-/*---------------------------------------------------------------------------*/
 /// Remove a grouping table, and optionally all its members.
 ///
 /// Any groups containing the grouping table are updated, and all members (if not
@@ -759,16 +801,16 @@ pub fn ffgtch_safe(
 /// If the (deleted) members are members of another grouping table then those
 /// tables are also updated. The CHDU of the FITS file pointed to by gfptr must
 /// be positioned to the grouping table to be deleted.
+///
+/// # Parameters
+///
+/// * `gfptr`  — FITS file pointer to group
+/// * `rmopt`  — code specifying if member elements are to be deleted: OPT_RM_GPT ==>
+///             remove only group table OPT_RM_ALL ==> recursively remove members and
+///             their members (if groups)
+/// * `status` — return status code
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
-pub unsafe extern "C" fn ffgtrm(
-    gfptr: *mut fitsfile, /* FITS file pointer to group                   */
-    rmopt: c_int,         /* code specifying if member
-                          elements are to be deleted:
-                          OPT_RM_GPT ==> remove only group table
-                          OPT_RM_ALL ==> recursively remove members
-                          and their members (if groups)                */
-    status: *mut c_int, /* return status code                           */
-) -> c_int {
+pub unsafe extern "C" fn ffgtrm(gfptr: *mut fitsfile, rmopt: c_int, status: *mut c_int) -> c_int {
     // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
@@ -778,7 +820,6 @@ pub unsafe extern "C" fn ffgtrm(
     }
 }
 
-/*---------------------------------------------------------------------------*/
 /// Remove a grouping table, and optionally all its members.
 ///
 /// Any groups containing the grouping table are updated, and all members (if not
@@ -786,15 +827,15 @@ pub unsafe extern "C" fn ffgtrm(
 /// If the (deleted) members are members of another grouping table then those
 /// tables are also updated. The CHDU of the FITS file pointed to by gfptr must
 /// be positioned to the grouping table to be deleted.
-pub fn ffgtrm_safe(
-    gfptr: &mut fitsfile, /* FITS file pointer to group                   */
-    rmopt: c_int,         /* code specifying if member
-                          elements are to be deleted:
-                          OPT_RM_GPT ==> remove only group table
-                          OPT_RM_ALL ==> recursively remove members
-                          and their members (if groups)                */
-    status: &mut c_int, /* return status code                           */
-) -> c_int {
+///
+/// # Parameters
+///
+/// * `gfptr`  — FITS file pointer to group
+/// * `rmopt`  — code specifying if member elements are to be deleted: OPT_RM_GPT ==>
+///             remove only group table OPT_RM_ALL ==> recursively remove members and
+///             their members (if groups)
+/// * `status` — return status code
+pub fn ffgtrm_safe(gfptr: &mut fitsfile, rmopt: c_int, status: &mut c_int) -> c_int {
     let mut hdutype: c_int = 0;
 
     let mut i: c_long;
@@ -871,7 +912,6 @@ pub fn ffgtrm_safe(
     *status
 }
 
-/*---------------------------------------------------------------------------*/
 /// Copy a grouping table, and optionally all its members, to a new FITS file.
 ///
 /// If the cpopt is set to OPT_GCP_GPT (copy grouping table only) then the
@@ -884,15 +924,21 @@ pub fn ffgtrm_safe(
 /// Note that the recursive version of this function, ffgtcpr(), is called
 /// to perform the group table copy. In the case of cpopt == OPT_GCP_GPT
 /// ffgtcpr() does not actually use recursion.
+///
+/// # Parameters
+///
+/// * `infptr`  — input FITS file pointer
+/// * `outfptr` — output FITS file pointer
+/// * `cpopt`   — code specifying copy options: OPT_GCP_GPT (0) ==> copy only grouping
+///              table OPT_GCP_ALL (2) ==> recusrively copy members and their members
+///              (if groups)
+/// * `status`  — return status code
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgtcp(
-    infptr: *mut fitsfile,  /* input FITS file pointer                     */
-    outfptr: *mut fitsfile, /* output FITS file pointer                    */
-    cpopt: c_int,           /* code specifying copy options:
-                            OPT_GCP_GPT (0) ==> copy only grouping table
-                            OPT_GCP_ALL (2) ==> recusrively copy members
-                            and their members (if  groups)                  */
-    status: *mut c_int, /* return status code                          */
+    infptr: *mut fitsfile,
+    outfptr: *mut fitsfile,
+    cpopt: c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -904,7 +950,6 @@ pub unsafe extern "C" fn ffgtcp(
     }
 }
 
-/*---------------------------------------------------------------------------*/
 /// Copy a grouping table, and optionally all its members, to a new FITS file.
 ///
 /// If the cpopt is set to OPT_GCP_GPT (copy grouping table only) then the
@@ -917,14 +962,20 @@ pub unsafe extern "C" fn ffgtcp(
 /// Note that the recursive version of this function, ffgtcpr(), is called
 /// to perform the group table copy. In the case of cpopt == OPT_GCP_GPT
 /// ffgtcpr() does not actually use recursion.
+///
+/// # Parameters
+///
+/// * `infptr`  — input FITS file pointer
+/// * `outfptr` — output FITS file pointer
+/// * `cpopt`   — code specifying copy options: OPT_GCP_GPT (0) ==> copy only grouping
+///              table OPT_GCP_ALL (2) ==> recusrively copy members and their members
+///              (if groups)
+/// * `status`  — return status code
 pub fn ffgtcp_safe(
-    infptr: &mut fitsfile,  /* input FITS file pointer                     */
-    outfptr: &mut fitsfile, /* output FITS file pointer                    */
-    cpopt: c_int,           /* code specifying copy options:
-                            OPT_GCP_GPT (0) ==> copy only grouping table
-                            OPT_GCP_ALL (2) ==> recusrively copy members
-                            and their members (if  groups)                  */
-    status: &mut c_int, /* return status code                          */
+    infptr: &mut fitsfile,
+    outfptr: &mut fitsfile,
+    cpopt: c_int,
+    status: &mut c_int,
 ) -> c_int {
     let mut HDU = HDUtracker::default();
 
@@ -961,7 +1012,6 @@ pub fn ffgtcp_safe(
     *status
 }
 
-/*---------------------------------------------------------------------------*/
 /// Merge two grouping tables by combining their members into a single table.
 ///
 /// The source grouping table must be the CHDU of the fitsfile pointed to by
@@ -971,14 +1021,21 @@ pub fn ffgtcp_safe(
 /// grouping table continues to exist after the merge. If the mgopt parameter
 /// is OPT_MRG_MOV then the source grouping table is deleted after the merge,
 /// and all member HDUs are updated accordingly.
+///
+/// # Parameters
+///
+/// * `infptr`  — FITS file ptr to source grouping table
+/// * `outfptr` — FITS file ptr to target grouping table
+/// * `mgopt`   — code specifying merge options: OPT_MRG_COPY (0) ==> copy members to
+///              target group, leaving source group in place OPT_MRG_MOV (1) ==> move
+///              members to target group, source group is deleted after merge
+/// * `status`  — return status code
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgtmg(
-    infptr: *mut fitsfile,  /* FITS file ptr to source grouping table      */
-    outfptr: *mut fitsfile, /* FITS file ptr to target grouping table      */
-    mgopt: c_int,           /* code specifying merge options:
-                            OPT_MRG_COPY (0) ==> copy members to target group, leaving source group in place
-                            OPT_MRG_MOV  (1) ==> move members to target group, source group is deleted after merge    */
-    status: *mut c_int, /* return status code                         */
+    infptr: *mut fitsfile,
+    outfptr: *mut fitsfile,
+    mgopt: c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -990,7 +1047,6 @@ pub unsafe extern "C" fn ffgtmg(
     }
 }
 
-/*---------------------------------------------------------------------------*/
 /// Merge two grouping tables by combining their members into a single table.
 ///
 /// The source grouping table must be the CHDU of the fitsfile pointed to by
@@ -1000,13 +1056,20 @@ pub unsafe extern "C" fn ffgtmg(
 /// grouping table continues to exist after the merge. If the mgopt parameter
 /// is OPT_MRG_MOV then the source grouping table is deleted after the merge,
 /// and all member HDUs are updated accordingly.
+///
+/// # Parameters
+///
+/// * `infptr`  — FITS file ptr to source grouping table
+/// * `outfptr` — FITS file ptr to target grouping table
+/// * `mgopt`   — code specifying merge options: OPT_MRG_COPY (0) ==> copy members to
+///              target group, leaving source group in place OPT_MRG_MOV (1) ==> move
+///              members to target group, source group is deleted after merge
+/// * `status`  — return status code
 pub fn ffgtmg_safe(
-    infptr: &mut fitsfile,  /* FITS file ptr to source grouping table      */
-    outfptr: &mut fitsfile, /* FITS file ptr to target grouping table      */
-    mgopt: c_int,           /* code specifying merge options:
-                            OPT_MRG_COPY (0) ==> copy members to target group, leaving source group in place
-                            OPT_MRG_MOV  (1) ==> move members to target group, source group is deleted after merge    */
-    status: &mut c_int, /* return status code                         */
+    infptr: &mut fitsfile,
+    outfptr: &mut fitsfile,
+    mgopt: c_int,
+    status: &mut c_int,
 ) -> c_int {
     let mut i: c_long;
     let mut nmembers: c_long = 0;
@@ -1055,7 +1118,6 @@ pub fn ffgtmg_safe(
     *status
 }
 
-/*---------------------------------------------------------------------------*/
 /// "Compact" a group pointed to by the FITS file pointer gfptr.
 ///
 /// This is achieved by flattening the tree structure of a group and its
@@ -1064,14 +1126,16 @@ pub fn ffgtmg_safe(
 /// the grouping tables which are "compacted" are deleted. If the grouping
 /// table contains no members that are themselves grouping tables then this
 /// function performs a NOOP.
+///
+/// # Parameters
+///
+/// * `gfptr`  — FITS file pointer to grouping table
+/// * `cmopt`  — code specifying compact options OPT_CMT_MBR (1) ==> compact only direct
+///             members (if groups) OPT_CMT_MBR_DEL (11) ==> (1) + delete all compacted
+///             groups
+/// * `status` — return status code
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
-pub unsafe extern "C" fn ffgtcm(
-    gfptr: *mut fitsfile, /* FITS file pointer to grouping table          */
-    cmopt: c_int,         /* code specifying compact options
-                          OPT_CMT_MBR      (1) ==> compact only direct members (if groups)
-                          OPT_CMT_MBR_DEL (11) ==> (1) + delete all compacted groups    */
-    status: *mut c_int, /* return status code                           */
-) -> c_int {
+pub unsafe extern "C" fn ffgtcm(gfptr: *mut fitsfile, cmopt: c_int, status: *mut c_int) -> c_int {
     // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
@@ -1081,7 +1145,6 @@ pub unsafe extern "C" fn ffgtcm(
     }
 }
 
-/*---------------------------------------------------------------------------*/
 /// "Compact" a group pointed to by the FITS file pointer gfptr.
 ///
 /// This is achieved by flattening the tree structure of a group and its
@@ -1090,13 +1153,15 @@ pub unsafe extern "C" fn ffgtcm(
 /// the grouping tables which are "compacted" are deleted. If the grouping
 /// table contains no members that are themselves grouping tables then this
 /// function performs a NOOP.
-pub fn ffgtcm_safe(
-    gfptr: &mut fitsfile, /* FITS file pointer to grouping table          */
-    cmopt: c_int,         /* code specifying compact options
-                          OPT_CMT_MBR      (1) ==> compact only direct members (if groups)
-                          OPT_CMT_MBR_DEL (11) ==> (1) + delete all compacted groups    */
-    status: &mut c_int, /* return status code                           */
-) -> c_int {
+///
+/// # Parameters
+///
+/// * `gfptr`  — FITS file pointer to grouping table
+/// * `cmopt`  — code specifying compact options OPT_CMT_MBR (1) ==> compact only direct
+///             members (if groups) OPT_CMT_MBR_DEL (11) ==> (1) + delete all compacted
+///             groups
+/// * `status` — return status code
+pub fn ffgtcm_safe(gfptr: &mut fitsfile, cmopt: c_int, status: &mut c_int) -> c_int {
     let mut i: c_long;
     let mut nmembers: c_long = 0;
 
@@ -1201,17 +1266,23 @@ pub fn ffgtcm_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Check the integrity of a grouping table to make sure that all group members
 /// are accessible and all the links to other grouping tables are valid. The
 /// firstfailed parameter returns the member ID of the first member HDU to fail
 /// verification if positive or the first group link to fail if negative;
 /// otherwise firstfailed contains a return value of 0.
+///
+/// # Parameters
+///
+/// * `gfptr`       — FITS file pointer to group
+/// * `firstfailed` — Member ID (if positive) of first failed member HDU verify check or
+///                  GRPID index (if negitive) of first failed group link verify check.
+/// * `status`      — return status code
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgtvf(
-    gfptr: *mut fitsfile,     /* FITS file pointer to group             */
-    firstfailed: *mut c_long, /* Member ID (if positive) of first failed member HDU verify check or GRPID index (if negitive) of first failed group link verify check.                     */
-    status: *mut c_int,       /* return status code                     */
+    gfptr: *mut fitsfile,
+    firstfailed: *mut c_long,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -1223,17 +1294,19 @@ pub unsafe extern "C" fn ffgtvf(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Check the integrity of a grouping table to make sure that all group members
 /// are accessible and all the links to other grouping tables are valid. The
 /// firstfailed parameter returns the member ID of the first member HDU to fail
 /// verification if positive or the first group link to fail if negative;
 /// otherwise firstfailed contains a return value of 0.
-pub fn ffgtvf_safe(
-    gfptr: &mut fitsfile,     /* FITS file pointer to group             */
-    firstfailed: &mut c_long, /* Member ID (if positive) of first failed member HDU verify check or GRPID index (if negitive) of first failed group link verify check.                     */
-    status: &mut c_int,       /* return status code                     */
-) -> c_int {
+///
+/// # Parameters
+///
+/// * `gfptr`       — FITS file pointer to group
+/// * `firstfailed` — Member ID (if positive) of first failed member HDU verify check or
+///                  GRPID index (if negitive) of first failed group link verify check.
+/// * `status`      — return status code
+pub fn ffgtvf_safe(gfptr: &mut fitsfile, firstfailed: &mut c_long, status: &mut c_int) -> c_int {
     let mut i: c_long;
     let mut nmembers: c_long = 0;
     let mut ngroups: c_long = 0;
@@ -1324,7 +1397,6 @@ pub fn ffgtvf_safe(
     *status
 }
 
-/*---------------------------------------------------------------------------*/
 /// Open the grouping table that contains the member HDU.
 ///
 /// The member HDU must be the CHDU of the FITS file pointed to by mfptr, and the
@@ -1339,12 +1411,19 @@ pub fn ffgtvf_safe(
 /// such cases, the grpid index value specified in the function call shall
 /// identify the (grpid)th GRPID value. In the above example, if grpid == 3,
 /// then the group specified by GRPID5 would be opened.
+///
+/// # Parameters
+///
+/// * `mfptr`  — FITS file pointer to the member HDU
+/// * `grpid`  — group ID (GRPIDn index) within member HDU
+/// * `gfptr`  — FITS file pointer to grouping table HDU
+/// * `status` — return status code
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgtop(
-    mfptr: *mut fitsfile,      /* FITS file pointer to the member HDU          */
-    grpid: c_int,              /* group ID (GRPIDn index) within member HDU    */
-    gfptr: *mut *mut fitsfile, /* FITS file pointer to grouping table HDU      */
-    status: *mut c_int,        /* return status code                           */
+    mfptr: *mut fitsfile,
+    grpid: c_int,
+    gfptr: *mut *mut fitsfile,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -1360,7 +1439,6 @@ pub unsafe extern "C" fn ffgtop(
     }
 }
 
-/*---------------------------------------------------------------------------*/
 /// Open the grouping table that contains the member HDU.
 ///
 /// The member HDU must be the CHDU of the FITS file pointed to by mfptr, and the
@@ -1375,11 +1453,18 @@ pub unsafe extern "C" fn ffgtop(
 /// such cases, the grpid index value specified in the function call shall
 /// identify the (grpid)th GRPID value. In the above example, if grpid == 3,
 /// then the group specified by GRPID5 would be opened.
+///
+/// # Parameters
+///
+/// * `mfptr`  — FITS file pointer to the member HDU
+/// * `grpid`  — group ID (GRPIDn index) within member HDU
+/// * `gfptr`  — FITS file pointer to grouping table HDU
+/// * `status` — return status code
 pub fn ffgtop_safe(
-    mfptr: &mut fitsfile, /* FITS file pointer to the member HDU          */
-    grpid: c_int,         /* group ID (GRPIDn index) within member HDU    */
-    gfptr: &mut Option<Box<fitsfile>>, /* FITS file pointer to grouping table HDU      */
-    status: &mut c_int,   /* return status code                           */
+    mfptr: &mut fitsfile,
+    grpid: c_int,
+    gfptr: &mut Option<Box<fitsfile>>,
+    status: &mut c_int,
 ) -> c_int {
     let mut i: c_int;
     let mut found: c_int;
@@ -1725,7 +1810,6 @@ pub fn ffgtop_safe(
     *status
 }
 
-/*---------------------------------------------------------------------------*/
 /// Add a member HDU to an existing grouping table.
 ///
 /// The fitsfile pointer gfptr
@@ -1738,12 +1822,20 @@ pub fn ffgtop_safe(
 ///
 /// Note that if the member HDU to be added to the grouping table is already
 /// a member of the group then it will not be added a sceond time.
+///
+/// # Parameters
+///
+/// * `gfptr`  — FITS file pointer to grouping table HDU
+/// * `mfptr`  — FITS file pointer to member HDU
+/// * `hdupos` — member HDU position IF in the same file as the grouping table AND mfptr
+///             == NULL
+/// * `status` — return status code
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgtam(
-    gfptr: *mut fitsfile, /* FITS file pointer to grouping table HDU     */
-    mfptr: *mut fitsfile, /* FITS file pointer to member HDU             */
-    hdupos: c_int, /* member HDU position IF in the same file as the grouping table AND mfptr == NULL        */
-    status: *mut c_int, /* return status code                          */
+    gfptr: *mut fitsfile,
+    mfptr: *mut fitsfile,
+    hdupos: c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -1754,7 +1846,6 @@ pub unsafe extern "C" fn ffgtam(
     }
 }
 
-/*---------------------------------------------------------------------------*/
 /// Add a member HDU to an existing grouping table.
 ///
 /// The fitsfile pointer gfptr
@@ -1767,11 +1858,20 @@ pub unsafe extern "C" fn ffgtam(
 ///
 /// Note that if the member HDU to be added to the grouping table is already
 /// a member of the group then it will not be added a sceond time.
+///
+/// # Parameters
+///
+/// * `gfptr`  — FITS file pointer to grouping table HDU
+/// * `mfptr`  — FITS file pointer to member HDU; None if the member is in the same file
+///             as the grouping table
+/// * `hdupos` — member HDU position IF in the same file as the grouping table AND mfptr
+///             == NULL
+/// * `status` — return status code
 pub fn ffgtam_safe(
-    gfptr: &mut fitsfile, /* FITS file pointer to grouping table HDU     */
-    mut mfptr: Option<&mut fitsfile>, /* FITS file pointer to member HDU; None if the member is in the same file as the grouping table */
-    hdupos: c_int, /* member HDU position IF in the same file as the grouping table AND mfptr == NULL        */
-    status: &mut c_int, /* return status code                          */
+    gfptr: &mut fitsfile,
+    mut mfptr: Option<&mut fitsfile>,
+    hdupos: c_int,
+    status: &mut c_int,
 ) -> c_int {
     /* SPR 3463: consolidates the repeated "are the member and grouping-table
     files the same?" test, matching the C's combined
@@ -2620,17 +2720,22 @@ pub fn ffgtam_safe(
     *status
 }
 
-/*---------------------------------------------------------------------------*/
 /// Return the number of member HDUs in a grouping table.
 ///
 /// The fitsfile pointer gfptr must be positioned with the grouping table as the CHDU.
 /// The number of grouping table member HDUs is just the NAXIS2 value of the grouping
 /// table.
+///
+/// # Parameters
+///
+/// * `gfptr`    — FITS file pointer to grouping table
+/// * `nmembers` — member count of the grouping table
+/// * `status`   — return status code
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgtnm(
-    gfptr: *mut fitsfile,  /* FITS file pointer to grouping table        */
-    nmembers: *mut c_long, /* member count of the grouping table         */
-    status: *mut c_int,    /* return status code                         */
+    gfptr: *mut fitsfile,
+    nmembers: *mut c_long,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -2642,17 +2747,18 @@ pub unsafe extern "C" fn ffgtnm(
     }
 }
 
-/*---------------------------------------------------------------------------*/
 /// Return the number of member HDUs in a grouping table.
 ///
 /// The fitsfile pointer gfptr must be positioned with the grouping table as the CHDU.
 /// The number of grouping table member HDUs is just the NAXIS2 value of the grouping
 /// table.
-pub fn ffgtnm_safe(
-    gfptr: &mut fitsfile,  /* FITS file pointer to grouping table        */
-    nmembers: &mut c_long, /* member count of the grouping table         */
-    status: &mut c_int,    /* return status code                         */
-) -> c_int {
+///
+/// # Parameters
+///
+/// * `gfptr`    — FITS file pointer to grouping table
+/// * `nmembers` — member count of the grouping table
+/// * `status`   — return status code
+pub fn ffgtnm_safe(gfptr: &mut fitsfile, nmembers: &mut c_long, status: &mut c_int) -> c_int {
     let mut keyvalue: [c_char; FLEN_VALUE] = [0; FLEN_VALUE];
     let mut comment: [c_char; FLEN_COMMENT] = [0; FLEN_COMMENT];
 
@@ -2684,18 +2790,23 @@ pub fn ffgtnm_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Return the number of groups to which a HDU belongs, as defined by the number
 /// of GRPIDn/GRPLCn keyword records that appear in the HDU header. The
 /// fitsfile pointer mfptr must be positioned with the member HDU as the CHDU.
 /// Each time this function is called, the indicies of the GRPIDn/GRPLCn
 /// keywords are checked to make sure they are continuous (ie no gaps) and
 /// are re-enumerated to eliminate gaps if gaps are found to be present.
+///
+/// # Parameters
+///
+/// * `mfptr`   — FITS file pointer to member HDU
+/// * `ngroups` — total number of groups linked to HDU
+/// * `status`  — return status code
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgmng(
-    mfptr: *mut fitsfile, /* FITS file pointer to member HDU            */
-    ngroups: *mut c_long, /* total number of groups linked to HDU       */
-    status: *mut c_int,   /* return status code                         */
+    mfptr: *mut fitsfile,
+    ngroups: *mut c_long,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -2707,18 +2818,19 @@ pub unsafe extern "C" fn ffgmng(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Return the number of groups to which a HDU belongs, as defined by the number
 /// of GRPIDn/GRPLCn keyword records that appear in the HDU header. The
 /// fitsfile pointer mfptr must be positioned with the member HDU as the CHDU.
 /// Each time this function is called, the indicies of the GRPIDn/GRPLCn
 /// keywords are checked to make sure they are continuous (ie no gaps) and
 /// are re-enumerated to eliminate gaps if gaps are found to be present.
-pub fn ffgmng_safe(
-    mfptr: &mut fitsfile, /* FITS file pointer to member HDU            */
-    ngroups: &mut c_long, /* total number of groups linked to HDU       */
-    status: &mut c_int,   /* return status code                         */
-) -> c_int {
+///
+/// # Parameters
+///
+/// * `mfptr`   — FITS file pointer to member HDU
+/// * `ngroups` — total number of groups linked to HDU
+/// * `status`  — return status code
+pub fn ffgmng_safe(mfptr: &mut fitsfile, ngroups: &mut c_long, status: &mut c_int) -> c_int {
     let mut offset: c_int;
     let mut index: c_int;
     let mut newIndex: c_int;
@@ -2843,8 +2955,7 @@ pub fn ffgmng_safe(
     *status
 }
 
-/*---------------------------------------------------------------------------*/
-/// open a grouping table member, returning a pointer to the member's FITS file
+/// Open a grouping table member, returning a pointer to the member's FITS file
 /// with the CHDU set to the member HDU. The grouping table must be the CHDU of
 /// the FITS file pointed to by gfptr. The member to open is identified by its
 /// row number within the grouping table (first row/member == 1).
@@ -2856,12 +2967,19 @@ pub fn ffgmng_safe(
 /// to the CWD is given, and (3) a path relative to the grouping table file
 /// but not relative to the CWD is given. If all of these fail then the
 /// error FILE_NOT_FOUND is returned.
+///
+/// # Parameters
+///
+/// * `gfptr`  — FITS file pointer to grouping table
+/// * `member` — member ID (row num) within grouping table
+/// * `mfptr`  — FITS file pointer to member HDU
+/// * `status` — return status code
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgmop(
-    gfptr: *mut fitsfile,      /* FITS file pointer to grouping table          */
-    member: c_long,            /* member ID (row num) within grouping table    */
-    mfptr: *mut *mut fitsfile, /* FITS file pointer to member HDU              */
-    status: *mut c_int,        /* return status code                           */
+    gfptr: *mut fitsfile,
+    member: c_long,
+    mfptr: *mut *mut fitsfile,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -2877,8 +2995,7 @@ pub unsafe extern "C" fn ffgmop(
     }
 }
 
-/*---------------------------------------------------------------------------*/
-/// open a grouping table member, returning a pointer to the member's FITS file
+/// Open a grouping table member, returning a pointer to the member's FITS file
 /// with the CHDU set to the member HDU. The grouping table must be the CHDU of
 /// the FITS file pointed to by gfptr. The member to open is identified by its
 /// row number within the grouping table (first row/member == 1).
@@ -2892,11 +3009,17 @@ pub unsafe extern "C" fn ffgmop(
 /// error FILE_NOT_FOUND is returned.
 #[allow(clippy::if_same_then_else)]
 // C dispatch chain: distinct conditions deliberately share an action.
+/// # Parameters
+///
+/// * `gfptr`  — FITS file pointer to grouping table
+/// * `member` — member ID (row num) within grouping table
+/// * `mfptr`  — FITS file pointer to member HDU
+/// * `status` — return status code
 pub fn ffgmop_safe(
-    gfptr: &mut fitsfile, /* FITS file pointer to grouping table          */
-    member: c_long,       /* member ID (row num) within grouping table    */
-    mfptr: &mut Option<Box<fitsfile>>, /* FITS file pointer to member HDU              */
-    status: &mut c_int,   /* return status code                           */
+    gfptr: &mut fitsfile,
+    member: c_long,
+    mfptr: &mut Option<Box<fitsfile>>,
+    status: &mut c_int,
 ) -> c_int {
     let mut xtensionCol: c_int = 0;
     let mut extnameCol: c_int = 0;
@@ -3529,8 +3652,7 @@ pub fn ffgmop_safe(
     *status
 }
 
-/*---------------------------------------------------------------------------*/
-/// copy a member HDU of a grouping table to a new FITS file. The grouping table
+/// Copy a member HDU of a grouping table to a new FITS file. The grouping table
 /// must be the CHDU of the FITS file pointed to by gfptr. The copy of the
 /// group member shall be appended to the end of the FITS file pointed to by
 /// mfptr. If the cpopt parameter is set to OPT_MCP_ADD then the copy of the
@@ -3540,19 +3662,24 @@ pub fn ffgmop_safe(
 /// The copied member HDU also has its EXTVER value updated so that its
 /// combination of XTENSION, EXTNAME and EXVTER is unique within its new
 /// FITS file.
+///
+/// # Parameters
+///
+/// * `gfptr`  — FITS file pointer to group
+/// * `mfptr`  — FITS file pointer to new member FITS file
+/// * `member` — member ID (row num) within grouping table
+/// * `cpopt`  — code specifying copy options: OPT_MCP_ADD (0) ==> add copied member to
+///             the grouping table OPT_MCP_NADD (1) ==> do not add member copy to the
+///             grouping table OPT_MCP_REPL (2) ==> replace current member entry with
+///             member copy
+/// * `status` — return status code
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgmcp(
-    gfptr: *mut fitsfile, /* FITS file pointer to group                   */
-    mfptr: *mut fitsfile, /* FITS file pointer to new member FITS file                                    */
-    member: c_long,       /* member ID (row num) within grouping table    */
-    cpopt: c_int,         /* code specifying copy options:
-                          OPT_MCP_ADD  (0) ==> add copied member to the
-                                              grouping table
-                          OPT_MCP_NADD (1) ==> do not add member copy to
-                                              the grouping table
-                          OPT_MCP_REPL (2) ==> replace current member
-                                              entry with member copy  */
-    status: *mut c_int, /* return status code                           */
+    gfptr: *mut fitsfile,
+    mfptr: *mut fitsfile,
+    member: c_long,
+    cpopt: c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -3564,8 +3691,7 @@ pub unsafe extern "C" fn ffgmcp(
     }
 }
 
-/*---------------------------------------------------------------------------*/
-/// copy a member HDU of a grouping table to a new FITS file. The grouping table
+/// Copy a member HDU of a grouping table to a new FITS file. The grouping table
 /// must be the CHDU of the FITS file pointed to by gfptr. The copy of the
 /// group member shall be appended to the end of the FITS file pointed to by
 /// mfptr. If the cpopt parameter is set to OPT_MCP_ADD then the copy of the
@@ -3575,18 +3701,23 @@ pub unsafe extern "C" fn ffgmcp(
 /// The copied member HDU also has its EXTVER value updated so that its
 /// combination of XTENSION, EXTNAME and EXVTER is unique within its new
 /// FITS file.
+///
+/// # Parameters
+///
+/// * `gfptr`  — FITS file pointer to group
+/// * `mfptr`  — FITS file pointer to new member FITS file
+/// * `member` — member ID (row num) within grouping table
+/// * `cpopt`  — code specifying copy options: OPT_MCP_ADD (0) ==> add copied member to
+///             the grouping table OPT_MCP_NADD (1) ==> do not add member copy to the
+///             grouping table OPT_MCP_REPL (2) ==> replace current member entry with
+///             member copy
+/// * `status` — return status code
 pub fn ffgmcp_safe(
-    gfptr: &mut fitsfile, /* FITS file pointer to group                   */
-    mfptr: &mut fitsfile, /* FITS file pointer to new member FITS file                                    */
-    member: c_long,       /* member ID (row num) within grouping table    */
-    cpopt: c_int,         /* code specifying copy options:
-                          OPT_MCP_ADD  (0) ==> add copied member to the
-                                              grouping table
-                          OPT_MCP_NADD (1) ==> do not add member copy to
-                                              the grouping table
-                          OPT_MCP_REPL (2) ==> replace current member
-                                              entry with member copy  */
-    status: &mut c_int, /* return status code                           */
+    gfptr: &mut fitsfile,
+    mfptr: &mut fitsfile,
+    member: c_long,
+    cpopt: c_int,
+    status: &mut c_int,
 ) -> c_int {
     let mut numkeys: c_int = 0;
     let mut keypos: c_int = 0;
@@ -3815,8 +3946,7 @@ pub fn ffgmcp_safe(
     *status
 }
 
-/*---------------------------------------------------------------------------*/
-/// transfer a group member from one grouping table to another. The source
+/// Transfer a group member from one grouping table to another. The source
 /// grouping table must be the CHDU of the fitsfile pointed to by infptr, and
 /// the destination grouping table must be the CHDU of the fitsfile to by
 /// outfptr. If the tfopt parameter is OPT_MCP_ADD then the member is made a
@@ -3824,15 +3954,22 @@ pub fn ffgmcp_safe(
 /// the tfopt parameter is OPT_MCP_MOV then the member is deleted from the
 /// source group after the transfer to the destination group. The member to be
 /// transfered is identified by its row number within the source grouping table.
+///
+/// # Parameters
+///
+/// * `infptr`  — FITS file pointer to source grouping table
+/// * `outfptr` — FITS file pointer to target grouping table
+/// * `member`  — member ID within source grouping table
+/// * `tfopt`   — code specifying transfer opts: OPT_MCP_ADD (0) ==> copy member to
+///              dest. OPT_MCP_MOV (3) ==> move member to dest.
+/// * `status`  — return status code
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgmtf(
-    infptr: *mut fitsfile,  /* FITS file pointer to source grouping table */
-    outfptr: *mut fitsfile, /* FITS file pointer to target grouping table */
-    member: c_long,         /* member ID within source grouping table     */
-    tfopt: c_int,           /* code specifying transfer opts:
-                            OPT_MCP_ADD (0) ==> copy member to dest.
-                            OPT_MCP_MOV (3) ==> move member to dest.   */
-    status: *mut c_int, /* return status code                         */
+    infptr: *mut fitsfile,
+    outfptr: *mut fitsfile,
+    member: c_long,
+    tfopt: c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -3844,7 +3981,6 @@ pub unsafe extern "C" fn ffgmtf(
     }
 }
 
-/*---------------------------------------------------------------------------*/
 /// Transfer a group member from one grouping table to another. The source
 /// grouping table must be the CHDU of the fitsfile pointed to by infptr, and
 /// the destination grouping table must be the CHDU of the fitsfile to by
@@ -3853,14 +3989,21 @@ pub unsafe extern "C" fn ffgmtf(
 /// the tfopt parameter is OPT_MCP_MOV then the member is deleted from the
 /// source group after the transfer to the destination group. The member to be
 /// transfered is identified by its row number within the source grouping table.
+///
+/// # Parameters
+///
+/// * `infptr`  — FITS file pointer to source grouping table
+/// * `outfptr` — FITS file pointer to target grouping table
+/// * `member`  — member ID within source grouping table
+/// * `tfopt`   — code specifying transfer opts: OPT_MCP_ADD (0) ==> copy member to
+///              dest. OPT_MCP_MOV (3) ==> move member to dest.
+/// * `status`  — return status code
 pub fn ffgmtf_safe(
-    infptr: &mut fitsfile,  /* FITS file pointer to source grouping table */
-    outfptr: &mut fitsfile, /* FITS file pointer to target grouping table */
-    member: c_long,         /* member ID within source grouping table     */
-    tfopt: c_int,           /* code specifying transfer opts:
-                            OPT_MCP_ADD (0) ==> copy member to dest.
-                            OPT_MCP_MOV (3) ==> move member to dest.   */
-    status: &mut c_int, /* return status code                         */
+    infptr: &mut fitsfile,
+    outfptr: &mut fitsfile,
+    member: c_long,
+    tfopt: c_int,
+    status: &mut c_int,
 ) -> c_int {
     let mut mfptr: Option<Box<fitsfile>> = None;
 
@@ -3899,22 +4042,27 @@ pub fn ffgmtf_safe(
     *status
 }
 
-/*---------------------------------------------------------------------------*/
-/// remove a member HDU from a grouping table. The fitsfile pointer gfptr must
+/// Remove a member HDU from a grouping table. The fitsfile pointer gfptr must
 /// be positioned with the grouping table as the CHDU, and the member to
 /// delete is identified by its row number in the table (first member == 1).
 /// The rmopt parameter determines if the member entry is deleted from the
 /// grouping table (in which case GRPIDn and GRPLCn keywords in the member
 /// HDU's header shall be updated accordingly) or if the member HDU shall
 /// itself be removed from its FITS file.
+///
+/// # Parameters
+///
+/// * `gfptr`  — FITS file pointer to group table
+/// * `member` — member ID (row num) in the group
+/// * `rmopt`  — code specifying the delete option: OPT_RM_ENTRY ==> delete the member
+///             entry OPT_RM_MBR ==> delete entry and member HDU
+/// * `status` — return status code
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgmrm(
-    gfptr: *mut fitsfile, /* FITS file pointer to group table             */
-    member: c_long,       /* member ID (row num) in the group             */
-    rmopt: c_int,         /* code specifying the delete option:
-                          OPT_RM_ENTRY ==> delete the member entry
-                          OPT_RM_MBR   ==> delete entry and member HDU */
-    status: *mut c_int, /* return status code                          */
+    gfptr: *mut fitsfile,
+    member: c_long,
+    rmopt: c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -3925,21 +4073,26 @@ pub unsafe extern "C" fn ffgmrm(
     }
 }
 
-/*---------------------------------------------------------------------------*/
-/// remove a member HDU from a grouping table. The fitsfile pointer gfptr must
+/// Remove a member HDU from a grouping table. The fitsfile pointer gfptr must
 /// be positioned with the grouping table as the CHDU, and the member to
 /// delete is identified by its row number in the table (first member == 1).
 /// The rmopt parameter determines if the member entry is deleted from the
 /// grouping table (in which case GRPIDn and GRPLCn keywords in the member
 /// HDU's header shall be updated accordingly) or if the member HDU shall
 /// itself be removed from its FITS file.
+///
+/// # Parameters
+///
+/// * `gfptr`  — FITS file pointer to group table
+/// * `member` — member ID (row num) in the group
+/// * `rmopt`  — code specifying the delete option: OPT_RM_ENTRY ==> delete the member
+///             entry OPT_RM_MBR ==> delete entry and member HDU
+/// * `status` — return status code
 pub fn ffgmrm_safe(
-    gfptr: &mut fitsfile, /* FITS file pointer to group table             */
-    member: c_long,       /* member ID (row num) in the group             */
-    rmopt: c_int,         /* code specifying the delete option:
-                          OPT_RM_ENTRY ==> delete the member entry
-                          OPT_RM_MBR   ==> delete entry and member HDU */
-    status: &mut c_int, /* return status code                          */
+    gfptr: &mut fitsfile,
+    member: c_long,
+    rmopt: c_int,
+    status: &mut c_int,
 ) -> c_int {
     let mut found: c_int;
     let mut hdutype: c_int = 0;
@@ -4451,28 +4604,36 @@ pub fn ffgmrm_safe(
                  Grouping Table support functions
 ---------------------------------------------------------------------------*/
 
-/****************************************************************************/
 /// Examine the grouping table pointed to by gfptr and determine the column
 /// index ID of each possible grouping column. If a column is not found then
 /// an index of 0 is returned. the grptype parameter returns the structure
 /// of the grouping table ==> what columns are defined.
+///
+/// # Parameters
+///
+/// * `gfptr`       — pointer to the grouping table
+/// * `xtensionCol` — column ID of the MEMBER_XTENSION column
+/// * `extnameCol`  — column ID of the MEMBER_NAME column
+/// * `extverCol`   — column ID of the MEMBER_VERSION column
+/// * `positionCol` — column ID of the MEMBER_POSITION column
+/// * `locationCol` — column ID of the MEMBER_LOCATION column
+/// * `uriCol`      — column ID of the MEMBER_URI_TYPE column
+/// * `grptype`     — group structure type code specifying the grouping table columns
+///                  that are defined: GT_ID_ALL_URI (0) ==> all columns defined
+///                  GT_ID_REF (1) ==> reference cols only GT_ID_POS (2) ==> position
+///                  col only GT_ID_ALL (3) ==> ref & pos cols GT_ID_REF_URI (11) ==>
+///                  ref & loc cols GT_ID_POS_URI (12) ==> pos & loc cols
+/// * `status`      — return status code
 pub(crate) fn ffgtgc(
-    gfptr: &mut fitsfile,    /* pointer to the grouping table                */
-    xtensionCol: &mut c_int, /* column ID of the MEMBER_XTENSION column      */
-    extnameCol: &mut c_int,  /* column ID of the MEMBER_NAME column          */
-    extverCol: &mut c_int,   /* column ID of the MEMBER_VERSION column       */
-    positionCol: &mut c_int, /* column ID of the MEMBER_POSITION column      */
-    locationCol: &mut c_int, /* column ID of the MEMBER_LOCATION column      */
-    uriCol: &mut c_int,      /* column ID of the MEMBER_URI_TYPE column      */
-    grptype: &mut c_int,     /* group structure type code specifying the
-                             grouping table columns that are defined:
-                             GT_ID_ALL_URI  (0) ==> all columns defined
-                             GT_ID_REF      (1) ==> reference cols only
-                             GT_ID_POS      (2) ==> position col only
-                             GT_ID_ALL      (3) ==> ref & pos cols
-                             GT_ID_REF_URI (11) ==> ref & loc cols
-                             GT_ID_POS_URI (12) ==> pos & loc cols        */
-    status: &mut c_int, /* return status code                           */
+    gfptr: &mut fitsfile,
+    xtensionCol: &mut c_int,
+    extnameCol: &mut c_int,
+    extverCol: &mut c_int,
+    positionCol: &mut c_int,
+    locationCol: &mut c_int,
+    uriCol: &mut c_int,
+    grptype: &mut c_int,
+    status: &mut c_int,
 ) -> c_int {
     let mut keyvalue: [c_char; FLEN_VALUE] = [0; FLEN_VALUE];
     let mut comment: [c_char; FLEN_COMMENT] = [0; FLEN_COMMENT];
@@ -4667,7 +4828,6 @@ pub(crate) fn ffgtgc(
     *status
 }
 
-/*****************************************************************************/
 /// Perform validation on column formats to ensure this matches the grouping
 /// format the get functions expect.  Particularly want to check widths of
 /// string columns.
@@ -4800,32 +4960,44 @@ pub(crate) fn ffvcfm(
     *status
 }
 
-/*****************************************************************************/
 /// Create the TTYPE and TFORM values for the grouping table according to the
 /// value of the grouptype parameter and the values of the *col flags. The
 /// resulting TTYPE and TFORM are returned in ttype[] and tform[] respectively.
 /// The number of TTYPE and TFORMs returned is given by ncols. Both the TTYPE[]
 /// and TTFORM[] arrays must contain enough pre-allocated strings to hold
 /// the returned information.
+///
+/// # Parameters
+///
+/// * `grouptype`   — code specifying the type of grouping table information:
+///                  GT_ID_ALL_URI 0 ==> defualt (all columns) GT_ID_REF 1 ==> ID by
+///                  reference GT_ID_POS 2 ==> ID by position GT_ID_ALL 3 ==> ID by
+///                  ref. and position GT_ID_REF_URI 11 ==> (1) + URI info
+///                  GT_ID_POS_URI 12 ==> (2) + URI info
+/// * `xtensioncol` — does MEMBER_XTENSION already exist?
+/// * `extnamecol`  — does MEMBER_NAME aleady exist?
+/// * `extvercol`   — does MEMBER_VERSION already exist?
+/// * `positioncol` — does MEMBER_POSITION already exist?
+/// * `locationcol` — does MEMBER_LOCATION already exist?
+/// * `uricol`      — does MEMBER_URI_TYPE aleardy exist?
+/// * `ttype`       — array of grouping table column TTYPE names to define (if *col var
+///                  false)
+/// * `tform`       — array of grouping table column TFORM values to define (if*col
+///                  variable false)
+/// * `ncols`       — number of TTYPE and TFORM values returned
+/// * `status`      — return status code
 pub(crate) fn ffgtdc(
-    grouptype: c_int,            /* code specifying the type of
-                                 grouping table information:
-                                 GT_ID_ALL_URI  0 ==> defualt (all columns)
-                                 GT_ID_REF      1 ==> ID by reference
-                                 GT_ID_POS      2 ==> ID by position
-                                 GT_ID_ALL      3 ==> ID by ref. and position
-                                 GT_ID_REF_URI 11 ==> (1) + URI info
-                                 GT_ID_POS_URI 12 ==> (2) + URI info       */
-    xtensioncol: c_int,          /* does MEMBER_XTENSION already exist?         */
-    extnamecol: c_int,           /* does MEMBER_NAME aleady exist?              */
-    extvercol: c_int,            /* does MEMBER_VERSION already exist?          */
-    positioncol: c_int,          /* does MEMBER_POSITION already exist?         */
-    locationcol: c_int,          /* does MEMBER_LOCATION already exist?         */
-    uricol: c_int,               /* does MEMBER_URI_TYPE aleardy exist?         */
-    ttype: &mut [&mut [c_char]], /* array of grouping table column TTYPE names to define (if *col var false)               */
-    tform: &mut [&mut [c_char]], /* array of grouping table column TFORM values to define (if*col variable false)           */
-    ncols: &mut c_int,           /* number of TTYPE and TFORM values returned   */
-    status: &mut c_int,          /* return status code                          */
+    grouptype: c_int,
+    xtensioncol: c_int,
+    extnamecol: c_int,
+    extvercol: c_int,
+    positioncol: c_int,
+    locationcol: c_int,
+    uricol: c_int,
+    ttype: &mut [&mut [c_char]],
+    tform: &mut [&mut [c_char]],
+    ncols: &mut c_int,
+    status: &mut c_int,
 ) -> c_int {
     let mut i: usize = 0;
 
@@ -4992,18 +5164,18 @@ pub(crate) fn ffgtdc(
     *status
 }
 
-/*****************************************************************************/
 /// Examine all the GRPIDn and GRPLCn keywords in the member HDUs header
 /// and remove the member from the grouping tables referenced; This
 /// effectively "unlinks" the member from all of its groups. The rmopt
 /// specifies if the GRPIDn/GRPLCn keywords are to be removed from the
 /// member HDUs header after the unlinking.
-pub(crate) fn ffgmul(
-    mfptr: &mut fitsfile, /* pointer to the grouping table member HDU    */
-    rmopt: c_int,         /* 0 ==> leave GRPIDn/GRPLCn keywords,
-                          1 ==> remove GRPIDn/GRPLCn keywords         */
-    status: &mut c_int, /* return status code                          */
-) -> c_int {
+///
+/// # Parameters
+///
+/// * `mfptr`  — pointer to the grouping table member HDU
+/// * `rmopt`  — 0 ==> leave GRPIDn/GRPLCn keywords, 1 ==> remove GRPIDn/GRPLCn keywords
+/// * `status` — return status code
+pub(crate) fn ffgmul(mfptr: &mut fitsfile, rmopt: c_int, status: &mut c_int) -> c_int {
     let mut memberPosition: c_int = 0;
     let mut iomode: c_int = 0;
 
@@ -5261,7 +5433,6 @@ pub(crate) fn ffgmul(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Try to find the entry for the member HDU defined by the xtension, extname,
 /// extver, position, and location parameters within the grouping table
 /// pointed to by gfptr. If the member HDU is found then its ID (row number)
@@ -5275,15 +5446,25 @@ pub(crate) fn ffgmul(
 /// easily then the reference information for a group member.
 #[allow(clippy::if_same_then_else)]
 // C dispatch chain: distinct conditions deliberately share an action.
+/// # Parameters
+///
+/// * `gfptr`    — pointer to grouping table HDU to search
+/// * `xtension` — XTENSION value for member HDU
+/// * `extname`  — EXTNAME value for member HDU
+/// * `extver`   — EXTVER value for member HDU
+/// * `position` — HDU position value for member HDU
+/// * `location` — FITS file location value for member HDU
+/// * `member`   — member HDU ID within group table (if found)
+/// * `status`   — return status code
 pub(crate) fn ffgmf(
-    gfptr: &mut fitsfile,        /* pointer to grouping table HDU to search       */
-    xtension: &[c_char],         /* XTENSION value for member HDU                */
-    extname: &[c_char],          /* EXTNAME value for member HDU                 */
-    extver: c_int,               /* EXTVER value for member HDU                  */
-    position: c_int,             /* HDU position value for member HDU            */
-    location: Option<&[c_char]>, /* FITS file location value for member HDU      */
-    member: &mut c_long,         /* member HDU ID within group table (if found)  */
-    status: &mut c_int,          /* return status code                           */
+    gfptr: &mut fitsfile,
+    xtension: &[c_char],
+    extname: &[c_char],
+    extver: c_int,
+    position: c_int,
+    location: Option<&[c_char]>,
+    member: &mut c_long,
+    status: &mut c_int,
 ) -> c_int {
     let mut xtensionCol: c_int = 0;
     let mut extnameCol: c_int = 0;
@@ -5660,18 +5841,19 @@ pub(crate) fn ffgmf(
                       Recursive Group Functions
 --------------------------------------------------------------------------*/
 
-/****************************************************************************/
 /// Recursively remove a grouping table and all its members. Each member of
 /// the grouping table pointed to by gfptr it processed. If the member is itself
 /// a grouping table then ffgtrmr() is recursively called to process all
 /// of its members. The HDUtracker struct *HDU is used to make sure a member
 /// is not processed twice, thus avoiding an infinite loop (e.g., a grouping
 /// table contains itself as a member).
-pub(crate) fn ffgtrmr(
-    gfptr: &mut fitsfile, /* FITS file pointer to group               */
-    HDU: &mut HDUtracker, /* list of processed HDUs                   */
-    status: &mut c_int,   /* return status code                       */
-) -> c_int {
+///
+/// # Parameters
+///
+/// * `gfptr`  — FITS file pointer to group
+/// * `HDU`    — list of processed HDUs
+/// * `status` — return status code
+pub(crate) fn ffgtrmr(gfptr: &mut fitsfile, HDU: &mut HDUtracker, status: &mut c_int) -> c_int {
     let mut i: c_int;
     let mut hdutype: c_int = 0;
 
@@ -5792,7 +5974,6 @@ pub(crate) fn ffgtrmr(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy a Group to a new FITS file. If the cpopt parameter is set to
 /// OPT_GCP_GPT (copy grouping table only) then the existing members have their
 /// GRPIDn and GRPLCn keywords updated to reflect the existance of the new group,
@@ -5804,15 +5985,22 @@ pub(crate) fn ffgtrmr(
 /// Note that this function is recursive. When copt is OPT_GCP_ALL it will call
 /// itself whenever a member HDU of the current grouping table is itself a
 /// grouping table (i.e., EXTNAME = 'GROUPING').
+///
+/// # Parameters
+///
+/// * `infptr`  — input FITS file pointer
+/// * `outfptr` — output FITS file pointer
+/// * `cpopt`   — code specifying copy options: OPT_GCP_GPT (0) ==> cp only grouping
+///              table OPT_GCP_ALL (2) ==> recusrively copy members and their members
+///              (if groups)
+/// * `HDU`     — list of already copied HDUs
+/// * `status`  — return status code
 pub(crate) fn ffgtcpr(
-    infptr: &mut fitsfile,  /* input FITS file pointer                 */
-    outfptr: &mut fitsfile, /* output FITS file pointer                */
-    cpopt: c_int,           /* code specifying copy options:
-                            OPT_GCP_GPT (0) ==> cp only grouping table
-                            OPT_GCP_ALL (2) ==> recusrively copy
-                            members and their members (if groups)   */
-    HDU: &mut HDUtracker, /* list of already copied HDUs             */
-    status: &mut c_int,   /* return status code                      */
+    infptr: &mut fitsfile,
+    outfptr: &mut fitsfile,
+    cpopt: c_int,
+    HDU: &mut HDUtracker,
+    status: &mut c_int,
 ) -> c_int {
     let mut i: c_int;
     let nexclude: c_int = 8;
@@ -6177,16 +6365,22 @@ pub(crate) fn ffgtcpr(
               HDUtracker struct manipulation functions
 --------------------------------------------------------------------------*/
 
-/****************************************************************************/
-/// add an HDU to the HDUtracker struct pointed to by HDU. The HDU is only
+/// Add an HDU to the HDUtracker struct pointed to by HDU. The HDU is only
 /// added if it does not already reside in the HDUtracker. If it already
 /// resides in the HDUtracker then the new HDU postion and file name are
 /// returned in  newPosition and newFileName (if != NULL)
+///
+/// # Parameters
+///
+/// * `mfptr`       — pointer to an member HDU
+/// * `HDU`         — pointer to an HDU tracker struct
+/// * `newPosition` — new HDU position of the member HDU; None if not requested
+/// * `newFileName` — file containing member HDU; None if not requested
 pub(crate) fn fftsad(
-    mfptr: &mut fitsfile,               /* pointer to an member HDU             */
-    HDU: &mut HDUtracker,               /* pointer to an HDU tracker struct     */
-    newPosition: Option<&mut c_int>, /* new HDU position of the member HDU; None if not requested   */
-    newFileName: Option<&mut [c_char]>, /* file containing member HDU; None if not requested           */
+    mfptr: &mut fitsfile,
+    HDU: &mut HDUtracker,
+    newPosition: Option<&mut c_int>,
+    newFileName: Option<&mut [c_char]>,
 ) -> c_int {
     let mut i: c_int;
     let mut hdunum: c_int = 0;
@@ -6274,17 +6468,23 @@ pub(crate) fn fftsad(
     status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Update the HDU information in the HDUtracker struct pointed to by HDU. The
 /// HDU to update is pointed to by mfptr. If non-zero, the value of newPosition
 /// is used to update the HDU->newPosition[] value for the mfptr, and if
 /// non-NULL the newFileName value is used to update the HDU->newFilename[]
 /// value for mfptr.
+///
+/// # Parameters
+///
+/// * `mfptr`       — pointer to an member HDU
+/// * `HDU`         — pointer to an HDU tracker struct
+/// * `newPosition` — new HDU position of the member HDU; 0 to leave unchanged
+/// * `newFileName` — file containing member HDU; None to leave unchanged
 pub(crate) fn fftsud(
-    mfptr: &mut fitsfile,           /* pointer to an member HDU             */
-    HDU: &mut HDUtracker,           /* pointer to an HDU tracker struct     */
-    newPosition: c_int,             /* new HDU position of the member HDU; 0 to leave unchanged */
-    newFileName: Option<&[c_char]>, /* file containing member HDU; None to leave unchanged   */
+    mfptr: &mut fitsfile,
+    HDU: &mut HDUtracker,
+    newPosition: c_int,
+    newFileName: Option<&[c_char]>,
 ) -> c_int {
     let mut i: c_int;
     let mut hdunum: c_int = 0;
@@ -6338,7 +6538,6 @@ pub(crate) fn fftsud(
     status
 }
 
-/*---------------------------------------------------------------------------*/
 /// Strip off all single quote characters "'" and blank spaces from a keyword
 /// value retrieved via fits_read_key*() routines
 ///
@@ -6398,16 +6597,22 @@ pub(crate) fn prepare_keyvalue(keyvalue: &mut [c_char]) /* string containing key
       Host dependent directory path to/from URL functions
 --------------------------------------------------------------------------*/
 
-/*------------------------------------------------------------------------*/
 /// Convert a file path into its Unix-style equivelent for URL
 /// purposes. Note that this process is platform dependent. This
 /// function supports Unix, MSDOS/WIN32, VMS and Macintosh platforms.
 /// The plaform dependant code is conditionally compiled depending upon
 /// the setting of the appropriate C preprocessor macros.
+///
+/// # Parameters
+///
+/// * `inpath`    — input file path string
+/// * `maxlength` — I max number of chars that can be written to output, including
+///                terminating NULL
+/// * `outpath`   — output file path string
 pub(crate) fn fits_path2url(
-    inpath: &[c_char],      /* input file path string                  */
-    maxlength: usize, /* I max number of chars that can be written to output, including terminating NULL */
-    outpath: &mut [c_char], /* output file path string                 */
+    inpath: &[c_char],
+    maxlength: usize,
+    outpath: &mut [c_char],
     status: &mut c_int,
 ) -> c_int {
     let mut buff: [c_char; FLEN_FILENAME] = [0; FLEN_FILENAME];
@@ -6577,15 +6782,19 @@ pub(crate) fn fits_path2url(
     *status
 }
 
-/*---------------------------------------------------------------------------*/
 /// Convert a Unix-style URL into a platform dependent directory path.
 /// Note that this process is platform dependent. This
 /// function supports Unix, MSDOS/WIN32, VMS and Macintosh platforms. Each
 /// platform dependent code segment is conditionally compiled depending
 /// upon the setting of the appropriate C preprocesser macros.
+///
+/// # Parameters
+///
+/// * `inpath`  — input file path string
+/// * `outpath` — output file path string
 pub(crate) fn fits_url2path(
-    inpath: &[c_char],      /* input file path string  */
-    outpath: &mut [c_char], /* output file path string */
+    inpath: &[c_char],
+    outpath: &mut [c_char],
     status: &mut c_int,
 ) -> c_int {
     let mut buff: [c_char; FLEN_FILENAME] = [0; FLEN_FILENAME];
@@ -6709,7 +6918,6 @@ pub(crate) fn fits_url2path(
     *status
 }
 
-/****************************************************************************/
 /// Retrieve the string containing the current working directory absolute
 /// path in Unix-like URL standard notation. It is assumed that the CWD
 /// string has a size of at least FLEN_FILENAME.
@@ -6718,10 +6926,11 @@ pub(crate) fn fits_url2path(
 /// function supports Unix, MSDOS/WIN32, VMS and Macintosh platforms. Each
 /// platform dependent code segment is conditionally compiled depending
 /// upon the setting of the appropriate C preprocesser macros.
-pub(crate) fn fits_get_cwd(
-    cwd: &mut [c_char], /* IO current working directory string */
-    status: &mut c_int,
-) -> c_int {
+///
+/// # Parameters
+///
+/// * `cwd` — IO current working directory string
+pub(crate) fn fits_get_cwd(cwd: &mut [c_char], status: &mut c_int) -> c_int {
     let mut buff: [c_char; FLEN_FILENAME] = [0; FLEN_FILENAME];
     let current_dir;
 
@@ -6780,7 +6989,6 @@ pub(crate) fn fits_get_cwd(
     *status
 }
 
-/*---------------------------------------------------------------------------*/
 /// For grouping convention purposes, determine the URL of the FITS file
 /// associated with the fitsfile pointer fptr. The true access type (file://,
 /// mem://, shmem://, root://), starting "official" access type, and iostate
@@ -6790,13 +6998,21 @@ pub(crate) fn fits_get_cwd(
 /// URL, and the the accessType string has enough room to hold the access type.
 #[allow(clippy::if_same_then_else)]
 // C dispatch chain: distinct conditions deliberately share an action.
+/// # Parameters
+///
+/// * `fptr`        — I ptr to FITS file to evaluate
+/// * `realURL`     — O URL of real FITS file
+/// * `startURL`    — O URL of starting FITS file
+/// * `realAccess`  — O true access method of FITS file
+/// * `startAccess` — O "official" access of FITS file
+/// * `iostate`     — O can this file be modified?
 pub(crate) fn fits_get_url(
-    fptr: &mut fitsfile,        /* I ptr to FITS file to evaluate    */
-    realURL: &mut [c_char],     /* O URL of real FITS file           */
-    startURL: &mut [c_char],    /* O URL of starting FITS file       */
-    realAccess: &mut [c_char],  /* O true access method of FITS file */
-    startAccess: &mut [c_char], /* O "official" access of FITS file  */
-    iostate: &mut c_int,        /* O can this file be modified?      */
+    fptr: &mut fitsfile,
+    realURL: &mut [c_char],
+    startURL: &mut [c_char],
+    realAccess: &mut [c_char],
+    startAccess: &mut [c_char],
+    iostate: &mut c_int,
     status: &mut c_int,
 ) -> c_int {
     let i: usize;
@@ -7079,17 +7295,17 @@ pub(crate) fn fits_get_url(
 
 // HAVE NOT INCLUDED THIS SET OF FUNTIONS.
 
-/*--------------------------------------------------------------------------*/
 /// Clean the URL by eliminating any ".." or "." specifiers in the inURL
 /// string, and write the output to the outURL string.
 ///
 /// Note that this function must have a valid Unix-style URL as input; platform
 /// dependent path strings are not allowed.
-pub(crate) fn fits_clean_url(
-    inURL: &[c_char],      /* I input URL string                      */
-    outURL: &mut [c_char], /* O output URL string                     */
-    status: &mut c_int,
-) -> c_int {
+///
+/// # Parameters
+///
+/// * `inURL`  — I input URL string
+/// * `outURL` — O output URL string
+pub(crate) fn fits_clean_url(inURL: &[c_char], outURL: &mut [c_char], status: &mut c_int) -> c_int {
     let mut mystack: VecDeque<&[c_char]> = VecDeque::new(); /* stack to hold pieces of URL */
 
     let mut inURL_ptr = inURL;
@@ -7206,7 +7422,6 @@ pub(crate) fn fits_clean_url(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Create a relative URL to the file referenced by absURL with respect to the
 /// reference URL refURL. The relative URL is returned in relURL.
 ///
@@ -7229,10 +7444,16 @@ pub(crate) fn fits_clean_url(
 /// Which is syntically correct but meaningless. The problem is that a file
 /// with an access method of ftp:// cannot be expressed a a relative URL to
 /// a local disk file.
+///
+/// # Parameters
+///
+/// * `refURL` — I reference URL string
+/// * `absURL` — I absoulute URL string to process
+/// * `relURL` — O resulting relative URL string
 pub(crate) fn fits_url2relurl(
-    refURL: &[c_char],     /* I reference URL string             */
-    absURL: &[c_char],     /* I absoulute URL string to process  */
-    relURL: &mut [c_char], /* O resulting relative URL string    */
+    refURL: &[c_char],
+    absURL: &[c_char],
+    relURL: &mut [c_char],
     status: &mut c_int,
 ) -> c_int {
     let mut i: c_int;
@@ -7348,23 +7569,28 @@ pub(crate) fn fits_url2relurl(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Create an absolute URL from a relative url and a reference URL. The
 /// reference URL is given by the FITS file pointed to by fptr.
 ///
 /// The construction of the absolute URL from the partial and reference URl
 /// is performed using the rules set forth in:
 ///
-/// http://www.w3.org/Addressing/URL/URL_TOC.html
+/// <http://www.w3.org/Addressing/URL/URL_TOC.html>
 /// and
-/// http://www.w3.org/Addressing/URL/4_3_Partial.html
+/// <http://www.w3.org/Addressing/URL/4_3_Partial.html>
 ///
 /// Note that the relative URL string relURL must conform to the Unix-like
 /// URL syntax; host dependent partial URL strings are not allowed.
+///
+/// # Parameters
+///
+/// * `refURL` — I reference URL string
+/// * `relURL` — I relative URL string to process
+/// * `absURL` — O absolute URL string
 pub fn fits_relurl2url(
-    refURL: &[c_char],     /* I reference URL string             */
-    relURL: &[c_char],     /* I relative URL string to process   */
-    absURL: &mut [c_char], /* O absolute URL string              */
+    refURL: &[c_char],
+    relURL: &[c_char],
+    absURL: &mut [c_char],
     status: &mut c_int,
 ) -> c_int {
     let mut i: usize;
@@ -7524,7 +7750,6 @@ pub fn fits_relurl2url(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Encode all URL "unsafe" and "reserved" characters using the "%XX"
 /// convention, where XX stand for the two hexidecimal digits of the
 /// encode character's ASCII code.
@@ -7536,11 +7761,18 @@ pub fn fits_relurl2url(
 /// be set to size 0 and an error status will be returned.
 ///
 /// This function was adopted from code in the libwww.a library available
-/// via the W3 consortium <URL: http://www.w3.org>
+/// via the W3 consortium, <http://www.w3.org>
+///
+/// # Parameters
+///
+/// * `inpath`    — I URL to be encoded
+/// * `maxlength` — I max number of chars that may be copied to outpath, including
+///                terminating NULL.
+/// * `outpath`   — O output encoded URL
 pub(crate) fn fits_encode_url(
-    inpath: &[c_char],      /* I URL  to be encoded                  */
-    maxlength: usize, /* I max number of chars that may be copied to outpath, including terminating NULL. */
-    outpath: &mut [c_char], /* O output encoded URL                  */
+    inpath: &[c_char],
+    maxlength: usize,
+    outpath: &mut [c_char],
     status: &mut c_int,
 ) -> c_int {
     let mut a: c_uchar;
@@ -7622,8 +7854,7 @@ pub(crate) fn fits_encode_url(
     *status
 }
 
-/*---------------------------------------------------------------------------*/
-/// unencode all URL "unsafe" and "reserved" characters to their actual
+/// Unencode all URL "unsafe" and "reserved" characters to their actual
 /// ASCII representation. All tokens of the form "%XX" where XX is the
 /// hexidecimal code for an ASCII character, are searched for and
 /// translated into the actuall ASCII character (so three chars become
@@ -7633,10 +7864,15 @@ pub(crate) fn fits_encode_url(
 /// URL.
 ///
 /// This function was adopted from code in the libwww.a library available
-/// via the W3 consortium <URL: http://www.w3.org>
+/// via the W3 consortium, <http://www.w3.org>
+///
+/// # Parameters
+///
+/// * `inpath`  — I input URL with encoding
+/// * `outpath` — O unencoded URL
 pub(crate) fn fits_unencode_url(
-    inpath: &[c_char],      /* I input URL with encoding            */
-    outpath: &mut [c_char], /* O unencoded URL                      */
+    inpath: &[c_char],
+    outpath: &mut [c_char],
     status: &mut c_int,
 ) -> c_int {
     if *status != 0 {
@@ -7696,7 +7932,6 @@ pub(crate) fn fits_unencode_url(
     *status
 }
 
-/*---------------------------------------------------------------------------*/
 /// Return a True (1) or False (0) value indicating whether or not the passed
 /// URL string contains an access method specifier or not. Note that this is
 /// a boolean function and it neither reads nor returns the standard error

--- a/src/grparser.rs
+++ b/src/grparser.rs
@@ -1,3 +1,18 @@
+//! The header template parser.
+//!
+//! Reads a template file describing a set of HDUs -- their keywords, and for
+//! tables their columns -- and creates them in a FITS file. This is what
+//! `fits_create_template` and the `filename(template)` form of the extended
+//! filename syntax use.
+//!
+//! The template syntax has its own error codes, the `NGP_*` constants in
+//! [`crate::fitsio`], chosen so as not to collide with the library's own.
+//!
+//! Ported from CFITSIO's `grparser.c`, by Jerzy Borkowski of the Integral
+//! Science Data Centre. See the "Template File Format" chapter of the CFITSIO
+//! User's Reference Guide.
+#![warn(missing_docs)]
+
 use core::ffi::CStr;
 use core::ptr;
 use core::slice;
@@ -77,44 +92,69 @@ fn ngp_alloc_boxed(size: usize) -> Result<Box<[c_char]>, c_int> {
     Ok(vec.into_boxed_slice())
 }
 
-/* type definitions */
-
+/// One line of a template, split into its parts.
+///
+/// The indices are offsets into `line`, so the parts borrow the line rather
+/// than copying out of it.
 #[repr(C)]
 #[derive(Clone, Default)]
 pub struct NgpRawLine {
+    /// The line as read, NUL-terminated.
     pub line: Box<[c_char]>,
+    /// Offset of the keyword name within `line`, if there is one.
     pub name_idx: Option<usize>,
+    /// Offset of the value within `line`, if there is one.
     pub value_idx: Option<usize>,
+    /// Token type of the line.
     pub type_: c_int,
+    /// Offset of the comment within `line`, if there is one.
     pub comment_idx: Option<usize>,
+    /// Format code of the value.
     pub format: c_int,
+    /// Flags recording which parts were present.
     pub flags: c_int,
 }
 
+/// A complex value in a template.
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct NgpComplex {
+    /// Real part.
     pub re: f64,
+    /// Imaginary part.
     pub im: f64,
 }
 
+/// The value of a template token, whose type is given by the enclosing
+/// [`NgpToken`]'s `type_`.
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union NgpTokval {
+    /// String value.
     pub s: *mut c_char,
+    /// Logical value.
     pub b: c_char,
+    /// Integer value.
     pub i: c_int,
+    /// Long integer value.
     pub l: c_long,
+    /// Floating point value.
     pub d: f64,
+    /// Complex value.
     pub c: NgpComplex,
 }
 
+/// One keyword parsed out of a template: its name, value and comment.
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct NgpToken {
+    /// Which arm of `value` is live.
     pub type_: c_int,
+    /// Keyword name.
     pub name: [c_char; NGP_MAX_NAME],
+    /// Keyword value.
     pub value: NgpTokval,
+    /// Keyword comment.
     pub comment: [c_char; NGP_MAX_COMMENT],
 }
 
@@ -129,21 +169,31 @@ impl Default for NgpToken {
     }
 }
 
+/// The keywords of one HDU described by a template.
 #[repr(C)]
 pub struct NgpHdu {
+    /// Number of tokens in `tok`.
     pub tokcnt: c_int,
+    /// The keywords, in the order the template gave them.
     pub tok: Vec<NgpToken>,
 }
 
+/// One entry of the table of recognized template directives.
 #[repr(C)]
 pub struct NgpTkdef {
+    /// The directive as it appears in a template, e.g. `\\INCLUDE`.
     pub name: &'static CStr,
+    /// The token code it maps to.
     pub code: c_int,
 }
 
+/// Tracks the highest `EXTVER` seen for an `EXTNAME`, so that auto-numbered
+/// extensions get successive versions.
 #[repr(C)]
 pub struct NgpExtverTab {
+    /// The extension name.
     pub extname: Box<[c_char]>,
+    /// The highest version number used for it so far.
     pub version: c_int,
 }
 
@@ -321,7 +371,7 @@ fn ngp_delete_extver_tab(parser_state: &mut GRParseState) -> c_int {
     NGP_OK
 }
 
-/// read one line from file
+/// Read one line from file
 fn ngp_line_from_file(reader: &mut BufReader<File>, line_out: &mut Box<[c_char]>) -> c_int {
     let mut r = NGP_OK; /* initialize stuff, reset err code */
     let mut llen: usize = 0; /* 0 characters read so far */
@@ -400,7 +450,7 @@ fn ngp_line_from_file(reader: &mut BufReader<File>, line_out: &mut Box<[c_char]>
     r /* return  status code */
 }
 
-/// free current line structure
+/// Free current line structure
 fn ngp_free_line(parser_state: &mut GRParseState) -> c_int {
     if !parser_state.NGP_CURLINE.line.is_empty() {
         parser_state.NGP_CURLINE.line = Box::default();
@@ -414,7 +464,7 @@ fn ngp_free_line(parser_state: &mut GRParseState) -> c_int {
     NGP_OK
 }
 
-/// free cached line structure
+/// Free cached line structure
 fn ngp_free_prevline(parser_state: &mut GRParseState) -> c_int {
     if !parser_state.NGP_PREVLINE.line.is_empty() {
         parser_state.NGP_PREVLINE.line = Box::default();
@@ -428,7 +478,7 @@ fn ngp_free_prevline(parser_state: &mut GRParseState) -> c_int {
     NGP_OK
 }
 
-/// read one line
+/// Read one line
 fn ngp_read_line_buffered(parser_state: &mut GRParseState, reader: &mut BufReader<File>) -> c_int {
     ngp_free_line(parser_state); /* first free current line (if any) */
 
@@ -445,7 +495,7 @@ fn ngp_read_line_buffered(parser_state: &mut GRParseState, reader: &mut BufReade
     ngp_line_from_file(reader, &mut parser_state.NGP_CURLINE.line)
 }
 
-/// unread line
+/// Unread line
 fn ngp_unread_line(parser_state: &mut GRParseState) -> c_int {
     if parser_state.NGP_CURLINE.line.is_empty() {
         /* nothing to unread */
@@ -462,7 +512,7 @@ fn ngp_unread_line(parser_state: &mut GRParseState) -> c_int {
     NGP_OK
 }
 
-/// a first guess line decomposition
+/// A first guess line decomposition
 fn ngp_extract_tokens(cl: &mut NgpRawLine) -> c_int {
     let mut p_idx: usize; // Index into line buffer
     let mut s_idx: usize;
@@ -830,7 +880,7 @@ fn find_include_file(fname: &[c_char], master_dir: &Path) -> Option<PathBuf> {
     None
 }
 
-/// try to open include file.
+/// Try to open include file.
 /// If open fails and fname
 /// does not specify absolute pathname, try to open fname
 /// in any directory specified in CFITSIO_INCLUDE_FILES
@@ -864,7 +914,7 @@ fn ngp_include_file(parser_state: &mut GRParseState, fname: &[c_char]) -> c_int 
     NGP_OK
 }
 
-/// read line in the intelligent way.
+/// Read line in the intelligent way.
 /// All \INCLUDE directives are handled,
 /// empty and comment line skipped. If this function returns NGP_OK, than
 /// decomposed line (name, type, value in proper type and comment) are
@@ -1173,7 +1223,7 @@ fn ngp_read_line(parser_state: &mut GRParseState, ignore_blank_lines: c_int) -> 
     }
 }
 
-/// check whether keyword can be written as is
+/// Check whether keyword can be written as is
 fn ngp_keyword_is_write(ngp_tok: &NgpToken) -> c_int {
     /* indexed variables not to write */
     let nm: [&[c_char]; 3] = [cs!(c"NAXIS"), cs!(c"TFORM"), cs!(c"TTYPE")];
@@ -1243,7 +1293,7 @@ fn ngp_keyword_is_write(ngp_tok: &NgpToken) -> c_int {
     NGP_BAD_ARG
 }
 
-/// write (almost) all keywords from given HDU to disk
+/// Write (almost) all keywords from given HDU to disk
 fn ngp_keyword_all_write(ngph: &mut NgpHdu, ffp: &mut fitsfile, mode: c_int) -> c_int {
     let mut ib: c_int;
     let mut buf: [c_char; 200] = [0; 200];
@@ -1368,14 +1418,14 @@ fn ngp_keyword_all_write(ngph: &mut NgpHdu, ffp: &mut fitsfile, mode: c_int) -> 
     r
 }
 
-/// init HDU structure
+/// Init HDU structure
 fn ngp_hdu_init(ngph: &mut NgpHdu) -> c_int {
     ngph.tok = Vec::new();
     ngph.tokcnt = 0;
     NGP_OK
 }
 
-/// clear HDU structure
+/// Clear HDU structure
 fn ngp_hdu_clear(ngph: &mut NgpHdu) -> c_int {
     for i in 0..ngph.tokcnt {
         let token = &mut ngph.tok[i as usize];
@@ -1401,7 +1451,7 @@ fn ngp_hdu_clear(ngph: &mut NgpHdu) -> c_int {
     NGP_OK
 }
 
-/// insert new token to HDU structure
+/// Insert new token to HDU structure
 fn ngp_hdu_insert_token(ngph: &mut NgpHdu, newtok: &mut NgpToken) -> c_int {
     unsafe {
         ngph.tok.push(*newtok);
@@ -1502,7 +1552,7 @@ fn ngp_append_columns(ff: &mut fitsfile, ngph: &mut NgpHdu, aftercol: c_int) -> 
     }
 }
 
-/// read complete HDU
+/// Read complete HDU
 fn ngp_read_xtension(
     parser_state: &mut GRParseState,
     ff: &mut fitsfile,
@@ -1789,7 +1839,7 @@ fn ngp_read_xtension(
     }
 }
 
-/// read complete GROUP
+/// Read complete GROUP
 fn ngp_read_group(
     parser_state: &mut GRParseState,
     ff: &mut fitsfile,
@@ -1937,14 +1987,19 @@ fn ngp_read_group(
 
 /* top level API functions */
 
-/*--------------------------------------------------------------------------*/
 /// Read whole template
 /// ff should point to the opened empty fits file.
+///
+/// # Parameters
+///
+/// * `ff`           — (I) FITS file pointer
+/// * `ngp_template` — (I) template string
+/// * `status`       — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn fits_execute_template(
-    ff: *mut fitsfile,           /* I - FITS file pointer */
-    ngp_template: *const c_char, /* I - template string */
-    status: *mut c_int,          /* IO - error status */
+    ff: *mut fitsfile,
+    ngp_template: *const c_char,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -1970,13 +2025,18 @@ pub unsafe extern "C" fn fits_execute_template(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read whole template
 /// ff should point to the opened empty fits file.
+///
+/// # Parameters
+///
+/// * `ff`           — (I) FITS file pointer
+/// * `ngp_template` — (I) template string
+/// * `status`       — (IO) error status
 pub fn fits_execute_template_safe(
-    ff: &mut fitsfile,       /* I - FITS file pointer */
-    ngp_template: &[c_char], /* I - template string */
-    status: &mut c_int,      /* IO - error status */
+    ff: &mut fitsfile,
+    ngp_template: &[c_char],
+    status: &mut c_int,
 ) -> c_int {
     let mut r: c_int = 0;
     let mut exit_flg: c_int = 0;

--- a/src/helpers/aligned.rs
+++ b/src/helpers/aligned.rs
@@ -1,3 +1,6 @@
+//! A heap byte buffer with an alignment guarantee.
+#![warn(missing_docs)]
+
 use alloc::collections::TryReserveError;
 use core::ops::{Deref, DerefMut};
 

--- a/src/helpers/boxed.rs
+++ b/src/helpers/boxed.rs
@@ -1,3 +1,11 @@
+//! Fallible heap allocation.
+//!
+//! CFITSIO checks every `malloc` and reports
+//! [`MEMORY_ALLOCATION`](crate::fitsio::MEMORY_ALLOCATION) rather than
+//! aborting, so the port needs a `Box::new` that returns an error instead of
+//! panicking on allocation failure.
+#![warn(missing_docs)]
+
 use alloc::alloc::alloc;
 use core::alloc::Layout;
 use core::error::Error;

--- a/src/helpers/cfile.rs
+++ b/src/helpers/cfile.rs
@@ -1,3 +1,6 @@
+//! Adapters between C stream I/O and the Rust `Read` / `Write` traits.
+#![warn(missing_docs)]
+
 use std::{
     fs::File,
     io::{self, Read, Write},

--- a/src/helpers/mod.rs
+++ b/src/helpers/mod.rs
@@ -1,3 +1,10 @@
+//! Small Rust-side helpers with no CFITSIO counterpart.
+//!
+//! These exist to express in safe Rust what the C did with raw allocation and
+//! `FILE*` I/O: fallible boxing, an over-aligned byte buffer, a `Read`/`Write`
+//! adapter over a C stream, and the test fixtures.
+#![warn(missing_docs)]
+
 pub mod aligned;
 pub mod boxed;
 pub mod cfile;

--- a/src/helpers/testhelpers.rs
+++ b/src/helpers/testhelpers.rs
@@ -1,3 +1,8 @@
+//! Fixtures shared by the ported CFITSIO test programs.
+//!
+//! See `TEST_CONVERSION.md` for how a C `test_*.c` maps onto these.
+#![warn(missing_docs)]
+
 use core::ffi::CStr;
 use std::{f32, f64};
 
@@ -65,11 +70,12 @@ pub fn path_with_ext(path: &str, ext: &str) -> [c_char; FLEN_FILENAME] {
     to_buf(&s)
 }
 
-/// Helper function for float comparisons
+/// Whether two `f32` values are equal to within one epsilon.
 pub fn floats_close_f32(a: f32, b: f32) -> bool {
     (a - b).abs() < f32::EPSILON
 }
 
+/// Whether two `f64` values are equal to within one epsilon.
 pub fn floats_close_f64(a: f64, b: f64) -> bool {
     (a - b).abs() < f64::EPSILON
 }

--- a/src/helpers/vec_raw_parts.rs
+++ b/src/helpers/vec_raw_parts.rs
@@ -1,3 +1,6 @@
+//! Decomposing a `Vec` into the raw parts the C-facing structures hold.
+#![warn(missing_docs)]
+
 use core::mem::ManuallyDrop;
 
 /// Decomposes a `Vec<T>` into its raw components: `(pointer, length, capacity)`.
@@ -5,12 +8,12 @@ use core::mem::ManuallyDrop;
 /// Returns the raw pointer to the underlying data, the length of
 /// the vector (in elements), and the allocated capacity of the
 /// data (in elements). These are the same arguments in the same
-/// order as the arguments to [`from_raw_parts`].
+/// order as the arguments to [`Vec::from_raw_parts`].
 ///
 /// After calling this function, the caller is responsible for the
 /// memory previously managed by the `Vec`. The only way to do
 /// this is to convert the raw pointer, length, and capacity back
-/// into a `Vec` with the [`from_raw_parts`] function, allowing
+/// into a `Vec` with the [`Vec::from_raw_parts`] function, allowing
 /// the destructor to perform the cleanup.
 #[must_use = "losing the pointer will leak memory"]
 pub(crate) fn vec_into_raw_parts<T>(v: Vec<T>) -> (*mut T, usize, usize) {

--- a/src/histo.rs
+++ b/src/histo.rs
@@ -1,4 +1,16 @@
-/*   Globally defined histogram parameters */
+//! Binning table columns into a histogram image.
+//!
+//! Given a table and a binning specification -- which columns, over what range,
+//! with what bin width -- these routines produce an image whose pixels count
+//! the rows falling in each bin. This is what the `[bin ...]` clause of the
+//! extended filename syntax invokes, so opening a table with a bin
+//! specification hands back an image.
+//!
+//! Ported from CFITSIO's `histo.c`, written by William Pence at the High Energy
+//! Astrophysics Science Archive Research Center (HEASARC), NASA Goddard Space
+//! Flight Center. See the "Column Binning or Histogramming Routines" section of
+//! the CFITSIO User's Reference Guide.
+#![warn(missing_docs)]
 
 use core::ffi::{CStr, c_void};
 use core::slice;
@@ -113,7 +125,6 @@ impl Default for HistUnion {
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Parse the extended input binning specification string, returning
 /// the binning parameters.  Supports up to 4 dimensions.  The binspec
 /// string has one of these forms:
@@ -138,34 +149,53 @@ impl Default for HistUnion {
 /// passed back to the caller.  Storage may be allocated by this routine,
 /// If *exprs is non-zero upon return, the caller is responsible to
 /// free(*exprs).  Upon return, the contains of exprs is,
+/// ```text
 ///     (*exprs)[0] = expression for column 1 (or 0 if none)
 ///     (*exprs)[1] = expression for column 2 (or 0 if none)
 ///     (*exprs)[2] = expression for column 3 (or 0 if none)
 ///     (*exprs)[3] = expression for column 4 (or 0 if none)
 ///     (*exprs)[4] = expression for weighting (or 0 if none)
+/// ```
 ///
 /// If the user specifies a column name and not an expression for bin
-/// axis i, then the corresponding (*exprs)[i] will be a null pointer.
+/// axis i, then the corresponding `(*exprs)[i]` will be a null pointer.
 ///
 /// To be recognized as an expression, the weighting expression must be
 /// enclosed in parentheses.
 ///
 /// Expressions are never allowed using the bin (xcol,ycol) notation.
+///
+/// # Parameters
+///
+/// * `binspec`   — (I) binning specification
+/// * `imagetype` — (O) image type, TINT or TSHORT
+/// * `histaxis`  — (O) no. of axes in the histogram
+/// * `colname`   — column name for axis
+/// * `minin`     — minimum value for each axis
+/// * `maxin`     — maximum value for each axis
+/// * `binsizein` — size of bins on each axis
+/// * `minname`   — keyword name for min
+/// * `maxname`   — keyword name for max
+/// * `binname`   — keyword name for binsize
+/// * `weight`    — weighting factor
+/// * `wtname`    — keyword or column name for weight
+/// * `recip`     — the reciprocal of the weight?
+/// * `exprs`     — returned with expressions (or 0)
 pub(crate) fn ffbinse(
-    binspec: &[c_char],                      /* I - binning specification */
-    imagetype: &mut c_int,                   /* O - image type, TINT or TSHORT */
-    histaxis: &mut c_int,                    /* O - no. of axes in the histogram */
-    colname: &mut [[c_char; FLEN_VALUE]; 4], /* column name for axis */
-    minin: &mut [f64; 4],                    /* minimum value for each axis */
-    maxin: &mut [f64; 4],                    /* maximum value for each axis */
-    binsizein: &mut [f64; 4],                /* size of bins on each axis */
-    minname: &mut [[c_char; FLEN_VALUE]; 4], /* keyword name for min */
-    maxname: &mut [[c_char; FLEN_VALUE]; 4], /* keyword name for max */
-    binname: &mut [[c_char; FLEN_VALUE]; 4], /* keyword name for binsize */
-    weight: &mut f64,                        /* weighting factor          */
-    wtname: &mut [c_char; 71],               /* keyword or column name for weight */
-    recip: &mut c_int,                       /* the reciprocal of the weight? */
-    exprs: Option<&mut [Box<[c_char]>; 5]>,  /* returned with expressions (or 0) */
+    binspec: &[c_char],
+    imagetype: &mut c_int,
+    histaxis: &mut c_int,
+    colname: &mut [[c_char; FLEN_VALUE]; 4],
+    minin: &mut [f64; 4],
+    maxin: &mut [f64; 4],
+    binsizein: &mut [f64; 4],
+    minname: &mut [[c_char; FLEN_VALUE]; 4],
+    maxname: &mut [[c_char; FLEN_VALUE]; 4],
+    binname: &mut [[c_char; FLEN_VALUE]; 4],
+    weight: &mut f64,
+    wtname: &mut [c_char; 71],
+    recip: &mut c_int,
+    exprs: Option<&mut [Box<[c_char]>; 5]>,
     status: &mut c_int,
 ) -> c_int {
     let ii: c_int = 0;
@@ -629,23 +659,38 @@ pub(crate) fn ffbinse(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Parse non-extended expression, but otherwise the same as ffbinse()
+///
+/// # Parameters
+///
+/// * `binspec`   — (I) binning specification
+/// * `imagetype` — (O) image type, TINT or TSHORT
+/// * `histaxis`  — (O) no. of axes in the histogram
+/// * `colname`   — column name for axis
+/// * `minin`     — minimum value for each axis
+/// * `maxin`     — maximum value for each axis
+/// * `binsizein` — size of bins on each axis
+/// * `minname`   — keyword name for min
+/// * `maxname`   — keyword name for max
+/// * `binname`   — keyword name for binsize
+/// * `weight`    — weighting factor
+/// * `wtname`    — keyword or column name for weight
+/// * `recip`     — the reciprocal of the weight?
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffbins(
-    binspec: *const c_char,                  /* I - binning specification */
-    imagetype: *mut c_int,                   /* O - image type, TINT or TSHORT */
-    histaxis: *mut c_int,                    /* O - no. of axes in the histogram */
-    colname: *mut [[c_char; FLEN_VALUE]; 4], /* column name for axis */
-    minin: *mut f64,                         /* minimum value for each axis */
-    maxin: *mut f64,                         /* maximum value for each axis */
-    binsizein: *mut f64,                     /* size of bins on each axis */
-    minname: *mut [[c_char; FLEN_VALUE]; 4], /* keyword name for min */
-    maxname: *mut [[c_char; FLEN_VALUE]; 4], /* keyword name for max */
-    binname: *mut [[c_char; FLEN_VALUE]; 4], /* keyword name for binsize */
-    weight: *mut f64,                        /* weighting factor          */
-    wtname: *mut [c_char; FLEN_VALUE],       /* keyword or column name for weight */
-    recip: *mut c_int,                       /* the reciprocal of the weight? */
+    binspec: *const c_char,
+    imagetype: *mut c_int,
+    histaxis: *mut c_int,
+    colname: *mut [[c_char; FLEN_VALUE]; 4],
+    minin: *mut f64,
+    maxin: *mut f64,
+    binsizein: *mut f64,
+    minname: *mut [[c_char; FLEN_VALUE]; 4],
+    maxname: *mut [[c_char; FLEN_VALUE]; 4],
+    binname: *mut [[c_char; FLEN_VALUE]; 4],
+    weight: *mut f64,
+    wtname: *mut [c_char; FLEN_VALUE],
+    recip: *mut c_int,
     status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
@@ -674,22 +719,37 @@ pub unsafe extern "C" fn ffbins(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Parse non-extended expression, but otherwise the same as ffbinse()
+///
+/// # Parameters
+///
+/// * `binspec`   — (I) binning specification
+/// * `imagetype` — (O) image type, TINT or TSHORT
+/// * `histaxis`  — (O) no. of axes in the histogram
+/// * `colname`   — column name for axis
+/// * `minin`     — minimum value for each axis
+/// * `maxin`     — maximum value for each axis
+/// * `binsizein` — size of bins on each axis
+/// * `minname`   — keyword name for min
+/// * `maxname`   — keyword name for max
+/// * `binname`   — keyword name for binsize
+/// * `weight`    — weighting factor
+/// * `wtcol`     — keyword or column name for weight
+/// * `recip`     — the reciprocal of the weight?
 pub fn ffbins_safe(
-    binspec: &[c_char],                      /* I - binning specification */
-    imagetype: &mut c_int,                   /* O - image type, TINT or TSHORT */
-    histaxis: &mut c_int,                    /* O - no. of axes in the histogram */
-    colname: &mut [[c_char; FLEN_VALUE]; 4], /* column name for axis */
-    minin: &mut [f64; 4],                    /* minimum value for each axis */
-    maxin: &mut [f64; 4],                    /* maximum value for each axis */
-    binsizein: &mut [f64; 4],                /* size of bins on each axis */
-    minname: &mut [[c_char; FLEN_VALUE]; 4], /* keyword name for min */
-    maxname: &mut [[c_char; FLEN_VALUE]; 4], /* keyword name for max */
-    binname: &mut [[c_char; FLEN_VALUE]; 4], /* keyword name for binsize */
-    weight: &mut f64,                        /* weighting factor          */
-    wtcol: &mut [c_char; FLEN_VALUE],        /* keyword or column name for weight */
-    recip: &mut c_int,                       /* the reciprocal of the weight? */
+    binspec: &[c_char],
+    imagetype: &mut c_int,
+    histaxis: &mut c_int,
+    colname: &mut [[c_char; FLEN_VALUE]; 4],
+    minin: &mut [f64; 4],
+    maxin: &mut [f64; 4],
+    binsizein: &mut [f64; 4],
+    minname: &mut [[c_char; FLEN_VALUE]; 4],
+    maxname: &mut [[c_char; FLEN_VALUE]; 4],
+    binname: &mut [[c_char; FLEN_VALUE]; 4],
+    weight: &mut f64,
+    wtcol: &mut [c_char; FLEN_VALUE],
+    recip: &mut c_int,
     status: &mut c_int,
 ) -> c_int {
     ffbinse(
@@ -699,7 +759,6 @@ pub fn ffbins_safe(
     )
 }
 
-/*--------------------------------------------------------------------------*/
 /// Parse the input binning range specification string, returning
 /// the column name, histogram min and max values, and bin size.
 ///
@@ -966,7 +1025,6 @@ pub(crate) fn ffbinre(
 
     *status
 }
-/*--------------------------------------------------------------------------*/
 /// Parse the input binning range specification string, returning
 /// the column name, histogram min and max values, and bin size.
 ///
@@ -1025,7 +1083,6 @@ pub unsafe extern "C" fn ffbinr(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Parse the input binning range specification string, returning
 /// the column name, histogram min and max values, and bin size.
 ///
@@ -1047,25 +1104,44 @@ pub fn ffbinr_safe(
     )
 }
 
-/*--------------------------------------------------------------------------*/
+/// # Parameters
+///
+/// * `fptr`      — (IO) pointer to table with X and Y cols, on output, points to
+///                histogram image
+/// * `outfile`   — (I) name for the output histogram file
+/// * `imagetype` — (I) datatype for image: TINT, TSHORT, etc
+/// * `naxis`     — (I) number of axes in the histogram image
+/// * `colname`   — (I) column names
+/// * `colexpr`   — (I) optionally, expression intead of colum
+/// * `minin`     — (I) minimum histogram value, for each axis
+/// * `maxin`     — (I) maximum histogram value, for each axis
+/// * `binsizein` — (I) bin size along each axis
+/// * `minname`   — (I) optional keywords for min
+/// * `maxname`   — (I) optional keywords for max
+/// * `binname`   — (I) optional keywords for binsize
+/// * `weightin`  — (I) binning weighting factor
+/// * `wtcol`     — (I) optional keyword or col for weight
+/// * `wtexpr`    — (I) optionally, weight expression
+/// * `recip`     — (I) use reciprocal of the weight?
+/// * `selectrow` — (I) optional array (length = no. of
 pub(crate) fn ffhist2e(
-    fptr: &mut Option<Box<fitsfile>>, /* IO - pointer to table with X and Y cols, on output, points to histogram image    */
-    outfile: &[c_char],               /* I - name for the output histogram file      */
-    imagetype: c_int,                 /* I - datatype for image: TINT, TSHORT, etc   */
-    naxis: c_int,                     /* I - number of axes in the histogram image   */
-    colname: &[[c_char; FLEN_VALUE]; 4], /* I - column names               */
-    colexpr: Option<&[Option<&[c_char]>; 4]>, /* I - optionally, expression intead of colum  */
-    minin: &[f64],                    /* I - minimum histogram value, for each axis */
-    maxin: &[f64],                    /* I - maximum histogram value, for each axis */
-    binsizein: &[f64],                /* I - bin size along each axis               */
-    minname: &[[c_char; FLEN_VALUE]; 4], /* I - optional keywords for min    */
-    maxname: &[[c_char; FLEN_VALUE]; 4], /* I - optional keywords for max    */
-    binname: &[[c_char; FLEN_VALUE]; 4], /* I - optional keywords for binsize */
-    weightin: f64,                    /* I - binning weighting factor          */
-    wtcol: &[c_char; FLEN_VALUE],     /* I - optional keyword or col for weight*/
-    wtexpr: Option<&[c_char]>,        /* I - optionally, weight expression     */
-    recip: c_int,                     /* I - use reciprocal of the weight?     */
-    selectrow: Option<&[c_char]>,     /* I - optional array (length = no. of   */
+    fptr: &mut Option<Box<fitsfile>>,
+    outfile: &[c_char],
+    imagetype: c_int,
+    naxis: c_int,
+    colname: &[[c_char; FLEN_VALUE]; 4],
+    colexpr: Option<&[Option<&[c_char]>; 4]>,
+    minin: &[f64],
+    maxin: &[f64],
+    binsizein: &[f64],
+    minname: &[[c_char; FLEN_VALUE]; 4],
+    maxname: &[[c_char; FLEN_VALUE]; 4],
+    binname: &[[c_char; FLEN_VALUE]; 4],
+    weightin: f64,
+    wtcol: &[c_char; FLEN_VALUE],
+    wtexpr: Option<&[c_char]>,
+    recip: c_int,
+    selectrow: Option<&[c_char]>,
     /* rows in the table).  If the element is true */
     /* then the corresponding row of the table will*/
     /* be included in the histogram, otherwise the */
@@ -1327,26 +1403,43 @@ pub(crate) fn ffhist2e(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Non-extended-syntax version of ffhist2e()
+///
+/// # Parameters
+///
+/// * `fptr`      — (IO) pointer to table with X and Y cols;
+/// * `outfile`   — (I) name for the output histogram file
+/// * `imagetype` — (I) datatype for image: TINT, TSHORT, etc
+/// * `naxis`     — (I) number of axes in the histogram image
+/// * `colname`   — (I) column names
+/// * `minin`     — (I) minimum histogram value, for each axis
+/// * `maxin`     — (I) maximum histogram value, for each axis
+/// * `binsizein` — (I) bin size along each axis
+/// * `minname`   — (I) optional keywords for min
+/// * `maxname`   — (I) optional keywords for max
+/// * `binname`   — (I) optional keywords for binsize
+/// * `weightin`  — (I) binning weighting factor
+/// * `wtcol`     — (I) optional keyword or col for weight
+/// * `recip`     — (I) use reciprocal of the weight?
+/// * `selectrow` — (I) optional array (length = no. of
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffhist2(
-    fptr: *mut Option<Box<fitsfile>>, /* IO - pointer to table with X and Y cols;    */
+    fptr: *mut Option<Box<fitsfile>>,
     /*     on output, points to histogram image    */
-    outfile: *const c_char, /* I - name for the output histogram file      */
-    imagetype: c_int,       /* I - datatype for image: TINT, TSHORT, etc   */
-    naxis: c_int,           /* I - number of axes in the histogram image   */
-    colname: *const [[c_char; FLEN_VALUE]; 4], /* I - column names               */
-    minin: *const f64,      /* I - minimum histogram value, for each axis */
-    maxin: *const f64,      /* I - maximum histogram value, for each axis */
-    binsizein: *const f64,  /* I - bin size along each axis               */
-    minname: *const [[c_char; FLEN_VALUE]; 4], /* I - optional keywords for min    */
-    maxname: *const [[c_char; FLEN_VALUE]; 4], /* I - optional keywords for max    */
-    binname: *const [[c_char; FLEN_VALUE]; 4], /* I - optional keywords for binsize */
-    weightin: f64,          /* I - binning weighting factor          */
-    wtcol: *const [c_char; FLEN_VALUE], /* I - optional keyword or col for weight*/
-    recip: c_int,           /* I - use reciprocal of the weight?     */
-    selectrow: *const c_char, /* I - optional array (length = no. of   */
+    outfile: *const c_char,
+    imagetype: c_int,
+    naxis: c_int,
+    colname: *const [[c_char; FLEN_VALUE]; 4],
+    minin: *const f64,
+    maxin: *const f64,
+    binsizein: *const f64,
+    minname: *const [[c_char; FLEN_VALUE]; 4],
+    maxname: *const [[c_char; FLEN_VALUE]; 4],
+    binname: *const [[c_char; FLEN_VALUE]; 4],
+    weightin: f64,
+    wtcol: *const [c_char; FLEN_VALUE],
+    recip: c_int,
+    selectrow: *const c_char,
     /* rows in the table).  If the element is true */
     /* then the corresponding row of the table will*/
     /* be included in the histogram, otherwise the */
@@ -1386,25 +1479,42 @@ pub unsafe extern "C" fn ffhist2(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Non-extended-syntax version of ffhist2e()
+///
+/// # Parameters
+///
+/// * `fptr`      — (IO) pointer to table with X and Y cols;
+/// * `outfile`   — (I) name for the output histogram file
+/// * `imagetype` — (I) datatype for image: TINT, TSHORT, etc
+/// * `naxis`     — (I) number of axes in the histogram image
+/// * `colname`   — (I) column names
+/// * `minin`     — (I) minimum histogram value, for each axis
+/// * `maxin`     — (I) maximum histogram value, for each axis
+/// * `binsizein` — (I) bin size along each axis
+/// * `minname`   — (I) optional keywords for min
+/// * `maxname`   — (I) optional keywords for max
+/// * `binname`   — (I) optional keywords for binsize
+/// * `weightin`  — (I) binning weighting factor
+/// * `wtcol`     — (I) optional keyword or col for weight
+/// * `recip`     — (I) use reciprocal of the weight?
+/// * `selectrow` — (I) optional array (length = no. of
 pub fn ffhist2_safe(
-    fptr: &mut Option<Box<fitsfile>>, /* IO - pointer to table with X and Y cols;    */
+    fptr: &mut Option<Box<fitsfile>>,
     /*     on output, points to histogram image    */
-    outfile: &[c_char], /* I - name for the output histogram file      */
-    imagetype: c_int,   /* I - datatype for image: TINT, TSHORT, etc   */
-    naxis: c_int,       /* I - number of axes in the histogram image   */
-    colname: &[[c_char; FLEN_VALUE]; 4], /* I - column names               */
-    minin: &[f64],      /* I - minimum histogram value, for each axis */
-    maxin: &[f64],      /* I - maximum histogram value, for each axis */
-    binsizein: &[f64],  /* I - bin size along each axis               */
-    minname: &[[c_char; FLEN_VALUE]; 4], /* I - optional keywords for min    */
-    maxname: &[[c_char; FLEN_VALUE]; 4], /* I - optional keywords for max    */
-    binname: &[[c_char; FLEN_VALUE]; 4], /* I - optional keywords for binsize */
-    weightin: f64,      /* I - binning weighting factor          */
-    wtcol: &[c_char; FLEN_VALUE], /* I - optional keyword or col for weight*/
-    recip: c_int,       /* I - use reciprocal of the weight?     */
-    selectrow: Option<&[c_char]>, /* I - optional array (length = no. of   */
+    outfile: &[c_char],
+    imagetype: c_int,
+    naxis: c_int,
+    colname: &[[c_char; FLEN_VALUE]; 4],
+    minin: &[f64],
+    maxin: &[f64],
+    binsizein: &[f64],
+    minname: &[[c_char; FLEN_VALUE]; 4],
+    maxname: &[[c_char; FLEN_VALUE]; 4],
+    binname: &[[c_char; FLEN_VALUE]; 4],
+    weightin: f64,
+    wtcol: &[c_char; FLEN_VALUE],
+    recip: c_int,
+    selectrow: Option<&[c_char]>,
     /* rows in the table).  If the element is true */
     /* then the corresponding row of the table will*/
     /* be included in the histogram, otherwise the */
@@ -1418,26 +1528,43 @@ pub fn ffhist2_safe(
     )
 }
 
-/*--------------------------------------------------------------------------*/
-/// ffhist3: same as ffhist2, but does not close the original file
+/// Ffhist3: same as ffhist2, but does not close the original file
 ///  and/or replace the original file pointer
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) pointer to table with X and Y cols;
+/// * `outfile`   — (I) name for the output histogram file
+/// * `imagetype` — (I) datatype for image: TINT, TSHORT, etc
+/// * `naxis`     — (I) number of axes in the histogram image
+/// * `colname`   — (I) column names
+/// * `minin`     — (I) minimum histogram value, for each axis
+/// * `maxin`     — (I) maximum histogram value, for each axis
+/// * `binsizein` — (I) bin size along each axis
+/// * `minname`   — (I) optional keywords for min
+/// * `maxname`   — (I) optional keywords for max
+/// * `binname`   — (I) optional keywords for binsize
+/// * `weightin`  — (I) binning weighting factor
+/// * `wtcol`     — (I) optional keyword or col for weight
+/// * `recip`     — (I) use reciprocal of the weight?
+/// * `selectrow` — (I) optional array (length = no. of
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffhist3(
-    fptr: *const *mut fitsfile, /* I - pointer to table with X and Y cols;    */
-    outfile: *const c_char,     /* I - name for the output histogram file      */
-    imagetype: c_int,           /* I - datatype for image: TINT, TSHORT, etc   */
-    naxis: c_int,               /* I - number of axes in the histogram image   */
-    colname: *const [[c_char; FLEN_VALUE]; 4], /* I - column names               */
-    minin: *const f64,          /* I - minimum histogram value, for each axis */
-    maxin: *const f64,          /* I - maximum histogram value, for each axis */
-    binsizein: *const f64,      /* I - bin size along each axis               */
-    minname: *const [[c_char; FLEN_VALUE]; 4], /* I - optional keywords for min    */
-    maxname: *const [[c_char; FLEN_VALUE]; 4], /* I - optional keywords for max    */
-    binname: *const [[c_char; FLEN_VALUE]; 4], /* I - optional keywords for binsize */
-    weightin: f64,              /* I - binning weighting factor          */
-    wtcol: *const [c_char; FLEN_VALUE], /* I - optional keyword or col for weight*/
-    recip: c_int,               /* I - use reciprocal of the weight?     */
-    selectrow: *const c_char,   /* I - optional array (length = no. of   */
+    fptr: *const *mut fitsfile,
+    outfile: *const c_char,
+    imagetype: c_int,
+    naxis: c_int,
+    colname: *const [[c_char; FLEN_VALUE]; 4],
+    minin: *const f64,
+    maxin: *const f64,
+    binsizein: *const f64,
+    minname: *const [[c_char; FLEN_VALUE]; 4],
+    maxname: *const [[c_char; FLEN_VALUE]; 4],
+    binname: *const [[c_char; FLEN_VALUE]; 4],
+    weightin: f64,
+    wtcol: *const [c_char; FLEN_VALUE],
+    recip: c_int,
+    selectrow: *const c_char,
     /* rows in the table).  If the element is true */
     /* then the corresponding row of the table will*/
     /* be included in the histogram, otherwise the */
@@ -1480,25 +1607,42 @@ pub unsafe extern "C" fn ffhist3(
     }
 }
 
-/*--------------------------------------------------------------------------*/
-/// ffhist3: same as ffhist2, but does not close the original file
+/// Ffhist3: same as ffhist2, but does not close the original file
 ///  and/or replace the original file pointer
+///
+/// # Parameters
+///
+/// * `fptr`      — (IO) pointer to table with X and Y cols;
+/// * `outfile`   — (I) name for the output histogram file
+/// * `imagetype` — (I) datatype for image: TINT, TSHORT, etc
+/// * `naxis`     — (I) number of axes in the histogram image
+/// * `colname`   — (I) column names
+/// * `minin`     — (I) minimum histogram value, for each axis
+/// * `maxin`     — (I) maximum histogram value, for each axis
+/// * `binsizein` — (I) bin size along each axis
+/// * `minname`   — (I) optional keywords for min
+/// * `maxname`   — (I) optional keywords for max
+/// * `binname`   — (I) optional keywords for binsize
+/// * `weightin`  — (I) binning weighting factor
+/// * `wtcol`     — (I) optional keyword or col for weight
+/// * `recip`     — (I) use reciprocal of the weight?
+/// * `selectrow` — (I) optional array (length = no. of
 pub fn ffhist3_safe(
-    fptr: &mut fitsfile, /* IO - pointer to table with X and Y cols;    */
-    outfile: &[c_char],  /* I - name for the output histogram file      */
-    imagetype: c_int,    /* I - datatype for image: TINT, TSHORT, etc   */
-    naxis: c_int,        /* I - number of axes in the histogram image   */
-    colname: &[[c_char; FLEN_VALUE]; 4], /* I - column names               */
-    minin: &[f64],       /* I - minimum histogram value, for each axis */
-    maxin: &[f64],       /* I - maximum histogram value, for each axis */
-    binsizein: &[f64],   /* I - bin size along each axis               */
-    minname: &[[c_char; FLEN_VALUE]; 4], /* I - optional keywords for min    */
-    maxname: &[[c_char; FLEN_VALUE]; 4], /* I - optional keywords for max    */
-    binname: &[[c_char; FLEN_VALUE]; 4], /* I - optional keywords for binsize */
-    weightin: f64,       /* I - binning weighting factor          */
-    wtcol: &[c_char; FLEN_VALUE], /* I - optional keyword or col for weight*/
-    recip: c_int,        /* I - use reciprocal of the weight?     */
-    selectrow: Option<&[c_char]>, /* I - optional array (length = no. of   */
+    fptr: &mut fitsfile,
+    outfile: &[c_char],
+    imagetype: c_int,
+    naxis: c_int,
+    colname: &[[c_char; FLEN_VALUE]; 4],
+    minin: &[f64],
+    maxin: &[f64],
+    binsizein: &[f64],
+    minname: &[[c_char; FLEN_VALUE]; 4],
+    maxname: &[[c_char; FLEN_VALUE]; 4],
+    binname: &[[c_char; FLEN_VALUE]; 4],
+    weightin: f64,
+    wtcol: &[c_char; FLEN_VALUE],
+    recip: c_int,
+    selectrow: Option<&[c_char]>,
     /* rows in the table).  If the element is true */
     /* then the corresponding row of the table will*/
     /* be included in the histogram, otherwise the */
@@ -1673,24 +1817,41 @@ pub fn ffhist3_safe(
     Some(histptr)
 }
 
-/*--------------------------------------------------------------------------*/
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
+/// # Parameters
+///
+/// * `fptr`      — (I) pointer to table with X and Y cols; on output, points to
+///                histogram image
+/// * `outfile`   — (I) name for the output histogram file
+/// * `imagetype` — (I) datatype for image: TINT, TSHORT, etc
+/// * `naxis`     — (I) number of axes in the histogram image
+/// * `colname`   — (I) column names
+/// * `minin`     — (I) minimum histogram value, for each axis
+/// * `maxin`     — (I) maximum histogram value, for each axis
+/// * `binsizein` — (I) bin size along each axis
+/// * `minname`   — (I) optional keywords for min
+/// * `maxname`   — (I) optional keywords for max
+/// * `binname`   — (I) optional keywords for binsize
+/// * `weightin`  — (I) binning weighting factor
+/// * `wtcol`     — (I) optional keyword or col for weight
+/// * `recip`     — (I) use reciprocal of the weight?
+/// * `selectrow` — (I) optional array (length = no. of
 pub unsafe extern "C" fn ffhist(
-    fptr: *mut Option<Box<fitsfile>>, /* I - pointer to table with X and Y cols; on output, points to histogram image    */
-    outfile: *const c_char,           /* I - name for the output histogram file      */
-    imagetype: c_int,                 /* I - datatype for image: TINT, TSHORT, etc   */
-    naxis: c_int,                     /* I - number of axes in the histogram image   */
-    colname: *mut [[c_char; FLEN_VALUE]; 4], /* I - column names               */
-    minin: *mut f64,                  /* I - minimum histogram value, for each axis */
-    maxin: *mut f64,                  /* I - maximum histogram value, for each axis */
-    binsizein: *mut f64,              /* I - bin size along each axis               */
-    minname: *const [[c_char; FLEN_VALUE]; 4], /* I - optional keywords for min    */
-    maxname: *const [[c_char; FLEN_VALUE]; 4], /* I - optional keywords for max    */
-    binname: *const [[c_char; FLEN_VALUE]; 4], /* I - optional keywords for binsize */
-    weightin: f64,                    /* I - binning weighting factor          */
-    wtcol: *const [c_char; FLEN_VALUE], /* I - optional keyword or col for weight*/
-    recip: c_int,                     /* I - use reciprocal of the weight?     */
-    selectrow: *const c_char,         /* I - optional array (length = no. of   */
+    fptr: *mut Option<Box<fitsfile>>,
+    outfile: *const c_char,
+    imagetype: c_int,
+    naxis: c_int,
+    colname: *mut [[c_char; FLEN_VALUE]; 4],
+    minin: *mut f64,
+    maxin: *mut f64,
+    binsizein: *mut f64,
+    minname: *const [[c_char; FLEN_VALUE]; 4],
+    maxname: *const [[c_char; FLEN_VALUE]; 4],
+    binname: *const [[c_char; FLEN_VALUE]; 4],
+    weightin: f64,
+    wtcol: *const [c_char; FLEN_VALUE],
+    recip: c_int,
+    selectrow: *const c_char,
     /* rows in the table).  If the element is true */
     /* then the corresponding row of the table will*/
     /* be included in the histogram, otherwise the */
@@ -1729,23 +1890,40 @@ pub unsafe extern "C" fn ffhist(
     }
 }
 
-/*--------------------------------------------------------------------------*/
+/// # Parameters
+///
+/// * `fptr`      — (I) pointer to table with X and Y cols; on output, points to
+///                histogram image
+/// * `outfile`   — (I) name for the output histogram file
+/// * `imagetype` — (I) datatype for image: TINT, TSHORT, etc
+/// * `naxis`     — (I) number of axes in the histogram image
+/// * `colname`   — (I) column names
+/// * `minin`     — (I) minimum histogram value, for each axis
+/// * `maxin`     — (I) maximum histogram value, for each axis
+/// * `binsizein` — (I) bin size along each axis
+/// * `minname`   — (I) optional keywords for min
+/// * `maxname`   — (I) optional keywords for max
+/// * `binname`   — (I) optional keywords for binsize
+/// * `weightin`  — (I) binning weighting factor
+/// * `wtcol`     — (I) optional keyword or col for weight
+/// * `recip`     — (I) use reciprocal of the weight?
+/// * `selectrow` — (I) optional array (length = no. of
 pub fn ffhist_safe(
-    fptr: &mut Option<Box<fitsfile>>, /* I - pointer to table with X and Y cols; on output, points to histogram image    */
-    outfile: &[c_char],               /* I - name for the output histogram file      */
-    imagetype: c_int,                 /* I - datatype for image: TINT, TSHORT, etc   */
-    naxis: c_int,                     /* I - number of axes in the histogram image   */
-    colname: &mut [[c_char; FLEN_VALUE]; 4], /* I - column names               */
-    minin: &mut [f64],                /* I - minimum histogram value, for each axis */
-    maxin: &mut [f64],                /* I - maximum histogram value, for each axis */
-    binsizein: &mut [f64],            /* I - bin size along each axis               */
-    minname: &[[c_char; FLEN_VALUE]; 4], /* I - optional keywords for min    */
-    maxname: &[[c_char; FLEN_VALUE]; 4], /* I - optional keywords for max    */
-    binname: &[[c_char; FLEN_VALUE]; 4], /* I - optional keywords for binsize */
-    weightin: f64,                    /* I - binning weighting factor          */
-    wtcol: &[c_char; FLEN_VALUE],     /* I - optional keyword or col for weight*/
-    recip: c_int,                     /* I - use reciprocal of the weight?     */
-    selectrow: Option<&[c_char]>,     /* I - optional array (length = no. of   */
+    fptr: &mut Option<Box<fitsfile>>,
+    outfile: &[c_char],
+    imagetype: c_int,
+    naxis: c_int,
+    colname: &mut [[c_char; FLEN_VALUE]; 4],
+    minin: &mut [f64],
+    maxin: &mut [f64],
+    binsizein: &mut [f64],
+    minname: &[[c_char; FLEN_VALUE]; 4],
+    maxname: &[[c_char; FLEN_VALUE]; 4],
+    binname: &[[c_char; FLEN_VALUE]; 4],
+    weightin: f64,
+    wtcol: &[c_char; FLEN_VALUE],
+    recip: c_int,
+    selectrow: Option<&[c_char]>,
     /* rows in the table).  If the element is true */
     /* then the corresponding row of the table will*/
     /* be included in the histogram, otherwise the */
@@ -2730,26 +2908,42 @@ pub fn ffhist_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Single-precision version
+///
+/// # Parameters
+///
+/// * `fptr`      — (IO) pointer to table to be binned ;
+/// * `naxis`     — (I) number of axes/columns in the binned image
+/// * `colname`   — (I) optional column names
+/// * `minin`     — (I) optional lower bound value for each axis
+/// * `maxin`     — (I) optional upper bound value, for each axis
+/// * `binsizein` — (I) optional bin size along each axis
+/// * `minname`   — (I) optional keywords for min
+/// * `maxname`   — (I) optional keywords for max
+/// * `binname`   — (I) optional keywords for binsize
+/// * `colnum`    — (O) column numbers, to be binned
+/// * `haxes`     — (O) number of bins in each histogram axis
+/// * `amin`      — (O) lower bound of the histogram axes
+/// * `amax`      — (O) upper bound of the histogram axes
+/// * `binsize`   — (O) width of histogram bins/pixels on each axis
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn fits_calc_binning(
-    fptr: *mut fitsfile, /* IO - pointer to table to be binned      ;       */
-    naxis: c_int,        /* I - number of axes/columns in the binned image  */
-    colname: *mut [[c_char; FLEN_VALUE]; 4], /* I - optional column names         */
-    minin: *mut f64,     /* I - optional lower bound value for each axis  */
-    maxin: *mut f64,     /* I - optional upper bound value, for each axis */
-    binsizein: *mut f64, /* I - optional bin size along each axis         */
-    minname: *mut [[c_char; FLEN_VALUE]; 4], /* I - optional keywords for min       */
-    maxname: *mut [[c_char; FLEN_VALUE]; 4], /* I - optional keywords for max       */
-    binname: *mut [[c_char; FLEN_VALUE]; 4], /* I - optional keywords for binsize   */
+    fptr: *mut fitsfile,
+    naxis: c_int,
+    colname: *mut [[c_char; FLEN_VALUE]; 4],
+    minin: *mut f64,
+    maxin: *mut f64,
+    binsizein: *mut f64,
+    minname: *mut [[c_char; FLEN_VALUE]; 4],
+    maxname: *mut [[c_char; FLEN_VALUE]; 4],
+    binname: *mut [[c_char; FLEN_VALUE]; 4],
 
     /* The returned parameters for each axis of the n-dimensional histogram are */
-    colnum: *mut c_int, /* O - column numbers, to be binned */
-    haxes: *mut c_long, /* O - number of bins in each histogram axis */
-    amin: *mut f32,     /* O - lower bound of the histogram axes */
-    amax: *mut f32,     /* O - upper bound of the histogram axes */
-    binsize: *mut f32,  /* O - width of histogram bins/pixels on each axis */
+    colnum: *mut c_int,
+    haxes: *mut c_long,
+    amin: *mut f32,
+    amax: *mut f32,
+    binsize: *mut f32,
     status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
@@ -2777,25 +2971,41 @@ pub unsafe extern "C" fn fits_calc_binning(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Single-precision version
+///
+/// # Parameters
+///
+/// * `fptr`      — (IO) pointer to table to be binned ;
+/// * `naxis`     — (I) number of axes/columns in the binned image
+/// * `colname`   — (I) optional column names
+/// * `minin`     — (I) optional lower bound value for each axis
+/// * `maxin`     — (I) optional upper bound value, for each axis
+/// * `binsizein` — (I) optional bin size along each axis
+/// * `minname`   — (I) optional keywords for min
+/// * `maxname`   — (I) optional keywords for max
+/// * `binname`   — (I) optional keywords for binsize
+/// * `colnum`    — (O) column numbers, to be binned
+/// * `haxes`     — (O) number of bins in each histogram axis
+/// * `amin`      — (O) lower bound of the histogram axes
+/// * `amax`      — (O) upper bound of the histogram axes
+/// * `binsize`   — (O) width of histogram bins/pixels on each axis
 pub fn fits_calc_binning_safe(
-    fptr: &mut fitsfile, /* IO - pointer to table to be binned      ;       */
-    naxis: c_int,        /* I - number of axes/columns in the binned image  */
-    colname: &mut [[c_char; FLEN_VALUE]; 4], /* I - optional column names         */
-    minin: &mut [f64],   /* I - optional lower bound value for each axis  */
-    maxin: &mut [f64],   /* I - optional upper bound value, for each axis */
-    binsizein: &mut [f64], /* I - optional bin size along each axis         */
-    minname: &mut [[c_char; FLEN_VALUE]; 4], /* I - optional keywords for min       */
-    maxname: &mut [[c_char; FLEN_VALUE]; 4], /* I - optional keywords for max       */
-    binname: &mut [[c_char; FLEN_VALUE]; 4], /* I - optional keywords for binsize   */
+    fptr: &mut fitsfile,
+    naxis: c_int,
+    colname: &mut [[c_char; FLEN_VALUE]; 4],
+    minin: &mut [f64],
+    maxin: &mut [f64],
+    binsizein: &mut [f64],
+    minname: &mut [[c_char; FLEN_VALUE]; 4],
+    maxname: &mut [[c_char; FLEN_VALUE]; 4],
+    binname: &mut [[c_char; FLEN_VALUE]; 4],
 
     /* The returned parameters for each axis of the n-dimensional histogram are */
-    colnum: &mut [c_int], /* O - column numbers, to be binned */
-    haxes: &mut [c_long], /* O - number of bins in each histogram axis */
-    amin: &mut [f32],     /* O - lower bound of the histogram axes */
-    amax: &mut [f32],     /* O - upper bound of the histogram axes */
-    binsize: &mut [f32],  /* O - width of histogram bins/pixels on each axis */
+    colnum: &mut [c_int],
+    haxes: &mut [c_long],
+    amin: &mut [f32],
+    amax: &mut [f32],
+    binsize: &mut [f32],
     status: &mut c_int,
 ) -> c_int {
     let mut amind: [f64; 4] = [0.0; 4];
@@ -2836,31 +3046,50 @@ pub fn fits_calc_binning_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Double-precision version with extended syntax
 /// Calculate the actual binning parameters, based on various user inputoptions.
 ///
-/// Note: caller is responsible to free parsers[*] upon return using ffcprs()
+/// Note: caller is responsible to free `parsers[*]` upon return using `ffcprs()`
+///
+/// # Parameters
+///
+/// * `fptr`      — (IO) pointer to table to be binned ;
+/// * `naxis`     — (I) number of axes/columns in the binned image
+/// * `colname`   — (I) optional column names
+/// * `colexpr`   — (I) optional column expressions instead of name
+/// * `minin`     — (IO) optional lower bound value for each axis
+/// * `maxin`     — (IO) optional upper bound value, for each axis
+/// * `binsizein` — (IO) optional bin size along each axis
+/// * `minname`   — (I) optional keywords for min
+/// * `maxname`   — (I) optional keywords for max
+/// * `binname`   — (I) optional keywords for binsize
+/// * `colnum`    — (O) column numbers, to be binned
+/// * `datatypes` — (O) datatype for each column
+/// * `haxes`     — (O) number of bins in each histogram axis
+/// * `amin`      — (O) lower bound of the histogram axes
+/// * `amax`      — (O) upper bound of the histogram axes
+/// * `binsize`   — (O) width of histogram bins/pixels on each axis
+/// * `repeat`    — (O) vector repeat of input columns
 pub(crate) fn fits_calc_binningde(
-    fptr: &mut fitsfile, /* IO - pointer to table to be binned      ;       */
-    naxis: c_int,        /* I - number of axes/columns in the binned image  */
-    colname: &mut [[c_char; FLEN_VALUE]; 4], /* I - optional column names         */
-    colexpr: Option<&[Option<&[c_char]>; 4]>, /* I - optional column expressions instead of name    */
-    minin: &mut [f64],                        /* IO - optional lower bound value for each axis  */
-    maxin: &mut [f64],                        /* IO - optional upper bound value, for each axis */
-    binsizein: &mut [f64],                    /* IO - optional bin size along each axis         */
-    minname: &[[c_char; FLEN_VALUE]; 4],      /* I - optional keywords for min       */
-    maxname: &[[c_char; FLEN_VALUE]; 4],      /* I - optional keywords for max       */
-    binname: &[[c_char; FLEN_VALUE]; 4],      /* I - optional keywords for binsize   */
+    fptr: &mut fitsfile,
+    naxis: c_int,
+    colname: &mut [[c_char; FLEN_VALUE]; 4],
+    colexpr: Option<&[Option<&[c_char]>; 4]>,
+    minin: &mut [f64],
+    maxin: &mut [f64],
+    binsizein: &mut [f64],
+    minname: &[[c_char; FLEN_VALUE]; 4],
+    maxname: &[[c_char; FLEN_VALUE]; 4],
+    binname: &[[c_char; FLEN_VALUE]; 4],
 
     /* The returned parameters for each axis of the n-dimensional histogram are */
-    colnum: &mut [c_int],                /* O - column numbers, to be binned */
-    mut datatypes: Option<&mut [c_int]>, /* O - datatype for each column */
-    haxes: &mut [c_long],                /* O - number of bins in each histogram axis */
-    amin: &mut [f64],                    /* O - lower bound of the histogram axes */
-    amax: &mut [f64],                    /* O - upper bound of the histogram axes */
-    binsize: &mut [f64],                 /* O - width of histogram bins/pixels on each axis */
-    mut repeat: Option<&mut c_long>,     /* O - vector repeat of input columns */
+    colnum: &mut [c_int],
+    mut datatypes: Option<&mut [c_int]>,
+    haxes: &mut [c_long],
+    amin: &mut [f64],
+    amax: &mut [f64],
+    binsize: &mut [f64],
+    mut repeat: Option<&mut c_long>,
     status: &mut c_int,
 ) -> c_int {
     let mut colptr: &mut tcolumn;
@@ -3420,27 +3649,43 @@ pub(crate) fn fits_calc_binningde(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Double-precision version, with non-extended syntax
 /// Calculate the actual binning parameters, based on various user input options.
+///
+/// # Parameters
+///
+/// * `fptr`      — (IO) pointer to table to be binned ;
+/// * `naxis`     — (I) number of axes/columns in the binned image
+/// * `colname`   — (I) optional column names
+/// * `minin`     — (I) optional lower bound value for each axis
+/// * `maxin`     — (I) optional upper bound value, for each axis
+/// * `binsizein` — (I) optional bin size along each axis
+/// * `minname`   — (I) optional keywords for min
+/// * `maxname`   — (I) optional keywords for max
+/// * `binname`   — (I) optional keywords for binsize
+/// * `colnum`    — (O) column numbers, to be binned
+/// * `haxes`     — (O) number of bins in each histogram axis
+/// * `amin`      — (O) lower bound of the histogram axes
+/// * `amax`      — (O) upper bound of the histogram axes
+/// * `binsize`   — (O) width of histogram bins/pixels on each axis
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn fits_calc_binningd(
-    fptr: *mut fitsfile, /* IO - pointer to table to be binned      ;       */
-    naxis: c_int,        /* I - number of axes/columns in the binned image  */
-    colname: *mut [[c_char; FLEN_VALUE]; 4], /* I - optional column names         */
-    minin: *mut f64,     /* I - optional lower bound value for each axis  */
-    maxin: *mut f64,     /* I - optional upper bound value, for each axis */
-    binsizein: *mut f64, /* I - optional bin size along each axis         */
-    minname: *const [[c_char; FLEN_VALUE]; 4], /* I - optional keywords for min       */
-    maxname: *const [[c_char; FLEN_VALUE]; 4], /* I - optional keywords for max       */
-    binname: *const [[c_char; FLEN_VALUE]; 4], /* I - optional keywords for binsize   */
+    fptr: *mut fitsfile,
+    naxis: c_int,
+    colname: *mut [[c_char; FLEN_VALUE]; 4],
+    minin: *mut f64,
+    maxin: *mut f64,
+    binsizein: *mut f64,
+    minname: *const [[c_char; FLEN_VALUE]; 4],
+    maxname: *const [[c_char; FLEN_VALUE]; 4],
+    binname: *const [[c_char; FLEN_VALUE]; 4],
 
     /* The returned parameters for each axis of the n-dimensional histogram are */
-    colnum: *mut c_int, /* O - column numbers, to be binned */
-    haxes: *mut c_long, /* O - number of bins in each histogram axis */
-    amin: *mut f64,     /* O - lower bound of the histogram axes */
-    amax: *mut f64,     /* O - upper bound of the histogram axes */
-    binsize: *mut f64,  /* O - width of histogram bins/pixels on each axis */
+    colnum: *mut c_int,
+    haxes: *mut c_long,
+    amin: *mut f64,
+    amax: *mut f64,
+    binsize: *mut f64,
     status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
@@ -3471,26 +3716,42 @@ pub unsafe extern "C" fn fits_calc_binningd(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Double-precision version, with non-extended syntax
 /// Calculate the actual binning parameters, based on various user inputoptions.
+///
+/// # Parameters
+///
+/// * `fptr`      — (IO) pointer to table to be binned ;
+/// * `naxis`     — (I) number of axes/columns in the binned image
+/// * `colname`   — (I) optional column names
+/// * `minin`     — (IO) optional lower bound value for each axis
+/// * `maxin`     — (IO) optional upper bound value, for each axis
+/// * `binsizein` — (IO) optional bin size along each axis
+/// * `minname`   — (I) optional keywords for min
+/// * `maxname`   — (I) optional keywords for max
+/// * `binname`   — (I) optional keywords for binsize
+/// * `colnum`    — (O) column numbers, to be binned
+/// * `haxes`     — (O) number of bins in each histogram axis
+/// * `amin`      — (O) lower bound of the histogram axes
+/// * `amax`      — (O) upper bound of the histogram axes
+/// * `binsize`   — (O) width of histogram bins/pixels on each axis
 pub fn fits_calc_binningd_safe(
-    fptr: &mut fitsfile, /* IO - pointer to table to be binned      ;       */
-    naxis: c_int,        /* I - number of axes/columns in the binned image  */
-    colname: &mut [[c_char; FLEN_VALUE]; 4], /* I - optional column names         */
-    minin: &mut [f64],   /* IO - optional lower bound value for each axis  */
-    maxin: &mut [f64],   /* IO - optional upper bound value, for each axis */
-    binsizein: &mut [f64], /* IO - optional bin size along each axis         */
-    minname: &[[c_char; FLEN_VALUE]; 4], /* I - optional keywords for min       */
-    maxname: &[[c_char; FLEN_VALUE]; 4], /* I - optional keywords for max       */
-    binname: &[[c_char; FLEN_VALUE]; 4], /* I - optional keywords for binsize   */
+    fptr: &mut fitsfile,
+    naxis: c_int,
+    colname: &mut [[c_char; FLEN_VALUE]; 4],
+    minin: &mut [f64],
+    maxin: &mut [f64],
+    binsizein: &mut [f64],
+    minname: &[[c_char; FLEN_VALUE]; 4],
+    maxname: &[[c_char; FLEN_VALUE]; 4],
+    binname: &[[c_char; FLEN_VALUE]; 4],
 
     /* The returned parameters for each axis of the n-dimensional histogram are */
-    colnum: &mut [c_int], /* O - column numbers, to be binned */
-    haxes: &mut [c_long], /* O - number of bins in each histogram axis */
-    amin: &mut [f64],     /* O - lower bound of the histogram axes */
-    amax: &mut [f64],     /* O - upper bound of the histogram axes */
-    binsize: &mut [f64],  /* O - width of histogram bins/pixels on each axis */
+    colnum: &mut [c_int],
+    haxes: &mut [c_long],
+    amin: &mut [f64],
+    amax: &mut [f64],
+    binsize: &mut [f64],
     status: &mut c_int,
 ) -> c_int {
     fits_calc_binningde(
@@ -3499,16 +3760,24 @@ pub fn fits_calc_binningd_safe(
     )
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write default WCS keywords in the output histogram image header
 /// if the keywords do not already exist.
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) pointer to table to be binned
+/// * `histptr` — (I) pointer to output histogram image HDU
+/// * `naxis`   — (I) number of axes in the histogram image
+/// * `colnum`  — (I) column numbers (array length = naxis)
+/// * `colname` — (I) if expression, then column name to use
+/// * `colexpr` — (I) if expression, then column name to use
 pub(crate) fn fits_write_keys_histoe(
-    fptr: &mut fitsfile,    /* I - pointer to table to be binned              */
-    histptr: &mut fitsfile, /* I - pointer to output histogram image HDU      */
-    naxis: c_int,           /* I - number of axes in the histogram image      */
-    colnum: &[c_int],       /* I - column numbers (array length = naxis)      */
-    colname: Option<&[[c_char; FLEN_VALUE]; 4]>, /* I - if expression, then column name to use */
-    colexpr: Option<&[Option<&[c_char]>; 4]>, /* I - if expression, then column name to use */
+    fptr: &mut fitsfile,
+    histptr: &mut fitsfile,
+    naxis: c_int,
+    colnum: &[c_int],
+    colname: Option<&[[c_char; FLEN_VALUE]; 4]>,
+    colexpr: Option<&[Option<&[c_char]>; 4]>,
     status: &mut c_int,
 ) -> c_int {
     let mut tstatus: c_int = 0;
@@ -3622,13 +3891,18 @@ pub(crate) fn fits_write_keys_histoe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
+/// # Parameters
+///
+/// * `fptr`    — (I) pointer to table to be binned
+/// * `histptr` — (I) pointer to output histogram image HDU
+/// * `naxis`   — (I) number of axes in the histogram image
+/// * `colnum`  — (I) column numbers (array length = naxis)
 pub unsafe extern "C" fn fits_write_keys_histo(
-    fptr: *mut fitsfile,    /* I - pointer to table to be binned              */
-    histptr: *mut fitsfile, /* I - pointer to output histogram image HDU      */
-    naxis: c_int,           /* I - number of axes in the histogram image      */
-    colnum: *const c_int,   /* I - column numbers (array length = naxis)      */
+    fptr: *mut fitsfile,
+    histptr: *mut fitsfile,
+    naxis: c_int,
+    colnum: *const c_int,
     status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
@@ -3643,24 +3917,34 @@ pub unsafe extern "C" fn fits_write_keys_histo(
     }
 }
 
-/*--------------------------------------------------------------------------*/
+/// # Parameters
+///
+/// * `fptr`    — (I) pointer to table to be binned
+/// * `histptr` — (I) pointer to output histogram image HDU
+/// * `naxis`   — (I) number of axes in the histogram image
+/// * `colnum`  — (I) column numbers (array length = naxis)
 pub fn fits_write_keys_histo_safe(
-    fptr: &mut fitsfile,    /* I - pointer to table to be binned              */
-    histptr: &mut fitsfile, /* I - pointer to output histogram image HDU      */
-    naxis: c_int,           /* I - number of axes in the histogram image      */
-    colnum: &[c_int],       /* I - column numbers (array length = naxis)      */
+    fptr: &mut fitsfile,
+    histptr: &mut fitsfile,
+    naxis: c_int,
+    colnum: &[c_int],
     status: &mut c_int,
 ) -> c_int {
     fits_write_keys_histoe(fptr, histptr, naxis, colnum, None, None, status)
 }
 
-/*--------------------------------------------------------------------------*/
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
+/// # Parameters
+///
+/// * `fptr`    — (I) pointer to table to be binned
+/// * `naxis`   — (I) number of axes in the histogram image
+/// * `amin`    — (I) first pixel include in each axis
+/// * `binsize` — (I) binning factor for each axis
 pub unsafe extern "C" fn fits_rebin_wcs(
-    fptr: *mut fitsfile, /* I - pointer to table to be binned           */
-    naxis: c_int,        /* I - number of axes in the histogram image   */
-    amin: *mut f32,      /* I - first pixel include in each axis        */
-    binsize: *mut f32,   /* I - binning factor for each axis            */
+    fptr: *mut fitsfile,
+    naxis: c_int,
+    amin: *mut f32,
+    binsize: *mut f32,
     status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
@@ -3674,12 +3958,17 @@ pub unsafe extern "C" fn fits_rebin_wcs(
     }
 }
 
-/*--------------------------------------------------------------------------*/
+/// # Parameters
+///
+/// * `fptr`    — (I) pointer to table to be binned
+/// * `naxis`   — (I) number of axes in the histogram image
+/// * `amin`    — (I) first pixel include in each axis
+/// * `binsize` — (I) binning factor for each axis
 pub fn fits_rebin_wcs_safe(
-    fptr: &mut fitsfile, /* I - pointer to table to be binned           */
-    naxis: c_int,        /* I - number of axes in the histogram image   */
-    amin: &mut [f32],    /* I - first pixel include in each axis        */
-    binsize: &mut [f32], /* I - binning factor for each axis            */
+    fptr: &mut fitsfile,
+    naxis: c_int,
+    amin: &mut [f32],
+    binsize: &mut [f32],
     status: &mut c_int,
 ) -> c_int {
     let mut amind: [f64; 4] = [0.0; 4];
@@ -3698,16 +3987,22 @@ pub fn fits_rebin_wcs_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Double precision version
 /// Update the  WCS keywords that define the location of the reference
 /// pixel, and the pixel size, along each axis.
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) pointer to table to be binned
+/// * `naxis`   — (I) number of axes in the histogram image
+/// * `amin`    — (I) first pixel include in each axis
+/// * `binsize` — (I) binning factor for each axis
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn fits_rebin_wcsd(
-    fptr: *mut fitsfile, /* I - pointer to table to be binned           */
-    naxis: c_int,        /* I - number of axes in the histogram image   */
-    amin: *mut f64,      /* I - first pixel include in each axis        */
-    binsize: *mut f64,   /* I - binning factor for each axis            */
+    fptr: *mut fitsfile,
+    naxis: c_int,
+    amin: *mut f64,
+    binsize: *mut f64,
     status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
@@ -3721,15 +4016,21 @@ pub unsafe extern "C" fn fits_rebin_wcsd(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Double precision version
 /// Update the  WCS keywords that define the location of the reference
 /// pixel, and the pixel size, along each axis.
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) pointer to table to be binned
+/// * `naxis`   — (I) number of axes in the histogram image
+/// * `amin`    — (I) first pixel include in each axis
+/// * `binsize` — (I) binning factor for each axis
 pub fn fits_rebin_wcsd_safe(
-    fptr: &mut fitsfile, /* I - pointer to table to be binned           */
-    naxis: c_int,        /* I - number of axes in the histogram image   */
-    amin: &mut [f64],    /* I - first pixel include in each axis        */
-    binsize: &mut [f64], /* I - binning factor for each axis            */
+    fptr: &mut fitsfile,
+    naxis: c_int,
+    amin: &mut [f64],
+    binsize: &mut [f64],
     status: &mut c_int,
 ) -> c_int {
     let mut ii: c_int;
@@ -3853,23 +4154,38 @@ pub fn fits_rebin_wcsd_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Single-precision version
+///
+/// # Parameters
+///
+/// * `fptr`      — (IO) pointer to table with X and Y cols;
+/// * `histptr`   — (I) pointer to output FITS image
+/// * `bitpix`    — (I) datatype for image: 16, 32, -32, etc
+/// * `naxis`     — (I) number of axes in the histogram image
+/// * `naxes`     — (I) size of axes in the histogram image
+/// * `colnum`    — (I) column numbers (array length = naxis)
+/// * `amin`      — (I) minimum histogram value, for each axis
+/// * `amax`      — (I) maximum histogram value, for each axis
+/// * `binsize`   — (I) bin size along each axis
+/// * `weight`    — (I) binning weighting factor
+/// * `wtcolnum`  — (I) optional keyword or col for weight
+/// * `recip`     — (I) use reciprocal of the weight?
+/// * `selectrow` — (I) optional array (length = no. of
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn fits_make_hist(
-    fptr: *mut fitsfile,      /* IO - pointer to table with X and Y cols; */
-    histptr: *mut fitsfile,   /* I - pointer to output FITS image      */
-    bitpix: c_int,            /* I - datatype for image: 16, 32, -32, etc    */
-    naxis: c_int,             /* I - number of axes in the histogram image   */
-    naxes: *const c_long,     /* I - size of axes in the histogram image   */
-    colnum: *const c_int,     /* I - column numbers (array length = naxis)   */
-    amin: *const f32,         /* I - minimum histogram value, for each axis */
-    amax: *const f32,         /* I - maximum histogram value, for each axis */
-    binsize: *const f32,      /* I - bin size along each axis               */
-    weight: f32,              /* I - binning weighting factor          */
-    wtcolnum: c_int,          /* I - optional keyword or col for weight*/
-    recip: c_int,             /* I - use reciprocal of the weight?     */
-    selectrow: *const c_char, /* I - optional array (length = no. of   */
+    fptr: *mut fitsfile,
+    histptr: *mut fitsfile,
+    bitpix: c_int,
+    naxis: c_int,
+    naxes: *const c_long,
+    colnum: *const c_int,
+    amin: *const f32,
+    amax: *const f32,
+    binsize: *const f32,
+    weight: f32,
+    wtcolnum: c_int,
+    recip: c_int,
+    selectrow: *const c_char,
     /* rows in the table).  If the element is true */
     /* then the corresponding row of the table will*/
     /* be included in the histogram, otherwise the */
@@ -3904,22 +4220,37 @@ pub unsafe extern "C" fn fits_make_hist(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Single-precision version
+///
+/// # Parameters
+///
+/// * `fptr`      — (IO) pointer to table with X and Y cols;
+/// * `histptr`   — (I) pointer to output FITS image
+/// * `bitpix`    — (I) datatype for image: 16, 32, -32, etc
+/// * `naxis`     — (I) number of axes in the histogram image
+/// * `naxes`     — (I) size of axes in the histogram image
+/// * `colnum`    — (I) column numbers (array length = naxis)
+/// * `amin`      — (I) minimum histogram value, for each axis
+/// * `amax`      — (I) maximum histogram value, for each axis
+/// * `binsize`   — (I) bin size along each axis
+/// * `weight`    — (I) binning weighting factor
+/// * `wtcolnum`  — (I) optional keyword or col for weight
+/// * `recip`     — (I) use reciprocal of the weight?
+/// * `selectrow` — (I) optional array (length = no. of
 pub fn fits_make_hist_safe(
-    fptr: &mut fitsfile,          /* IO - pointer to table with X and Y cols; */
-    histptr: &mut fitsfile,       /* I - pointer to output FITS image      */
-    bitpix: c_int,                /* I - datatype for image: 16, 32, -32, etc    */
-    naxis: c_int,                 /* I - number of axes in the histogram image   */
-    naxes: &[c_long],             /* I - size of axes in the histogram image   */
-    colnum: &[c_int],             /* I - column numbers (array length = naxis)   */
-    amin: &[f32],                 /* I - minimum histogram value, for each axis */
-    amax: &[f32],                 /* I - maximum histogram value, for each axis */
-    binsize: &[f32],              /* I - bin size along each axis               */
-    weight: f32,                  /* I - binning weighting factor          */
-    wtcolnum: c_int,              /* I - optional keyword or col for weight*/
-    recip: c_int,                 /* I - use reciprocal of the weight?     */
-    selectrow: Option<&[c_char]>, /* I - optional array (length = no. of   */
+    fptr: &mut fitsfile,
+    histptr: &mut fitsfile,
+    bitpix: c_int,
+    naxis: c_int,
+    naxes: &[c_long],
+    colnum: &[c_int],
+    amin: &[f32],
+    amax: &[f32],
+    binsize: &[f32],
+    weight: f32,
+    wtcolnum: c_int,
+    recip: c_int,
+    selectrow: Option<&[c_char]>,
     /* rows in the table).  If the element is true */
     /* then the corresponding row of the table will*/
     /* be included in the histogram, otherwise the */
@@ -3950,28 +4281,46 @@ pub fn fits_make_hist_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Double-precision version
+///
+/// # Parameters
+///
+/// * `fptr`      — (IO) pointer to table with X and Y cols;
+/// * `histptr`   — (I) pointer to output FITS image
+/// * `datatypes` — (I) datatype of input (or 0 for auto)
+/// * `bitpix`    — (I) datatype for image: 16, 32, -32, etc
+/// * `naxis`     — (I) number of axes in the histogram image
+/// * `naxes`     — (I) size of axes in the histogram image
+/// * `colnum`    — (I) column numbers (array length = naxis)
+/// * `colexpr`   — (I) optional expression instead of column
+/// * `amin`      — (I) minimum histogram value, for each axis
+/// * `amax`      — (I) maximum histogram value, for each axis
+/// * `binsize`   — (I) bin size along each axis
+/// * `weight`    — (I) binning weighting factor (0 or DOUBLENULLVALUE means null)
+/// * `wtcolnum`  — (I) optional keyword or col for weight
+/// * `wtexpr`    — (I) optional weighting expression
+/// * `recip`     — (I) use reciprocal of the weight?
+/// * `selectrow` — (I) optional array (length = no. of
 pub(crate) fn fits_make_histde(
-    fptr: &mut fitsfile,    /* IO - pointer to table with X and Y cols; */
-    histptr: &mut fitsfile, /* I - pointer to output FITS image      */
-    mut datatypes: Option<&mut [c_int]>, /*  I - datatype of input (or 0 for auto) */
-    bitpix: c_int,          /* I - datatype for image: 16, 32, -32, etc    */
-    naxis: c_int,           /* I - number of axes in the histogram image   */
-    naxes: &[c_long],       /* I - size of axes in the histogram image   */
-    colnum: &[c_int],       /* I - column numbers (array length = naxis)   */
-    colexpr: Option<&[Option<&[c_char]>; 4]>, /* I - optional expression instead of column */
-    amin: &[f64],           /* I - minimum histogram value, for each axis */
-    amax: &[f64],           /* I - maximum histogram value, for each axis */
-    binsize: &[f64],        /* I - bin size along each axis               */
-    mut weight: f64,        /* I - binning weighting factor (0 or DOUBLENULLVALUE means null) */
-    wtcolnum: c_int,        /* I - optional keyword or col for weight*/
-    wtexpr: Option<&[c_char]>, /* I - optional weighting expression */
+    fptr: &mut fitsfile,
+    histptr: &mut fitsfile,
+    mut datatypes: Option<&mut [c_int]>,
+    bitpix: c_int,
+    naxis: c_int,
+    naxes: &[c_long],
+    colnum: &[c_int],
+    colexpr: Option<&[Option<&[c_char]>; 4]>,
+    amin: &[f64],
+    amax: &[f64],
+    binsize: &[f64],
+    mut weight: f64,
+    wtcolnum: c_int,
+    wtexpr: Option<&[c_char]>,
     /*  disambiguation of weight values */
     /*    non-null weight: use that value */
     /*    null weight: use wtexpr if non-null, else wtcolnum */
-    recip: c_int,                 /* I - use reciprocal of the weight?     */
-    selectrow: Option<&[c_char]>, /* I - optional array (length = no. of   */
+    recip: c_int,
+    selectrow: Option<&[c_char]>,
     /* rows in the table).  If the element is true */
     /* then the corresponding row of the table will*/
     /* be included in the histogram, otherwise the */
@@ -4412,23 +4761,38 @@ pub(crate) fn fits_make_histde(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Double-precision version, non-extended syntax
+///
+/// # Parameters
+///
+/// * `fptr`      — (IO) pointer to table with X and Y cols;
+/// * `histptr`   — (I) pointer to output FITS image
+/// * `bitpix`    — (I) datatype for image: 16, 32, -32, etc
+/// * `naxis`     — (I) number of axes in the histogram image
+/// * `naxes`     — (I) size of axes in the histogram image
+/// * `colnum`    — (I) column numbers (array length = naxis)
+/// * `amin`      — (I) minimum histogram value, for each axis
+/// * `amax`      — (I) maximum histogram value, for each axis
+/// * `binsize`   — (I) bin size along each axis
+/// * `weight`    — (I) binning weighting factor
+/// * `wtcolnum`  — (I) optional keyword or col for weight
+/// * `recip`     — (I) use reciprocal of the weight?
+/// * `selectrow` — (I) optional array (length = no. of
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn fits_make_histd(
-    fptr: *mut fitsfile,      /* IO - pointer to table with X and Y cols; */
-    histptr: *mut fitsfile,   /* I - pointer to output FITS image      */
-    bitpix: c_int,            /* I - datatype for image: 16, 32, -32, etc    */
-    naxis: c_int,             /* I - number of axes in the histogram image   */
-    naxes: *const c_long,     /* I - size of axes in the histogram image   */
-    colnum: *const c_int,     /* I - column numbers (array length = naxis)   */
-    amin: *const f64,         /* I - minimum histogram value, for each axis */
-    amax: *const f64,         /* I - maximum histogram value, for each axis */
-    binsize: *const f64,      /* I - bin size along each axis               */
-    weight: f64,              /* I - binning weighting factor          */
-    wtcolnum: c_int,          /* I - optional keyword or col for weight*/
-    recip: c_int,             /* I - use reciprocal of the weight?     */
-    selectrow: *const c_char, /* I - optional array (length = no. of   */
+    fptr: *mut fitsfile,
+    histptr: *mut fitsfile,
+    bitpix: c_int,
+    naxis: c_int,
+    naxes: *const c_long,
+    colnum: *const c_int,
+    amin: *const f64,
+    amax: *const f64,
+    binsize: *const f64,
+    weight: f64,
+    wtcolnum: c_int,
+    recip: c_int,
+    selectrow: *const c_char,
     /* rows in the table).  If the element is true */
     /* then the corresponding row of the table will*/
     /* be included in the histogram, otherwise the */
@@ -4463,22 +4827,37 @@ pub unsafe extern "C" fn fits_make_histd(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Double-precision version, non-extended syntax
+///
+/// # Parameters
+///
+/// * `fptr`      — (IO) pointer to table with X and Y cols;
+/// * `histptr`   — (I) pointer to output FITS image
+/// * `bitpix`    — (I) datatype for image: 16, 32, -32, etc
+/// * `naxis`     — (I) number of axes in the histogram image
+/// * `naxes`     — (I) size of axes in the histogram image
+/// * `colnum`    — (I) column numbers (array length = naxis)
+/// * `amin`      — (I) minimum histogram value, for each axis
+/// * `amax`      — (I) maximum histogram value, for each axis
+/// * `binsize`   — (I) bin size along each axis
+/// * `weight`    — (I) binning weighting factor (0 or DOUBLENULLVALUE means null)
+/// * `wtcolnum`  — (I) optional keyword or col for weight
+/// * `recip`     — (I) use reciprocal of the weight?
+/// * `selectrow` — (I) optional array (length = no. of
 pub fn fits_make_histd_safe(
-    fptr: &mut fitsfile,          /* IO - pointer to table with X and Y cols; */
-    histptr: &mut fitsfile,       /* I - pointer to output FITS image      */
-    bitpix: c_int,                /* I - datatype for image: 16, 32, -32, etc    */
-    naxis: c_int,                 /* I - number of axes in the histogram image   */
-    naxes: &[c_long],             /* I - size of axes in the histogram image   */
-    colnum: &[c_int],             /* I - column numbers (array length = naxis)   */
-    amin: &[f64],                 /* I - minimum histogram value, for each axis */
-    amax: &[f64],                 /* I - maximum histogram value, for each axis */
-    binsize: &[f64],              /* I - bin size along each axis               */
-    weight: f64,     /* I - binning weighting factor (0 or DOUBLENULLVALUE means null) */
-    wtcolnum: c_int, /* I - optional keyword or col for weight*/
-    recip: c_int,    /* I - use reciprocal of the weight?     */
-    selectrow: Option<&[c_char]>, /* I - optional array (length = no. of   */
+    fptr: &mut fitsfile,
+    histptr: &mut fitsfile,
+    bitpix: c_int,
+    naxis: c_int,
+    naxes: &[c_long],
+    colnum: &[c_int],
+    amin: &[f64],
+    amax: &[f64],
+    binsize: &[f64],
+    weight: f64,
+    wtcolnum: c_int,
+    recip: c_int,
+    selectrow: Option<&[c_char]>,
     /* rows in the table).  If the element is true */
     /* then the corresponding row of the table will*/
     /* be included in the histogram, otherwise the */
@@ -4492,7 +4871,6 @@ pub fn fits_make_histd_safe(
     )
 }
 
-/*--------------------------------------------------------------------------*/
 /// Simple utility routine to compute the min and max value in a column
 pub(crate) fn fits_get_col_minmax(
     fptr: &mut fitsfile,
@@ -4557,17 +4935,26 @@ struct histo_minmax_workfn_struct {
     ngood: c_long,
 }
 
-/*---------------------------------------------------------------------------*/
 /// Iterator work function which evaluates a parser result and computes
 /// min max value
+///
+/// # Parameters
+///
+/// * `totalrows` — (I) Total rows to be processed
+/// * `offset`    — (I) Number of rows skipped at start
+/// * `firstrow`  — (I) First row of this iteration
+/// * `nrows`     — (I) Number of rows in this iter
+/// * `nCols`     — (I) Number of columns in use
+/// * `colData`   — (IO) Column information/data
+/// * `userPtr`   — (I) Data handling instructions
 extern "C" fn histo_minmax_expr_workfn(
-    totalrows: c_long,         /* I - Total rows to be processed     */
-    offset: c_long,            /* I - Number of rows skipped at start*/
-    firstrow: c_long,          /* I - First row of this iteration    */
-    nrows: c_long,             /* I - Number of rows in this iter    */
-    nCols: c_int,              /* I - Number of columns in use       */
-    colData: *mut iteratorCol, /* IO- Column information/data        */
-    userPtr: *mut c_void,      /* I - Data handling instructions     */
+    totalrows: c_long,
+    offset: c_long,
+    firstrow: c_long,
+    nrows: c_long,
+    nCols: c_int,
+    colData: *mut iteratorCol,
+    userPtr: *mut c_void,
 ) -> c_int {
     let userPtr = unsafe { &mut *userPtr.cast::<histo_minmax_workfn_struct>() };
     let mut status: c_int = 0;
@@ -4615,7 +5002,6 @@ extern "C" fn histo_minmax_expr_workfn(
     status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Simple utility routine to compute the min and max value in an expression
 fn fits_get_expr_minmax(
     fptr: &mut fitsfile,
@@ -4808,7 +5194,6 @@ fn fits_get_expr_minmax(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Interator work function that writes out the histogram.
 /// The histogram values are calculated by another work function, ffcalchisto.
 /// This work function only gets called once, and totaln = nvalues.
@@ -4839,7 +5224,6 @@ extern "C" fn ffwritehisto(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Interator work function that writes out the histogram.
 /// The histogram values are calculated by another work function, ffcalchisto.
 /// This work function only gets called once, and totaln = nvalues.
@@ -4924,7 +5308,6 @@ fn ffwritehisto_safe(
     status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Interator work function that calculates values for the 2D histogram.
 extern "C" fn ffcalchist(
     totalrows: c_long,
@@ -5191,9 +5574,7 @@ mod tests {
         expected.as_bytes() == bytes
     }
 
-    /*--------------------------------------------------------------------------*/
     /* Test ffbins: Parse basic binning specification strings */
-    /*--------------------------------------------------------------------------*/
 
     #[test]
     fn test_ffbins_simple_binsize() {
@@ -5672,9 +6053,7 @@ mod tests {
         assert_eq!(binsizein[0], 2.0);
     }
 
-    /*--------------------------------------------------------------------------*/
     /* Test ffbinse: Extended binning specification with expressions */
-    /*--------------------------------------------------------------------------*/
 
     #[test]
     fn test_ffbinse_with_expression() {
@@ -5811,9 +6190,7 @@ mod tests {
         assert!(c_str_eq(&exprs[1], "(sqrt(Y))"));
     }
 
-    /*--------------------------------------------------------------------------*/
     /* Test ffbinr: Parse binning range specification */
-    /*--------------------------------------------------------------------------*/
 
     #[test]
     fn test_ffbinr_column_only() {
@@ -6070,9 +6447,7 @@ mod tests {
         assert_eq!(maxin, 100.0);
     }
 
-    /*--------------------------------------------------------------------------*/
     /* Test ffbinre: Extended range parser with expressions */
-    /*--------------------------------------------------------------------------*/
 
     #[test]
     fn test_ffbinre_with_expression() {

--- a/src/imcompress.rs
+++ b/src/imcompress.rs
@@ -1,3 +1,25 @@
+//! The tiled-image compression driver.
+//!
+//! A tile-compressed image is not stored as an image at all: it is a binary
+//! table whose `COMPRESSED_DATA` column holds one variable-length byte array
+//! per tile, with `ZIMAGE`, `ZCMPTYPE`, `ZBITPIX`, `ZNAXISn` and `ZTILEn`
+//! keywords recording the image it represents. This module is what makes that
+//! table look like an image to the rest of the library: it splits an image into
+//! tiles, compresses each, and reassembles them on the way back.
+//!
+//! The codecs themselves are external crates -- `ricecomp`, `pliocomp` and
+//! `hcompress` -- plus `libz-rs-sys` for GZIP and `libbz2-rs-sys` for BZIP2.
+//! What lives here is the driver: tile geometry, the `ZSCALE`/`ZZERO` scaling,
+//! null handling via `ZBLANK`, and the dithering that
+//! [`crate::quantize`] applies when a floating point image is compressed
+//! lossily.
+//!
+//! Ported from CFITSIO's `imcompress.c`, written by William Pence at the High
+//! Energy Astrophysics Science Archive Research Center (HEASARC), NASA Goddard
+//! Space Flight Center. See the "Image Compression" section of the CFITSIO
+//! User's Reference Guide.
+#![warn(missing_docs)]
+
 use crate::helpers::aligned::AlignedBytes;
 use core::ffi::CStr;
 use core::slice;
@@ -180,7 +202,10 @@ pub(crate) fn fits_init_randoms() -> c_int {
     }
 }
 
-/*--------------------------------------------------------------------------*/
+/// Error callback the bzip2 library calls on an internal failure.
+///
+/// Declared by the bzip2 code in `bzlib_private.h`; it is never expected to be
+/// reached, and pushes a message onto the error stack if it is.
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub extern "C" fn bz_internal_error(_errcode: c_int) {
     // FFI WRAPPER
@@ -189,18 +214,23 @@ pub extern "C" fn bz_internal_error(_errcode: c_int) {
     ffpmsg_str("This should never happen");
 }
 
-/*--------------------------------------------------------------------------*/
 /// This routine specifies the image compression algorithm that should be
 /// used when writing a FITS image.  The image is divided into tiles, and
 /// each tile is compressed and stored in a row of at variable length binary
 /// table column.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `ctype`  — image compression type code;
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn fits_set_compression_type(
-    fptr: *mut fitsfile, /* I - FITS file pointer     */
-    ctype: c_int,        /* image compression type code;                        */
+    fptr: *mut fitsfile,
+    ctype: c_int,
     /* allowed values: RICE_1, GZIP_1, GZIP_2, PLIO_1,     */
     /*  HCOMPRESS_1, BZIP2_1, and NOCOMPRESS               */
-    status: *mut c_int, /* IO - error status                                   */
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -211,17 +241,22 @@ pub unsafe extern "C" fn fits_set_compression_type(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// This routine specifies the image compression algorithm that should be
 /// used when writing a FITS image.  The image is divided into tiles, and
 /// each tile is compressed and stored in a row of at variable length binary
 /// table column.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `ctype`  — image compression type code;
+/// * `status` — (IO) error status
 pub fn fits_set_compression_type_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer     */
-    ctype: c_int,        /* image compression type code;                        */
+    fptr: &mut fitsfile,
+    ctype: c_int,
     /* allowed values: RICE_1, GZIP_1, GZIP_2, PLIO_1,     */
     /*  HCOMPRESS_1, BZIP2_1, and NOCOMPRESS               */
-    status: &mut c_int, /* IO - error status                                   */
+    status: &mut c_int,
 ) -> c_int {
     if ctype != RICE_1
         && ctype != GZIP_1
@@ -241,18 +276,24 @@ pub fn fits_set_compression_type_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// This routine specifies the size (dimension) of the image
 /// compression  tiles that should be used when writing a FITS
 /// image.  The image is divided into tiles, and each tile is compressed
 /// and stored in a row of at variable length binary table column.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `ndim`   — number of dimensions in the compressed image
+/// * `dims`   — size of image compression tile in each dimension
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn fits_set_tile_dim(
-    fptr: *mut fitsfile, /* I - FITS file pointer             */
-    ndim: c_int,         /* number of dimensions in the compressed image      */
-    dims: *const c_long, /* size of image compression tile in each dimension  */
+    fptr: *mut fitsfile,
+    ndim: c_int,
+    dims: *const c_long,
     /* default tile size = (NAXIS1, 1, 1, ...)            */
-    status: *mut c_int, /* IO - error status                        */
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -271,17 +312,23 @@ pub unsafe extern "C" fn fits_set_tile_dim(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// This routine specifies the size (dimension) of the image
 /// compression  tiles that should be used when writing a FITS
 /// image.  The image is divided into tiles, and each tile is compressed
 /// and stored in a row of at variable length binary table column.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `ndim`   — number of dimensions in the compressed image
+/// * `dims`   — size of image compression tile in each dimension
+/// * `status` — (IO) error status
 pub fn fits_set_tile_dim_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer             */
-    ndim: c_int,         /* number of dimensions in the compressed image      */
-    dims: &[c_long],     /* size of image compression tile in each dimension  */
+    fptr: &mut fitsfile,
+    ndim: c_int,
+    dims: &[c_long],
     /* default tile size = (NAXIS1, 1, 1, ...)            */
-    status: &mut c_int, /* IO - error status                        */
+    status: &mut c_int,
 ) -> c_int {
     if ndim < 0 || ndim > MAX_COMPRESS_DIM as c_int {
         *status = BAD_DIMEN;
@@ -294,16 +341,21 @@ pub fn fits_set_tile_dim_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// This routine specifies the value of the quantization level, q,  that
 /// should be used when compressing floating point images.  The image is
 /// divided into tiles, and each tile is compressed and stored in a row
 /// of at variable length binary table column.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `qlevel` — floating point quantization level
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn fits_set_quantize_level(
-    fptr: *mut fitsfile, /* I - FITS file pointer   */
-    qlevel: f32,         /* floating point quantization level      */
-    status: *mut c_int,  /* IO - error status                */
+    fptr: *mut fitsfile,
+    qlevel: f32,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -314,16 +366,17 @@ pub unsafe extern "C" fn fits_set_quantize_level(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// This routine specifies the value of the quantization level, q,  that
 /// should be used when compressing floating point images.  The image is
 /// divided into tiles, and each tile is compressed and stored in a row
 /// of at variable length binary table column.
-pub fn fits_set_quantize_level_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer   */
-    qlevel: f32,         /* floating point quantization level      */
-    status: &mut c_int,  /* IO - error status                */
-) -> c_int {
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `qlevel` — floating point quantization level
+/// * `status` — (IO) error status
+pub fn fits_set_quantize_level_safe(fptr: &mut fitsfile, qlevel: f32, status: &mut c_int) -> c_int {
     if qlevel == 0. {
         /* this means don't quantize the floating point values. Instead, */
         /* the floating point values will be losslessly compressed */
@@ -335,17 +388,22 @@ pub fn fits_set_quantize_level_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 ///This routine specifies what type of dithering (randomization) should
 ///be performed when quantizing floating point images to integer prior to
 ///compression.   A value of -1 means do no dithering.  A value of 0 means
 ///use the default SUBTRACTIVE_DITHER_1 (which is equivalent to dither = 1).
 ///A value of 2 means use SUBTRACTIVE_DITHER_2.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `method` — quantization method
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn fits_set_quantize_method(
-    fptr: *mut fitsfile, /* I - FITS file pointer   */
-    method: c_int,       /* quantization method       */
-    status: *mut c_int,  /* IO - error status                */
+    fptr: *mut fitsfile,
+    method: c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -356,16 +414,21 @@ pub unsafe extern "C" fn fits_set_quantize_method(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 ///This routine specifies what type of dithering (randomization) should
 ///be performed when quantizing floating point images to integer prior to
 ///compression.   A value of -1 means do no dithering.  A value of 0 means
 ///use the default SUBTRACTIVE_DITHER_1 (which is equivalent to dither = 1).
 ///A value of 2 means use SUBTRACTIVE_DITHER_2.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `method` — quantization method
+/// * `status` — (IO) error status
 pub fn fits_set_quantize_method_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer   */
-    method: c_int,       /* quantization method       */
-    status: &mut c_int,  /* IO - error status                */
+    fptr: &mut fitsfile,
+    method: c_int,
+    status: &mut c_int,
 ) -> c_int {
     let mut method = method;
 
@@ -382,15 +445,20 @@ pub fn fits_set_quantize_method_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
-/// the name of this routine has changed.  This is kept here only for backwards
+/// The name of this routine has changed.  This is kept here only for backwards
 /// compatibility for any software that may be calling the old routine.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `dither` — dither type
+/// * `status` — (IO) error status
 #[deprecated]
 #[cfg_attr(not(test), unsafe(no_mangle))]
 pub unsafe extern "C" fn fits_set_quantize_dither(
-    fptr: *mut fitsfile, /* I - FITS file pointer   */
-    dither: c_int,       /* dither type      */
-    status: *mut c_int,  /* IO - error status                */
+    fptr: *mut fitsfile,
+    dither: c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -401,18 +469,22 @@ pub unsafe extern "C" fn fits_set_quantize_dither(
     }
 }
 
-/*--------------------------------------------------------------------------*/
-/// the name of this routine has changed.  This is kept here only for backwards
+/// The name of this routine has changed.  This is kept here only for backwards
 /// compatibility for any software that may be calling the old routine.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `dither` — dither type
+/// * `status` — (IO) error status
 pub fn fits_set_quantize_dither_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer   */
-    dither: c_int,       /* dither type      */
-    status: &mut c_int,  /* IO - error status                */
+    fptr: &mut fitsfile,
+    dither: c_int,
+    status: &mut c_int,
 ) -> c_int {
     fits_set_quantize_method_safe(fptr, dither, status)
 }
 
-/*--------------------------------------------------------------------------*/
 /// This routine specifies the value of the offset that should be applied when
 /// calculating the random dithering when quantizing floating point iamges.
 /// A random offset should be applied to each image to avoid quantization
@@ -423,11 +495,17 @@ pub fn fits_set_quantize_dither_safe(
 /// offset = 0 means use the default random dithering based on system time
 /// offset = negative means randomly chose dithering based on 1st tile checksum
 /// offset = [1 - 10000] means use that particular dithering pattern
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `seed`   — random dithering seed value (1 to 10000)
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn fits_set_dither_seed(
-    fptr: *mut fitsfile, /* I - FITS file pointer   */
-    seed: c_int,         /* random dithering seed value (1 to 10000) */
-    status: *mut c_int,  /* IO - error status                */
+    fptr: *mut fitsfile,
+    seed: c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -438,7 +516,6 @@ pub unsafe extern "C" fn fits_set_dither_seed(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// This routine specifies the value of the offset that should be applied when
 /// calculating the random dithering when quantizing floating point iamges.
 /// A random offset should be applied to each image to avoid quantization
@@ -449,11 +526,13 @@ pub unsafe extern "C" fn fits_set_dither_seed(
 /// offset = 0 means use the default random dithering based on system time
 /// offset = negative means randomly chose dithering based on 1st tile checksum
 /// offset = [1 - 10000] means use that particular dithering pattern
-pub fn fits_set_dither_seed_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer   */
-    seed: c_int,         /* random dithering seed value (1 to 10000) */
-    status: &mut c_int,  /* IO - error status                */
-) -> c_int {
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `seed`   — random dithering seed value (1 to 10000)
+/// * `status` — (IO) error status
+pub fn fits_set_dither_seed_safe(fptr: &mut fitsfile, seed: c_int, status: &mut c_int) -> c_int {
     /* if positive, ensure that the value is in the range 1 to 10000 */
     if seed > 10000 {
         ffpmsg_str("illegal dithering seed value (fits_set_dither_seed)");
@@ -465,14 +544,19 @@ pub fn fits_set_dither_seed_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// The name of this routine has changed.  This is kept just for
 /// backwards compatibility with any software that calls the old name
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `offset` — random dithering offset value (1 to 10000)
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn fits_set_dither_offset(
-    fptr: *mut fitsfile, /* I - FITS file pointer   */
-    offset: c_int,       /* random dithering offset value (1 to 10000) */
-    status: *mut c_int,  /* IO - error status                */
+    fptr: *mut fitsfile,
+    offset: c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -484,18 +568,22 @@ pub unsafe extern "C" fn fits_set_dither_offset(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// The name of this routine has changed.  This is kept just for
 /// backwards compatibility with any software that calls the old name
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `offset` — random dithering offset value (1 to 10000)
+/// * `status` — (IO) error status
 pub fn fits_set_dither_offset_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer   */
-    offset: c_int,       /* random dithering offset value (1 to 10000) */
-    status: &mut c_int,  /* IO - error status                */
+    fptr: &mut fitsfile,
+    offset: c_int,
+    status: &mut c_int,
 ) -> c_int {
     fits_set_dither_seed_safe(fptr, offset, status)
 }
 
-/*--------------------------------------------------------------------------*/
 /// ********************************************************************
 /// ********************************************************************
 /// THIS ROUTINE IS PROVIDED ONLY FOR BACKWARDS COMPATIBILITY;
@@ -510,13 +598,19 @@ pub fn fits_set_dither_offset_safe(
 ///
 /// Feb 2008:  the "noisebits" parameter has been replaced with the more
 /// general "quantize level" parameter.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `noisebits` — noise_bits parameter value
+/// * `status`    — (IO) error status
 #[deprecated]
 #[cfg_attr(not(test), unsafe(no_mangle))]
 pub unsafe extern "C" fn fits_set_noise_bits(
-    fptr: *mut fitsfile, /* I - FITS file pointer   */
-    noisebits: c_int,    /* noise_bits parameter value       */
+    fptr: *mut fitsfile,
+    noisebits: c_int,
     /* (default = 4)                    */
-    status: *mut c_int, /* IO - error status                */
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -528,7 +622,6 @@ pub unsafe extern "C" fn fits_set_noise_bits(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// ********************************************************************
 /// ********************************************************************
 /// THIS ROUTINE IS PROVIDED ONLY FOR BACKWARDS COMPATIBILITY;
@@ -543,12 +636,18 @@ pub unsafe extern "C" fn fits_set_noise_bits(
 ///
 /// Feb 2008:  the "noisebits" parameter has been replaced with the more
 /// general "quantize level" parameter.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `noisebits` — noise_bits parameter value
+/// * `status`    — (IO) error status
 #[deprecated]
 pub fn fits_set_noise_bits_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer   */
-    noisebits: c_int,    /* noise_bits parameter value       */
+    fptr: &mut fitsfile,
+    noisebits: c_int,
     /* (default = 4)                    */
-    status: &mut c_int, /* IO - error status                */
+    status: &mut c_int,
 ) -> c_int {
     if noisebits < 1 || noisebits > 16 {
         *status = DATA_COMPRESSION_ERR;
@@ -560,14 +659,19 @@ pub fn fits_set_noise_bits_safe(
     fits_set_quantize_level_safe(fptr, qlevel, status)
 }
 
-/*--------------------------------------------------------------------------*/
 /// This routine specifies the value of the hcompress scale parameter.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `scale`  — hcompress scale parameter value
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn fits_set_hcomp_scale(
-    fptr: *mut fitsfile, /* I - FITS file pointer   */
-    scale: f32,          /* hcompress scale parameter value       */
+    fptr: *mut fitsfile,
+    scale: f32,
     /* (default = 0.0)                    */
-    status: *mut c_int, /* IO - error status                */
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -577,30 +681,40 @@ pub unsafe extern "C" fn fits_set_hcomp_scale(
         fits_set_hcomp_scale_safe(fptr, scale, status)
     }
 }
-/*--------------------------------------------------------------------------*/
 /// This routine specifies the value of the hcompress scale parameter.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `scale`  — hcompress scale parameter value
+/// * `status` — (IO) error status
 pub fn fits_set_hcomp_scale_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer   */
-    scale: f32,          /* hcompress scale parameter value       */
+    fptr: &mut fitsfile,
+    scale: f32,
     /* (default = 0.0)                    */
-    status: &mut c_int, /* IO - error status                */
+    status: &mut c_int,
 ) -> c_int {
     fptr.Fptr.request_hcomp_scale = scale;
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// This routine specifies the value of the hcompress smooth parameter.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `smooth` — hcompress smooth parameter value
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn fits_set_hcomp_smooth(
-    fptr: *mut fitsfile, /* I - FITS file pointer   */
-    smooth: c_int,       /* hcompress smooth parameter value       */
+    fptr: *mut fitsfile,
+    smooth: c_int,
     /* if scale > 1 and smooth != 0, then */
     /*  the image will be smoothed when it is */
     /* decompressed to remove some of the */
     /* 'blockiness' in the image produced */
     /* by the lossy compression    */
-    status: *mut c_int, /* IO - error status                */
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -611,27 +725,33 @@ pub unsafe extern "C" fn fits_set_hcomp_smooth(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// This routine specifies the value of the hcompress smooth parameter.
-pub fn fits_set_hcomp_smooth_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer   */
-    smooth: c_int,       /* hcompress smooth parameter value       */
-    status: &mut c_int,  /* IO - error status                */
-) -> c_int {
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `smooth` — hcompress smooth parameter value
+/// * `status` — (IO) error status
+pub fn fits_set_hcomp_smooth_safe(fptr: &mut fitsfile, smooth: c_int, status: &mut c_int) -> c_int {
     (fptr.Fptr).request_hcomp_smooth = smooth;
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// This routine specifies whether images with integer pixel values should
 /// quantized and compressed the same way float images are compressed.
 /// The default is to not do this, and instead apply a lossless compression
 /// algorithm to integer images.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `lossy_int` — (I) True (!= 0) or False (0)
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn fits_set_lossy_int(
-    fptr: *mut fitsfile, /* I - FITS file pointer   */
-    lossy_int: c_int,    /* I - True (!= 0) or False (0) */
-    status: *mut c_int,  /* IO - error status                */
+    fptr: *mut fitsfile,
+    lossy_int: c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -642,30 +762,36 @@ pub unsafe extern "C" fn fits_set_lossy_int(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// This routine specifies whether images with integer pixel values should
 /// quantized and compressed the same way float images are compressed.
 /// The default is to not do this, and instead apply a lossless compression
 /// algorithm to integer images.
-pub fn fits_set_lossy_int_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer   */
-    lossy_int: c_int,    /* I - True (!= 0) or False (0) */
-    status: &mut c_int,  /* IO - error status                */
-) -> c_int {
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `lossy_int` — (I) True (!= 0) or False (0)
+/// * `status`    — (IO) error status
+pub fn fits_set_lossy_int_safe(fptr: &mut fitsfile, lossy_int: c_int, status: &mut c_int) -> c_int {
     (fptr.Fptr).request_lossy_int_compress = lossy_int;
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// This routine specifies whether the HDU that is being compressed is so large
 /// (i.e., > 4 GB) that the 'Q' type variable length array columns should be used
 /// rather than the normal 'P' type.  The allows the heap pointers to be stored
 /// as 64-bit quantities, rather than just 32-bits.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `huge`   — (I) True (!= 0) or False (0)
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn fits_set_huge_hdu(
-    fptr: *mut fitsfile, /* I - FITS file pointer   */
-    huge: c_int,         /* I - True (!= 0) or False (0) */
-    status: *mut c_int,  /* IO - error status                */
+    fptr: *mut fitsfile,
+    huge: c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -676,32 +802,38 @@ pub unsafe extern "C" fn fits_set_huge_hdu(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// This routine specifies whether the HDU that is being compressed is so large
 /// (i.e., > 4 GB) that the 'Q' type variable length array columns should be used
 /// rather than the normal 'P' type.  The allows the heap pointers to be stored
 /// as 64-bit quantities, rather than just 32-bits.
-pub fn fits_set_huge_hdu_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer   */
-    huge: c_int,         /* I - True (!= 0) or False (0) */
-    status: &mut c_int,  /* IO - error status                */
-) -> c_int {
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `huge`   — (I) True (!= 0) or False (0)
+/// * `status` — (IO) error status
+pub fn fits_set_huge_hdu_safe(fptr: &mut fitsfile, huge: c_int, status: &mut c_int) -> c_int {
     (fptr.Fptr).request_huge_hdu = huge;
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// This routine returns the image compression algorithm that should be
 /// used when writing a FITS image.  The image is divided into tiles, and
 /// each tile is compressed and stored in a row of at variable length binary
 /// table column.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `ctype`  — image compression type code;
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn fits_get_compression_type(
-    fptr: *mut fitsfile, /* I - FITS file pointer     */
-    ctype: *mut c_int,   /* image compression type code;                        */
+    fptr: *mut fitsfile,
+    ctype: *mut c_int,
     /* allowed values:                                     */
     /* RICE_1, GZIP_1, GZIP_2, PLIO_1, HCOMPRESS_1, BZIP2_1 */
-    status: *mut c_int, /* IO - error status                                   */
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -713,17 +845,22 @@ pub unsafe extern "C" fn fits_get_compression_type(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// This routine returns the image compression algorithm that should be
 /// used when writing a FITS image.  The image is divided into tiles, and
 /// each tile is compressed and stored in a row of at variable length binary
 /// table column.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `ctype`  — image compression type code;
+/// * `status` — (IO) error status
 pub fn fits_get_compression_type_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer     */
-    ctype: &mut c_int,   /* image compression type code;                        */
+    fptr: &mut fitsfile,
+    ctype: &mut c_int,
     /* allowed values:                                     */
     /* RICE_1, GZIP_1, GZIP_2, PLIO_1, HCOMPRESS_1, BZIP2_1 */
-    status: &mut c_int, /* IO - error status                                   */
+    status: &mut c_int,
 ) -> c_int {
     *ctype = (fptr.Fptr).request_compress_type;
 
@@ -743,18 +880,24 @@ pub fn fits_get_compression_type_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// This routine returns the size (dimension) of the image
 /// compression  tiles that should be used when writing a FITS
 /// image.  The image is divided into tiles, and each tile is compressed
 /// and stored in a row of at variable length binary table column.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `ndim`   — number of dimensions in the compressed image
+/// * `dims`   — size of image compression tile in each dimension
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn fits_get_tile_dim(
-    fptr: *mut fitsfile, /* I - FITS file pointer             */
-    ndim: c_int,         /* number of dimensions in the compressed image      */
-    dims: *mut c_long,   /* size of image compression tile in each dimension  */
+    fptr: *mut fitsfile,
+    ndim: c_int,
+    dims: *mut c_long,
     /* default tile size = (NAXIS1, 1, 1, ...)           */
-    status: *mut c_int, /* IO - error status                        */
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -773,17 +916,23 @@ pub unsafe extern "C" fn fits_get_tile_dim(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// This routine returns the size (dimension) of the image
 /// compression  tiles that should be used when writing a FITS
 /// image.  The image is divided into tiles, and each tile is compressed
 /// and stored in a row of at variable length binary table column.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `ndim`   — number of dimensions in the compressed image
+/// * `dims`   — size of image compression tile in each dimension
+/// * `status` — (IO) error status
 pub fn fits_get_tile_dim_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer             */
-    ndim: c_int,         /* number of dimensions in the compressed image      */
-    dims: &mut [c_long], /* size of image compression tile in each dimension  */
+    fptr: &mut fitsfile,
+    ndim: c_int,
+    dims: &mut [c_long],
     /* default tile size = (NAXIS1, 1, 1, ...)           */
-    status: &mut c_int, /* IO - error status                        */
+    status: &mut c_int,
 ) -> c_int {
     if ndim < 0 || ndim > MAX_COMPRESS_DIM as c_int {
         *status = BAD_DIMEN;
@@ -796,7 +945,16 @@ pub fn fits_get_tile_dim_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
+/// Clear the compression parameters recorded for the current HDU.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `status` — (IO) error status
+///
+/// # Safety
+///
+/// `fptr` and `status` must be non-null and valid.
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn fits_unset_compression_param(
     fptr: *mut fitsfile,
@@ -811,7 +969,12 @@ pub unsafe extern "C" fn fits_unset_compression_param(
     }
 }
 
-/*--------------------------------------------------------------------------*/
+/// Clear the compression parameters recorded for the current HDU.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `status` — (IO) error status
 pub fn fits_unset_compression_param_safe(fptr: &mut fitsfile, status: &mut c_int) -> c_int {
     (fptr.Fptr).compress_type = 0;
     (fptr.Fptr).quantize_level = 0.0;
@@ -826,7 +989,19 @@ pub fn fits_unset_compression_param_safe(fptr: &mut fitsfile, status: &mut c_int
     *status
 }
 
-/*--------------------------------------------------------------------------*/
+/// Clear the compression settings requested for the next image written.
+///
+/// These are the `request_*` fields, which are what a `fits_set_*` call sets;
+/// they become the HDU's actual parameters when an image is compressed.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `status` — (IO) error status
+///
+/// # Safety
+///
+/// `fptr` and `status` must be non-null and valid.
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn fits_unset_compression_request(
     fptr: *mut fitsfile,
@@ -841,7 +1016,12 @@ pub unsafe extern "C" fn fits_unset_compression_request(
     }
 }
 
-/*--------------------------------------------------------------------------*/
+/// Clear the compression settings requested for the next image written.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `status` — (IO) error status
 pub fn fits_unset_compression_request_safe(fptr: &mut fitsfile, status: &mut c_int) -> c_int {
     (fptr.Fptr).request_compress_type = 0;
     (fptr.Fptr).request_quantize_level = 0.0;
@@ -858,7 +1038,6 @@ pub fn fits_unset_compression_request_safe(fptr: &mut fitsfile, status: &mut c_i
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Set the preference for various compression options, based
 /// on keywords in the input file that
 /// provide guidance about how the HDU should be compressed when written
@@ -879,7 +1058,6 @@ pub unsafe extern "C" fn fits_set_compression_pref(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Set the preference for various compression options, based
 /// on keywords in the input file that
 /// provide guidance about how the HDU should be compressed when written
@@ -1052,7 +1230,6 @@ pub fn fits_set_compression_pref_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// ********************************************************************
 /// ********************************************************************
 /// THIS ROUTINE IS PROVIDED ONLY FOR BACKWARDS COMPATIBILITY;
@@ -1073,13 +1250,19 @@ pub fn fits_set_compression_pref_safe(
 /// noise bits = natural logarithm (quantize level) / natural log (2)
 ///
 /// This result is rounded to the nearest integer.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `noisebits` — noise_bits parameter value
+/// * `status`    — (IO) error status
 #[deprecated]
 #[cfg_attr(not(test), unsafe(no_mangle))]
 pub unsafe extern "C" fn fits_get_noise_bits(
-    fptr: *mut fitsfile,   /* I - FITS file pointer   */
-    noisebits: *mut c_int, /* noise_bits parameter value       */
+    fptr: *mut fitsfile,
+    noisebits: *mut c_int,
     /* (default = 4)                    */
-    status: *mut c_int, /* IO - error status                */
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -1091,12 +1274,17 @@ pub unsafe extern "C" fn fits_get_noise_bits(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Get the noise_bits parameter value.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `noisebits` — noise_bits parameter value
+/// * `status`    — (IO) error status
 pub fn fits_get_noise_bits_safe(
-    fptr: &mut fitsfile,   /* I - FITS file pointer   */
-    noisebits: &mut c_int, /* noise_bits parameter value       */
-    status: &mut c_int,    /* IO - error status                */
+    fptr: &mut fitsfile,
+    noisebits: &mut c_int,
+    status: &mut c_int,
 ) -> c_int {
     let qlevel: f64 = f64::from((fptr.Fptr).request_quantize_level);
 
@@ -1108,16 +1296,21 @@ pub fn fits_get_noise_bits_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// This routine returns the value of the noice_bits parameter that
 /// should be used when compressing floating point images.  The image is
 /// divided into tiles, and each tile is compressed and stored in a row
 /// of at variable length binary table column.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `qlevel` — quantize level parameter value
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn fits_get_quantize_level(
-    fptr: *mut fitsfile, /* I - FITS file pointer   */
-    qlevel: *mut f32,    /* quantize level parameter value       */
-    status: *mut c_int,  /* IO - error status                */
+    fptr: *mut fitsfile,
+    qlevel: *mut f32,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -1129,15 +1322,20 @@ pub unsafe extern "C" fn fits_get_quantize_level(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// This routine returns the value of the noice_bits parameter that
 /// should be used when compressing floating point images.  The image is
 /// divided into tiles, and each tile is compressed and stored in a row
 /// of at variable length binary table column.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `qlevel` — quantize level parameter value
+/// * `status` — (IO) error status
 pub fn fits_get_quantize_level_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer   */
-    qlevel: &mut f32,    /* quantize level parameter value       */
-    status: &mut c_int,  /* IO - error status                */
+    fptr: &mut fitsfile,
+    qlevel: &mut f32,
+    status: &mut c_int,
 ) -> c_int {
     if (fptr.Fptr).request_quantize_level == NO_QUANTIZE {
         *qlevel = 0.0;
@@ -1148,16 +1346,21 @@ pub fn fits_get_quantize_level_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// This routine returns the value of the dithering offset parameter that
 /// is used when compressing floating point images.  The image is
 /// divided into tiles, and each tile is compressed and stored in a row
 /// of at variable length binary table column.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `offset` — dithering offset parameter value
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn fits_get_dither_seed(
-    fptr: *mut fitsfile, /* I - FITS file pointer   */
-    offset: *mut c_int,  /* dithering offset parameter value       */
-    status: *mut c_int,  /* IO - error status                */
+    fptr: *mut fitsfile,
+    offset: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -1169,30 +1372,40 @@ pub unsafe extern "C" fn fits_get_dither_seed(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// This routine returns the value of the dithering offset parameter that
 /// is used when compressing floating point images.  The image is
 /// divided into tiles, and each tile is compressed and stored in a row
 /// of at variable length binary table column.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `offset` — dithering offset parameter value
+/// * `status` — (IO) error status
 pub fn fits_get_dither_seed_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer   */
-    offset: &mut c_int,  /* dithering offset parameter value       */
-    status: &mut c_int,  /* IO - error status                */
+    fptr: &mut fitsfile,
+    offset: &mut c_int,
+    status: &mut c_int,
 ) -> c_int {
     *offset = (fptr.Fptr).request_dither_seed;
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// This routine returns the value of the noice_bits parameter that
 /// should be used when compressing floating point images.  The image is
 /// divided into tiles, and each tile is compressed and stored in a row
 /// of at variable length binary table column.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `scale`  — Hcompress scale parameter value
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn fits_get_hcomp_scale(
-    fptr: *mut fitsfile, /* I - FITS file pointer   */
-    scale: *mut f32,     /* Hcompress scale parameter value       */
-    status: *mut c_int,  /* IO - error status                */
+    fptr: *mut fitsfile,
+    scale: *mut f32,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -1204,23 +1417,32 @@ pub unsafe extern "C" fn fits_get_hcomp_scale(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Get the Hcompress scale parameter value.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `scale`  — Hcompress scale parameter value
+/// * `status` — (IO) error status
 pub fn fits_get_hcomp_scale_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer   */
-    scale: &mut f32,     /* Hcompress scale parameter value       */
-    status: &mut c_int,  /* IO - error status                */
+    fptr: &mut fitsfile,
+    scale: &mut f32,
+    status: &mut c_int,
 ) -> c_int {
     *scale = (fptr.Fptr).request_hcomp_scale;
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `smooth` — Hcompress smooth parameter value
+/// * `status` — (IO) error status
 pub unsafe extern "C" fn fits_get_hcomp_smooth(
-    fptr: *mut fitsfile, /* I - FITS file pointer   */
-    smooth: *mut c_int,  /* Hcompress smooth parameter value       */
-    status: *mut c_int,  /* IO - error status                */
+    fptr: *mut fitsfile,
+    smooth: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -1232,32 +1454,40 @@ pub unsafe extern "C" fn fits_get_hcomp_smooth(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Get the Hcompress smooth parameter value.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `smooth` — Hcompress smooth parameter value
+/// * `status` — (IO) error status
 pub fn fits_get_hcomp_smooth_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer   */
-    smooth: &mut c_int,  /* Hcompress smooth parameter value       */
-    status: &mut c_int,  /* IO - error status                */
+    fptr: &mut fitsfile,
+    smooth: &mut c_int,
+    status: &mut c_int,
 ) -> c_int {
     *smooth = (fptr.Fptr).request_hcomp_smooth;
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
+/// # Parameters
+///
+/// * `infptr`  — pointer to image to be compressed
+/// * `outfptr` — empty HDU for output compressed image
+/// * `status`  — (IO) error status
 pub unsafe extern "C" fn fits_img_compress(
-    infptr: *mut fitsfile,  /* pointer to image to be compressed */
-    outfptr: *mut fitsfile, /* empty HDU for output compressed image */
-    status: *mut c_int,     /* IO - error status               */
+    infptr: *mut fitsfile,
+    outfptr: *mut fitsfile,
+    status: *mut c_int,
+    /*
+    This routine initializes the output table, copies all the keywords,
+    and  loops through the input image, compressing the data and
+    writing the compressed tiles to the output table.
 
-                            /*
-                            This routine initializes the output table, copies all the keywords,
-                            and  loops through the input image, compressing the data and
-                            writing the compressed tiles to the output table.
-
-                            This is a high level routine that is called by the fpack and funpack
-                            FITS compression utilities.
-                            */
+    This is a high level routine that is called by the fpack and funpack
+    FITS compression utilities.
+    */
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -1269,15 +1499,20 @@ pub unsafe extern "C" fn fits_img_compress(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Compress an image and write to output table.
 /// This routine initializes the output table, copies all the keywords,
 /// and loops through the input image, compressing the data and
 /// writing the compressed tiles to the output table.
+///
+/// # Parameters
+///
+/// * `infptr`  — pointer to image to be compressed
+/// * `outfptr` — empty HDU for output compressed image
+/// * `status`  — (IO) error status
 pub fn fits_img_compress_safe(
-    infptr: &mut fitsfile,  /* pointer to image to be compressed */
-    outfptr: &mut fitsfile, /* empty HDU for output compressed image */
-    status: &mut c_int,     /* IO - error status               */
+    infptr: &mut fitsfile,
+    outfptr: &mut fitsfile,
+    status: &mut c_int,
 ) -> c_int {
     let mut bitpix: c_int = 0;
     let mut naxis: c_int = 0;
@@ -1390,14 +1625,17 @@ pub fn fits_img_compress_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
-/// create a BINTABLE extension for the output compressed image.
+/// Create a BINTABLE extension for the output compressed image.
+///
+/// # Parameters
+///
+/// * `writebitpix` — write the ZBITPIX, ZNAXIS, and ZNAXES keyword?
 pub(crate) fn imcomp_init_table(
     outfptr: &mut fitsfile,
     inbitpix: c_int,
     naxis: c_int,
     naxes: &[c_long],
-    writebitpix: bool, /* write the ZBITPIX, ZNAXIS, and ZNAXES keyword? */
+    writebitpix: bool,
     status: &mut c_int,
 ) -> c_int {
     let mut keyname: [c_char; FLEN_KEYWORD] = [0; FLEN_KEYWORD];
@@ -1991,7 +2229,6 @@ pub(crate) fn imcomp_init_table(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// This function returns the maximum number of bytes in a compressed
 /// image line.
 ///
@@ -2046,7 +2283,6 @@ fn imcomp_calc_max_elem(comptype: c_int, nx: c_int, zbitpix: c_int, blocksize: c
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// This routine does the following:
 /// - reads an image one tile at a time
 /// - if it is a float or double image, then it tries to quantize the pixels
@@ -2384,7 +2620,6 @@ fn imcomp_compress_image(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// This is the main compression routine.
 ///
 /// This routine does the following to the input tile of pixels:
@@ -2403,9 +2638,13 @@ fn imcomp_compress_image(
 /// that is supported when writing to normal FITS images.  The datatype of the
 /// input array must have the same datatype (either signed or unsigned) as the
 /// output (compressed) FITS image in some cases.
+///
+/// # Parameters
+///
+/// * `row` — tile number = row in the binary table that holds the compressed data
 fn imcomp_compress_tile(
     outfptr: &mut fitsfile,
-    row: c_long, /* tile number = row in the binary table that holds the compressed data */
+    row: c_long,
     datatype: c_int,
     tiledata: &mut [u8],
     tilelen: c_long,
@@ -3247,7 +3486,6 @@ fn imcomp_compress_tile(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 fn imcomp_write_nocompress_tile(
     outfptr: &mut fitsfile,
     row: c_long,
@@ -3310,7 +3548,6 @@ fn imcomp_write_nocompress_tile(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Prepare the input tile array of pixels for compression.
 /// Convert input integer*2 tile array in place to 4 or 8-byte ints for compression,
 /// If needed, convert 4 or 8-byte ints and do null value substitution.
@@ -3444,7 +3681,6 @@ fn imcomp_convert_tile_tshort(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Prepare the input  tile array of pixels for compression.
 /// Convert input unsigned integer*2 tile array in place to 4 or 8-byte ints
 /// for compression,
@@ -3544,7 +3780,6 @@ fn imcomp_convert_tile_tushort(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Prepare the input tile array of pixels for compression.
 /// Convert input integer tile array in place to 4 or 8-byte ints for compression,
 /// If needed, do null value substitution.
@@ -3594,7 +3829,6 @@ fn imcomp_convert_tile_tint(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Prepare the input tile array of pixels for compression.
 /// Convert input unsigned integer tile array in place to 4 or 8-byte ints for compression,
 /// If needed, do null value substitution.
@@ -3655,7 +3889,6 @@ fn imcomp_convert_tile_tuint(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Prepare the input tile array of pixels for compression.
 /// Convert input unsigned integer*1 tile array in place to 4 or 8-byte ints for compression,
 /// If needed, convert 4 or 8-byte ints and do null value substitution.
@@ -3739,7 +3972,6 @@ fn imcomp_convert_tile_tbyte(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Prepare the input tile array of pixels for compression.
 /// Convert input integer*1 tile array in place to 4 or 8-byte ints for compression,
 /// If needed, convert 4 or 8-byte ints and do null value substitution.
@@ -3829,7 +4061,6 @@ fn imcomp_convert_tile_tsbyte(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Prepare the input tile array of pixels for compression.
 /// Convert input float tile array in place to 4 or 8-byte ints for compression,
 /// If needed, convert 4 or 8-byte ints and do null value substitution.
@@ -4017,7 +4248,6 @@ fn imcomp_convert_tile_tfloat(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Prepare the input tile array of pixels for compression.
 /// Convert input double tile array in place to 4-byte ints for compression,
 /// If needed, convert 4 or 8-byte ints and do null value substitution.
@@ -4182,8 +4412,7 @@ fn imcomp_convert_tile_tdouble(
     *status
 }
 
-/*---------------------------------------------------------------------------*/
-/// do null value substitution AND scaling of the integer array.
+/// Do null value substitution AND scaling of the integer array.
 /// If array value = nullflagval, then set the value to nullval.
 /// Otherwise, inverse scale the integer value.
 fn imcomp_nullscale(
@@ -4219,8 +4448,7 @@ fn imcomp_nullscale(
     *status
 }
 
-/*---------------------------------------------------------------------------*/
-/// do null value substitution.
+/// Do null value substitution.
 /// If array value = nullflagval, then set the value to nullval.
 fn imcomp_nullvalues(
     idata: &mut [c_int],
@@ -4237,8 +4465,7 @@ fn imcomp_nullvalues(
     *status
 }
 
-/*---------------------------------------------------------------------------*/
-/// do inverse scaling the integer values.
+/// Do inverse scaling the integer values.
 fn imcomp_scalevalues(
     idata: &mut [c_int],
     tilelen: c_long,
@@ -4266,8 +4493,7 @@ fn imcomp_scalevalues(
     *status
 }
 
-/*---------------------------------------------------------------------------*/
-/// do null value substitution AND scaling of the integer array.
+/// Do null value substitution AND scaling of the integer array.
 /// If array value = nullflagval, then set the value to nullval.
 /// Otherwise, inverse scale the integer value.
 fn imcomp_nullscalei2(
@@ -4303,8 +4529,7 @@ fn imcomp_nullscalei2(
     *status
 }
 
-/*---------------------------------------------------------------------------*/
-/// do null value substitution.
+/// Do null value substitution.
 /// If array value = nullflagval, then set the value to nullval.
 fn imcomp_nullvaluesi2(
     idata: &mut [c_short],
@@ -4321,8 +4546,7 @@ fn imcomp_nullvaluesi2(
     *status
 }
 
-/*---------------------------------------------------------------------------*/
-/// do inverse scaling the integer values.
+/// Do inverse scaling the integer values.
 fn imcomp_scalevaluesi2(
     idata: &mut [c_short],
     tilelen: c_long,
@@ -4350,8 +4574,7 @@ fn imcomp_scalevaluesi2(
     *status
 }
 
-/*---------------------------------------------------------------------------*/
-/// do null value substitution  of the float array.
+/// Do null value substitution  of the float array.
 /// If array value = nullflagval, then set the output value to FLOATNULLVALUE.
 fn imcomp_nullfloats(
     fdata: &[f32],
@@ -4407,8 +4630,7 @@ fn imcomp_nullfloats(
     *status
 }
 
-/*---------------------------------------------------------------------------*/
-/// do null value substitution  of the float array.
+/// Do null value substitution  of the float array.
 /// If array value = nullflagval, then set the output value to FLOATNULLVALUE.
 fn imcomp_nullfloats_inplace(
     idata: &mut [i32],
@@ -4466,8 +4688,7 @@ fn imcomp_nullfloats_inplace(
     *status
 }
 
-/*---------------------------------------------------------------------------*/
-/// do null value substitution  of the float array.
+/// Do null value substitution  of the float array.
 /// If array value = nullflagval, then set the output value to FLOATNULLVALUE.
 /// Otherwise, inverse scale the integer value.
 fn imcomp_nullscalefloats(
@@ -4526,8 +4747,7 @@ fn imcomp_nullscalefloats(
     *status
 }
 
-/*---------------------------------------------------------------------------*/
-/// do null value substitution  of the float array.
+/// Do null value substitution  of the float array.
 /// If array value = nullflagval, then set the output value to FLOATNULLVALUE.
 /// Otherwise, inverse scale the integer value.
 fn imcomp_nullscalefloats_inplace(
@@ -4588,8 +4808,7 @@ fn imcomp_nullscalefloats_inplace(
     *status
 }
 
-/*---------------------------------------------------------------------------*/
-/// do null value substitution  of the float array.
+/// Do null value substitution  of the float array.
 /// If array value = nullflagval, then set the output value to FLOATNULLVALUE.
 /// Otherwise, inverse scale the integer value.
 fn imcomp_nulldoubles(
@@ -4645,8 +4864,7 @@ fn imcomp_nulldoubles(
     *status
 }
 
-/*---------------------------------------------------------------------------*/
-/// do null value substitution  of the float array.
+/// Do null value substitution  of the float array.
 /// If array value = nullflagval, then set the output value to FLOATNULLVALUE.
 /// Otherwise, inverse scale the integer value.
 fn imcomp_nulldoubles_inplace(
@@ -4704,8 +4922,7 @@ fn imcomp_nulldoubles_inplace(
     *status
 }
 
-/*---------------------------------------------------------------------------*/
-/// do null value substitution  of the float array.
+/// Do null value substitution  of the float array.
 /// If array value = nullflagval, then set the output value to FLOATNULLVALUE.
 /// Otherwise, inverse scale the integer value.
 fn imcomp_nullscaledoubles(
@@ -4764,8 +4981,7 @@ fn imcomp_nullscaledoubles(
     *status
 }
 
-/*---------------------------------------------------------------------------*/
-/// do null value substitution  of the float array.
+/// Do null value substitution  of the float array.
 /// If array value = nullflagval, then set the output value to FLOATNULLVALUE.
 /// Otherwise, inverse scale the integer value.
 fn imcomp_nullscaledoubles_inplace(
@@ -4825,20 +5041,30 @@ fn imcomp_nullscaledoubles_inplace(
     *status
 }
 
-/*---------------------------------------------------------------------------*/
 /// Write a section of a compressed image.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `datatype`  — (I) datatype of the array to be written
+/// * `infpixel`  — (I) 'bottom left corner' of the subsection
+/// * `inlpixel`  — (I) 'top right corner' of the subsection
+/// * `nullcheck` — (I) 0 for no null checking
+/// * `array`     — (I) array of values to be written
+/// * `nullval`   — (I) undefined pixel value
+/// * `status`    — (IO) error status
 pub(crate) fn fits_write_compressed_img(
-    fptr: &mut fitsfile,      /* I - FITS file pointer     */
-    datatype: c_int,          /* I - datatype of the array to be written      */
-    infpixel: &[c_long],      /* I - 'bottom left corner' of the subsection   */
-    inlpixel: &[c_long],      /* I - 'top right corner' of the subsection     */
-    nullcheck: NullCheckType, /* I - 0 for no null checking                   */
+    fptr: &mut fitsfile,
+    datatype: c_int,
+    infpixel: &[c_long],
+    inlpixel: &[c_long],
+    nullcheck: NullCheckType,
     /*     1: pixels that are = nullval will be     */
     /*     written with the FITS null pixel value   */
     /*     (floating point arrays only)             */
-    array: &[u8],                /* I - array of values to be written            */
-    nullval: &Option<NullValue>, /* I - undefined pixel value                    */
-    status: &mut c_int,          /* IO - error status                            */
+    array: &[u8],
+    nullval: &Option<NullValue>,
+    status: &mut c_int,
 ) -> c_int {
     let mut tiledim: [c_int; MAX_COMPRESS_DIM] = [0; MAX_COMPRESS_DIM];
     let mut naxis: [c_long; MAX_COMPRESS_DIM] = [0; MAX_COMPRESS_DIM];
@@ -5130,7 +5356,6 @@ pub(crate) fn fits_write_compressed_img(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write a consecutive set of pixels to a compressed image.  This routine
 /// interpretes the n-dimensional image as a long one-dimensional array.
 /// This is actually a rather inconvenient way to write compressed images in
@@ -5139,18 +5364,29 @@ pub(crate) fn fits_write_compressed_img(
 ///
 /// The general strategy used here is to write the requested pixels in blocks
 /// that correspond to rectangular image sections.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `datatype`  — (I) datatype of the array to be written
+/// * `fpixel`    — (I) 'first pixel to write
+/// * `npixel`    — (I) number of pixels to write
+/// * `nullcheck` — (I) 0 for no null checking
+/// * `array`     — (I) array of values to write
+/// * `nullval`   — (I) value used to represent undefined pixels
+/// * `status`    — (IO) error status
 pub(crate) fn fits_write_compressed_pixels(
-    fptr: &mut fitsfile,      /* I - FITS file pointer   */
-    datatype: c_int,          /* I - datatype of the array to be written      */
-    fpixel: LONGLONG,         /* I - 'first pixel to write          */
-    npixel: LONGLONG,         /* I - number of pixels to write      */
-    nullcheck: NullCheckType, /* I - 0 for no null checking                   */
+    fptr: &mut fitsfile,
+    datatype: c_int,
+    fpixel: LONGLONG,
+    npixel: LONGLONG,
+    nullcheck: NullCheckType,
     /*     1: pixels that are = nullval will be     */
     /*     written with the FITS null pixel value   */
     /*     (floating point arrays only)             */
-    array: &[u8],                /* I - array of values to write                */
-    nullval: &Option<NullValue>, /* I - value used to represent undefined pixels*/
-    status: &mut c_int,          /* IO - error status                           */
+    array: &[u8],
+    nullval: &Option<NullValue>,
+    status: &mut c_int,
 ) -> c_int {
     let mut naxis: c_int = 0;
     let mut bytesperpixel: c_int = 0;
@@ -5311,27 +5547,41 @@ pub(crate) fn fits_write_compressed_pixels(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
-/// in general we have to write the first partial row of the image,
+/// In general we have to write the first partial row of the image,
 /// followed by the middle complete rows, followed by the last
 /// partial row of the image.  If the first or last rows are complete,
 /// then write them at the same time as all the middle rows.
+///
+/// # Parameters
+///
+/// * `fptr`          — (I) FITS file
+/// * `datatype`      — (I) datatype of the array to be written
+/// * `bytesperpixel` — (I) number of bytes per pixel in array
+/// * `nplane`        — (I) which plane of the cube to write
+/// * `firstcoord`    — I coordinate of first pixel to write
+/// * `lastcoord`     — I coordinate of last pixel to write
+/// * `naxes`         — I size of each image dimension
+/// * `nullcheck`     — (I) 0 for no null checking
+/// * `array`         — (I) array of values that are written
+/// * `nullval`       — (I) value for undefined pixels
+/// * `nread`         — (O) total number of pixels written
+/// * `status`        — (IO) error status
 fn fits_write_compressed_img_plane(
-    fptr: &mut fitsfile,       /* I - FITS file    */
-    datatype: c_int,           /* I - datatype of the array to be written    */
-    bytesperpixel: c_int,      /* I - number of bytes per pixel in array */
-    nplane: c_long,            /* I - which plane of the cube to write      */
-    firstcoord: &mut [c_long], /* I coordinate of first pixel to write */
-    lastcoord: &[c_long],      /* I coordinate of last pixel to write */
-    naxes: &[c_long],          /* I size of each image dimension */
-    nullcheck: NullCheckType,  /* I - 0 for no null checking                   */
+    fptr: &mut fitsfile,
+    datatype: c_int,
+    bytesperpixel: c_int,
+    nplane: c_long,
+    firstcoord: &mut [c_long],
+    lastcoord: &[c_long],
+    naxes: &[c_long],
+    nullcheck: NullCheckType,
     /*     1: pixels that are = nullval will be     */
     /*     written with the FITS null pixel value   */
     /*     (floating point arrays only)             */
-    array: &[u8],                /* I - array of values that are written        */
-    nullval: &Option<NullValue>, /* I - value for undefined pixels              */
-    nread: &mut c_long,          /* O - total number of pixels written          */
-    status: &mut c_int,          /* IO - error status                           */
+    array: &[u8],
+    nullval: &Option<NullValue>,
+    nread: &mut c_long,
+    status: &mut c_int,
 ) -> c_int {
     /* bottom left coord. and top right coord. */
     let mut blc: [c_long; MAX_COMPRESS_DIM] = [0; MAX_COMPRESS_DIM];
@@ -5445,13 +5695,18 @@ fn fits_write_compressed_img_plane(
 /* ###                 Image Decompression Routines                     ### */
 /* ######################################################################## */
 
-/*--------------------------------------------------------------------------*/
 /// This routine decompresses the whole image and writes it to the output file.
+///
+/// # Parameters
+///
+/// * `infptr`  — image (bintable) to uncompress
+/// * `outfptr` — empty HDU for output uncompressed image
+/// * `status`  — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn fits_img_decompress(
-    infptr: *mut fitsfile,  /* image (bintable) to uncompress */
-    outfptr: *mut fitsfile, /* empty HDU for output uncompressed image */
-    status: *mut c_int,     /* IO - error status               */
+    infptr: *mut fitsfile,
+    outfptr: *mut fitsfile,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -5463,12 +5718,17 @@ pub unsafe extern "C" fn fits_img_decompress(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// This routine decompresses the whole image and writes it to the output file.
+///
+/// # Parameters
+///
+/// * `infptr`  — image (bintable) to uncompress
+/// * `outfptr` — empty HDU for output uncompressed image
+/// * `status`  — (IO) error status
 pub fn fits_img_decompress_safe(
-    infptr: &mut fitsfile,  /* image (bintable) to uncompress */
-    outfptr: &mut fitsfile, /* empty HDU for output uncompressed image */
-    status: &mut c_int,     /* IO - error status               */
+    infptr: &mut fitsfile,
+    outfptr: &mut fitsfile,
+    status: &mut c_int,
 ) -> c_int {
     let mut datatype: c_int = 0;
     let mut nullcheck: NullCheckType = NullCheckType::None;
@@ -5543,16 +5803,21 @@ pub fn fits_img_decompress_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// THIS IS AN OBSOLETE ROUTINE.  USE fits_img_decompress instead!!!
 ///
 /// This routine decompresses the whole image and writes it to the output file.
+///
+/// # Parameters
+///
+/// * `infptr`  — image (bintable) to uncompress
+/// * `outfptr` — empty HDU for output uncompressed image
+/// * `status`  — (IO) error status
 #[deprecated(note = "Use fits_img_decompress instead")]
 #[cfg_attr(not(test), unsafe(no_mangle))]
 pub unsafe extern "C" fn fits_decompress_img(
-    infptr: *mut fitsfile,  /* image (bintable) to uncompress */
-    outfptr: *mut fitsfile, /* empty HDU for output uncompressed image */
-    status: *mut c_int,     /* IO - error status               */
+    infptr: *mut fitsfile,
+    outfptr: *mut fitsfile,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -5564,14 +5829,19 @@ pub unsafe extern "C" fn fits_decompress_img(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// THIS IS AN OBSOLETE ROUTINE.  USE fits_img_decompress instead!!!
 ///
 /// This routine decompresses the whole image and writes it to the output file.
+///
+/// # Parameters
+///
+/// * `infptr`  — image (bintable) to uncompress
+/// * `outfptr` — empty HDU for output uncompressed image
+/// * `status`  — (IO) error status
 fn fits_decompress_img_safe(
-    infptr: &mut fitsfile,  /* image (bintable) to uncompress */
-    outfptr: &mut fitsfile, /* empty HDU for output uncompressed image */
-    status: &mut c_int,     /* IO - error status               */
+    infptr: &mut fitsfile,
+    outfptr: &mut fitsfile,
+    status: &mut c_int,
 ) -> c_int {
     let mut datatype: c_int = 0;
     let mut byte_per_pix: usize = 0;
@@ -5714,14 +5984,19 @@ fn fits_decompress_img_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// This routine reads the header of the input tile compressed image and
 /// converts it to that of a standard uncompress FITS image.
+///
+/// # Parameters
+///
+/// * `infptr`  — image (bintable) to uncompress
+/// * `outfptr` — empty HDU for output uncompressed image
+/// * `status`  — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn fits_img_decompress_header(
-    infptr: *mut fitsfile,  /* image (bintable) to uncompress */
-    outfptr: *mut fitsfile, /* empty HDU for output uncompressed image */
-    status: *mut c_int,     /* IO - error status               */
+    infptr: *mut fitsfile,
+    outfptr: *mut fitsfile,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -5733,13 +6008,18 @@ pub unsafe extern "C" fn fits_img_decompress_header(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// This routine reads the header of the input tile compressed image and
 /// converts it to that of a standard uncompress FITS image.
+///
+/// # Parameters
+///
+/// * `infptr`  — image (bintable) to uncompress
+/// * `outfptr` — empty HDU for output uncompressed image
+/// * `status`  — (IO) error status
 pub fn fits_img_decompress_header_safe(
-    infptr: &mut fitsfile,  /* image (bintable) to uncompress */
-    outfptr: &mut fitsfile, /* empty HDU for output uncompressed image */
-    status: &mut c_int,     /* IO - error status               */
+    infptr: &mut fitsfile,
+    outfptr: &mut fitsfile,
+    status: &mut c_int,
 ) -> c_int {
     let mut writeprime = false;
     let mut hdupos: c_int = 0;
@@ -5922,24 +6202,37 @@ pub fn fits_img_decompress_header_safe(
     *status
 }
 
-/*---------------------------------------------------------------------------*/
 /// Read a section of a compressed image;  Note: lpixel may be larger than the
 /// size of the uncompressed image.  Only the pixels within the image will be
 /// returned.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `datatype`  — (I) datatype of the array to be returned
+/// * `infpixel`  — (I) 'bottom left corner' of the subsection
+/// * `inlpixel`  — (I) 'top right corner' of the subsection
+/// * `ininc`     — (I) increment to be applied in each dimension
+/// * `nullcheck` — (I) 0 for no null checking
+/// * `nullval`   — (I) value for undefined pixels
+/// * `array`     — (O) array of values that are returned
+/// * `nullarray` — (O) array of flags = 1 if nullcheck = 2
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `status`    — (IO) error status
 pub(crate) fn fits_read_compressed_img(
-    fptr: &mut fitsfile,          /* I - FITS file pointer      */
-    datatype: c_int,              /* I - datatype of the array to be returned      */
-    infpixel: &[LONGLONG],        /* I - 'bottom left corner' of the subsection    */
-    inlpixel: &[LONGLONG],        /* I - 'top right corner' of the subsection      */
-    ininc: &[c_long],             /* I - increment to be applied in each dimension */
-    mut nullcheck: NullCheckType, /* I - 0 for no null checking                   */
+    fptr: &mut fitsfile,
+    datatype: c_int,
+    infpixel: &[LONGLONG],
+    inlpixel: &[LONGLONG],
+    ininc: &[c_long],
+    mut nullcheck: NullCheckType,
     /*     1: set undefined pixels = nullval       */
     /*     2: set nullarray=1 for undefined pixels */
-    nullval: &Option<NullValue>, /* I - value for undefined pixels              */
-    array: &mut [u8],            /* O - array of values that are returned       */
-    mut nullarray: Option<&mut [c_char]>, /* O - array of flags = 1 if nullcheck = 2     */
-    mut anynul: Option<&mut c_int>, /* O - set to 1 if any values are null; else 0 */
-    status: &mut c_int,          /* IO - error status                           */
+    nullval: &Option<NullValue>,
+    array: &mut [u8],
+    mut nullarray: Option<&mut [c_char]>,
+    mut anynul: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     let mut naxis: [c_long; MAX_COMPRESS_DIM] = [0; MAX_COMPRESS_DIM];
     let mut tiledim: [c_long; MAX_COMPRESS_DIM] = [0; MAX_COMPRESS_DIM];
@@ -6191,21 +6484,33 @@ pub(crate) fn fits_read_compressed_img(
     *status
 }
 
-/*---------------------------------------------------------------------------*/
 /// This is similar to fits_read_compressed_img, except that it writes
 /// the pixels to the output image, on a tile by tile basis instead of returning
 /// the array.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `datatype`  — (I) datatype of the array to be returned
+/// * `infpixel`  — (I) 'bottom left corner' of the subsection
+/// * `inlpixel`  — (I) 'top right corner' of the subsection
+/// * `ininc`     — (I) increment to be applied in each dimension
+/// * `nullcheck` — (I) 0 for no null checking, 1: set undefined pixels = nullval
+/// * `nullval`   — (I) value for undefined pixels
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `outfptr`   — (I) FITS file pointer
+/// * `status`    — (IO) error status
 fn fits_read_write_compressed_img(
-    fptr: &mut fitsfile,            /* I - FITS file pointer      */
-    datatype: c_int,                /* I - datatype of the array to be returned      */
-    infpixel: &[LONGLONG],          /* I - 'bottom left corner' of the subsection    */
-    inlpixel: &[LONGLONG],          /* I - 'top right corner' of the subsection      */
-    ininc: &[c_long],               /* I - increment to be applied in each dimension */
-    mut nullcheck: NullCheckType, /* I - 0 for no null checking, 1: set undefined pixels = nullval                  */
-    nullval: &Option<NullValue>,  /* I - value for undefined pixels              */
-    mut anynul: Option<&mut c_int>, /* O - set to 1 if any values are null; else 0 */
-    outfptr: &mut fitsfile,       /* I - FITS file pointer                    */
-    status: &mut c_int,           /* IO - error status                           */
+    fptr: &mut fitsfile,
+    datatype: c_int,
+    infpixel: &[LONGLONG],
+    inlpixel: &[LONGLONG],
+    ininc: &[c_long],
+    mut nullcheck: NullCheckType,
+    nullval: &Option<NullValue>,
+    mut anynul: Option<&mut c_int>,
+    outfptr: &mut fitsfile,
+    status: &mut c_int,
 ) -> c_int {
     let mut naxis: [c_long; MAX_COMPRESS_DIM] = [0; MAX_COMPRESS_DIM];
     let mut tiledim: [c_long; MAX_COMPRESS_DIM] = [0; MAX_COMPRESS_DIM];
@@ -6456,7 +6761,6 @@ fn fits_read_write_compressed_img(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read a consecutive set of pixels from a compressed image.  This routine
 /// interpretes the n-dimensional image as a long one-dimensional array.
 /// This is actually a rather inconvenient way to read compressed images in
@@ -6465,19 +6769,32 @@ fn fits_read_write_compressed_img(
 ///
 /// The general strategy used here is to read the requested pixels in blocks
 /// that correspond to rectangular image sections.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `datatype`  — (I) datatype of the array to be returned
+/// * `fpixel`    — (I) 'first pixel to read
+/// * `npixel`    — (I) number of pixels to read
+/// * `nullcheck` — (I) 0 for no null checking
+/// * `nullval`   — (I) value for undefined pixels
+/// * `array`     — (O) array of values that are returned
+/// * `nullarray` — (O) array of flags = 1 if nullcheck = 2
+/// * `anynul`    — (O) set to 1 if any values are null; else 0
+/// * `status`    — (IO) error status
 pub(crate) fn fits_read_compressed_pixels(
-    fptr: &mut fitsfile,      /* I - FITS file pointer    */
-    datatype: c_int,          /* I - datatype of the array to be returned     */
-    fpixel: LONGLONG,         /* I - 'first pixel to read          */
-    npixel: LONGLONG,         /* I - number of pixels to read      */
-    nullcheck: NullCheckType, /* I - 0 for no null checking                   */
+    fptr: &mut fitsfile,
+    datatype: c_int,
+    fpixel: LONGLONG,
+    npixel: LONGLONG,
+    nullcheck: NullCheckType,
     /*     1: set undefined pixels = nullval       */
     /*     2: set nullarray=1 for undefined pixels */
-    nullval: &Option<NullValue>, /* I - value for undefined pixels              */
-    array: &mut [u8],            /* O - array of values that are returned       */
-    mut nullarray: Option<&mut [c_char]>, /* O - array of flags = 1 if nullcheck = 2     */
-    mut anynul: Option<&mut c_int>, /* O - set to 1 if any values are null; else 0 */
-    status: &mut c_int,          /* IO - error status                           */
+    nullval: &Option<NullValue>,
+    array: &mut [u8],
+    mut nullarray: Option<&mut [c_char]>,
+    mut anynul: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     let mut naxis: c_int = 0;
     let mut bytesperpixel: usize = 0;
@@ -6672,29 +6989,46 @@ pub(crate) fn fits_read_compressed_pixels(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
-/// in general we have to read the first partial row of the image,
+/// In general we have to read the first partial row of the image,
 /// followed by the middle complete rows, followed by the last
 /// partial row of the image.  If the first or last rows are complete,
 /// then read them at the same time as all the middle rows.
+///
+/// # Parameters
+///
+/// * `fptr`          — (I) FITS file
+/// * `datatype`      — (I) datatype of the array to be returned
+/// * `bytesperpixel` — (I) number of bytes per pixel in array
+/// * `nplane`        — (I) which plane of the cube to read
+/// * `firstcoord`    — coordinate of first pixel to read
+/// * `lastcoord`     — coordinate of last pixel to read
+/// * `inc`           — increment of pixels to read
+/// * `naxes`         — size of each image dimension
+/// * `nullcheck`     — (I) 0 for no null checking
+/// * `nullval`       — (I) value for undefined pixels
+/// * `array`         — (O) array of values that are returned
+/// * `nullarray`     — (O) array of flags = 1 if nullcheck = 2
+/// * `anynul`        — (O) set to 1 if any values are null; else 0
+/// * `nread`         — (O) total number of pixels read and returned
+/// * `status`        — (IO) error status
 fn fits_read_compressed_img_plane(
-    fptr: &mut fitsfile,         /* I - FITS file   */
-    datatype: c_int,             /* I - datatype of the array to be returned      */
-    bytesperpixel: c_int,        /* I - number of bytes per pixel in array */
-    nplane: c_long,              /* I - which plane of the cube to read      */
-    firstcoord: &mut [LONGLONG], /* coordinate of first pixel to read */
-    lastcoord: &[LONGLONG],      /* coordinate of last pixel to read */
-    inc: &[c_long],              /* increment of pixels to read */
-    naxes: &[c_long],            /* size of each image dimension */
-    nullcheck: NullCheckType,    /* I - 0 for no null checking                   */
+    fptr: &mut fitsfile,
+    datatype: c_int,
+    bytesperpixel: c_int,
+    nplane: c_long,
+    firstcoord: &mut [LONGLONG],
+    lastcoord: &[LONGLONG],
+    inc: &[c_long],
+    naxes: &[c_long],
+    nullcheck: NullCheckType,
     /*     1: set undefined pixels = nullval       */
     /*     2: set nullarray=1 for undefined pixels */
-    nullval: &Option<NullValue>, /* I - value for undefined pixels              */
-    array: &mut [u8],            /* O - array of values that are returned       */
-    mut nullarray: Option<&mut [c_char]>, /* O - array of flags = 1 if nullcheck = 2     */
-    mut anynul: Option<&mut c_int>, /* O - set to 1 if any values are null; else 0 */
-    nread: &mut c_long,          /* O - total number of pixels read and returned*/
-    status: &mut c_int,          /* IO - error status                           */
+    nullval: &Option<NullValue>,
+    array: &mut [u8],
+    mut nullarray: Option<&mut [c_char]>,
+    mut anynul: Option<&mut c_int>,
+    nread: &mut c_long,
+    status: &mut c_int,
 ) -> c_int {
     /* bottom left coord. and top right coord. */
     let mut blc: [LONGLONG; MAX_COMPRESS_DIM] = [0; MAX_COMPRESS_DIM];
@@ -6855,7 +7189,6 @@ fn fits_read_compressed_img_plane(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// This routine reads keywords from a BINTABLE extension containing a
 /// compressed image.
 pub(crate) fn imcomp_get_compressed_image_par(infptr: &mut fitsfile, status: &mut c_int) -> c_int {
@@ -7352,7 +7685,6 @@ pub(crate) fn imcomp_get_compressed_image_par(infptr: &mut fitsfile, status: &mu
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// This routine reads the header keywords from the input image and
 /// copies them to the output image;  the manditory structural keywords
 /// and the checksum keywords are not copied. If the DATE keyword is copied,
@@ -7406,7 +7738,6 @@ fn imcomp_copy_imheader(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// This routine copies the header keywords from the uncompressed input image
 /// and to the compressed image (in a binary table)
 fn imcomp_copy_img2comp(
@@ -7550,7 +7881,6 @@ fn imcomp_copy_img2comp(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// This routine copies the header keywords from the compressed input image
 /// and to the uncompressed image (in a binary table)
 fn imcomp_copy_comp2img(
@@ -7666,7 +7996,6 @@ fn imcomp_copy_comp2img(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// This routine copies any unexpected keywords from the primary array
 /// of the compressed input image into the header of the uncompressed image
 /// (which is the primary array of the output file).
@@ -7706,20 +8035,29 @@ fn imcomp_copy_prime2img(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// This routine decompresses one tile of the image
 #[allow(clippy::if_same_then_else)]
 // C dispatch chain: distinct conditions deliberately share an action.
+/// # Parameters
+///
+/// * `nrow`       — (I) row of table to read and uncompress
+/// * `tilelen`    — (I) number of pixels in the tile
+/// * `datatype`   — (I) datatype to be returned in 'buffer'
+/// * `nullcheck`  — (I) 0 for no null checking
+/// * `nulval`     — (I) value to be used for undefined pixels
+/// * `buffer`     — (O) buffer for returned decompressed values
+/// * `bnullarray` — (O) buffer for returned null flags
+/// * `anynul`     — (O) any null values returned?
 fn imcomp_decompress_tile(
     infptr: &mut fitsfile,
-    nrow: c_int,                    /* I - row of table to read and uncompress */
-    tilelen: c_int,                 /* I - number of pixels in the tile        */
-    datatype: c_int,                /* I - datatype to be returned in 'buffer' */
-    mut nullcheck: NullCheckType,   /* I - 0 for no null checking */
-    nulval: &Option<NullValue>,     /* I - value to be used for undefined pixels */
-    buffer: &mut [u8],              /* O - buffer for returned decompressed values */
-    bnullarray: &mut [c_char],      /* O - buffer for returned null flags */
-    mut anynul: Option<&mut c_int>, /* O - any null values returned?  */
+    nrow: c_int,
+    tilelen: c_int,
+    datatype: c_int,
+    mut nullcheck: NullCheckType,
+    nulval: &Option<NullValue>,
+    buffer: &mut [u8],
+    bnullarray: &mut [c_char],
+    mut anynul: Option<&mut c_int>,
     status: &mut c_int,
 ) -> c_int {
     let mut tiledatatype: c_int = 0;
@@ -9541,16 +9879,24 @@ fn imcomp_decompress_tile(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
-/// test if there are any intersecting pixels between this tile and the section
+/// Test if there are any intersecting pixels between this tile and the section
 /// of the image defined by fixel, lpixel, ininc.
+///
+/// # Parameters
+///
+/// * `ndim`    — (I) number of dimension in the tile and image
+/// * `tfpixel` — (I) first pixel number in each dim. of the tile
+/// * `tlpixel` — (I) last pixel number in each dim. of the tile
+/// * `fpixel`  — (I) first pixel number in each dim. of the image
+/// * `lpixel`  — (I) last pixel number in each dim. of the image
+/// * `ininc`   — (I) increment to be applied in each image dimen.
 fn imcomp_test_overlap(
-    ndim: c_int,        /* I - number of dimension in the tile and image */
-    tfpixel: &[c_long], /* I - first pixel number in each dim. of the tile */
-    tlpixel: &[c_long], /* I - last pixel number in each dim. of the tile */
-    fpixel: &[c_long],  /* I - first pixel number in each dim. of the image */
-    lpixel: &[c_long],  /* I - last pixel number in each dim. of the image */
-    ininc: &[c_long],   /* I - increment to be applied in each image dimen. */
+    ndim: c_int,
+    tfpixel: &[c_long],
+    tlpixel: &[c_long],
+    fpixel: &[c_long],
+    lpixel: &[c_long],
+    ininc: &[c_long],
     status: &mut c_int,
 ) -> c_int {
     let mut imgdim: [c_long; MAX_COMPRESS_DIM] = [0; MAX_COMPRESS_DIM]; /* product of preceding dimensions in the  output image, allowing for inc factor */
@@ -9636,21 +9982,34 @@ fn imcomp_test_overlap(
     1 /* there appears to be  intersecting pixels */
 }
 
-/*--------------------------------------------------------------------------*/
-/// copy the intersecting pixels from a decompressed tile to the output image.
+/// Copy the intersecting pixels from a decompressed tile to the output image.
 /// Both the tile and the image must have the same number of dimensions.
+///
+/// # Parameters
+///
+/// * `tile`       — (I) multi dimensional array of tile pixels
+/// * `pixlen`     — (I) number of bytes in each tile or image pixel
+/// * `ndim`       — (I) number of dimension in the tile and image
+/// * `tfpixel`    — (I) first pixel number in each dim. of the tile
+/// * `tlpixel`    — (I) last pixel number in each dim. of the tile
+/// * `bnullarray` — (I) array of null flags; used if nullcheck = 2
+/// * `image`      — (O) multi dimensional output image
+/// * `fpixel`     — (I) first pixel number in each dim. of the image
+/// * `lpixel`     — (I) last pixel number in each dim. of the image
+/// * `ininc`      — (I) increment to be applied in each image dimen.
+/// * `nullcheck`  — (I) 0, 1: do nothing; 2: set nullarray for nulls
 fn imcomp_copy_overlap(
-    tile: &[c_char],          /* I - multi dimensional array of tile pixels */
-    pixlen: c_int,            /* I - number of bytes in each tile or image pixel */
-    ndim: c_int,              /* I - number of dimension in the tile and image */
-    tfpixel: &[c_long],       /* I - first pixel number in each dim. of the tile */
-    tlpixel: &[c_long],       /* I - last pixel number in each dim. of the tile */
-    bnullarray: &[c_char],    /* I - array of null flags; used if nullcheck = 2 */
-    image: &mut [c_char],     /* O - multi dimensional output image */
-    fpixel: &[c_long],        /* I - first pixel number in each dim. of the image */
-    lpixel: &[c_long],        /* I - last pixel number in each dim. of the image */
-    ininc: &[c_long],         /* I - increment to be applied in each image dimen. */
-    nullcheck: NullCheckType, /* I - 0, 1: do nothing; 2: set nullarray for nulls */
+    tile: &[c_char],
+    pixlen: c_int,
+    ndim: c_int,
+    tfpixel: &[c_long],
+    tlpixel: &[c_long],
+    bnullarray: &[c_char],
+    image: &mut [c_char],
+    fpixel: &[c_long],
+    lpixel: &[c_long],
+    ininc: &[c_long],
+    nullcheck: NullCheckType,
     mut nullarray: Option<&mut [c_char]>,
     status: &mut c_int,
 ) -> c_int {
@@ -9910,20 +10269,32 @@ fn imcomp_copy_overlap(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Similar to imcomp_copy_overlap, except it copies the overlapping pixels from
 /// the 'image' to the 'tile'.
+///
+/// # Parameters
+///
+/// * `tile`        — (O) multi dimensional array of tile pixels
+/// * `pixlen`      — (I) number of bytes in each tile or image pixel
+/// * `ndim`        — (I) number of dimension in the tile and image
+/// * `tfpixel`     — (I) first pixel number in each dim. of the tile
+/// * `tlpixel`     — (I) last pixel number in each dim. of the tile
+/// * `_bnullarray` — (I) array of null flags; used if nullcheck = 2
+/// * `image`       — (I) multi dimensional output image
+/// * `fpixel`      — (I) first pixel number in each dim. of the image
+/// * `lpixel`      — (I) last pixel number in each dim. of the image
+/// * `_nullcheck`  — (I) 0, 1: do nothing; 2: set nullarray for nulls
 fn imcomp_merge_overlap(
-    tile: &mut [c_char],       /* O - multi dimensional array of tile pixels */
-    pixlen: c_int,             /* I - number of bytes in each tile or image pixel */
-    ndim: c_int,               /* I - number of dimension in the tile and image */
-    tfpixel: &[c_long],        /* I - first pixel number in each dim. of the tile */
-    tlpixel: &[c_long],        /* I - last pixel number in each dim. of the tile */
-    _bnullarray: &[c_char],    /* I - array of null flags; used if nullcheck = 2 */
-    image: &[c_char],          /* I - multi dimensional output image */
-    fpixel: &[c_long],         /* I - first pixel number in each dim. of the image */
-    lpixel: &[c_long],         /* I - last pixel number in each dim. of the image */
-    _nullcheck: NullCheckType, /* I - 0, 1: do nothing; 2: set nullarray for nulls */
+    tile: &mut [c_char],
+    pixlen: c_int,
+    ndim: c_int,
+    tfpixel: &[c_long],
+    tlpixel: &[c_long],
+    _bnullarray: &[c_char],
+    image: &[c_char],
+    fpixel: &[c_long],
+    lpixel: &[c_long],
+    _nullcheck: NullCheckType,
     status: &mut c_int,
 ) -> c_int {
     let mut imgdim: [c_long; MAX_COMPRESS_DIM] = [0; MAX_COMPRESS_DIM]; // product of preceding dimensions in the output image, allowing for inc factor
@@ -10168,24 +10539,39 @@ fn imcomp_merge_overlap(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Unquantize byte values into the scaled floating point values
+///
+/// # Parameters
+///
+/// * `row`            — tile number = row number in table
+/// * `input`          — (I) array of values to be converted
+/// * `ntodo`          — (I) number of elements in the array
+/// * `scale`          — (I) FITS TSCALn or BSCALE value
+/// * `zero`           — (I) FITS TZEROn or BZERO value
+/// * `_dither_method` — (I) dithering method to use
+/// * `nullcheck`      — (I) null checking code; 0 = don't check
+/// * `tnull`          — (I) value of FITS TNonen keyword if any
+/// * `nullval`        — (I) set null pixels, if nullcheck = 1
+/// * `nullarray`      — (I) bad pixel array, if nullcheck = 2
+/// * `anynull`        — (O) set to 1 if any pixels are null
+/// * `output`         — (O) array of converted pixels
+/// * `status`         — (IO) error status
 fn unquantize_i1r4(
-    row: c_long,              /* tile number = row number in table  */
-    input: &[c_uchar],        /* I - array of values to be converted     */
-    ntodo: c_long,            /* I - number of elements in the array     */
-    scale: f64,               /* I - FITS TSCALn or BSCALE value         */
-    zero: f64,                /* I - FITS TZEROn or BZERO  value         */
-    _dither_method: c_int,    /* I - dithering method to use             */
-    nullcheck: NullCheckType, /* I - null checking code; 0 = don't check */
+    row: c_long,
+    input: &[c_uchar],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    _dither_method: c_int,
+    nullcheck: NullCheckType,
     /*     1:set null pixels = nullval         */
     /*     2: if null pixel, set nullarray = 1 */
-    tnull: c_uchar,              /* I - value of FITS TNonen keyword if any */
-    nullval: f32,                /* I - set null pixels, if nullcheck = 1   */
-    nullarray: &mut [c_char],    /* I - bad pixel array, if nullcheck = 2   */
-    anynull: Option<&mut c_int>, /* O - set to 1 if any pixels are null     */
-    output: &mut [f32],          /* O - array of converted pixels           */
-    status: &mut c_int,          /* IO - error status                       */
+    tnull: c_uchar,
+    nullval: f32,
+    nullarray: &mut [c_char],
+    anynull: Option<&mut c_int>,
+    output: &mut [f32],
+    status: &mut c_int,
 ) -> c_int {
     let mut nextrand: c_int = 0;
     let mut iseed: c_int = 0;
@@ -10259,24 +10645,39 @@ fn unquantize_i1r4(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Unquantize short integer values into the scaled floating point values
+///
+/// # Parameters
+///
+/// * `row`            — seed for random values
+/// * `input`          — (I) array of values to be converted
+/// * `ntodo`          — (I) number of elements in the array
+/// * `scale`          — (I) FITS TSCALn or BSCALE value
+/// * `zero`           — (I) FITS TZEROn or BZERO value
+/// * `_dither_method` — (I) dithering method to use
+/// * `nullcheck`      — (I) null checking code; 0 = don't check
+/// * `tnull`          — (I) value of FITS TNonen keyword if any
+/// * `nullval`        — (I) set null pixels, if nullcheck = 1
+/// * `nullarray`      — (I) bad pixel array, if nullcheck = 2
+/// * `anynull`        — (O) set to 1 if any pixels are null
+/// * `output`         — (O) array of converted pixels
+/// * `status`         — (IO) error status
 fn unquantize_i2r4(
-    row: c_long,              /* seed for random values  */
-    input: &[c_short],        /* I - array of values to be converted     */
-    ntodo: c_long,            /* I - number of elements in the array     */
-    scale: f64,               /* I - FITS TSCALn or BSCALE value         */
-    zero: f64,                /* I - FITS TZEROn or BZERO  value         */
-    _dither_method: c_int,    /* I - dithering method to use             */
-    nullcheck: NullCheckType, /* I - null checking code; 0 = don't check */
+    row: c_long,
+    input: &[c_short],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    _dither_method: c_int,
+    nullcheck: NullCheckType,
     /*     1:set null pixels = nullval         */
     /*     2: if null pixel, set nullarray = 1 */
-    tnull: c_short,              /* I - value of FITS TNonen keyword if any */
-    nullval: f32,                /* I - set null pixels, if nullcheck = 1   */
-    nullarray: &mut [c_char],    /* I - bad pixel array, if nullcheck = 2   */
-    anynull: Option<&mut c_int>, /* O - set to 1 if any pixels are null     */
-    output: &mut [f32],          /* O - array of converted pixels           */
-    status: &mut c_int,          /* IO - error status                       */
+    tnull: c_short,
+    nullval: f32,
+    nullarray: &mut [c_char],
+    anynull: Option<&mut c_int>,
+    output: &mut [f32],
+    status: &mut c_int,
 ) -> c_int {
     let mut nextrand: c_int = 0;
     let mut iseed: c_int = 0;
@@ -10351,24 +10752,39 @@ fn unquantize_i2r4(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Unquantize int integer values into the scaled floating point values
+///
+/// # Parameters
+///
+/// * `row`           — tile number = row number in table
+/// * `input`         — (I) array of values to be converted
+/// * `ntodo`         — (I) number of elements in the array
+/// * `scale`         — (I) FITS TSCALn or BSCALE value
+/// * `zero`          — (I) FITS TZEROn or BZERO value
+/// * `dither_method` — (I) dithering method to use
+/// * `nullcheck`     — (I) null checking code; 0 = don't check
+/// * `tnull`         — (I) value of FITS TNonen keyword if any
+/// * `nullval`       — (I) set null pixels, if nullcheck = 1
+/// * `nullarray`     — (I) bad pixel array, if nullcheck = 2
+/// * `anynull`       — (O) set to 1 if any pixels are null
+/// * `output`        — (O) array of converted pixels
+/// * `status`        — (IO) error status
 fn unquantize_i4r4(
-    row: c_long,              /* tile number = row number in table    */
-    input: &[INT32BIT],       /* I - array of values to be converted     */
-    ntodo: c_long,            /* I - number of elements in the array     */
-    scale: f64,               /* I - FITS TSCALn or BSCALE value         */
-    zero: f64,                /* I - FITS TZEROn or BZERO  value         */
-    dither_method: c_int,     /* I - dithering method to use             */
-    nullcheck: NullCheckType, /* I - null checking code; 0 = don't check */
+    row: c_long,
+    input: &[INT32BIT],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    dither_method: c_int,
+    nullcheck: NullCheckType,
     /*     1:set null pixels = nullval         */
     /*     2: if null pixel, set nullarray = 1 */
-    tnull: INT32BIT,             /* I - value of FITS TNonen keyword if any */
-    nullval: f32,                /* I - set null pixels, if nullcheck = 1   */
-    nullarray: &mut [c_char],    /* I - bad pixel array, if nullcheck = 2   */
-    anynull: Option<&mut c_int>, /* O - set to 1 if any pixels are null     */
-    output: &mut [f32],          /* O - array of converted pixels           */
-    status: &mut c_int,          /* IO - error status                       */
+    tnull: INT32BIT,
+    nullval: f32,
+    nullarray: &mut [c_char],
+    anynull: Option<&mut c_int>,
+    output: &mut [f32],
+    status: &mut c_int,
 ) -> c_int {
     let mut nextrand: c_int = 0;
     let mut iseed: c_int = 0;
@@ -10441,24 +10857,39 @@ fn unquantize_i4r4(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Unquantize byte values into the scaled floating point values
+///
+/// # Parameters
+///
+/// * `row`            — tile number = row number in table
+/// * `input`          — (I) array of values to be converted
+/// * `ntodo`          — (I) number of elements in the array
+/// * `scale`          — (I) FITS TSCALn or BSCALE value
+/// * `zero`           — (I) FITS TZEROn or BZERO value
+/// * `_dither_method` — (I) dithering method to use
+/// * `nullcheck`      — (I) null checking code; 0 = don't check
+/// * `tnull`          — (I) value of FITS TNonen keyword if any
+/// * `nullval`        — (I) set null pixels, if nullcheck = 1
+/// * `nullarray`      — (I) bad pixel array, if nullcheck = 2
+/// * `anynull`        — (O) set to 1 if any pixels are null
+/// * `output`         — (O) array of converted pixels
+/// * `status`         — (IO) error status
 fn unquantize_i1r8(
-    row: c_long,              /* tile number = row number in table  */
-    input: &[c_uchar],        /* I - array of values to be converted     */
-    ntodo: c_long,            /* I - number of elements in the array     */
-    scale: f64,               /* I - FITS TSCALn or BSCALE value         */
-    zero: f64,                /* I - FITS TZEROn or BZERO  value         */
-    _dither_method: c_int,    /* I - dithering method to use             */
-    nullcheck: NullCheckType, /* I - null checking code; 0 = don't check */
+    row: c_long,
+    input: &[c_uchar],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    _dither_method: c_int,
+    nullcheck: NullCheckType,
     /*     1:set null pixels = nullval         */
     /*     2: if null pixel, set nullarray = 1 */
-    tnull: c_uchar,              /* I - value of FITS TNonen keyword if any */
-    nullval: f64,                /* I - set null pixels, if nullcheck = 1   */
-    nullarray: &mut [c_char],    /* I - bad pixel array, if nullcheck = 2   */
-    anynull: Option<&mut c_int>, /* O - set to 1 if any pixels are null     */
-    output: &mut [f64],          /* O - array of converted pixels           */
-    status: &mut c_int,          /* IO - error status                       */
+    tnull: c_uchar,
+    nullval: f64,
+    nullarray: &mut [c_char],
+    anynull: Option<&mut c_int>,
+    output: &mut [f64],
+    status: &mut c_int,
 ) -> c_int {
     let mut nextrand: c_int = 0;
     let mut iseed: c_int = 0;
@@ -10533,26 +10964,40 @@ fn unquantize_i1r8(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
+/// # Parameters
+///
+/// * `row`            — tile number = row number in table
+/// * `input`          — (I) array of values to be converted
+/// * `ntodo`          — (I) number of elements in the array
+/// * `scale`          — (I) FITS TSCALn or BSCALE value
+/// * `zero`           — (I) FITS TZEROn or BZERO value
+/// * `_dither_method` — (I) dithering method to use
+/// * `nullcheck`      — (I) null checking code; 0 = don't check
+/// * `tnull`          — (I) value of FITS TNonen keyword if any
+/// * `nullval`        — (I) set null pixels, if nullcheck = 1
+/// * `nullarray`      — (I) bad pixel array, if nullcheck = 2
+/// * `anynull`        — (O) set to 1 if any pixels are null
+/// * `output`         — (O) array of converted pixels
+/// * `status`         — (IO) error status
 fn unquantize_i2r8(
-    row: c_long,              /* tile number = row number in table  */
-    input: &[c_short],        /* I - array of values to be converted     */
-    ntodo: c_long,            /* I - number of elements in the array     */
-    scale: f64,               /* I - FITS TSCALn or BSCALE value         */
-    zero: f64,                /* I - FITS TZEROn or BZERO  value         */
-    _dither_method: c_int,    /* I - dithering method to use             */
-    nullcheck: NullCheckType, /* I - null checking code; 0 = don't check */
+    row: c_long,
+    input: &[c_short],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    _dither_method: c_int,
+    nullcheck: NullCheckType,
     /*     1:set null pixels = nullval         */
     /*     2: if null pixel, set nullarray = 1 */
-    tnull: c_short,              /* I - value of FITS TNonen keyword if any */
-    nullval: f64,                /* I - set null pixels, if nullcheck = 1   */
-    nullarray: &mut [c_char],    /* I - bad pixel array, if nullcheck = 2   */
-    anynull: Option<&mut c_int>, /* O - set to 1 if any pixels are null     */
-    output: &mut [f64],          /* O - array of converted pixels           */
-    status: &mut c_int,          /* IO - error status                       */
-                                 /*
-                                 Unquantize short integer values into the scaled floating point values
-                                 */
+    tnull: c_short,
+    nullval: f64,
+    nullarray: &mut [c_char],
+    anynull: Option<&mut c_int>,
+    output: &mut [f64],
+    status: &mut c_int,
+    /*
+    Unquantize short integer values into the scaled floating point values
+    */
 ) -> c_int {
     let mut nextrand: c_int = 0;
     let mut iseed: c_int = 0;
@@ -10625,24 +11070,39 @@ fn unquantize_i2r8(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Unquantize int integer values into the scaled floating point values
+///
+/// # Parameters
+///
+/// * `row`           — tile number = row number in table
+/// * `input`         — (I) array of values to be converted
+/// * `ntodo`         — (I) number of elements in the array
+/// * `scale`         — (I) FITS TSCALn or BSCALE value
+/// * `zero`          — (I) FITS TZEROn or BZERO value
+/// * `dither_method` — (I) dithering method to use
+/// * `nullcheck`     — (I) null checking code; 0 = don't check
+/// * `tnull`         — (I) value of FITS TNonen keyword if any
+/// * `nullval`       — (I) set null pixels, if nullcheck = 1
+/// * `nullarray`     — (I) bad pixel array, if nullcheck = 2
+/// * `anynull`       — (O) set to 1 if any pixels are null
+/// * `output`        — (O) array of converted pixels
+/// * `status`        — (IO) error status
 fn unquantize_i4r8(
-    row: c_long,              /* tile number = row number in table    */
-    input: &[INT32BIT],       /* I - array of values to be converted     */
-    ntodo: c_long,            /* I - number of elements in the array     */
-    scale: f64,               /* I - FITS TSCALn or BSCALE value         */
-    zero: f64,                /* I - FITS TZEROn or BZERO  value         */
-    dither_method: c_int,     /* I - dithering method to use             */
-    nullcheck: NullCheckType, /* I - null checking code; 0 = don't check */
+    row: c_long,
+    input: &[INT32BIT],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    dither_method: c_int,
+    nullcheck: NullCheckType,
     /*     1:set null pixels = nullval         */
     /*     2: if null pixel, set nullarray = 1 */
-    tnull: INT32BIT,             /* I - value of FITS TNonen keyword if any */
-    nullval: f64,                /* I - set null pixels, if nullcheck = 1   */
-    nullarray: &mut [c_char],    /* I - bad pixel array, if nullcheck = 2   */
-    anynull: Option<&mut c_int>, /* O - set to 1 if any pixels are null     */
-    output: &mut [f64],          /* O - array of converted pixels           */
-    status: &mut c_int,          /* IO - error status                       */
+    tnull: INT32BIT,
+    nullval: f64,
+    nullarray: &mut [c_char],
+    anynull: Option<&mut c_int>,
+    output: &mut [f64],
+    status: &mut c_int,
 ) -> c_int {
     let mut nextrand: c_int = 0;
     let mut iseed: c_int = 0;
@@ -10715,8 +11175,7 @@ fn unquantize_i4r8(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
-/// convert pixels that are equal to nullflag to NaNs.
+/// Convert pixels that are equal to nullflag to NaNs.
 /// Note that indata and outdata point to the same location.
 fn imcomp_float2nan(
     indata: &[f32],
@@ -10734,8 +11193,7 @@ fn imcomp_float2nan(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
-/// convert pixels that are equal to nullflag to NaNs.
+/// Convert pixels that are equal to nullflag to NaNs.
 /// Note that indata and outdata point to the same location.
 fn imcomp_float2nan_inplace(
     indata: &mut [f32],
@@ -10752,8 +11210,7 @@ fn imcomp_float2nan_inplace(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
-/// convert pixels that are equal to nullflag to NaNs.
+/// Convert pixels that are equal to nullflag to NaNs.
 /// Note that indata and outdata point to the same location.
 fn imcomp_double2nan(
     indata: &[f64],
@@ -10771,8 +11228,7 @@ fn imcomp_double2nan(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
-/// convert pixels that are equal to nullflag to NaNs.
+/// Convert pixels that are equal to nullflag to NaNs.
 /// Note that indata and outdata point to the same location.
 fn imcomp_double2nan_inplace(
     indata: &mut [f64],
@@ -10793,7 +11249,6 @@ fn imcomp_double2nan_inplace(
 /*    TABLE COMPRESSION ROUTINES                                           */
 /* =-====================================================================== */
 
-/*--------------------------------------------------------------------------*/
 /// Compress the input FITS Binary Table.
 ///
 /// First divide the table into equal sized chunks (analogous to image tiles)
@@ -10847,6 +11302,17 @@ pub unsafe extern "C" fn fits_compress_table(
     }
 }
 
+/// Compress a binary table, writing the result to `outfptr`.
+///
+/// The table is transposed from row-major to column-major in chunks, so that
+/// each column's values sit together and compress well, then each column is
+/// compressed with the algorithm suited to its datatype.
+///
+/// # Parameters
+///
+/// * `infptr`  — (I) FITS file pointer to the input table
+/// * `outfptr` — (I) FITS file pointer to the output table
+/// * `status`  — (IO) error status
 pub fn fits_compress_table_safe(
     infptr: &mut fitsfile,
     outfptr: &mut fitsfile,
@@ -11352,9 +11818,7 @@ pub fn fits_compress_table_safe(
                 if coltype[ii] < 0 {
                     /* this is a variable length array (VLA) column */
 
-                    /*=========================================================================*/
                     /* variable-length array columns are a complicated special case  */
-                    /*=========================================================================*/
 
                     /* allocate memory to hold all the VLA descriptors from the input table, plus */
                     /* room to hold the descriptors to the compressed VLAs in the output table */
@@ -11868,7 +12332,6 @@ pub fn fits_compress_table_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Uncompress the table that was compressed with fits_compress_table
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn fits_uncompress_table(
@@ -11886,7 +12349,6 @@ pub unsafe extern "C" fn fits_uncompress_table(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Uncompress the table that was compressed with fits_compress_table
 pub fn fits_uncompress_table_safe(
     infptr: &mut fitsfile,
@@ -11995,7 +12457,6 @@ pub fn fits_uncompress_table_safe(
             return *status;
         }
 
-        /**** get size of the uncompressed table */
         fits_read_key_lng(
             infptr,
             cs!(c"ZNAXIS1"),
@@ -12959,8 +13420,7 @@ pub fn fits_uncompress_table_safe(
         *status
     }
 }
-/*--------------------------------------------------------------------------*/
-/// shuffle the bytes in an array of 2-byte integers in the heap
+/// Shuffle the bytes in an array of 2-byte integers in the heap
 fn fits_shuffle_2bytes(heap: &mut [c_char], length: LONGLONG, status: &mut c_int) -> c_int {
     let length = length as usize;
     let heap = cast_slice_mut(heap);
@@ -12988,8 +13448,7 @@ fn fits_shuffle_2bytes(heap: &mut [c_char], length: LONGLONG, status: &mut c_int
     *status
 }
 
-/*--------------------------------------------------------------------------*/
-/// shuffle the bytes in an array of 4-byte integers or floats
+/// Shuffle the bytes in an array of 4-byte integers or floats
 fn fits_shuffle_4bytes(heap: &mut [c_char], length: LONGLONG, status: &mut c_int) -> c_int {
     let length = length as usize;
     let heap = cast_slice_mut(heap);
@@ -13023,8 +13482,7 @@ fn fits_shuffle_4bytes(heap: &mut [c_char], length: LONGLONG, status: &mut c_int
     *status
 }
 
-/*--------------------------------------------------------------------------*/
-/// shuffle the bytes in an array of 8-byte integers or doubles in the heap
+/// Shuffle the bytes in an array of 8-byte integers or doubles in the heap
 fn fits_shuffle_8bytes(heap: &mut [c_char], length: LONGLONG, status: &mut c_int) -> c_int {
     let length = length as usize;
     let heap = cast_slice_mut(heap);
@@ -13108,7 +13566,6 @@ fn fits_shuffle_8bytes(heap: &mut [c_char], length: LONGLONG, status: &mut c_int
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Undo the byte shuffling of an array of `length` values of `NBYTES` bytes each.
 ///
 /// The shuffled heap holds `NBYTES` planes of `length` bytes: every value's first
@@ -13129,31 +13586,27 @@ fn unshuffle_bytes<const NBYTES: usize>(heap: &mut [c_char], length: usize) {
     }
 }
 
-/*--------------------------------------------------------------------------*/
-/// unshuffle the bytes in an array of 2-byte integers
+/// Unshuffle the bytes in an array of 2-byte integers
 fn fits_unshuffle_2bytes(heap: &mut [c_char], length: LONGLONG, status: &mut c_int) -> c_int {
     unshuffle_bytes::<2>(heap, length as usize);
 
     *status
 }
 
-/*--------------------------------------------------------------------------*/
-/// unshuffle the bytes in an array of 4-byte integers or floats
+/// Unshuffle the bytes in an array of 4-byte integers or floats
 fn fits_unshuffle_4bytes(heap: &mut [c_char], length: LONGLONG, status: &mut c_int) -> c_int {
     unshuffle_bytes::<4>(heap, length as usize);
 
     *status
 }
 
-/*--------------------------------------------------------------------------*/
-/// unshuffle the bytes in an array of 8-byte integers or doubles
+/// Unshuffle the bytes in an array of 8-byte integers or doubles
 fn fits_unshuffle_8bytes(heap: &mut [c_char], length: LONGLONG, status: &mut c_int) -> c_int {
     unshuffle_bytes::<8>(heap, length as usize);
 
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Convert the input array of 32-bit integers into an array of 64-bit integers,
 /// in place. This will overwrite the input array with the new longer array starting
 /// at the same memory location.
@@ -13227,7 +13680,6 @@ fn fits_int_to_longlong_inplace(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Convert the input array of 16-bit integers into an array of 32-bit integers,
 /// in place. This will overwrite the input array with the new longer array starting
 /// at the same memory location.
@@ -13302,7 +13754,6 @@ fn fits_short_to_int_inplace(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Convert the input array of 16-bit unsigned integers into an array of 32-bit
 /// integers, in place. This will overwrite the input array with the new longer
 /// array starting at the same memory location.
@@ -13377,7 +13828,6 @@ fn fits_ushort_to_int_inplace(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Convert the input array of 8-bit unsigned integers into an array of 32-bit
 /// integers, in place. This will overwrite the input array with the new longer
 /// array starting at the same memory location.
@@ -13393,7 +13843,7 @@ fn fits_ushort_to_int_inplace(
 fn fits_ubyte_to_int_inplace(
     ubytearray: &mut [c_uchar],
     length: c_long,
-    status: &mut c_int, /* */
+    status: &mut c_int,
 ) -> c_int {
     let mut ntodo: c_long;
     let mut firstelem: usize;
@@ -13451,7 +13901,6 @@ fn fits_ubyte_to_int_inplace(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Convert the input array of 8-bit signed integers into an array of 32-bit
 /// integers, in place. This will overwrite the input array with the new longer
 /// array starting at the same memory location.
@@ -13530,7 +13979,6 @@ fn fits_sbyte_to_int_inplace(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// The quantizing algorithms treat all N-dimensional tiles as if they
 /// were 2 dimensions (trowsize * ntrows).  This sets trowsize to the
 /// first dimensional size encountered that's > 1 (typically the X

--- a/src/iraffits.rs
+++ b/src/iraffits.rs
@@ -1,48 +1,23 @@
-/*------------------------------------------------------------------------*/
-/*                                                                        */
-/*  These routines have been modified by William Pence for use by CFITSIO */
-/*        The original files were provided by Doug Mink                   */
-/*------------------------------------------------------------------------*/
-
-/* File imhfile.c
-* August 6, 1998
-* By Doug Mink, based on Mike VanHilst's readiraf.c
-
-* Module:      imhfile.c (IRAF .imh image file reading and writing)
-* Purpose:     Read and write IRAF image files (and translate headers)
-* Subroutine:  irafrhead (filename, lfhead, fitsheader, lihead)
-*              Read IRAF image header
-* Subroutine:  irafrimage (fitsheader)
-*              Read IRAF image pixels (call after irafrhead)
-* Subroutine:	same_path (pixname, hdrname)
-*		Put filename and header path together
-* Subroutine:	iraf2fits (hdrname, irafheader, nbiraf, nbfits)
-*		Convert IRAF image header to FITS image header
-* Subroutine:  irafgeti4 (irafheader, offset)
-*		Get 4-byte integer from arbitrary part of IRAF header
-* Subroutine:  irafgetc2 (irafheader, offset)
-*		Get character string from arbitrary part of IRAF v.1 header
-* Subroutine:  irafgetc (irafheader, offset)
-*		Get character string from arbitrary part of IRAF header
-* Subroutine:  iraf2str (irafstring, nchar)
-* 		Convert 2-byte/char IRAF string to 1-byte/char string
-* Subroutine:	irafswap (bitpix,string,nbytes)
-*		Swap bytes in string in place, with FITS bits/pixel code
-* Subroutine:	irafswap2 (string,nbytes)
-*		Swap bytes in string in place
-* Subroutine	irafswap4 (string,nbytes)
-*		Reverse bytes of Integer*4 or Real*4 vector in place
-* Subroutine	irafswap8 (string,nbytes)
-*		Reverse bytes of Real*8 vector in place
-
-
-* Copyright:   2000 Smithsonian Astrophysical Observatory
-*              You may do anything you like with this file except remove
-*              this copyright.  The Smithsonian Astrophysical Observatory
-*              makes no representations about the suitability of this
-*              software for any purpose.  It is provided "as is" without
-*              express or implied warranty.
-*/
+//! Reading IRAF `.imh` image files and translating their headers to FITS.
+//!
+//! An IRAF image is a pair of files: a header (`.imh`) and a pixel file, whose
+//! path the header records. Opening one here reads the header, converts it into
+//! an equivalent FITS header, and reads the pixels, so that the rest of the
+//! library sees an ordinary in-memory FITS image.
+//!
+//! The two formats differ in byte order and in string representation -- IRAF
+//! v.1 headers store two bytes per character -- so most of this module is
+//! conversion rather than I/O.
+//!
+//! Based on `imhfile.c` by Doug Mink, August 6 1998, in turn based on Mike
+//! VanHilst's `readiraf.c`, modified by William Pence for use by CFITSIO.
+//!
+//! Copyright 2000 Smithsonian Astrophysical Observatory. You may do anything
+//! you like with this file except remove this copyright. The Smithsonian
+//! Astrophysical Observatory makes no representations about the suitability of
+//! this software for any purpose. It is provided "as is" without express or
+//! implied warranty.
+#![warn(missing_docs)]
 
 use crate::c_types::{c_char, c_int};
 use crate::helpers::vec_raw_parts::vec_into_raw_parts;
@@ -135,12 +110,16 @@ const MAXINT: c_int = 2147483647; /* Biggest number that can fit in long */
 static SWAPHEAD: Mutex<bool> = Mutex::new(false); /* =1 to swap data bytes of IRAF header values */
 static SWAPDATA: Mutex<bool> = Mutex::new(false); /* =1 to swap bytes in IRAF data pixels */
 
-/*--------------------------------------------------------------------------*/
 /// Delete the iraf .imh header file and the associated .pix data file
+///
+/// # Parameters
+///
+/// * `filename` — name of input file
+/// * `status`   — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn fits_delete_iraf_file(
-    filename: *const c_char, /* name of input file      */
-    status: *mut c_int,      /* IO - error status       */
+    filename: *const c_char,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -151,12 +130,13 @@ pub unsafe extern "C" fn fits_delete_iraf_file(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Delete the iraf .imh header file and the associated .pix data file
-pub fn fits_delete_iraf_file_safe(
-    filename: &[c_char], /* name of input file      */
-    status: &mut c_int,  /* IO - error status       */
-) -> c_int {
+///
+/// # Parameters
+///
+/// * `filename` — name of input file
+/// * `status`   — (IO) error status
+pub fn fits_delete_iraf_file_safe(filename: &[c_char], status: &mut c_int) -> c_int {
     let mut lenirafhead: usize = 0;
     let mut pixfilename: [c_char; SZ_IM2PIXFILE + 1] = [0; SZ_IM2PIXFILE + 1];
 
@@ -196,15 +176,22 @@ pub fn fits_delete_iraf_file_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Driver routine that reads an IRAF image into memory, also converting
 /// it into FITS format.
+///
+/// # Parameters
+///
+/// * `filename` — name of input file
+/// * `buffptr`  — (O) memory pointer (initially ptr::null_mut())
+/// * `buffsize` — (O) size of mem buffer, in bytes
+/// * `filesize` — (O) size of FITS file, in bytes
+/// * `status`   — (IO) error status
 pub(crate) fn iraf2mem(
-    filename: &[c_char],       /* name of input file                 */
-    buffptr: *mut *mut c_char, /* O - memory pointer (initially ptr::null_mut())    */
-    buffsize: &mut usize,      /* O - size of mem buffer, in bytes        */
-    filesize: &mut usize,      /* O - size of FITS file, in bytes         */
-    status: &mut c_int,        /* IO - error status                       */
+    filename: &[c_char],
+    buffptr: *mut *mut c_char,
+    buffsize: &mut usize,
+    filesize: &mut usize,
+    status: &mut c_int,
 ) -> c_int {
     let mut lenirafhead: usize = 0;
     let buffptr = unsafe { buffptr.as_mut().expect(NULL_MSG) };
@@ -256,16 +243,16 @@ pub(crate) fn iraf2mem(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// irafrdhead  (was irafrhead in D. Mink's original code)
 /// Open and read the iraf .imh file.
 /// The imhdr format is defined in iraf/lib/imhdr.h, some of which defines or mimicked, above.
 // `std::io::ErrorKind` is retained deliberately: the `core::io` equivalent is still unstable.
 #[allow(clippy::std_instead_of_core)]
-fn irafrdhead(
-    filename: &[c_char], /* Name of IRAF header file */
-    lihead: &mut usize,  /* Length of IRAF image header in bytes (returned) */
-) -> Result<Vec<c_char>, Error> {
+/// # Parameters
+///
+/// * `filename` — Name of IRAF header file
+/// * `lihead`   — Length of IRAF image header in bytes (returned)
+fn irafrdhead(filename: &[c_char], lihead: &mut usize) -> Result<Vec<c_char>, Error> {
     use std::io::ErrorKind;
 
     let mut errmsg: [c_char; FLEN_ERRMSG] = [0; FLEN_ERRMSG];
@@ -353,11 +340,15 @@ fn irafrdhead(
     Ok(irafheader)
 }
 
-/*--------------------------------------------------------------------------*/
+/// # Parameters
+///
+/// * `buffptr`  — FITS image header (filled)
+/// * `buffsize` — allocated size of the buffer
+/// * `filesize` — actual size of the FITS file
 fn irafrdimage(
-    buffptr: &mut Vec<c_char>, /* FITS image header (filled) */
-    buffsize: &mut usize,      /* allocated size of the buffer */
-    filesize: &mut usize,      /* actual size of the FITS file */
+    buffptr: &mut Vec<c_char>,
+    buffsize: &mut usize,
+    filesize: &mut usize,
     status: &mut c_int,
 ) -> c_int {
     let mut nax: c_int = 1;
@@ -568,7 +559,6 @@ fn irafrdimage(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Return IRAF image format version number from magic word in IRAF header
 fn head_version(irafheader: &[c_char] /* IRAF image header from file */) -> c_int {
     /* Check header file magic word */
@@ -583,7 +573,6 @@ fn head_version(irafheader: &[c_char] /* IRAF image header from file */) -> c_in
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Return IRAF image format version number from magic word in IRAF pixel file
 fn pix_version(irafheader: &[c_char] /* IRAF image header from file */) -> c_int {
     /* Check pixel file header magic word */
@@ -598,14 +587,15 @@ fn pix_version(irafheader: &[c_char] /* IRAF image header from file */) -> c_int
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Verify that file is valid IRAF imhdr or impix by checking first 5 chars
 /// Returns 0 on success, 1 on failure
-fn irafncmp(
-    irafheader: &[c_char], /* IRAF image header from file */
-    teststring: &[c_char], /* C character string to compare */
-    nc: usize,             /* Number of characters to compate */
-) -> c_int {
+///
+/// # Parameters
+///
+/// * `irafheader` — IRAF image header from file
+/// * `teststring` — C character string to compare
+/// * `nc`         — Number of characters to compate
+fn irafncmp(irafheader: &[c_char], teststring: &[c_char], nc: usize) -> c_int {
     let line = iraf2str(irafheader, nc);
 
     if line.is_none() {
@@ -620,15 +610,23 @@ fn irafncmp(
         1
     }
 }
-/*--------------------------------------------------------------------------*/
 /// Convert IRAF image header to FITS image header, returning FITS header
+///
+/// # Parameters
+///
+/// * `hdrname`    — IRAF header file name (may be path)
+/// * `irafheader` — IRAF image header
+/// * `nbiraf`     — Number of bytes in IRAF header
+/// * `buffptr`    — pointer to the FITS header
+/// * `nbfits`     — allocated size of the FITS header buffer
+/// * `fitssize`   — Number of bytes in FITS header (returned)
 fn iraftofits(
-    hdrname: &[c_char],        /* IRAF header file name (may be path) */
-    irafheader: &[c_char],     /* IRAF image header */
-    nbiraf: usize,             /* Number of bytes in IRAF header */
-    buffptr: &mut Vec<c_char>, /* pointer to the FITS header  */
-    nbfits: &mut usize,        /* allocated size of the FITS header buffer */
-    fitssize: &mut usize,      /* Number of bytes in FITS header (returned) */
+    hdrname: &[c_char],
+    irafheader: &[c_char],
+    nbiraf: usize,
+    buffptr: &mut Vec<c_char>,
+    nbfits: &mut usize,
+    fitssize: &mut usize,
     /*  = number of bytes to the end of the END keyword */
     status: &mut c_int,
 ) -> c_int {
@@ -1051,12 +1049,17 @@ fn iraftofits(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// get the IRAF pixel file name
+///
+/// # Parameters
+///
+/// * `hdrname`     — IRAF header file name (may be path)
+/// * `irafheader`  — IRAF image header
+/// * `pixfilename` — IRAF pixel file name
 fn getirafpixname(
-    hdrname: &[c_char],         /* IRAF header file name (may be path) */
-    irafheader: &[c_char],      /* IRAF image header */
-    pixfilename: &mut [c_char], /* IRAF pixel file name */
+    hdrname: &[c_char],
+    irafheader: &[c_char],
+    pixfilename: &mut [c_char],
     status: &mut c_int,
 ) -> c_int {
     let mut newpixname = None;
@@ -1102,7 +1105,6 @@ fn getirafpixname(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /* True if `c` is a directory separator.  CFITSIO only looks for '/', but on
  * Windows header pathnames arrive with '\' separators, so accept both there;
  * otherwise the directory prefix is stripped and the pixel file can't be found. */
@@ -1110,7 +1112,6 @@ fn is_path_sep(c: c_char) -> bool {
     c == bb(b'/') || (cfg!(target_os = "windows") && c == bb(b'\\'))
 }
 
-/*--------------------------------------------------------------------------*/
 /* True if `pixname` already contains a directory separator.  CFITSIO only
  * tests for '/', which is how it decides a pixel file name is "bare" (no path)
  * and needs the header directory prepended.  On Windows a resolved absolute
@@ -1122,12 +1123,12 @@ fn has_path_sep(s: &[c_char]) -> bool {
         || (cfg!(target_os = "windows") && strchr_safe(s, bb(b'\\')).is_some())
 }
 
-/*--------------------------------------------------------------------------*/
 /* Put filename and header path together */
-fn same_path(
-    pixname: &[c_char], /* IRAF pixel file pathname */
-    hdrname: &[c_char], /* IRAF image header file pathname */
-) -> Option<Vec<c_char>> {
+/// # Parameters
+///
+/// * `pixname` — IRAF pixel file pathname
+/// * `hdrname` — IRAF image header file pathname
+fn same_path(pixname: &[c_char], hdrname: &[c_char]) -> Option<Vec<c_char>> {
     /*  WDP - 10/16/2007 - increased allocation to avoid possible overflow */
     /*    newpixname =  calloc (SZ_IM2PIXFILE, sizeof (char)); */
 
@@ -1182,17 +1183,18 @@ fn same_path(
     Some(newpixname)
 }
 
-/*--------------------------------------------------------------------------*/
 ///  check if the IRAF file is in big endian (sun) format (= 0) or not
 ///  This is done by checking the 4 byte integer in the header that
 ///  represents the iraf pixel type.  This 4-byte word is guaranteed to
 ///  have the least sig byte != 0 and the most sig byte = 0,  so if the
 ///  first byte of the word != 0, then the file in little endian format
 ///  like on an Alpha machine.                                          
-fn isirafswapped(
-    irafheader: &[c_char], /* IRAF image header */
-    offset: usize,         /* Number of bytes to skip before number */
-) -> bool {
+///
+/// # Parameters
+///
+/// * `irafheader` — IRAF image header
+/// * `offset`     — Number of bytes to skip before number
+fn isirafswapped(irafheader: &[c_char], offset: usize) -> bool {
     let mut swapped = false;
 
     swapped = irafheader[offset] != 0;
@@ -1200,11 +1202,11 @@ fn isirafswapped(
     swapped
 }
 
-/*--------------------------------------------------------------------------*/
-fn irafgeti4(
-    irafheader: &[c_char], /* IRAF image header */
-    offset: usize,         /* Number of bytes to skip before number */
-) -> c_int {
+/// # Parameters
+///
+/// * `irafheader` — IRAF image header
+/// * `offset`     — Number of bytes to skip before number
+fn irafgeti4(irafheader: &[c_char], offset: usize) -> c_int {
     let cheader = irafheader;
 
     let mut itemp: [c_int; 1] = [0; 1];
@@ -1227,25 +1229,27 @@ fn irafgeti4(
     itemp[0]
 }
 
-/*--------------------------------------------------------------------------*/
 /// IRAFGETC2 -- Get character string from arbitrary part of v.1 IRAF header
-fn irafgetc2(
-    irafheader: &[c_char], /* IRAF image header */
-    offset: usize,         /* Number of bytes to skip before string */
-    nc: usize,             /* Maximum number of characters in string */
-) -> Option<Vec<c_char>> {
+///
+/// # Parameters
+///
+/// * `irafheader` — IRAF image header
+/// * `offset`     — Number of bytes to skip before string
+/// * `nc`         — Maximum number of characters in string
+fn irafgetc2(irafheader: &[c_char], offset: usize, nc: usize) -> Option<Vec<c_char>> {
     let irafstring = irafgetc(irafheader, offset, 2 * (nc + 1));
 
     iraf2str(&irafstring.unwrap(), nc)
 }
 
-/*--------------------------------------------------------------------------*/
 /// IRAFGETC -- Get character string from arbitrary part of IRAF header
-fn irafgetc(
-    irafheader: &[c_char], /* IRAF image header */
-    offset: usize,         /* Number of bytes to skip before string */
-    nc: usize,             /* Maximum number of characters in string */
-) -> Option<Vec<c_char>> {
+///
+/// # Parameters
+///
+/// * `irafheader` — IRAF image header
+/// * `offset`     — Number of bytes to skip before string
+/// * `nc`         — Maximum number of characters in string
+fn irafgetc(irafheader: &[c_char], offset: usize, nc: usize) -> Option<Vec<c_char>> {
     let cheader = irafheader;
 
     let mut ctemp = Vec::new();
@@ -1265,12 +1269,13 @@ fn irafgetc(
     Some(ctemp)
 }
 
-/*--------------------------------------------------------------------------*/
 /// Convert IRAF 2-byte/char string to 1-byte/char string
-fn iraf2str(
-    irafstring: &[c_char], /* IRAF 2-byte/character string */
-    nchar: usize,          /* Number of characters in string */
-) -> Option<Vec<c_char>> {
+///
+/// # Parameters
+///
+/// * `irafstring` — IRAF 2-byte/character string
+/// * `nchar`      — Number of characters in string
+fn iraf2str(irafstring: &[c_char], nchar: usize) -> Option<Vec<c_char>> {
     let mut string = Vec::new();
 
     if string.try_reserve_exact(nchar + 1).is_err() {
@@ -1292,14 +1297,19 @@ fn iraf2str(
     Some(string)
 }
 
-/*--------------------------------------------------------------------------*/
 /// IRAFSWAP -- Reverse bytes of any type of vector in place
+///
+/// # Parameters
+///
+/// * `bitpix` — Number of bits per pixel
+/// * `string` — Address of starting point of bytes to swap
+/// * `nbytes` — Number of bytes to swap
 fn irafswap(
-    bitpix: c_int, /* Number of bits per pixel */
+    bitpix: c_int,
     /*  16 = short, -16 = unsigned short, 32 = int */
     /* -32 = float, -64 = double */
-    string: &mut [c_char], /* Address of starting point of bytes to swap */
-    nbytes: usize,         /* Number of bytes to swap */
+    string: &mut [c_char],
+    nbytes: usize,
 ) {
     match bitpix {
         16 => {
@@ -1336,12 +1346,13 @@ fn irafswap(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 ///IRAFSWAP2 -- Swap bytes in string in place
-fn irafswap2(
-    string: &mut [c_char], /* Address of starting point of bytes to swap */
-    nbytes: usize,         /* Number of bytes to swap */
-) {
+///
+/// # Parameters
+///
+/// * `string` — Address of starting point of bytes to swap
+/// * `nbytes` — Number of bytes to swap
+fn irafswap2(string: &mut [c_char], nbytes: usize) {
     let slast = nbytes;
     let mut sbyte = 0;
     while sbyte < slast {
@@ -1350,12 +1361,13 @@ fn irafswap2(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// IRAFSWAP4 -- Reverse bytes of Integer*4 or Real*4 vector in place
-fn irafswap4(
-    string: &mut [c_char], /* Address of Integer*4 or Real*4 vector */
-    nbytes: usize,         /* Number of bytes to reverse */
-) {
+///
+/// # Parameters
+///
+/// * `string` — Address of Integer*4 or Real*4 vector
+/// * `nbytes` — Number of bytes to reverse
+fn irafswap4(string: &mut [c_char], nbytes: usize) {
     let slast = nbytes;
     let mut sbyte = 0;
     while sbyte < slast {
@@ -1371,12 +1383,13 @@ fn irafswap4(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// IRAFSWAP8 -- Reverse bytes of Real*8 vector in place
-fn irafswap8(
-    string: &mut [c_char], /* Address of Real*8 vector */
-    nbytes: usize,         /* Number of bytes to reverse */
-) {
+///
+/// # Parameters
+///
+/// * `string` — Address of Real*8 vector
+/// * `nbytes` — Number of bytes to reverse
+fn irafswap8(string: &mut [c_char], nbytes: usize) {
     let slast = nbytes;
     let mut sbyte = 0;
     while sbyte < slast {
@@ -1400,7 +1413,6 @@ fn irafswap8(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 fn machswap() -> bool {
     let mut itest: [c_int; 1] = [1; 1];
     let ctest: &[c_char] = cast_slice_mut(&mut itest);
@@ -1408,24 +1420,21 @@ fn machswap() -> bool {
     ctest[0] != 0
 }
 
-/*--------------------------------------------------------------------------*/
 /*             the following routines were originally in hget.c             */
-/*--------------------------------------------------------------------------*/
 
 static LHEAD0: usize = 0;
 
-/*--------------------------------------------------------------------------*/
 /// Extract long value for variable from FITS header string
-fn hgeti4(
-    hstring: &mut [c_char], /* character string containing FITS header information
-                            in the format <keyword>= <value> {/ <comment>} */
-    keyword: &[c_char], /* character string containing the name of the keyword
-                        the value of which is returned.  hget searches for a
-                        line beginning with this string.  if "[n]" is present,
-                        the n'th token in the value is returned.
-                        (the first 8 characters must be unique) */
-    ival: &mut c_int,
-) -> c_int {
+///
+/// # Parameters
+///
+/// * `hstring` — character string containing FITS header information in the format
+///              `<keyword>`= `<value>` {/ `<comment>`}
+/// * `keyword` — character string containing the name of the keyword the value of which
+///              is returned. hget searches for a line beginning with this string. if
+///              "`[n]`" is present, the n'th token in the value is returned. (the
+///              first 8 characters must be unique)
+fn hgeti4(hstring: &mut [c_char], keyword: &[c_char], ival: &mut c_int) -> c_int {
     let mut dval: f64 = 0.0;
     let mut minint: c_int = 0;
     let mut val: [c_char; 30] = [0; 30];
@@ -1456,19 +1465,19 @@ fn hgeti4(
     }
 }
 
-/*-------------------------------------------------------------------*/
 /// Extract string value for variable from FITS header string
-fn hgets(
-    hstring: &mut [c_char], /* character string containing FITS header information
-                            in the format <keyword>= <value> {/ <comment>} */
-    keyword: &[c_char], /* character string containing the name of the keyword
-                        the value of which is returned.  hget searches for a
-                        line beginning with this string.  if "[n]" is present,
-                        the n'th token in the value is returned.
-                        (the first 8 characters must be unique) */
-    lstr: usize,        /* Size of str in characters */
-    str: &mut [c_char], /* String (returned) */
-) -> c_int {
+///
+/// # Parameters
+///
+/// * `hstring` — character string containing FITS header information in the format
+///              `<keyword>`= `<value>` {/ `<comment>`}
+/// * `keyword` — character string containing the name of the keyword the value of which
+///              is returned. hget searches for a line beginning with this string. if
+///              "`[n]`" is present, the n'th token in the value is returned. (the
+///              first 8 characters must be unique)
+/// * `lstr`    — Size of str in characters
+/// * `str`     — String (returned)
+fn hgets(hstring: &mut [c_char], keyword: &[c_char], lstr: usize, str: &mut [c_char]) -> c_int {
     let mut lval: usize = 0;
 
     /* Get value and comment from header string */
@@ -1490,17 +1499,17 @@ fn hgets(
     }
 }
 
-/*-------------------------------------------------------------------*/
 /// Extract character value for variable from FITS header string
-fn hgetc(
-    hstring: &mut [c_char], /* character string containing FITS header information
-                            in the format <keyword>= <value> {/ <comment>} */
-    keyword0: &[c_char], /* character string containing the name of the keyword
-                         the value of which is returned.  hget searches for a
-                         line beginning with this string.  if "[n]" is present,
-                         the n'th token in the value is returned.
-                         (the first 8 characters must be unique) */
-) -> Option<Vec<c_char>> {
+///
+/// # Parameters
+///
+/// * `hstring`  — character string containing FITS header information in the format
+///               `<keyword>`= `<value>` {/ `<comment>`}
+/// * `keyword0` — character string containing the name of the keyword the value of
+///               which is returned. hget searches for a line beginning with this
+///               string. if "`[n]`" is present, the n'th token in the value is
+///               returned. (the first 8 characters must be unique)
+fn hgetc(hstring: &mut [c_char], keyword0: &[c_char]) -> Option<Vec<c_char>> {
     let mut cval: [c_char; 80] = [0; 80];
     // let value: Option<usize>;
     let mut squot: [c_char; 2] = [0; 2];
@@ -1665,22 +1674,24 @@ fn hgetc(
     Some(Vec::from(cval))
 }
 
-/*-------------------------------------------------------------------*/
 /// Find beginning of fillable blank line before FITS header keyword line
+///
+/// # Parameters
+///
+/// * `hstring` — character string containing fits-style header information in the
+///              format `<keyword>`= `<value>` {/ `<comment>`} the default is that each
+///              entry is 80 characters long; however, lines may be of arbitrary length
+///              terminated by nulls, carriage returns or linefeeds, if packed is true.
+/// * `keyword` — character string containing the name of the variable to be returned.
+///              ksearch searches for a line beginning with this string. The string may
+///              be a character literal or a character variable terminated by a null or
+///              '$'. it is truncated to 8 characters.
 fn blsearch(
     /* Find entry for keyword keyword in FITS header string hstring.
     (the keyword may have a maximum of eight letters)
     ptr::null_mut() is returned if the keyword is not found */
-    hstring: &mut [c_char], /* character string containing fits-style header
-                            information in the format <keyword>= <value> {/ <comment>}
-                            the default is that each entry is 80 characters long;
-                            however, lines may be of arbitrary length terminated by
-                            nulls, carriage returns or linefeeds, if packed is true.  */
-    keyword: &[c_char], /* character string containing the name of the variable
-                        to be returned.  ksearch searches for a line beginning
-                        with this string.  The string may be a character
-                        literal or a character variable terminated by a null
-                        or '$'.  it is truncated to 8 characters. */
+    hstring: &mut [c_char],
+    keyword: &[c_char],
 ) -> Option<usize> {
     let mut lhstr: usize = 0;
 
@@ -1758,22 +1769,24 @@ fn blsearch(
     if bval < pval { Some(bval) } else { None }
 }
 
-/*-------------------------------------------------------------------*/
 /// Find FITS header line containing specified keyword
+///
+/// # Parameters
+///
+/// * `hstring` — character string containing fits-style header information in the
+///              format `<keyword>`= `<value>` {/ `<comment>`} the default is that each
+///              entry is 80 characters long; however, lines may be of arbitrary length
+///              terminated by nulls, carriage returns or linefeeds, if packed is true.
+/// * `keyword` — character string containing the name of the variable to be returned.
+///              ksearch searches for a line beginning with this string. The string may
+///              be a character literal or a character variable terminated by a null or
+///              '$'. it is truncated to 8 characters.
 fn ksearch(
     /* Find entry for keyword keyword in FITS header string hstring.
     (the keyword may have a maximum of eight letters)
     ptr::null_mut() is returned if the keyword is not found */
-    hstring: &mut [c_char], /* character string containing fits-style header
-                            information in the format <keyword>= <value> {/ <comment>}
-                            the default is that each entry is 80 characters long;
-                            however, lines may be of arbitrary length terminated by
-                            nulls, carriage returns or linefeeds, if packed is true.  */
-    keyword: &[c_char], /* character string containing the name of the variable
-                        to be returned.  ksearch searches for a line beginning
-                        with this string.  The string may be a character
-                        literal or a character variable terminated by a null
-                        or '$'.  it is truncated to 8 characters. */
+    hstring: &mut [c_char],
+    keyword: &[c_char],
 ) -> Option<usize> {
     let mut icol: usize = 0;
     let mut lkey: usize = 0;
@@ -1837,23 +1850,25 @@ fn ksearch(
     pval
 }
 
-/*-------------------------------------------------------------------*/
 /// Find string s2 within null-terminated string s1
-fn strsrch(
-    s1: &[c_char], /* String to search */
-    s2: &[c_char], /* String to look for */
-) -> Option<usize> {
+///
+/// # Parameters
+///
+/// * `s1` — String to search
+/// * `s2` — String to look for
+fn strsrch(s1: &[c_char], s2: &[c_char]) -> Option<usize> {
     let ls1 = strlen_safe(s1);
     strnsrch(s1, s2, ls1)
 }
 
-/*-------------------------------------------------------------------*/
 /// Find string s2 within string s1
-fn strnsrch(
-    s1: &[c_char], /* String to search */
-    s2: &[c_char], /* String to look for */
-    ls1: usize,    /* Length of string being searched */
-) -> Option<usize> {
+///
+/// # Parameters
+///
+/// * `s1`  — String to search
+/// * `s2`  — String to look for
+/// * `ls1` — Length of string being searched
+fn strnsrch(s1: &[c_char], s2: &[c_char], ls1: usize) -> Option<usize> {
     let mut cfirst: c_char = 0;
     let mut clast: c_char = 0;
     let mut i: usize = 0;
@@ -1911,24 +1926,21 @@ fn strnsrch(
     None
 }
 
-/*-------------------------------------------------------------------*/
 /*             the following routines were originally in hget.c      */
-/*-------------------------------------------------------------------*/
 
-/*-------------------------------------------------------------------*/
 /// HPUTI4 - Set int keyword = ival in FITS header string
-fn hputi4(
-    hstring: &mut [c_char], /* character string containing FITS-style header
-                            information in the format
-                            <keyword>= <value> {/ <comment>}
-                            each entry is padded with spaces to 80 characters */
-
-    keyword: &[c_char], /* character string containing the name of the variable
-                        to be returned.  hput searches for a line beginning
-                        with this string, and if there isn't one, creates one.
-                           The first 8 characters of keyword must be unique. */
-    ival: c_int, /* int number */
-) {
+///
+/// # Parameters
+///
+/// * `hstring` — character string containing FITS-style header information in the
+///              format `<keyword>`= `<value>` {/ `<comment>`} each entry is padded
+///              with spaces to 80 characters
+/// * `keyword` — character string containing the name of the variable to be returned.
+///              hput searches for a line beginning with this string, and if there
+///              isn't one, creates one. The first 8 characters of keyword must be
+///              unique.
+/// * `ival`    — int number
+fn hputi4(hstring: &mut [c_char], keyword: &[c_char], ival: c_int) {
     let mut value: [c_char; 30] = [0; 30];
 
     /* Translate value from binary to ASCII */
@@ -1940,13 +1952,14 @@ fn hputi4(
     /* Return to calling program */
 }
 
-/*-------------------------------------------------------------------*/
 /// HPUTL - Set keyword = F if lval=0, else T, in FITS header string
-fn hputl(
-    hstring: &mut [c_char], /* FITS header */
-    keyword: &[c_char],     /* Keyword name */
-    lval: c_int,            /* logical variable (0=false, else true) */
-) {
+///
+/// # Parameters
+///
+/// * `hstring` — FITS header
+/// * `keyword` — Keyword name
+/// * `lval`    — logical variable (0=false, else true)
+fn hputl(hstring: &mut [c_char], keyword: &[c_char], lval: c_int) {
     let mut value: [c_char; 8] = [0; 8];
 
     /* Translate value from binary to ASCII */
@@ -1962,14 +1975,15 @@ fn hputl(
     /* Return to calling program */
 }
 
-/*-------------------------------------------------------------------*/
 ///  HPUTS - Set character string keyword = 'cval' in FITS header string
-fn hputs(
-    hstring: &mut [c_char], /* FITS header */
-    keyword: &[c_char],     /* Keyword name */
-    cval: &[c_char],        /* character string containing the value for variable
-                            keyword.  trailing and leading blanks are removed.  */
-) {
+///
+/// # Parameters
+///
+/// * `hstring` — FITS header
+/// * `keyword` — Keyword name
+/// * `cval`    — character string containing the value for variable keyword. trailing
+///              and leading blanks are removed.
+fn hputs(hstring: &mut [c_char], keyword: &[c_char], cval: &[c_char]) {
     let squot = 39;
     let mut value: [c_char; 70] = [0; 70];
 
@@ -1992,14 +2006,13 @@ fn hputs(
     /* Return to calling program */
 }
 
-/*---------------------------------------------------------------------*/
 /// HPUTC - Set character string keyword = value in FITS header string
-fn hputc(
-    hstring: &mut [c_char],
-    keyword: &[c_char],
-    value: &[c_char], /* character string containing the value for variable
-                      keyword.  trailing and leading blanks are removed.  */
-) {
+///
+/// # Parameters
+///
+/// * `value` — character string containing the value for variable keyword. trailing and
+///            leading blanks are removed.
+fn hputc(hstring: &mut [c_char], keyword: &[c_char], value: &[c_char]) {
     let squot: c_char = 39 as c_int as c_char;
     let mut line: [c_char; 100] = [0; 100];
     let mut newcom: [c_char; 50] = [0; 50];
@@ -2160,7 +2173,6 @@ fn hputc(
     }
 }
 
-/*-------------------------------------------------------------------*/
 /// HPUTCOM - Set comment for keyword or on line in FITS header string
 fn hputcom(hstring: &mut [c_char], keyword: &[c_char], comment: &[c_char]) {
     let mut squot: c_char = 0;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,6 +53,43 @@
 #![deny(clippy::std_instead_of_core, clippy::std_instead_of_alloc)]
 // #![deny(clippy::unnecessary_cast)]
 
+//! A Rust port of [CFITSIO](https://heasarc.gsfc.nasa.gov/fitsio/), the
+//! reference library for reading and writing FITS files.
+//!
+//! # Layout
+//!
+//! Every public CFITSIO routine `ffxyz` exists in three forms:
+//!
+//! * `ffxyz` — a `#[no_mangle] pub unsafe extern "C" fn` C ABI entry point,
+//!   which null-checks its raw pointers and delegates. These are
+//!   `#[deprecated]` so that internal callers reach for the safe form instead.
+//! * `ffxyz_safe` — the safe implementation, taking references, slices and
+//!   `Option`s. An opened file is an `Option<Box<fitsfile>>`.
+//! * an alias under its `fits_*` spelling in [`aliases`].
+//!
+//! [`aliases::c_api`] and [`aliases::rust_api`] mirror CFITSIO's `fitsio.h` and
+//! `longnam.h` exactly, and are the intended entry point; the implementation
+//! modules are exposed mainly so that the port can be read against the original
+//! C. [`fitsio`] holds the datatypes, symbolic constants and error status
+//! codes.
+//!
+//! # Error handling
+//!
+//! Routines return a `c_int` status code and also write it through their
+//! `status` parameter; `0` means success. A non-zero status on input is
+//! generally passed straight back out, so a sequence of calls can be made
+//! without checking in between. The symbolic names are in [`fitsio`], and
+//! [`aliases::rust_api::fits_get_errstatus`] turns one into a message.
+//!
+//! # Compression
+//!
+//! The PLIO, Rice and Hcompress codecs are the separate `pliocomp`, `ricecomp`
+//! and `hcompress` crates; GZIP uses `libz-rs-sys` and BZIP2 uses
+//! `libbz2-rs-sys` behind the default `bzip2` feature. Quantization
+//! ([`quantize`]) and the tiled-image driver ([`imcompress`]) are in this
+//! crate.
+#![warn(missing_docs)]
+
 extern crate alloc;
 
 pub mod c_types;
@@ -146,8 +183,13 @@ use fitsio::{
 
 use crate::c_types::*;
 
+/// Serializes the critical sections that CFITSIO guards with `FFLOCK`.
 pub(crate) static MUTEX_LOCK: Mutex<bool> = Mutex::new(false);
 
+/// Enter a critical section, as CFITSIO's `FFLOCK` macro does.
+///
+/// Recovers from a poisoned mutex rather than panicking; see the comment in the
+/// body for why.
 pub(crate) fn FFLOCK<'a>() -> MutexGuard<'a, bool> {
     // Recover from a poisoned mutex rather than panicking. The guarded value is
     // just a sentinel bool used to serialize critical sections, so it isn't
@@ -159,15 +201,23 @@ pub(crate) fn FFLOCK<'a>() -> MutexGuard<'a, bool> {
         .unwrap_or_else(|poisoned| poisoned.into_inner())
 }
 
+/// Leave a critical section entered with [`FFLOCK`], as CFITSIO's `FFUNLOCK`
+/// macro does.
 pub(crate) fn FFUNLOCK(p: MutexGuard<'_, bool>) {
     drop(p);
 }
 
+/// Hands out a raw mutable pointer to `Self`, for the `extern "C"` entry
+/// points that must return one.
 pub trait ToRaw {
+    /// The raw mutable pointer to `self`.
     fn as_raw_mut(&mut self) -> *mut Self;
 }
 
+/// Flattens an optional buffer to the raw pointer the C API expects, mapping
+/// `None` to null.
 pub trait AsMutPtr<T> {
+    /// The raw pointer to the first element, or null if there is no buffer.
     fn as_mut_ptr(&self) -> *mut T;
 }
 
@@ -180,11 +230,17 @@ impl<T> AsMutPtr<T> for Option<&mut [T]> {
     }
 }
 
+/// Reinterprets a byte literal as a `c_char`, whose signedness is
+/// target-dependent.
 #[inline(always)]
 pub fn bb(n: u8) -> c_char {
     n as c_char
 }
 
+/// Formats into a `[c_char]` buffer, truncating at `$len - 1` and
+/// nul-terminating, as C's `snprintf` does.
+///
+/// Evaluates to the number of characters written, excluding the terminator.
 #[macro_export]
 macro_rules! int_snprintf {
     ($dst:expr, $len:expr, $($arg:tt)*) => {
@@ -204,6 +260,11 @@ macro_rules! int_snprintf {
     };
 }
 
+/// Borrows a `[c_char]` buffer as a string for formatting, stopping at the
+/// first nul.
+///
+/// FITS buffers can hold arbitrary bytes and may have no terminator at all, so
+/// invalid UTF-8 is replaced rather than causing a panic.
 #[macro_export]
 macro_rules! slice_to_str {
     ($e:expr) => {
@@ -218,6 +279,8 @@ macro_rules! slice_to_str {
     };
 }
 
+/// Borrows a `&CStr` literal as the `&[c_char]` the safe routines take,
+/// including its nul terminator.
 #[macro_export]
 macro_rules! cs {
     ($e: expr) => {
@@ -225,6 +288,13 @@ macro_rules! cs {
     };
 }
 
+/// Rebinds a `*const c_char` parameter as an `Option<&[c_char]>`, mapping null
+/// to `None`.
+///
+/// # Safety
+///
+/// The pointer, if non-null, must point at a nul-terminated string that stays
+/// valid for the lifetime of the binding.
 #[macro_export]
 macro_rules! nullable_slice_cstr {
     ($e: ident) => {
@@ -235,6 +305,13 @@ macro_rules! nullable_slice_cstr {
     };
 }
 
+/// Rebinds a `*mut c_char` parameter as an `Option<&mut [c_char]>`, mapping
+/// null to `None`.
+///
+/// # Safety
+///
+/// The pointer, if non-null, must point at a nul-terminated string that stays
+/// valid and uniquely borrowed for the lifetime of the binding.
 #[macro_export]
 macro_rules! nullable_slice_cstr_mut {
     ($e: ident) => {
@@ -250,6 +327,13 @@ macro_rules! nullable_slice_cstr_mut {
     };
 }
 
+/// Rebinds a non-null `*const c_char` parameter as a `&[c_char]`, including
+/// its nul terminator.
+///
+/// # Safety
+///
+/// The pointer must be non-null and point at a nul-terminated string that stays
+/// valid for the lifetime of the binding.
 #[macro_export]
 macro_rules! raw_to_slice {
     ($e: ident) => {
@@ -266,15 +350,29 @@ pub(crate) type TKeywordVecs<'a> = (
     Option<Vec<Option<&'a [c_char]>>>,
 );
 
+/// The raw `char **` column-keyword arrays a table-creation entry point
+/// receives, held together so they can be converted as a unit.
 pub(crate) struct TKeywords<'a> {
-    tfields: c_int,              /* I - number of columns in the table           */
-    ttype: *const *const c_char, /* I - name of each column                      */
-    tform: *const *const c_char, /* I - value of TFORMn keyword for each column  */
-    tunit: *const *const c_char, /* I - value of TUNITn keyword for each column  */
+    /// Number of columns in the table.
+    tfields: c_int,
+    /// Name of each column.
+    ttype: *const *const c_char,
+    /// Value of the `TFORMn` keyword for each column.
+    tform: *const *const c_char,
+    /// Value of the `TUNITn` keyword for each column.
+    tunit: *const *const c_char,
     marker: PhantomData<&'a ()>,
 }
 
 impl<'a> TKeywords<'a> {
+    /// Wraps the raw column-keyword arrays.
+    ///
+    /// # Parameters
+    ///
+    /// * `tfields` — (I) number of columns in the table
+    /// * `ttype`   — (I) name of each column
+    /// * `tform`   — (I) value of the `TFORMn` keyword for each column
+    /// * `tunit`   — (I) value of the `TUNITn` keyword for each column, or null
     pub fn new(
         tfields: c_int,
         ttype: *const *const c_char,
@@ -290,6 +388,15 @@ impl<'a> TKeywords<'a> {
         }
     }
 
+    /// Converts the raw arrays into borrowed slices.
+    ///
+    /// Returns empty vectors if `tfields` is 0 or if `ttype` or `tform` is
+    /// null, and `None` for `tunit` if that array is null.
+    ///
+    /// # Safety
+    ///
+    /// Each non-null pointer must point at `tfields` nul-terminated strings
+    /// that outlive `'a`.
     pub unsafe fn tkeywords_to_vecs(&'a self) -> TKeywordVecs<'a> {
         unsafe {
             // Handle case where tfields is 0 or pointers are null
@@ -342,6 +449,8 @@ impl<'a> TKeywords<'a> {
     }
 }
 
+/// Number of pixels in an image section running from `blc` to `trc` in steps
+/// of `inc`, along every axis.
 pub(crate) fn calculate_subsection_length(blc: &[c_long], trc: &[c_long], inc: &[c_long]) -> usize {
     assert!(blc.len() == trc.len() && blc.len() == inc.len());
 
@@ -357,6 +466,8 @@ pub(crate) fn calculate_subsection_length(blc: &[c_long], trc: &[c_long], inc: &
     acc
 }
 
+/// Number of pixels in an image section running from `blc` to `trc` with a
+/// step of one along every axis.
 pub(crate) fn calculate_subsection_length_unit(blc: &[c_long], trc: &[c_long]) -> usize {
     assert!(blc.len() == trc.len());
 
@@ -372,40 +483,69 @@ pub(crate) fn calculate_subsection_length_unit(blc: &[c_long], trc: &[c_long]) -
     acc
 }
 
+/// Borrows each `Vec` in a slice as a shared slice.
 pub(crate) fn vecs_to_slices<T>(vecs: &[Vec<T>]) -> Vec<&[T]> {
     vecs.iter().map(Vec::as_slice).collect()
 }
 
+/// Borrows each `Vec` in a slice as a mutable slice.
 pub(crate) fn vecs_to_slices_mut<T>(vecs: &mut [Vec<T>]) -> Vec<&mut [T]> {
     vecs.iter_mut().map(Vec::as_mut_slice).collect()
 }
 
 #[derive(Debug, PartialEq, Clone, Copy)]
+/// How a read routine should report undefined pixels.
 pub enum NullCheckType {
-    None = 0,         // No null checking
-    SetPixel = 1,     // Set undefined pixels as a null value
-    SetNullArray = 2, // Set a null array = 1 for undefined pixels
+    /// Do no null checking.
+    None = 0,
+    /// Set undefined pixels to the caller's null value.
+    SetPixel = 1,
+    /// Set the corresponding entry of a null array to 1 for undefined pixels.
+    SetNullArray = 2,
 }
 
+/// A null value of any of the datatypes the API accepts, as read from the
+/// caller's `void *`.
+///
+/// The C passes the null value as an untyped pointer alongside a datatype code;
+/// this carries the two together so the value cannot be read at the wrong type.
 #[derive(Debug, PartialEq, Clone)]
 pub enum NullValue {
+    /// A `float` null value.
     Float(f32),
+    /// A `double` null value.
     Double(f64),
+    /// A `long` null value.
     Long(c_long),
+    /// An `unsigned long` null value.
     ULong(c_ulong),
+    /// A signed 64-bit integer null value.
     LONGLONG(LONGLONG),
+    /// An unsigned 64-bit integer null value.
     ULONGLONG(ULONGLONG),
+    /// An `int` null value.
     Int(c_int),
+    /// An `unsigned int` null value.
     UInt(c_uint),
+    /// A `short` null value.
     Short(c_short),
+    /// An `unsigned short` null value.
     UShort(c_ushort),
+    /// A signed byte null value.
     Byte(i8),
+    /// An unsigned byte null value.
     UByte(c_uchar),
+    /// A logical null value.
     Logical(c_char),
+    /// A string null value.
     String(CString),
 }
 
 impl NullValue {
+    /// The null value widened to an `f64`, for the comparisons the scaling
+    /// code does in floating point.
+    ///
+    /// Returns `0.0` for [`NullValue::String`], which has no numeric value.
     pub fn get_value_as_f64(&self) -> f64 {
         match self {
             NullValue::Float(v) => f64::from(*v),
@@ -425,6 +565,17 @@ impl NullValue {
         }
     }
 
+    /// Reads a null value of the given datatype out of a caller-supplied
+    /// pointer.
+    ///
+    /// Returns `None` if `value` is null or `datatype` is not a recognized
+    /// code; the caller decides which of those is an error.
+    ///
+    /// # Safety
+    ///
+    /// `value`, if non-null, must point at a readable value of the type
+    /// `datatype` names. It is read unaligned, since the C commonly points it
+    /// into a byte buffer.
     pub fn from_raw_ptr(datatype: c_int, value: *const c_void) -> Option<Self> {
         if value.is_null() {
             return None;
@@ -482,28 +633,57 @@ impl NullValue {
     }
 }
 
+/// A borrowed keyword value of any of the datatypes the API accepts.
+///
+/// The shared counterpart of [`KeywordDatatypeMut`], used by the routines that
+/// write a keyword whose type is chosen at run time.
 #[derive(Debug, PartialEq)]
 pub enum KeywordDatatype<'a> {
+    /// A keyword value that is an unsigned byte.
     TBYTE(&'a c_uchar),
+    /// A keyword value that is a signed byte.
     TSBYTE(&'a c_schar),
+    /// A keyword value that is a `short`.
     TSHORT(&'a c_short),
+    /// A keyword value that is an `unsigned short`.
     TUSHORT(&'a c_ushort),
+    /// A keyword value that is an `int`.
     TINT(&'a c_int),
+    /// A keyword value that is an `unsigned int`.
     TUINT(&'a c_uint),
+    /// A keyword value that is a `long`.
     TLONG(&'a c_long),
+    /// A keyword value that is an `unsigned long`.
     TULONG(&'a c_ulong),
+    /// A keyword value that is a `float`.
     TFLOAT(&'a f32),
+    /// A keyword value that is a `double`.
     TDOUBLE(&'a f64),
+    /// A keyword value that is a string.
     TSTRING(&'a [c_char]),
+    /// A keyword value that is a logical value.
     TLOGICAL(&'a c_int),
+    /// A keyword value that is a single-precision complex value.
     TCOMPLEX(&'a [f32; 2]),
+    /// A keyword value that is a double-precision complex value.
     TDBLCOMPLEX(&'a [f64; 2]),
+    /// A keyword value that is an unsigned 64-bit integer.
     TULONGLONG(&'a ULONGLONG),
+    /// A keyword value that is a signed 64-bit integer.
     TLONGLONG(&'a LONGLONG),
+    /// The datatype code was not recognized; it is carried through so the
+    /// caller can report it.
     INVALID(c_int),
 }
 
 impl KeywordDatatype<'_> {
+    /// Borrows a keyword value of the given datatype from a caller-supplied
+    /// pointer, yielding [`KeywordDatatype::INVALID`] for an unrecognized code.
+    ///
+    /// # Safety
+    ///
+    /// `value` must be non-null and point at a readable, correctly aligned
+    /// value of the type `datatype` names, living at least as long as `'_`.
     pub fn from_datatype(datatype: c_int, value: *const c_void) -> Self {
         match datatype {
             TBYTE => KeywordDatatype::TBYTE(unsafe { &*value.cast::<c_uchar>() }),
@@ -528,6 +708,8 @@ impl KeywordDatatype<'_> {
         }
     }
 
+    /// The datatype code this variant corresponds to, or the code that was not
+    /// recognized for [`KeywordDatatype::INVALID`].
     pub fn to_datatype_code(&self) -> c_int {
         match self {
             KeywordDatatype::TBYTE(_) => TBYTE,
@@ -551,28 +733,61 @@ impl KeywordDatatype<'_> {
     }
 }
 
+/// A mutably borrowed keyword value of any of the datatypes the API accepts.
+///
+/// The mutable counterpart of [`KeywordDatatype`], used by the routines that
+/// read a keyword into a caller-supplied location whose type is chosen at run
+/// time.
 #[derive(Debug, PartialEq)]
 pub enum KeywordDatatypeMut<'a> {
+    /// A keyword value that is an unsigned byte.
     TBYTE(&'a mut c_uchar),
+    /// A keyword value that is a signed byte.
     TSBYTE(&'a mut c_char),
+    /// A keyword value that is a `short`.
     TSHORT(&'a mut c_short),
+    /// A keyword value that is an `unsigned short`.
     TUSHORT(&'a mut c_ushort),
+    /// A keyword value that is an `int`.
     TINT(&'a mut c_int),
+    /// A keyword value that is an `unsigned int`.
     TUINT(&'a mut c_uint),
+    /// A keyword value that is a `long`.
     TLONG(&'a mut c_long),
+    /// A keyword value that is an `unsigned long`.
     TULONG(&'a mut c_ulong),
+    /// A keyword value that is a `float`.
     TFLOAT(&'a mut f32),
+    /// A keyword value that is a `double`.
     TDOUBLE(&'a mut f64),
+    /// A keyword value that is a string.
     TSTRING(&'a mut [c_char; FLEN_VALUE]),
+    /// A keyword value that is a logical value.
     TLOGICAL(&'a mut c_int),
+    /// A keyword value that is a single-precision complex value.
     TCOMPLEX(&'a mut [f32; 2]),
+    /// A keyword value that is a double-precision complex value.
     TDBLCOMPLEX(&'a mut [f64; 2]),
+    /// A keyword value that is an unsigned 64-bit integer.
     TULONGLONG(&'a mut ULONGLONG),
+    /// A keyword value that is a signed 64-bit integer.
     TLONGLONG(&'a mut LONGLONG),
+    /// The datatype code was not recognized; it is carried through so the
+    /// caller can report it.
     INVALID(c_int),
 }
 
 impl KeywordDatatypeMut<'_> {
+    /// Mutably borrows a keyword value of the given datatype from a
+    /// caller-supplied pointer, yielding [`KeywordDatatypeMut::INVALID`] for an
+    /// unrecognized code.
+    ///
+    /// # Safety
+    ///
+    /// `value` must be non-null and point at a writable, correctly aligned,
+    /// uniquely borrowed value of the type `datatype` names, living at least as
+    /// long as `'_`. For [`TSTRING`] it must have room for [`FLEN_VALUE`]
+    /// characters.
     pub fn from_datatype(datatype: c_int, value: *mut c_void) -> Self {
         match datatype {
             TBYTE => KeywordDatatypeMut::TBYTE(unsafe { &mut *value.cast::<c_uchar>() }),
@@ -601,6 +816,8 @@ impl KeywordDatatypeMut<'_> {
         }
     }
 
+    /// The datatype code this variant corresponds to, or the code that was not
+    /// recognized for [`KeywordDatatypeMut::INVALID`].
     pub fn to_datatype_code(&self) -> c_int {
         match self {
             KeywordDatatypeMut::TBYTE(_) => TBYTE,
@@ -624,6 +841,8 @@ impl KeywordDatatypeMut<'_> {
     }
 }
 
+/// Width in bytes of one element of a datatype, or `None` if the code is not
+/// recognized. `TSTRING` reports the width of a pointer.
 pub(crate) fn bytes_per_datatype(datatype: c_int) -> Option<usize> {
     match datatype {
         TBIT => Some(1),
@@ -647,7 +866,10 @@ pub(crate) fn bytes_per_datatype(datatype: c_int) -> Option<usize> {
     }
 }
 
-//https://stackoverflow.com/questions/65601579/parse-an-integer-ignoring-any-non-numeric-suffix
+/// Parses a leading integer, ignoring any non-numeric suffix, as C's `atoi`
+/// does.
+///
+/// See <https://stackoverflow.com/questions/65601579/parse-an-integer-ignoring-any-non-numeric-suffix>.
 fn atoi<F: FromStr>(input: &str) -> Result<F, <F as FromStr>::Err> {
     let input = input.trim();
 
@@ -670,7 +892,8 @@ fn atoi<F: FromStr>(input: &str) -> Result<F, <F as FromStr>::Err> {
     input[..end_idx].parse::<F>()
 }
 
-/// Parse a c_char slice to c_int, matching C's atoi behavior (returns 0 on error)
+/// Parses a `[c_char]` buffer as a `c_int`, matching C's `atoi`: returns 0
+/// rather than an error on anything unparseable.
 fn parse_c_int(cs: &[c_char]) -> c_int {
     // Convert c_char slice to UTF-8 string
     if let Ok(s) = str::from_utf8(cast_slice(cs)) {
@@ -681,7 +904,10 @@ fn parse_c_int(cs: &[c_char]) -> c_int {
     }
 }
 
-// https://stackoverflow.com/questions/65264069/alignment-of-floating-point-numbers-printed-in-scientific-notation
+/// Formats a `double` in scientific notation with a fixed-width exponent, so
+/// that a column of them lines up as C's `%E` does.
+///
+/// See <https://stackoverflow.com/questions/65264069/alignment-of-floating-point-numbers-printed-in-scientific-notation>.
 fn fmt_f64(num: f64, precision: usize, exp_pad: usize) -> String {
     let mut num = format!("{num:.precision$E}");
     // Safe to `unwrap` as `num` is guaranteed to contain `'e'`
@@ -696,29 +922,40 @@ fn fmt_f64(num: f64, precision: usize, exp_pad: usize) -> String {
     num.to_string()
 }
 
+/// `fopen` mode string for writing a binary file.
 const WB_MODE: *const c_char = c"wb".as_ptr().cast::<c_char>();
+/// `fopen` mode string for reading a binary file.
 const RB_MODE: *const c_char = c"rb".as_ptr().cast::<c_char>();
 
 #[cfg(not(target_os = "windows"))]
 unsafe extern "C" {
 
+    /// The C runtime's standard input stream.
     #[cfg_attr(target_os = "macos", link_name = "__stdinp")]
     pub unsafe static mut stdin: *mut FILE;
 
+    /// The C runtime's standard output stream.
     #[cfg_attr(target_os = "macos", link_name = "__stdoutp")]
     pub unsafe static mut stdout: *mut FILE;
 
+    /// The C runtime's standard error stream.
     #[cfg_attr(target_os = "macos", link_name = "__stderrp")]
     pub unsafe static mut stderr: *mut FILE;
 }
 
 #[cfg(windows)]
 unsafe extern "C" {
+    /// The Windows CRT accessor for the standard streams, which are not
+    /// exported as symbols there. Index 0 is stdin, 1 stdout, 2 stderr.
     pub unsafe fn __acrt_iob_func(idx: libc::c_uint) -> *mut FILE;
 }
 
 #[macro_export]
 #[cfg(not(target_os = "windows"))]
+/// The C runtime's standard input stream.
+///
+/// A macro because Windows has no exported symbol for it: there the streams
+/// are reached through `__acrt_iob_func`.
 macro_rules! STDIN {
     () => {
         $crate::stdin
@@ -727,6 +964,10 @@ macro_rules! STDIN {
 
 #[macro_export]
 #[cfg(windows)]
+/// The C runtime's standard input stream.
+///
+/// A macro because Windows has no exported symbol for it: there the streams
+/// are reached through `__acrt_iob_func`.
 macro_rules! STDIN {
     () => {
         $crate::__acrt_iob_func(0)
@@ -735,6 +976,10 @@ macro_rules! STDIN {
 
 #[macro_export]
 #[cfg(not(target_os = "windows"))]
+/// The C runtime's standard output stream.
+///
+/// A macro because Windows has no exported symbol for it: there the streams
+/// are reached through `__acrt_iob_func`.
 macro_rules! STDOUT {
     () => {
         $crate::stdout
@@ -743,6 +988,10 @@ macro_rules! STDOUT {
 
 #[macro_export]
 #[cfg(windows)]
+/// The C runtime's standard output stream.
+///
+/// A macro because Windows has no exported symbol for it: there the streams
+/// are reached through `__acrt_iob_func`.
 macro_rules! STDOUT {
     () => {
         $crate::__acrt_iob_func(1)
@@ -751,6 +1000,10 @@ macro_rules! STDOUT {
 
 #[macro_export]
 #[cfg(not(target_os = "windows"))]
+/// The C runtime's standard error stream.
+///
+/// A macro because Windows has no exported symbol for it: there the streams
+/// are reached through `__acrt_iob_func`.
 macro_rules! STDERR {
     () => {
         $crate::stderr
@@ -759,6 +1012,10 @@ macro_rules! STDERR {
 
 #[macro_export]
 #[cfg(windows)]
+/// The C runtime's standard error stream.
+///
+/// A macro because Windows has no exported symbol for it: there the streams
+/// are reached through `__acrt_iob_func`.
 macro_rules! STDERR {
     () => {
         $crate::__acrt_iob_func(2)

--- a/src/modkey.rs
+++ b/src/modkey.rs
@@ -1,9 +1,21 @@
-/*  This file, modkey.rs, contains routines that modify, insert, or update  */
-/*  keywords in a FITS header.                                             */
-
-/*  The FITSIO software was written by William Pence at the High Energy    */
-/*  Astrophysic Science Archive Research Center (HEASARC) at the NASA      */
-/*  Goddard Space Flight Center.                                           */
+//! Routines that modify, insert, or update keywords in a FITS header.
+//!
+//! Three distinct operations, easily confused:
+//!
+//! * **modify** (`ffmky*`) changes the value of a keyword that must already
+//!   exist, leaving its comment alone;
+//! * **update** (`ffuky*`) changes it if it exists and appends it if it does
+//!   not;
+//! * **insert** (`ffiky*`) always adds a new card, at the current position
+//!   rather than at the end of the header.
+//!
+//! Also here are the routines that rename a keyword, modify only the comment
+//! field, and modify a value that uses the long-string convention.
+//!
+//! Ported from CFITSIO's `modkey.c`, written by William Pence at the High
+//! Energy Astrophysics Science Archive Research Center (HEASARC), NASA Goddard
+//! Space Flight Center.
+#![warn(missing_docs)]
 
 use core::ffi::CStr;
 
@@ -30,17 +42,25 @@ use crate::{bb, cs};
 use crate::{buffers::*, raw_to_slice};
 use crate::{fitsio::*, int_snprintf, slice_to_str};
 
-/*--------------------------------------------------------------------------*/
 /// Update the keyword, value and comment in the FITS header.
 /// The datatype is specified by the 2nd argument.
+///
+/// # Parameters
+///
+/// * `fptr`     — (I) FITS file pointer
+/// * `datatype` — (I) datatype of the value
+/// * `keyname`  — (I) name of keyword to write
+/// * `value`    — (I) keyword value
+/// * `comm`     — (I) keyword comment
+/// * `status`   — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffuky(
-    fptr: *mut fitsfile,    /* I - FITS file pointer        */
-    datatype: c_int,        /* I - datatype of the value    */
-    keyname: *const c_char, /* I - name of keyword to write */
-    value: *const c_void,   /* I - keyword value            */
-    comm: *const c_char,    /* I - keyword comment          */
-    status: *mut c_int,     /* IO - error status            */
+    fptr: *mut fitsfile,
+    datatype: c_int,
+    keyname: *const c_char,
+    value: *const c_void,
+    comm: *const c_char,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -56,17 +76,24 @@ pub unsafe extern "C" fn ffuky(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Update the keyword, value and comment in the FITS header.
 /// The datatype is specified by the 2nd argument.
 ///
 /// Heavily modified for safety.
+///
+/// # Parameters
+///
+/// * `fptr`     — (I) FITS file pointer
+/// * `datatype` — (I) datatype of the value
+/// * `keyname`  — (I) name of keyword to write
+/// * `comm`     — (I) keyword comment
+/// * `status`   — (IO) error status
 pub fn ffuky_safe(
-    fptr: &mut fitsfile,       /* I - FITS file pointer        */
-    datatype: KeywordDatatype, /* I - datatype of the value    */
-    keyname: &[c_char],        /* I - name of keyword to write */
-    comm: Option<&[c_char]>,   /* I - keyword comment          */
-    status: &mut c_int,        /* IO - error status            */
+    fptr: &mut fitsfile,
+    datatype: KeywordDatatype,
+    keyname: &[c_char],
+    comm: Option<&[c_char]>,
+    status: &mut c_int,
 ) -> c_int {
     if *status > 0 {
         /* inherit input status value if > 0 */
@@ -129,13 +156,18 @@ pub fn ffuky_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) keyword name
+/// * `comm`    — (I) keyword comment
+/// * `status`  — (IO) error status
 pub unsafe extern "C" fn ffukyu(
-    fptr: *mut fitsfile,    /* I - FITS file pointer  */
-    keyname: *const c_char, /* I - keyword name       */
-    comm: *const c_char,    /* I - keyword comment    */
-    status: *mut c_int,     /* IO - error status      */
+    fptr: *mut fitsfile,
+    keyname: *const c_char,
+    comm: *const c_char,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -149,12 +181,17 @@ pub unsafe extern "C" fn ffukyu(
     }
 }
 
-/*--------------------------------------------------------------------------*/
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) keyword name
+/// * `comm`    — (I) keyword comment
+/// * `status`  — (IO) error status
 pub fn ffukyu_safe(
-    fptr: &mut fitsfile,     /* I - FITS file pointer  */
-    keyname: &[c_char],      /* I - keyword name       */
-    comm: Option<&[c_char]>, /* I - keyword comment    */
-    status: &mut c_int,      /* IO - error status      */
+    fptr: &mut fitsfile,
+    keyname: &[c_char],
+    comm: Option<&[c_char]>,
+    status: &mut c_int,
 ) -> c_int {
     if *status > 0 {
         /* inherit input status value if > 0 */
@@ -170,14 +207,20 @@ pub fn ffukyu_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) keyword name
+/// * `value`   — (I) keyword value
+/// * `comm`    — (I) keyword comment
+/// * `status`  — (IO) error status
 pub unsafe extern "C" fn ffukys(
-    fptr: *mut fitsfile,    /* I - FITS file pointer  */
-    keyname: *const c_char, /* I - keyword name       */
-    value: *const c_char,   /* I - keyword value      */
-    comm: *const c_char,    /* I - keyword comment    */
-    status: *mut c_int,     /* IO - error status      */
+    fptr: *mut fitsfile,
+    keyname: *const c_char,
+    value: *const c_char,
+    comm: *const c_char,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -196,13 +239,19 @@ pub unsafe extern "C" fn ffukys(
     }
 }
 
-/*--------------------------------------------------------------------------*/
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) keyword name
+/// * `value`   — (I) keyword value
+/// * `comm`    — (I) keyword comment
+/// * `status`  — (IO) error status
 pub fn ffukys_safe(
-    fptr: &mut fitsfile,     /* I - FITS file pointer  */
-    keyname: &[c_char],      /* I - keyword name       */
-    value: &[c_char],        /* I - keyword value      */
-    comm: Option<&[c_char]>, /* I - keyword comment    */
-    status: &mut c_int,      /* IO - error status      */
+    fptr: &mut fitsfile,
+    keyname: &[c_char],
+    value: &[c_char],
+    comm: Option<&[c_char]>,
+    status: &mut c_int,
 ) -> c_int {
     if *status > 0 {
         /* inherit input status value if > 0 */
@@ -218,14 +267,20 @@ pub fn ffukys_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) keyword name
+/// * `value`   — (I) keyword value
+/// * `comm`    — (I) keyword comment
+/// * `status`  — (IO) error status
 pub unsafe extern "C" fn ffukls(
-    fptr: *mut fitsfile,    /* I - FITS file pointer  */
-    keyname: *const c_char, /* I - keyword name       */
-    value: *const c_char,   /* I - keyword value      */
-    comm: *const c_char,    /* I - keyword comment    */
-    status: *mut c_int,     /* IO - error status      */
+    fptr: *mut fitsfile,
+    keyname: *const c_char,
+    value: *const c_char,
+    comm: *const c_char,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -240,13 +295,19 @@ pub unsafe extern "C" fn ffukls(
     }
 }
 
-/*--------------------------------------------------------------------------*/
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) keyword name
+/// * `value`   — (I) keyword value
+/// * `comm`    — (I) keyword comment
+/// * `status`  — (IO) error status
 pub fn ffukls_safe(
-    fptr: &mut fitsfile,     /* I - FITS file pointer  */
-    keyname: &[c_char],      /* I - keyword name       */
-    value: &[c_char],        /* I - keyword value      */
-    comm: Option<&[c_char]>, /* I - keyword comment    */
-    status: &mut c_int,      /* IO - error status      */
+    fptr: &mut fitsfile,
+    keyname: &[c_char],
+    value: &[c_char],
+    comm: Option<&[c_char]>,
+    status: &mut c_int,
 ) -> c_int {
     /* update a long string keyword */
     let mut junk: [c_char; FLEN_ERRMSG] = [0; FLEN_ERRMSG];
@@ -269,14 +330,20 @@ pub fn ffukls_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) keyword name
+/// * `value`   — (I) keyword value
+/// * `comm`    — (I) keyword comment
+/// * `status`  — (IO) error status
 pub unsafe extern "C" fn ffukyl(
-    fptr: *mut fitsfile,    /* I - FITS file pointer  */
-    keyname: *const c_char, /* I - keyword name       */
-    value: c_int,           /* I - keyword value      */
-    comm: *const c_char,    /* I - keyword comment    */
-    status: *mut c_int,     /* IO - error status      */
+    fptr: *mut fitsfile,
+    keyname: *const c_char,
+    value: c_int,
+    comm: *const c_char,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -290,13 +357,19 @@ pub unsafe extern "C" fn ffukyl(
     }
 }
 
-/*--------------------------------------------------------------------------*/
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) keyword name
+/// * `value`   — (I) keyword value
+/// * `comm`    — (I) keyword comment
+/// * `status`  — (IO) error status
 pub fn ffukyl_safe(
-    fptr: &mut fitsfile,     /* I - FITS file pointer  */
-    keyname: &[c_char],      /* I - keyword name       */
-    value: c_int,            /* I - keyword value      */
-    comm: Option<&[c_char]>, /* I - keyword comment    */
-    status: &mut c_int,      /* IO - error status      */
+    fptr: &mut fitsfile,
+    keyname: &[c_char],
+    value: c_int,
+    comm: Option<&[c_char]>,
+    status: &mut c_int,
 ) -> c_int {
     if *status > 0 {
         /* inherit input status value if > 0 */
@@ -312,14 +385,20 @@ pub fn ffukyl_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) keyword name
+/// * `value`   — (I) keyword value
+/// * `comm`    — (I) keyword comment
+/// * `status`  — (IO) error status
 pub unsafe extern "C" fn ffukyj(
-    fptr: *mut fitsfile,    /* I - FITS file pointer  */
-    keyname: *const c_char, /* I - keyword name       */
-    value: LONGLONG,        /* I - keyword value      */
-    comm: *const c_char,    /* I - keyword comment    */
-    status: *mut c_int,     /* IO - error status      */
+    fptr: *mut fitsfile,
+    keyname: *const c_char,
+    value: LONGLONG,
+    comm: *const c_char,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -333,13 +412,19 @@ pub unsafe extern "C" fn ffukyj(
     }
 }
 
-/*--------------------------------------------------------------------------*/
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) keyword name
+/// * `value`   — (I) keyword value
+/// * `comm`    — (I) keyword comment
+/// * `status`  — (IO) error status
 pub fn ffukyj_safe(
-    fptr: &mut fitsfile,     /* I - FITS file pointer  */
-    keyname: &[c_char],      /* I - keyword name       */
-    value: LONGLONG,         /* I - keyword value      */
-    comm: Option<&[c_char]>, /* I - keyword comment    */
-    status: &mut c_int,      /* IO - error status      */
+    fptr: &mut fitsfile,
+    keyname: &[c_char],
+    value: LONGLONG,
+    comm: Option<&[c_char]>,
+    status: &mut c_int,
 ) -> c_int {
     if *status > 0 {
         /* inherit input status value if > 0 */
@@ -355,14 +440,20 @@ pub fn ffukyj_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) keyword name
+/// * `value`   — (I) keyword value
+/// * `comm`    — (I) keyword comment
+/// * `status`  — (IO) error status
 pub unsafe extern "C" fn ffukyuj(
-    fptr: *mut fitsfile,    /* I - FITS file pointer  */
-    keyname: *const c_char, /* I - keyword name       */
-    value: ULONGLONG,       /* I - keyword value      */
-    comm: *const c_char,    /* I - keyword comment    */
-    status: *mut c_int,     /* IO - error status      */
+    fptr: *mut fitsfile,
+    keyname: *const c_char,
+    value: ULONGLONG,
+    comm: *const c_char,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -376,13 +467,19 @@ pub unsafe extern "C" fn ffukyuj(
     }
 }
 
-/*--------------------------------------------------------------------------*/
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) keyword name
+/// * `value`   — (I) keyword value
+/// * `comm`    — (I) keyword comment
+/// * `status`  — (IO) error status
 pub fn ffukyuj_safe(
-    fptr: &mut fitsfile,     /* I - FITS file pointer  */
-    keyname: &[c_char],      /* I - keyword name       */
-    value: ULONGLONG,        /* I - keyword value      */
-    comm: Option<&[c_char]>, /* I - keyword comment    */
-    status: &mut c_int,      /* IO - error status      */
+    fptr: &mut fitsfile,
+    keyname: &[c_char],
+    value: ULONGLONG,
+    comm: Option<&[c_char]>,
+    status: &mut c_int,
 ) -> c_int {
     if *status > 0 {
         /* inherit input status value if > 0 */
@@ -398,15 +495,22 @@ pub fn ffukyuj_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) keyword name
+/// * `value`   — (I) keyword value
+/// * `decim`   — (I) no of decimals
+/// * `comm`    — (I) keyword comment
+/// * `status`  — (IO) error status
 pub unsafe extern "C" fn ffukyf(
-    fptr: *mut fitsfile,    /* I - FITS file pointer  */
-    keyname: *const c_char, /* I - keyword name       */
-    value: f32,             /* I - keyword value      */
-    decim: c_int,           /* I - no of decimals     */
-    comm: *const c_char,    /* I - keyword comment    */
-    status: *mut c_int,     /* IO - error status      */
+    fptr: *mut fitsfile,
+    keyname: *const c_char,
+    value: f32,
+    decim: c_int,
+    comm: *const c_char,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -420,14 +524,21 @@ pub unsafe extern "C" fn ffukyf(
     }
 }
 
-/*--------------------------------------------------------------------------*/
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) keyword name
+/// * `value`   — (I) keyword value
+/// * `decim`   — (I) no of decimals
+/// * `comm`    — (I) keyword comment
+/// * `status`  — (IO) error status
 pub fn ffukyf_safe(
-    fptr: &mut fitsfile,     /* I - FITS file pointer  */
-    keyname: &[c_char],      /* I - keyword name       */
-    value: f32,              /* I - keyword value      */
-    decim: c_int,            /* I - no of decimals     */
-    comm: Option<&[c_char]>, /* I - keyword comment    */
-    status: &mut c_int,      /* IO - error status      */
+    fptr: &mut fitsfile,
+    keyname: &[c_char],
+    value: f32,
+    decim: c_int,
+    comm: Option<&[c_char]>,
+    status: &mut c_int,
 ) -> c_int {
     if *status > 0 {
         /* inherit input status value if > 0 */
@@ -443,15 +554,22 @@ pub fn ffukyf_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) keyword name
+/// * `value`   — (I) keyword value
+/// * `decim`   — (I) no of decimals
+/// * `comm`    — (I) keyword comment
+/// * `status`  — (IO) error status
 pub unsafe extern "C" fn ffukye(
-    fptr: *mut fitsfile,    /* I - FITS file pointer  */
-    keyname: *const c_char, /* I - keyword name       */
-    value: f32,             /* I - keyword value      */
-    decim: c_int,           /* I - no of decimals     */
-    comm: *const c_char,    /* I - keyword comment    */
-    status: *mut c_int,     /* IO - error status      */
+    fptr: *mut fitsfile,
+    keyname: *const c_char,
+    value: f32,
+    decim: c_int,
+    comm: *const c_char,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -465,14 +583,21 @@ pub unsafe extern "C" fn ffukye(
     }
 }
 
-/*--------------------------------------------------------------------------*/
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) keyword name
+/// * `value`   — (I) keyword value
+/// * `decim`   — (I) no of decimals
+/// * `comm`    — (I) keyword comment
+/// * `status`  — (IO) error status
 pub fn ffukye_safe(
-    fptr: &mut fitsfile,     /* I - FITS file pointer  */
-    keyname: &[c_char],      /* I - keyword name       */
-    value: f32,              /* I - keyword value      */
-    decim: c_int,            /* I - no of decimals     */
-    comm: Option<&[c_char]>, /* I - keyword comment    */
-    status: &mut c_int,      /* IO - error status      */
+    fptr: &mut fitsfile,
+    keyname: &[c_char],
+    value: f32,
+    decim: c_int,
+    comm: Option<&[c_char]>,
+    status: &mut c_int,
 ) -> c_int {
     if *status > 0 {
         /* inherit input status value if > 0 */
@@ -488,15 +613,22 @@ pub fn ffukye_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) keyword name
+/// * `value`   — (I) keyword value
+/// * `decim`   — (I) no of decimals
+/// * `comm`    — (I) keyword comment
+/// * `status`  — (IO) error status
 pub unsafe extern "C" fn ffukyg(
-    fptr: *mut fitsfile,    /* I - FITS file pointer  */
-    keyname: *const c_char, /* I - keyword name       */
-    value: f64,             /* I - keyword value      */
-    decim: c_int,           /* I - no of decimals     */
-    comm: *const c_char,    /* I - keyword comment    */
-    status: *mut c_int,     /* IO - error status      */
+    fptr: *mut fitsfile,
+    keyname: *const c_char,
+    value: f64,
+    decim: c_int,
+    comm: *const c_char,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -510,14 +642,21 @@ pub unsafe extern "C" fn ffukyg(
     }
 }
 
-/*--------------------------------------------------------------------------*/
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) keyword name
+/// * `value`   — (I) keyword value
+/// * `decim`   — (I) no of decimals
+/// * `comm`    — (I) keyword comment
+/// * `status`  — (IO) error status
 pub fn ffukyg_safe(
-    fptr: &mut fitsfile,     /* I - FITS file pointer  */
-    keyname: &[c_char],      /* I - keyword name       */
-    value: f64,              /* I - keyword value      */
-    decim: c_int,            /* I - no of decimals     */
-    comm: Option<&[c_char]>, /* I - keyword comment    */
-    status: &mut c_int,      /* IO - error status      */
+    fptr: &mut fitsfile,
+    keyname: &[c_char],
+    value: f64,
+    decim: c_int,
+    comm: Option<&[c_char]>,
+    status: &mut c_int,
 ) -> c_int {
     if *status > 0 {
         /* inherit input status value if > 0 */
@@ -533,15 +672,22 @@ pub fn ffukyg_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) keyword name
+/// * `value`   — (I) keyword value
+/// * `decim`   — (I) no of decimals
+/// * `comm`    — (I) keyword comment
+/// * `status`  — (IO) error status
 pub unsafe extern "C" fn ffukyd(
-    fptr: *mut fitsfile,    /* I - FITS file pointer  */
-    keyname: *const c_char, /* I - keyword name       */
-    value: f64,             /* I - keyword value      */
-    decim: c_int,           /* I - no of decimals     */
-    comm: *const c_char,    /* I - keyword comment    */
-    status: *mut c_int,     /* IO - error status      */
+    fptr: *mut fitsfile,
+    keyname: *const c_char,
+    value: f64,
+    decim: c_int,
+    comm: *const c_char,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -555,14 +701,21 @@ pub unsafe extern "C" fn ffukyd(
     }
 }
 
-/*--------------------------------------------------------------------------*/
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) keyword name
+/// * `value`   — (I) keyword value
+/// * `decim`   — (I) no of decimals
+/// * `comm`    — (I) keyword comment
+/// * `status`  — (IO) error status
 pub fn ffukyd_safe(
-    fptr: &mut fitsfile,     /* I - FITS file pointer  */
-    keyname: &[c_char],      /* I - keyword name       */
-    value: f64,              /* I - keyword value      */
-    decim: c_int,            /* I - no of decimals     */
-    comm: Option<&[c_char]>, /* I - keyword comment    */
-    status: &mut c_int,      /* IO - error status      */
+    fptr: &mut fitsfile,
+    keyname: &[c_char],
+    value: f64,
+    decim: c_int,
+    comm: Option<&[c_char]>,
+    status: &mut c_int,
 ) -> c_int {
     if *status > 0 {
         /* inherit input status value if > 0 */
@@ -578,15 +731,22 @@ pub fn ffukyd_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) keyword name
+/// * `value`   — (I) keyword value
+/// * `decim`   — (I) no of decimals
+/// * `comm`    — (I) keyword comment
+/// * `status`  — (IO) error status
 pub unsafe extern "C" fn ffukfc(
-    fptr: *mut fitsfile,    /* I - FITS file pointer  */
-    keyname: *const c_char, /* I - keyword name       */
-    value: *const [f32; 2], /* I - keyword value      */
-    decim: c_int,           /* I - no of decimals     */
-    comm: *const c_char,    /* I - keyword comment    */
-    status: *mut c_int,     /* IO - error status      */
+    fptr: *mut fitsfile,
+    keyname: *const c_char,
+    value: *const [f32; 2],
+    decim: c_int,
+    comm: *const c_char,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -600,14 +760,21 @@ pub unsafe extern "C" fn ffukfc(
     }
 }
 
-/*--------------------------------------------------------------------------*/
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) keyword name
+/// * `value`   — (I) keyword value
+/// * `decim`   — (I) no of decimals
+/// * `comm`    — (I) keyword comment
+/// * `status`  — (IO) error status
 pub fn ffukfc_safe(
-    fptr: &mut fitsfile,     /* I - FITS file pointer  */
-    keyname: &[c_char],      /* I - keyword name       */
-    value: &[f32; 2],        /* I - keyword value      */
-    decim: c_int,            /* I - no of decimals     */
-    comm: Option<&[c_char]>, /* I - keyword comment    */
-    status: &mut c_int,      /* IO - error status      */
+    fptr: &mut fitsfile,
+    keyname: &[c_char],
+    value: &[f32; 2],
+    decim: c_int,
+    comm: Option<&[c_char]>,
+    status: &mut c_int,
 ) -> c_int {
     if *status > 0 {
         /* inherit input status value if > 0 */
@@ -623,15 +790,22 @@ pub fn ffukfc_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) keyword name
+/// * `value`   — (I) keyword value
+/// * `decim`   — (I) no of decimals
+/// * `comm`    — (I) keyword comment
+/// * `status`  — (IO) error status
 pub unsafe extern "C" fn ffukyc(
-    fptr: *mut fitsfile,    /* I - FITS file pointer  */
-    keyname: *const c_char, /* I - keyword name       */
-    value: *const [f32; 2], /* I - keyword value      */
-    decim: c_int,           /* I - no of decimals     */
-    comm: *const c_char,    /* I - keyword comment    */
-    status: *mut c_int,     /* IO - error status      */
+    fptr: *mut fitsfile,
+    keyname: *const c_char,
+    value: *const [f32; 2],
+    decim: c_int,
+    comm: *const c_char,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -646,14 +820,21 @@ pub unsafe extern "C" fn ffukyc(
     }
 }
 
-/*--------------------------------------------------------------------------*/
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) keyword name
+/// * `value`   — (I) keyword value
+/// * `decim`   — (I) no of decimals
+/// * `comm`    — (I) keyword comment
+/// * `status`  — (IO) error status
 pub fn ffukyc_safe(
-    fptr: &mut fitsfile,     /* I - FITS file pointer  */
-    keyname: &[c_char],      /* I - keyword name       */
-    value: &[f32; 2],        /* I - keyword value      */
-    decim: c_int,            /* I - no of decimals     */
-    comm: Option<&[c_char]>, /* I - keyword comment    */
-    status: &mut c_int,      /* IO - error status      */
+    fptr: &mut fitsfile,
+    keyname: &[c_char],
+    value: &[f32; 2],
+    decim: c_int,
+    comm: Option<&[c_char]>,
+    status: &mut c_int,
 ) -> c_int {
     if *status > 0 {
         /* inherit input status value if > 0 */
@@ -669,15 +850,22 @@ pub fn ffukyc_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) keyword name
+/// * `value`   — (I) keyword value
+/// * `decim`   — (I) no of decimals
+/// * `comm`    — (I) keyword comment
+/// * `status`  — (IO) error status
 pub unsafe extern "C" fn ffukfm(
-    fptr: *mut fitsfile,    /* I - FITS file pointer  */
-    keyname: *const c_char, /* I - keyword name       */
-    value: *const [f64; 2], /* I - keyword value      */
-    decim: c_int,           /* I - no of decimals     */
-    comm: *const c_char,    /* I - keyword comment    */
-    status: *mut c_int,     /* IO - error status      */
+    fptr: *mut fitsfile,
+    keyname: *const c_char,
+    value: *const [f64; 2],
+    decim: c_int,
+    comm: *const c_char,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -692,14 +880,21 @@ pub unsafe extern "C" fn ffukfm(
     }
 }
 
-/*--------------------------------------------------------------------------*/
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) keyword name
+/// * `value`   — (I) keyword value
+/// * `decim`   — (I) no of decimals
+/// * `comm`    — (I) keyword comment
+/// * `status`  — (IO) error status
 pub fn ffukfm_safe(
-    fptr: &mut fitsfile,     /* I - FITS file pointer  */
-    keyname: &[c_char],      /* I - keyword name       */
-    value: &[f64; 2],        /* I - keyword value      */
-    decim: c_int,            /* I - no of decimals     */
-    comm: Option<&[c_char]>, /* I - keyword comment    */
-    status: &mut c_int,      /* IO - error status      */
+    fptr: &mut fitsfile,
+    keyname: &[c_char],
+    value: &[f64; 2],
+    decim: c_int,
+    comm: Option<&[c_char]>,
+    status: &mut c_int,
 ) -> c_int {
     if *status > 0 {
         /* inherit input status value if > 0 */
@@ -715,15 +910,22 @@ pub fn ffukfm_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) keyword name
+/// * `value`   — (I) keyword value
+/// * `decim`   — (I) no of decimals
+/// * `comm`    — (I) keyword comment
+/// * `status`  — (IO) error status
 pub unsafe extern "C" fn ffukym(
-    fptr: *mut fitsfile,    /* I - FITS file pointer  */
-    keyname: *const c_char, /* I - keyword name       */
-    value: *const [f64; 2], /* I - keyword value      */
-    decim: c_int,           /* I - no of decimals     */
-    comm: *const c_char,    /* I - keyword comment    */
-    status: *mut c_int,     /* IO - error status      */
+    fptr: *mut fitsfile,
+    keyname: *const c_char,
+    value: *const [f64; 2],
+    decim: c_int,
+    comm: *const c_char,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -738,14 +940,21 @@ pub unsafe extern "C" fn ffukym(
     }
 }
 
-/*--------------------------------------------------------------------------*/
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) keyword name
+/// * `value`   — (I) keyword value
+/// * `decim`   — (I) no of decimals
+/// * `comm`    — (I) keyword comment
+/// * `status`  — (IO) error status
 pub fn ffukym_safe(
-    fptr: &mut fitsfile,     /* I - FITS file pointer  */
-    keyname: &[c_char],      /* I - keyword name       */
-    value: &[f64; 2],        /* I - keyword value      */
-    decim: c_int,            /* I - no of decimals     */
-    comm: Option<&[c_char]>, /* I - keyword comment    */
-    status: &mut c_int,      /* IO - error status      */
+    fptr: &mut fitsfile,
+    keyname: &[c_char],
+    value: &[f64; 2],
+    decim: c_int,
+    comm: Option<&[c_char]>,
+    status: &mut c_int,
 ) -> c_int {
     if *status > 0 {
         /* inherit input status value if > 0 */
@@ -761,13 +970,18 @@ pub fn ffukym_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) keyword name
+/// * `card`    — (I) card string value
+/// * `status`  — (IO) error status
 pub unsafe extern "C" fn ffucrd(
-    fptr: *mut fitsfile,    /* I - FITS file pointer  */
-    keyname: *const c_char, /* I - keyword name       */
-    card: *const c_char,    /* I - card string value  */
-    status: *mut c_int,     /* IO - error status      */
+    fptr: *mut fitsfile,
+    keyname: *const c_char,
+    card: *const c_char,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -780,12 +994,17 @@ pub unsafe extern "C" fn ffucrd(
     }
 }
 
-/*--------------------------------------------------------------------------*/
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) keyword name
+/// * `card`    — (I) card string value
+/// * `status`  — (IO) error status
 pub fn ffucrd_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer  */
-    keyname: &[c_char],  /* I - keyword name       */
-    card: &[c_char],     /* I - card string value  */
-    status: &mut c_int,  /* IO - error status      */
+    fptr: &mut fitsfile,
+    keyname: &[c_char],
+    card: &[c_char],
+    status: &mut c_int,
 ) -> c_int {
     let mut tstatus = 0;
 
@@ -803,13 +1022,18 @@ pub fn ffucrd_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `nkey`   — (I) number of the keyword to modify
+/// * `card`   — (I) card string value
+/// * `status` — (IO) error status
 pub unsafe extern "C" fn ffmrec(
-    fptr: *mut fitsfile, /* I - FITS file pointer               */
-    nkey: c_int,         /* I - number of the keyword to modify */
-    card: *const c_char, /* I - card string value               */
-    status: *mut c_int,  /* IO - error status                   */
+    fptr: *mut fitsfile,
+    nkey: c_int,
+    card: *const c_char,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -822,13 +1046,13 @@ pub unsafe extern "C" fn ffmrec(
     }
 }
 
-/*--------------------------------------------------------------------------*/
-pub fn ffmrec_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer               */
-    nkey: c_int,         /* I - number of the keyword to modify */
-    card: &[c_char],     /* I - card string value               */
-    status: &mut c_int,  /* IO - error status                   */
-) -> c_int {
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `nkey`   — (I) number of the keyword to modify
+/// * `card`   — (I) card string value
+/// * `status` — (IO) error status
+pub fn ffmrec_safe(fptr: &mut fitsfile, nkey: c_int, card: &[c_char], status: &mut c_int) -> c_int {
     if *status > 0 {
         /* inherit input status value if > 0 */
         return *status;
@@ -839,13 +1063,18 @@ pub fn ffmrec_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) keyword name
+/// * `card`    — (I) card string value
+/// * `status`  — (IO) error status
 pub unsafe extern "C" fn ffmcrd(
-    fptr: *mut fitsfile,    /* I - FITS file pointer  */
-    keyname: *const c_char, /* I - keyword name       */
-    card: *const c_char,    /* I - card string value  */
-    status: *mut c_int,     /* IO - error status      */
+    fptr: *mut fitsfile,
+    keyname: *const c_char,
+    card: *const c_char,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -859,12 +1088,17 @@ pub unsafe extern "C" fn ffmcrd(
     }
 }
 
-/*--------------------------------------------------------------------------*/
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) keyword name
+/// * `card`    — (I) card string value
+/// * `status`  — (IO) error status
 pub fn ffmcrd_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer  */
-    keyname: &[c_char],  /* I - keyword name       */
-    card: &[c_char],     /* I - card string value  */
-    status: &mut c_int,  /* IO - error status      */
+    fptr: &mut fitsfile,
+    keyname: &[c_char],
+    card: &[c_char],
+    status: &mut c_int,
 ) -> c_int {
     let mut tcard: [c_char; FLEN_CARD] = [0; FLEN_CARD];
     let mut valstring: [c_char; FLEN_CARD] = [0; FLEN_CARD];
@@ -920,13 +1154,18 @@ pub fn ffmcrd_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `oldname` — (I) existing keyword name
+/// * `newname` — (I) new name for keyword
+/// * `status`  — (IO) error status
 pub unsafe extern "C" fn ffmnam(
-    fptr: *mut fitsfile,    /* I - FITS file pointer     */
-    oldname: *const c_char, /* I - existing keyword name */
-    newname: *const c_char, /* I - new name for keyword  */
-    status: *mut c_int,     /* IO - error status         */
+    fptr: *mut fitsfile,
+    oldname: *const c_char,
+    newname: *const c_char,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -940,12 +1179,17 @@ pub unsafe extern "C" fn ffmnam(
     }
 }
 
-/*--------------------------------------------------------------------------*/
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `oldname` — (I) existing keyword name
+/// * `newname` — (I) new name for keyword
+/// * `status`  — (IO) error status
 pub fn ffmnam_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer     */
-    oldname: &[c_char],  /* I - existing keyword name */
-    newname: &[c_char],  /* I - new name for keyword  */
-    status: &mut c_int,  /* IO - error status         */
+    fptr: &mut fitsfile,
+    oldname: &[c_char],
+    newname: &[c_char],
+    status: &mut c_int,
 ) -> c_int {
     let mut comm: [c_char; FLEN_COMMENT] = [0; FLEN_COMMENT];
     let mut value: [c_char; FLEN_VALUE] = [0; FLEN_VALUE];
@@ -966,13 +1210,18 @@ pub fn ffmnam_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) keyword name
+/// * `comm`    — (I) keyword comment
+/// * `status`  — (IO) error status
 pub unsafe extern "C" fn ffmcom(
-    fptr: *mut fitsfile,    /* I - FITS file pointer  */
-    keyname: *const c_char, /* I - keyword name       */
-    comm: *const c_char,    /* I - keyword comment    */
-    status: *mut c_int,     /* IO - error status      */
+    fptr: *mut fitsfile,
+    keyname: *const c_char,
+    comm: *const c_char,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -986,12 +1235,17 @@ pub unsafe extern "C" fn ffmcom(
     }
 }
 
-/*--------------------------------------------------------------------------*/
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) keyword name
+/// * `comm`    — (I) keyword comment
+/// * `status`  — (IO) error status
 pub fn ffmcom_safe(
-    fptr: &mut fitsfile,     /* I - FITS file pointer  */
-    keyname: &[c_char],      /* I - keyword name       */
-    comm: Option<&[c_char]>, /* I - keyword comment    */
-    status: &mut c_int,      /* IO - error status      */
+    fptr: &mut fitsfile,
+    keyname: &[c_char],
+    comm: Option<&[c_char]>,
+    status: &mut c_int,
 ) -> c_int {
     let mut oldcomm: [c_char; FLEN_COMMENT] = [0; FLEN_COMMENT];
     let mut value: [c_char; FLEN_VALUE] = [0; FLEN_VALUE];
@@ -1012,19 +1266,27 @@ pub fn ffmcom_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write (put) the units string into the comment field of the existing keyword.
 ///
 /// This routine uses a  FITS convention  in which the units are enclosed in
 /// square brackets following the '/' comment field delimiter, e.g.:
 ///
+/// ```text
 /// KEYWORD =                   12 / [kpc] comment string goes here
+/// ```
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) keyword name
+/// * `unit`    — (I) keyword unit string
+/// * `status`  — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffpunt(
-    fptr: *mut fitsfile,    /* I - FITS file pointer   */
-    keyname: *const c_char, /* I - keyword name        */
-    unit: *const c_char,    /* I - keyword unit string */
-    status: *mut c_int,     /* IO - error status       */
+    fptr: *mut fitsfile,
+    keyname: *const c_char,
+    unit: *const c_char,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -1038,18 +1300,26 @@ pub unsafe extern "C" fn ffpunt(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write (put) the units string into the comment field of the existing keyword.
 ///
 /// This routine uses a  FITS convention  in which the units are enclosed in
 /// square brackets following the '/' comment field delimiter, e.g.:
 ///
+/// ```text
 /// KEYWORD =                   12 / [kpc] comment string goes here
+/// ```
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) keyword name
+/// * `unit`    — (I) keyword unit string
+/// * `status`  — (IO) error status
 pub fn ffpunt_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer   */
-    keyname: &[c_char],  /* I - keyword name        */
-    unit: &[c_char],     /* I - keyword unit string */
-    status: &mut c_int,  /* IO - error status       */
+    fptr: &mut fitsfile,
+    keyname: &[c_char],
+    unit: &[c_char],
+    status: &mut c_int,
 ) -> c_int {
     let mut oldcomm: [c_char; FLEN_COMMENT] = [0; FLEN_COMMENT];
     let mut newcomm: [c_char; FLEN_COMMENT] = [0; FLEN_COMMENT];
@@ -1104,13 +1374,18 @@ pub fn ffpunt_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) keyword name
+/// * `comm`    — (I) keyword comment
+/// * `status`  — (IO) error status
 pub unsafe extern "C" fn ffmkyu(
-    fptr: *mut fitsfile,    /* I - FITS file pointer  */
-    keyname: *const c_char, /* I - keyword name       */
-    comm: *const c_char,    /* I - keyword comment    */
-    status: *mut c_int,     /* IO - error status      */
+    fptr: *mut fitsfile,
+    keyname: *const c_char,
+    comm: *const c_char,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -1124,12 +1399,17 @@ pub unsafe extern "C" fn ffmkyu(
     }
 }
 
-/*--------------------------------------------------------------------------*/
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) keyword name
+/// * `comm`    — (I) keyword comment
+/// * `status`  — (IO) error status
 pub fn ffmkyu_safe(
-    fptr: &mut fitsfile,     /* I - FITS file pointer  */
-    keyname: &[c_char],      /* I - keyword name       */
-    comm: Option<&[c_char]>, /* I - keyword comment    */
-    status: &mut c_int,      /* IO - error status      */
+    fptr: &mut fitsfile,
+    keyname: &[c_char],
+    comm: Option<&[c_char]>,
+    status: &mut c_int,
 ) -> c_int {
     let mut valstring: [c_char; FLEN_VALUE] = [0; FLEN_VALUE];
     let mut oldcomm: [c_char; FLEN_COMMENT] = [0; FLEN_COMMENT];
@@ -1164,14 +1444,20 @@ pub fn ffmkyu_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) keyword name
+/// * `value`   — (I) keyword value
+/// * `comm`    — (I) keyword comment
+/// * `status`  — (IO) error status
 pub unsafe extern "C" fn ffmkys(
-    fptr: *mut fitsfile,    /* I - FITS file pointer  */
-    keyname: *const c_char, /* I - keyword name       */
-    value: *const c_char,   /* I - keyword value      */
-    comm: *const c_char,    /* I - keyword comment    */
-    status: *mut c_int,     /* IO - error status      */
+    fptr: *mut fitsfile,
+    keyname: *const c_char,
+    value: *const c_char,
+    comm: *const c_char,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -1190,13 +1476,19 @@ pub unsafe extern "C" fn ffmkys(
     }
 }
 
-/*--------------------------------------------------------------------------*/
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) keyword name
+/// * `value`   — (I) keyword value
+/// * `comm`    — (I) keyword comment
+/// * `status`  — (IO) error status
 pub fn ffmkys_safe(
-    fptr: &mut fitsfile,     /* I - FITS file pointer  */
-    keyname: &[c_char],      /* I - keyword name       */
-    value: &[c_char],        /* I - keyword value      */
-    comm: Option<&[c_char]>, /* I - keyword comment    */
-    status: &mut c_int,      /* IO - error status      */
+    fptr: &mut fitsfile,
+    keyname: &[c_char],
+    value: &[c_char],
+    comm: Option<&[c_char]>,
+    status: &mut c_int,
 ) -> c_int {
     /* NOTE: This routine does not support long continued strings */
     /*  It will correctly overwrite an existing long continued string, */
@@ -1270,7 +1562,6 @@ pub fn ffmkys_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Modify the value and optionally the comment of a long string keyword.
 ///
 /// This routine supports the
@@ -1281,13 +1572,21 @@ pub fn ffmkys_safe(
 /// 69 characters in length.
 ///
 /// This routine is not very efficient, so it should be used sparingly.
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) name of keyword to write
+/// * `value`   — (I) keyword value
+/// * `incomm`  — (I) keyword comment
+/// * `status`  — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffmkls(
-    fptr: *mut fitsfile,    /* I - FITS file pointer        */
-    keyname: *const c_char, /* I - name of keyword to write */
-    value: *const c_char,   /* I - keyword value            */
-    incomm: *const c_char,  /* I - keyword comment          */
-    status: *mut c_int,     /* IO - error status            */
+    fptr: *mut fitsfile,
+    keyname: *const c_char,
+    value: *const c_char,
+    incomm: *const c_char,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -1303,7 +1602,6 @@ pub unsafe extern "C" fn ffmkls(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Modify the value and optionally the comment of a long string keyword.
 ///
 /// This routine supports the
@@ -1314,12 +1612,20 @@ pub unsafe extern "C" fn ffmkls(
 /// 69 characters in length.
 ///
 /// This routine is not very efficient, so it should be used sparingly.
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) name of keyword to write
+/// * `value`   — (I) keyword value
+/// * `incomm`  — (I) keyword comment
+/// * `status`  — (IO) error status
 pub fn ffmkls_safe(
-    fptr: &mut fitsfile,       /* I - FITS file pointer        */
-    keyname: &[c_char],        /* I - name of keyword to write */
-    value: &[c_char],          /* I - keyword value            */
-    incomm: Option<&[c_char]>, /* I - keyword comment          */
-    status: &mut c_int,        /* IO - error status            */
+    fptr: &mut fitsfile,
+    keyname: &[c_char],
+    value: &[c_char],
+    incomm: Option<&[c_char]>,
+    status: &mut c_int,
 ) -> c_int {
     let mut card: [c_char; FLEN_CARD] = [0; FLEN_CARD];
     let mut comm: Option<Vec<c_char>> = None;
@@ -1391,14 +1697,20 @@ pub fn ffmkls_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) keyword name
+/// * `value`   — (I) keyword value
+/// * `comm`    — (I) keyword comment
+/// * `status`  — (IO) error status
 pub unsafe extern "C" fn ffmkyl(
-    fptr: *mut fitsfile,    /* I - FITS file pointer  */
-    keyname: *const c_char, /* I - keyword name       */
-    value: c_int,           /* I - keyword value      */
-    comm: *const c_char,    /* I - keyword comment    */
-    status: *mut c_int,     /* IO - error status      */
+    fptr: *mut fitsfile,
+    keyname: *const c_char,
+    value: c_int,
+    comm: *const c_char,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -1412,13 +1724,19 @@ pub unsafe extern "C" fn ffmkyl(
     }
 }
 
-/*--------------------------------------------------------------------------*/
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) keyword name
+/// * `value`   — (I) keyword value
+/// * `comm`    — (I) keyword comment
+/// * `status`  — (IO) error status
 pub fn ffmkyl_safe(
-    fptr: &mut fitsfile,     /* I - FITS file pointer  */
-    keyname: &[c_char],      /* I - keyword name       */
-    value: c_int,            /* I - keyword value      */
-    comm: Option<&[c_char]>, /* I - keyword comment    */
-    status: &mut c_int,      /* IO - error status      */
+    fptr: &mut fitsfile,
+    keyname: &[c_char],
+    value: c_int,
+    comm: Option<&[c_char]>,
+    status: &mut c_int,
 ) -> c_int {
     let mut oldcomm: [c_char; FLEN_COMMENT] = [0; FLEN_COMMENT];
     let mut valstring: [c_char; FLEN_VALUE] = [0; FLEN_VALUE];
@@ -1453,14 +1771,20 @@ pub fn ffmkyl_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) keyword name
+/// * `value`   — (I) keyword value
+/// * `comm`    — (I) keyword comment
+/// * `status`  — (IO) error status
 pub unsafe extern "C" fn ffmkyj(
-    fptr: *mut fitsfile,    /* I - FITS file pointer  */
-    keyname: *const c_char, /* I - keyword name       */
-    value: LONGLONG,        /* I - keyword value      */
-    comm: *const c_char,    /* I - keyword comment    */
-    status: *mut c_int,     /* IO - error status      */
+    fptr: *mut fitsfile,
+    keyname: *const c_char,
+    value: LONGLONG,
+    comm: *const c_char,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -1474,13 +1798,19 @@ pub unsafe extern "C" fn ffmkyj(
     }
 }
 
-/*--------------------------------------------------------------------------*/
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) keyword name
+/// * `value`   — (I) keyword value
+/// * `comm`    — (I) keyword comment
+/// * `status`  — (IO) error status
 pub fn ffmkyj_safe(
-    fptr: &mut fitsfile,     /* I - FITS file pointer  */
-    keyname: &[c_char],      /* I - keyword name       */
-    value: LONGLONG,         /* I - keyword value      */
-    comm: Option<&[c_char]>, /* I - keyword comment    */
-    status: &mut c_int,      /* IO - error status      */
+    fptr: &mut fitsfile,
+    keyname: &[c_char],
+    value: LONGLONG,
+    comm: Option<&[c_char]>,
+    status: &mut c_int,
 ) -> c_int {
     let mut valstring: [c_char; FLEN_VALUE] = [0; FLEN_VALUE];
     let mut oldcomm: [c_char; FLEN_COMMENT] = [0; FLEN_COMMENT];
@@ -1511,14 +1841,20 @@ pub fn ffmkyj_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) keyword name
+/// * `value`   — (I) keyword value
+/// * `comm`    — (I) keyword comment
+/// * `status`  — (IO) error status
 pub unsafe extern "C" fn ffmkyuj(
-    fptr: *mut fitsfile,    /* I - FITS file pointer  */
-    keyname: *const c_char, /* I - keyword name       */
-    value: ULONGLONG,       /* I - keyword value      */
-    comm: *const c_char,    /* I - keyword comment    */
-    status: *mut c_int,     /* IO - error status      */
+    fptr: *mut fitsfile,
+    keyname: *const c_char,
+    value: ULONGLONG,
+    comm: *const c_char,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -1532,13 +1868,19 @@ pub unsafe extern "C" fn ffmkyuj(
     }
 }
 
-/*--------------------------------------------------------------------------*/
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) keyword name
+/// * `value`   — (I) keyword value
+/// * `comm`    — (I) keyword comment
+/// * `status`  — (IO) error status
 pub fn ffmkyuj_safe(
-    fptr: &mut fitsfile,     /* I - FITS file pointer  */
-    keyname: &[c_char],      /* I - keyword name       */
-    value: ULONGLONG,        /* I - keyword value      */
-    comm: Option<&[c_char]>, /* I - keyword comment    */
-    status: &mut c_int,      /* IO - error status      */
+    fptr: &mut fitsfile,
+    keyname: &[c_char],
+    value: ULONGLONG,
+    comm: Option<&[c_char]>,
+    status: &mut c_int,
 ) -> c_int {
     let mut valstring: [c_char; FLEN_VALUE] = [0; FLEN_VALUE];
     let mut oldcomm: [c_char; FLEN_COMMENT] = [0; FLEN_COMMENT];
@@ -1571,15 +1913,22 @@ pub fn ffmkyuj_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) keyword name
+/// * `value`   — (I) keyword value
+/// * `decim`   — (I) no of decimals
+/// * `comm`    — (I) keyword comment
+/// * `status`  — (IO) error status
 pub unsafe extern "C" fn ffmkyf(
-    fptr: *mut fitsfile,    /* I - FITS file pointer  */
-    keyname: *const c_char, /* I - keyword name       */
-    value: f32,             /* I - keyword value      */
-    decim: c_int,           /* I - no of decimals     */
-    comm: *const c_char,    /* I - keyword comment    */
-    status: *mut c_int,     /* IO - error status      */
+    fptr: *mut fitsfile,
+    keyname: *const c_char,
+    value: f32,
+    decim: c_int,
+    comm: *const c_char,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -1593,14 +1942,21 @@ pub unsafe extern "C" fn ffmkyf(
     }
 }
 
-/*--------------------------------------------------------------------------*/
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) keyword name
+/// * `value`   — (I) keyword value
+/// * `decim`   — (I) no of decimals
+/// * `comm`    — (I) keyword comment
+/// * `status`  — (IO) error status
 pub fn ffmkyf_safe(
-    fptr: &mut fitsfile,     /* I - FITS file pointer  */
-    keyname: &[c_char],      /* I - keyword name       */
-    value: f32,              /* I - keyword value      */
-    decim: c_int,            /* I - no of decimals     */
-    comm: Option<&[c_char]>, /* I - keyword comment    */
-    status: &mut c_int,      /* IO - error status      */
+    fptr: &mut fitsfile,
+    keyname: &[c_char],
+    value: f32,
+    decim: c_int,
+    comm: Option<&[c_char]>,
+    status: &mut c_int,
 ) -> c_int {
     let mut oldcomm: [c_char; FLEN_COMMENT] = [0; FLEN_COMMENT];
     let mut valstring: [c_char; FLEN_VALUE] = [0; FLEN_VALUE];
@@ -1635,15 +1991,22 @@ pub fn ffmkyf_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) keyword name
+/// * `value`   — (I) keyword value
+/// * `decim`   — (I) no of decimals
+/// * `comm`    — (I) keyword comment
+/// * `status`  — (IO) error status
 pub unsafe extern "C" fn ffmkye(
-    fptr: *mut fitsfile,    /* I - FITS file pointer  */
-    keyname: *const c_char, /* I - keyword name       */
-    value: f32,             /* I - keyword value      */
-    decim: c_int,           /* I - no of decimals     */
-    comm: *const c_char,    /* I - keyword comment    */
-    status: *mut c_int,     /* IO - error status      */
+    fptr: *mut fitsfile,
+    keyname: *const c_char,
+    value: f32,
+    decim: c_int,
+    comm: *const c_char,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -1657,14 +2020,21 @@ pub unsafe extern "C" fn ffmkye(
     }
 }
 
-/*--------------------------------------------------------------------------*/
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) keyword name
+/// * `value`   — (I) keyword value
+/// * `decim`   — (I) no of decimals
+/// * `comm`    — (I) keyword comment
+/// * `status`  — (IO) error status
 pub fn ffmkye_safe(
-    fptr: &mut fitsfile,     /* I - FITS file pointer  */
-    keyname: &[c_char],      /* I - keyword name       */
-    value: f32,              /* I - keyword value      */
-    decim: c_int,            /* I - no of decimals     */
-    comm: Option<&[c_char]>, /* I - keyword comment    */
-    status: &mut c_int,      /* IO - error status      */
+    fptr: &mut fitsfile,
+    keyname: &[c_char],
+    value: f32,
+    decim: c_int,
+    comm: Option<&[c_char]>,
+    status: &mut c_int,
 ) -> c_int {
     let mut oldcomm: [c_char; FLEN_COMMENT] = [0; FLEN_COMMENT];
     let mut valstring: [c_char; FLEN_VALUE] = [0; FLEN_VALUE];
@@ -1699,15 +2069,22 @@ pub fn ffmkye_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) keyword name
+/// * `value`   — (I) keyword value
+/// * `decim`   — (I) no of decimals
+/// * `comm`    — (I) keyword comment
+/// * `status`  — (IO) error status
 pub unsafe extern "C" fn ffmkyg(
-    fptr: *mut fitsfile,    /* I - FITS file pointer  */
-    keyname: *const c_char, /* I - keyword name       */
-    value: f64,             /* I - keyword value      */
-    decim: c_int,           /* I - no of decimals     */
-    comm: *const c_char,    /* I - keyword comment    */
-    status: *mut c_int,     /* IO - error status      */
+    fptr: *mut fitsfile,
+    keyname: *const c_char,
+    value: f64,
+    decim: c_int,
+    comm: *const c_char,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -1721,14 +2098,21 @@ pub unsafe extern "C" fn ffmkyg(
     }
 }
 
-/*--------------------------------------------------------------------------*/
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) keyword name
+/// * `value`   — (I) keyword value
+/// * `decim`   — (I) no of decimals
+/// * `comm`    — (I) keyword comment
+/// * `status`  — (IO) error status
 pub fn ffmkyg_safe(
-    fptr: &mut fitsfile,     /* I - FITS file pointer  */
-    keyname: &[c_char],      /* I - keyword name       */
-    value: f64,              /* I - keyword value      */
-    decim: c_int,            /* I - no of decimals     */
-    comm: Option<&[c_char]>, /* I - keyword comment    */
-    status: &mut c_int,      /* IO - error status      */
+    fptr: &mut fitsfile,
+    keyname: &[c_char],
+    value: f64,
+    decim: c_int,
+    comm: Option<&[c_char]>,
+    status: &mut c_int,
 ) -> c_int {
     let mut oldcomm: [c_char; FLEN_COMMENT] = [0; FLEN_COMMENT];
     let mut valstring: [c_char; FLEN_VALUE] = [0; FLEN_VALUE];
@@ -1763,15 +2147,22 @@ pub fn ffmkyg_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) keyword name
+/// * `value`   — (I) keyword value
+/// * `decim`   — (I) no of decimals
+/// * `comm`    — (I) keyword comment
+/// * `status`  — (IO) error status
 pub unsafe extern "C" fn ffmkyd(
-    fptr: *mut fitsfile,    /* I - FITS file pointer  */
-    keyname: *const c_char, /* I - keyword name       */
-    value: f64,             /* I - keyword value      */
-    decim: c_int,           /* I - no of decimals     */
-    comm: *const c_char,    /* I - keyword comment    */
-    status: *mut c_int,     /* IO - error status      */
+    fptr: *mut fitsfile,
+    keyname: *const c_char,
+    value: f64,
+    decim: c_int,
+    comm: *const c_char,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -1785,14 +2176,21 @@ pub unsafe extern "C" fn ffmkyd(
     }
 }
 
-/*--------------------------------------------------------------------------*/
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) keyword name
+/// * `value`   — (I) keyword value
+/// * `decim`   — (I) no of decimals
+/// * `comm`    — (I) keyword comment
+/// * `status`  — (IO) error status
 pub fn ffmkyd_safe(
-    fptr: &mut fitsfile,     /* I - FITS file pointer  */
-    keyname: &[c_char],      /* I - keyword name       */
-    value: f64,              /* I - keyword value      */
-    decim: c_int,            /* I - no of decimals     */
-    comm: Option<&[c_char]>, /* I - keyword comment    */
-    status: &mut c_int,      /* IO - error status      */
+    fptr: &mut fitsfile,
+    keyname: &[c_char],
+    value: f64,
+    decim: c_int,
+    comm: Option<&[c_char]>,
+    status: &mut c_int,
 ) -> c_int {
     let mut oldcomm: [c_char; FLEN_COMMENT] = [0; FLEN_COMMENT];
     let mut valstring: [c_char; FLEN_VALUE] = [0; FLEN_VALUE];
@@ -1827,15 +2225,22 @@ pub fn ffmkyd_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) keyword name
+/// * `value`   — (I) keyword value
+/// * `decim`   — (I) no of decimals
+/// * `comm`    — (I) keyword comment
+/// * `status`  — (IO) error status
 pub unsafe extern "C" fn ffmkfc(
-    fptr: *mut fitsfile,    /* I - FITS file pointer  */
-    keyname: *const c_char, /* I - keyword name       */
-    value: *const [f32; 2], /* I - keyword value      */
-    decim: c_int,           /* I - no of decimals     */
-    comm: *const c_char,    /* I - keyword comment    */
-    status: *mut c_int,     /* IO - error status      */
+    fptr: *mut fitsfile,
+    keyname: *const c_char,
+    value: *const [f32; 2],
+    decim: c_int,
+    comm: *const c_char,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -1850,14 +2255,21 @@ pub unsafe extern "C" fn ffmkfc(
     }
 }
 
-/*--------------------------------------------------------------------------*/
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) keyword name
+/// * `value`   — (I) keyword value
+/// * `decim`   — (I) no of decimals
+/// * `comm`    — (I) keyword comment
+/// * `status`  — (IO) error status
 pub fn ffmkfc_safe(
-    fptr: &mut fitsfile,     /* I - FITS file pointer  */
-    keyname: &[c_char],      /* I - keyword name       */
-    value: &[f32; 2],        /* I - keyword value      */
-    decim: c_int,            /* I - no of decimals     */
-    comm: Option<&[c_char]>, /* I - keyword comment    */
-    status: &mut c_int,      /* IO - error status      */
+    fptr: &mut fitsfile,
+    keyname: &[c_char],
+    value: &[f32; 2],
+    decim: c_int,
+    comm: Option<&[c_char]>,
+    status: &mut c_int,
 ) -> c_int {
     let mut valstring: [c_char; FLEN_VALUE] = [0; FLEN_VALUE];
     let mut tmpstring: [c_char; FLEN_VALUE] = [0; FLEN_VALUE];
@@ -1903,15 +2315,22 @@ pub fn ffmkfc_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) keyword name
+/// * `value`   — (I) keyword value
+/// * `decim`   — (I) no of decimals
+/// * `comm`    — (I) keyword comment
+/// * `status`  — (IO) error status
 pub unsafe extern "C" fn ffmkyc(
-    fptr: *mut fitsfile,    /* I - FITS file pointer  */
-    keyname: *const c_char, /* I - keyword name       */
-    value: *const [f32; 2], /* I - keyword value      */
-    decim: c_int,           /* I - no of decimals     */
-    comm: *const c_char,    /* I - keyword comment    */
-    status: *mut c_int,     /* IO - error status      */
+    fptr: *mut fitsfile,
+    keyname: *const c_char,
+    value: *const [f32; 2],
+    decim: c_int,
+    comm: *const c_char,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -1926,14 +2345,21 @@ pub unsafe extern "C" fn ffmkyc(
     }
 }
 
-/*--------------------------------------------------------------------------*/
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) keyword name
+/// * `value`   — (I) keyword value
+/// * `decim`   — (I) no of decimals
+/// * `comm`    — (I) keyword comment
+/// * `status`  — (IO) error status
 pub fn ffmkyc_safe(
-    fptr: &mut fitsfile,     /* I - FITS file pointer  */
-    keyname: &[c_char],      /* I - keyword name       */
-    value: &[f32; 2],        /* I - keyword value      */
-    decim: c_int,            /* I - no of decimals     */
-    comm: Option<&[c_char]>, /* I - keyword comment    */
-    status: &mut c_int,      /* IO - error status      */
+    fptr: &mut fitsfile,
+    keyname: &[c_char],
+    value: &[f32; 2],
+    decim: c_int,
+    comm: Option<&[c_char]>,
+    status: &mut c_int,
 ) -> c_int {
     let mut valstring: [c_char; FLEN_VALUE] = [0; FLEN_VALUE];
     let mut tmpstring: [c_char; FLEN_VALUE] = [0; FLEN_VALUE];
@@ -1979,15 +2405,22 @@ pub fn ffmkyc_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) keyword name
+/// * `value`   — (I) keyword value
+/// * `decim`   — (I) no of decimals
+/// * `comm`    — (I) keyword comment
+/// * `status`  — (IO) error status
 pub unsafe extern "C" fn ffmkfm(
-    fptr: *mut fitsfile,    /* I - FITS file pointer  */
-    keyname: *const c_char, /* I - keyword name       */
-    value: *const [f64; 2], /* I - keyword value      */
-    decim: c_int,           /* I - no of decimals     */
-    comm: *const c_char,    /* I - keyword comment    */
-    status: *mut c_int,     /* IO - error status      */
+    fptr: *mut fitsfile,
+    keyname: *const c_char,
+    value: *const [f64; 2],
+    decim: c_int,
+    comm: *const c_char,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -2002,14 +2435,21 @@ pub unsafe extern "C" fn ffmkfm(
     }
 }
 
-/*--------------------------------------------------------------------------*/
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) keyword name
+/// * `value`   — (I) keyword value
+/// * `decim`   — (I) no of decimals
+/// * `comm`    — (I) keyword comment
+/// * `status`  — (IO) error status
 pub fn ffmkfm_safe(
-    fptr: &mut fitsfile,     /* I - FITS file pointer  */
-    keyname: &[c_char],      /* I - keyword name       */
-    value: &[f64; 2],        /* I - keyword value      */
-    decim: c_int,            /* I - no of decimals     */
-    comm: Option<&[c_char]>, /* I - keyword comment    */
-    status: &mut c_int,      /* IO - error status      */
+    fptr: &mut fitsfile,
+    keyname: &[c_char],
+    value: &[f64; 2],
+    decim: c_int,
+    comm: Option<&[c_char]>,
+    status: &mut c_int,
 ) -> c_int {
     let mut valstring: [c_char; FLEN_VALUE] = [0; FLEN_VALUE];
     let mut tmpstring: [c_char; FLEN_VALUE] = [0; FLEN_VALUE];
@@ -2055,15 +2495,22 @@ pub fn ffmkfm_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) keyword name
+/// * `value`   — (I) keyword value
+/// * `decim`   — (I) no of decimals
+/// * `comm`    — (I) keyword comment
+/// * `status`  — (IO) error status
 pub unsafe extern "C" fn ffmkym(
-    fptr: *mut fitsfile,    /* I - FITS file pointer  */
-    keyname: *const c_char, /* I - keyword name       */
-    value: *const [f64; 2], /* I - keyword value      */
-    decim: c_int,           /* I - no of decimals     */
-    comm: *const c_char,    /* I - keyword comment    */
-    status: *mut c_int,     /* IO - error status      */
+    fptr: *mut fitsfile,
+    keyname: *const c_char,
+    value: *const [f64; 2],
+    decim: c_int,
+    comm: *const c_char,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -2078,14 +2525,21 @@ pub unsafe extern "C" fn ffmkym(
     }
 }
 
-/*--------------------------------------------------------------------------*/
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) keyword name
+/// * `value`   — (I) keyword value
+/// * `decim`   — (I) no of decimals
+/// * `comm`    — (I) keyword comment
+/// * `status`  — (IO) error status
 pub fn ffmkym_safe(
-    fptr: &mut fitsfile,     /* I - FITS file pointer  */
-    keyname: &[c_char],      /* I - keyword name       */
-    value: &[f64; 2],        /* I - keyword value      */
-    decim: c_int,            /* I - no of decimals     */
-    comm: Option<&[c_char]>, /* I - keyword comment    */
-    status: &mut c_int,      /* IO - error status      */
+    fptr: &mut fitsfile,
+    keyname: &[c_char],
+    value: &[f64; 2],
+    decim: c_int,
+    comm: Option<&[c_char]>,
+    status: &mut c_int,
 ) -> c_int {
     let mut valstring: [c_char; FLEN_VALUE] = [0; FLEN_VALUE];
     let mut tmpstring: [c_char; FLEN_VALUE] = [0; FLEN_VALUE];
@@ -2131,14 +2585,20 @@ pub fn ffmkym_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Insert a null-valued keyword and comment into the FITS header.  
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) keyword name
+/// * `comm`    — (I) keyword comment
+/// * `status`  — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffikyu(
-    fptr: *mut fitsfile,    /* I - FITS file pointer  */
-    keyname: *const c_char, /* I - keyword name       */
-    comm: *const c_char,    /* I - keyword comment    */
-    status: *mut c_int,     /* IO - error status      */
+    fptr: *mut fitsfile,
+    keyname: *const c_char,
+    comm: *const c_char,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -2152,13 +2612,19 @@ pub unsafe extern "C" fn ffikyu(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Insert a null-valued keyword and comment into the FITS header.
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) keyword name
+/// * `comm`    — (I) keyword comment
+/// * `status`  — (IO) error status
 pub fn ffikyu_safer(
-    fptr: &mut fitsfile,     /* I - FITS file pointer  */
-    keyname: &[c_char],      /* I - keyword name       */
-    comm: Option<&[c_char]>, /* I - keyword comment    */
-    status: &mut c_int,      /* IO - error status      */
+    fptr: &mut fitsfile,
+    keyname: &[c_char],
+    comm: Option<&[c_char]>,
+    status: &mut c_int,
 ) -> c_int {
     let mut valstring: [c_char; FLEN_VALUE] = [0; FLEN_VALUE];
     let mut card: [c_char; FLEN_CARD] = [0; FLEN_CARD];
@@ -2175,14 +2641,20 @@ pub fn ffikyu_safer(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) keyword name
+/// * `value`   — (I) keyword value
+/// * `comm`    — (I) keyword comment
+/// * `status`  — (IO) error status
 pub unsafe extern "C" fn ffikys(
-    fptr: *mut fitsfile,    /* I - FITS file pointer  */
-    keyname: *const c_char, /* I - keyword name       */
-    value: *const c_char,   /* I - keyword value      */
-    comm: *const c_char,    /* I - keyword comment    */
-    status: *mut c_int,     /* IO - error status      */
+    fptr: *mut fitsfile,
+    keyname: *const c_char,
+    value: *const c_char,
+    comm: *const c_char,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -2197,14 +2669,21 @@ pub unsafe extern "C" fn ffikys(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Insert a string keyword into the FITS header at the current position.
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) keyword name
+/// * `value`   — (I) keyword value
+/// * `comm`    — (I) keyword comment
+/// * `status`  — (IO) error status
 pub fn ffikys_safer(
-    fptr: &mut fitsfile,     /* I - FITS file pointer  */
-    keyname: &[c_char],      /* I - keyword name       */
-    value: &[c_char],        /* I - keyword value      */
-    comm: Option<&[c_char]>, /* I - keyword comment    */
-    status: &mut c_int,      /* IO - error status      */
+    fptr: &mut fitsfile,
+    keyname: &[c_char],
+    value: &[c_char],
+    comm: Option<&[c_char]>,
+    status: &mut c_int,
 ) -> c_int {
     let mut valstring: [c_char; FLEN_VALUE] = [0; FLEN_VALUE];
     let mut card: [c_char; FLEN_CARD] = [0; FLEN_CARD];
@@ -2222,20 +2701,27 @@ pub fn ffikys_safer(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Insert a long string keyword.  This routine supports the
 /// HEASARC long string convention and can insert arbitrarily long string
 /// keyword values.  The value is continued over multiple keywords that
 /// have the name COMTINUE without an equal sign in column 9 of the card.
 /// This routine also supports simple string keywords which are less than
 /// 69 characters in length.
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) name of keyword to write
+/// * `value`   — (I) keyword value
+/// * `comm`    — (I) keyword comment
+/// * `status`  — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffikls(
-    fptr: *mut fitsfile,    /* I - FITS file pointer        */
-    keyname: *const c_char, /* I - name of keyword to write */
-    value: *const c_char,   /* I - keyword value            */
-    comm: *const c_char,    /* I - keyword comment          */
-    status: *mut c_int,     /* IO - error status            */
+    fptr: *mut fitsfile,
+    keyname: *const c_char,
+    value: *const c_char,
+    comm: *const c_char,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -2250,19 +2736,26 @@ pub unsafe extern "C" fn ffikls(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Insert a long string keyword.  This routine supports the
 /// HEASARC long string convention and can insert arbitrarily long string
 /// keyword values.  The value is continued over multiple keywords that
 /// have the name COMTINUE without an equal sign in column 9 of the card.
 /// This routine also supports simple string keywords which are less than
 /// 69 characters in length.
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) name of keyword to write
+/// * `value`   — (I) keyword value
+/// * `comm`    — (I) keyword comment
+/// * `status`  — (IO) error status
 pub fn ffikls_safe(
-    fptr: &mut fitsfile,     /* I - FITS file pointer        */
-    keyname: &[c_char],      /* I - name of keyword to write */
-    value: &[c_char],        /* I - keyword value            */
-    comm: Option<&[c_char]>, /* I - keyword comment          */
-    status: &mut c_int,      /* IO - error status            */
+    fptr: &mut fitsfile,
+    keyname: &[c_char],
+    value: &[c_char],
+    comm: Option<&[c_char]>,
+    status: &mut c_int,
 ) -> c_int {
     let mut valstring: [c_char; FLEN_VALUE] = [0; FLEN_VALUE];
     let mut card: [c_char; FLEN_CARD] = [0; FLEN_CARD];
@@ -2361,14 +2854,20 @@ pub fn ffikls_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) keyword name
+/// * `value`   — (I) keyword value
+/// * `comm`    — (I) keyword comment
+/// * `status`  — (IO) error status
 pub unsafe extern "C" fn ffikyl(
-    fptr: *mut fitsfile,    /* I - FITS file pointer  */
-    keyname: *const c_char, /* I - keyword name       */
-    value: c_int,           /* I - keyword value      */
-    comm: *const c_char,    /* I - keyword comment    */
-    status: *mut c_int,     /* IO - error status      */
+    fptr: *mut fitsfile,
+    keyname: *const c_char,
+    value: c_int,
+    comm: *const c_char,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -2382,14 +2881,21 @@ pub unsafe extern "C" fn ffikyl(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Insert a logical keyword into the FITS header at the current position.
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) keyword name
+/// * `value`   — (I) keyword value
+/// * `comm`    — (I) keyword comment
+/// * `status`  — (IO) error status
 pub fn ffikyl_safer(
-    fptr: &mut fitsfile,     /* I - FITS file pointer  */
-    keyname: &[c_char],      /* I - keyword name       */
-    value: c_int,            /* I - keyword value      */
-    comm: Option<&[c_char]>, /* I - keyword comment    */
-    status: &mut c_int,      /* IO - error status      */
+    fptr: &mut fitsfile,
+    keyname: &[c_char],
+    value: c_int,
+    comm: Option<&[c_char]>,
+    status: &mut c_int,
 ) -> c_int {
     let mut valstring: [c_char; FLEN_VALUE] = [0; FLEN_VALUE];
     let mut card: [c_char; FLEN_CARD] = [0; FLEN_CARD];
@@ -2406,14 +2912,20 @@ pub fn ffikyl_safer(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) keyword name
+/// * `value`   — (I) keyword value
+/// * `comm`    — (I) keyword comment
+/// * `status`  — (IO) error status
 pub unsafe extern "C" fn ffikyj(
-    fptr: *mut fitsfile,    /* I - FITS file pointer  */
-    keyname: *const c_char, /* I - keyword name       */
-    value: LONGLONG,        /* I - keyword value      */
-    comm: *const c_char,    /* I - keyword comment    */
-    status: *mut c_int,     /* IO - error status      */
+    fptr: *mut fitsfile,
+    keyname: *const c_char,
+    value: LONGLONG,
+    comm: *const c_char,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -2427,13 +2939,19 @@ pub unsafe extern "C" fn ffikyj(
     }
 }
 
-/*--------------------------------------------------------------------------*/
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) keyword name
+/// * `value`   — (I) keyword value
+/// * `comm`    — (I) keyword comment
+/// * `status`  — (IO) error status
 pub fn ffikyj_safe(
-    fptr: &mut fitsfile,     /* I - FITS file pointer  */
-    keyname: &[c_char],      /* I - keyword name       */
-    value: LONGLONG,         /* I - keyword value      */
-    comm: Option<&[c_char]>, /* I - keyword comment    */
-    status: &mut c_int,      /* IO - error status      */
+    fptr: &mut fitsfile,
+    keyname: &[c_char],
+    value: LONGLONG,
+    comm: Option<&[c_char]>,
+    status: &mut c_int,
 ) -> c_int {
     let mut valstring: [c_char; FLEN_VALUE] = [0; FLEN_VALUE];
     let mut card: [c_char; FLEN_CARD] = [0; FLEN_CARD];
@@ -2450,14 +2968,21 @@ pub fn ffikyj_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) keyword name
+/// * `value`   — (I) keyword value
+/// * `decim`   — (I) no of decimals
+/// * `comm`    — (I) keyword comment
+/// * `status`  — (IO) error status
 pub fn ffikyf_safe(
-    fptr: &mut fitsfile,     /* I - FITS file pointer  */
-    keyname: &[c_char],      /* I - keyword name       */
-    value: f32,              /* I - keyword value      */
-    decim: c_int,            /* I - no of decimals     */
-    comm: Option<&[c_char]>, /* I - keyword comment    */
-    status: &mut c_int,      /* IO - error status      */
+    fptr: &mut fitsfile,
+    keyname: &[c_char],
+    value: f32,
+    decim: c_int,
+    comm: Option<&[c_char]>,
+    status: &mut c_int,
 ) -> c_int {
     if *status > 0 {
         /* inherit input status value if > 0 */
@@ -2474,15 +2999,22 @@ pub fn ffikyf_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) keyword name
+/// * `value`   — (I) keyword value
+/// * `decim`   — (I) no of decimals
+/// * `comm`    — (I) keyword comment
+/// * `status`  — (IO) error status
 pub unsafe extern "C" fn ffikyf(
-    fptr: *mut fitsfile,    /* I - FITS file pointer  */
-    keyname: *const c_char, /* I - keyword name       */
-    value: f32,             /* I - keyword value      */
-    decim: c_int,           /* I - no of decimals     */
-    comm: *const c_char,    /* I - keyword comment    */
-    status: *mut c_int,     /* IO - error status      */
+    fptr: *mut fitsfile,
+    keyname: *const c_char,
+    value: f32,
+    decim: c_int,
+    comm: *const c_char,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -2496,15 +3028,22 @@ pub unsafe extern "C" fn ffikyf(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) keyword name
+/// * `value`   — (I) keyword value
+/// * `decim`   — (I) no of decimals
+/// * `comm`    — (I) keyword comment
+/// * `status`  — (IO) error status
 pub unsafe extern "C" fn ffikye(
-    fptr: *mut fitsfile,    /* I - FITS file pointer  */
-    keyname: *const c_char, /* I - keyword name       */
-    value: f32,             /* I - keyword value      */
-    decim: c_int,           /* I - no of decimals     */
-    comm: *const c_char,    /* I - keyword comment    */
-    status: *mut c_int,     /* IO - error status      */
+    fptr: *mut fitsfile,
+    keyname: *const c_char,
+    value: f32,
+    decim: c_int,
+    comm: *const c_char,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -2518,15 +3057,23 @@ pub unsafe extern "C" fn ffikye(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Insert a float keyword into the FITS header at the current position.
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) keyword name
+/// * `value`   — (I) keyword value
+/// * `decim`   — (I) no of decimals
+/// * `comm`    — (I) keyword comment
+/// * `status`  — (IO) error status
 pub fn ffikye_safer(
-    fptr: &mut fitsfile,     /* I - FITS file pointer  */
-    keyname: &[c_char],      /* I - keyword name       */
-    value: f32,              /* I - keyword value      */
-    decim: c_int,            /* I - no of decimals     */
-    comm: Option<&[c_char]>, /* I - keyword comment    */
-    status: &mut c_int,      /* IO - error status      */
+    fptr: &mut fitsfile,
+    keyname: &[c_char],
+    value: f32,
+    decim: c_int,
+    comm: Option<&[c_char]>,
+    status: &mut c_int,
 ) -> c_int {
     let mut valstring: [c_char; FLEN_VALUE] = [0; FLEN_VALUE];
     let mut card: [c_char; FLEN_CARD] = [0; FLEN_CARD];
@@ -2543,15 +3090,22 @@ pub fn ffikye_safer(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) keyword name
+/// * `value`   — (I) keyword value
+/// * `decim`   — (I) no of decimals
+/// * `comm`    — (I) keyword comment
+/// * `status`  — (IO) error status
 pub unsafe extern "C" fn ffikyg(
-    fptr: *mut fitsfile,    /* I - FITS file pointer  */
-    keyname: *const c_char, /* I - keyword name       */
-    value: f64,             /* I - keyword value      */
-    decim: c_int,           /* I - no of decimals     */
-    comm: *const c_char,    /* I - keyword comment    */
-    status: *mut c_int,     /* IO - error status      */
+    fptr: *mut fitsfile,
+    keyname: *const c_char,
+    value: f64,
+    decim: c_int,
+    comm: *const c_char,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -2565,15 +3119,23 @@ pub unsafe extern "C" fn ffikyg(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Insert a double keyword into the FITS header at the current position.
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) keyword name
+/// * `value`   — (I) keyword value
+/// * `decim`   — (I) no of decimals
+/// * `comm`    — (I) keyword comment
+/// * `status`  — (IO) error status
 pub fn ffikyg_safer(
-    fptr: &mut fitsfile,     /* I - FITS file pointer  */
-    keyname: &[c_char],      /* I - keyword name       */
-    value: f64,              /* I - keyword value      */
-    decim: c_int,            /* I - no of decimals     */
-    comm: Option<&[c_char]>, /* I - keyword comment    */
-    status: &mut c_int,      /* IO - error status      */
+    fptr: &mut fitsfile,
+    keyname: &[c_char],
+    value: f64,
+    decim: c_int,
+    comm: Option<&[c_char]>,
+    status: &mut c_int,
 ) -> c_int {
     let mut valstring: [c_char; FLEN_VALUE] = [0; FLEN_VALUE];
     let mut card: [c_char; FLEN_CARD] = [0; FLEN_CARD];
@@ -2590,15 +3152,22 @@ pub fn ffikyg_safer(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) keyword name
+/// * `value`   — (I) keyword value
+/// * `decim`   — (I) no of decimals
+/// * `comm`    — (I) keyword comment
+/// * `status`  — (IO) error status
 pub unsafe extern "C" fn ffikyd(
-    fptr: *mut fitsfile,    /* I - FITS file pointer  */
-    keyname: *const c_char, /* I - keyword name       */
-    value: f64,             /* I - keyword value      */
-    decim: c_int,           /* I - no of decimals     */
-    comm: *const c_char,    /* I - keyword comment    */
-    status: *mut c_int,     /* IO - error status      */
+    fptr: *mut fitsfile,
+    keyname: *const c_char,
+    value: f64,
+    decim: c_int,
+    comm: *const c_char,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -2612,15 +3181,23 @@ pub unsafe extern "C" fn ffikyd(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Insert a double keyword into the FITS header at the current position.
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) keyword name
+/// * `value`   — (I) keyword value
+/// * `decim`   — (I) no of decimals
+/// * `comm`    — (I) keyword comment
+/// * `status`  — (IO) error status
 pub fn ffikyd_safer(
-    fptr: &mut fitsfile,     /* I - FITS file pointer  */
-    keyname: &[c_char],      /* I - keyword name       */
-    value: f64,              /* I - keyword value      */
-    decim: c_int,            /* I - no of decimals     */
-    comm: Option<&[c_char]>, /* I - keyword comment    */
-    status: &mut c_int,      /* IO - error status      */
+    fptr: &mut fitsfile,
+    keyname: &[c_char],
+    value: f64,
+    decim: c_int,
+    comm: Option<&[c_char]>,
+    status: &mut c_int,
 ) -> c_int {
     let mut valstring: [c_char; FLEN_VALUE] = [0; FLEN_VALUE];
     let mut card: [c_char; FLEN_CARD] = [0; FLEN_CARD];
@@ -2637,15 +3214,22 @@ pub fn ffikyd_safer(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) keyword name
+/// * `value`   — (I) keyword value
+/// * `decim`   — (I) no of decimals
+/// * `comm`    — (I) keyword comment
+/// * `status`  — (IO) error status
 pub unsafe extern "C" fn ffikfc(
-    fptr: *const fitsfile,  /* I - FITS file pointer  */
-    keyname: *const c_char, /* I - keyword name       */
-    value: *const [f32; 2], /* I - keyword value      */
-    decim: c_int,           /* I - no of decimals     */
-    comm: *const c_char,    /* I - keyword comment    */
-    status: *mut c_int,     /* IO - error status      */
+    fptr: *const fitsfile,
+    keyname: *const c_char,
+    value: *const [f32; 2],
+    decim: c_int,
+    comm: *const c_char,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -2660,15 +3244,23 @@ pub unsafe extern "C" fn ffikfc(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Insert a complex float keyword into the FITS header at the current position.
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) keyword name
+/// * `value`   — (I) keyword value
+/// * `decim`   — (I) no of decimals
+/// * `comm`    — (I) keyword comment
+/// * `status`  — (IO) error status
 pub fn ffikfc_safer(
-    fptr: &mut fitsfile,     /* I - FITS file pointer  */
-    keyname: &[c_char],      /* I - keyword name       */
-    value: &[f32; 2],        /* I - keyword value      */
-    decim: c_int,            /* I - no of decimals     */
-    comm: Option<&[c_char]>, /* I - keyword comment    */
-    status: &mut c_int,      /* IO - error status      */
+    fptr: &mut fitsfile,
+    keyname: &[c_char],
+    value: &[f32; 2],
+    decim: c_int,
+    comm: Option<&[c_char]>,
+    status: &mut c_int,
 ) -> c_int {
     let mut valstring: [c_char; FLEN_VALUE] = [0; FLEN_VALUE];
     let mut tmpstring: [c_char; FLEN_VALUE] = [0; FLEN_VALUE];
@@ -2703,15 +3295,22 @@ pub fn ffikfc_safer(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) keyword name
+/// * `value`   — (I) keyword value
+/// * `decim`   — (I) no of decimals
+/// * `comm`    — (I) keyword comment
+/// * `status`  — (IO) error status
 pub unsafe extern "C" fn ffikyc(
-    fptr: *const fitsfile,  /* I - FITS file pointer  */
-    keyname: *const c_char, /* I - keyword name       */
-    value: *const [f32; 2], /* I - keyword value      */
-    decim: c_int,           /* I - no of decimals     */
-    comm: *const c_char,    /* I - keyword comment    */
-    status: *mut c_int,     /* IO - error status      */
+    fptr: *const fitsfile,
+    keyname: *const c_char,
+    value: *const [f32; 2],
+    decim: c_int,
+    comm: *const c_char,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -2726,15 +3325,23 @@ pub unsafe extern "C" fn ffikyc(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Insert a complex float keyword into the FITS header at the current position.
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) keyword name
+/// * `value`   — (I) keyword value
+/// * `decim`   — (I) no of decimals
+/// * `comm`    — (I) keyword comment
+/// * `status`  — (IO) error status
 pub fn ffikyc_safer(
-    fptr: &mut fitsfile,     /* I - FITS file pointer  */
-    keyname: &[c_char],      /* I - keyword name       */
-    value: &[f32; 2],        /* I - keyword value      */
-    decim: c_int,            /* I - no of decimals     */
-    comm: Option<&[c_char]>, /* I - keyword comment    */
-    status: &mut c_int,      /* IO - error status      */
+    fptr: &mut fitsfile,
+    keyname: &[c_char],
+    value: &[f32; 2],
+    decim: c_int,
+    comm: Option<&[c_char]>,
+    status: &mut c_int,
 ) -> c_int {
     let mut valstring: [c_char; FLEN_VALUE] = [0; FLEN_VALUE];
     let mut tmpstring: [c_char; FLEN_VALUE] = [0; FLEN_VALUE];
@@ -2769,15 +3376,22 @@ pub fn ffikyc_safer(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) keyword name
+/// * `value`   — (I) keyword value
+/// * `decim`   — (I) no of decimals
+/// * `comm`    — (I) keyword comment
+/// * `status`  — (IO) error status
 pub unsafe extern "C" fn ffikfm(
-    fptr: *const fitsfile,  /* I - FITS file pointer  */
-    keyname: *const c_char, /* I - keyword name       */
-    value: *const [f64; 2], /* I - keyword value      */
-    decim: c_int,           /* I - no of decimals     */
-    comm: *const c_char,    /* I - keyword comment    */
-    status: *mut c_int,     /* IO - error status      */
+    fptr: *const fitsfile,
+    keyname: *const c_char,
+    value: *const [f64; 2],
+    decim: c_int,
+    comm: *const c_char,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -2792,15 +3406,23 @@ pub unsafe extern "C" fn ffikfm(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Insert a complex double keyword into the FITS header at the current position.
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) keyword name
+/// * `value`   — (I) keyword value
+/// * `decim`   — (I) no of decimals
+/// * `comm`    — (I) keyword comment
+/// * `status`  — (IO) error status
 pub fn ffikfm_safer(
-    fptr: &mut fitsfile,     /* I - FITS file pointer  */
-    keyname: &[c_char],      /* I - keyword name       */
-    value: &[f64; 2],        /* I - keyword value      */
-    decim: c_int,            /* I - no of decimals     */
-    comm: Option<&[c_char]>, /* I - keyword comment    */
-    status: &mut c_int,      /* IO - error status      */
+    fptr: &mut fitsfile,
+    keyname: &[c_char],
+    value: &[f64; 2],
+    decim: c_int,
+    comm: Option<&[c_char]>,
+    status: &mut c_int,
 ) -> c_int {
     let mut valstring: [c_char; FLEN_VALUE] = [0; FLEN_VALUE];
     let mut tmpstring: [c_char; FLEN_VALUE] = [0; FLEN_VALUE];
@@ -2835,15 +3457,22 @@ pub fn ffikfm_safer(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) keyword name
+/// * `value`   — (I) keyword value
+/// * `decim`   — (I) no of decimals
+/// * `comm`    — (I) keyword comment
+/// * `status`  — (IO) error status
 pub unsafe extern "C" fn ffikym(
-    fptr: *mut fitsfile,    /* I - FITS file pointer  */
-    keyname: *const c_char, /* I - keyword name       */
-    value: *const [f64; 2], /* I - keyword value      */
-    decim: c_int,           /* I - no of decimals     */
-    comm: *const c_char,    /* I - keyword comment    */
-    status: *mut c_int,     /* IO - error status      */
+    fptr: *mut fitsfile,
+    keyname: *const c_char,
+    value: *const [f64; 2],
+    decim: c_int,
+    comm: *const c_char,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -2858,15 +3487,23 @@ pub unsafe extern "C" fn ffikym(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Insert a complex double keyword into the FITS header at the current position.
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) keyword name
+/// * `value`   — (I) keyword value
+/// * `decim`   — (I) no of decimals
+/// * `comm`    — (I) keyword comment
+/// * `status`  — (IO) error status
 pub fn ffikym_safe(
-    fptr: &mut fitsfile,     /* I - FITS file pointer  */
-    keyname: &[c_char],      /* I - keyword name       */
-    value: &[f64; 2],        /* I - keyword value      */
-    decim: c_int,            /* I - no of decimals     */
-    comm: Option<&[c_char]>, /* I - keyword comment    */
-    status: &mut c_int,      /* IO - error status      */
+    fptr: &mut fitsfile,
+    keyname: &[c_char],
+    value: &[f64; 2],
+    decim: c_int,
+    comm: Option<&[c_char]>,
+    status: &mut c_int,
 ) -> c_int {
     let mut valstring: [c_char; FLEN_VALUE] = [0; FLEN_VALUE];
     let mut tmpstring: [c_char; FLEN_VALUE] = [0; FLEN_VALUE];
@@ -2901,13 +3538,18 @@ pub fn ffikym_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `nkey`   — (I) position to insert new keyword
+/// * `card`   — (I) card string value
+/// * `status` — (IO) error status
 pub unsafe extern "C" fn ffirec(
-    fptr: *mut fitsfile, /* I - FITS file pointer              */
-    nkey: c_int,         /* I - position to insert new keyword */
-    card: *const c_char, /* I - card string value              */
-    status: *mut c_int,  /* IO - error status                  */
+    fptr: *mut fitsfile,
+    nkey: c_int,
+    card: *const c_char,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -2920,13 +3562,13 @@ pub unsafe extern "C" fn ffirec(
     }
 }
 
-/*--------------------------------------------------------------------------*/
-pub fn ffirec_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer              */
-    nkey: c_int,         /* I - position to insert new keyword */
-    card: &[c_char],     /* I - card string value              */
-    status: &mut c_int,  /* IO - error status                  */
-) -> c_int {
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `nkey`   — (I) position to insert new keyword
+/// * `card`   — (I) card string value
+/// * `status` — (IO) error status
+pub fn ffirec_safe(fptr: &mut fitsfile, nkey: c_int, card: &[c_char], status: &mut c_int) -> c_int {
     if *status > 0 {
         /* inherit input status value if > 0 */
         return *status;
@@ -2938,13 +3580,18 @@ pub fn ffirec_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Insert a keyword at the position of (fptr->Fptr)->nextkey
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `card`   — (I) card string value
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffikey(
-    fptr: *mut fitsfile, /* I - FITS file pointer  */
-    card: *const c_char, /* I - card string value  */
-    status: *mut c_int,  /* IO - error status      */
+    fptr: *mut fitsfile,
+    card: *const c_char,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -2957,13 +3604,14 @@ pub unsafe extern "C" fn ffikey(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Insert a keyword at the position of (fptr->Fptr)->nextkey
-pub fn ffikey_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer  */
-    card: &[c_char],     /* I - card string value  */
-    status: &mut c_int,  /* IO - error status      */
-) -> c_int {
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `card`   — (I) card string value
+/// * `status` — (IO) error status
+pub fn ffikey_safe(fptr: &mut fitsfile, card: &[c_char], status: &mut c_int) -> c_int {
     let mut nblocks = 0;
     let buff1: [c_char; FLEN_CARD] = [0; FLEN_CARD];
     let mut buff2: [c_char; FLEN_CARD] = [0; FLEN_CARD];
@@ -3059,13 +3707,18 @@ pub fn ffikey_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
-/// delete a specified header keyword
+/// Delete a specified header keyword
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) keyword name
+/// * `status`  — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffdkey(
-    fptr: *mut fitsfile,    /* I - FITS file pointer  */
-    keyname: *const c_char, /* I - keyword name       */
-    status: *mut c_int,     /* IO - error status      */
+    fptr: *mut fitsfile,
+    keyname: *const c_char,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -3078,13 +3731,14 @@ pub unsafe extern "C" fn ffdkey(
     }
 }
 
-/*--------------------------------------------------------------------------*/
-/// delete a specified header keyword
-pub fn ffdkey_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer  */
-    keyname: &[c_char],  /* I - keyword name       */
-    status: &mut c_int,  /* IO - error status      */
-) -> c_int {
+/// Delete a specified header keyword
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) keyword name
+/// * `status`  — (IO) error status
+pub fn ffdkey_safe(fptr: &mut fitsfile, keyname: &[c_char], status: &mut c_int) -> c_int {
     let mut valstring: [c_char; FLEN_VALUE] = [0; FLEN_VALUE];
     let mut comm: [c_char; FLEN_COMMENT] = [0; FLEN_COMMENT];
     let mut value: [c_char; FLEN_VALUE] = [0; FLEN_VALUE];
@@ -3148,13 +3802,18 @@ pub fn ffdkey_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
-/// delete a specified header keyword containing the input string
+/// Delete a specified header keyword containing the input string
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `string` — (I) keyword name
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffdstr(
-    fptr: *mut fitsfile,   /* I - FITS file pointer  */
-    string: *const c_char, /* I - keyword name       */
-    status: *mut c_int,    /* IO - error status      */
+    fptr: *mut fitsfile,
+    string: *const c_char,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -3167,13 +3826,14 @@ pub unsafe extern "C" fn ffdstr(
     }
 }
 
-/*--------------------------------------------------------------------------*/
-/// delete a specified header keyword containing the input string
-pub fn ffdstr_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer  */
-    string: &[c_char],   /* I - keyword string     */
-    status: &mut c_int,  /* IO - error status      */
-) -> c_int {
+/// Delete a specified header keyword containing the input string
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `string` — (I) keyword string
+/// * `status` — (IO) error status
+pub fn ffdstr_safe(fptr: &mut fitsfile, string: &[c_char], status: &mut c_int) -> c_int {
     let mut valstring: [c_char; FLEN_VALUE] = [0; FLEN_VALUE];
     let mut comm: [c_char; FLEN_COMMENT] = [0; FLEN_COMMENT];
     let mut value: [c_char; FLEN_VALUE] = [0; FLEN_VALUE];
@@ -3242,14 +3902,15 @@ pub fn ffdstr_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Delete a header keyword at position keypos. The 1st keyword is at keypos=1.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `keypos` — (I) position in header of keyword to delete
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
-pub unsafe extern "C" fn ffdrec(
-    fptr: *mut fitsfile, /* I - FITS file pointer  */
-    keypos: c_int,       /* I - position in header of keyword to delete */
-    status: *mut c_int,  /* IO - error status      */
-) -> c_int {
+pub unsafe extern "C" fn ffdrec(fptr: *mut fitsfile, keypos: c_int, status: *mut c_int) -> c_int {
     // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
@@ -3259,13 +3920,14 @@ pub unsafe extern "C" fn ffdrec(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Delete a header keyword at position keypos. The 1st keyword is at keypos=1.
-pub fn ffdrec_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer  */
-    keypos: c_int,       /* I - position in header of keyword to delete */
-    status: &mut c_int,  /* IO - error status      */
-) -> c_int {
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `keypos` — (I) position in header of keyword to delete
+/// * `status` — (IO) error status
+pub fn ffdrec_safe(fptr: &mut fitsfile, keypos: c_int, status: &mut c_int) -> c_int {
     let mut nshift = 0;
     let mut bytepos: LONGLONG = 0;
 

--- a/src/pliocomp.rs
+++ b/src/pliocomp.rs
@@ -1,3 +1,10 @@
+//! A thin wrapper over the `pliocomp` crate's PLIO codec.
+//!
+//! Dead code: this module is not declared in `lib.rs`, and
+//! [`crate::imcompress`] calls the `pliocomp` crate directly. Kept for
+//! reference against the C.
+#![warn(missing_docs)]
+
 use pliocomp;
 
 /// Convert a pixel array to a line list.

--- a/src/putcol.rs
+++ b/src/putcol.rs
@@ -1,9 +1,18 @@
-/*  This file, putcol.rs, contains routines that write data elements to     */
-/*  a FITS image or table. These are the generic routines.                 */
-
-/*  The FITSIO software was written by William Pence at the High Energy    */
-/*  Astrophysic Science Archive Research Center (HEASARC) at the NASA      */
-/*  Goddard Space Flight Center.                                           */
+//! Generic-datatype routines that write data elements to a FITS image or table.
+//!
+//! The write-side counterpart of [`crate::getcol`]: these take a `datatype`
+//! code at run time and dispatch to the corresponding typed module -- `putcolb`
+//! for [`TBYTE`], `putcold` for [`TDOUBLE`], and so on.
+//!
+//! Writing converts in the opposite direction to reading: the value stored is
+//! `(the value supplied - TZEROn) / TSCALn`, cast to the column's own type, so
+//! a column stored as 16-bit integers can be written from doubles. A supplied
+//! value equal to `nulval` is stored as the column's null value.
+//!
+//! Ported from CFITSIO's `putcol.c`, written by William Pence at the High
+//! Energy Astrophysics Science Archive Research Center (HEASARC), NASA Goddard
+//! Space Flight Center.
+#![warn(missing_docs)]
 
 use core::ffi::CStr;
 use core::slice;
@@ -59,7 +68,6 @@ use crate::raw_to_slice;
 use crate::wrappers::*;
 use crate::{bytes_per_datatype, fitsio::*, int_snprintf};
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of pixels to the primary array.  The datatype of the
 /// input array is defined by the 2nd argument. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
@@ -67,14 +75,23 @@ use crate::{bytes_per_datatype, fitsio::*, int_snprintf};
 ///
 /// This routine is simillar to ffppr, except it supports writing to
 /// large images with more than 2**31 pixels.
+///
+/// # Parameters
+///
+/// * `fptr`     — (I) FITS file pointer
+/// * `datatype` — (I) datatype of the value
+/// * `firstpix` — (I) coord of first pixel to write(1 based)
+/// * `nelem`    — (I) number of values to write
+/// * `array`    — (I) array of values that are written
+/// * `status`   — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffppx(
-    fptr: *mut fitsfile,     /* I - FITS file pointer                       */
-    datatype: c_int,         /* I - datatype of the value                   */
-    firstpix: *const c_long, /* I - coord of  first pixel to write(1 based) */
-    nelem: LONGLONG,         /* I - number of values to write               */
-    array: *const c_void,    /* I - array of values that are written        */
-    status: *mut c_int,      /* IO - error status                           */
+    fptr: *mut fitsfile,
+    datatype: c_int,
+    firstpix: *const c_long,
+    nelem: LONGLONG,
+    array: *const c_void,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -100,7 +117,6 @@ pub unsafe extern "C" fn ffppx(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of pixels to the primary array.  The datatype of the
 /// input array is defined by the 2nd argument. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
@@ -108,13 +124,22 @@ pub unsafe extern "C" fn ffppx(
 ///
 /// This routine is simillar to ffppr, except it supports writing to
 /// large images with more than 2**31 pixels.
+///
+/// # Parameters
+///
+/// * `fptr`     — (I) FITS file pointer
+/// * `datatype` — (I) datatype of the value
+/// * `firstpix` — (I) coord of first pixel to write(1 based)
+/// * `nelem`    — (I) number of values to write
+/// * `array`    — (I) array of values that are written
+/// * `status`   — (IO) error status
 pub fn ffppx_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                       */
-    datatype: c_int,     /* I - datatype of the value                   */
-    firstpix: &[c_long], /* I - coord of  first pixel to write(1 based) */
-    nelem: LONGLONG,     /* I - number of values to write               */
-    array: &[u8],        /* I - array of values that are written        */
-    status: &mut c_int,  /* IO - error status                           */
+    fptr: &mut fitsfile,
+    datatype: c_int,
+    firstpix: &[c_long],
+    nelem: LONGLONG,
+    array: &[u8],
+    status: &mut c_int,
 ) -> c_int {
     let mut naxis: c_int = 0;
     let group: c_long = 1;
@@ -181,7 +206,6 @@ pub fn ffppx_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of pixels to the primary array.  The datatype of the
 /// input array is defined by the 2nd argument. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
@@ -189,14 +213,23 @@ pub fn ffppx_safe(
 ///
 /// This routine is simillar to ffppr, except it supports writing to
 /// large images with more than 2**31 pixels.
+///
+/// # Parameters
+///
+/// * `fptr`     — (I) FITS file pointer
+/// * `datatype` — (I) datatype of the value
+/// * `firstpix` — (I) coord of first pixel to write(1 based)
+/// * `nelem`    — (I) number of values to write
+/// * `array`    — (I) array of values that are written
+/// * `status`   — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffppxll(
-    fptr: *mut fitsfile,       /* I - FITS file pointer                       */
-    datatype: c_int,           /* I - datatype of the value                   */
-    firstpix: *const LONGLONG, /* I - coord of  first pixel to write(1 based) */
-    nelem: LONGLONG,           /* I - number of values to write               */
-    array: *const c_void,      /* I - array of values that are written        */
-    status: *mut c_int,        /* IO - error status                           */
+    fptr: *mut fitsfile,
+    datatype: c_int,
+    firstpix: *const LONGLONG,
+    nelem: LONGLONG,
+    array: *const c_void,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -221,7 +254,6 @@ pub unsafe extern "C" fn ffppxll(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of pixels to the primary array.  The datatype of the
 /// input array is defined by the 2nd argument. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
@@ -229,13 +261,22 @@ pub unsafe extern "C" fn ffppxll(
 ///
 /// This routine is simillar to ffppr, except it supports writing to
 /// large images with more than 2**31 pixels.
+///
+/// # Parameters
+///
+/// * `fptr`     — (I) FITS file pointer
+/// * `datatype` — (I) datatype of the value
+/// * `firstpix` — (I) coord of first pixel to write(1 based)
+/// * `nelem`    — (I) number of values to write
+/// * `array`    — (I) array of values that are written
+/// * `status`   — (IO) error status
 pub fn ffppxll_safe(
-    fptr: &mut fitsfile,   /* I - FITS file pointer                       */
-    datatype: c_int,       /* I - datatype of the value                   */
-    firstpix: &[LONGLONG], /* I - coord of  first pixel to write(1 based) */
-    nelem: LONGLONG,       /* I - number of values to write               */
-    array: &[u8],          /* I - array of values that are written        */
-    status: &mut c_int,    /* IO - error status                           */
+    fptr: &mut fitsfile,
+    datatype: c_int,
+    firstpix: &[LONGLONG],
+    nelem: LONGLONG,
+    array: &[u8],
+    status: &mut c_int,
 ) -> c_int {
     let mut naxis: c_int = 0;
     let group: c_long = 1;
@@ -302,7 +343,6 @@ pub fn ffppxll_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of values to the primary array.  The datatype of the
 /// input array is defined by the 2nd argument. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
@@ -310,15 +350,25 @@ pub fn ffppxll_safe(
 ///
 /// This routine supports writing to large images with
 /// more than 2**31 pixels.
+///
+/// # Parameters
+///
+/// * `fptr`     — (I) FITS file pointer
+/// * `datatype` — (I) datatype of the value
+/// * `firstpix` — (I) first vector element to write(1 = 1st)
+/// * `nelem`    — (I) number of values to write
+/// * `array`    — (I) array of values that are written
+/// * `nulval`   — (I) pointer to the null value
+/// * `status`   — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffppxn(
-    fptr: *mut fitsfile,   /* I - FITS file pointer                       */
-    datatype: c_int,       /* I - datatype of the value                   */
-    firstpix: *mut c_long, /* I - first vector element to write(1 = 1st)  */
-    nelem: LONGLONG,       /* I - number of values to write               */
-    array: *const c_void,  /* I - array of values that are written        */
-    nulval: *const c_void, /* I - pointer to the null value               */
-    status: *mut c_int,    /* IO - error status                           */
+    fptr: *mut fitsfile,
+    datatype: c_int,
+    firstpix: *mut c_long,
+    nelem: LONGLONG,
+    array: *const c_void,
+    nulval: *const c_void,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -345,7 +395,6 @@ pub unsafe extern "C" fn ffppxn(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of values to the primary array.  The datatype of the
 /// input array is defined by the 2nd argument. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
@@ -353,14 +402,24 @@ pub unsafe extern "C" fn ffppxn(
 ///
 /// This routine supports writing to large images with
 /// more than 2**31 pixels.
+///
+/// # Parameters
+///
+/// * `fptr`     — (I) FITS file pointer
+/// * `datatype` — (I) datatype of the value
+/// * `firstpix` — (I) first vector element to write(1 = 1st)
+/// * `nelem`    — (I) number of values to write
+/// * `array`    — (I) array of values that are written
+/// * `nulval`   — (I) pointer to the null value
+/// * `status`   — (IO) error status
 pub fn ffppxn_safe(
-    fptr: &mut fitsfile,       /* I - FITS file pointer                       */
-    datatype: c_int,           /* I - datatype of the value                   */
-    firstpix: &[c_long],       /* I - first vector element to write(1 = 1st)  */
-    nelem: LONGLONG,           /* I - number of values to write               */
-    array: &[u8],              /* I - array of values that are written        */
-    nulval: Option<NullValue>, /* I - pointer to the null value               */
-    status: &mut c_int,        /* IO - error status                           */
+    fptr: &mut fitsfile,
+    datatype: c_int,
+    firstpix: &[c_long],
+    nelem: LONGLONG,
+    array: &[u8],
+    nulval: Option<NullValue>,
+    status: &mut c_int,
 ) -> c_int {
     let mut naxis = 0;
 
@@ -533,7 +592,6 @@ pub fn ffppxn_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of values to the primary array.  The datatype of the
 /// input array is defined by the 2nd argument. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
@@ -541,15 +599,25 @@ pub fn ffppxn_safe(
 ///
 /// This routine supports writing to large images with
 /// more than 2**31 pixels.
+///
+/// # Parameters
+///
+/// * `fptr`     — (I) FITS file pointer
+/// * `datatype` — (I) datatype of the value
+/// * `firstpix` — (I) first vector element to write(1 = 1st)
+/// * `nelem`    — (I) number of values to write
+/// * `array`    — (I) array of values that are written
+/// * `nulval`   — (I) pointer to the null value
+/// * `status`   — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffppxnll(
-    fptr: *mut fitsfile,       /* I - FITS file pointer                       */
-    datatype: c_int,           /* I - datatype of the value                   */
-    firstpix: *const LONGLONG, /* I - first vector element to write(1 = 1st)  */
-    nelem: LONGLONG,           /* I - number of values to write               */
-    array: *const c_void,      /* I - array of values that are written        */
-    nulval: *const c_void,     /* I - pointer to the null value               */
-    status: *mut c_int,        /* IO - error status                           */
+    fptr: *mut fitsfile,
+    datatype: c_int,
+    firstpix: *const LONGLONG,
+    nelem: LONGLONG,
+    array: *const c_void,
+    nulval: *const c_void,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -575,7 +643,6 @@ pub unsafe extern "C" fn ffppxnll(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of values to the primary array.  The datatype of the
 /// input array is defined by the 2nd argument. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
@@ -583,14 +650,24 @@ pub unsafe extern "C" fn ffppxnll(
 ///
 /// This routine supports writing to large images with
 /// more than 2**31 pixels.
+///
+/// # Parameters
+///
+/// * `fptr`     — (I) FITS file pointer
+/// * `datatype` — (I) datatype of the value
+/// * `firstpix` — (I) first vector element to write(1 = 1st)
+/// * `nelem`    — (I) number of values to write
+/// * `array`    — (I) array of values that are written
+/// * `nulval`   — (I) pointer to the null value
+/// * `status`   — (IO) error status
 pub fn ffppxnll_safe(
-    fptr: &mut fitsfile,       /* I - FITS file pointer                       */
-    datatype: c_int,           /* I - datatype of the value                   */
-    firstpix: &[LONGLONG],     /* I - first vector element to write(1 = 1st)  */
-    nelem: LONGLONG,           /* I - number of values to write               */
-    array: &[u8],              /* I - array of values that are written        */
-    nulval: Option<NullValue>, /* I - pointer to the null value               */
-    status: &mut c_int,        /* IO - error status                           */
+    fptr: &mut fitsfile,
+    datatype: c_int,
+    firstpix: &[LONGLONG],
+    nelem: LONGLONG,
+    array: &[u8],
+    nulval: Option<NullValue>,
+    status: &mut c_int,
 ) -> c_int {
     let mut naxis = 0;
 
@@ -765,19 +842,27 @@ pub fn ffppxnll_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of values to the primary array.  The datatype of the
 /// input array is defined by the 2nd argument. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
 /// the FITS array is not the same as the array being written).
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `datatype`  — (I) datatype of the value
+/// * `firstelem` — (I) first vector element to write(1 = 1st)
+/// * `nelem`     — (I) number of values to write
+/// * `array`     — (I) array of values that are written
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffppr(
-    fptr: *mut fitsfile,  /* I - FITS file pointer                       */
-    datatype: c_int,      /* I - datatype of the value                   */
-    firstelem: LONGLONG,  /* I - first vector element to write(1 = 1st)  */
-    nelem: LONGLONG,      /* I - number of values to write               */
-    array: *const c_void, /* I - array of values that are written        */
-    status: *mut c_int,   /* IO - error status                           */
+    fptr: *mut fitsfile,
+    datatype: c_int,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: *const c_void,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -798,18 +883,26 @@ pub unsafe extern "C" fn ffppr(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of values to the primary array.  The datatype of the
 /// input array is defined by the 2nd argument. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
 /// the FITS array is not the same as the array being written).
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `datatype`  — (I) datatype of the value
+/// * `firstelem` — (I) first vector element to write(1 = 1st)
+/// * `nelem`     — (I) number of values to write
+/// * `array`     — (I) array of values that are written
+/// * `status`    — (IO) error status
 pub fn ffppr_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                       */
-    datatype: c_int,     /* I - datatype of the value                   */
-    firstelem: LONGLONG, /* I - first vector element to write(1 = 1st)  */
-    nelem: LONGLONG,     /* I - number of values to write               */
-    array: &[u8],        /* I - array of values that are written        */
-    status: &mut c_int,  /* IO - error status                           */
+    fptr: &mut fitsfile,
+    datatype: c_int,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: &[u8],
+    status: &mut c_int,
 ) -> c_int {
     let group: c_long = 1;
 
@@ -860,20 +953,29 @@ pub fn ffppr_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of values to the primary array.  The datatype of the
 /// input array is defined by the 2nd argument. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
 /// the FITS array is not the same as the array being written).
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `datatype`  — (I) datatype of the value
+/// * `firstelem` — (I) first vector element to write(1 = 1st)
+/// * `nelem`     — (I) number of values to write
+/// * `array`     — (I) array of values that are written
+/// * `nulval`    — (I) pointer to the null value
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffppn(
-    fptr: *mut fitsfile,   /* I - FITS file pointer                       */
-    datatype: c_int,       /* I - datatype of the value                   */
-    firstelem: LONGLONG,   /* I - first vector element to write(1 = 1st)  */
-    nelem: LONGLONG,       /* I - number of values to write               */
-    array: *const c_void,  /* I - array of values that are written        */
-    nulval: *const c_void, /* I - pointer to the null value               */
-    status: *mut c_int,    /* IO - error status                           */
+    fptr: *mut fitsfile,
+    datatype: c_int,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: *const c_void,
+    nulval: *const c_void,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -895,19 +997,28 @@ pub unsafe extern "C" fn ffppn(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of values to the primary array.  The datatype of the
 /// input array is defined by the 2nd argument. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
 /// the FITS array is not the same as the array being written).
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `datatype`  — (I) datatype of the value
+/// * `firstelem` — (I) first vector element to write(1 = 1st)
+/// * `nelem`     — (I) number of values to write
+/// * `array`     — (I) array of values that are written
+/// * `nulval`    — (I) pointer to the null value
+/// * `status`    — (IO) error status
 pub fn ffppn_safe(
-    fptr: &mut fitsfile,       /* I - FITS file pointer                       */
-    datatype: c_int,           /* I - datatype of the value                   */
-    firstelem: LONGLONG,       /* I - first vector element to write(1 = 1st)  */
-    nelem: LONGLONG,           /* I - number of values to write               */
-    array: &[u8],              /* I - array of values that are written        */
-    nulval: Option<NullValue>, /* I - pointer to the null value               */
-    status: &mut c_int,        /* IO - error status                           */
+    fptr: &mut fitsfile,
+    datatype: c_int,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: &[u8],
+    nulval: Option<NullValue>,
+    status: &mut c_int,
 ) -> c_int {
     let group: c_long = 1;
 
@@ -1114,7 +1225,6 @@ pub fn ffppn_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write a section of values to the primary array. The datatype of the
 /// input array is defined by the 2nd argument.  Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
@@ -1122,14 +1232,23 @@ pub fn ffppn_safe(
 ///
 /// This routine supports writing to large images with
 /// more than 2**31 pixels.
+///
+/// # Parameters
+///
+/// * `fptr`     — (I) FITS file pointer
+/// * `datatype` — (I) datatype of the value
+/// * `blc`      — (I) 'bottom left corner' of the subsection
+/// * `trc`      — (I) 'top right corner' of the subsection
+/// * `array`    — (I) array of values that are written
+/// * `status`   — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffpss(
-    fptr: *mut fitsfile,  /* I - FITS file pointer                       */
-    datatype: c_int,      /* I - datatype of the value                   */
-    blc: *const c_long,   /* I - 'bottom left corner' of the subsection  */
-    trc: *const c_long,   /* I - 'top right corner' of the subsection    */
-    array: *const c_void, /* I - array of values that are written        */
-    status: *mut c_int,   /* IO - error status                           */
+    fptr: *mut fitsfile,
+    datatype: c_int,
+    blc: *const c_long,
+    trc: *const c_long,
+    array: *const c_void,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -1160,7 +1279,6 @@ pub unsafe extern "C" fn ffpss(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write a section of values to the primary array. The datatype of the
 /// input array is defined by the 2nd argument.  Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
@@ -1168,13 +1286,22 @@ pub unsafe extern "C" fn ffpss(
 ///
 /// This routine supports writing to large images with
 /// more than 2**31 pixels.
+///
+/// # Parameters
+///
+/// * `fptr`     — (I) FITS file pointer
+/// * `datatype` — (I) datatype of the value
+/// * `blc`      — (I) 'bottom left corner' of the subsection
+/// * `trc`      — (I) 'top right corner' of the subsection
+/// * `array`    — (I) array of values that are written
+/// * `status`   — (IO) error status
 pub fn ffpss_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                       */
-    datatype: c_int,     /* I - datatype of the value                   */
-    blc: &[c_long],      /* I - 'bottom left corner' of the subsection  */
-    trc: &[c_long],      /* I - 'top right corner' of the subsection    */
-    array: &[u8],        /* I - array of values that are written        */
-    status: &mut c_int,  /* IO - error status                           */
+    fptr: &mut fitsfile,
+    datatype: c_int,
+    blc: &[c_long],
+    trc: &[c_long],
+    array: &[u8],
+    status: &mut c_int,
 ) -> c_int {
     let mut naxis: c_int = 0;
     let mut naxes: [c_long; 9] = [0; 9];
@@ -1233,21 +1360,31 @@ pub fn ffpss_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of values to a table column.  The datatype of the
 /// input array is defined by the 2nd argument. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
 /// the FITS column is not the same as the array being written).
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `datatype`  — (I) datatype of the value
+/// * `colnum`    — (I) number of column to write (1 = 1st col)
+/// * `firstrow`  — (I) first row to write (1 = 1st row)
+/// * `firstelem` — (I) first vector element to write (1 = 1st)
+/// * `nelem`     — (I) number of elements to write
+/// * `array`     — (I) array of values that are written
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffpcl(
-    fptr: *mut fitsfile,  /* I - FITS file pointer                       */
-    datatype: c_int,      /* I - datatype of the value                   */
-    colnum: c_int,        /* I - number of column to write (1 = 1st col) */
-    firstrow: LONGLONG,   /* I - first row to write (1 = 1st row)        */
-    firstelem: LONGLONG,  /* I - first vector element to write (1 = 1st) */
-    nelem: LONGLONG,      /* I - number of elements to write             */
-    array: *const c_void, /* I - array of values that are written        */
-    status: *mut c_int,   /* IO - error status                           */
+    fptr: *mut fitsfile,
+    datatype: c_int,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: *const c_void,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -1277,20 +1414,30 @@ pub unsafe extern "C" fn ffpcl(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of values to a table column.  The datatype of the
 /// input array is defined by the 2nd argument. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
 /// the FITS column is not the same as the array being written).
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `datatype`  — (I) datatype of the value
+/// * `colnum`    — (I) number of column to write (1 = 1st col)
+/// * `firstrow`  — (I) first row to write (1 = 1st row)
+/// * `firstelem` — (I) first vector element to write (1 = 1st)
+/// * `nelem`     — (I) number of elements to write
+/// * `array`     — (I) array of values that are written
+/// * `status`    — (IO) error status
 pub fn ffpcl_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                       */
-    datatype: c_int,     /* I - datatype of the value                   */
-    colnum: c_int,       /* I - number of column to write (1 = 1st col) */
-    firstrow: LONGLONG,  /* I - first row to write (1 = 1st row)        */
-    firstelem: LONGLONG, /* I - first vector element to write (1 = 1st) */
-    nelem: LONGLONG,     /* I - number of elements to write             */
-    array: &[u8],        /* I - array of values that are written        */
-    status: &mut c_int,  /* IO - error status                           */
+    fptr: &mut fitsfile,
+    datatype: c_int,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: &[u8],
+    status: &mut c_int,
 ) -> c_int {
     if *status > 0 {
         /* inherit input status value if > 0 */
@@ -1522,22 +1669,33 @@ pub fn ffpcl_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of values to a table column.  The datatype of the
 /// input array is defined by the 2nd argument. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
 /// the FITS column is not the same as the array being written).
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `datatype`  — (I) datatype of the value
+/// * `colnum`    — (I) number of column to write (1 = 1st col)
+/// * `firstrow`  — (I) first row to write (1 = 1st row)
+/// * `firstelem` — (I) first vector element to write (1 = 1st)
+/// * `nelem`     — (I) number of elements to write
+/// * `array`     — (I) array of values that are written
+/// * `nulval`    — (I) pointer to the null value
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffpcn(
-    fptr: *mut fitsfile,   /* I - FITS file pointer                       */
-    datatype: c_int,       /* I - datatype of the value                   */
-    colnum: c_int,         /* I - number of column to write (1 = 1st col) */
-    firstrow: LONGLONG,    /* I - first row to write (1 = 1st row)        */
-    firstelem: LONGLONG,   /* I - first vector element to write (1 = 1st) */
-    nelem: LONGLONG,       /* I - number of elements to write             */
-    array: *const c_void,  /* I - array of values that are written        */
-    nulval: *const c_void, /* I - pointer to the null value               */
-    status: *mut c_int,    /* IO - error status                           */
+    fptr: *mut fitsfile,
+    datatype: c_int,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: *const c_void,
+    nulval: *const c_void,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -1569,21 +1727,32 @@ pub unsafe extern "C" fn ffpcn(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of values to a table column.  The datatype of the
 /// input array is defined by the 2nd argument. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
 /// the FITS column is not the same as the array being written).
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `datatype`  — (I) datatype of the value
+/// * `colnum`    — (I) number of column to write (1 = 1st col)
+/// * `firstrow`  — (I) first row to write (1 = 1st row)
+/// * `firstelem` — (I) first vector element to write (1 = 1st)
+/// * `nelem`     — (I) number of elements to write
+/// * `array`     — (I) array of values that are written
+/// * `nulval`    — (I) pointer to the null value
+/// * `status`    — (IO) error status
 pub fn ffpcn_safe(
-    fptr: &mut fitsfile,       /* I - FITS file pointer                       */
-    datatype: c_int,           /* I - datatype of the value                   */
-    colnum: c_int,             /* I - number of column to write (1 = 1st col) */
-    firstrow: LONGLONG,        /* I - first row to write (1 = 1st row)        */
-    firstelem: LONGLONG,       /* I - first vector element to write (1 = 1st) */
-    nelem: LONGLONG,           /* I - number of elements to write             */
-    array: &[u8],              /* I - array of values that are written        */
-    nulval: Option<NullValue>, /* I - pointer to the null value               */
-    status: &mut c_int,        /* IO - error status                           */
+    fptr: &mut fitsfile,
+    datatype: c_int,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: &[u8],
+    nulval: Option<NullValue>,
+    status: &mut c_int,
 ) -> c_int {
     if *status > 0 {
         /* inherit input status value if > 0 */
@@ -1878,26 +2047,37 @@ pub fn ffpcn_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write arrays of values to NCOLS table columns. This is an optimization
 /// to write all columns in one pass through the table.  The datatypes of the
 /// input arrays are defined by the 3rd argument.  Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
 /// the FITS array is not the same as the array being written).
-/// Undefined elements for column i that are equal to *(nulval[i]) are set to
-/// the defined null value, unless nulval[i]=0,
+/// Undefined elements for column `i` that are equal to `*(nulval[i])` are set to
+/// the defined null value, unless `nulval[i]=0`,
 /// in which case no checking for undefined values will be performed.
+///
+/// # Parameters
+///
+/// * `fptr`     — (I) FITS file pointer
+/// * `ncols`    — (I) number of columns to write
+/// * `datatype` — (I) datatypes of the values
+/// * `colnum`   — (I) columns numbers to write (1 = 1st col)
+/// * `firstrow` — (I) first row to write (1 = 1st row)
+/// * `nrows`    — (I) number of rows to write
+/// * `array`    — (I) array of pointers to values to write
+/// * `nulval`   — (I) array of pointers to values for undefined pixels
+/// * `status`   — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffpcln(
-    fptr: *mut fitsfile,          /* I - FITS file pointer                       */
-    ncols: c_int,                 /* I - number of columns to write              */
-    datatype: *const c_int,       /* I - datatypes of the values                 */
-    colnum: *const c_int,         /* I - columns numbers to write (1 = 1st col)  */
-    firstrow: LONGLONG,           /* I - first row to write (1 = 1st row)    */
-    nrows: LONGLONG,              /* I - number of rows to write             */
-    array: *const *const c_void,  /* I - array of pointers to values to write    */
-    nulval: *const *const c_void, /* I - array of pointers to values for undefined pixels */
-    status: *mut c_int,           /* IO - error status                           */
+    fptr: *mut fitsfile,
+    ncols: c_int,
+    datatype: *const c_int,
+    colnum: *const c_int,
+    firstrow: LONGLONG,
+    nrows: LONGLONG,
+    array: *const *const c_void,
+    nulval: *const *const c_void,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -1914,25 +2094,36 @@ pub unsafe extern "C" fn ffpcln(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write arrays of values to NCOLS table columns. This is an optimization
 /// to write all columns in one pass through the table.  The datatypes of the
 /// input arrays are defined by the 3rd argument.  Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
 /// the FITS array is not the same as the array being written).
-/// Undefined elements for column i that are equal to *(nulval[i]) are set to
-/// the defined null value, unless nulval[i]=0,
+/// Undefined elements for column `i` that are equal to `*(nulval[i])` are set to
+/// the defined null value, unless `nulval[i]=0`,
 /// in which case no checking for undefined values will be performed.
+///
+/// # Parameters
+///
+/// * `fptr`     — (I) FITS file pointer
+/// * `ncols`    — (I) number of columns to write
+/// * `datatype` — (I) datatypes of the values
+/// * `colnum`   — (I) columns numbers to write (1 = 1st col)
+/// * `firstrow` — (I) first row to write (1 = 1st row)
+/// * `nrows`    — (I) number of rows to write
+/// * `array`    — (I) array of pointers to values to write
+/// * `nulval`   — (I) array of pointers to values for undefined pixels
+/// * `status`   — (IO) error status
 pub fn ffpcln_safe(
-    fptr: &mut fitsfile,      /* I - FITS file pointer                       */
-    ncols: c_int,             /* I - number of columns to write              */
-    datatype: &[c_int],       /* I - datatypes of the values                 */
-    colnum: &[c_int],         /* I - columns numbers to write (1 = 1st col)  */
-    firstrow: LONGLONG,       /* I - first row to write (1 = 1st row)    */
-    nrows: LONGLONG,          /* I - number of rows to write             */
-    array: &[*const c_void],  /* I - array of pointers to values to write    */
-    nulval: &[*const c_void], /* I - array of pointers to values for undefined pixels */
-    status: &mut c_int,       /* IO - error status                           */
+    fptr: &mut fitsfile,
+    ncols: c_int,
+    datatype: &[c_int],
+    colnum: &[c_int],
+    firstrow: LONGLONG,
+    nrows: LONGLONG,
+    array: &[*const c_void],
+    nulval: &[*const c_void],
+    status: &mut c_int,
 ) -> c_int {
     let mut ntotrows: LONGLONG = 0;
     let mut nrowbuf: c_long = 0;
@@ -2084,15 +2275,22 @@ pub fn ffpcln_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
-/// set all the parameters for an iterator column, by column name
+/// Set all the parameters for an iterator column, by column name
+///
+/// # Parameters
+///
+/// * `col`      — (I) iterator col structure
+/// * `fptr`     — (I) FITS file pointer
+/// * `colname`  — (I) column name
+/// * `datatype` — (I) column datatype
+/// * `iotype`   — (I) InputCol, InputOutputCol, or OutputCol
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn fits_iter_set_by_name(
-    col: *mut iteratorCol,  /* I - iterator col structure */
-    fptr: *mut fitsfile,    /* I - FITS file pointer                      */
-    colname: *const c_char, /* I - column name                            */
-    datatype: c_int,        /* I - column datatype                        */
-    iotype: c_int,          /* I - InputCol, InputOutputCol, or OutputCol */
+    col: *mut iteratorCol,
+    fptr: *mut fitsfile,
+    colname: *const c_char,
+    datatype: c_int,
+    iotype: c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -2105,14 +2303,21 @@ pub unsafe extern "C" fn fits_iter_set_by_name(
     }
 }
 
-/*--------------------------------------------------------------------------*/
-/// set all the parameters for an iterator column, by column name
+/// Set all the parameters for an iterator column, by column name
+///
+/// # Parameters
+///
+/// * `col`      — (I) iterator col structure
+/// * `fptr`     — (I) FITS file pointer
+/// * `colname`  — (I) column name
+/// * `datatype` — (I) column datatype
+/// * `iotype`   — (I) InputCol, InputOutputCol, or OutputCol
 pub fn fits_iter_set_by_name_safe(
-    col: &mut iteratorCol, /* I - iterator col structure */
-    fptr: &mut fitsfile,   /* I - FITS file pointer                      */
-    colname: &[c_char],    /* I - column name                            */
-    datatype: c_int,       /* I - column datatype                        */
-    iotype: c_int,         /* I - InputCol, InputOutputCol, or OutputCol */
+    col: &mut iteratorCol,
+    fptr: &mut fitsfile,
+    colname: &[c_char],
+    datatype: c_int,
+    iotype: c_int,
 ) -> c_int {
     col.fptr = fptr;
     strncpy_safe(&mut col.colname, colname, 69);
@@ -2124,15 +2329,22 @@ pub fn fits_iter_set_by_name_safe(
     0
 }
 
-/*--------------------------------------------------------------------------*/
-/// set all the parameters for an iterator column, by column number
+/// Set all the parameters for an iterator column, by column number
+///
+/// # Parameters
+///
+/// * `col`      — (I) iterator col structure
+/// * `fptr`     — (I) FITS file pointer
+/// * `colnum`   — (I) column number
+/// * `datatype` — (I) column datatype
+/// * `iotype`   — (I) InputCol, InputOutputCol, or OutputCol
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn fits_iter_set_by_num(
-    col: *mut iteratorCol, /* I - iterator col structure */
-    fptr: *mut fitsfile,   /* I - FITS file pointer                      */
-    colnum: c_int,         /* I - column number                          */
-    datatype: c_int,       /* I - column datatype                        */
-    iotype: c_int,         /* I - InputCol, InputOutputCol, or OutputCol */
+    col: *mut iteratorCol,
+    fptr: *mut fitsfile,
+    colnum: c_int,
+    datatype: c_int,
+    iotype: c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -2143,14 +2355,21 @@ pub unsafe extern "C" fn fits_iter_set_by_num(
     }
 }
 
-/*--------------------------------------------------------------------------*/
-/// set all the parameters for an iterator column, by column number
+/// Set all the parameters for an iterator column, by column number
+///
+/// # Parameters
+///
+/// * `col`      — (I) iterator col structure
+/// * `fptr`     — (I) FITS file pointer
+/// * `colnum`   — (I) column number
+/// * `datatype` — (I) column datatype
+/// * `iotype`   — (I) InputCol, InputOutputCol, or OutputCol
 pub fn fits_iter_set_by_num_safe(
-    col: &mut iteratorCol, /* I - iterator col structure */
-    fptr: *mut fitsfile,   /* I - FITS file pointer                      */
-    colnum: c_int,         /* I - column number                          */
-    datatype: c_int,       /* I - column datatype                        */
-    iotype: c_int,         /* I - InputCol, InputOutputCol, or OutputCol */
+    col: &mut iteratorCol,
+    fptr: *mut fitsfile,
+    colnum: c_int,
+    datatype: c_int,
+    iotype: c_int,
 ) -> c_int {
     col.fptr = fptr;
     col.colnum = colnum;
@@ -2160,13 +2379,14 @@ pub fn fits_iter_set_by_num_safe(
     0
 }
 
-/*--------------------------------------------------------------------------*/
-/// set iterator column parameter
+/// Set iterator column parameter
+///
+/// # Parameters
+///
+/// * `col`  — (I) iterator column structure
+/// * `fptr` — (I) FITS file pointer
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
-pub unsafe extern "C" fn fits_iter_set_file(
-    col: *mut iteratorCol, /* I - iterator column structure   */
-    fptr: *mut fitsfile,   /* I - FITS file pointer                      */
-) -> c_int {
+pub unsafe extern "C" fn fits_iter_set_file(col: *mut iteratorCol, fptr: *mut fitsfile) -> c_int {
     // FFI WRAPPER
     unsafe {
         let col = col.as_mut().expect(NULL_MSG);
@@ -2176,22 +2396,27 @@ pub unsafe extern "C" fn fits_iter_set_file(
     }
 }
 
-/*--------------------------------------------------------------------------*/
-/// set iterator column parameter
-pub fn fits_iter_set_file_safe(
-    col: &mut iteratorCol, /* I - iterator column structure   */
-    fptr: &mut fitsfile,   /* I - FITS file pointer                      */
-) -> c_int {
+/// Set iterator column parameter
+///
+/// # Parameters
+///
+/// * `col`  — (I) iterator column structure
+/// * `fptr` — (I) FITS file pointer
+pub fn fits_iter_set_file_safe(col: &mut iteratorCol, fptr: &mut fitsfile) -> c_int {
     col.fptr = fptr;
     0
 }
 
-/*--------------------------------------------------------------------------*/
-/// set iterator column parameter
+/// Set iterator column parameter
+///
+/// # Parameters
+///
+/// * `col`     — (I) iterator col structure
+/// * `colname` — (I) column name
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn fits_iter_set_colname(
-    col: *mut iteratorCol,  /* I - iterator col structure  */
-    colname: *const c_char, /* I - column name                            */
+    col: *mut iteratorCol,
+    colname: *const c_char,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -2201,25 +2426,27 @@ pub unsafe extern "C" fn fits_iter_set_colname(
     }
 }
 
-/*--------------------------------------------------------------------------*/
-/// set iterator column parameter
-pub fn fits_iter_set_colname_safe(
-    col: &mut iteratorCol, /* I - iterator col structure  */
-    colname: &[c_char],    /* I - column name                            */
-) -> c_int {
+/// Set iterator column parameter
+///
+/// # Parameters
+///
+/// * `col`     — (I) iterator col structure
+/// * `colname` — (I) column name
+pub fn fits_iter_set_colname_safe(col: &mut iteratorCol, colname: &[c_char]) -> c_int {
     strncpy_safe(&mut col.colname, colname, 69);
     col.colname[69] = 0;
     col.colnum = 0; /* set column number undefined since name is given */
     0
 }
 
-/*--------------------------------------------------------------------------*/
-/// set iterator column parameter
+/// Set iterator column parameter
+///
+/// # Parameters
+///
+/// * `col`    — (I) iterator column structure
+/// * `colnum` — (I) column number
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
-pub unsafe extern "C" fn fits_iter_set_colnum(
-    col: *mut iteratorCol, /* I - iterator column structure */
-    colnum: c_int,         /* I - column number                          */
-) -> c_int {
+pub unsafe extern "C" fn fits_iter_set_colnum(col: *mut iteratorCol, colnum: c_int) -> c_int {
     // FFI WRAPPER
     unsafe {
         let col = col.as_mut().expect(NULL_MSG);
@@ -2227,23 +2454,25 @@ pub unsafe extern "C" fn fits_iter_set_colnum(
     }
 }
 
-/*--------------------------------------------------------------------------*/
-/// set iterator column parameter
-pub fn fits_iter_set_colnum_safe(
-    col: &mut iteratorCol, /* I - iterator column structure */
-    colnum: c_int,         /* I - column number                          */
-) -> c_int {
+/// Set iterator column parameter
+///
+/// # Parameters
+///
+/// * `col`    — (I) iterator column structure
+/// * `colnum` — (I) column number
+pub fn fits_iter_set_colnum_safe(col: &mut iteratorCol, colnum: c_int) -> c_int {
     col.colnum = colnum;
     0
 }
 
-/*--------------------------------------------------------------------------*/
-/// set iterator column parameter
+/// Set iterator column parameter
+///
+/// # Parameters
+///
+/// * `col`      — (I) iterator col structure
+/// * `datatype` — (I) column datatype
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
-pub unsafe extern "C" fn fits_iter_set_datatype(
-    col: *mut iteratorCol, /* I - iterator col structure */
-    datatype: c_int,       /* I - column datatype                        */
-) -> c_int {
+pub unsafe extern "C" fn fits_iter_set_datatype(col: *mut iteratorCol, datatype: c_int) -> c_int {
     // FFI WRAPPER
     unsafe {
         let col = col.as_mut().expect(NULL_MSG);
@@ -2251,23 +2480,25 @@ pub unsafe extern "C" fn fits_iter_set_datatype(
     }
 }
 
-/*--------------------------------------------------------------------------*/
-/// set iterator column parameter
-pub fn fits_iter_set_datatype_safe(
-    col: &mut iteratorCol, /* I - iterator col structure */
-    datatype: c_int,       /* I - column datatype                        */
-) -> c_int {
+/// Set iterator column parameter
+///
+/// # Parameters
+///
+/// * `col`      — (I) iterator col structure
+/// * `datatype` — (I) column datatype
+pub fn fits_iter_set_datatype_safe(col: &mut iteratorCol, datatype: c_int) -> c_int {
     col.datatype = datatype;
     0
 }
 
-/*--------------------------------------------------------------------------*/
-/// set iterator column parameter
+/// Set iterator column parameter
+///
+/// # Parameters
+///
+/// * `col`    — (I) iterator column structure
+/// * `iotype` — (I) InputCol, InputOutputCol, or OutputCol
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
-pub unsafe extern "C" fn fits_iter_set_iotype(
-    col: *mut iteratorCol, /* I - iterator column structure */
-    iotype: c_int,         /* I - InputCol, InputOutputCol, or OutputCol */
-) -> c_int {
+pub unsafe extern "C" fn fits_iter_set_iotype(col: *mut iteratorCol, iotype: c_int) -> c_int {
     // FFI WRAPPER
     unsafe {
         let col = col.as_mut().expect(NULL_MSG);
@@ -2275,22 +2506,24 @@ pub unsafe extern "C" fn fits_iter_set_iotype(
     }
 }
 
-/*--------------------------------------------------------------------------*/
-/// set iterator column parameter
-pub fn fits_iter_set_iotype_safe(
-    col: &mut iteratorCol, /* I - iterator column structure */
-    iotype: c_int,         /* I - InputCol, InputOutputCol, or OutputCol */
-) -> c_int {
+/// Set iterator column parameter
+///
+/// # Parameters
+///
+/// * `col`    — (I) iterator column structure
+/// * `iotype` — (I) InputCol, InputOutputCol, or OutputCol
+pub fn fits_iter_set_iotype_safe(col: &mut iteratorCol, iotype: c_int) -> c_int {
     col.iotype = iotype;
     0
 }
 
-/*--------------------------------------------------------------------------*/
-/// get iterator column parameter
+/// Get iterator column parameter
+///
+/// # Parameters
+///
+/// * `col` — (I) iterator col structure
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
-pub unsafe extern "C" fn fits_iter_get_file(
-    col: *mut iteratorCol, /* I -iterator col structure */
-) -> *mut fitsfile {
+pub unsafe extern "C" fn fits_iter_get_file(col: *mut iteratorCol) -> *mut fitsfile {
     // FFI WRAPPER
     unsafe {
         let col = col.as_mut().expect(NULL_MSG);
@@ -2298,20 +2531,22 @@ pub unsafe extern "C" fn fits_iter_get_file(
     }
 }
 
-/*--------------------------------------------------------------------------*/
-/// get iterator column parameter
-pub fn fits_iter_get_file_safe(
-    col: &mut iteratorCol, /* I -iterator col structure */
-) -> *mut fitsfile {
+/// Get iterator column parameter
+///
+/// # Parameters
+///
+/// * `col` — (I) iterator col structure
+pub fn fits_iter_get_file_safe(col: &mut iteratorCol) -> *mut fitsfile {
     col.fptr
 }
 
-/*--------------------------------------------------------------------------*/
-/// get iterator column parameter
+/// Get iterator column parameter
+///
+/// # Parameters
+///
+/// * `col` — (I) iterator col structure
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
-pub unsafe extern "C" fn fits_iter_get_colname(
-    col: *mut iteratorCol, /* I -iterator col structure */
-) -> *const c_char {
+pub unsafe extern "C" fn fits_iter_get_colname(col: *mut iteratorCol) -> *const c_char {
     // FFI WRAPPER
     unsafe {
         let col = col.as_mut().expect(NULL_MSG);
@@ -2319,20 +2554,22 @@ pub unsafe extern "C" fn fits_iter_get_colname(
     }
 }
 
-/*--------------------------------------------------------------------------*/
-/// get iterator column parameter
-pub fn fits_iter_get_colname_safe(
-    col: &mut iteratorCol, /* I -iterator col structure */
-) -> &[c_char; 70] {
+/// Get iterator column parameter
+///
+/// # Parameters
+///
+/// * `col` — (I) iterator col structure
+pub fn fits_iter_get_colname_safe(col: &mut iteratorCol) -> &[c_char; 70] {
     &col.colname
 }
 
-/*--------------------------------------------------------------------------*/
-/// get iterator column parameter
+/// Get iterator column parameter
+///
+/// # Parameters
+///
+/// * `col` — (I) iterator column structure
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
-pub unsafe extern "C" fn fits_iter_get_colnum(
-    col: *mut iteratorCol, /* I - iterator column structure */
-) -> c_int {
+pub unsafe extern "C" fn fits_iter_get_colnum(col: *mut iteratorCol) -> c_int {
     // FFI WRAPPER
     unsafe {
         let col = col.as_mut().expect(NULL_MSG);
@@ -2340,20 +2577,22 @@ pub unsafe extern "C" fn fits_iter_get_colnum(
     }
 }
 
-/*--------------------------------------------------------------------------*/
-/// get iterator column parameter
-pub fn fits_iter_get_colnum_safe(
-    col: &mut iteratorCol, /* I - iterator column structure */
-) -> c_int {
+/// Get iterator column parameter
+///
+/// # Parameters
+///
+/// * `col` — (I) iterator column structure
+pub fn fits_iter_get_colnum_safe(col: &mut iteratorCol) -> c_int {
     col.colnum
 }
 
-/*--------------------------------------------------------------------------*/
-/// get iterator column parameter
+/// Get iterator column parameter
+///
+/// # Parameters
+///
+/// * `col` — (I) iterator col structure
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
-pub unsafe extern "C" fn fits_iter_get_datatype(
-    col: *mut iteratorCol, /* I - iterator col structure */
-) -> c_int {
+pub unsafe extern "C" fn fits_iter_get_datatype(col: *mut iteratorCol) -> c_int {
     // FFI WRAPPER
     unsafe {
         let col = col.as_mut().expect(NULL_MSG);
@@ -2361,20 +2600,22 @@ pub unsafe extern "C" fn fits_iter_get_datatype(
     }
 }
 
-/*--------------------------------------------------------------------------*/
-/// get iterator column parameter
-pub fn fits_iter_get_datatype_safe(
-    col: &mut iteratorCol, /* I - iterator col structure */
-) -> c_int {
+/// Get iterator column parameter
+///
+/// # Parameters
+///
+/// * `col` — (I) iterator col structure
+pub fn fits_iter_get_datatype_safe(col: &mut iteratorCol) -> c_int {
     col.datatype
 }
 
-/*--------------------------------------------------------------------------*/
-/// get iterator column parameter
+/// Get iterator column parameter
+///
+/// # Parameters
+///
+/// * `col` — (I) iterator column structure
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
-pub unsafe extern "C" fn fits_iter_get_iotype(
-    col: *mut iteratorCol, /* I - iterator column structure */
-) -> c_int {
+pub unsafe extern "C" fn fits_iter_get_iotype(col: *mut iteratorCol) -> c_int {
     // FFI WRAPPER
     unsafe {
         let col = col.as_mut().expect(NULL_MSG);
@@ -2382,20 +2623,22 @@ pub unsafe extern "C" fn fits_iter_get_iotype(
     }
 }
 
-/*--------------------------------------------------------------------------*/
-/// get iterator column parameter
-pub fn fits_iter_get_iotype_safe(
-    col: &mut iteratorCol, /* I - iterator column structure */
-) -> c_int {
+/// Get iterator column parameter
+///
+/// # Parameters
+///
+/// * `col` — (I) iterator column structure
+pub fn fits_iter_get_iotype_safe(col: &mut iteratorCol) -> c_int {
     col.iotype
 }
 
-/*--------------------------------------------------------------------------*/
-/// get iterator column parameter
+/// Get iterator column parameter
+///
+/// # Parameters
+///
+/// * `col` — (I) iterator col structure
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
-pub unsafe extern "C" fn fits_iter_get_array(
-    col: *mut iteratorCol, /* I - iterator col structure */
-) -> *const c_void {
+pub unsafe extern "C" fn fits_iter_get_array(col: *mut iteratorCol) -> *const c_void {
     // FFI WRAPPER
     unsafe {
         let col = col.as_mut().expect(NULL_MSG);
@@ -2403,20 +2646,22 @@ pub unsafe extern "C" fn fits_iter_get_array(
     }
 }
 
-/*--------------------------------------------------------------------------*/
-/// get iterator column parameter
-pub fn fits_iter_get_array_safe(
-    col: &mut iteratorCol, /* I - iterator col structure */
-) -> *const c_void {
+/// Get iterator column parameter
+///
+/// # Parameters
+///
+/// * `col` — (I) iterator col structure
+pub fn fits_iter_get_array_safe(col: &mut iteratorCol) -> *const c_void {
     col.array
 }
 
-/*--------------------------------------------------------------------------*/
-/// get iterator column parameter
+/// Get iterator column parameter
+///
+/// # Parameters
+///
+/// * `col` — (I) iterator column structure
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
-pub unsafe extern "C" fn fits_iter_get_tlmin(
-    col: *mut iteratorCol, /* I - iterator column structure */
-) -> c_long {
+pub unsafe extern "C" fn fits_iter_get_tlmin(col: *mut iteratorCol) -> c_long {
     // FFI WRAPPER
     unsafe {
         let col = col.as_mut().expect(NULL_MSG);
@@ -2424,20 +2669,22 @@ pub unsafe extern "C" fn fits_iter_get_tlmin(
     }
 }
 
-/*--------------------------------------------------------------------------*/
-/// get iterator column parameter
-pub fn fits_iter_get_tlmin_safe(
-    col: &mut iteratorCol, /* I - iterator column structure */
-) -> c_long {
+/// Get iterator column parameter
+///
+/// # Parameters
+///
+/// * `col` — (I) iterator column structure
+pub fn fits_iter_get_tlmin_safe(col: &mut iteratorCol) -> c_long {
     col.tlmin
 }
 
-/*--------------------------------------------------------------------------*/
-/// get iterator column parameter
+/// Get iterator column parameter
+///
+/// # Parameters
+///
+/// * `col` — (I) iterator column structure
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
-pub unsafe extern "C" fn fits_iter_get_tlmax(
-    col: *mut iteratorCol, /* I - iterator column structure */
-) -> c_long {
+pub unsafe extern "C" fn fits_iter_get_tlmax(col: *mut iteratorCol) -> c_long {
     // FFI WRAPPER
     unsafe {
         let col = col.as_mut().expect(NULL_MSG);
@@ -2445,20 +2692,22 @@ pub unsafe extern "C" fn fits_iter_get_tlmax(
     }
 }
 
-/*--------------------------------------------------------------------------*/
-/// get iterator column parameter
-pub fn fits_iter_get_tlmax_safe(
-    col: &mut iteratorCol, /* I - iterator column structure */
-) -> c_long {
+/// Get iterator column parameter
+///
+/// # Parameters
+///
+/// * `col` — (I) iterator column structure
+pub fn fits_iter_get_tlmax_safe(col: &mut iteratorCol) -> c_long {
     col.tlmax
 }
 
-/*--------------------------------------------------------------------------*/
-/// get iterator column parameter
+/// Get iterator column parameter
+///
+/// # Parameters
+///
+/// * `col` — (I) iterator col structure
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
-pub unsafe extern "C" fn fits_iter_get_repeat(
-    col: *mut iteratorCol, /* I - iterator col structure */
-) -> c_long {
+pub unsafe extern "C" fn fits_iter_get_repeat(col: *mut iteratorCol) -> c_long {
     // FFI WRAPPER
     unsafe {
         let col = col.as_mut().expect(NULL_MSG);
@@ -2466,20 +2715,22 @@ pub unsafe extern "C" fn fits_iter_get_repeat(
     }
 }
 
-/*--------------------------------------------------------------------------*/
-/// get iterator column parameter
-pub fn fits_iter_get_repeat_safe(
-    col: &mut iteratorCol, /* I - iterator col structure */
-) -> c_long {
+/// Get iterator column parameter
+///
+/// # Parameters
+///
+/// * `col` — (I) iterator col structure
+pub fn fits_iter_get_repeat_safe(col: &mut iteratorCol) -> c_long {
     col.repeat
 }
 
-/*--------------------------------------------------------------------------*/
-/// get iterator column parameter
+/// Get iterator column parameter
+///
+/// # Parameters
+///
+/// * `col` — (I) iterator col structure
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
-pub unsafe extern "C" fn fits_iter_get_tunit(
-    col: *mut iteratorCol, /* I - iterator col structure */
-) -> *const c_char {
+pub unsafe extern "C" fn fits_iter_get_tunit(col: *mut iteratorCol) -> *const c_char {
     // FFI WRAPPER
     unsafe {
         let col = col.as_mut().expect(NULL_MSG);
@@ -2487,20 +2738,22 @@ pub unsafe extern "C" fn fits_iter_get_tunit(
     }
 }
 
-/*--------------------------------------------------------------------------*/
-/// get iterator column parameter
-pub fn fits_iter_get_tunit_safe(
-    col: &mut iteratorCol, /* I - iterator col structure */
-) -> &[c_char; 70] {
+/// Get iterator column parameter
+///
+/// # Parameters
+///
+/// * `col` — (I) iterator col structure
+pub fn fits_iter_get_tunit_safe(col: &mut iteratorCol) -> &[c_char; 70] {
     &col.tunit
 }
 
-/*--------------------------------------------------------------------------*/
-/// get iterator column parameter
+/// Get iterator column parameter
+///
+/// # Parameters
+///
+/// * `col` — (I) iterator col structure
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
-pub unsafe extern "C" fn fits_iter_get_tdisp(
-    col: *mut iteratorCol, /* I -iterator col structure   */
-) -> *const c_char {
+pub unsafe extern "C" fn fits_iter_get_tdisp(col: *mut iteratorCol) -> *const c_char {
     // FFI WRAPPER
     unsafe {
         let col = col.as_mut().expect(NULL_MSG);
@@ -2508,15 +2761,15 @@ pub unsafe extern "C" fn fits_iter_get_tdisp(
     }
 }
 
-/*--------------------------------------------------------------------------*/
-/// get iterator column parameter
-pub fn fits_iter_get_tdisp_safe(
-    col: &mut iteratorCol, /* I -iterator col structure   */
-) -> &[c_char; 70] {
+/// Get iterator column parameter
+///
+/// # Parameters
+///
+/// * `col` — (I) iterator col structure
+pub fn fits_iter_get_tdisp_safe(col: &mut iteratorCol) -> &[c_char; 70] {
     &col.tdisp
 }
 
-/*--------------------------------------------------------------------------*/
 /// The iterator function.  This function will pass the specified
 /// columns from a FITS table or pixels from a FITS image to the
 /// user-supplied function.  Depending on the size of the table
@@ -2558,7 +2811,6 @@ pub unsafe extern "C" fn ffiter(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Iterate through the specified columns or rows of data in a table
 /// or image, calling a user-supplied function for each group of rows.
 /// The columns are passed by reference as iteratorCol structs. This
@@ -2595,7 +2847,6 @@ pub fn ffiter_safe(
     )
 }
 
-/*--------------------------------------------------------------------------*/
 /// The body of [`ffiter_safe`], with the column array passed as a raw pointer
 /// instead of as a `&mut [iteratorCol]`.
 ///
@@ -2747,11 +2998,9 @@ pub(crate) fn ffiter_internal(
         return *status;
     }
 
-    /*------------------------------------------------------------*/
     /* Make sure column numbers and datatypes are in legal range  */
     /* and column numbers and datatypes are legal.                */
     /* Also fill in other parameters in the column structure.     */
-    /*------------------------------------------------------------*/
 
     /* Assumptions throughout regarding the existence of cols[jj].fptr:
      1) cols[0].fptr must not be NULL
@@ -3022,9 +3271,7 @@ pub(crate) fn ffiter_internal(
             jj += 1;
         } /* end of loop over all columns */
 
-        /*-----------------------------------------------------------------*/
         /* use the first file to set the total number of values to process */
-        /*-----------------------------------------------------------------*/
 
         offset = offset.max(0); /* make sure offset is legal */
 
@@ -3110,9 +3357,7 @@ pub(crate) fn ffiter_internal(
         totaln -= offset;
         totaln = totaln.max(0); /* don't allow negative number */
 
-        /*------------------------------------------------------------------*/
         /* Determine number of values to pass to work function on each loop */
-        /*------------------------------------------------------------------*/
 
         if n_per_loop == 0 {
             /* Determine optimum number of values for each iteration.    */
@@ -3161,10 +3406,8 @@ pub(crate) fn ffiter_internal(
             n_optimum = n_per_loop.min(totaln);
         }
 
-        /*--------------------------------------*/
         /* allocate work arrays for each column */
         /* and determine the null pixel value   */
-        /*--------------------------------------*/
 
         col = vec![ColNulls::default(); n_cols as usize]; /* memory for the null values */
 
@@ -3718,9 +3961,7 @@ pub(crate) fn ffiter_internal(
                 }
             }
 
-            /*--------------------------------------------------*/
             /* main loop while there are values left to process */
-            /*--------------------------------------------------*/
 
             nleft = totaln;
 
@@ -3854,8 +4095,15 @@ pub(crate) fn ffiter_internal(
                 /* call work function */
 
                 if hdutype == IMAGE_HDU {
-                    *status =
-                        workfn(totaln, offset, felement, ntodo, n_cols, cols_ptr, userPointer);
+                    *status = workfn(
+                        totaln,
+                        offset,
+                        felement,
+                        ntodo,
+                        n_cols,
+                        cols_ptr,
+                        userPointer,
+                    );
                 } else {
                     *status = workfn(totaln, offset, frow, ntodo, n_cols, cols_ptr, userPointer);
                 }
@@ -4046,9 +4294,7 @@ pub(crate) fn ffiter_internal(
 
         // cleanup:
 
-        /*----------------------------------*/
         /* free work arrays for the columns */
-        /*----------------------------------*/
 
         for jj in 0..n_cols as usize {
             /* The C guards these on `if (cols[jj].array)`, i.e. non-null.

--- a/src/putcolb.rs
+++ b/src/putcolb.rs
@@ -1,9 +1,14 @@
-/*  This file, putcolb.rs, contains routines that write data elements to    */
-/*  a FITS image or table with char (byte) datatype.                       */
-
-/*  The FITSIO software was written by William Pence at the High Energy    */
-/*  Astrophysic Science Archive Research Center (HEASARC) at the NASA      */
-/*  Goddard Space Flight Center.                                           */
+//! Routines that write data elements to a FITS image or table, with
+//! unsigned char (byte) datatype.
+//!
+//! The [`TBYTE`] arm of the typed column I/O family. [`crate::putcol`]
+//! dispatches here when a caller asks for this datatype at run time; the
+//! write-side counterpart is [`crate::getcolb`].
+//!
+//! Ported from CFITSIO's `putcolb.c`, written by William Pence at the High
+//! Energy Astrophysics Science Archive Research Center (HEASARC), NASA Goddard
+//! Space Flight Center.
+#![warn(missing_docs)]
 
 use core::slice;
 use core::{cmp, mem};
@@ -25,7 +30,6 @@ use crate::relibc::header::stdio::snprintf_f64;
 use crate::wrappers::*;
 use crate::{buffers::*, int_snprintf, slice_to_str};
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
 /// the FITS array is not the same as the array being written).
@@ -34,14 +38,23 @@ use crate::{buffers::*, int_snprintf, slice_to_str};
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to write(1 = 1st group)
+/// * `firstelem` — (I) first vector element to write(1 = 1st)
+/// * `nelem`     — (I) number of values to write
+/// * `array`     — (I) array of values that are written
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffpprb(
-    fptr: *mut fitsfile, /* I - FITS file pointer                       */
-    group: c_long,       /* I - group to write(1 = 1st group)           */
-    firstelem: LONGLONG, /* I - first vector element to write(1 = 1st)  */
-    nelem: LONGLONG,     /* I - number of values to write               */
-    array: *const u8,    /* I - array of values that are written   */
-    status: *mut c_int,  /* IO - error status                           */
+    fptr: *mut fitsfile,
+    group: c_long,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: *const u8,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -54,7 +67,6 @@ pub unsafe extern "C" fn ffpprb(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
 /// the FITS array is not the same as the array being written).
@@ -63,13 +75,22 @@ pub unsafe extern "C" fn ffpprb(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to write(1 = 1st group)
+/// * `firstelem` — (I) first vector element to write(1 = 1st)
+/// * `nelem`     — (I) number of values to write
+/// * `array`     — (I) array of values that are written
+/// * `status`    — (IO) error status
 pub fn ffpprb_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                       */
-    group: c_long,       /* I - group to write(1 = 1st group)           */
-    firstelem: LONGLONG, /* I - first vector element to write(1 = 1st)  */
-    nelem: LONGLONG,     /* I - number of values to write               */
-    array: &[u8],        /* I - array of values that are written   */
-    status: &mut c_int,  /* IO - error status                           */
+    fptr: &mut fitsfile,
+    group: c_long,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: &[u8],
+    status: &mut c_int,
 ) -> c_int {
     let nullvalue: u8 = 0;
 
@@ -103,7 +124,6 @@ pub fn ffpprb_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of the
 /// FITS array is not the same as the array being written).  Any array values
@@ -114,15 +134,25 @@ pub fn ffpprb_safe(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to write(1 = 1st group)
+/// * `firstelem` — (I) first vector element to write(1 = 1st)
+/// * `nelem`     — (I) number of values to write
+/// * `array`     — (I) array of values that are written
+/// * `nulval`    — (I) undefined pixel value
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffppnb(
-    fptr: *mut fitsfile, /* I - FITS file pointer                       */
-    group: c_long,       /* I - group to write(1 = 1st group)           */
-    firstelem: LONGLONG, /* I - first vector element to write(1 = 1st)  */
-    nelem: LONGLONG,     /* I - number of values to write               */
-    array: *const u8,    /* I - array of values that are written   */
-    nulval: u8,          /* I - undefined pixel value              */
-    status: *mut c_int,  /* IO - error status                           */
+    fptr: *mut fitsfile,
+    group: c_long,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: *const u8,
+    nulval: u8,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -135,7 +165,6 @@ pub unsafe extern "C" fn ffppnb(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of the
 /// FITS array is not the same as the array being written).  Any array values
@@ -146,14 +175,24 @@ pub unsafe extern "C" fn ffppnb(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to write(1 = 1st group)
+/// * `firstelem` — (I) first vector element to write(1 = 1st)
+/// * `nelem`     — (I) number of values to write
+/// * `array`     — (I) array of values that are written
+/// * `nulval`    — (I) undefined pixel value
+/// * `status`    — (IO) error status
 pub fn ffppnb_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                       */
-    group: c_long,       /* I - group to write(1 = 1st group)           */
-    firstelem: LONGLONG, /* I - first vector element to write(1 = 1st)  */
-    nelem: LONGLONG,     /* I - number of values to write               */
-    array: &[u8],        /* I - array of values that are written   */
-    nulval: u8,          /* I - undefined pixel value              */
-    status: &mut c_int,  /* IO - error status                           */
+    fptr: &mut fitsfile,
+    group: c_long,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: &[u8],
+    nulval: u8,
+    status: &mut c_int,
 ) -> c_int {
     let mut nullvalue: u8 = 0;
 
@@ -190,19 +229,28 @@ pub fn ffppnb_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an entire 2-D array of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of the
 /// FITS array is not the same as the array being written).
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `group`  — (I) group to write(1 = 1st group)
+/// * `ncols`  — (I) number of pixels in each row of array
+/// * `naxis1` — (I) FITS image NAXIS1 value
+/// * `naxis2` — (I) FITS image NAXIS2 value
+/// * `array`  — (I) array to be written
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffp2db(
-    fptr: *mut fitsfile, /* I - FITS file pointer                     */
-    group: c_long,       /* I - group to write(1 = 1st group)         */
-    ncols: LONGLONG,     /* I - number of pixels in each row of array */
-    naxis1: LONGLONG,    /* I - FITS image NAXIS1 value               */
-    naxis2: LONGLONG,    /* I - FITS image NAXIS2 value               */
-    array: *const u8,    /* I - array to be written               */
-    status: *mut c_int,  /* IO - error status                         */
+    fptr: *mut fitsfile,
+    group: c_long,
+    ncols: LONGLONG,
+    naxis1: LONGLONG,
+    naxis2: LONGLONG,
+    array: *const u8,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -215,18 +263,27 @@ pub unsafe extern "C" fn ffp2db(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an entire 2-D array of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of the
 /// FITS array is not the same as the array being written).
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `group`  — (I) group to write(1 = 1st group)
+/// * `ncols`  — (I) number of pixels in each row of array
+/// * `naxis1` — (I) FITS image NAXIS1 value
+/// * `naxis2` — (I) FITS image NAXIS2 value
+/// * `array`  — (I) array to be written
+/// * `status` — (IO) error status
 pub fn ffp2db_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                     */
-    group: c_long,       /* I - group to write(1 = 1st group)         */
-    ncols: LONGLONG,     /* I - number of pixels in each row of array */
-    naxis1: LONGLONG,    /* I - FITS image NAXIS1 value               */
-    naxis2: LONGLONG,    /* I - FITS image NAXIS2 value               */
-    array: &[u8],        /* I - array to be written               */
-    status: &mut c_int,  /* IO - error status                         */
+    fptr: &mut fitsfile,
+    group: c_long,
+    ncols: LONGLONG,
+    naxis1: LONGLONG,
+    naxis2: LONGLONG,
+    array: &[u8],
+    status: &mut c_int,
 ) -> c_int {
     /* call the 3D writing routine, with the 3rd dimension = 1 */
 
@@ -235,7 +292,6 @@ pub fn ffp2db_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an entire 3-D cube of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of the
 /// FITS array is not the same as the array being written).
@@ -244,17 +300,29 @@ pub fn ffp2db_safe(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `group`  — (I) group to write(1 = 1st group)
+/// * `ncols`  — (I) number of pixels in each row of array
+/// * `nrows`  — (I) number of rows in each plane of array
+/// * `naxis1` — (I) FITS image NAXIS1 value
+/// * `naxis2` — (I) FITS image NAXIS2 value
+/// * `naxis3` — (I) FITS image NAXIS3 value
+/// * `array`  — (I) array to be written
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffp3db(
-    fptr: *mut fitsfile, /* I - FITS file pointer                     */
-    group: c_long,       /* I - group to write(1 = 1st group)         */
-    ncols: LONGLONG,     /* I - number of pixels in each row of array */
-    nrows: LONGLONG,     /* I - number of rows in each plane of array */
-    naxis1: LONGLONG,    /* I - FITS image NAXIS1 value               */
-    naxis2: LONGLONG,    /* I - FITS image NAXIS2 value               */
-    naxis3: LONGLONG,    /* I - FITS image NAXIS3 value               */
-    array: *const u8,    /* I - array to be written               */
-    status: *mut c_int,  /* IO - error status                         */
+    fptr: *mut fitsfile,
+    group: c_long,
+    ncols: LONGLONG,
+    nrows: LONGLONG,
+    naxis1: LONGLONG,
+    naxis2: LONGLONG,
+    naxis3: LONGLONG,
+    array: *const u8,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -268,7 +336,6 @@ pub unsafe extern "C" fn ffp3db(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an entire 3-D cube of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of the
 /// FITS array is not the same as the array being written).
@@ -277,16 +344,28 @@ pub unsafe extern "C" fn ffp3db(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `group`  — (I) group to write(1 = 1st group)
+/// * `ncols`  — (I) number of pixels in each row of array
+/// * `nrows`  — (I) number of rows in each plane of array
+/// * `naxis1` — (I) FITS image NAXIS1 value
+/// * `naxis2` — (I) FITS image NAXIS2 value
+/// * `naxis3` — (I) FITS image NAXIS3 value
+/// * `array`  — (I) array to be written
+/// * `status` — (IO) error status
 pub fn ffp3db_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                     */
-    group: c_long,       /* I - group to write(1 = 1st group)         */
-    ncols: LONGLONG,     /* I - number of pixels in each row of array */
-    nrows: LONGLONG,     /* I - number of rows in each plane of array */
-    naxis1: LONGLONG,    /* I - FITS image NAXIS1 value               */
-    naxis2: LONGLONG,    /* I - FITS image NAXIS2 value               */
-    naxis3: LONGLONG,    /* I - FITS image NAXIS3 value               */
-    array: &[u8],        /* I - array to be written               */
-    status: &mut c_int,  /* IO - error status                         */
+    fptr: &mut fitsfile,
+    group: c_long,
+    ncols: LONGLONG,
+    nrows: LONGLONG,
+    naxis1: LONGLONG,
+    naxis2: LONGLONG,
+    naxis3: LONGLONG,
+    array: &[u8],
+    status: &mut c_int,
 ) -> c_int {
     let fpixel: [c_long; 3] = [1; 3];
     let mut lpixel: [c_long; 3] = [0; 3];
@@ -364,7 +443,6 @@ pub fn ffp3db_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write a subsection of pixels to the primary array or image.
 ///
 /// A subsection is defined to be any contiguous rectangular
@@ -372,16 +450,27 @@ pub fn ffp3db_safe(
 /// Data conversion and scaling will be performed if necessary
 /// (e.g, if the datatype of the FITS array is not the same as
 /// the array being written).
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `group`  — (I) group to write(1 = 1st group)
+/// * `naxis`  — (I) number of data axes in array
+/// * `naxes`  — (I) size of each FITS axis
+/// * `fpixel` — (I) 1st pixel in each axis to write (1=1st)
+/// * `lpixel` — (I) last pixel in each axis to write
+/// * `array`  — (I) array to be written
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffpssb(
-    fptr: *mut fitsfile,   /* I - FITS file pointer                       */
-    group: c_long,         /* I - group to write(1 = 1st group)           */
-    naxis: c_long,         /* I - number of data axes in array            */
-    naxes: *const c_long,  /* I - size of each FITS axis                  */
-    fpixel: *const c_long, /* I - 1st pixel in each axis to write (1=1st) */
-    lpixel: *const c_long, /* I - last pixel in each axis to write        */
-    array: *const u8,      /* I - array to be written                 */
-    status: *mut c_int,    /* IO - error status                           */
+    fptr: *mut fitsfile,
+    group: c_long,
+    naxis: c_long,
+    naxes: *const c_long,
+    fpixel: *const c_long,
+    lpixel: *const c_long,
+    array: *const u8,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -403,7 +492,6 @@ pub unsafe extern "C" fn ffpssb(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write a subsection of pixels to the primary array or image.
 ///
 /// A subsection is defined to be any contiguous rectangular
@@ -411,15 +499,26 @@ pub unsafe extern "C" fn ffpssb(
 /// Data conversion and scaling will be performed if necessary
 /// (e.g, if the datatype of the FITS array is not the same as
 /// the array being written).
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `group`  — (I) group to write(1 = 1st group)
+/// * `naxis`  — (I) number of data axes in array
+/// * `naxes`  — (I) size of each FITS axis
+/// * `fpixel` — (I) 1st pixel in each axis to write (1=1st)
+/// * `lpixel` — (I) last pixel in each axis to write
+/// * `array`  — (I) array to be written
+/// * `status` — (IO) error status
 pub fn ffpssb_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                       */
-    group: c_long,       /* I - group to write(1 = 1st group)           */
-    naxis: c_long,       /* I - number of data axes in array            */
-    naxes: &[c_long],    /* I - size of each FITS axis                  */
-    fpixel: &[c_long],   /* I - 1st pixel in each axis to write (1=1st) */
-    lpixel: &[c_long],   /* I - last pixel in each axis to write        */
-    array: &[u8],        /* I - array to be written                 */
-    status: &mut c_int,  /* IO - error status                           */
+    fptr: &mut fitsfile,
+    group: c_long,
+    naxis: c_long,
+    naxes: &[c_long],
+    fpixel: &[c_long],
+    lpixel: &[c_long],
+    array: &[u8],
+    status: &mut c_int,
 ) -> c_int {
     let mut fpix: [LONGLONG; 7] = [0; 7];
     let mut dimen: [LONGLONG; 7] = [0; 7];
@@ -547,7 +646,6 @@ pub fn ffpssb_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of group parameters to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
 /// the FITS array is not the same as the array being written).
@@ -556,14 +654,23 @@ pub fn ffpssb_safe(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to write(1 = 1st group)
+/// * `firstelem` — (I) first vector element to write(1 = 1st)
+/// * `nelem`     — (I) number of values to write
+/// * `array`     — (I) array of values that are written
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffpgpb(
-    fptr: *mut fitsfile, /* I - FITS file pointer                      */
-    group: c_long,       /* I - group to write(1 = 1st group)          */
-    firstelem: c_long,   /* I - first vector element to write(1 = 1st) */
-    nelem: c_long,       /* I - number of values to write              */
-    array: *const u8,    /* I - array of values that are written   */
-    status: *mut c_int,  /* IO - error status                          */
+    fptr: *mut fitsfile,
+    group: c_long,
+    firstelem: c_long,
+    nelem: c_long,
+    array: *const u8,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -576,7 +683,6 @@ pub unsafe extern "C" fn ffpgpb(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of group parameters to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
 /// the FITS array is not the same as the array being written).
@@ -585,13 +691,22 @@ pub unsafe extern "C" fn ffpgpb(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to write(1 = 1st group)
+/// * `firstelem` — (I) first vector element to write(1 = 1st)
+/// * `nelem`     — (I) number of values to write
+/// * `array`     — (I) array of values that are written
+/// * `status`    — (IO) error status
 pub fn ffpgpb_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                      */
-    group: c_long,       /* I - group to write(1 = 1st group)          */
-    firstelem: c_long,   /* I - first vector element to write(1 = 1st) */
-    nelem: c_long,       /* I - number of values to write              */
-    array: &[u8],        /* I - array of values that are written   */
-    status: &mut c_int,  /* IO - error status                          */
+    fptr: &mut fitsfile,
+    group: c_long,
+    firstelem: c_long,
+    nelem: c_long,
+    array: &[u8],
+    status: &mut c_int,
 ) -> c_int {
     let row = cmp::max(1, group);
 
@@ -607,7 +722,6 @@ pub fn ffpgpb_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of values to a column in the current FITS HDU.
 ///
 /// The column number may refer to a real column in an ASCII or binary table,
@@ -620,15 +734,25 @@ pub fn ffpgpb_safe(
 ///
 /// The input array of values will be converted to the datatype of the column
 /// and will be inverse-scaled by the FITS TSCALn and TZEROn values if necessary.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to write (1 = 1st col)
+/// * `firstrow`  — (I) first row to write (1 = 1st row)
+/// * `firstelem` — (I) first vector element to write (1 = 1st)
+/// * `nelem`     — (I) number of values to write
+/// * `array`     — (I) array of values to write
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffpclb(
-    fptr: *mut fitsfile, /* I - FITS file pointer                       */
-    colnum: c_int,       /* I - number of column to write (1 = 1st col) */
-    firstrow: LONGLONG,  /* I - first row to write (1 = 1st row)        */
-    firstelem: LONGLONG, /* I - first vector element to write (1 = 1st) */
-    nelem: LONGLONG,     /* I - number of values to write               */
-    array: *const u8,    /* I - array of values to write           */
-    status: *mut c_int,  /* IO - error status                           */
+    fptr: *mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: *const u8,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -649,7 +773,6 @@ pub unsafe extern "C" fn ffpclb(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of values to a column in the current FITS HDU.
 ///
 /// The column number may refer to a real column in an ASCII or binary table,
@@ -662,14 +785,24 @@ pub unsafe extern "C" fn ffpclb(
 ///
 /// The input array of values will be converted to the datatype of the column
 /// and will be inverse-scaled by the FITS TSCALn and TZEROn values if necessary.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to write (1 = 1st col)
+/// * `firstrow`  — (I) first row to write (1 = 1st row)
+/// * `firstelem` — (I) first vector element to write (1 = 1st)
+/// * `nelem`     — (I) number of values to write
+/// * `array`     — (I) array of values to write
+/// * `status`    — (IO) error status
 pub fn ffpclb_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                       */
-    colnum: c_int,       /* I - number of column to write (1 = 1st col) */
-    firstrow: LONGLONG,  /* I - first row to write (1 = 1st row)        */
-    firstelem: LONGLONG, /* I - first vector element to write (1 = 1st) */
-    nelem: LONGLONG,     /* I - number of values to write               */
-    array: &[u8],        /* I - array of values to write           */
-    status: &mut c_int,  /* IO - error status                           */
+    fptr: &mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: &[u8],
+    status: &mut c_int,
 ) -> c_int {
     let mut writemode: c_int = 0;
     let mut tcode: c_int = 0;
@@ -703,9 +836,7 @@ pub fn ffpclb_safe(
         return *status;
     }
 
-    /*---------------------------------------------------*/
     /*  Check input and get parameters about the column: */
-    /*---------------------------------------------------*/
 
     /* IMPORTANT NOTE: that the special case of using this subroutine
     to write bytes to a character column are handled internally
@@ -765,12 +896,10 @@ pub fn ffpclb_safe(
         writeraw = false;
     }
 
-    /*---------------------------------------------------------------------*/
     /*  Now write the pixels to the FITS column.                           */
     /*  First call the ffXXfYY routine to  (1) convert the datatype        */
     /*  if necessary, and (2) scale the values by the FITS TSCALn and      */
     /*  TZEROn linear scaling parameters into a temporary buffer.          */
-    /*---------------------------------------------------------------------*/
     remain = nelem; /* remaining number of values to write  */
     next = 0; /* next element in array to be written  */
     rownum = 0; /* row number, relative to firstrow     */
@@ -951,9 +1080,7 @@ pub fn ffpclb_safe(
             }
         } /* End of switch block */
 
-        /*-------------------------*/
         /*  Check for fatal error  */
-        /*-------------------------*/
         if *status > 0 {
             /* test for error during previous write operation */
             int_snprintf!(
@@ -967,9 +1094,7 @@ pub fn ffpclb_safe(
             return *status;
         }
 
-        /*--------------------------------------------*/
         /*  increment the counters for the next loop  */
-        /*--------------------------------------------*/
         remain -= ntodo as LONGLONG;
         if remain > 0 {
             next += ntodo as LONGLONG;
@@ -983,9 +1108,7 @@ pub fn ffpclb_safe(
         }
     } /*  End of main while Loop  */
 
-    /*--------------------------------*/
     /*  check for numerical overflow  */
-    /*--------------------------------*/
     if *status == OVERFLOW_ERR {
         ffpmsg_str("Numerical overflow during type conversion while writing FITS data.");
         *status = NUM_OVERFLOW;
@@ -994,23 +1117,33 @@ pub fn ffpclb_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of elements to the specified column of a table.  Any input
 /// pixels equal to the value of nulvalue will be replaced by the appropriate
 /// null value in the output FITS file.
 ///
 /// The input array of values will be converted to the datatype of the column
 /// and will be inverse-scaled by the FITS TSCALn and TZEROn values if necessary
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to write (1 = 1st col)
+/// * `firstrow`  — (I) first row to write (1 = 1st row)
+/// * `firstelem` — (I) first vector element to write (1 = 1st)
+/// * `nelem`     — (I) number of values to write
+/// * `array`     — (I) array of values to write
+/// * `nulvalue`  — (I) flag for undefined pixels
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffpcnb(
-    fptr: *mut fitsfile, /* I - FITS file pointer                       */
-    colnum: c_int,       /* I - number of column to write (1 = 1st col) */
-    firstrow: LONGLONG,  /* I - first row to write (1 = 1st row)        */
-    firstelem: LONGLONG, /* I - first vector element to write (1 = 1st) */
-    nelem: LONGLONG,     /* I - number of values to write               */
-    array: *const u8,    /* I - array of values to write         */
-    nulvalue: u8,        /* I - flag for undefined pixels        */
-    status: *mut c_int,  /* IO - error status                           */
+    fptr: *mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: *const u8,
+    nulvalue: u8,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -1031,22 +1164,32 @@ pub unsafe extern "C" fn ffpcnb(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of elements to the specified column of a table.  Any input
 /// pixels equal to the value of nulvalue will be replaced by the appropriate
 /// null value in the output FITS file.
 ///
 /// The input array of values will be converted to the datatype of the column
 /// and will be inverse-scaled by the FITS TSCALn and TZEROn values if necessary
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to write (1 = 1st col)
+/// * `firstrow`  — (I) first row to write (1 = 1st row)
+/// * `firstelem` — (I) first vector element to write (1 = 1st)
+/// * `nelem`     — (I) number of values to write
+/// * `array`     — (I) array of values to write
+/// * `nulvalue`  — (I) flag for undefined pixels
+/// * `status`    — (IO) error status
 pub fn ffpcnb_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                       */
-    colnum: c_int,       /* I - number of column to write (1 = 1st col) */
-    firstrow: LONGLONG,  /* I - first row to write (1 = 1st row)        */
-    firstelem: LONGLONG, /* I - first vector element to write (1 = 1st) */
-    nelem: LONGLONG,     /* I - number of values to write               */
-    array: &[u8],        /* I - array of values to write         */
-    nulvalue: u8,        /* I - flag for undefined pixels        */
-    status: &mut c_int,  /* IO - error status                           */
+    fptr: &mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: &[u8],
+    nulvalue: u8,
+    status: &mut c_int,
 ) -> c_int {
     let mut ngood: LONGLONG = 0;
     let mut nbad: LONGLONG = 0;
@@ -1200,17 +1343,24 @@ pub fn ffpcnb_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write a stream of bytes to the current FITS HDU.  This primative routine is mainly
 /// for writing non-standard "conforming" extensions and should not be used
 /// for standard IMAGE, TABLE or BINTABLE extensions.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `offset` — (I) byte offset from start of extension data
+/// * `nelem`  — (I) number of elements to write
+/// * `buffer` — (I) stream of bytes to write
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffpextn(
-    fptr: *mut fitsfile,   /* I - FITS file pointer                        */
-    offset: LONGLONG,      /* I - byte offset from start of extension data */
-    nelem: LONGLONG,       /* I - number of elements to write              */
-    buffer: *const c_void, /* I - stream of bytes to write                 */
-    status: *mut c_int,    /* IO - error status                            */
+    fptr: *mut fitsfile,
+    offset: LONGLONG,
+    nelem: LONGLONG,
+    buffer: *const c_void,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -1222,16 +1372,23 @@ pub unsafe extern "C" fn ffpextn(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write a stream of bytes to the current FITS HDU.  This primative routine is mainly
 /// for writing non-standard "conforming" extensions and should not be used
 /// for standard IMAGE, TABLE or BINTABLE extensions.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `offset` — (I) byte offset from start of extension data
+/// * `nelem`  — (I) number of elements to write
+/// * `buffer` — (I) stream of bytes to write
+/// * `status` — (IO) error status
 pub fn ffpextn_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                        */
-    offset: LONGLONG,    /* I - byte offset from start of extension data */
-    nelem: LONGLONG,     /* I - number of elements to write              */
-    buffer: &[u8],       /* I - stream of bytes to write                 */
-    status: &mut c_int,  /* IO - error status                            */
+    fptr: &mut fitsfile,
+    offset: LONGLONG,
+    nelem: LONGLONG,
+    buffer: &[u8],
+    status: &mut c_int,
 ) -> c_int {
     if *status > 0 {
         /* inherit input status value if > 0 */
@@ -1256,16 +1413,24 @@ pub fn ffpextn_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output prior to writing output to a FITS file.
 /// Do datatype conversion and scaling if required
+///
+/// # Parameters
+///
+/// * `input`  — (I) array of values to be converted
+/// * `ntodo`  — (I) number of elements in the array
+/// * `scale`  — (I) FITS TSCALn or BSCALE value
+/// * `zero`   — (I) FITS TZEROn or BZERO value
+/// * `output` — (O) output array of converted values
+/// * `status` — (IO) error status
 pub(crate) fn ffi1fi1(
-    input: &[u8],       /* I - array of values to be converted  */
-    ntodo: c_long,      /* I - number of elements in the array  */
-    scale: f64,         /* I - FITS TSCALn or BSCALE value      */
-    zero: f64,          /* I - FITS TZEROn or BZERO  value      */
-    output: &mut [u8],  /* O - output array of converted values */
-    status: &mut c_int, /* IO - error status                    */
+    input: &[u8],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    output: &mut [u8],
+    status: &mut c_int,
 ) -> c_int {
     if scale == 1.0 && zero == 0.0 {
         output.copy_from_slice(input); /* just copy input to output */
@@ -1287,16 +1452,24 @@ pub(crate) fn ffi1fi1(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output prior to writing output to a FITS file.
 /// Do datatype conversion and scaling if required
+///
+/// # Parameters
+///
+/// * `input`  — (I) array of values to be converted
+/// * `ntodo`  — (I) number of elements in the array
+/// * `scale`  — (I) FITS TSCALn or BSCALE value
+/// * `zero`   — (I) FITS TZEROn or BZERO value
+/// * `output` — (O) output array of converted values
+/// * `status` — (IO) error status
 pub(crate) fn ffi1fi2(
-    input: &[u8],           /* I - array of values to be converted  */
-    ntodo: c_long,          /* I - number of elements in the array  */
-    scale: f64,             /* I - FITS TSCALn or BSCALE value      */
-    zero: f64,              /* I - FITS TZEROn or BZERO  value      */
-    output: &mut [c_short], /* O - output array of converted values */
-    status: &mut c_int,     /* IO - error status                    */
+    input: &[u8],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    output: &mut [c_short],
+    status: &mut c_int,
 ) -> c_int {
     if scale == 1.0 && zero == 0.0 {
         for ii in 0..(ntodo as usize) {
@@ -1322,16 +1495,24 @@ pub(crate) fn ffi1fi2(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output prior to writing output to a FITS file.
 /// Do datatype conversion and scaling if required
+///
+/// # Parameters
+///
+/// * `input`  — (I) array of values to be converted
+/// * `ntodo`  — (I) number of elements in the array
+/// * `scale`  — (I) FITS TSCALn or BSCALE value
+/// * `zero`   — (I) FITS TZEROn or BZERO value
+/// * `output` — (O) output array of converted values
+/// * `status` — (IO) error status
 pub(crate) fn ffi1fi4(
-    input: &[u8],            /* I - array of values to be converted  */
-    ntodo: c_long,           /* I - number of elements in the array  */
-    scale: f64,              /* I - FITS TSCALn or BSCALE value      */
-    zero: f64,               /* I - FITS TZEROn or BZERO  value      */
-    output: &mut [INT32BIT], /* O - output array of converted values */
-    status: &mut c_int,      /* IO - error status                    */
+    input: &[u8],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    output: &mut [INT32BIT],
+    status: &mut c_int,
 ) -> c_int {
     if scale == 1.0 && zero == 0.0 {
         for ii in 0..(ntodo as usize) {
@@ -1357,16 +1538,24 @@ pub(crate) fn ffi1fi4(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output prior to writing output to a FITS file.
 /// Do datatype conversion and scaling if required
+///
+/// # Parameters
+///
+/// * `input`  — (I) array of values to be converted
+/// * `ntodo`  — (I) number of elements in the array
+/// * `scale`  — (I) FITS TSCALn or BSCALE value
+/// * `zero`   — (I) FITS TZEROn or BZERO value
+/// * `output` — (O) output array of converted values
+/// * `status` — (IO) error status
 pub(crate) fn ffi1fi8(
-    input: &[u8],            /* I - array of values to be converted  */
-    ntodo: c_long,           /* I - number of elements in the array  */
-    scale: f64,              /* I - FITS TSCALn or BSCALE value      */
-    zero: f64,               /* I - FITS TZEROn or BZERO  value      */
-    output: &mut [LONGLONG], /* O - output array of converted values */
-    status: &mut c_int,      /* IO - error status                    */
+    input: &[u8],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    output: &mut [LONGLONG],
+    status: &mut c_int,
 ) -> c_int {
     if scale == 1.0 && zero == 9223372036854775808. {
         /* Writing to unsigned long long column. */
@@ -1403,16 +1592,24 @@ pub(crate) fn ffi1fi8(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output prior to writing output to a FITS file.
 /// Do datatype conversion and scaling if required.
+///
+/// # Parameters
+///
+/// * `input`  — (I) array of values to be converted
+/// * `ntodo`  — (I) number of elements in the array
+/// * `scale`  — (I) FITS TSCALn or BSCALE value
+/// * `zero`   — (I) FITS TZEROn or BZERO value
+/// * `output` — (O) output array of converted values
+/// * `status` — (IO) error status
 pub(crate) fn ffi1fr4(
-    input: &[u8],       /* I - array of values to be converted  */
-    ntodo: c_long,      /* I - number of elements in the array  */
-    scale: f64,         /* I - FITS TSCALn or BSCALE value      */
-    zero: f64,          /* I - FITS TZEROn or BZERO  value      */
-    output: &mut [f32], /* O - output array of converted values */
-    status: &mut c_int, /* IO - error status                    */
+    input: &[u8],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    output: &mut [f32],
+    status: &mut c_int,
 ) -> c_int {
     if scale == 1.0 && zero == 0.0 {
         for ii in 0..(ntodo as usize) {
@@ -1426,16 +1623,24 @@ pub(crate) fn ffi1fr4(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output prior to writing output to a FITS file.
 /// Do datatype conversion and scaling if required.
+///
+/// # Parameters
+///
+/// * `input`  — (I) array of values to be converted
+/// * `ntodo`  — (I) number of elements in the array
+/// * `scale`  — (I) FITS TSCALn or BSCALE value
+/// * `zero`   — (I) FITS TZEROn or BZERO value
+/// * `output` — (O) output array of converted values
+/// * `status` — (IO) error status
 pub(crate) fn ffi1fr8(
-    input: &[u8],       /* I - array of values to be converted  */
-    ntodo: c_long,      /* I - number of elements in the array  */
-    scale: f64,         /* I - FITS TSCALn or BSCALE value      */
-    zero: f64,          /* I - FITS TZEROn or BZERO  value      */
-    output: &mut [f64], /* O - output array of converted values */
-    status: &mut c_int, /* IO - error status                    */
+    input: &[u8],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    output: &mut [f64],
+    status: &mut c_int,
 ) -> c_int {
     if scale == 1.0 && zero == 0.0 {
         for ii in 0..(ntodo as usize) {
@@ -1449,18 +1654,28 @@ pub(crate) fn ffi1fr8(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output prior to writing output to a FITS file.
 /// Do scaling if required.
+///
+/// # Parameters
+///
+/// * `input`  — (I) array of values to be converted
+/// * `ntodo`  — (I) number of elements in the array
+/// * `scale`  — (I) FITS TSCALn or BSCALE value
+/// * `zero`   — (I) FITS TZEROn or BZERO value
+/// * `cform`  — (I) format for output string values
+/// * `twidth` — (I) width of each field, in chars
+/// * `output` — (O) output array of converted values
+/// * `status` — (IO) error status
 pub(crate) fn ffi1fstr(
-    input: &[u8],          /* I - array of values to be converted  */
-    ntodo: c_long,         /* I - number of elements in the array  */
-    scale: f64,            /* I - FITS TSCALn or BSCALE value      */
-    zero: f64,             /* I - FITS TZEROn or BZERO  value      */
-    cform: &[c_char],      /* I - format for output string values  */
-    twidth: c_long,        /* I - width of each field, in chars    */
-    output: &mut [c_char], /* O - output array of converted values */
-    status: &mut c_int,    /* IO - error status                    */
+    input: &[u8],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    cform: &[c_char],
+    twidth: c_long,
+    output: &mut [c_char],
+    status: &mut c_int,
 ) -> c_int {
     let mut ci = 0;
 

--- a/src/putcold.rs
+++ b/src/putcold.rs
@@ -1,9 +1,14 @@
-/*  This file, putcold.rs, contains routines that write data elements to    */
-/*  a FITS image or table, with double datatype.                           */
-
-/*  The FITSIO software was written by William Pence at the High Energy    */
-/*  Astrophysic Science Archive Research Center (HEASARC) at the NASA      */
-/*  Goddard Space Flight Center.                                           */
+//! Routines that write data elements to a FITS image or table, with double
+//! datatype.
+//!
+//! The [`TDOUBLE`] arm of the typed column I/O family. [`crate::putcol`]
+//! dispatches here when a caller asks for this datatype at run time; the
+//! write-side counterpart is [`crate::getcold`].
+//!
+//! Ported from CFITSIO's `putcold.c`, written by William Pence at the High
+//! Energy Astrophysics Science Archive Research Center (HEASARC), NASA Goddard
+//! Space Flight Center.
+#![warn(missing_docs)]
 
 use core::slice;
 use core::{cmp, mem};
@@ -25,7 +30,6 @@ use crate::relibc::header::stdio::snprintf_f64;
 use crate::wrappers::strlen_safe;
 use crate::{buffers::*, int_snprintf, slice_to_str};
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
 /// the FITS array is not the same as the array being written).
@@ -34,14 +38,23 @@ use crate::{buffers::*, int_snprintf, slice_to_str};
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to write(1 = 1st group)
+/// * `firstelem` — (I) first vector element to write(1 = 1st)
+/// * `nelem`     — (I) number of values to write
+/// * `array`     — (I) array of values that are written
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffpprd(
-    fptr: *mut fitsfile, /* I - FITS file pointer                       */
-    group: c_long,       /* I - group to write(1 = 1st group)           */
-    firstelem: LONGLONG, /* I - first vector element to write(1 = 1st)  */
-    nelem: LONGLONG,     /* I - number of values to write               */
-    array: *const f64,   /* I - array of values that are written        */
-    status: *mut c_int,  /* IO - error status                           */
+    fptr: *mut fitsfile,
+    group: c_long,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: *const f64,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -54,7 +67,6 @@ pub unsafe extern "C" fn ffpprd(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
 /// the FITS array is not the same as the array being written).
@@ -63,13 +75,22 @@ pub unsafe extern "C" fn ffpprd(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to write(1 = 1st group)
+/// * `firstelem` — (I) first vector element to write(1 = 1st)
+/// * `nelem`     — (I) number of values to write
+/// * `array`     — (I) array of values that are written
+/// * `status`    — (IO) error status
 pub fn ffpprd_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                       */
-    group: c_long,       /* I - group to write(1 = 1st group)           */
-    firstelem: LONGLONG, /* I - first vector element to write(1 = 1st)  */
-    nelem: LONGLONG,     /* I - number of values to write               */
-    array: &[f64],       /* I - array of values that are written        */
-    status: &mut c_int,  /* IO - error status                           */
+    fptr: &mut fitsfile,
+    group: c_long,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: &[f64],
+    status: &mut c_int,
 ) -> c_int {
     let nullvalue: f64 = 0.0;
 
@@ -102,7 +123,6 @@ pub fn ffpprd_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of the
 /// FITS array is not the same as the array being written).  Any array values
@@ -113,15 +133,25 @@ pub fn ffpprd_safe(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to write(1 = 1st group)
+/// * `firstelem` — (I) first vector element to write(1 = 1st)
+/// * `nelem`     — (I) number of values to write
+/// * `array`     — (I) array of values that are written
+/// * `nulval`    — (I) undefined pixel value
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffppnd(
-    fptr: *mut fitsfile, /* I - FITS file pointer                       */
-    group: c_long,       /* I - group to write(1 = 1st group)           */
-    firstelem: LONGLONG, /* I - first vector element to write(1 = 1st)  */
-    nelem: LONGLONG,     /* I - number of values to write               */
-    array: *const f64,   /* I - array of values that are written        */
-    nulval: f64,         /* I - undefined pixel value                   */
-    status: *mut c_int,  /* IO - error status                           */
+    fptr: *mut fitsfile,
+    group: c_long,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: *const f64,
+    nulval: f64,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -133,7 +163,6 @@ pub unsafe extern "C" fn ffppnd(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of the
 /// FITS array is not the same as the array being written).  Any array values
@@ -144,14 +173,24 @@ pub unsafe extern "C" fn ffppnd(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to write(1 = 1st group)
+/// * `firstelem` — (I) first vector element to write(1 = 1st)
+/// * `nelem`     — (I) number of values to write
+/// * `array`     — (I) array of values that are written
+/// * `nulval`    — (I) undefined pixel value
+/// * `status`    — (IO) error status
 pub fn ffppnd_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                       */
-    group: c_long,       /* I - group to write(1 = 1st group)           */
-    firstelem: LONGLONG, /* I - first vector element to write(1 = 1st)  */
-    nelem: LONGLONG,     /* I - number of values to write               */
-    array: &[f64],       /* I - array of values that are written        */
-    nulval: f64,         /* I - undefined pixel value                   */
-    status: &mut c_int,  /* IO - error status                           */
+    fptr: &mut fitsfile,
+    group: c_long,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: &[f64],
+    nulval: f64,
+    status: &mut c_int,
 ) -> c_int {
     let mut nullvalue: f64 = 0.0;
 
@@ -189,19 +228,28 @@ pub fn ffppnd_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an entire 2-D array of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of the
 /// FITS array is not the same as the array being written).
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `group`  — (I) group to write(1 = 1st group)
+/// * `ncols`  — (I) number of pixels in each row of array
+/// * `naxis1` — (I) FITS image NAXIS1 value
+/// * `naxis2` — (I) FITS image NAXIS2 value
+/// * `array`  — (I) array to be written
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffp2dd(
-    fptr: *mut fitsfile, /* I - FITS file pointer                     */
-    group: c_long,       /* I - group to write(1 = 1st group)         */
-    ncols: LONGLONG,     /* I - number of pixels in each row of array */
-    naxis1: LONGLONG,    /* I - FITS image NAXIS1 value               */
-    naxis2: LONGLONG,    /* I - FITS image NAXIS2 value               */
-    array: *const f64,   /* I - array to be written                   */
-    status: *mut c_int,  /* IO - error status                         */
+    fptr: *mut fitsfile,
+    group: c_long,
+    ncols: LONGLONG,
+    naxis1: LONGLONG,
+    naxis2: LONGLONG,
+    array: *const f64,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -214,18 +262,27 @@ pub unsafe extern "C" fn ffp2dd(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an entire 2-D array of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of the
 /// FITS array is not the same as the array being written).
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `group`  — (I) group to write(1 = 1st group)
+/// * `ncols`  — (I) number of pixels in each row of array
+/// * `naxis1` — (I) FITS image NAXIS1 value
+/// * `naxis2` — (I) FITS image NAXIS2 value
+/// * `array`  — (I) array to be written
+/// * `status` — (IO) error status
 pub fn ffp2dd_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                     */
-    group: c_long,       /* I - group to write(1 = 1st group)         */
-    ncols: LONGLONG,     /* I - number of pixels in each row of array */
-    naxis1: LONGLONG,    /* I - FITS image NAXIS1 value               */
-    naxis2: LONGLONG,    /* I - FITS image NAXIS2 value               */
-    array: &[f64],       /* I - array to be written                   */
-    status: &mut c_int,  /* IO - error status                         */
+    fptr: &mut fitsfile,
+    group: c_long,
+    ncols: LONGLONG,
+    naxis1: LONGLONG,
+    naxis2: LONGLONG,
+    array: &[f64],
+    status: &mut c_int,
 ) -> c_int {
     /* call the 3D writing routine, with the 3rd dimension = 1 */
     ffp3dd_safe(fptr, group, ncols, naxis2, naxis1, naxis2, 1, array, status);
@@ -233,7 +290,6 @@ pub fn ffp2dd_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an entire 3-D cube of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of the
 /// FITS array is not the same as the array being written).
@@ -242,17 +298,29 @@ pub fn ffp2dd_safe(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `group`  — (I) group to write(1 = 1st group)
+/// * `ncols`  — (I) number of pixels in each row of array
+/// * `nrows`  — (I) number of rows in each plane of array
+/// * `naxis1` — (I) FITS image NAXIS1 value
+/// * `naxis2` — (I) FITS image NAXIS2 value
+/// * `naxis3` — (I) FITS image NAXIS3 value
+/// * `array`  — (I) array to be written
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffp3dd(
-    fptr: *mut fitsfile, /* I - FITS file pointer                     */
-    group: c_long,       /* I - group to write(1 = 1st group)         */
-    ncols: LONGLONG,     /* I - number of pixels in each row of array */
-    nrows: LONGLONG,     /* I - number of rows in each plane of array */
-    naxis1: LONGLONG,    /* I - FITS image NAXIS1 value               */
-    naxis2: LONGLONG,    /* I - FITS image NAXIS2 value               */
-    naxis3: LONGLONG,    /* I - FITS image NAXIS3 value               */
-    array: *const f64,   /* I - array to be written                   */
-    status: *mut c_int,  /* IO - error status                         */
+    fptr: *mut fitsfile,
+    group: c_long,
+    ncols: LONGLONG,
+    nrows: LONGLONG,
+    naxis1: LONGLONG,
+    naxis2: LONGLONG,
+    naxis3: LONGLONG,
+    array: *const f64,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -267,7 +335,6 @@ pub unsafe extern "C" fn ffp3dd(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an entire 3-D cube of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of the
 /// FITS array is not the same as the array being written).
@@ -276,16 +343,28 @@ pub unsafe extern "C" fn ffp3dd(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `group`  — (I) group to write(1 = 1st group)
+/// * `ncols`  — (I) number of pixels in each row of array
+/// * `nrows`  — (I) number of rows in each plane of array
+/// * `naxis1` — (I) FITS image NAXIS1 value
+/// * `naxis2` — (I) FITS image NAXIS2 value
+/// * `naxis3` — (I) FITS image NAXIS3 value
+/// * `array`  — (I) array to be written
+/// * `status` — (IO) error status
 pub fn ffp3dd_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                     */
-    group: c_long,       /* I - group to write(1 = 1st group)         */
-    ncols: LONGLONG,     /* I - number of pixels in each row of array */
-    nrows: LONGLONG,     /* I - number of rows in each plane of array */
-    naxis1: LONGLONG,    /* I - FITS image NAXIS1 value               */
-    naxis2: LONGLONG,    /* I - FITS image NAXIS2 value               */
-    naxis3: LONGLONG,    /* I - FITS image NAXIS3 value               */
-    array: &[f64],       /* I - array to be written                   */
-    status: &mut c_int,  /* IO - error status                         */
+    fptr: &mut fitsfile,
+    group: c_long,
+    ncols: LONGLONG,
+    nrows: LONGLONG,
+    naxis1: LONGLONG,
+    naxis2: LONGLONG,
+    naxis3: LONGLONG,
+    array: &[f64],
+    status: &mut c_int,
 ) -> c_int {
     let fpixel: [c_long; 3] = [1; 3];
     let mut lpixel: [c_long; 3] = [0; 3];
@@ -363,7 +442,6 @@ pub fn ffp3dd_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write a subsection of pixels to the primary array or image.
 ///
 /// A subsection is defined to be any contiguous rectangular
@@ -371,16 +449,27 @@ pub fn ffp3dd_safe(
 /// Data conversion and scaling will be performed if necessary
 /// (e.g, if the datatype of the FITS array is not the same as
 /// the array being written).
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `group`  — (I) group to write(1 = 1st group)
+/// * `naxis`  — (I) number of data axes in array
+/// * `naxes`  — (I) size of each FITS axis
+/// * `fpixel` — (I) 1st pixel in each axis to write (1=1st)
+/// * `lpixel` — (I) last pixel in each axis to write
+/// * `array`  — (I) array to be written
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffpssd(
-    fptr: *mut fitsfile,   /* I - FITS file pointer                       */
-    group: c_long,         /* I - group to write(1 = 1st group)           */
-    naxis: c_long,         /* I - number of data axes in array            */
-    naxes: *const c_long,  /* I - size of each FITS axis                  */
-    fpixel: *const c_long, /* I - 1st pixel in each axis to write (1=1st) */
-    lpixel: *const c_long, /* I - last pixel in each axis to write        */
-    array: *const f64,     /* I - array to be written                     */
-    status: *mut c_int,    /* IO - error status                           */
+    fptr: *mut fitsfile,
+    group: c_long,
+    naxis: c_long,
+    naxes: *const c_long,
+    fpixel: *const c_long,
+    lpixel: *const c_long,
+    array: *const f64,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -402,7 +491,6 @@ pub unsafe extern "C" fn ffpssd(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write a subsection of pixels to the primary array or image.
 ///
 /// A subsection is defined to be any contiguous rectangular
@@ -410,15 +498,26 @@ pub unsafe extern "C" fn ffpssd(
 /// Data conversion and scaling will be performed if necessary
 /// (e.g, if the datatype of the FITS array is not the same as
 /// the array being written).
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `group`  — (I) group to write(1 = 1st group)
+/// * `naxis`  — (I) number of data axes in array
+/// * `naxes`  — (I) size of each FITS axis
+/// * `fpixel` — (I) 1st pixel in each axis to write (1=1st)
+/// * `lpixel` — (I) last pixel in each axis to write
+/// * `array`  — (I) array to be written
+/// * `status` — (IO) error status
 pub fn ffpssd_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                       */
-    group: c_long,       /* I - group to write(1 = 1st group)           */
-    naxis: c_long,       /* I - number of data axes in array            */
-    naxes: &[c_long],    /* I - size of each FITS axis                  */
-    fpixel: &[c_long],   /* I - 1st pixel in each axis to write (1=1st) */
-    lpixel: &[c_long],   /* I - last pixel in each axis to write        */
-    array: &[f64],       /* I - array to be written                     */
-    status: &mut c_int,  /* IO - error status                           */
+    fptr: &mut fitsfile,
+    group: c_long,
+    naxis: c_long,
+    naxes: &[c_long],
+    fpixel: &[c_long],
+    lpixel: &[c_long],
+    array: &[f64],
+    status: &mut c_int,
 ) -> c_int {
     let mut fpix: [LONGLONG; 7] = [0; 7];
     let mut dimen: [LONGLONG; 7] = [0; 7];
@@ -545,7 +644,6 @@ pub fn ffpssd_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of group parameters to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
 /// the FITS array is not the same as the array being written).
@@ -554,14 +652,23 @@ pub fn ffpssd_safe(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to write(1 = 1st group)
+/// * `firstelem` — (I) first vector element to write(1 = 1st)
+/// * `nelem`     — (I) number of values to write
+/// * `array`     — (I) array of values that are written
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffpgpd(
-    fptr: *mut fitsfile, /* I - FITS file pointer                      */
-    group: c_long,       /* I - group to write(1 = 1st group)          */
-    firstelem: c_long,   /* I - first vector element to write(1 = 1st) */
-    nelem: c_long,       /* I - number of values to write              */
-    array: *const f64,   /* I - array of values that are written       */
-    status: *mut c_int,  /* IO - error status                          */
+    fptr: *mut fitsfile,
+    group: c_long,
+    firstelem: c_long,
+    nelem: c_long,
+    array: *const f64,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -573,7 +680,6 @@ pub unsafe extern "C" fn ffpgpd(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of group parameters to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
 /// the FITS array is not the same as the array being written).
@@ -582,13 +688,22 @@ pub unsafe extern "C" fn ffpgpd(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to write(1 = 1st group)
+/// * `firstelem` — (I) first vector element to write(1 = 1st)
+/// * `nelem`     — (I) number of values to write
+/// * `array`     — (I) array of values that are written
+/// * `status`    — (IO) error status
 pub fn ffpgpd_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                      */
-    group: c_long,       /* I - group to write(1 = 1st group)          */
-    firstelem: c_long,   /* I - first vector element to write(1 = 1st) */
-    nelem: c_long,       /* I - number of values to write              */
-    array: &[f64],       /* I - array of values that are written       */
-    status: &mut c_int,  /* IO - error status                          */
+    fptr: &mut fitsfile,
+    group: c_long,
+    firstelem: c_long,
+    nelem: c_long,
+    array: &[f64],
+    status: &mut c_int,
 ) -> c_int {
     let row = cmp::max(1, group);
 
@@ -604,7 +719,6 @@ pub fn ffpgpd_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of values to a column in the current FITS HDU.
 ///
 /// The column number may refer to a real column in an ASCII or binary table,
@@ -617,15 +731,25 @@ pub fn ffpgpd_safe(
 ///
 /// The input array of values will be converted to the datatype of the column
 /// and will be inverse-scaled by the FITS TSCALn and TZEROn values if necessary.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to write (1 = 1st col)
+/// * `firstrow`  — (I) first row to write (1 = 1st row)
+/// * `firstelem` — (I) first vector element to write (1 = 1st)
+/// * `nelem`     — (I) number of values to write
+/// * `array`     — (I) array of values to write
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffpcld(
-    fptr: *mut fitsfile, /* I - FITS file pointer                       */
-    colnum: c_int,       /* I - number of column to write (1 = 1st col) */
-    firstrow: LONGLONG,  /* I - first row to write (1 = 1st row)        */
-    firstelem: LONGLONG, /* I - first vector element to write (1 = 1st) */
-    nelem: LONGLONG,     /* I - number of values to write               */
-    array: *const f64,   /* I - array of values to write                */
-    status: *mut c_int,  /* IO - error status                           */
+    fptr: *mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: *const f64,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -646,7 +770,6 @@ pub unsafe extern "C" fn ffpcld(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of values to a column in the current FITS HDU.
 ///
 /// The column number may refer to a real column in an ASCII or binary table,
@@ -659,14 +782,24 @@ pub unsafe extern "C" fn ffpcld(
 ///
 /// The input array of values will be converted to the datatype of the column
 /// and will be inverse-scaled by the FITS TSCALn and TZEROn values if necessary.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to write (1 = 1st col)
+/// * `firstrow`  — (I) first row to write (1 = 1st row)
+/// * `firstelem` — (I) first vector element to write (1 = 1st)
+/// * `nelem`     — (I) number of values to write
+/// * `array`     — (I) array of values to write
+/// * `status`    — (IO) error status
 pub fn ffpcld_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                       */
-    colnum: c_int,       /* I - number of column to write (1 = 1st col) */
-    firstrow: LONGLONG,  /* I - first row to write (1 = 1st row)        */
-    firstelem: LONGLONG, /* I - first vector element to write (1 = 1st) */
-    nelem: LONGLONG,     /* I - number of values to write               */
-    array: &[f64],       /* I - array of values to write                */
-    status: &mut c_int,  /* IO - error status                           */
+    fptr: &mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: &[f64],
+    status: &mut c_int,
 ) -> c_int {
     let mut tcode: c_int = 0;
     let mut maxelem2: c_int = 0;
@@ -699,9 +832,7 @@ pub fn ffpcld_safe(
         return *status;
     }
 
-    /*---------------------------------------------------*/
     /*  Check input and get parameters about the column: */
-    /*---------------------------------------------------*/
     if ffgcprll(
         fptr,
         colnum,
@@ -752,12 +883,10 @@ pub fn ffpcld_safe(
         writeraw = false;
     }
 
-    /*---------------------------------------------------------------------*/
     /*  Now write the pixels to the FITS column.                           */
     /*  First call the ffXXfYY routine to  (1) convert the datatype        */
     /*  if necessary, and (2) scale the values by the FITS TSCALn and      */
     /*  TZEROn linear scaling parameters into a temporary buffer.          */
-    /*---------------------------------------------------------------------*/
     remain = nelem; /* remaining number of values to write  */
     next = 0; /* next element in array to be written  */
     rownum = 0; /* row number, relative to firstrow     */
@@ -929,9 +1058,7 @@ pub fn ffpcld_safe(
             }
         } /* End of switch block */
 
-        /*-------------------------*/
         /*  Check for fatal error  */
-        /*-------------------------*/
         if *status > 0 {
             /* test for error during previous write operation */
 
@@ -946,9 +1073,7 @@ pub fn ffpcld_safe(
             return *status;
         }
 
-        /*--------------------------------------------*/
         /*  increment the counters for the next loop  */
-        /*--------------------------------------------*/
         remain -= ntodo as LONGLONG;
         if remain > 0 {
             next += ntodo as LONGLONG;
@@ -962,9 +1087,7 @@ pub fn ffpcld_safe(
         }
     } /*  End of main while Loop  */
 
-    /*--------------------------------*/
     /*  check for numerical overflow  */
-    /*--------------------------------*/
     if *status == OVERFLOW_ERR {
         ffpmsg_str("Numerical overflow during type conversion while writing FITS data.");
         *status = NUM_OVERFLOW;
@@ -973,7 +1096,6 @@ pub fn ffpcld_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of double complex values to a column in the current FITS HDU.
 ///
 /// Each complex number if interpreted as a pair of float values.
@@ -991,15 +1113,25 @@ pub fn ffpcld_safe(
 /// TZERO keywords should not be used with complex numbers because mathmatically
 /// the scaling should only be applied to the real (first) component of the
 /// complex value.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to write (1 = 1st col)
+/// * `firstrow`  — (I) first row to write (1 = 1st row)
+/// * `firstelem` — (I) first vector element to write (1 = 1st)
+/// * `nelem`     — (I) number of values to write
+/// * `array`     — (I) array of values to write
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffpclm(
-    fptr: *mut fitsfile, /* I - FITS file pointer                       */
-    colnum: c_int,       /* I - number of column to write (1 = 1st col) */
-    firstrow: LONGLONG,  /* I - first row to write (1 = 1st row)        */
-    firstelem: LONGLONG, /* I - first vector element to write (1 = 1st) */
-    nelem: LONGLONG,     /* I - number of values to write               */
-    array: *const f64,   /* I - array of values to write                */
-    status: *mut c_int,  /* IO - error status                           */
+    fptr: *mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: *const f64,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -1020,7 +1152,6 @@ pub unsafe extern "C" fn ffpclm(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of double complex values to a column in the current FITS HDU.
 /// Each complex number if interpreted as a pair of float values.
 /// The column number may refer to a real column in an ASCII or binary table,
@@ -1037,14 +1168,24 @@ pub unsafe extern "C" fn ffpclm(
 /// TZERO keywords should not be used with complex numbers because mathmatically
 /// the scaling should only be applied to the real (first) component of the
 /// complex value.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to write (1 = 1st col)
+/// * `firstrow`  — (I) first row to write (1 = 1st row)
+/// * `firstelem` — (I) first vector element to write (1 = 1st)
+/// * `nelem`     — (I) number of values to write
+/// * `array`     — (I) array of values to write
+/// * `status`    — (IO) error status
 pub fn ffpclm_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                       */
-    colnum: c_int,       /* I - number of column to write (1 = 1st col) */
-    firstrow: LONGLONG,  /* I - first row to write (1 = 1st row)        */
-    firstelem: LONGLONG, /* I - first vector element to write (1 = 1st) */
-    nelem: LONGLONG,     /* I - number of values to write               */
-    array: &[f64],       /* I - array of values to write                */
-    status: &mut c_int,  /* IO - error status                           */
+    fptr: &mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: &[f64],
+    status: &mut c_int,
 ) -> c_int {
     /* simply multiply the number of elements by 2, and call ffpcld */
     ffpcld_safe(
@@ -1059,23 +1200,33 @@ pub fn ffpclm_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of elements to the specified column of a table.  Any input
 /// pixels equal to the value of nulvalue will be replaced by the appropriate
 /// null value in the output FITS file.
 ///
 /// The input array of values will be converted to the datatype of the column
 /// and will be inverse-scaled by the FITS TSCALn and TZEROn values if necessary
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to write (1 = 1st col)
+/// * `firstrow`  — (I) first row to write (1 = 1st row)
+/// * `firstelem` — (I) first vector element to write (1 = 1st)
+/// * `nelem`     — (I) number of values to write
+/// * `array`     — (I) array of values to write
+/// * `nulvalue`  — (I) value used to flag undefined pixels
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffpcnd(
-    fptr: *mut fitsfile, /* I - FITS file pointer                       */
-    colnum: c_int,       /* I - number of column to write (1 = 1st col) */
-    firstrow: LONGLONG,  /* I - first row to write (1 = 1st row)        */
-    firstelem: LONGLONG, /* I - first vector element to write (1 = 1st) */
-    nelem: LONGLONG,     /* I - number of values to write               */
-    array: *const f64,   /* I - array of values to write                */
-    nulvalue: f64,       /* I - value used to flag undefined pixels     */
-    status: *mut c_int,  /* IO - error status                           */
+    fptr: *mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: *const f64,
+    nulvalue: f64,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -1097,22 +1248,32 @@ pub unsafe extern "C" fn ffpcnd(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of elements to the specified column of a table.  Any input
 /// pixels equal to the value of nulvalue will be replaced by the appropriate
 /// null value in the output FITS file.
 ///
 /// The input array of values will be converted to the datatype of the column
 /// and will be inverse-scaled by the FITS TSCALn and TZEROn values if necessary
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to write (1 = 1st col)
+/// * `firstrow`  — (I) first row to write (1 = 1st row)
+/// * `firstelem` — (I) first vector element to write (1 = 1st)
+/// * `nelem`     — (I) number of values to write
+/// * `array`     — (I) array of values to write
+/// * `nulvalue`  — (I) value used to flag undefined pixels
+/// * `status`    — (IO) error status
 pub fn ffpcnd_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                       */
-    colnum: c_int,       /* I - number of column to write (1 = 1st col) */
-    firstrow: LONGLONG,  /* I - first row to write (1 = 1st row)        */
-    firstelem: LONGLONG, /* I - first vector element to write (1 = 1st) */
-    nelem: LONGLONG,     /* I - number of values to write               */
-    array: &[f64],       /* I - array of values to write                */
-    nulvalue: f64,       /* I - value used to flag undefined pixels     */
-    status: &mut c_int,  /* IO - error status                           */
+    fptr: &mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: &[f64],
+    nulvalue: f64,
+    status: &mut c_int,
 ) -> c_int {
     let mut ngood: LONGLONG = 0;
     let mut nbad: LONGLONG = 0;
@@ -1269,16 +1430,24 @@ pub fn ffpcnd_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output prior to writing output to a FITS file.
 /// Do datatype conversion and scaling if required.
+///
+/// # Parameters
+///
+/// * `input`  — (I) array of values to be converted
+/// * `ntodo`  — (I) number of elements in the array
+/// * `scale`  — (I) FITS TSCALn or BSCALE value
+/// * `zero`   — (I) FITS TZEROn or BZERO value
+/// * `output` — (O) output array of converted values
+/// * `status` — (IO) error status
 pub(crate) fn ffr8fi1(
-    input: &[f64],      /* I - array of values to be converted  */
-    ntodo: c_long,      /* I - number of elements in the array  */
-    scale: f64,         /* I - FITS TSCALn or BSCALE value      */
-    zero: f64,          /* I - FITS TZEROn or BZERO  value      */
-    output: &mut [u8],  /* O - output array of converted values */
-    status: &mut c_int, /* IO - error status                    */
+    input: &[f64],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    output: &mut [u8],
+    status: &mut c_int,
 ) -> c_int {
     if scale == 1.0 && zero == 0.0 {
         for ii in 0..(ntodo as usize) {
@@ -1310,16 +1479,24 @@ pub(crate) fn ffr8fi1(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output prior to writing output to a FITS file.
 /// Do datatype conversion and scaling if required.
+///
+/// # Parameters
+///
+/// * `input`  — (I) array of values to be converted
+/// * `ntodo`  — (I) number of elements in the array
+/// * `scale`  — (I) FITS TSCALn or BSCALE value
+/// * `zero`   — (I) FITS TZEROn or BZERO value
+/// * `output` — (O) output array of converted values
+/// * `status` — (IO) error status
 pub(crate) fn ffr8fi2(
-    input: &[f64],          /* I - array of values to be converted  */
-    ntodo: c_long,          /* I - number of elements in the array  */
-    scale: f64,             /* I - FITS TSCALn or BSCALE value      */
-    zero: f64,              /* I - FITS TZEROn or BZERO  value      */
-    output: &mut [c_short], /* O - output array of converted values */
-    status: &mut c_int,     /* IO - error status                    */
+    input: &[f64],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    output: &mut [c_short],
+    status: &mut c_int,
 ) -> c_int {
     if scale == 1.0 && zero == 0.0 {
         for ii in 0..(ntodo as usize) {
@@ -1353,16 +1530,24 @@ pub(crate) fn ffr8fi2(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output prior to writing output to a FITS file.
 /// Do datatype conversion and scaling if required.
+///
+/// # Parameters
+///
+/// * `input`  — (I) array of values to be converted
+/// * `ntodo`  — (I) number of elements in the array
+/// * `scale`  — (I) FITS TSCALn or BSCALE value
+/// * `zero`   — (I) FITS TZEROn or BZERO value
+/// * `output` — (O) output array of converted values
+/// * `status` — (IO) error status
 pub(crate) fn ffr8fi4(
-    input: &[f64],           /* I - array of values to be converted  */
-    ntodo: c_long,           /* I - number of elements in the array  */
-    scale: f64,              /* I - FITS TSCALn or BSCALE value      */
-    zero: f64,               /* I - FITS TZEROn or BZERO  value      */
-    output: &mut [INT32BIT], /* O - output array of converted values */
-    status: &mut c_int,      /* IO - error status                    */
+    input: &[f64],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    output: &mut [INT32BIT],
+    status: &mut c_int,
 ) -> c_int {
     if scale == 1.0 && zero == 0.0 {
         for ii in 0..(ntodo as usize) {
@@ -1396,16 +1581,24 @@ pub(crate) fn ffr8fi4(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output prior to writing output to a FITS file.
 /// Do datatype conversion and scaling if required.
+///
+/// # Parameters
+///
+/// * `input`  — (I) array of values to be converted
+/// * `ntodo`  — (I) number of elements in the array
+/// * `scale`  — (I) FITS TSCALn or BSCALE value
+/// * `zero`   — (I) FITS TZEROn or BZERO value
+/// * `output` — (O) output array of converted values
+/// * `status` — (IO) error status
 pub(crate) fn ffr8fi8(
-    input: &[f64],           /* I - array of values to be converted  */
-    ntodo: c_long,           /* I - number of elements in the array  */
-    scale: f64,              /* I - FITS TSCALn or BSCALE value      */
-    zero: f64,               /* I - FITS TZEROn or BZERO  value      */
-    output: &mut [LONGLONG], /* O - output array of converted values */
-    status: &mut c_int,      /* IO - error status                    */
+    input: &[f64],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    output: &mut [LONGLONG],
+    status: &mut c_int,
 ) -> c_int {
     if scale == 1.0 && zero == 9223372036854775808. {
         /* Writing to unsigned long long column. Input values must not be negative */
@@ -1455,16 +1648,24 @@ pub(crate) fn ffr8fi8(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output prior to writing output to a FITS file.
 /// Do datatype conversion and scaling if required.
+///
+/// # Parameters
+///
+/// * `input`  — (I) array of values to be converted
+/// * `ntodo`  — (I) number of elements in the array
+/// * `scale`  — (I) FITS TSCALn or BSCALE value
+/// * `zero`   — (I) FITS TZEROn or BZERO value
+/// * `output` — (O) output array of converted values
+/// * `status` — (IO) error status
 pub(crate) fn ffr8fr4(
-    input: &[f64],      /* I - array of values to be converted  */
-    ntodo: c_long,      /* I - number of elements in the array  */
-    scale: f64,         /* I - FITS TSCALn or BSCALE value      */
-    zero: f64,          /* I - FITS TZEROn or BZERO  value      */
-    output: &mut [f32], /* O - output array of converted values */
-    status: &mut c_int, /* IO - error status                    */
+    input: &[f64],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    output: &mut [f32],
+    status: &mut c_int,
 ) -> c_int {
     if scale == 1.0 && zero == 0.0 {
         for ii in 0..(ntodo as usize) {
@@ -1478,16 +1679,24 @@ pub(crate) fn ffr8fr4(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output prior to writing output to a FITS file.
 /// Do datatype conversion and scaling if required.
+///
+/// # Parameters
+///
+/// * `input`  — (I) array of values to be converted
+/// * `ntodo`  — (I) number of elements in the array
+/// * `scale`  — (I) FITS TSCALn or BSCALE value
+/// * `zero`   — (I) FITS TZEROn or BZERO value
+/// * `output` — (O) output array of converted values
+/// * `status` — (IO) error status
 pub(crate) fn ffr8fr8(
-    input: &[f64],      /* I - array of values to be converted  */
-    ntodo: c_long,      /* I - number of elements in the array  */
-    scale: f64,         /* I - FITS TSCALn or BSCALE value      */
-    zero: f64,          /* I - FITS TZEROn or BZERO  value      */
-    output: &mut [f64], /* O - output array of converted values */
-    status: &mut c_int, /* IO - error status                    */
+    input: &[f64],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    output: &mut [f64],
+    status: &mut c_int,
 ) -> c_int {
     let ntodo = ntodo as usize;
 
@@ -1502,18 +1711,28 @@ pub(crate) fn ffr8fr8(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output prior to writing output to a FITS file.
 /// Do scaling if required.
+///
+/// # Parameters
+///
+/// * `input`  — (I) array of values to be converted
+/// * `ntodo`  — (I) number of elements in the array
+/// * `scale`  — (I) FITS TSCALn or BSCALE value
+/// * `zero`   — (I) FITS TZEROn or BZERO value
+/// * `cform`  — (I) format for output string values
+/// * `twidth` — (I) width of each field, in chars
+/// * `output` — (O) output array of converted values
+/// * `status` — (IO) error status
 pub(crate) fn ffr8fstr(
-    input: &[f64],         /* I - array of values to be converted  */
-    ntodo: c_long,         /* I - number of elements in the array  */
-    scale: f64,            /* I - FITS TSCALn or BSCALE value      */
-    zero: f64,             /* I - FITS TZEROn or BZERO  value      */
-    cform: &[c_char],      /* I - format for output string values  */
-    twidth: c_long,        /* I - width of each field, in chars    */
-    output: &mut [c_char], /* O - output array of converted values */
-    status: &mut c_int,    /* IO - error status                    */
+    input: &[f64],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    cform: &[c_char],
+    twidth: c_long,
+    output: &mut [c_char],
+    status: &mut c_int,
 ) -> c_int {
     let mut oi = 0;
 

--- a/src/putcole.rs
+++ b/src/putcole.rs
@@ -1,9 +1,14 @@
-/*  This file, putcole.rs, contains routines that write data elements to    */
-/*  a FITS image or table, with float datatype.                            */
-
-/*  The FITSIO software was written by William Pence at the High Energy    */
-/*  Astrophysic Science Archive Research Center (HEASARC) at the NASA      */
-/*  Goddard Space Flight Center.                                           */
+//! Routines that write data elements to a FITS image or table, with float
+//! datatype.
+//!
+//! The [`TFLOAT`] arm of the typed column I/O family. [`crate::putcol`]
+//! dispatches here when a caller asks for this datatype at run time; the
+//! write-side counterpart is [`crate::getcole`].
+//!
+//! Ported from CFITSIO's `putcole.c`, written by William Pence at the High
+//! Energy Astrophysics Science Archive Research Center (HEASARC), NASA Goddard
+//! Space Flight Center.
+#![warn(missing_docs)]
 
 use core::slice;
 use core::{cmp, mem};
@@ -25,7 +30,6 @@ use crate::relibc::header::stdio::snprintf_f64;
 use crate::wrappers::strlen_safe;
 use crate::{buffers::*, int_snprintf, slice_to_str};
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
 /// the FITS array is not the same as the array being written).
@@ -38,14 +42,23 @@ use crate::{buffers::*, int_snprintf, slice_to_str};
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to write(1 = 1st group)
+/// * `firstelem` — (I) first vector element to write(1 = 1st)
+/// * `nelem`     — (I) number of values to write
+/// * `array`     — (I) array of values that are written
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffppre(
-    fptr: *mut fitsfile, /* I - FITS file pointer                       */
-    group: c_long,       /* I - group to write(1 = 1st group)           */
-    firstelem: LONGLONG, /* I - first vector element to write(1 = 1st)  */
-    nelem: LONGLONG,     /* I - number of values to write               */
-    array: *const f32,   /* I - array of values that are written        */
-    status: *mut c_int,  /* IO - error status                           */
+    fptr: *mut fitsfile,
+    group: c_long,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: *const f32,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -57,7 +70,6 @@ pub unsafe extern "C" fn ffppre(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
 /// the FITS array is not the same as the array being written).
@@ -70,13 +82,22 @@ pub unsafe extern "C" fn ffppre(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to write(1 = 1st group)
+/// * `firstelem` — (I) first vector element to write(1 = 1st)
+/// * `nelem`     — (I) number of values to write
+/// * `array`     — (I) array of values that are written
+/// * `status`    — (IO) error status
 pub fn ffppre_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                       */
-    group: c_long,       /* I - group to write(1 = 1st group)           */
-    firstelem: LONGLONG, /* I - first vector element to write(1 = 1st)  */
-    nelem: LONGLONG,     /* I - number of values to write               */
-    array: &[f32],       /* I - array of values that are written        */
-    status: &mut c_int,  /* IO - error status                           */
+    fptr: &mut fitsfile,
+    group: c_long,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: &[f32],
+    status: &mut c_int,
 ) -> c_int {
     let nullvalue: f32 = 0.0;
 
@@ -109,7 +130,6 @@ pub fn ffppre_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of the
 /// FITS array is not the same as the array being written).  Any array values
@@ -124,15 +144,25 @@ pub fn ffppre_safe(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to write(1 = 1st group)
+/// * `firstelem` — (I) first vector element to write(1 = 1st)
+/// * `nelem`     — (I) number of values to write
+/// * `array`     — (I) array of values that are written
+/// * `nulval`    — (I) undefined pixel value
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffppne(
-    fptr: *mut fitsfile, /* I - FITS file pointer                       */
-    group: c_long,       /* I - group to write(1 = 1st group)           */
-    firstelem: LONGLONG, /* I - first vector element to write(1 = 1st)  */
-    nelem: LONGLONG,     /* I - number of values to write               */
-    array: *const f32,   /* I - array of values that are written        */
-    nulval: f32,         /* I - undefined pixel value                   */
-    status: *mut c_int,  /* IO - error status                           */
+    fptr: *mut fitsfile,
+    group: c_long,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: *const f32,
+    nulval: f32,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -144,7 +174,6 @@ pub unsafe extern "C" fn ffppne(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of the
 /// FITS array is not the same as the array being written).  Any array values
@@ -159,14 +188,24 @@ pub unsafe extern "C" fn ffppne(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to write(1 = 1st group)
+/// * `firstelem` — (I) first vector element to write(1 = 1st)
+/// * `nelem`     — (I) number of values to write
+/// * `array`     — (I) array of values that are written
+/// * `nulval`    — (I) undefined pixel value
+/// * `status`    — (IO) error status
 pub fn ffppne_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                       */
-    group: c_long,       /* I - group to write(1 = 1st group)           */
-    firstelem: LONGLONG, /* I - first vector element to write(1 = 1st)  */
-    nelem: LONGLONG,     /* I - number of values to write               */
-    array: &[f32],       /* I - array of values that are written        */
-    nulval: f32,         /* I - undefined pixel value                   */
-    status: &mut c_int,  /* IO - error status                           */
+    fptr: &mut fitsfile,
+    group: c_long,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: &[f32],
+    nulval: f32,
+    status: &mut c_int,
 ) -> c_int {
     let nullvalue: f32;
 
@@ -202,22 +241,31 @@ pub fn ffppne_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an entire 2-D array of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of the
 /// FITS array is not the same as the array being written).
 ///
 /// This routine does not support writing to large images with
 /// more than 2**31 pixels.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `group`  — (I) group to write(1 = 1st group)
+/// * `ncols`  — (I) number of pixels in each row of array
+/// * `naxis1` — (I) FITS image NAXIS1 value
+/// * `naxis2` — (I) FITS image NAXIS2 value
+/// * `array`  — (I) array to be written
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffp2de(
-    fptr: *mut fitsfile, /* I - FITS file pointer                     */
-    group: c_long,       /* I - group to write(1 = 1st group)         */
-    ncols: LONGLONG,     /* I - number of pixels in each row of array */
-    naxis1: LONGLONG,    /* I - FITS image NAXIS1 value               */
-    naxis2: LONGLONG,    /* I - FITS image NAXIS2 value               */
-    array: *const f32,   /* I - array to be written                   */
-    status: *mut c_int,  /* IO - error status                         */
+    fptr: *mut fitsfile,
+    group: c_long,
+    ncols: LONGLONG,
+    naxis1: LONGLONG,
+    naxis2: LONGLONG,
+    array: *const f32,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -230,21 +278,30 @@ pub unsafe extern "C" fn ffp2de(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an entire 2-D array of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of the
 /// FITS array is not the same as the array being written).
 ///
 /// This routine does not support writing to large images with
 /// more than 2**31 pixels.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `group`  — (I) group to write(1 = 1st group)
+/// * `ncols`  — (I) number of pixels in each row of array
+/// * `naxis1` — (I) FITS image NAXIS1 value
+/// * `naxis2` — (I) FITS image NAXIS2 value
+/// * `array`  — (I) array to be written
+/// * `status` — (IO) error status
 pub fn ffp2de_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                     */
-    group: c_long,       /* I - group to write(1 = 1st group)         */
-    ncols: LONGLONG,     /* I - number of pixels in each row of array */
-    naxis1: LONGLONG,    /* I - FITS image NAXIS1 value               */
-    naxis2: LONGLONG,    /* I - FITS image NAXIS2 value               */
-    array: &[f32],       /* I - array to be written                   */
-    status: &mut c_int,  /* IO - error status                         */
+    fptr: &mut fitsfile,
+    group: c_long,
+    ncols: LONGLONG,
+    naxis1: LONGLONG,
+    naxis2: LONGLONG,
+    array: &[f32],
+    status: &mut c_int,
 ) -> c_int {
     /* call the 3D writing routine, with the 3rd dimension = 1 */
     ffp3de_safe(fptr, group, ncols, naxis2, naxis1, naxis2, 1, array, status);
@@ -252,7 +309,6 @@ pub fn ffp2de_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an entire 3-D cube of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of the
 /// FITS array is not the same as the array being written).
@@ -264,17 +320,29 @@ pub fn ffp2de_safe(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `group`  — (I) group to write(1 = 1st group)
+/// * `ncols`  — (I) number of pixels in each row of array
+/// * `nrows`  — (I) number of rows in each plane of array
+/// * `naxis1` — (I) FITS image NAXIS1 value
+/// * `naxis2` — (I) FITS image NAXIS2 value
+/// * `naxis3` — (I) FITS image NAXIS3 value
+/// * `array`  — (I) array to be written
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffp3de(
-    fptr: *mut fitsfile, /* I - FITS file pointer                     */
-    group: c_long,       /* I - group to write(1 = 1st group)         */
-    ncols: LONGLONG,     /* I - number of pixels in each row of array */
-    nrows: LONGLONG,     /* I - number of rows in each plane of array */
-    naxis1: LONGLONG,    /* I - FITS image NAXIS1 value               */
-    naxis2: LONGLONG,    /* I - FITS image NAXIS2 value               */
-    naxis3: LONGLONG,    /* I - FITS image NAXIS3 value               */
-    array: *const f32,   /* I - array to be written                   */
-    status: *mut c_int,  /* IO - error status                         */
+    fptr: *mut fitsfile,
+    group: c_long,
+    ncols: LONGLONG,
+    nrows: LONGLONG,
+    naxis1: LONGLONG,
+    naxis2: LONGLONG,
+    naxis3: LONGLONG,
+    array: *const f32,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -289,7 +357,6 @@ pub unsafe extern "C" fn ffp3de(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an entire 3-D cube of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of the
 /// FITS array is not the same as the array being written).
@@ -301,16 +368,28 @@ pub unsafe extern "C" fn ffp3de(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `group`  — (I) group to write(1 = 1st group)
+/// * `ncols`  — (I) number of pixels in each row of array
+/// * `nrows`  — (I) number of rows in each plane of array
+/// * `naxis1` — (I) FITS image NAXIS1 value
+/// * `naxis2` — (I) FITS image NAXIS2 value
+/// * `naxis3` — (I) FITS image NAXIS3 value
+/// * `array`  — (I) array to be written
+/// * `status` — (IO) error status
 pub fn ffp3de_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                     */
-    group: c_long,       /* I - group to write(1 = 1st group)         */
-    ncols: LONGLONG,     /* I - number of pixels in each row of array */
-    nrows: LONGLONG,     /* I - number of rows in each plane of array */
-    naxis1: LONGLONG,    /* I - FITS image NAXIS1 value               */
-    naxis2: LONGLONG,    /* I - FITS image NAXIS2 value               */
-    naxis3: LONGLONG,    /* I - FITS image NAXIS3 value               */
-    array: &[f32],       /* I - array to be written                   */
-    status: &mut c_int,  /* IO - error status                         */
+    fptr: &mut fitsfile,
+    group: c_long,
+    ncols: LONGLONG,
+    nrows: LONGLONG,
+    naxis1: LONGLONG,
+    naxis2: LONGLONG,
+    naxis3: LONGLONG,
+    array: &[f32],
+    status: &mut c_int,
 ) -> c_int {
     let fpixel: [c_long; 3] = [1; 3];
     let mut lpixel: [c_long; 3] = [0; 3];
@@ -388,7 +467,6 @@ pub fn ffp3de_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write a subsection of pixels to the primary array or image.
 ///
 /// A subsection is defined to be any contiguous rectangular
@@ -396,16 +474,27 @@ pub fn ffp3de_safe(
 /// Data conversion and scaling will be performed if necessary
 /// (e.g, if the datatype of the FITS array is not the same as
 /// the array being written).
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `group`  — (I) group to write(1 = 1st group)
+/// * `naxis`  — (I) number of data axes in array
+/// * `naxes`  — (I) size of each FITS axis
+/// * `fpixel` — (I) 1st pixel in each axis to write (1=1st)
+/// * `lpixel` — (I) last pixel in each axis to write
+/// * `array`  — (I) array to be written
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffpsse(
-    fptr: *mut fitsfile,   /* I - FITS file pointer                       */
-    group: c_long,         /* I - group to write(1 = 1st group)           */
-    naxis: c_long,         /* I - number of data axes in array            */
-    naxes: *const c_long,  /* I - size of each FITS axis                  */
-    fpixel: *const c_long, /* I - 1st pixel in each axis to write (1=1st) */
-    lpixel: *const c_long, /* I - last pixel in each axis to write        */
-    array: *const f32,     /* I - array to be written                     */
-    status: *mut c_int,    /* IO - error status                           */
+    fptr: *mut fitsfile,
+    group: c_long,
+    naxis: c_long,
+    naxes: *const c_long,
+    fpixel: *const c_long,
+    lpixel: *const c_long,
+    array: *const f32,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -427,7 +516,6 @@ pub unsafe extern "C" fn ffpsse(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write a subsection of pixels to the primary array or image.
 ///
 /// A subsection is defined to be any contiguous rectangular
@@ -435,15 +523,26 @@ pub unsafe extern "C" fn ffpsse(
 /// Data conversion and scaling will be performed if necessary
 /// (e.g, if the datatype of the FITS array is not the same as
 /// the array being written).
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `group`  — (I) group to write(1 = 1st group)
+/// * `naxis`  — (I) number of data axes in array
+/// * `naxes`  — (I) size of each FITS axis
+/// * `fpixel` — (I) 1st pixel in each axis to write (1=1st)
+/// * `lpixel` — (I) last pixel in each axis to write
+/// * `array`  — (I) array to be written
+/// * `status` — (IO) error status
 pub fn ffpsse_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                       */
-    group: c_long,       /* I - group to write(1 = 1st group)           */
-    naxis: c_long,       /* I - number of data axes in array            */
-    naxes: &[c_long],    /* I - size of each FITS axis                  */
-    fpixel: &[c_long],   /* I - 1st pixel in each axis to write (1=1st) */
-    lpixel: &[c_long],   /* I - last pixel in each axis to write        */
-    array: &[f32],       /* I - array to be written                     */
-    status: &mut c_int,  /* IO - error status                           */
+    fptr: &mut fitsfile,
+    group: c_long,
+    naxis: c_long,
+    naxes: &[c_long],
+    fpixel: &[c_long],
+    lpixel: &[c_long],
+    array: &[f32],
+    status: &mut c_int,
 ) -> c_int {
     let mut fpix: [LONGLONG; 7] = [0; 7];
     let mut dimen: [LONGLONG; 7] = [0; 7];
@@ -570,7 +669,6 @@ pub fn ffpsse_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of group parameters to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
 /// the FITS array is not the same as the array being written).
@@ -579,14 +677,23 @@ pub fn ffpsse_safe(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to write(1 = 1st group)
+/// * `firstelem` — (I) first vector element to write(1 = 1st)
+/// * `nelem`     — (I) number of values to write
+/// * `array`     — (I) array of values that are written
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffpgpe(
-    fptr: *mut fitsfile, /* I - FITS file pointer                      */
-    group: c_long,       /* I - group to write(1 = 1st group)          */
-    firstelem: c_long,   /* I - first vector element to write(1 = 1st) */
-    nelem: c_long,       /* I - number of values to write              */
-    array: *const f32,   /* I - array of values that are written       */
-    status: *mut c_int,  /* IO - error status                          */
+    fptr: *mut fitsfile,
+    group: c_long,
+    firstelem: c_long,
+    nelem: c_long,
+    array: *const f32,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -599,7 +706,6 @@ pub unsafe extern "C" fn ffpgpe(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of group parameters to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
 /// the FITS array is not the same as the array being written).
@@ -608,13 +714,22 @@ pub unsafe extern "C" fn ffpgpe(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to write(1 = 1st group)
+/// * `firstelem` — (I) first vector element to write(1 = 1st)
+/// * `nelem`     — (I) number of values to write
+/// * `array`     — (I) array of values that are written
+/// * `status`    — (IO) error status
 pub fn ffpgpe_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                      */
-    group: c_long,       /* I - group to write(1 = 1st group)          */
-    firstelem: c_long,   /* I - first vector element to write(1 = 1st) */
-    nelem: c_long,       /* I - number of values to write              */
-    array: &[f32],       /* I - array of values that are written       */
-    status: &mut c_int,  /* IO - error status                          */
+    fptr: &mut fitsfile,
+    group: c_long,
+    firstelem: c_long,
+    nelem: c_long,
+    array: &[f32],
+    status: &mut c_int,
 ) -> c_int {
     let row = cmp::max(1, group);
 
@@ -630,7 +745,6 @@ pub fn ffpgpe_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of values to a column in the current FITS HDU.
 ///
 /// The column number may refer to a real column in an ASCII or binary table,
@@ -643,15 +757,25 @@ pub fn ffpgpe_safe(
 ///
 /// The input array of values will be converted to the datatype of the column
 /// and will be inverse-scaled by the FITS TSCALn and TZEROn values if necessary.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to write (1 = 1st col)
+/// * `firstrow`  — (I) first row to write (1 = 1st row)
+/// * `firstelem` — (I) first vector element to write (1 = 1st)
+/// * `nelem`     — (I) number of values to write
+/// * `array`     — (I) array of values to write
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffpcle(
-    fptr: *mut fitsfile, /* I - FITS file pointer                       */
-    colnum: c_int,       /* I - number of column to write (1 = 1st col) */
-    firstrow: LONGLONG,  /* I - first row to write (1 = 1st row)        */
-    firstelem: LONGLONG, /* I - first vector element to write (1 = 1st) */
-    nelem: LONGLONG,     /* I - number of values to write               */
-    array: *const f32,   /* I - array of values to write                */
-    status: *mut c_int,  /* IO - error status                           */
+    fptr: *mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: *const f32,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -672,7 +796,6 @@ pub unsafe extern "C" fn ffpcle(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of values to a column in the current FITS HDU.
 ///
 /// The column number may refer to a real column in an ASCII or binary table,
@@ -685,14 +808,24 @@ pub unsafe extern "C" fn ffpcle(
 ///
 /// The input array of values will be converted to the datatype of the column
 /// and will be inverse-scaled by the FITS TSCALn and TZEROn values if necessary.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to write (1 = 1st col)
+/// * `firstrow`  — (I) first row to write (1 = 1st row)
+/// * `firstelem` — (I) first vector element to write (1 = 1st)
+/// * `nelem`     — (I) number of values to write
+/// * `array`     — (I) array of values to write
+/// * `status`    — (IO) error status
 pub fn ffpcle_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                       */
-    colnum: c_int,       /* I - number of column to write (1 = 1st col) */
-    firstrow: LONGLONG,  /* I - first row to write (1 = 1st row)        */
-    firstelem: LONGLONG, /* I - first vector element to write (1 = 1st) */
-    nelem: LONGLONG,     /* I - number of values to write               */
-    array: &[f32],       /* I - array of values to write                */
-    status: &mut c_int,  /* IO - error status                           */
+    fptr: &mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: &[f32],
+    status: &mut c_int,
 ) -> c_int {
     let mut tcode: c_int = 0;
     let mut maxelem2: c_int = 0;
@@ -725,9 +858,7 @@ pub fn ffpcle_safe(
         return *status;
     }
 
-    /*---------------------------------------------------*/
     /*  Check input and get parameters about the column: */
-    /*---------------------------------------------------*/
     if ffgcprll(
         fptr,
         colnum,
@@ -778,12 +909,10 @@ pub fn ffpcle_safe(
         writeraw = false;
     }
 
-    /*---------------------------------------------------------------------*/
     /*  Now write the pixels to the FITS column.                           */
     /*  First call the ffXXfYY routine to  (1) convert the datatype        */
     /*  if necessary, and (2) scale the values by the FITS TSCALn and      */
     /*  TZEROn linear scaling parameters into a temporary buffer.          */
-    /*---------------------------------------------------------------------*/
     remain = nelem; /* remaining number of values to write  */
     next = 0; /* next element in array to be written  */
     rownum = 0; /* row number, relative to firstrow     */
@@ -950,9 +1079,7 @@ pub fn ffpcle_safe(
             }
         } /* End of switch block */
 
-        /*-------------------------*/
         /*  Check for fatal error  */
-        /*-------------------------*/
         if *status > 0 {
             /* test for error during previous write operation */
 
@@ -967,9 +1094,7 @@ pub fn ffpcle_safe(
             return *status;
         }
 
-        /*--------------------------------------------*/
         /*  increment the counters for the next loop  */
-        /*--------------------------------------------*/
         remain -= ntodo as LONGLONG;
         if remain > 0 {
             next += ntodo as LONGLONG;
@@ -983,9 +1108,7 @@ pub fn ffpcle_safe(
         }
     } /*  End of main while Loop  */
 
-    /*--------------------------------*/
     /*  check for numerical overflow  */
-    /*--------------------------------*/
     if *status == OVERFLOW_ERR {
         ffpmsg_str("Numerical overflow during type conversion while writing FITS data.");
         *status = NUM_OVERFLOW;
@@ -994,7 +1117,6 @@ pub fn ffpcle_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of complex values to a column in the current FITS HDU.
 ///
 /// Each complex number if interpreted as a pair of float values.
@@ -1012,15 +1134,25 @@ pub fn ffpcle_safe(
 /// TZERO keywords should not be used with complex numbers because mathmatically
 /// the scaling should only be applied to the real (first) component of the
 /// complex value.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to write (1 = 1st col)
+/// * `firstrow`  — (I) first row to write (1 = 1st row)
+/// * `firstelem` — (I) first vector element to write (1 = 1st)
+/// * `nelem`     — (I) number of values to write
+/// * `array`     — (I) array of values to write
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffpclc(
-    fptr: *mut fitsfile, /* I - FITS file pointer                       */
-    colnum: c_int,       /* I - number of column to write (1 = 1st col) */
-    firstrow: LONGLONG,  /* I - first row to write (1 = 1st row)        */
-    firstelem: LONGLONG, /* I - first vector element to write (1 = 1st) */
-    nelem: LONGLONG,     /* I - number of values to write               */
-    array: *const f32,   /* I - array of values to write                */
-    status: *mut c_int,  /* IO - error status                           */
+    fptr: *mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: *const f32,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -1041,7 +1173,6 @@ pub unsafe extern "C" fn ffpclc(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of complex values to a column in the current FITS HDU.
 /// Each complex number if interpreted as a pair of float values.
 /// The column number may refer to a real column in an ASCII or binary table,
@@ -1058,14 +1189,24 @@ pub unsafe extern "C" fn ffpclc(
 /// TZERO keywords should not be used with complex numbers because mathmatically
 /// the scaling should only be applied to the real (first) component of the
 /// complex value.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to write (1 = 1st col)
+/// * `firstrow`  — (I) first row to write (1 = 1st row)
+/// * `firstelem` — (I) first vector element to write (1 = 1st)
+/// * `nelem`     — (I) number of values to write
+/// * `array`     — (I) array of values to write
+/// * `status`    — (IO) error status
 pub fn ffpclc_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                       */
-    colnum: c_int,       /* I - number of column to write (1 = 1st col) */
-    firstrow: LONGLONG,  /* I - first row to write (1 = 1st row)        */
-    firstelem: LONGLONG, /* I - first vector element to write (1 = 1st) */
-    nelem: LONGLONG,     /* I - number of values to write               */
-    array: &[f32],       /* I - array of values to write                */
-    status: &mut c_int,  /* IO - error status                           */
+    fptr: &mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: &[f32],
+    status: &mut c_int,
 ) -> c_int {
     /* simply multiply the number of elements by 2, and call ffpcle */
     ffpcle_safe(
@@ -1080,23 +1221,33 @@ pub fn ffpclc_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of elements to the specified column of a table.  Any input
 /// pixels equal to the value of nulvalue will be replaced by the appropriate
 /// null value in the output FITS file.
 ///
 /// The input array of values will be converted to the datatype of the column
 /// and will be inverse-scaled by the FITS TSCALn and TZEROn values if necessary
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to write (1 = 1st col)
+/// * `firstrow`  — (I) first row to write (1 = 1st row)
+/// * `firstelem` — (I) first vector element to write (1 = 1st)
+/// * `nelem`     — (I) number of values to write
+/// * `array`     — (I) array of values to write
+/// * `nulvalue`  — (I) value used to flag undefined pixels
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffpcne(
-    fptr: *mut fitsfile, /* I - FITS file pointer                       */
-    colnum: c_int,       /* I - number of column to write (1 = 1st col) */
-    firstrow: LONGLONG,  /* I - first row to write (1 = 1st row)        */
-    firstelem: LONGLONG, /* I - first vector element to write (1 = 1st) */
-    nelem: LONGLONG,     /* I - number of values to write               */
-    array: *const f32,   /* I - array of values to write                */
-    nulvalue: f32,       /* I - value used to flag undefined pixels     */
-    status: *mut c_int,  /* IO - error status                           */
+    fptr: *mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: *const f32,
+    nulvalue: f32,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -1118,22 +1269,32 @@ pub unsafe extern "C" fn ffpcne(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of elements to the specified column of a table.  Any input
 /// pixels equal to the value of nulvalue will be replaced by the appropriate
 /// null value in the output FITS file.
 ///
 /// The input array of values will be converted to the datatype of the column
 /// and will be inverse-scaled by the FITS TSCALn and TZEROn values if necessary
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to write (1 = 1st col)
+/// * `firstrow`  — (I) first row to write (1 = 1st row)
+/// * `firstelem` — (I) first vector element to write (1 = 1st)
+/// * `nelem`     — (I) number of values to write
+/// * `array`     — (I) array of values to write
+/// * `nulvalue`  — (I) value used to flag undefined pixels
+/// * `status`    — (IO) error status
 pub fn ffpcne_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                       */
-    colnum: c_int,       /* I - number of column to write (1 = 1st col) */
-    firstrow: LONGLONG,  /* I - first row to write (1 = 1st row)        */
-    firstelem: LONGLONG, /* I - first vector element to write (1 = 1st) */
-    nelem: LONGLONG,     /* I - number of values to write               */
-    array: &[f32],       /* I - array of values to write                */
-    nulvalue: f32,       /* I - value used to flag undefined pixels     */
-    status: &mut c_int,  /* IO - error status                           */
+    fptr: &mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: &[f32],
+    nulvalue: f32,
+    status: &mut c_int,
 ) -> c_int {
     let mut ngood: LONGLONG = 0;
     let mut nbad: LONGLONG = 0;
@@ -1292,16 +1453,24 @@ pub fn ffpcne_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output prior to writing output to a FITS file.
 /// Do datatype conversion and scaling if required.
+///
+/// # Parameters
+///
+/// * `input`  — (I) array of values to be converted
+/// * `ntodo`  — (I) number of elements in the array
+/// * `scale`  — (I) FITS TSCALn or BSCALE value
+/// * `zero`   — (I) FITS TZEROn or BZERO value
+/// * `output` — (O) output array of converted values
+/// * `status` — (IO) error status
 pub(crate) fn ffr4fi1(
-    input: &[f32],      /* I - array of values to be converted  */
-    ntodo: c_long,      /* I - number of elements in the array  */
-    scale: f64,         /* I - FITS TSCALn or BSCALE value      */
-    zero: f64,          /* I - FITS TZEROn or BZERO  value      */
-    output: &mut [u8],  /* O - output array of converted values */
-    status: &mut c_int, /* IO - error status                    */
+    input: &[f32],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    output: &mut [u8],
+    status: &mut c_int,
 ) -> c_int {
     if scale == 1.0 && zero == 0.0 {
         for ii in 0..(ntodo as usize) {
@@ -1333,16 +1502,24 @@ pub(crate) fn ffr4fi1(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output prior to writing output to a FITS file.
 /// Do datatype conversion and scaling if required.
+///
+/// # Parameters
+///
+/// * `input`  — (I) array of values to be converted
+/// * `ntodo`  — (I) number of elements in the array
+/// * `scale`  — (I) FITS TSCALn or BSCALE value
+/// * `zero`   — (I) FITS TZEROn or BZERO value
+/// * `output` — (O) output array of converted values
+/// * `status` — (IO) error status
 pub(crate) fn ffr4fi2(
-    input: &[f32],          /* I - array of values to be converted  */
-    ntodo: c_long,          /* I - number of elements in the array  */
-    scale: f64,             /* I - FITS TSCALn or BSCALE value      */
-    zero: f64,              /* I - FITS TZEROn or BZERO  value      */
-    output: &mut [c_short], /* O - output array of converted values */
-    status: &mut c_int,     /* IO - error status                    */
+    input: &[f32],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    output: &mut [c_short],
+    status: &mut c_int,
 ) -> c_int {
     if scale == 1.0 && zero == 0.0 {
         for ii in 0..(ntodo as usize) {
@@ -1376,16 +1553,24 @@ pub(crate) fn ffr4fi2(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output prior to writing output to a FITS file.
 /// Do datatype conversion and scaling if required.
+///
+/// # Parameters
+///
+/// * `input`  — (I) array of values to be converted
+/// * `ntodo`  — (I) number of elements in the array
+/// * `scale`  — (I) FITS TSCALn or BSCALE value
+/// * `zero`   — (I) FITS TZEROn or BZERO value
+/// * `output` — (O) output array of converted values
+/// * `status` — (IO) error status
 pub(crate) fn ffr4fi4(
-    input: &[f32],           /* I - array of values to be converted  */
-    ntodo: c_long,           /* I - number of elements in the array  */
-    scale: f64,              /* I - FITS TSCALn or BSCALE value      */
-    zero: f64,               /* I - FITS TZEROn or BZERO  value      */
-    output: &mut [INT32BIT], /* O - output array of converted values */
-    status: &mut c_int,      /* IO - error status                    */
+    input: &[f32],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    output: &mut [INT32BIT],
+    status: &mut c_int,
 ) -> c_int {
     if scale == 1.0 && zero == 0.0 {
         for ii in 0..(ntodo as usize) {
@@ -1419,16 +1604,24 @@ pub(crate) fn ffr4fi4(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output prior to writing output to a FITS file.
 /// Do datatype conversion and scaling if required.
+///
+/// # Parameters
+///
+/// * `input`  — (I) array of values to be converted
+/// * `ntodo`  — (I) number of elements in the array
+/// * `scale`  — (I) FITS TSCALn or BSCALE value
+/// * `zero`   — (I) FITS TZEROn or BZERO value
+/// * `output` — (O) output array of converted values
+/// * `status` — (IO) error status
 pub(crate) fn ffr4fi8(
-    input: &[f32],           /* I - array of values to be converted  */
-    ntodo: c_long,           /* I - number of elements in the array  */
-    scale: f64,              /* I - FITS TSCALn or BSCALE value      */
-    zero: f64,               /* I - FITS TZEROn or BZERO  value      */
-    output: &mut [LONGLONG], /* O - output array of converted values */
-    status: &mut c_int,      /* IO - error status                    */
+    input: &[f32],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    output: &mut [LONGLONG],
+    status: &mut c_int,
 ) -> c_int {
     if scale == 1.0 && zero == 9223372036854775808. {
         /* Writing to unsigned long long column. Input values must not be negative */
@@ -1478,16 +1671,24 @@ pub(crate) fn ffr4fi8(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output prior to writing output to a FITS file.
 /// Do datatype conversion and scaling if required.
+///
+/// # Parameters
+///
+/// * `input`  — (I) array of values to be converted
+/// * `ntodo`  — (I) number of elements in the array
+/// * `scale`  — (I) FITS TSCALn or BSCALE value
+/// * `zero`   — (I) FITS TZEROn or BZERO value
+/// * `output` — (O) output array of converted values
+/// * `status` — (IO) error status
 pub(crate) fn ffr4fr4(
-    input: &[f32],      /* I - array of values to be converted  */
-    ntodo: c_long,      /* I - number of elements in the array  */
-    scale: f64,         /* I - FITS TSCALn or BSCALE value      */
-    zero: f64,          /* I - FITS TZEROn or BZERO  value      */
-    output: &mut [f32], /* O - output array of converted values */
-    status: &mut c_int, /* IO - error status                    */
+    input: &[f32],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    output: &mut [f32],
+    status: &mut c_int,
 ) -> c_int {
     let ntodo = ntodo as usize;
     if scale == 1.0 && zero == 0.0 {
@@ -1500,16 +1701,24 @@ pub(crate) fn ffr4fr4(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output prior to writing output to a FITS file.
 /// Do datatype conversion and scaling if required.
+///
+/// # Parameters
+///
+/// * `input`  — (I) array of values to be converted
+/// * `ntodo`  — (I) number of elements in the array
+/// * `scale`  — (I) FITS TSCALn or BSCALE value
+/// * `zero`   — (I) FITS TZEROn or BZERO value
+/// * `output` — (O) output array of converted values
+/// * `status` — (IO) error status
 pub(crate) fn ffr4fr8(
-    input: &[f32],      /* I - array of values to be converted  */
-    ntodo: c_long,      /* I - number of elements in the array  */
-    scale: f64,         /* I - FITS TSCALn or BSCALE value      */
-    zero: f64,          /* I - FITS TZEROn or BZERO  value      */
-    output: &mut [f64], /* O - output array of converted values */
-    status: &mut c_int, /* IO - error status                    */
+    input: &[f32],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    output: &mut [f64],
+    status: &mut c_int,
 ) -> c_int {
     if scale == 1.0 && zero == 0.0 {
         for ii in 0..(ntodo as usize) {
@@ -1523,18 +1732,28 @@ pub(crate) fn ffr4fr8(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output prior to writing output to a FITS file.
 /// Do scaling if required.
+///
+/// # Parameters
+///
+/// * `input`  — (I) array of values to be converted
+/// * `ntodo`  — (I) number of elements in the array
+/// * `scale`  — (I) FITS TSCALn or BSCALE value
+/// * `zero`   — (I) FITS TZEROn or BZERO value
+/// * `cform`  — (I) format for output string values
+/// * `twidth` — (I) width of each field, in chars
+/// * `output` — (O) output array of converted values
+/// * `status` — (IO) error status
 pub(crate) fn ffr4fstr(
-    input: &[f32],         /* I - array of values to be converted  */
-    ntodo: c_long,         /* I - number of elements in the array  */
-    scale: f64,            /* I - FITS TSCALn or BSCALE value      */
-    zero: f64,             /* I - FITS TZEROn or BZERO  value      */
-    cform: &[c_char],      /* I - format for output string values  */
-    twidth: c_long,        /* I - width of each field, in chars    */
-    output: &mut [c_char], /* O - output array of converted values */
-    status: &mut c_int,    /* IO - error status                    */
+    input: &[f32],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    cform: &[c_char],
+    twidth: c_long,
+    output: &mut [c_char],
+    status: &mut c_int,
 ) -> c_int {
     let mut ci = 0;
 

--- a/src/putcoli.rs
+++ b/src/putcoli.rs
@@ -1,9 +1,14 @@
-/*  This file, putcoli.rs, contains routines that write data elements to    */
-/*  a FITS image or table, with short datatype.                            */
-
-/*  The FITSIO software was written by William Pence at the High Energy    */
-/*  Astrophysic Science Archive Research Center (HEASARC) at the NASA      */
-/*  Goddard Space Flight Center.                                           */
+//! Routines that write data elements to a FITS image or table, with short
+//! datatype.
+//!
+//! The [`TSHORT`] arm of the typed column I/O family. [`crate::putcol`]
+//! dispatches here when a caller asks for this datatype at run time; the
+//! write-side counterpart is [`crate::getcoli`].
+//!
+//! Ported from CFITSIO's `putcoli.c`, written by William Pence at the High
+//! Energy Astrophysics Science Archive Research Center (HEASARC), NASA Goddard
+//! Space Flight Center.
+#![warn(missing_docs)]
 
 use core::slice;
 use core::{cmp, mem};
@@ -25,7 +30,6 @@ use crate::relibc::header::stdio::snprintf_f64;
 use crate::wrappers::strlen_safe;
 use crate::{buffers::*, int_snprintf, slice_to_str};
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
 /// the FITS array is not the same as the array being written).
@@ -34,14 +38,23 @@ use crate::{buffers::*, int_snprintf, slice_to_str};
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to write (1 = 1st group)
+/// * `firstelem` — (I) first vector element to write (1 = 1st)
+/// * `nelem`     — (I) number of values to write
+/// * `array`     — (I) array of values that are written
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffppri(
-    fptr: *mut fitsfile,   /* I - FITS file pointer                       */
-    group: c_long,         /* I - group to write (1 = 1st group)          */
-    firstelem: LONGLONG,   /* I - first vector element to write (1 = 1st) */
-    nelem: LONGLONG,       /* I - number of values to write               */
-    array: *const c_short, /* I - array of values that are written        */
-    status: *mut c_int,    /* IO - error status                           */
+    fptr: *mut fitsfile,
+    group: c_long,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: *const c_short,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -54,7 +67,6 @@ pub unsafe extern "C" fn ffppri(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
 /// the FITS array is not the same as the array being written).
@@ -63,13 +75,22 @@ pub unsafe extern "C" fn ffppri(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to write (1 = 1st group)
+/// * `firstelem` — (I) first vector element to write (1 = 1st)
+/// * `nelem`     — (I) number of values to write
+/// * `array`     — (I) array of values that are written
+/// * `status`    — (IO) error status
 pub fn ffppri_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                       */
-    group: c_long,       /* I - group to write (1 = 1st group)          */
-    firstelem: LONGLONG, /* I - first vector element to write (1 = 1st) */
-    nelem: LONGLONG,     /* I - number of values to write               */
-    array: &[c_short],   /* I - array of values that are written        */
-    status: &mut c_int,  /* IO - error status                           */
+    fptr: &mut fitsfile,
+    group: c_long,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: &[c_short],
+    status: &mut c_int,
 ) -> c_int {
     let nullvalue: c_short = 0;
 
@@ -103,7 +124,6 @@ pub fn ffppri_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of the
 /// FITS array is not the same as the array being written).  Any array values
@@ -114,15 +134,25 @@ pub fn ffppri_safe(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to write(1 = 1st group)
+/// * `firstelem` — (I) first vector element to write(1 = 1st)
+/// * `nelem`     — (I) number of values to write
+/// * `array`     — (I) array of values that are written
+/// * `nulval`    — (I) undefined pixel value
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffppni(
-    fptr: *mut fitsfile,   /* I - FITS file pointer                       */
-    group: c_long,         /* I - group to write(1 = 1st group)           */
-    firstelem: LONGLONG,   /* I - first vector element to write(1 = 1st)  */
-    nelem: LONGLONG,       /* I - number of values to write               */
-    array: *const c_short, /* I - array of values that are written        */
-    nulval: c_short,       /* I - undefined pixel value                   */
-    status: *mut c_int,    /* IO - error status                           */
+    fptr: *mut fitsfile,
+    group: c_long,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: *const c_short,
+    nulval: c_short,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -135,7 +165,6 @@ pub unsafe extern "C" fn ffppni(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of the
 /// FITS array is not the same as the array being written).  Any array values
@@ -146,14 +175,24 @@ pub unsafe extern "C" fn ffppni(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to write(1 = 1st group)
+/// * `firstelem` — (I) first vector element to write(1 = 1st)
+/// * `nelem`     — (I) number of values to write
+/// * `array`     — (I) array of values that are written
+/// * `nulval`    — (I) undefined pixel value
+/// * `status`    — (IO) error status
 pub fn ffppni_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                       */
-    group: c_long,       /* I - group to write(1 = 1st group)           */
-    firstelem: LONGLONG, /* I - first vector element to write(1 = 1st)  */
-    nelem: LONGLONG,     /* I - number of values to write               */
-    array: &[c_short],   /* I - array of values that are written        */
-    nulval: c_short,     /* I - undefined pixel value                   */
-    status: &mut c_int,  /* IO - error status                           */
+    fptr: &mut fitsfile,
+    group: c_long,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: &[c_short],
+    nulval: c_short,
+    status: &mut c_int,
 ) -> c_int {
     let nullvalue: c_short;
 
@@ -189,19 +228,28 @@ pub fn ffppni_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an entire 2-D array of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of the
 /// FITS array is not the same as the array being written).
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `group`  — (I) group to write(1 = 1st group)
+/// * `ncols`  — (I) number of pixels in each row of array
+/// * `naxis1` — (I) FITS image NAXIS1 value
+/// * `naxis2` — (I) FITS image NAXIS2 value
+/// * `array`  — (I) array to be written
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffp2di(
-    fptr: *mut fitsfile,   /* I - FITS file pointer                     */
-    group: c_long,         /* I - group to write(1 = 1st group)         */
-    ncols: LONGLONG,       /* I - number of pixels in each row of array */
-    naxis1: LONGLONG,      /* I - FITS image NAXIS1 value               */
-    naxis2: LONGLONG,      /* I - FITS image NAXIS2 value               */
-    array: *const c_short, /* I - array to be written                   */
-    status: *mut c_int,    /* IO - error status                         */
+    fptr: *mut fitsfile,
+    group: c_long,
+    ncols: LONGLONG,
+    naxis1: LONGLONG,
+    naxis2: LONGLONG,
+    array: *const c_short,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -214,18 +262,27 @@ pub unsafe extern "C" fn ffp2di(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an entire 2-D array of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of the
 /// FITS array is not the same as the array being written).
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `group`  — (I) group to write(1 = 1st group)
+/// * `ncols`  — (I) number of pixels in each row of array
+/// * `naxis1` — (I) FITS image NAXIS1 value
+/// * `naxis2` — (I) FITS image NAXIS2 value
+/// * `array`  — (I) array to be written
+/// * `status` — (IO) error status
 pub fn ffp2di_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                     */
-    group: c_long,       /* I - group to write(1 = 1st group)         */
-    ncols: LONGLONG,     /* I - number of pixels in each row of array */
-    naxis1: LONGLONG,    /* I - FITS image NAXIS1 value               */
-    naxis2: LONGLONG,    /* I - FITS image NAXIS2 value               */
-    array: &[c_short],   /* I - array to be written                   */
-    status: &mut c_int,  /* IO - error status                         */
+    fptr: &mut fitsfile,
+    group: c_long,
+    ncols: LONGLONG,
+    naxis1: LONGLONG,
+    naxis2: LONGLONG,
+    array: &[c_short],
+    status: &mut c_int,
 ) -> c_int {
     /* call the 3D writing routine, with the 3rd dimension = 1 */
     ffp3di_safe(fptr, group, ncols, naxis2, naxis1, naxis2, 1, array, status);
@@ -233,7 +290,6 @@ pub fn ffp2di_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an entire 3-D cube of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of the
 /// FITS array is not the same as the array being written).
@@ -242,17 +298,29 @@ pub fn ffp2di_safe(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `group`  — (I) group to write(1 = 1st group)
+/// * `ncols`  — (I) number of pixels in each row of array
+/// * `nrows`  — (I) number of rows in each plane of array
+/// * `naxis1` — (I) FITS image NAXIS1 value
+/// * `naxis2` — (I) FITS image NAXIS2 value
+/// * `naxis3` — (I) FITS image NAXIS3 value
+/// * `array`  — (I) array to be written
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffp3di(
-    fptr: *mut fitsfile,   /* I - FITS file pointer                     */
-    group: c_long,         /* I - group to write(1 = 1st group)         */
-    ncols: LONGLONG,       /* I - number of pixels in each row of array */
-    nrows: LONGLONG,       /* I - number of rows in each plane of array */
-    naxis1: LONGLONG,      /* I - FITS image NAXIS1 value               */
-    naxis2: LONGLONG,      /* I - FITS image NAXIS2 value               */
-    naxis3: LONGLONG,      /* I - FITS image NAXIS3 value               */
-    array: *const c_short, /* I - array to be written                   */
-    status: *mut c_int,    /* IO - error status                         */
+    fptr: *mut fitsfile,
+    group: c_long,
+    ncols: LONGLONG,
+    nrows: LONGLONG,
+    naxis1: LONGLONG,
+    naxis2: LONGLONG,
+    naxis3: LONGLONG,
+    array: *const c_short,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -267,7 +335,6 @@ pub unsafe extern "C" fn ffp3di(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an entire 3-D cube of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of the
 /// FITS array is not the same as the array being written).
@@ -276,16 +343,28 @@ pub unsafe extern "C" fn ffp3di(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `group`  — (I) group to write(1 = 1st group)
+/// * `ncols`  — (I) number of pixels in each row of array
+/// * `nrows`  — (I) number of rows in each plane of array
+/// * `naxis1` — (I) FITS image NAXIS1 value
+/// * `naxis2` — (I) FITS image NAXIS2 value
+/// * `naxis3` — (I) FITS image NAXIS3 value
+/// * `array`  — (I) array to be written
+/// * `status` — (IO) error status
 pub fn ffp3di_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                     */
-    group: c_long,       /* I - group to write(1 = 1st group)         */
-    ncols: LONGLONG,     /* I - number of pixels in each row of array */
-    nrows: LONGLONG,     /* I - number of rows in each plane of array */
-    naxis1: LONGLONG,    /* I - FITS image NAXIS1 value               */
-    naxis2: LONGLONG,    /* I - FITS image NAXIS2 value               */
-    naxis3: LONGLONG,    /* I - FITS image NAXIS3 value               */
-    array: &[c_short],   /* I - array to be written                   */
-    status: &mut c_int,  /* IO - error status                         */
+    fptr: &mut fitsfile,
+    group: c_long,
+    ncols: LONGLONG,
+    nrows: LONGLONG,
+    naxis1: LONGLONG,
+    naxis2: LONGLONG,
+    naxis3: LONGLONG,
+    array: &[c_short],
+    status: &mut c_int,
 ) -> c_int {
     let fpixel: [c_long; 3] = [1; 3];
     let mut lpixel: [c_long; 3] = [0; 3];
@@ -362,7 +441,6 @@ pub fn ffp3di_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write a subsection of pixels to the primary array or image.
 ///
 /// A subsection is defined to be any contiguous rectangular
@@ -370,16 +448,27 @@ pub fn ffp3di_safe(
 /// Data conversion and scaling will be performed if necessary
 /// (e.g, if the datatype of the FITS array is not the same as
 /// the array being written).
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `group`  — (I) group to write(1 = 1st group)
+/// * `naxis`  — (I) number of data axes in array
+/// * `naxes`  — (I) size of each FITS axis
+/// * `fpixel` — (I) 1st pixel in each axis to write (1=1st)
+/// * `lpixel` — (I) last pixel in each axis to write
+/// * `array`  — (I) array to be written
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffpssi(
-    fptr: *mut fitsfile,   /* I - FITS file pointer                       */
-    group: c_long,         /* I - group to write(1 = 1st group)           */
-    naxis: c_long,         /* I - number of data axes in array            */
-    naxes: *const c_long,  /* I - size of each FITS axis                  */
-    fpixel: *const c_long, /* I - 1st pixel in each axis to write (1=1st) */
-    lpixel: *const c_long, /* I - last pixel in each axis to write        */
-    array: *const c_short, /* I - array to be written                     */
-    status: *mut c_int,    /* IO - error status                           */
+    fptr: *mut fitsfile,
+    group: c_long,
+    naxis: c_long,
+    naxes: *const c_long,
+    fpixel: *const c_long,
+    lpixel: *const c_long,
+    array: *const c_short,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -402,7 +491,6 @@ pub unsafe extern "C" fn ffpssi(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write a subsection of pixels to the primary array or image.
 ///
 /// A subsection is defined to be any contiguous rectangular
@@ -410,15 +498,26 @@ pub unsafe extern "C" fn ffpssi(
 /// Data conversion and scaling will be performed if necessary
 /// (e.g, if the datatype of the FITS array is not the same as
 /// the array being written).
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `group`  — (I) group to write(1 = 1st group)
+/// * `naxis`  — (I) number of data axes in array
+/// * `naxes`  — (I) size of each FITS axis
+/// * `fpixel` — (I) 1st pixel in each axis to write (1=1st)
+/// * `lpixel` — (I) last pixel in each axis to write
+/// * `array`  — (I) array to be written
+/// * `status` — (IO) error status
 pub fn ffpssi_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                       */
-    group: c_long,       /* I - group to write(1 = 1st group)           */
-    naxis: c_long,       /* I - number of data axes in array            */
-    naxes: &[c_long],    /* I - size of each FITS axis                  */
-    fpixel: &[c_long],   /* I - 1st pixel in each axis to write (1=1st) */
-    lpixel: &[c_long],   /* I - last pixel in each axis to write        */
-    array: &[c_short],   /* I - array to be written                     */
-    status: &mut c_int,  /* IO - error status                           */
+    fptr: &mut fitsfile,
+    group: c_long,
+    naxis: c_long,
+    naxes: &[c_long],
+    fpixel: &[c_long],
+    lpixel: &[c_long],
+    array: &[c_short],
+    status: &mut c_int,
 ) -> c_int {
     let mut fpix: [LONGLONG; 7] = [0; 7];
     let mut dimen: [LONGLONG; 7] = [0; 7];
@@ -545,7 +644,6 @@ pub fn ffpssi_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of group parameters to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
 /// the FITS array is not the same as the array being written).
@@ -554,14 +652,23 @@ pub fn ffpssi_safe(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to write(1 = 1st group)
+/// * `firstelem` — (I) first vector element to write(1 = 1st)
+/// * `nelem`     — (I) number of values to write
+/// * `array`     — (I) array of values that are written
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffpgpi(
-    fptr: *mut fitsfile,   /* I - FITS file pointer                      */
-    group: c_long,         /* I - group to write(1 = 1st group)          */
-    firstelem: c_long,     /* I - first vector element to write(1 = 1st) */
-    nelem: c_long,         /* I - number of values to write              */
-    array: *const c_short, /* I - array of values that are written       */
-    status: *mut c_int,    /* IO - error status                          */
+    fptr: *mut fitsfile,
+    group: c_long,
+    firstelem: c_long,
+    nelem: c_long,
+    array: *const c_short,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -574,7 +681,6 @@ pub unsafe extern "C" fn ffpgpi(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of group parameters to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
 /// the FITS array is not the same as the array being written).
@@ -583,13 +689,22 @@ pub unsafe extern "C" fn ffpgpi(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to write(1 = 1st group)
+/// * `firstelem` — (I) first vector element to write(1 = 1st)
+/// * `nelem`     — (I) number of values to write
+/// * `array`     — (I) array of values that are written
+/// * `status`    — (IO) error status
 pub fn ffpgpi_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                      */
-    group: c_long,       /* I - group to write(1 = 1st group)          */
-    firstelem: c_long,   /* I - first vector element to write(1 = 1st) */
-    nelem: c_long,       /* I - number of values to write              */
-    array: &[c_short],   /* I - array of values that are written       */
-    status: &mut c_int,  /* IO - error status                          */
+    fptr: &mut fitsfile,
+    group: c_long,
+    firstelem: c_long,
+    nelem: c_long,
+    array: &[c_short],
+    status: &mut c_int,
 ) -> c_int {
     let row = cmp::max(1, group);
 
@@ -605,7 +720,6 @@ pub fn ffpgpi_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of values to a column in the current FITS HDU.
 ///
 /// The column number may refer to a real column in an ASCII or binary table,
@@ -618,15 +732,25 @@ pub fn ffpgpi_safe(
 ///
 /// The input array of values will be converted to the datatype of the column
 /// and will be inverse-scaled by the FITS TSCALn and TZEROn values if necessary.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to write (1 = 1st col)
+/// * `firstrow`  — (I) first row to write (1 = 1st row)
+/// * `firstelem` — (I) first vector element to write (1 = 1st)
+/// * `nelem`     — (I) number of values to write
+/// * `array`     — (I) array of values to write
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffpcli(
-    fptr: *mut fitsfile,   /* I - FITS file pointer                       */
-    colnum: c_int,         /* I - number of column to write (1 = 1st col) */
-    firstrow: LONGLONG,    /* I - first row to write (1 = 1st row)        */
-    firstelem: LONGLONG,   /* I - first vector element to write (1 = 1st) */
-    nelem: LONGLONG,       /* I - number of values to write               */
-    array: *const c_short, /* I - array of values to write                */
-    status: *mut c_int,    /* IO - error status                           */
+    fptr: *mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: *const c_short,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -647,7 +771,6 @@ pub unsafe extern "C" fn ffpcli(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of values to a column in the current FITS HDU.
 ///
 /// The column number may refer to a real column in an ASCII or binary table,
@@ -660,14 +783,24 @@ pub unsafe extern "C" fn ffpcli(
 ///
 /// The input array of values will be converted to the datatype of the column
 /// and will be inverse-scaled by the FITS TSCALn and TZEROn values if necessary.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to write (1 = 1st col)
+/// * `firstrow`  — (I) first row to write (1 = 1st row)
+/// * `firstelem` — (I) first vector element to write (1 = 1st)
+/// * `nelem`     — (I) number of values to write
+/// * `array`     — (I) array of values to write
+/// * `status`    — (IO) error status
 pub fn ffpcli_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                       */
-    colnum: c_int,       /* I - number of column to write (1 = 1st col) */
-    firstrow: LONGLONG,  /* I - first row to write (1 = 1st row)        */
-    firstelem: LONGLONG, /* I - first vector element to write (1 = 1st) */
-    nelem: LONGLONG,     /* I - number of values to write               */
-    array: &[c_short],   /* I - array of values to write                */
-    status: &mut c_int,  /* IO - error status                           */
+    fptr: &mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: &[c_short],
+    status: &mut c_int,
 ) -> c_int {
     let mut tcode: c_int = 0;
     let mut maxelem2: c_int = 0;
@@ -700,9 +833,7 @@ pub fn ffpcli_safe(
         return *status;
     }
 
-    /*---------------------------------------------------*/
     /*  Check input and get parameters about the column: */
-    /*---------------------------------------------------*/
     if ffgcprll(
         fptr,
         colnum,
@@ -753,12 +884,10 @@ pub fn ffpcli_safe(
         writeraw = false;
     }
 
-    /*---------------------------------------------------------------------*/
     /*  Now write the pixels to the FITS column.                           */
     /*  First call the ffXXfYY routine to  (1) convert the datatype        */
     /*  if necessary, and (2) scale the values by the FITS TSCALn and      */
     /*  TZEROn linear scaling parameters into a temporary buffer.          */
-    /*---------------------------------------------------------------------*/
     remain = nelem; /* remaining number of values to write  */
     next = 0; /* next element in array to be written  */
     rownum = 0; /* row number, relative to firstrow     */
@@ -930,9 +1059,7 @@ pub fn ffpcli_safe(
             }
         } /* End of switch block */
 
-        /*-------------------------*/
         /*  Check for fatal error  */
-        /*-------------------------*/
         if *status > 0 {
             /* test for error during previous write operation */
 
@@ -947,9 +1074,7 @@ pub fn ffpcli_safe(
             return *status;
         }
 
-        /*--------------------------------------------*/
         /*  increment the counters for the next loop  */
-        /*--------------------------------------------*/
         remain -= ntodo as LONGLONG;
         if remain > 0 {
             next += ntodo as LONGLONG;
@@ -963,9 +1088,7 @@ pub fn ffpcli_safe(
         }
     } /*  End of main while Loop  */
 
-    /*--------------------------------*/
     /*  check for numerical overflow  */
-    /*--------------------------------*/
     if *status == OVERFLOW_ERR {
         ffpmsg_str("Numerical overflow during type conversion while writing FITS data.");
         *status = NUM_OVERFLOW;
@@ -974,23 +1097,33 @@ pub fn ffpcli_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of elements to the specified column of a table.  Any input
 /// pixels equal to the value of nulvalue will be replaced by the appropriate
 /// null value in the output FITS file.
 ///
 /// The input array of values will be converted to the datatype of the column
 /// and will be inverse-scaled by the FITS TSCALn and TZEROn values if necessary
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to write (1 = 1st col)
+/// * `firstrow`  — (I) first row to write (1 = 1st row)
+/// * `firstelem` — (I) first vector element to write (1 = 1st)
+/// * `nelem`     — (I) number of values to write
+/// * `array`     — (I) array of values to write
+/// * `nulvalue`  — (I) value used to flag undefined pixels
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffpcni(
-    fptr: *mut fitsfile,   /* I - FITS file pointer                       */
-    colnum: c_int,         /* I - number of column to write (1 = 1st col) */
-    firstrow: LONGLONG,    /* I - first row to write (1 = 1st row)        */
-    firstelem: LONGLONG,   /* I - first vector element to write (1 = 1st) */
-    nelem: LONGLONG,       /* I - number of values to write               */
-    array: *const c_short, /* I - array of values to write                */
-    nulvalue: c_short,     /* I - value used to flag undefined pixels     */
-    status: *mut c_int,    /* IO - error status                           */
+    fptr: *mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: *const c_short,
+    nulvalue: c_short,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -1012,22 +1145,32 @@ pub unsafe extern "C" fn ffpcni(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of elements to the specified column of a table.  Any input
 /// pixels equal to the value of nulvalue will be replaced by the appropriate
 /// null value in the output FITS file.
 ///
 /// The input array of values will be converted to the datatype of the column
 /// and will be inverse-scaled by the FITS TSCALn and TZEROn values if necessary
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to write (1 = 1st col)
+/// * `firstrow`  — (I) first row to write (1 = 1st row)
+/// * `firstelem` — (I) first vector element to write (1 = 1st)
+/// * `nelem`     — (I) number of values to write
+/// * `array`     — (I) array of values to write
+/// * `nulvalue`  — (I) value used to flag undefined pixels
+/// * `status`    — (IO) error status
 pub fn ffpcni_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                       */
-    colnum: c_int,       /* I - number of column to write (1 = 1st col) */
-    firstrow: LONGLONG,  /* I - first row to write (1 = 1st row)        */
-    firstelem: LONGLONG, /* I - first vector element to write (1 = 1st) */
-    nelem: LONGLONG,     /* I - number of values to write               */
-    array: &[c_short],   /* I - array of values to write                */
-    nulvalue: c_short,   /* I - value used to flag undefined pixels     */
-    status: &mut c_int,  /* IO - error status                           */
+    fptr: &mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: &[c_short],
+    nulvalue: c_short,
+    status: &mut c_int,
 ) -> c_int {
     let mut ngood: LONGLONG = 0;
     let mut nbad: LONGLONG = 0;
@@ -1181,16 +1324,24 @@ pub fn ffpcni_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output prior to writing output to a FITS file.
 /// Do datatype conversion and scaling if required
+///
+/// # Parameters
+///
+/// * `input`  — (I) array of values to be converted
+/// * `ntodo`  — (I) number of elements in the array
+/// * `scale`  — (I) FITS TSCALn or BSCALE value
+/// * `zero`   — (I) FITS TZEROn or BZERO value
+/// * `output` — (O) output array of converted values
+/// * `status` — (IO) error status
 pub(crate) fn ffi2fi1(
-    input: &[c_short],  /* I - array of values to be converted  */
-    ntodo: c_long,      /* I - number of elements in the array  */
-    scale: f64,         /* I - FITS TSCALn or BSCALE value      */
-    zero: f64,          /* I - FITS TZEROn or BZERO  value      */
-    output: &mut [u8],  /* O - output array of converted values */
-    status: &mut c_int, /* IO - error status                    */
+    input: &[c_short],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    output: &mut [u8],
+    status: &mut c_int,
 ) -> c_int {
     if scale == 1.0 && zero == 0.0 {
         for ii in 0..(ntodo as usize) {
@@ -1222,19 +1373,27 @@ pub(crate) fn ffi2fi1(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output prior to writing output to a FITS file.
 /// Do datatype conversion and scaling if required
+///
+/// # Parameters
+///
+/// * `input`  — (I) array of values to be converted
+/// * `ntodo`  — (I) number of elements in the array
+/// * `scale`  — (I) FITS TSCALn or BSCALE value
+/// * `zero`   — (I) FITS TZEROn or BZERO value
+/// * `output` — (O) output array of converted values
+/// * `status` — (IO) error status
 pub(crate) fn ffi2fi2(
-    input: &[c_short],      /* I - array of values to be converted  */
-    ntodo: c_long,          /* I - number of elements in the array  */
-    scale: f64,             /* I - FITS TSCALn or BSCALE value      */
-    zero: f64,              /* I - FITS TZEROn or BZERO  value      */
-    output: &mut [c_short], /* O - output array of converted values */
-    status: &mut c_int,     /* IO - error status                    */
-                            /*
+    input: &[c_short],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    output: &mut [c_short],
+    status: &mut c_int,
+    /*
 
-                            */
+    */
 ) -> c_int {
     let ntodo = ntodo as usize;
 
@@ -1260,18 +1419,25 @@ pub(crate) fn ffi2fi2(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
+/// # Parameters
+///
+/// * `input`  — (I) array of values to be converted
+/// * `ntodo`  — (I) number of elements in the array
+/// * `scale`  — (I) FITS TSCALn or BSCALE value
+/// * `zero`   — (I) FITS TZEROn or BZERO value
+/// * `output` — (O) output array of converted values
+/// * `status` — (IO) error status
 pub(crate) fn ffi2fi4(
-    input: &[c_short],       /* I - array of values to be converted  */
-    ntodo: c_long,           /* I - number of elements in the array  */
-    scale: f64,              /* I - FITS TSCALn or BSCALE value      */
-    zero: f64,               /* I - FITS TZEROn or BZERO  value      */
-    output: &mut [INT32BIT], /* O - output array of converted values */
-    status: &mut c_int,      /* IO - error status                    */
-                             /*
-                             Copy input to output prior to writing output to a FITS file.
-                             Do datatype conversion and scaling if required
-                             */
+    input: &[c_short],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    output: &mut [INT32BIT],
+    status: &mut c_int,
+    /*
+    Copy input to output prior to writing output to a FITS file.
+    Do datatype conversion and scaling if required
+    */
 ) -> c_int {
     if scale == 1.0 && zero == 0.0 {
         for ii in 0..(ntodo as usize) {
@@ -1297,18 +1463,25 @@ pub(crate) fn ffi2fi4(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
+/// # Parameters
+///
+/// * `input`  — (I) array of values to be converted
+/// * `ntodo`  — (I) number of elements in the array
+/// * `scale`  — (I) FITS TSCALn or BSCALE value
+/// * `zero`   — (I) FITS TZEROn or BZERO value
+/// * `output` — (O) output array of converted values
+/// * `status` — (IO) error status
 pub(crate) fn ffi2fi8(
-    input: &[c_short],       /* I - array of values to be converted  */
-    ntodo: c_long,           /* I - number of elements in the array  */
-    scale: f64,              /* I - FITS TSCALn or BSCALE value      */
-    zero: f64,               /* I - FITS TZEROn or BZERO  value      */
-    output: &mut [LONGLONG], /* O - output array of converted values */
-    status: &mut c_int,      /* IO - error status                    */
-                             /*
-                             Copy input to output prior to writing output to a FITS file.
-                             Do datatype conversion and scaling if required
-                             */
+    input: &[c_short],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    output: &mut [LONGLONG],
+    status: &mut c_int,
+    /*
+    Copy input to output prior to writing output to a FITS file.
+    Do datatype conversion and scaling if required
+    */
 ) -> c_int {
     if scale == 1.0 && zero == 9223372036854775808. {
         /* Writing to unsigned long long column. Input values must not be negative */
@@ -1347,16 +1520,24 @@ pub(crate) fn ffi2fi8(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output prior to writing output to a FITS file.
 /// Do datatype conversion and scaling if required.
+///
+/// # Parameters
+///
+/// * `input`  — (I) array of values to be converted
+/// * `ntodo`  — (I) number of elements in the array
+/// * `scale`  — (I) FITS TSCALn or BSCALE value
+/// * `zero`   — (I) FITS TZEROn or BZERO value
+/// * `output` — (O) output array of converted values
+/// * `status` — (IO) error status
 pub(crate) fn ffi2fr4(
-    input: &[c_short],  /* I - array of values to be converted  */
-    ntodo: c_long,      /* I - number of elements in the array  */
-    scale: f64,         /* I - FITS TSCALn or BSCALE value      */
-    zero: f64,          /* I - FITS TZEROn or BZERO  value      */
-    output: &mut [f32], /* O - output array of converted values */
-    status: &mut c_int, /* IO - error status                    */
+    input: &[c_short],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    output: &mut [f32],
+    status: &mut c_int,
 ) -> c_int {
     if scale == 1.0 && zero == 0.0 {
         for ii in 0..(ntodo as usize) {
@@ -1370,16 +1551,24 @@ pub(crate) fn ffi2fr4(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output prior to writing output to a FITS file.
 /// Do datatype conversion and scaling if required.
+///
+/// # Parameters
+///
+/// * `input`  — (I) array of values to be converted
+/// * `ntodo`  — (I) number of elements in the array
+/// * `scale`  — (I) FITS TSCALn or BSCALE value
+/// * `zero`   — (I) FITS TZEROn or BZERO value
+/// * `output` — (O) output array of converted values
+/// * `status` — (IO) error status
 pub(crate) fn ffi2fr8(
-    input: &[c_short],  /* I - array of values to be converted  */
-    ntodo: c_long,      /* I - number of elements in the array  */
-    scale: f64,         /* I - FITS TSCALn or BSCALE value      */
-    zero: f64,          /* I - FITS TZEROn or BZERO  value      */
-    output: &mut [f64], /* O - output array of converted values */
-    status: &mut c_int, /* IO - error status                    */
+    input: &[c_short],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    output: &mut [f64],
+    status: &mut c_int,
 ) -> c_int {
     if scale == 1.0 && zero == 0.0 {
         for ii in 0..(ntodo as usize) {
@@ -1393,18 +1582,28 @@ pub(crate) fn ffi2fr8(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output prior to writing output to a FITS file.
 /// Do scaling if required.
+///
+/// # Parameters
+///
+/// * `input`  — (I) array of values to be converted
+/// * `ntodo`  — (I) number of elements in the array
+/// * `scale`  — (I) FITS TSCALn or BSCALE value
+/// * `zero`   — (I) FITS TZEROn or BZERO value
+/// * `cform`  — (I) format for output string values
+/// * `twidth` — (I) width of each field, in chars
+/// * `output` — (O) output array of converted values
+/// * `status` — (IO) error status
 pub(crate) fn ffi2fstr(
-    input: &[c_short],     /* I - array of values to be converted  */
-    ntodo: c_long,         /* I - number of elements in the array  */
-    scale: f64,            /* I - FITS TSCALn or BSCALE value      */
-    zero: f64,             /* I - FITS TZEROn or BZERO  value      */
-    cform: &[c_char],      /* I - format for output string values  */
-    twidth: c_long,        /* I - width of each field, in chars    */
-    output: &mut [c_char], /* O - output array of converted values */
-    status: &mut c_int,    /* IO - error status                    */
+    input: &[c_short],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    cform: &[c_char],
+    twidth: c_long,
+    output: &mut [c_char],
+    status: &mut c_int,
 ) -> c_int {
     let mut oi = 0;
 

--- a/src/putcolj.rs
+++ b/src/putcolj.rs
@@ -1,9 +1,14 @@
-/*  This file, putcolj.rs, contains routines that write data elements to    */
-/*  a FITS image or table, with long datatype.                             */
-
-/*  The FITSIO software was written by William Pence at the High Energy    */
-/*  Astrophysic Science Archive Research Center (HEASARC) at the NASA      */
-/*  Goddard Space Flight Center.                                           */
+//! Routines that write data elements to a FITS image or table, with long
+//! datatype.
+//!
+//! The [`TLONG`] arm of the typed column I/O family. [`crate::putcol`]
+//! dispatches here when a caller asks for this datatype at run time; the
+//! write-side counterpart is [`crate::getcolj`].
+//!
+//! Ported from CFITSIO's `putcolj.c`, written by William Pence at the High
+//! Energy Astrophysics Science Archive Research Center (HEASARC), NASA Goddard
+//! Space Flight Center.
+#![warn(missing_docs)]
 
 use core::slice;
 use core::{cmp, mem};
@@ -25,7 +30,6 @@ use crate::relibc::header::stdio::{snprintf_f64, sprintf_f64};
 use crate::wrappers::strlen_safe;
 use crate::{buffers::*, int_snprintf, slice_to_str};
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
 /// the FITS array is not the same as the array being written).
@@ -34,14 +38,23 @@ use crate::{buffers::*, int_snprintf, slice_to_str};
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to write(1 = 1st group)
+/// * `firstelem` — (I) first vector element to write(1 = 1st)
+/// * `nelem`     — (I) number of values to write
+/// * `array`     — (I) array of values that are written
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffpprj(
-    fptr: *mut fitsfile,  /* I - FITS file pointer                       */
-    group: c_long,        /* I - group to write(1 = 1st group)           */
-    firstelem: LONGLONG,  /* I - first vector element to write(1 = 1st)  */
-    nelem: LONGLONG,      /* I - number of values to write               */
-    array: *const c_long, /* I - array of values that are written        */
-    status: *mut c_int,   /* IO - error status                           */
+    fptr: *mut fitsfile,
+    group: c_long,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: *const c_long,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -53,7 +66,6 @@ pub unsafe extern "C" fn ffpprj(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
 /// the FITS array is not the same as the array being written).
@@ -62,13 +74,22 @@ pub unsafe extern "C" fn ffpprj(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to write(1 = 1st group)
+/// * `firstelem` — (I) first vector element to write(1 = 1st)
+/// * `nelem`     — (I) number of values to write
+/// * `array`     — (I) array of values that are written
+/// * `status`    — (IO) error status
 pub fn ffpprj_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                       */
-    group: c_long,       /* I - group to write(1 = 1st group)           */
-    firstelem: LONGLONG, /* I - first vector element to write(1 = 1st)  */
-    nelem: LONGLONG,     /* I - number of values to write               */
-    array: &[c_long],    /* I - array of values that are written        */
-    status: &mut c_int,  /* IO - error status                           */
+    fptr: &mut fitsfile,
+    group: c_long,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: &[c_long],
+    status: &mut c_int,
 ) -> c_int {
     let nullvalue: c_long = 0;
 
@@ -101,7 +122,6 @@ pub fn ffpprj_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of the
 /// FITS array is not the same as the array being written).  Any array values
@@ -112,15 +132,25 @@ pub fn ffpprj_safe(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to write(1 = 1st group)
+/// * `firstelem` — (I) first vector element to write(1 = 1st)
+/// * `nelem`     — (I) number of values to write
+/// * `array`     — (I) array of values that are written
+/// * `nulval`    — (I) undefined pixel value
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffppnj(
-    fptr: *mut fitsfile,  /* I - FITS file pointer                       */
-    group: c_long,        /* I - group to write(1 = 1st group)           */
-    firstelem: LONGLONG,  /* I - first vector element to write(1 = 1st)  */
-    nelem: LONGLONG,      /* I - number of values to write               */
-    array: *const c_long, /* I - array of values that are written        */
-    nulval: c_long,       /* I - undefined pixel value                   */
-    status: *mut c_int,   /* IO - error status                           */
+    fptr: *mut fitsfile,
+    group: c_long,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: *const c_long,
+    nulval: c_long,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -132,7 +162,6 @@ pub unsafe extern "C" fn ffppnj(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of the
 /// FITS array is not the same as the array being written).  Any array values
@@ -143,14 +172,24 @@ pub unsafe extern "C" fn ffppnj(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to write(1 = 1st group)
+/// * `firstelem` — (I) first vector element to write(1 = 1st)
+/// * `nelem`     — (I) number of values to write
+/// * `array`     — (I) array of values that are written
+/// * `nulval`    — (I) undefined pixel value
+/// * `status`    — (IO) error status
 pub fn ffppnj_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                       */
-    group: c_long,       /* I - group to write(1 = 1st group)           */
-    firstelem: LONGLONG, /* I - first vector element to write(1 = 1st)  */
-    nelem: LONGLONG,     /* I - number of values to write               */
-    array: &[c_long],    /* I - array of values that are written        */
-    nulval: c_long,      /* I - undefined pixel value                   */
-    status: &mut c_int,  /* IO - error status                           */
+    fptr: &mut fitsfile,
+    group: c_long,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: &[c_long],
+    nulval: c_long,
+    status: &mut c_int,
 ) -> c_int {
     let mut nullvalue: c_long = 0;
 
@@ -186,19 +225,28 @@ pub fn ffppnj_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an entire 2-D array of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of the
 /// FITS array is not the same as the array being written).
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `group`  — (I) group to write(1 = 1st group)
+/// * `ncols`  — (I) number of pixels in each row of array
+/// * `naxis1` — (I) FITS image NAXIS1 value
+/// * `naxis2` — (I) FITS image NAXIS2 value
+/// * `array`  — (I) array to be written
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffp2dj(
-    fptr: *mut fitsfile,  /* I - FITS file pointer                     */
-    group: c_long,        /* I - group to write(1 = 1st group)         */
-    ncols: LONGLONG,      /* I - number of pixels in each row of array */
-    naxis1: LONGLONG,     /* I - FITS image NAXIS1 value               */
-    naxis2: LONGLONG,     /* I - FITS image NAXIS2 value               */
-    array: *const c_long, /* I - array to be written                   */
-    status: *mut c_int,   /* IO - error status                         */
+    fptr: *mut fitsfile,
+    group: c_long,
+    ncols: LONGLONG,
+    naxis1: LONGLONG,
+    naxis2: LONGLONG,
+    array: *const c_long,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -211,18 +259,27 @@ pub unsafe extern "C" fn ffp2dj(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an entire 2-D array of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of the
 /// FITS array is not the same as the array being written).
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `group`  — (I) group to write(1 = 1st group)
+/// * `ncols`  — (I) number of pixels in each row of array
+/// * `naxis1` — (I) FITS image NAXIS1 value
+/// * `naxis2` — (I) FITS image NAXIS2 value
+/// * `array`  — (I) array to be written
+/// * `status` — (IO) error status
 pub fn ffp2dj_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                     */
-    group: c_long,       /* I - group to write(1 = 1st group)         */
-    ncols: LONGLONG,     /* I - number of pixels in each row of array */
-    naxis1: LONGLONG,    /* I - FITS image NAXIS1 value               */
-    naxis2: LONGLONG,    /* I - FITS image NAXIS2 value               */
-    array: &[c_long],    /* I - array to be written                   */
-    status: &mut c_int,  /* IO - error status                         */
+    fptr: &mut fitsfile,
+    group: c_long,
+    ncols: LONGLONG,
+    naxis1: LONGLONG,
+    naxis2: LONGLONG,
+    array: &[c_long],
+    status: &mut c_int,
 ) -> c_int {
     /* call the 3D writing routine, with the 3rd dimension = 1 */
     ffp3dj_safe(fptr, group, ncols, naxis2, naxis1, naxis2, 1, array, status);
@@ -230,7 +287,6 @@ pub fn ffp2dj_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an entire 3-D cube of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of the
 /// FITS array is not the same as the array being written).
@@ -239,17 +295,29 @@ pub fn ffp2dj_safe(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `group`  — (I) group to write(1 = 1st group)
+/// * `ncols`  — (I) number of pixels in each row of array
+/// * `nrows`  — (I) number of rows in each plane of array
+/// * `naxis1` — (I) FITS image NAXIS1 value
+/// * `naxis2` — (I) FITS image NAXIS2 value
+/// * `naxis3` — (I) FITS image NAXIS3 value
+/// * `array`  — (I) array to be written
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffp3dj(
-    fptr: *mut fitsfile,  /* I - FITS file pointer                     */
-    group: c_long,        /* I - group to write(1 = 1st group)         */
-    ncols: LONGLONG,      /* I - number of pixels in each row of array */
-    nrows: LONGLONG,      /* I - number of rows in each plane of array */
-    naxis1: LONGLONG,     /* I - FITS image NAXIS1 value               */
-    naxis2: LONGLONG,     /* I - FITS image NAXIS2 value               */
-    naxis3: LONGLONG,     /* I - FITS image NAXIS3 value               */
-    array: *const c_long, /* I - array to be written                   */
-    status: *mut c_int,   /* IO - error status                         */
+    fptr: *mut fitsfile,
+    group: c_long,
+    ncols: LONGLONG,
+    nrows: LONGLONG,
+    naxis1: LONGLONG,
+    naxis2: LONGLONG,
+    naxis3: LONGLONG,
+    array: *const c_long,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -264,7 +332,6 @@ pub unsafe extern "C" fn ffp3dj(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an entire 3-D cube of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of the
 /// FITS array is not the same as the array being written).
@@ -273,16 +340,28 @@ pub unsafe extern "C" fn ffp3dj(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `group`  — (I) group to write(1 = 1st group)
+/// * `ncols`  — (I) number of pixels in each row of array
+/// * `nrows`  — (I) number of rows in each plane of array
+/// * `naxis1` — (I) FITS image NAXIS1 value
+/// * `naxis2` — (I) FITS image NAXIS2 value
+/// * `naxis3` — (I) FITS image NAXIS3 value
+/// * `array`  — (I) array to be written
+/// * `status` — (IO) error status
 pub fn ffp3dj_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                     */
-    group: c_long,       /* I - group to write(1 = 1st group)         */
-    ncols: LONGLONG,     /* I - number of pixels in each row of array */
-    nrows: LONGLONG,     /* I - number of rows in each plane of array */
-    naxis1: LONGLONG,    /* I - FITS image NAXIS1 value               */
-    naxis2: LONGLONG,    /* I - FITS image NAXIS2 value               */
-    naxis3: LONGLONG,    /* I - FITS image NAXIS3 value               */
-    array: &[c_long],    /* I - array to be written                   */
-    status: &mut c_int,  /* IO - error status                         */
+    fptr: &mut fitsfile,
+    group: c_long,
+    ncols: LONGLONG,
+    nrows: LONGLONG,
+    naxis1: LONGLONG,
+    naxis2: LONGLONG,
+    naxis3: LONGLONG,
+    array: &[c_long],
+    status: &mut c_int,
 ) -> c_int {
     let fpixel: [c_long; 3] = [1; 3];
     let mut lpixel: [c_long; 3] = [0; 3];
@@ -360,7 +439,6 @@ pub fn ffp3dj_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write a subsection of pixels to the primary array or image.
 ///
 /// A subsection is defined to be any contiguous rectangular
@@ -368,16 +446,27 @@ pub fn ffp3dj_safe(
 /// Data conversion and scaling will be performed if necessary
 /// (e.g, if the datatype of the FITS array is not the same as
 /// the array being written).
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `group`  — (I) group to write(1 = 1st group)
+/// * `naxis`  — (I) number of data axes in array
+/// * `naxes`  — (I) size of each FITS axis
+/// * `fpixel` — (I) 1st pixel in each axis to write (1=1st)
+/// * `lpixel` — (I) last pixel in each axis to write
+/// * `array`  — (I) array to be written
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffpssj(
-    fptr: *mut fitsfile,   /* I - FITS file pointer                       */
-    group: c_long,         /* I - group to write(1 = 1st group)           */
-    naxis: c_long,         /* I - number of data axes in array            */
-    naxes: *const c_long,  /* I - size of each FITS axis                  */
-    fpixel: *const c_long, /* I - 1st pixel in each axis to write (1=1st) */
-    lpixel: *const c_long, /* I - last pixel in each axis to write        */
-    array: *const c_long,  /* I - array to be written                     */
-    status: *mut c_int,    /* IO - error status                           */
+    fptr: *mut fitsfile,
+    group: c_long,
+    naxis: c_long,
+    naxes: *const c_long,
+    fpixel: *const c_long,
+    lpixel: *const c_long,
+    array: *const c_long,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -399,7 +488,6 @@ pub unsafe extern "C" fn ffpssj(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write a subsection of pixels to the primary array or image.
 ///
 /// A subsection is defined to be any contiguous rectangular
@@ -407,15 +495,26 @@ pub unsafe extern "C" fn ffpssj(
 /// Data conversion and scaling will be performed if necessary
 /// (e.g, if the datatype of the FITS array is not the same as
 /// the array being written).
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `group`  — (I) group to write(1 = 1st group)
+/// * `naxis`  — (I) number of data axes in array
+/// * `naxes`  — (I) size of each FITS axis
+/// * `fpixel` — (I) 1st pixel in each axis to write (1=1st)
+/// * `lpixel` — (I) last pixel in each axis to write
+/// * `array`  — (I) array to be written
+/// * `status` — (IO) error status
 pub fn ffpssj_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                       */
-    group: c_long,       /* I - group to write(1 = 1st group)           */
-    naxis: c_long,       /* I - number of data axes in array            */
-    naxes: &[c_long],    /* I - size of each FITS axis                  */
-    fpixel: &[c_long],   /* I - 1st pixel in each axis to write (1=1st) */
-    lpixel: &[c_long],   /* I - last pixel in each axis to write        */
-    array: &[c_long],    /* I - array to be written                     */
-    status: &mut c_int,  /* IO - error status                           */
+    fptr: &mut fitsfile,
+    group: c_long,
+    naxis: c_long,
+    naxes: &[c_long],
+    fpixel: &[c_long],
+    lpixel: &[c_long],
+    array: &[c_long],
+    status: &mut c_int,
 ) -> c_int {
     let mut fpix: [LONGLONG; 7] = [0; 7];
     let mut dimen: [LONGLONG; 7] = [0; 7];
@@ -542,7 +641,6 @@ pub fn ffpssj_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of group parameters to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
 /// the FITS array is not the same as the array being written).
@@ -551,14 +649,23 @@ pub fn ffpssj_safe(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to write(1 = 1st group)
+/// * `firstelem` — (I) first vector element to write(1 = 1st)
+/// * `nelem`     — (I) number of values to write
+/// * `array`     — (I) array of values that are written
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffpgpj(
-    fptr: *mut fitsfile,  /* I - FITS file pointer                      */
-    group: c_long,        /* I - group to write(1 = 1st group)          */
-    firstelem: c_long,    /* I - first vector element to write(1 = 1st) */
-    nelem: c_long,        /* I - number of values to write              */
-    array: *const c_long, /* I - array of values that are written       */
-    status: *mut c_int,   /* IO - error status                          */
+    fptr: *mut fitsfile,
+    group: c_long,
+    firstelem: c_long,
+    nelem: c_long,
+    array: *const c_long,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -571,7 +678,6 @@ pub unsafe extern "C" fn ffpgpj(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of group parameters to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
 /// the FITS array is not the same as the array being written).
@@ -580,13 +686,22 @@ pub unsafe extern "C" fn ffpgpj(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to write(1 = 1st group)
+/// * `firstelem` — (I) first vector element to write(1 = 1st)
+/// * `nelem`     — (I) number of values to write
+/// * `array`     — (I) array of values that are written
+/// * `status`    — (IO) error status
 pub fn ffpgpj_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                      */
-    group: c_long,       /* I - group to write(1 = 1st group)          */
-    firstelem: c_long,   /* I - first vector element to write(1 = 1st) */
-    nelem: c_long,       /* I - number of values to write              */
-    array: &[c_long],    /* I - array of values that are written       */
-    status: &mut c_int,  /* IO - error status                          */
+    fptr: &mut fitsfile,
+    group: c_long,
+    firstelem: c_long,
+    nelem: c_long,
+    array: &[c_long],
+    status: &mut c_int,
 ) -> c_int {
     let row = cmp::max(1, group);
 
@@ -602,7 +717,6 @@ pub fn ffpgpj_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of values to a column in the current FITS HDU.
 ///
 /// The column number may refer to a real column in an ASCII or binary table,
@@ -615,15 +729,25 @@ pub fn ffpgpj_safe(
 ///
 /// The input array of values will be converted to the datatype of the column
 /// and will be inverse-scaled by the FITS TSCALn and TZEROn values if necessary.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to write (1 = 1st col)
+/// * `firstrow`  — (I) first row to write (1 = 1st row)
+/// * `firstelem` — (I) first vector element to write (1 = 1st)
+/// * `nelem`     — (I) number of values to write
+/// * `array`     — (I) array of values to write
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffpclj(
-    fptr: *mut fitsfile,  /* I - FITS file pointer                       */
-    colnum: c_int,        /* I - number of column to write (1 = 1st col) */
-    firstrow: LONGLONG,   /* I - first row to write (1 = 1st row)        */
-    firstelem: LONGLONG,  /* I - first vector element to write (1 = 1st) */
-    nelem: LONGLONG,      /* I - number of values to write               */
-    array: *const c_long, /* I - array of values to write                */
-    status: *mut c_int,   /* IO - error status                           */
+    fptr: *mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: *const c_long,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -644,7 +768,6 @@ pub unsafe extern "C" fn ffpclj(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of values to a column in the current FITS HDU.
 ///
 /// The column number may refer to a real column in an ASCII or binary table,
@@ -657,14 +780,24 @@ pub unsafe extern "C" fn ffpclj(
 ///
 /// The input array of values will be converted to the datatype of the column
 /// and will be inverse-scaled by the FITS TSCALn and TZEROn values if necessary.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to write (1 = 1st col)
+/// * `firstrow`  — (I) first row to write (1 = 1st row)
+/// * `firstelem` — (I) first vector element to write (1 = 1st)
+/// * `nelem`     — (I) number of values to write
+/// * `array`     — (I) array of values to write
+/// * `status`    — (IO) error status
 pub fn ffpclj_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                       */
-    colnum: c_int,       /* I - number of column to write (1 = 1st col) */
-    firstrow: LONGLONG,  /* I - first row to write (1 = 1st row)        */
-    firstelem: LONGLONG, /* I - first vector element to write (1 = 1st) */
-    nelem: LONGLONG,     /* I - number of values to write               */
-    array: &[c_long],    /* I - array of values to write                */
-    status: &mut c_int,  /* IO - error status                           */
+    fptr: &mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: &[c_long],
+    status: &mut c_int,
 ) -> c_int {
     let mut tcode: c_int = 0;
     let mut maxelem2: c_int = 0;
@@ -697,9 +830,7 @@ pub fn ffpclj_safe(
         return *status;
     }
 
-    /*---------------------------------------------------*/
     /*  Check input and get parameters about the column: */
-    /*---------------------------------------------------*/
     if ffgcprll(
         fptr,
         colnum,
@@ -749,12 +880,10 @@ pub fn ffpclj_safe(
     } else {
         writeraw = false;
     }
-    /*---------------------------------------------------------------------*/
     /*  Now write the pixels to the FITS column.                           */
     /*  First call the ffXXfYY routine to  (1) convert the datatype        */
     /*  if necessary, and (2) scale the values by the FITS TSCALn and      */
     /*  TZEROn linear scaling parameters into a temporary buffer.          */
-    /*---------------------------------------------------------------------*/
     remain = nelem; /* remaining number of values to write  */
     next = 0; /* next element in array to be written  */
     rownum = 0; /* row number, relative to firstrow     */
@@ -935,9 +1064,7 @@ pub fn ffpclj_safe(
             }
         } /* End of switch block */
 
-        /*-------------------------*/
         /*  Check for fatal error  */
-        /*-------------------------*/
         if *status > 0 {
             /* test for error during previous write operation */
 
@@ -952,9 +1079,7 @@ pub fn ffpclj_safe(
             return *status;
         }
 
-        /*--------------------------------------------*/
         /*  increment the counters for the next loop  */
-        /*--------------------------------------------*/
         remain -= ntodo as LONGLONG;
         if remain > 0 {
             next += ntodo as LONGLONG;
@@ -968,9 +1093,7 @@ pub fn ffpclj_safe(
         }
     } /*  End of main while Loop  */
 
-    /*--------------------------------*/
     /*  check for numerical overflow  */
-    /*--------------------------------*/
     if *status == OVERFLOW_ERR {
         ffpmsg_str("Numerical overflow during type conversion while writing FITS data.");
         *status = NUM_OVERFLOW;
@@ -979,23 +1102,33 @@ pub fn ffpclj_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of elements to the specified column of a table.  Any input
 /// pixels equal to the value of nulvalue will be replaced by the appropriate
 /// null value in the output FITS file.
 ///
 /// The input array of values will be converted to the datatype of the column
 /// and will be inverse-scaled by the FITS TSCALn and TZEROn values if necessary
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to write (1 = 1st col)
+/// * `firstrow`  — (I) first row to write (1 = 1st row)
+/// * `firstelem` — (I) first vector element to write (1 = 1st)
+/// * `nelem`     — (I) number of values to write
+/// * `array`     — (I) array of values to write
+/// * `nulvalue`  — (I) value used to flag undefined pixels
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffpcnj(
-    fptr: *mut fitsfile,  /* I - FITS file pointer                       */
-    colnum: c_int,        /* I - number of column to write (1 = 1st col) */
-    firstrow: LONGLONG,   /* I - first row to write (1 = 1st row)        */
-    firstelem: LONGLONG,  /* I - first vector element to write (1 = 1st) */
-    nelem: LONGLONG,      /* I - number of values to write               */
-    array: *const c_long, /* I - array of values to write                */
-    nulvalue: c_long,     /* I - value used to flag undefined pixels     */
-    status: *mut c_int,   /* IO - error status                           */
+    fptr: *mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: *const c_long,
+    nulvalue: c_long,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -1017,22 +1150,32 @@ pub unsafe extern "C" fn ffpcnj(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of elements to the specified column of a table.  Any input
 /// pixels equal to the value of nulvalue will be replaced by the appropriate
 /// null value in the output FITS file.
 ///
 /// The input array of values will be converted to the datatype of the column
 /// and will be inverse-scaled by the FITS TSCALn and TZEROn values if necessary
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to write (1 = 1st col)
+/// * `firstrow`  — (I) first row to write (1 = 1st row)
+/// * `firstelem` — (I) first vector element to write (1 = 1st)
+/// * `nelem`     — (I) number of values to write
+/// * `array`     — (I) array of values to write
+/// * `nulvalue`  — (I) value used to flag undefined pixels
+/// * `status`    — (IO) error status
 pub fn ffpcnj_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                       */
-    colnum: c_int,       /* I - number of column to write (1 = 1st col) */
-    firstrow: LONGLONG,  /* I - first row to write (1 = 1st row)        */
-    firstelem: LONGLONG, /* I - first vector element to write (1 = 1st) */
-    nelem: LONGLONG,     /* I - number of values to write               */
-    array: &[c_long],    /* I - array of values to write                */
-    nulvalue: c_long,    /* I - value used to flag undefined pixels     */
-    status: &mut c_int,  /* IO - error status                           */
+    fptr: &mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: &[c_long],
+    nulvalue: c_long,
+    status: &mut c_int,
 ) -> c_int {
     let mut ngood: LONGLONG = 0;
     let mut nbad: LONGLONG = 0;
@@ -1186,16 +1329,24 @@ pub fn ffpcnj_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output prior to writing output to a FITS file.
 /// Do datatype conversion and scaling if required.
+///
+/// # Parameters
+///
+/// * `input`  — (I) array of values to be converted
+/// * `ntodo`  — (I) number of elements in the array
+/// * `scale`  — (I) FITS TSCALn or BSCALE value
+/// * `zero`   — (I) FITS TZEROn or BZERO value
+/// * `output` — (O) output array of converted values
+/// * `status` — (IO) error status
 pub(crate) fn ffi4fi1(
-    input: &[c_long],   /* I - array of values to be converted  */
-    ntodo: c_long,      /* I - number of elements in the array  */
-    scale: f64,         /* I - FITS TSCALn or BSCALE value      */
-    zero: f64,          /* I - FITS TZEROn or BZERO  value      */
-    output: &mut [u8],  /* O - output array of converted values */
-    status: &mut c_int, /* IO - error status                    */
+    input: &[c_long],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    output: &mut [u8],
+    status: &mut c_int,
 ) -> c_int {
     if scale == 1.0 && zero == 0.0 {
         for ii in 0..(ntodo as usize) {
@@ -1227,18 +1378,25 @@ pub(crate) fn ffi4fi1(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
+/// # Parameters
+///
+/// * `input`  — (I) array of values to be converted
+/// * `ntodo`  — (I) number of elements in the array
+/// * `scale`  — (I) FITS TSCALn or BSCALE value
+/// * `zero`   — (I) FITS TZEROn or BZERO value
+/// * `output` — (O) output array of converted values
+/// * `status` — (IO) error status
 pub(crate) fn ffi4fi2(
-    input: &[c_long],       /* I - array of values to be converted  */
-    ntodo: c_long,          /* I - number of elements in the array  */
-    scale: f64,             /* I - FITS TSCALn or BSCALE value      */
-    zero: f64,              /* I - FITS TZEROn or BZERO  value      */
-    output: &mut [c_short], /* O - output array of converted values */
-    status: &mut c_int,     /* IO - error status                    */
-                            /*
-                            Copy input to output prior to writing output to a FITS file.
-                            Do datatype conversion and scaling if required.
-                            */
+    input: &[c_long],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    output: &mut [c_short],
+    status: &mut c_int,
+    /*
+    Copy input to output prior to writing output to a FITS file.
+    Do datatype conversion and scaling if required.
+    */
 ) -> c_int {
     if scale == 1.0 && zero == 0.0 {
         for ii in 0..(ntodo as usize) {
@@ -1272,18 +1430,25 @@ pub(crate) fn ffi4fi2(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
+/// # Parameters
+///
+/// * `input`  — (I) array of values to be converted
+/// * `ntodo`  — (I) number of elements in the array
+/// * `scale`  — (I) FITS TSCALn or BSCALE value
+/// * `zero`   — (I) FITS TZEROn or BZERO value
+/// * `output` — (O) output array of converted values
+/// * `status` — (IO) error status
 pub(crate) fn ffi4fi4(
-    input: &[c_long],        /* I - array of values to be converted  */
-    ntodo: c_long,           /* I - number of elements in the array  */
-    scale: f64,              /* I - FITS TSCALn or BSCALE value      */
-    zero: f64,               /* I - FITS TZEROn or BZERO  value      */
-    output: &mut [INT32BIT], /* O - output array of converted values */
-    status: &mut c_int,      /* IO - error status                    */
-                             /*
-                             Copy input to output prior to writing output to a FITS file.
-                             Do datatype conversion and scaling if required
-                             */
+    input: &[c_long],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    output: &mut [INT32BIT],
+    status: &mut c_int,
+    /*
+    Copy input to output prior to writing output to a FITS file.
+    Do datatype conversion and scaling if required
+    */
 ) -> c_int {
     if scale == 1.0 && zero == 0.0 {
         for ii in 0..(ntodo as usize) {
@@ -1309,18 +1474,25 @@ pub(crate) fn ffi4fi4(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
+/// # Parameters
+///
+/// * `input`  — (I) array of values to be converted
+/// * `ntodo`  — (I) number of elements in the array
+/// * `scale`  — (I) FITS TSCALn or BSCALE value
+/// * `zero`   — (I) FITS TZEROn or BZERO value
+/// * `output` — (O) output array of converted values
+/// * `status` — (IO) error status
 pub(crate) fn ffi4fi8(
-    input: &[c_long],        /* I - array of values to be converted  */
-    ntodo: c_long,           /* I - number of elements in the array  */
-    scale: f64,              /* I - FITS TSCALn or BSCALE value      */
-    zero: f64,               /* I - FITS TZEROn or BZERO  value      */
-    output: &mut [LONGLONG], /* O - output array of converted values */
-    status: &mut c_int,      /* IO - error status                    */
-                             /*
-                             Copy input to output prior to writing output to a FITS file.
-                             Do datatype conversion and scaling if required
-                             */
+    input: &[c_long],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    output: &mut [LONGLONG],
+    status: &mut c_int,
+    /*
+    Copy input to output prior to writing output to a FITS file.
+    Do datatype conversion and scaling if required
+    */
 ) -> c_int {
     let ntodo = ntodo as usize;
 
@@ -1361,18 +1533,25 @@ pub(crate) fn ffi4fi8(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
+/// # Parameters
+///
+/// * `input`  — (I) array of values to be converted
+/// * `ntodo`  — (I) number of elements in the array
+/// * `scale`  — (I) FITS TSCALn or BSCALE value
+/// * `zero`   — (I) FITS TZEROn or BZERO value
+/// * `output` — (O) output array of converted values
+/// * `status` — (IO) error status
 pub(crate) fn ffi4fr4(
-    input: &[c_long],   /* I - array of values to be converted  */
-    ntodo: c_long,      /* I - number of elements in the array  */
-    scale: f64,         /* I - FITS TSCALn or BSCALE value      */
-    zero: f64,          /* I - FITS TZEROn or BZERO  value      */
-    output: &mut [f32], /* O - output array of converted values */
-    status: &mut c_int, /* IO - error status                    */
-                        /*
-                        Copy input to output prior to writing output to a FITS file.
-                        Do datatype conversion and scaling if required.
-                        */
+    input: &[c_long],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    output: &mut [f32],
+    status: &mut c_int,
+    /*
+    Copy input to output prior to writing output to a FITS file.
+    Do datatype conversion and scaling if required.
+    */
 ) -> c_int {
     if scale == 1.0 && zero == 0.0 {
         for ii in 0..(ntodo as usize) {
@@ -1386,18 +1565,25 @@ pub(crate) fn ffi4fr4(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
+/// # Parameters
+///
+/// * `input`  — (I) array of values to be converted
+/// * `ntodo`  — (I) number of elements in the array
+/// * `scale`  — (I) FITS TSCALn or BSCALE value
+/// * `zero`   — (I) FITS TZEROn or BZERO value
+/// * `output` — (O) output array of converted values
+/// * `status` — (IO) error status
 pub(crate) fn ffi4fr8(
-    input: &[c_long],   /* I - array of values to be converted  */
-    ntodo: c_long,      /* I - number of elements in the array  */
-    scale: f64,         /* I - FITS TSCALn or BSCALE value      */
-    zero: f64,          /* I - FITS TZEROn or BZERO  value      */
-    output: &mut [f64], /* O - output array of converted values */
-    status: &mut c_int, /* IO - error status                    */
-                        /*
-                        Copy input to output prior to writing output to a FITS file.
-                        Do datatype conversion and scaling if required.
-                        */
+    input: &[c_long],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    output: &mut [f64],
+    status: &mut c_int,
+    /*
+    Copy input to output prior to writing output to a FITS file.
+    Do datatype conversion and scaling if required.
+    */
 ) -> c_int {
     if scale == 1.0 && zero == 0.0 {
         for ii in 0..(ntodo as usize) {
@@ -1411,18 +1597,28 @@ pub(crate) fn ffi4fr8(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output prior to writing output to a FITS file.
 /// Do scaling if required.
+///
+/// # Parameters
+///
+/// * `input`  — (I) array of values to be converted
+/// * `ntodo`  — (I) number of elements in the array
+/// * `scale`  — (I) FITS TSCALn or BSCALE value
+/// * `zero`   — (I) FITS TZEROn or BZERO value
+/// * `cform`  — (I) format for output string values
+/// * `twidth` — (I) width of each field, in chars
+/// * `output` — (O) output array of converted values
+/// * `status` — (IO) error status
 pub(crate) fn ffi4fstr(
-    input: &[c_long],      /* I - array of values to be converted  */
-    ntodo: c_long,         /* I - number of elements in the array  */
-    scale: f64,            /* I - FITS TSCALn or BSCALE value      */
-    zero: f64,             /* I - FITS TZEROn or BZERO  value      */
-    cform: &[c_char],      /* I - format for output string values  */
-    twidth: c_long,        /* I - width of each field, in chars    */
-    output: &mut [c_char], /* O - output array of converted values */
-    status: &mut c_int,    /* IO - error status                    */
+    input: &[c_long],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    cform: &[c_char],
+    twidth: c_long,
+    output: &mut [c_char],
+    status: &mut c_int,
 ) -> c_int {
     let mut oi = 0;
 
@@ -1463,7 +1659,6 @@ pub(crate) fn ffi4fstr(
 /*      the following routines support the 'long long' data type            */
 /* ======================================================================== */
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
 /// the FITS array is not the same as the array being written).
@@ -1472,14 +1667,23 @@ pub(crate) fn ffi4fstr(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to write(1 = 1st group)
+/// * `firstelem` — (I) first vector element to write(1 = 1st)
+/// * `nelem`     — (I) number of values to write
+/// * `array`     — (I) array of values that are written
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffpprjj(
-    fptr: *mut fitsfile,    /* I - FITS file pointer                       */
-    group: c_long,          /* I - group to write(1 = 1st group)           */
-    firstelem: LONGLONG,    /* I - first vector element to write(1 = 1st)  */
-    nelem: LONGLONG,        /* I - number of values to write               */
-    array: *const LONGLONG, /* I - array of values that are written       */
-    status: *mut c_int,     /* IO - error status                           */
+    fptr: *mut fitsfile,
+    group: c_long,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: *const LONGLONG,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -1492,7 +1696,6 @@ pub unsafe extern "C" fn ffpprjj(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
 /// the FITS array is not the same as the array being written).
@@ -1501,13 +1704,22 @@ pub unsafe extern "C" fn ffpprjj(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to write(1 = 1st group)
+/// * `firstelem` — (I) first vector element to write(1 = 1st)
+/// * `nelem`     — (I) number of values to write
+/// * `array`     — (I) array of values that are written
+/// * `status`    — (IO) error status
 pub fn ffpprjj_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                       */
-    group: c_long,       /* I - group to write(1 = 1st group)           */
-    firstelem: LONGLONG, /* I - first vector element to write(1 = 1st)  */
-    nelem: LONGLONG,     /* I - number of values to write               */
-    array: &[LONGLONG],  /* I - array of values that are written       */
-    status: &mut c_int,  /* IO - error status                           */
+    fptr: &mut fitsfile,
+    group: c_long,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: &[LONGLONG],
+    status: &mut c_int,
 ) -> c_int {
     if fits_is_compressed_image_safe(fptr, status) > 0 {
         /* this is a compressed image in a binary table */
@@ -1532,7 +1744,6 @@ pub fn ffpprjj_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of the
 /// FITS array is not the same as the array being written).  Any array values
@@ -1543,15 +1754,25 @@ pub fn ffpprjj_safe(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to write(1 = 1st group)
+/// * `firstelem` — (I) first vector element to write(1 = 1st)
+/// * `nelem`     — (I) number of values to write
+/// * `array`     — (I) array of values that are written
+/// * `nulval`    — (I) undefined pixel value
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffppnjj(
-    fptr: *mut fitsfile,    /* I - FITS file pointer                       */
-    group: c_long,          /* I - group to write(1 = 1st group)           */
-    firstelem: LONGLONG,    /* I - first vector element to write(1 = 1st)  */
-    nelem: LONGLONG,        /* I - number of values to write               */
-    array: *const LONGLONG, /* I - array of values that are written       */
-    nulval: LONGLONG,       /* I - undefined pixel value                   */
-    status: *mut c_int,     /* IO - error status                           */
+    fptr: *mut fitsfile,
+    group: c_long,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: *const LONGLONG,
+    nulval: LONGLONG,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -1564,7 +1785,6 @@ pub unsafe extern "C" fn ffppnjj(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of the
 /// FITS array is not the same as the array being written).  Any array values
@@ -1575,14 +1795,24 @@ pub unsafe extern "C" fn ffppnjj(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to write(1 = 1st group)
+/// * `firstelem` — (I) first vector element to write(1 = 1st)
+/// * `nelem`     — (I) number of values to write
+/// * `array`     — (I) array of values that are written
+/// * `nulval`    — (I) undefined pixel value
+/// * `status`    — (IO) error status
 pub fn ffppnjj_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                       */
-    group: c_long,       /* I - group to write(1 = 1st group)           */
-    firstelem: LONGLONG, /* I - first vector element to write(1 = 1st)  */
-    nelem: LONGLONG,     /* I - number of values to write               */
-    array: &[LONGLONG],  /* I - array of values that are written       */
-    nulval: LONGLONG,    /* I - undefined pixel value                   */
-    status: &mut c_int,  /* IO - error status                           */
+    fptr: &mut fitsfile,
+    group: c_long,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: &[LONGLONG],
+    nulval: LONGLONG,
+    status: &mut c_int,
 ) -> c_int {
     if fits_is_compressed_image_safe(fptr, status) > 0 {
         /* this is a compressed image in a binary table */
@@ -1608,19 +1838,28 @@ pub fn ffppnjj_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an entire 2-D array of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of the
 /// FITS array is not the same as the array being written).
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `group`  — (I) group to write(1 = 1st group)
+/// * `ncols`  — (I) number of pixels in each row of array
+/// * `naxis1` — (I) FITS image NAXIS1 value
+/// * `naxis2` — (I) FITS image NAXIS2 value
+/// * `array`  — (I) array to be written
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffp2djj(
-    fptr: *mut fitsfile,    /* I - FITS file pointer                     */
-    group: c_long,          /* I - group to write(1 = 1st group)         */
-    ncols: LONGLONG,        /* I - number of pixels in each row of array */
-    naxis1: LONGLONG,       /* I - FITS image NAXIS1 value               */
-    naxis2: LONGLONG,       /* I - FITS image NAXIS2 value               */
-    array: *const LONGLONG, /* I - array to be written                   */
-    status: *mut c_int,     /* IO - error status                         */
+    fptr: *mut fitsfile,
+    group: c_long,
+    ncols: LONGLONG,
+    naxis1: LONGLONG,
+    naxis2: LONGLONG,
+    array: *const LONGLONG,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -1633,18 +1872,27 @@ pub unsafe extern "C" fn ffp2djj(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an entire 2-D array of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of the
 /// FITS array is not the same as the array being written).
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `group`  — (I) group to write(1 = 1st group)
+/// * `ncols`  — (I) number of pixels in each row of array
+/// * `naxis1` — (I) FITS image NAXIS1 value
+/// * `naxis2` — (I) FITS image NAXIS2 value
+/// * `array`  — (I) array to be written
+/// * `status` — (IO) error status
 pub fn ffp2djj_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                     */
-    group: c_long,       /* I - group to write(1 = 1st group)         */
-    ncols: LONGLONG,     /* I - number of pixels in each row of array */
-    naxis1: LONGLONG,    /* I - FITS image NAXIS1 value               */
-    naxis2: LONGLONG,    /* I - FITS image NAXIS2 value               */
-    array: &[LONGLONG],  /* I - array to be written                   */
-    status: &mut c_int,  /* IO - error status                         */
+    fptr: &mut fitsfile,
+    group: c_long,
+    ncols: LONGLONG,
+    naxis1: LONGLONG,
+    naxis2: LONGLONG,
+    array: &[LONGLONG],
+    status: &mut c_int,
 ) -> c_int {
     /* call the 3D writing routine, with the 3rd dimension = 1 */
     ffp3djj_safe(fptr, group, ncols, naxis2, naxis1, naxis2, 1, array, status);
@@ -1652,7 +1900,6 @@ pub fn ffp2djj_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an entire 3-D cube of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of the
 /// FITS array is not the same as the array being written).
@@ -1661,17 +1908,29 @@ pub fn ffp2djj_safe(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `group`  — (I) group to write(1 = 1st group)
+/// * `ncols`  — (I) number of pixels in each row of array
+/// * `nrows`  — (I) number of rows in each plane of array
+/// * `naxis1` — (I) FITS image NAXIS1 value
+/// * `naxis2` — (I) FITS image NAXIS2 value
+/// * `naxis3` — (I) FITS image NAXIS3 value
+/// * `array`  — (I) array to be written
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffp3djj(
-    fptr: *mut fitsfile,    /* I - FITS file pointer                     */
-    group: c_long,          /* I - group to write(1 = 1st group)         */
-    ncols: LONGLONG,        /* I - number of pixels in each row of array */
-    nrows: LONGLONG,        /* I - number of rows in each plane of array */
-    naxis1: LONGLONG,       /* I - FITS image NAXIS1 value               */
-    naxis2: LONGLONG,       /* I - FITS image NAXIS2 value               */
-    naxis3: LONGLONG,       /* I - FITS image NAXIS3 value               */
-    array: *const LONGLONG, /* I - array to be written                   */
-    status: *mut c_int,     /* IO - error status                         */
+    fptr: *mut fitsfile,
+    group: c_long,
+    ncols: LONGLONG,
+    nrows: LONGLONG,
+    naxis1: LONGLONG,
+    naxis2: LONGLONG,
+    naxis3: LONGLONG,
+    array: *const LONGLONG,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -1686,7 +1945,6 @@ pub unsafe extern "C" fn ffp3djj(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an entire 3-D cube of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of the
 /// FITS array is not the same as the array being written).
@@ -1695,16 +1953,28 @@ pub unsafe extern "C" fn ffp3djj(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `group`  — (I) group to write(1 = 1st group)
+/// * `ncols`  — (I) number of pixels in each row of array
+/// * `nrows`  — (I) number of rows in each plane of array
+/// * `naxis1` — (I) FITS image NAXIS1 value
+/// * `naxis2` — (I) FITS image NAXIS2 value
+/// * `naxis3` — (I) FITS image NAXIS3 value
+/// * `array`  — (I) array to be written
+/// * `status` — (IO) error status
 pub fn ffp3djj_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                     */
-    group: c_long,       /* I - group to write(1 = 1st group)         */
-    ncols: LONGLONG,     /* I - number of pixels in each row of array */
-    nrows: LONGLONG,     /* I - number of rows in each plane of array */
-    naxis1: LONGLONG,    /* I - FITS image NAXIS1 value               */
-    naxis2: LONGLONG,    /* I - FITS image NAXIS2 value               */
-    naxis3: LONGLONG,    /* I - FITS image NAXIS3 value               */
-    array: &[LONGLONG],  /* I - array to be written                   */
-    status: &mut c_int,  /* IO - error status                         */
+    fptr: &mut fitsfile,
+    group: c_long,
+    ncols: LONGLONG,
+    nrows: LONGLONG,
+    naxis1: LONGLONG,
+    naxis2: LONGLONG,
+    naxis3: LONGLONG,
+    array: &[LONGLONG],
+    status: &mut c_int,
 ) -> c_int {
     if fits_is_compressed_image_safe(fptr, status) > 0 {
         /* this is a compressed image in a binary table */
@@ -1768,7 +2038,6 @@ pub fn ffp3djj_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write a subsection of pixels to the primary array or image.
 ///
 /// A subsection is defined to be any contiguous rectangular
@@ -1776,16 +2045,27 @@ pub fn ffp3djj_safe(
 /// Data conversion and scaling will be performed if necessary
 /// (e.g, if the datatype of the FITS array is not the same as
 /// the array being written).
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `group`  — (I) group to write(1 = 1st group)
+/// * `naxis`  — (I) number of data axes in array
+/// * `naxes`  — (I) size of each FITS axis
+/// * `fpixel` — (I) 1st pixel in each axis to write (1=1st)
+/// * `lpixel` — (I) last pixel in each axis to write
+/// * `array`  — (I) array to be written
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffpssjj(
-    fptr: *mut fitsfile,    /* I - FITS file pointer                       */
-    group: c_long,          /* I - group to write(1 = 1st group)           */
-    naxis: c_long,          /* I - number of data axes in array            */
-    naxes: *const c_long,   /* I - size of each FITS axis                  */
-    fpixel: *const c_long,  /* I - 1st pixel in each axis to write (1=1st) */
-    lpixel: *const c_long,  /* I - last pixel in each axis to write        */
-    array: *const LONGLONG, /* I - array to be written                     */
-    status: *mut c_int,     /* IO - error status                           */
+    fptr: *mut fitsfile,
+    group: c_long,
+    naxis: c_long,
+    naxes: *const c_long,
+    fpixel: *const c_long,
+    lpixel: *const c_long,
+    array: *const LONGLONG,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -1807,7 +2087,6 @@ pub unsafe extern "C" fn ffpssjj(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write a subsection of pixels to the primary array or image.
 ///
 /// A subsection is defined to be any contiguous rectangular
@@ -1815,15 +2094,26 @@ pub unsafe extern "C" fn ffpssjj(
 /// Data conversion and scaling will be performed if necessary
 /// (e.g, if the datatype of the FITS array is not the same as
 /// the array being written).
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `group`  — (I) group to write(1 = 1st group)
+/// * `naxis`  — (I) number of data axes in array
+/// * `naxes`  — (I) size of each FITS axis
+/// * `fpixel` — (I) 1st pixel in each axis to write (1=1st)
+/// * `lpixel` — (I) last pixel in each axis to write
+/// * `array`  — (I) array to be written
+/// * `status` — (IO) error status
 pub fn ffpssjj_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                       */
-    group: c_long,       /* I - group to write(1 = 1st group)           */
-    naxis: c_long,       /* I - number of data axes in array            */
-    naxes: &[c_long],    /* I - size of each FITS axis                  */
-    fpixel: &[c_long],   /* I - 1st pixel in each axis to write (1=1st) */
-    lpixel: &[c_long],   /* I - last pixel in each axis to write        */
-    array: &[LONGLONG],  /* I - array to be written                     */
-    status: &mut c_int,  /* IO - error status                           */
+    fptr: &mut fitsfile,
+    group: c_long,
+    naxis: c_long,
+    naxes: &[c_long],
+    fpixel: &[c_long],
+    lpixel: &[c_long],
+    array: &[LONGLONG],
+    status: &mut c_int,
 ) -> c_int {
     let mut fpix: [LONGLONG; 7] = [0; 7];
     let mut dimen: [LONGLONG; 7] = [0; 7];
@@ -1943,7 +2233,6 @@ pub fn ffpssjj_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of group parameters to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
 /// the FITS array is not the same as the array being written).
@@ -1952,14 +2241,23 @@ pub fn ffpssjj_safe(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to write(1 = 1st group)
+/// * `firstelem` — (I) first vector element to write(1 = 1st)
+/// * `nelem`     — (I) number of values to write
+/// * `array`     — (I) array of values that are written
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffpgpjj(
-    fptr: *mut fitsfile,    /* I - FITS file pointer                      */
-    group: c_long,          /* I - group to write(1 = 1st group)          */
-    firstelem: c_long,      /* I - first vector element to write(1 = 1st) */
-    nelem: c_long,          /* I - number of values to write              */
-    array: *const LONGLONG, /* I - array of values that are written       */
-    status: *mut c_int,     /* IO - error status                          */
+    fptr: *mut fitsfile,
+    group: c_long,
+    firstelem: c_long,
+    nelem: c_long,
+    array: *const LONGLONG,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -1972,7 +2270,6 @@ pub unsafe extern "C" fn ffpgpjj(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of group parameters to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
 /// the FITS array is not the same as the array being written).
@@ -1981,13 +2278,22 @@ pub unsafe extern "C" fn ffpgpjj(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to write(1 = 1st group)
+/// * `firstelem` — (I) first vector element to write(1 = 1st)
+/// * `nelem`     — (I) number of values to write
+/// * `array`     — (I) array of values that are written
+/// * `status`    — (IO) error status
 pub fn ffpgpjj_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                      */
-    group: c_long,       /* I - group to write(1 = 1st group)          */
-    firstelem: c_long,   /* I - first vector element to write(1 = 1st) */
-    nelem: c_long,       /* I - number of values to write              */
-    array: &[LONGLONG],  /* I - array of values that are written       */
-    status: &mut c_int,  /* IO - error status                          */
+    fptr: &mut fitsfile,
+    group: c_long,
+    firstelem: c_long,
+    nelem: c_long,
+    array: &[LONGLONG],
+    status: &mut c_int,
 ) -> c_int {
     let row = cmp::max(1, group);
 
@@ -2003,7 +2309,6 @@ pub fn ffpgpjj_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of values to a column in the current FITS HDU.
 ///
 /// The column number may refer to a real column in an ASCII or binary table,
@@ -2016,15 +2321,25 @@ pub fn ffpgpjj_safe(
 ///
 /// The input array of values will be converted to the datatype of the column
 /// and will be inverse-scaled by the FITS TSCALn and TZEROn values if necessary.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to write (1 = 1st col)
+/// * `firstrow`  — (I) first row to write (1 = 1st row)
+/// * `firstelem` — (I) first vector element to write (1 = 1st)
+/// * `nelem`     — (I) number of values to write
+/// * `array`     — (I) array of values to write
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffpcljj(
-    fptr: *mut fitsfile,    /* I - FITS file pointer                       */
-    colnum: c_int,          /* I - number of column to write (1 = 1st col) */
-    firstrow: LONGLONG,     /* I - first row to write (1 = 1st row)        */
-    firstelem: LONGLONG,    /* I - first vector element to write (1 = 1st) */
-    nelem: LONGLONG,        /* I - number of values to write               */
-    array: *const LONGLONG, /* I - array of values to write               */
-    status: *mut c_int,     /* IO - error status                           */
+    fptr: *mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: *const LONGLONG,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -2045,7 +2360,6 @@ pub unsafe extern "C" fn ffpcljj(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of values to a column in the current FITS HDU.
 ///
 /// The column number may refer to a real column in an ASCII or binary table,
@@ -2058,14 +2372,24 @@ pub unsafe extern "C" fn ffpcljj(
 ///
 /// The input array of values will be converted to the datatype of the column
 /// and will be inverse-scaled by the FITS TSCALn and TZEROn values if necessary.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to write (1 = 1st col)
+/// * `firstrow`  — (I) first row to write (1 = 1st row)
+/// * `firstelem` — (I) first vector element to write (1 = 1st)
+/// * `nelem`     — (I) number of values to write
+/// * `array`     — (I) array of values to write
+/// * `status`    — (IO) error status
 pub fn ffpcljj_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                       */
-    colnum: c_int,       /* I - number of column to write (1 = 1st col) */
-    firstrow: LONGLONG,  /* I - first row to write (1 = 1st row)        */
-    firstelem: LONGLONG, /* I - first vector element to write (1 = 1st) */
-    nelem: LONGLONG,     /* I - number of values to write               */
-    array: &[LONGLONG],  /* I - array of values to write               */
-    status: &mut c_int,  /* IO - error status                           */
+    fptr: &mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: &[LONGLONG],
+    status: &mut c_int,
 ) -> c_int {
     let mut tcode: c_int = 0;
     let mut maxelem2: c_int = 0;
@@ -2098,9 +2422,7 @@ pub fn ffpcljj_safe(
         return *status;
     }
 
-    /*---------------------------------------------------*/
     /*  Check input and get parameters about the column: */
-    /*---------------------------------------------------*/
     if ffgcprll(
         fptr,
         colnum,
@@ -2151,12 +2473,10 @@ pub fn ffpcljj_safe(
     } else {
         writeraw = false;
     }
-    /*---------------------------------------------------------------------*/
     /*  Now write the pixels to the FITS column.                           */
     /*  First call the ffXXfYY routine to  (1) convert the datatype        */
     /*  if necessary, and (2) scale the values by the FITS TSCALn and      */
     /*  TZEROn linear scaling parameters into a temporary buffer.          */
-    /*---------------------------------------------------------------------*/
     remain = nelem; /* remaining number of values to write  */
     next = 0; /* next element in array to be written  */
     rownum = 0; /* row number, relative to firstrow     */
@@ -2336,9 +2656,7 @@ pub fn ffpcljj_safe(
             }
         } /* End of switch block */
 
-        /*-------------------------*/
         /*  Check for fatal error  */
-        /*-------------------------*/
         if *status > 0 {
             /* test for error during previous write operation */
 
@@ -2353,9 +2671,7 @@ pub fn ffpcljj_safe(
             return *status;
         }
 
-        /*--------------------------------------------*/
         /*  increment the counters for the next loop  */
-        /*--------------------------------------------*/
         remain -= ntodo as LONGLONG;
         if remain > 0 {
             next += ntodo as LONGLONG;
@@ -2369,9 +2685,7 @@ pub fn ffpcljj_safe(
         }
     } /*  End of main while Loop  */
 
-    /*--------------------------------*/
     /*  check for numerical overflow  */
-    /*--------------------------------*/
     if *status == OVERFLOW_ERR {
         ffpmsg_str("Numerical overflow during type conversion while writing FITS data.");
         *status = NUM_OVERFLOW;
@@ -2380,23 +2694,33 @@ pub fn ffpcljj_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of elements to the specified column of a table.  Any input
 /// pixels equal to the value of nulvalue will be replaced by the appropriate
 /// null value in the output FITS file.
 ///
 /// The input array of values will be converted to the datatype of the column
 /// and will be inverse-scaled by the FITS TSCALn and TZEROn values if necessary
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to write (1 = 1st col)
+/// * `firstrow`  — (I) first row to write (1 = 1st row)
+/// * `firstelem` — (I) first vector element to write (1 = 1st)
+/// * `nelem`     — (I) number of values to write
+/// * `array`     — (I) array of values to write
+/// * `nulvalue`  — (I) value used to flag undefined pixels
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffpcnjj(
-    fptr: *mut fitsfile,    /* I - FITS file pointer                       */
-    colnum: c_int,          /* I - number of column to write (1 = 1st col) */
-    firstrow: LONGLONG,     /* I - first row to write (1 = 1st row)        */
-    firstelem: LONGLONG,    /* I - first vector element to write (1 = 1st) */
-    nelem: LONGLONG,        /* I - number of values to write               */
-    array: *const LONGLONG, /* I - array of values to write                */
-    nulvalue: LONGLONG,     /* I - value used to flag undefined pixels   */
-    status: *mut c_int,     /* IO - error status                           */
+    fptr: *mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: *const LONGLONG,
+    nulvalue: LONGLONG,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -2418,22 +2742,32 @@ pub unsafe extern "C" fn ffpcnjj(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of elements to the specified column of a table.  Any input
 /// pixels equal to the value of nulvalue will be replaced by the appropriate
 /// null value in the output FITS file.
 ///
 /// The input array of values will be converted to the datatype of the column
 /// and will be inverse-scaled by the FITS TSCALn and TZEROn values if necessary
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to write (1 = 1st col)
+/// * `firstrow`  — (I) first row to write (1 = 1st row)
+/// * `firstelem` — (I) first vector element to write (1 = 1st)
+/// * `nelem`     — (I) number of values to write
+/// * `array`     — (I) array of values to write
+/// * `nulvalue`  — (I) value used to flag undefined pixels
+/// * `status`    — (IO) error status
 pub fn ffpcnjj_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                       */
-    colnum: c_int,       /* I - number of column to write (1 = 1st col) */
-    firstrow: LONGLONG,  /* I - first row to write (1 = 1st row)        */
-    firstelem: LONGLONG, /* I - first vector element to write (1 = 1st) */
-    nelem: LONGLONG,     /* I - number of values to write               */
-    array: &[LONGLONG],  /* I - array of values to write                */
-    nulvalue: LONGLONG,  /* I - value used to flag undefined pixels   */
-    status: &mut c_int,  /* IO - error status                           */
+    fptr: &mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: &[LONGLONG],
+    nulvalue: LONGLONG,
+    status: &mut c_int,
 ) -> c_int {
     let mut ngood: LONGLONG = 0;
     let mut nbad: LONGLONG = 0;
@@ -2585,16 +2919,24 @@ pub fn ffpcnjj_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output prior to writing output to a FITS file.
 /// Do datatype conversion and scaling if required.
+///
+/// # Parameters
+///
+/// * `input`  — (I) array of values to be converted
+/// * `ntodo`  — (I) number of elements in the array
+/// * `scale`  — (I) FITS TSCALn or BSCALE value
+/// * `zero`   — (I) FITS TZEROn or BZERO value
+/// * `output` — (O) output array of converted values
+/// * `status` — (IO) error status
 pub(crate) fn ffi8fi1(
-    input: &[LONGLONG], /* I - array of values to be converted  */
-    ntodo: c_long,      /* I - number of elements in the array  */
-    scale: f64,         /* I - FITS TSCALn or BSCALE value      */
-    zero: f64,          /* I - FITS TZEROn or BZERO  value      */
-    output: &mut [u8],  /* O - output array of converted values */
-    status: &mut c_int, /* IO - error status                    */
+    input: &[LONGLONG],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    output: &mut [u8],
+    status: &mut c_int,
 ) -> c_int {
     if scale == 1.0 && zero == 0.0 {
         for ii in 0..(ntodo as usize) {
@@ -2626,16 +2968,24 @@ pub(crate) fn ffi8fi1(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output prior to writing output to a FITS file.
 /// Do datatype conversion and scaling if required.
+///
+/// # Parameters
+///
+/// * `input`  — (I) array of values to be converted
+/// * `ntodo`  — (I) number of elements in the array
+/// * `scale`  — (I) FITS TSCALn or BSCALE value
+/// * `zero`   — (I) FITS TZEROn or BZERO value
+/// * `output` — (O) output array of converted values
+/// * `status` — (IO) error status
 pub(crate) fn ffi8fi2(
-    input: &[LONGLONG],     /* I - array of values to be converted  */
-    ntodo: c_long,          /* I - number of elements in the array  */
-    scale: f64,             /* I - FITS TSCALn or BSCALE value      */
-    zero: f64,              /* I - FITS TZEROn or BZERO  value      */
-    output: &mut [c_short], /* O - output array of converted values */
-    status: &mut c_int,     /* IO - error status                    */
+    input: &[LONGLONG],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    output: &mut [c_short],
+    status: &mut c_int,
 ) -> c_int {
     if scale == 1.0 && zero == 0.0 {
         for ii in 0..(ntodo as usize) {
@@ -2669,16 +3019,24 @@ pub(crate) fn ffi8fi2(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output prior to writing output to a FITS file.
 /// Do datatype conversion and scaling if required
+///
+/// # Parameters
+///
+/// * `input`  — (I) array of values to be converted
+/// * `ntodo`  — (I) number of elements in the array
+/// * `scale`  — (I) FITS TSCALn or BSCALE value
+/// * `zero`   — (I) FITS TZEROn or BZERO value
+/// * `output` — (O) output array of converted values
+/// * `status` — (IO) error status
 pub(crate) fn ffi8fi4(
-    input: &[LONGLONG],      /* I - array of values to be converted  */
-    ntodo: c_long,           /* I - number of elements in the array  */
-    scale: f64,              /* I - FITS TSCALn or BSCALE value      */
-    zero: f64,               /* I - FITS TZEROn or BZERO  value      */
-    output: &mut [INT32BIT], /* O - output array of converted values */
-    status: &mut c_int,      /* IO - error status                    */
+    input: &[LONGLONG],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    output: &mut [INT32BIT],
+    status: &mut c_int,
 ) -> c_int {
     if scale == 1.0 && zero == 0.0 {
         for ii in 0..(ntodo as usize) {
@@ -2712,16 +3070,24 @@ pub(crate) fn ffi8fi4(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output prior to writing output to a FITS file.
 /// Do datatype conversion and scaling if required
+///
+/// # Parameters
+///
+/// * `input`  — (I) array of values to be converted
+/// * `ntodo`  — (I) number of elements in the array
+/// * `scale`  — (I) FITS TSCALn or BSCALE value
+/// * `zero`   — (I) FITS TZEROn or BZERO value
+/// * `output` — (O) output array of converted values
+/// * `status` — (IO) error status
 pub(crate) fn ffi8fi8(
-    input: &[LONGLONG],      /* I - array of values to be converted  */
-    ntodo: c_long,           /* I - number of elements in the array  */
-    scale: f64,              /* I - FITS TSCALn or BSCALE value      */
-    zero: f64,               /* I - FITS TZEROn or BZERO  value      */
-    output: &mut [LONGLONG], /* O - output array of converted values */
-    status: &mut c_int,      /* IO - error status                    */
+    input: &[LONGLONG],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    output: &mut [LONGLONG],
+    status: &mut c_int,
 ) -> c_int {
     let ntodo = ntodo as usize;
     if scale == 1.0 && zero == 9223372036854775808. {
@@ -2759,16 +3125,24 @@ pub(crate) fn ffi8fi8(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output prior to writing output to a FITS file.
 /// Do datatype conversion and scaling if required.
+///
+/// # Parameters
+///
+/// * `input`  — (I) array of values to be converted
+/// * `ntodo`  — (I) number of elements in the array
+/// * `scale`  — (I) FITS TSCALn or BSCALE value
+/// * `zero`   — (I) FITS TZEROn or BZERO value
+/// * `output` — (O) output array of converted values
+/// * `status` — (IO) error status
 pub(crate) fn ffi8fr4(
-    input: &[LONGLONG], /* I - array of values to be converted  */
-    ntodo: c_long,      /* I - number of elements in the array  */
-    scale: f64,         /* I - FITS TSCALn or BSCALE value      */
-    zero: f64,          /* I - FITS TZEROn or BZERO  value      */
-    output: &mut [f32], /* O - output array of converted values */
-    status: &mut c_int, /* IO - error status                    */
+    input: &[LONGLONG],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    output: &mut [f32],
+    status: &mut c_int,
 ) -> c_int {
     if scale == 1.0 && zero == 0.0 {
         for ii in 0..(ntodo as usize) {
@@ -2782,16 +3156,24 @@ pub(crate) fn ffi8fr4(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output prior to writing output to a FITS file.
 /// Do datatype conversion and scaling if required.
+///
+/// # Parameters
+///
+/// * `input`  — (I) array of values to be converted
+/// * `ntodo`  — (I) number of elements in the array
+/// * `scale`  — (I) FITS TSCALn or BSCALE value
+/// * `zero`   — (I) FITS TZEROn or BZERO value
+/// * `output` — (O) output array of converted values
+/// * `status` — (IO) error status
 pub(crate) fn ffi8fr8(
-    input: &[LONGLONG], /* I - array of values to be converted  */
-    ntodo: c_long,      /* I - number of elements in the array  */
-    scale: f64,         /* I - FITS TSCALn or BSCALE value      */
-    zero: f64,          /* I - FITS TZEROn or BZERO  value      */
-    output: &mut [f64], /* O - output array of converted values */
-    status: &mut c_int, /* IO - error status                    */
+    input: &[LONGLONG],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    output: &mut [f64],
+    status: &mut c_int,
 ) -> c_int {
     if scale == 1.0 && zero == 0.0 {
         for ii in 0..(ntodo as usize) {
@@ -2805,18 +3187,28 @@ pub(crate) fn ffi8fr8(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output prior to writing output to a FITS file.
 /// Do scaling if required.
+///
+/// # Parameters
+///
+/// * `input`  — (I) array of values to be converted
+/// * `ntodo`  — (I) number of elements in the array
+/// * `scale`  — (I) FITS TSCALn or BSCALE value
+/// * `zero`   — (I) FITS TZEROn or BZERO value
+/// * `cform`  — (I) format for output string values
+/// * `twidth` — (I) width of each field, in chars
+/// * `output` — (O) output array of converted values
+/// * `status` — (IO) error status
 pub(crate) fn ffi8fstr(
-    input: &[LONGLONG],    /* I - array of values to be converted  */
-    ntodo: c_long,         /* I - number of elements in the array  */
-    scale: f64,            /* I - FITS TSCALn or BSCALE value      */
-    zero: f64,             /* I - FITS TZEROn or BZERO  value      */
-    cform: &[c_char],      /* I - format for output string values  */
-    twidth: c_long,        /* I - width of each field, in chars    */
-    output: &mut [c_char], /* O - output array of converted values */
-    status: &mut c_int,    /* IO - error status                    */
+    input: &[LONGLONG],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    cform: &[c_char],
+    twidth: c_long,
+    output: &mut [c_char],
+    status: &mut c_int,
 ) -> c_int {
     let mut oi = 0;
 

--- a/src/putcolk.rs
+++ b/src/putcolk.rs
@@ -1,9 +1,14 @@
-/*  This file, putcolk.rs, contains routines that write data elements to    */
-/*  a FITS image or table, with 'int' datatype.                            */
-
-/*  The FITSIO software was written by William Pence at the High Energy    */
-/*  Astrophysic Science Archive Research Center (HEASARC) at the NASA      */
-/*  Goddard Space Flight Center.                                           */
+//! Routines that write data elements to a FITS image or table, with `int`
+//! datatype.
+//!
+//! The [`TINT`] arm of the typed column I/O family. [`crate::putcol`]
+//! dispatches here when a caller asks for this datatype at run time; the
+//! write-side counterpart is [`crate::getcolk`].
+//!
+//! Ported from CFITSIO's `putcolk.c`, written by William Pence at the High
+//! Energy Astrophysics Science Archive Research Center (HEASARC), NASA Goddard
+//! Space Flight Center.
+#![warn(missing_docs)]
 
 use core::slice;
 use core::{cmp, mem};
@@ -27,7 +32,6 @@ use crate::relibc::header::stdio::snprintf_f64;
 use crate::wrappers::strlen_safe;
 use crate::{buffers::*, int_snprintf, slice_to_str};
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
 /// the FITS array is not the same as the array being written).
@@ -36,14 +40,23 @@ use crate::{buffers::*, int_snprintf, slice_to_str};
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to write(1 = 1st group)
+/// * `firstelem` — (I) first vector element to write(1 = 1st)
+/// * `nelem`     — (I) number of values to write
+/// * `array`     — (I) array of values that are written
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffpprk(
-    fptr: *mut fitsfile, /* I - FITS file pointer                       */
-    group: c_long,       /* I - group to write(1 = 1st group)           */
-    firstelem: LONGLONG, /* I - first vector element to write(1 = 1st)  */
-    nelem: LONGLONG,     /* I - number of values to write               */
-    array: *const c_int, /* I - array of values that are written        */
-    status: *mut c_int,  /* IO - error status                           */
+    fptr: *mut fitsfile,
+    group: c_long,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: *const c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -56,7 +69,6 @@ pub unsafe extern "C" fn ffpprk(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
 /// the FITS array is not the same as the array being written).
@@ -65,13 +77,22 @@ pub unsafe extern "C" fn ffpprk(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to write(1 = 1st group)
+/// * `firstelem` — (I) first vector element to write(1 = 1st)
+/// * `nelem`     — (I) number of values to write
+/// * `array`     — (I) array of values that are written
+/// * `status`    — (IO) error status
 pub fn ffpprk_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                       */
-    group: c_long,       /* I - group to write(1 = 1st group)           */
-    firstelem: LONGLONG, /* I - first vector element to write(1 = 1st)  */
-    nelem: LONGLONG,     /* I - number of values to write               */
-    array: &[c_int],     /* I - array of values that are written        */
-    status: &mut c_int,  /* IO - error status                           */
+    fptr: &mut fitsfile,
+    group: c_long,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: &[c_int],
+    status: &mut c_int,
 ) -> c_int {
     let nullvalue: c_int = 0;
 
@@ -104,7 +125,6 @@ pub fn ffpprk_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of the
 /// FITS array is not the same as the array being written).  Any array values
@@ -115,15 +135,25 @@ pub fn ffpprk_safe(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to write(1 = 1st group)
+/// * `firstelem` — (I) first vector element to write(1 = 1st)
+/// * `nelem`     — (I) number of values to write
+/// * `array`     — (I) array of values that are written
+/// * `nulval`    — (I) undefined pixel value
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffppnk(
-    fptr: *mut fitsfile, /* I - FITS file pointer                       */
-    group: c_long,       /* I - group to write(1 = 1st group)           */
-    firstelem: LONGLONG, /* I - first vector element to write(1 = 1st)  */
-    nelem: LONGLONG,     /* I - number of values to write               */
-    array: *const c_int, /* I - array of values that are written        */
-    nulval: c_int,       /* I - undefined pixel value                   */
-    status: *mut c_int,  /* IO - error status                           */
+    fptr: *mut fitsfile,
+    group: c_long,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: *const c_int,
+    nulval: c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -136,7 +166,6 @@ pub unsafe extern "C" fn ffppnk(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of the
 /// FITS array is not the same as the array being written).  Any array values
@@ -147,14 +176,24 @@ pub unsafe extern "C" fn ffppnk(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to write(1 = 1st group)
+/// * `firstelem` — (I) first vector element to write(1 = 1st)
+/// * `nelem`     — (I) number of values to write
+/// * `array`     — (I) array of values that are written
+/// * `nulval`    — (I) undefined pixel value
+/// * `status`    — (IO) error status
 pub fn ffppnk_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                       */
-    group: c_long,       /* I - group to write(1 = 1st group)           */
-    firstelem: LONGLONG, /* I - first vector element to write(1 = 1st)  */
-    nelem: LONGLONG,     /* I - number of values to write               */
-    array: &[c_int],     /* I - array of values that are written        */
-    nulval: c_int,       /* I - undefined pixel value                   */
-    status: &mut c_int,  /* IO - error status                           */
+    fptr: &mut fitsfile,
+    group: c_long,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: &[c_int],
+    nulval: c_int,
+    status: &mut c_int,
 ) -> c_int {
     let mut nullvalue: c_int = 0;
 
@@ -190,19 +229,28 @@ pub fn ffppnk_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an entire 2-D array of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of the
 /// FITS array is not the same as the array being written).
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `group`  — (I) group to write(1 = 1st group)
+/// * `ncols`  — (I) number of pixels in each row of array
+/// * `naxis1` — (I) FITS image NAXIS1 value
+/// * `naxis2` — (I) FITS image NAXIS2 value
+/// * `array`  — (I) array to be written
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffp2dk(
-    fptr: *mut fitsfile, /* I - FITS file pointer                     */
-    group: c_long,       /* I - group to write(1 = 1st group)         */
-    ncols: LONGLONG,     /* I - number of pixels in each row of array */
-    naxis1: LONGLONG,    /* I - FITS image NAXIS1 value               */
-    naxis2: LONGLONG,    /* I - FITS image NAXIS2 value               */
-    array: *const c_int, /* I - array to be written                   */
-    status: *mut c_int,  /* IO - error status                         */
+    fptr: *mut fitsfile,
+    group: c_long,
+    ncols: LONGLONG,
+    naxis1: LONGLONG,
+    naxis2: LONGLONG,
+    array: *const c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -215,18 +263,27 @@ pub unsafe extern "C" fn ffp2dk(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an entire 2-D array of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of the
 /// FITS array is not the same as the array being written).
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `group`  — (I) group to write(1 = 1st group)
+/// * `ncols`  — (I) number of pixels in each row of array
+/// * `naxis1` — (I) FITS image NAXIS1 value
+/// * `naxis2` — (I) FITS image NAXIS2 value
+/// * `array`  — (I) array to be written
+/// * `status` — (IO) error status
 pub fn ffp2dk_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                     */
-    group: c_long,       /* I - group to write(1 = 1st group)         */
-    ncols: LONGLONG,     /* I - number of pixels in each row of array */
-    naxis1: LONGLONG,    /* I - FITS image NAXIS1 value               */
-    naxis2: LONGLONG,    /* I - FITS image NAXIS2 value               */
-    array: &[c_int],     /* I - array to be written                   */
-    status: &mut c_int,  /* IO - error status                         */
+    fptr: &mut fitsfile,
+    group: c_long,
+    ncols: LONGLONG,
+    naxis1: LONGLONG,
+    naxis2: LONGLONG,
+    array: &[c_int],
+    status: &mut c_int,
 ) -> c_int {
     /* call the 3D writing routine, with the 3rd dimension = 1 */
     ffp3dk_safe(fptr, group, ncols, naxis2, naxis1, naxis2, 1, array, status);
@@ -234,7 +291,6 @@ pub fn ffp2dk_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an entire 3-D cube of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of the
 /// FITS array is not the same as the array being written).
@@ -243,17 +299,29 @@ pub fn ffp2dk_safe(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `group`  — (I) group to write(1 = 1st group)
+/// * `ncols`  — (I) number of pixels in each row of array
+/// * `nrows`  — (I) number of rows in each plane of array
+/// * `naxis1` — (I) FITS image NAXIS1 value
+/// * `naxis2` — (I) FITS image NAXIS2 value
+/// * `naxis3` — (I) FITS image NAXIS3 value
+/// * `array`  — (I) array to be written
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffp3dk(
-    fptr: *mut fitsfile, /* I - FITS file pointer                     */
-    group: c_long,       /* I - group to write(1 = 1st group)         */
-    ncols: LONGLONG,     /* I - number of pixels in each row of array */
-    nrows: LONGLONG,     /* I - number of rows in each plane of array */
-    naxis1: LONGLONG,    /* I - FITS image NAXIS1 value               */
-    naxis2: LONGLONG,    /* I - FITS image NAXIS2 value               */
-    naxis3: LONGLONG,    /* I - FITS image NAXIS3 value               */
-    array: *const c_int, /* I - array to be written                   */
-    status: *mut c_int,  /* IO - error status                         */
+    fptr: *mut fitsfile,
+    group: c_long,
+    ncols: LONGLONG,
+    nrows: LONGLONG,
+    naxis1: LONGLONG,
+    naxis2: LONGLONG,
+    naxis3: LONGLONG,
+    array: *const c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -268,7 +336,6 @@ pub unsafe extern "C" fn ffp3dk(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an entire 3-D cube of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of the
 /// FITS array is not the same as the array being written).
@@ -277,16 +344,28 @@ pub unsafe extern "C" fn ffp3dk(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `group`  — (I) group to write(1 = 1st group)
+/// * `ncols`  — (I) number of pixels in each row of array
+/// * `nrows`  — (I) number of rows in each plane of array
+/// * `naxis1` — (I) FITS image NAXIS1 value
+/// * `naxis2` — (I) FITS image NAXIS2 value
+/// * `naxis3` — (I) FITS image NAXIS3 value
+/// * `array`  — (I) array to be written
+/// * `status` — (IO) error status
 pub fn ffp3dk_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                     */
-    group: c_long,       /* I - group to write(1 = 1st group)         */
-    ncols: LONGLONG,     /* I - number of pixels in each row of array */
-    nrows: LONGLONG,     /* I - number of rows in each plane of array */
-    naxis1: LONGLONG,    /* I - FITS image NAXIS1 value               */
-    naxis2: LONGLONG,    /* I - FITS image NAXIS2 value               */
-    naxis3: LONGLONG,    /* I - FITS image NAXIS3 value               */
-    array: &[c_int],     /* I - array to be written                   */
-    status: &mut c_int,  /* IO - error status                         */
+    fptr: &mut fitsfile,
+    group: c_long,
+    ncols: LONGLONG,
+    nrows: LONGLONG,
+    naxis1: LONGLONG,
+    naxis2: LONGLONG,
+    naxis3: LONGLONG,
+    array: &[c_int],
+    status: &mut c_int,
 ) -> c_int {
     let mut tablerow: c_long = 0;
     let fpixel: [c_long; 3] = [1, 1, 1];
@@ -366,7 +445,6 @@ pub fn ffp3dk_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write a subsection of pixels to the primary array or image.
 ///
 /// A subsection is defined to be any contiguous rectangular
@@ -374,16 +452,27 @@ pub fn ffp3dk_safe(
 /// Data conversion and scaling will be performed if necessary
 /// (e.g, if the datatype of the FITS array is not the same as
 /// the array being written).
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `group`  — (I) group to write(1 = 1st group)
+/// * `naxis`  — (I) number of data axes in array
+/// * `naxes`  — (I) size of each FITS axis
+/// * `fpixel` — (I) 1st pixel in each axis to write (1=1st)
+/// * `lpixel` — (I) last pixel in each axis to write
+/// * `array`  — (I) array to be written
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffpssk(
-    fptr: *mut fitsfile,   /* I - FITS file pointer                       */
-    group: c_long,         /* I - group to write(1 = 1st group)           */
-    naxis: c_long,         /* I - number of data axes in array            */
-    naxes: *const c_long,  /* I - size of each FITS axis                  */
-    fpixel: *const c_long, /* I - 1st pixel in each axis to write (1=1st) */
-    lpixel: *const c_long, /* I - last pixel in each axis to write        */
-    array: *const c_int,   /* I - array to be written                     */
-    status: *mut c_int,    /* IO - error status                           */
+    fptr: *mut fitsfile,
+    group: c_long,
+    naxis: c_long,
+    naxes: *const c_long,
+    fpixel: *const c_long,
+    lpixel: *const c_long,
+    array: *const c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -405,7 +494,6 @@ pub unsafe extern "C" fn ffpssk(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write a subsection of pixels to the primary array or image.
 ///
 /// A subsection is defined to be any contiguous rectangular
@@ -413,15 +501,26 @@ pub unsafe extern "C" fn ffpssk(
 /// Data conversion and scaling will be performed if necessary
 /// (e.g, if the datatype of the FITS array is not the same as
 /// the array being written).
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `group`  — (I) group to write(1 = 1st group)
+/// * `naxis`  — (I) number of data axes in array
+/// * `naxes`  — (I) size of each FITS axis
+/// * `fpixel` — (I) 1st pixel in each axis to write (1=1st)
+/// * `lpixel` — (I) last pixel in each axis to write
+/// * `array`  — (I) array to be written
+/// * `status` — (IO) error status
 pub fn ffpssk_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                       */
-    group: c_long,       /* I - group to write(1 = 1st group)           */
-    naxis: c_long,       /* I - number of data axes in array            */
-    naxes: &[c_long],    /* I - size of each FITS axis                  */
-    fpixel: &[c_long],   /* I - 1st pixel in each axis to write (1=1st) */
-    lpixel: &[c_long],   /* I - last pixel in each axis to write        */
-    array: &[c_int],     /* I - array to be written                     */
-    status: &mut c_int,  /* IO - error status                           */
+    fptr: &mut fitsfile,
+    group: c_long,
+    naxis: c_long,
+    naxes: &[c_long],
+    fpixel: &[c_long],
+    lpixel: &[c_long],
+    array: &[c_int],
+    status: &mut c_int,
 ) -> c_int {
     let mut fpix: [LONGLONG; 7] = [0; 7];
     let mut dimen: [LONGLONG; 7] = [0; 7];
@@ -547,7 +646,6 @@ pub fn ffpssk_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of group parameters to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
 /// the FITS array is not the same as the array being written).
@@ -556,14 +654,23 @@ pub fn ffpssk_safe(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to write(1 = 1st group)
+/// * `firstelem` — (I) first vector element to write(1 = 1st)
+/// * `nelem`     — (I) number of values to write
+/// * `array`     — (I) array of values that are written
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffpgpk(
-    fptr: *mut fitsfile, /* I - FITS file pointer                      */
-    group: c_long,       /* I - group to write(1 = 1st group)          */
-    firstelem: c_long,   /* I - first vector element to write(1 = 1st) */
-    nelem: c_long,       /* I - number of values to write              */
-    array: *const c_int, /* I - array of values that are written       */
-    status: *mut c_int,  /* IO - error status                          */
+    fptr: *mut fitsfile,
+    group: c_long,
+    firstelem: c_long,
+    nelem: c_long,
+    array: *const c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -575,7 +682,6 @@ pub unsafe extern "C" fn ffpgpk(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of group parameters to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
 /// the FITS array is not the same as the array being written).
@@ -584,13 +690,22 @@ pub unsafe extern "C" fn ffpgpk(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to write(1 = 1st group)
+/// * `firstelem` — (I) first vector element to write(1 = 1st)
+/// * `nelem`     — (I) number of values to write
+/// * `array`     — (I) array of values that are written
+/// * `status`    — (IO) error status
 pub fn ffpgpk_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                      */
-    group: c_long,       /* I - group to write(1 = 1st group)          */
-    firstelem: c_long,   /* I - first vector element to write(1 = 1st) */
-    nelem: c_long,       /* I - number of values to write              */
-    array: &[c_int],     /* I - array of values that are written       */
-    status: &mut c_int,  /* IO - error status                          */
+    fptr: &mut fitsfile,
+    group: c_long,
+    firstelem: c_long,
+    nelem: c_long,
+    array: &[c_int],
+    status: &mut c_int,
 ) -> c_int {
     let row = cmp::max(1, group);
 
@@ -606,7 +721,6 @@ pub fn ffpgpk_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of values to a column in the current FITS HDU.
 ///
 /// The column number may refer to a real column in an ASCII or binary table,
@@ -619,15 +733,25 @@ pub fn ffpgpk_safe(
 ///
 /// The input array of values will be converted to the datatype of the column
 /// and will be inverse-scaled by the FITS TSCALn and TZEROn values if necessary.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to write (1 = 1st col)
+/// * `firstrow`  — (I) first row to write (1 = 1st row)
+/// * `firstelem` — (I) first vector element to write (1 = 1st)
+/// * `nelem`     — (I) number of values to write
+/// * `array`     — (I) array of values to write
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffpclk(
-    fptr: *mut fitsfile, /* I - FITS file pointer                       */
-    colnum: c_int,       /* I - number of column to write (1 = 1st col) */
-    firstrow: LONGLONG,  /* I - first row to write (1 = 1st row)        */
-    firstelem: LONGLONG, /* I - first vector element to write (1 = 1st) */
-    nelem: LONGLONG,     /* I - number of values to write               */
-    array: *const c_int, /* I - array of values to write                */
-    status: *mut c_int,  /* IO - error status                           */
+    fptr: *mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: *const c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -648,7 +772,6 @@ pub unsafe extern "C" fn ffpclk(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of values to a column in the current FITS HDU.
 ///
 /// The column number may refer to a real column in an ASCII or binary table,
@@ -661,14 +784,24 @@ pub unsafe extern "C" fn ffpclk(
 ///
 /// The input array of values will be converted to the datatype of the column
 /// and will be inverse-scaled by the FITS TSCALn and TZEROn values if necessary.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to write (1 = 1st col)
+/// * `firstrow`  — (I) first row to write (1 = 1st row)
+/// * `firstelem` — (I) first vector element to write (1 = 1st)
+/// * `nelem`     — (I) number of values to write
+/// * `array`     — (I) array of values to write
+/// * `status`    — (IO) error status
 pub fn ffpclk_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                       */
-    colnum: c_int,       /* I - number of column to write (1 = 1st col) */
-    firstrow: LONGLONG,  /* I - first row to write (1 = 1st row)        */
-    firstelem: LONGLONG, /* I - first vector element to write (1 = 1st) */
-    nelem: LONGLONG,     /* I - number of values to write               */
-    array: &[c_int],     /* I - array of values to write                */
-    status: &mut c_int,  /* IO - error status                           */
+    fptr: &mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: &[c_int],
+    status: &mut c_int,
 ) -> c_int {
     let mut tcode: c_int = 0;
     let mut maxelem2: c_int = 0;
@@ -728,9 +861,7 @@ pub fn ffpclk_safe(
         int = 4 bytes, and long = 8 bytes.
         */
 
-        /*---------------------------------------------------*/
         /*  Check input and get parameters about the column: */
-        /*---------------------------------------------------*/
         if ffgcprll(
             fptr,
             colnum,
@@ -783,12 +914,10 @@ pub fn ffpclk_safe(
             writeraw = false;
         }
 
-        /*---------------------------------------------------------------------*/
         /*  Now write the pixels to the FITS column.                           */
         /*  First call the ffXXfYY routine to  (1) convert the datatype        */
         /*  if necessary, and (2) scale the values by the FITS TSCALn and      */
         /*  TZEROn linear scaling parameters into a temporary buffer.          */
-        /*---------------------------------------------------------------------*/
         remain = nelem; /* remaining number of values to write  */
         next = 0; /* next element in array to be written  */
         rownum = 0; /* row number, relative to firstrow     */
@@ -965,9 +1094,7 @@ pub fn ffpclk_safe(
                 }
             } /* End of switch block */
 
-            /*-------------------------*/
             /*  Check for fatal error  */
-            /*-------------------------*/
             if *status > 0 {
                 /* test for error during previous write operation */
 
@@ -982,9 +1109,7 @@ pub fn ffpclk_safe(
                 return *status;
             }
 
-            /*--------------------------------------------*/
             /*  increment the counters for the next loop  */
-            /*--------------------------------------------*/
             remain -= ntodo as LONGLONG;
             if remain != 0 {
                 next += ntodo as LONGLONG;
@@ -998,9 +1123,7 @@ pub fn ffpclk_safe(
             }
         } /*  End of main while Loop  */
 
-        /*--------------------------------*/
         /*  check for numerical overflow  */
-        /*--------------------------------*/
         if *status == OVERFLOW_ERR {
             ffpmsg_str("Numerical overflow during type conversion while writing FITS data.");
             *status = NUM_OVERFLOW;
@@ -1010,23 +1133,33 @@ pub fn ffpclk_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of elements to the specified column of a table.  Any input
 /// pixels equal to the value of nulvalue will be replaced by the appropriate
 /// null value in the output FITS file.
 ///
 /// The input array of values will be converted to the datatype of the column
 /// and will be inverse-scaled by the FITS TSCALn and TZEROn values if necessary
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to write (1 = 1st col)
+/// * `firstrow`  — (I) first row to write (1 = 1st row)
+/// * `firstelem` — (I) first vector element to write (1 = 1st)
+/// * `nelem`     — (I) number of values to write
+/// * `array`     — (I) array of values to write
+/// * `nulvalue`  — (I) value used to flag undefined pixels
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffpcnk(
-    fptr: *mut fitsfile, /* I - FITS file pointer                       */
-    colnum: c_int,       /* I - number of column to write (1 = 1st col) */
-    firstrow: LONGLONG,  /* I - first row to write (1 = 1st row)        */
-    firstelem: LONGLONG, /* I - first vector element to write (1 = 1st) */
-    nelem: LONGLONG,     /* I - number of values to write               */
-    array: *const c_int, /* I - array of values to write                */
-    nulvalue: c_int,     /* I - value used to flag undefined pixels     */
-    status: *mut c_int,  /* IO - error status                           */
+    fptr: *mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: *const c_int,
+    nulvalue: c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -1048,22 +1181,32 @@ pub unsafe extern "C" fn ffpcnk(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of elements to the specified column of a table.  Any input
 /// pixels equal to the value of nulvalue will be replaced by the appropriate
 /// null value in the output FITS file.
 ///
 /// The input array of values will be converted to the datatype of the column
 /// and will be inverse-scaled by the FITS TSCALn and TZEROn values if necessary
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to write (1 = 1st col)
+/// * `firstrow`  — (I) first row to write (1 = 1st row)
+/// * `firstelem` — (I) first vector element to write (1 = 1st)
+/// * `nelem`     — (I) number of values to write
+/// * `array`     — (I) array of values to write
+/// * `nulvalue`  — (I) value used to flag undefined pixels
+/// * `status`    — (IO) error status
 pub fn ffpcnk_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                       */
-    colnum: c_int,       /* I - number of column to write (1 = 1st col) */
-    firstrow: LONGLONG,  /* I - first row to write (1 = 1st row)        */
-    firstelem: LONGLONG, /* I - first vector element to write (1 = 1st) */
-    nelem: LONGLONG,     /* I - number of values to write               */
-    array: &[c_int],     /* I - array of values to write                */
-    nulvalue: c_int,     /* I - value used to flag undefined pixels     */
-    status: &mut c_int,  /* IO - error status                           */
+    fptr: &mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: &[c_int],
+    nulvalue: c_int,
+    status: &mut c_int,
 ) -> c_int {
     let mut ngood: LONGLONG = 0;
     let mut nbad: LONGLONG = 0;
@@ -1217,16 +1360,24 @@ pub fn ffpcnk_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output prior to writing output to a FITS file.
 /// Do datatype conversion and scaling if required.
+///
+/// # Parameters
+///
+/// * `input`  — (I) array of values to be converted
+/// * `ntodo`  — (I) number of elements in the array
+/// * `scale`  — (I) FITS TSCALn or BSCALE value
+/// * `zero`   — (I) FITS TZEROn or BZERO value
+/// * `output` — (O) output array of converted values
+/// * `status` — (IO) error status
 pub(crate) fn ffintfi1(
-    input: &[c_int],    /* I - array of values to be converted  */
-    ntodo: c_long,      /* I - number of elements in the array  */
-    scale: f64,         /* I - FITS TSCALn or BSCALE value      */
-    zero: f64,          /* I - FITS TZEROn or BZERO  value      */
-    output: &mut [u8],  /* O - output array of converted values */
-    status: &mut c_int, /* IO - error status                    */
+    input: &[c_int],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    output: &mut [u8],
+    status: &mut c_int,
 ) -> c_int {
     if scale == 1.0 && zero == 0.0 {
         for ii in 0..(ntodo as usize) {
@@ -1258,16 +1409,24 @@ pub(crate) fn ffintfi1(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output prior to writing output to a FITS file.
 /// Do datatype conversion and scaling if required.
+///
+/// # Parameters
+///
+/// * `input`  — (I) array of values to be converted
+/// * `ntodo`  — (I) number of elements in the array
+/// * `scale`  — (I) FITS TSCALn or BSCALE value
+/// * `zero`   — (I) FITS TZEROn or BZERO value
+/// * `output` — (O) output array of converted values
+/// * `status` — (IO) error status
 pub(crate) fn ffintfi2(
-    input: &[c_int],        /* I - array of values to be converted  */
-    ntodo: c_long,          /* I - number of elements in the array  */
-    scale: f64,             /* I - FITS TSCALn or BSCALE value      */
-    zero: f64,              /* I - FITS TZEROn or BZERO  value      */
-    output: &mut [c_short], /* O - output array of converted values */
-    status: &mut c_int,     /* IO - error status                    */
+    input: &[c_int],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    output: &mut [c_short],
+    status: &mut c_int,
 ) -> c_int {
     if scale == 1.0 && zero == 0.0 {
         for ii in 0..(ntodo as usize) {
@@ -1301,16 +1460,24 @@ pub(crate) fn ffintfi2(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output prior to writing output to a FITS file.
 /// Do datatype conversion and scaling if required
+///
+/// # Parameters
+///
+/// * `input`  — (I) array of values to be converted
+/// * `ntodo`  — (I) number of elements in the array
+/// * `scale`  — (I) FITS TSCALn or BSCALE value
+/// * `zero`   — (I) FITS TZEROn or BZERO value
+/// * `output` — (O) output array of converted values
+/// * `status` — (IO) error status
 pub(crate) fn ffintfi4(
-    input: &[c_int],         /* I - array of values to be converted  */
-    ntodo: c_long,           /* I - number of elements in the array  */
-    scale: f64,              /* I - FITS TSCALn or BSCALE value      */
-    zero: f64,               /* I - FITS TZEROn or BZERO  value      */
-    output: &mut [INT32BIT], /* O - output array of converted values */
-    status: &mut c_int,      /* IO - error status                    */
+    input: &[c_int],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    output: &mut [INT32BIT],
+    status: &mut c_int,
 ) -> c_int {
     assert!(output.len() >= ntodo as usize);
     assert!(input.len() >= ntodo as usize);
@@ -1337,16 +1504,24 @@ pub(crate) fn ffintfi4(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output prior to writing output to a FITS file.
 /// Do datatype conversion and scaling if required
+///
+/// # Parameters
+///
+/// * `input`  — (I) array of values to be converted
+/// * `ntodo`  — (I) number of elements in the array
+/// * `scale`  — (I) FITS TSCALn or BSCALE value
+/// * `zero`   — (I) FITS TZEROn or BZERO value
+/// * `output` — (O) output array of converted values
+/// * `status` — (IO) error status
 pub(crate) fn ffintfi8(
-    input: &[c_int],         /* I - array of values to be converted  */
-    ntodo: c_long,           /* I - number of elements in the array  */
-    scale: f64,              /* I - FITS TSCALn or BSCALE value      */
-    zero: f64,               /* I - FITS TZEROn or BZERO  value      */
-    output: &mut [LONGLONG], /* O - output array of converted values */
-    status: &mut c_int,      /* IO - error status                    */
+    input: &[c_int],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    output: &mut [LONGLONG],
+    status: &mut c_int,
 ) -> c_int {
     if scale == 1.0 && zero == 9223372036854775808.0 {
         /* Writing to unsigned long long column. Input values must not be negative */
@@ -1385,16 +1560,24 @@ pub(crate) fn ffintfi8(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output prior to writing output to a FITS file.
 /// Do datatype conversion and scaling if required.
+///
+/// # Parameters
+///
+/// * `input`  — (I) array of values to be converted
+/// * `ntodo`  — (I) number of elements in the array
+/// * `scale`  — (I) FITS TSCALn or BSCALE value
+/// * `zero`   — (I) FITS TZEROn or BZERO value
+/// * `output` — (O) output array of converted values
+/// * `status` — (IO) error status
 pub(crate) fn ffintfr4(
-    input: &[c_int],    /* I - array of values to be converted  */
-    ntodo: c_long,      /* I - number of elements in the array  */
-    scale: f64,         /* I - FITS TSCALn or BSCALE value      */
-    zero: f64,          /* I - FITS TZEROn or BZERO  value      */
-    output: &mut [f32], /* O - output array of converted values */
-    status: &mut c_int, /* IO - error status                    */
+    input: &[c_int],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    output: &mut [f32],
+    status: &mut c_int,
 ) -> c_int {
     if scale == 1.0 && zero == 0.0 {
         for ii in 0..(ntodo as usize) {
@@ -1408,16 +1591,24 @@ pub(crate) fn ffintfr4(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output prior to writing output to a FITS file.
 /// Do datatype conversion and scaling if required.
+///
+/// # Parameters
+///
+/// * `input`  — (I) array of values to be converted
+/// * `ntodo`  — (I) number of elements in the array
+/// * `scale`  — (I) FITS TSCALn or BSCALE value
+/// * `zero`   — (I) FITS TZEROn or BZERO value
+/// * `output` — (O) output array of converted values
+/// * `status` — (IO) error status
 pub(crate) fn ffintfr8(
-    input: &[c_int],    /* I - array of values to be converted  */
-    ntodo: c_long,      /* I - number of elements in the array  */
-    scale: f64,         /* I - FITS TSCALn or BSCALE value      */
-    zero: f64,          /* I - FITS TZEROn or BZERO  value      */
-    output: &mut [f64], /* O - output array of converted values */
-    status: &mut c_int, /* IO - error status                    */
+    input: &[c_int],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    output: &mut [f64],
+    status: &mut c_int,
 ) -> c_int {
     if scale == 1.0 && zero == 0.0 {
         for ii in 0..(ntodo as usize) {
@@ -1431,18 +1622,28 @@ pub(crate) fn ffintfr8(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output prior to writing output to a FITS file.
 /// Do scaling if required.
+///
+/// # Parameters
+///
+/// * `input`  — (I) array of values to be converted
+/// * `ntodo`  — (I) number of elements in the array
+/// * `scale`  — (I) FITS TSCALn or BSCALE value
+/// * `zero`   — (I) FITS TZEROn or BZERO value
+/// * `cform`  — (I) format for output string values
+/// * `twidth` — (I) width of each field, in chars
+/// * `output` — (O) output array of converted values
+/// * `status` — (IO) error status
 pub(crate) fn ffintfstr(
-    input: &[c_int],       /* I - array of values to be converted  */
-    ntodo: c_long,         /* I - number of elements in the array  */
-    scale: f64,            /* I - FITS TSCALn or BSCALE value      */
-    zero: f64,             /* I - FITS TZEROn or BZERO  value      */
-    cform: &[c_char],      /* I - format for output string values  */
-    twidth: c_long,        /* I - width of each field, in chars    */
-    output: &mut [c_char], /* O - output array of converted values */
-    status: &mut c_int,    /* IO - error status                    */
+    input: &[c_int],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    cform: &[c_char],
+    twidth: c_long,
+    output: &mut [c_char],
+    status: &mut c_int,
 ) -> c_int {
     let mut oi = 0;
 

--- a/src/putcoll.rs
+++ b/src/putcoll.rs
@@ -1,9 +1,14 @@
-/*  This file, putcoll.rs, contains routines that write data elements to    */
-/*  a FITS image or table, with logical datatype.                          */
-
-/*  The FITSIO software was written by William Pence at the High Energy    */
-/*  Astrophysic Science Archive Research Center (HEASARC) at the NASA      */
-/*  Goddard Space Flight Center.                                           */
+//! Routines that write data elements to a FITS image or table, with logical
+//! datatype.
+//!
+//! The [`TLOGICAL`] arm of the typed column I/O family. [`crate::putcol`]
+//! dispatches here when a caller asks for this datatype at run time; the
+//! write-side counterpart is [`crate::getcoll`].
+//!
+//! Ported from CFITSIO's `putcoll.c`, written by William Pence at the High
+//! Energy Astrophysics Science Archive Research Center (HEASARC), NASA Goddard
+//! Space Flight Center.
+#![warn(missing_docs)]
 
 use core::slice;
 
@@ -20,17 +25,26 @@ use crate::fitsio2::*;
 use crate::putcolu::ffpclu_safe;
 use crate::{buffers::*, int_snprintf};
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of logical values to a column in the current FITS HDU.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to write (1 = 1st col)
+/// * `firstrow`  — (I) first row to write (1 = 1st row)
+/// * `firstelem` — (I) first vector element to write (1 = 1st)
+/// * `nelem`     — (I) number of values to write
+/// * `array`     — (I) array of values to write
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffpcll(
-    fptr: *mut fitsfile,  /* I - FITS file pointer                       */
-    colnum: c_int,        /* I - number of column to write (1 = 1st col) */
-    firstrow: LONGLONG,   /* I - first row to write (1 = 1st row)        */
-    firstelem: LONGLONG,  /* I - first vector element to write (1 = 1st) */
-    nelem: LONGLONG,      /* I - number of values to write               */
-    array: *const c_char, /* I - array of values to write                */
-    status: *mut c_int,   /* IO - error status                           */
+    fptr: *mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: *const c_char,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -51,16 +65,25 @@ pub unsafe extern "C" fn ffpcll(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of logical values to a column in the current FITS HDU.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to write (1 = 1st col)
+/// * `firstrow`  — (I) first row to write (1 = 1st row)
+/// * `firstelem` — (I) first vector element to write (1 = 1st)
+/// * `nelem`     — (I) number of values to write
+/// * `array`     — (I) array of values to write
+/// * `status`    — (IO) error status
 pub fn ffpcll_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                       */
-    colnum: c_int,       /* I - number of column to write (1 = 1st col) */
-    firstrow: LONGLONG,  /* I - first row to write (1 = 1st row)        */
-    firstelem: LONGLONG, /* I - first vector element to write (1 = 1st) */
-    nelem: LONGLONG,     /* I - number of values to write               */
-    array: &[c_char],    /* I - array of values to write                */
-    status: &mut c_int,  /* IO - error status                           */
+    fptr: &mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: &[c_char],
+    status: &mut c_int,
 ) -> c_int {
     let mut tcode: c_int = 0;
     let mut maxelem: c_int = 0;
@@ -89,9 +112,7 @@ pub fn ffpcll_safe(
         return *status;
     }
 
-    /*---------------------------------------------------*/
     /*  Check input and get parameters about the column: */
-    /*---------------------------------------------------*/
     if ffgcprll(
         fptr,
         colnum,
@@ -124,9 +145,7 @@ pub fn ffpcll_safe(
         return *status;
     }
 
-    /*---------------------------------------------------------------------*/
     /*  Now write the logical values one at a time to the FITS column.     */
-    /*---------------------------------------------------------------------*/
     remain = nelem; /* remaining number of values to write  */
     next = 0; /* next element in array to be written  */
     rownum = 0; /* row number, relative to firstrow     */
@@ -155,9 +174,7 @@ pub fn ffpcll_safe(
             return *status;
         }
 
-        /*--------------------------------------------*/
         /*  increment the counters for the next loop  */
-        /*--------------------------------------------*/
         remain -= 1;
         if remain != 0 {
             next += 1;
@@ -174,20 +191,30 @@ pub fn ffpcll_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of elements to the specified column of a table.  Any input
 /// pixels flagged as null will be replaced by the appropriate
 /// null value in the output FITS file.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to write (1 = 1st col)
+/// * `firstrow`  — (I) first row to write (1 = 1st row)
+/// * `firstelem` — (I) first vector element to write (1 = 1st)
+/// * `nelem`     — (I) number of values to write
+/// * `array`     — (I) array of values to write
+/// * `nulvalue`  — (I) array flagging undefined pixels if true
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffpcnl(
-    fptr: *mut fitsfile,  /* I - FITS file pointer                       */
-    colnum: c_int,        /* I - number of column to write (1 = 1st col) */
-    firstrow: LONGLONG,   /* I - first row to write (1 = 1st row)        */
-    firstelem: LONGLONG,  /* I - first vector element to write (1 = 1st) */
-    nelem: LONGLONG,      /* I - number of values to write               */
-    array: *const c_char, /* I - array of values to write                */
-    nulvalue: c_char,     /* I - array flagging undefined pixels if true */
-    status: *mut c_int,   /* IO - error status                           */
+    fptr: *mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: *const c_char,
+    nulvalue: c_char,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -209,19 +236,29 @@ pub unsafe extern "C" fn ffpcnl(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of elements to the specified column of a table.  Any input
 /// pixels flagged as null will be replaced by the appropriate
 /// null value in the output FITS file.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to write (1 = 1st col)
+/// * `firstrow`  — (I) first row to write (1 = 1st row)
+/// * `firstelem` — (I) first vector element to write (1 = 1st)
+/// * `nelem`     — (I) number of values to write
+/// * `array`     — (I) array of values to write
+/// * `nulvalue`  — (I) array flagging undefined pixels if true
+/// * `status`    — (IO) error status
 pub fn ffpcnl_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                       */
-    colnum: c_int,       /* I - number of column to write (1 = 1st col) */
-    firstrow: LONGLONG,  /* I - first row to write (1 = 1st row)        */
-    firstelem: LONGLONG, /* I - first vector element to write (1 = 1st) */
-    nelem: LONGLONG,     /* I - number of values to write               */
-    array: &[c_char],    /* I - array of values to write                */
-    nulvalue: c_char,    /* I - array flagging undefined pixels if true */
-    status: &mut c_int,  /* IO - error status                           */
+    fptr: &mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: &[c_char],
+    nulvalue: c_char,
+    status: &mut c_int,
 ) -> c_int {
     let mut ngood: LONGLONG = 0;
     let mut nbad: LONGLONG = 0;
@@ -339,20 +376,29 @@ pub fn ffpcnl_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// write an array of logical values to a specified bit or byte
 /// column of the binary table.   If larray is TRUE, then the corresponding
 /// bit is set to 1, otherwise it is set to 0.
 /// The binary table column being written to must have datatype 'B' or 'X'.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `colnum` — (I) number of column to write (1 = 1st col)
+/// * `frow`   — (I) first row to write (1 = 1st row)
+/// * `fbit`   — (I) first bit to write (1 = 1st)
+/// * `nbit`   — (I) number of bits to write
+/// * `larray` — (I) array of logicals corresponding to bits
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffpclx(
-    fptr: *mut fitsfile,   /* I - FITS file pointer                       */
-    colnum: c_int,         /* I - number of column to write (1 = 1st col) */
-    frow: LONGLONG,        /* I - first row to write (1 = 1st row)        */
-    fbit: c_long,          /* I - first bit to write (1 = 1st)            */
-    nbit: c_long,          /* I - number of bits to write                 */
-    larray: *const c_char, /* I - array of logicals corresponding to bits */
-    status: *mut c_int,    /* IO - error status                           */
+    fptr: *mut fitsfile,
+    colnum: c_int,
+    frow: LONGLONG,
+    fbit: c_long,
+    nbit: c_long,
+    larray: *const c_char,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -365,19 +411,28 @@ pub unsafe extern "C" fn ffpclx(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// write an array of logical values to a specified bit or byte
 /// column of the binary table.   If larray is TRUE, then the corresponding
 /// bit is set to 1, otherwise it is set to 0.
 /// The binary table column being written to must have datatype 'B' or 'X'.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `colnum` — (I) number of column to write (1 = 1st col)
+/// * `frow`   — (I) first row to write (1 = 1st row)
+/// * `fbit`   — (I) first bit to write (1 = 1st)
+/// * `nbit`   — (I) number of bits to write
+/// * `larray` — (I) array of logicals corresponding to bits
+/// * `status` — (IO) error status
 pub fn ffpclx_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                       */
-    colnum: c_int,       /* I - number of column to write (1 = 1st col) */
-    frow: LONGLONG,      /* I - first row to write (1 = 1st row)        */
-    fbit: c_long,        /* I - first bit to write (1 = 1st)            */
-    nbit: c_long,        /* I - number of bits to write                 */
-    larray: &[c_char],   /* I - array of logicals corresponding to bits */
-    status: &mut c_int,  /* IO - error status                           */
+    fptr: &mut fitsfile,
+    colnum: c_int,
+    frow: LONGLONG,
+    fbit: c_long,
+    nbit: c_long,
+    larray: &[c_char],
+    status: &mut c_int,
 ) -> c_int {
     let mut bstart: LONGLONG = 0;
     let mut repeat: LONGLONG = 0;

--- a/src/putcols.rs
+++ b/src/putcols.rs
@@ -1,9 +1,15 @@
-/*  This file, putcols.rs, contains routines that write data elements to    */
-/*  a FITS image or table, of type character string.                       */
+//! Routines that write data elements to a FITS image or table, with
+//! character string datatype.
+//!
+//! The [`TSTRING`] arm of the typed column I/O family. [`crate::putcol`]
+//! dispatches here when a caller asks for this datatype at run time; the
+//! write-side counterpart is [`crate::getcols`].
+//!
+//! Ported from CFITSIO's `putcols.c`, written by William Pence at the High
+//! Energy Astrophysics Science Archive Research Center (HEASARC), NASA Goddard
+//! Space Flight Center.
+#![warn(missing_docs)]
 
-/*  The FITSIO software was written by William Pence at the High Energy    */
-/*  Astrophysic Science Archive Research Center (HEASARC) at the NASA      */
-/*  Goddard Space Flight Center.                                           */
 use core::ffi::CStr;
 use core::slice;
 use core::{cmp, mem};
@@ -20,17 +26,26 @@ use crate::putcolu::ffpclu_safe;
 use crate::wrappers::*;
 use crate::{buffers::*, int_snprintf};
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of string values to a column in the current FITS HDU.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to write (1 = 1st col)
+/// * `firstrow`  — (I) first row to write (1 = 1st row)
+/// * `firstelem` — (I) first vector element to write (1 = 1st)
+/// * `nelem`     — (I) number of strings to write
+/// * `array`     — (I) array of pointers to strings
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffpcls(
-    fptr: *mut fitsfile,         /* I - FITS file pointer                       */
-    colnum: c_int,               /* I - number of column to write (1 = 1st col) */
-    firstrow: LONGLONG,          /* I - first row to write (1 = 1st row)        */
-    firstelem: LONGLONG,         /* I - first vector element to write (1 = 1st) */
-    nelem: LONGLONG,             /* I - number of strings to write              */
-    array: *const *const c_char, /* I - array of pointers to strings            */
-    status: *mut c_int,          /* IO - error status                           */
+    fptr: *mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: *const *const c_char,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -57,16 +72,25 @@ pub unsafe extern "C" fn ffpcls(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of string values to a column in the current FITS HDU.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to write (1 = 1st col)
+/// * `firstrow`  — (I) first row to write (1 = 1st row)
+/// * `firstelem` — (I) first vector element to write (1 = 1st)
+/// * `nelem`     — (I) number of strings to write
+/// * `array`     — (I) array of pointers to strings
+/// * `status`    — (IO) error status
 pub fn ffpcls_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                       */
-    colnum: c_int,       /* I - number of column to write (1 = 1st col) */
-    firstrow: LONGLONG,  /* I - first row to write (1 = 1st row)        */
-    firstelem: LONGLONG, /* I - first vector element to write (1 = 1st) */
-    nelem: LONGLONG,     /* I - number of strings to write              */
-    array: &[&[c_char]], /* I - array of pointers to strings            */
-    status: &mut c_int,  /* IO - error status                           */
+    fptr: &mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: &[&[c_char]],
+    status: &mut c_int,
 ) -> c_int {
     let mut tcode: c_int;
     let mut maxelem: c_int = 0;
@@ -105,9 +129,7 @@ pub fn ffpcls_safe(
         return *status;
     }
 
-    /*---------------------------------------------------*/
     /*  Check input and get parameters about the column: */
-    /*---------------------------------------------------*/
     if colnum < 1 || colnum > fptr.Fptr.tfield {
         int_snprintf!(
             &mut message,
@@ -230,9 +252,7 @@ pub fn ffpcls_safe(
         *status = NOT_ASCII_COL;
         return *status;
     }
-    /*-------------------------------------------------------*/
     /*  Now write the strings to the FITS column.            */
-    /*-------------------------------------------------------*/
 
     next = 0; /* next element in array to be written  */
     rownum = 0; /* row number, relative to firstrow     */
@@ -313,9 +333,7 @@ pub fn ffpcls_safe(
             return *status;
         }
 
-        /*--------------------------------------------*/
         /*  increment the counters for the next loop  */
-        /*--------------------------------------------*/
         remain -= ntodo as LONGLONG;
         if remain > 0 {
             elemnum += ntodo as LONGLONG;
@@ -331,20 +349,30 @@ pub fn ffpcls_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 ///  Write an array of elements to the specified column of a table.  Any input
 ///  pixels flagged as null will be replaced by the appropriate
 ///  null value in the output FITS file.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to write (1 = 1st col)
+/// * `firstrow`  — (I) first row to write (1 = 1st row)
+/// * `firstelem` — (I) first vector element to write (1 = 1st)
+/// * `nelem`     — (I) number of values to write
+/// * `array`     — (I) array of values to write
+/// * `nulvalue`  — (I) string representing a null value
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffpcns(
-    fptr: *mut fitsfile,         /* I - FITS file pointer                       */
-    colnum: c_int,               /* I - number of column to write (1 = 1st col) */
-    firstrow: LONGLONG,          /* I - first row to write (1 = 1st row)        */
-    firstelem: LONGLONG,         /* I - first vector element to write (1 = 1st) */
-    nelem: LONGLONG,             /* I - number of values to write               */
-    array: *const *const c_char, /* I - array of values to write                */
-    nulvalue: *const c_char,     /* I - string representing a null value        */
-    status: *mut c_int,          /* IO - error status                           */
+    fptr: *mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: *const *const c_char,
+    nulvalue: *const c_char,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -374,19 +402,29 @@ pub unsafe extern "C" fn ffpcns(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 ///  Write an array of elements to the specified column of a table.  Any input
 ///  pixels flagged as null will be replaced by the appropriate
 ///  null value in the output FITS file.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to write (1 = 1st col)
+/// * `firstrow`  — (I) first row to write (1 = 1st row)
+/// * `firstelem` — (I) first vector element to write (1 = 1st)
+/// * `nelem`     — (I) number of values to write
+/// * `array`     — (I) array of values to write
+/// * `nulvalue`  — (I) string representing a null value
+/// * `status`    — (IO) error status
 pub fn ffpcns_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                       */
-    colnum: c_int,       /* I - number of column to write (1 = 1st col) */
-    firstrow: LONGLONG,  /* I - first row to write (1 = 1st row)        */
-    firstelem: LONGLONG, /* I - first vector element to write (1 = 1st) */
-    nelem: LONGLONG,     /* I - number of values to write               */
-    array: &[&[c_char]], /* I - array of values to write                */
-    nulvalue: &[c_char], /* I - string representing a null value        */
-    status: &mut c_int,  /* IO - error status                           */
+    fptr: &mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: &[&[c_char]],
+    nulvalue: &[c_char],
+    status: &mut c_int,
 ) -> c_int {
     let mut repeat: c_long = 0;
     let mut width: c_long = 0;

--- a/src/putcolsb.rs
+++ b/src/putcolsb.rs
@@ -1,9 +1,14 @@
-/*  This file, putcolsb.rs, contains routines that write data elements to   */
-/*  a FITS image or table with signed char (signed byte) datatype.         */
-
-/*  The FITSIO software was written by William Pence at the High Energy    */
-/*  Astrophysic Science Archive Research Center (HEASARC) at the NASA      */
-/*  Goddard Space Flight Center.                                           */
+//! Routines that write data elements to a FITS image or table, with signed
+//! char (signed byte) datatype.
+//!
+//! The [`TSBYTE`] arm of the typed column I/O family. [`crate::putcol`]
+//! dispatches here when a caller asks for this datatype at run time; the
+//! write-side counterpart is [`crate::getcolsb`].
+//!
+//! Ported from CFITSIO's `putcolsb.c`, written by William Pence at the High
+//! Energy Astrophysics Science Archive Research Center (HEASARC), NASA Goddard
+//! Space Flight Center.
+#![warn(missing_docs)]
 
 use core::slice;
 use core::{cmp, mem};
@@ -25,7 +30,6 @@ use crate::relibc::header::stdio::snprintf_f64;
 use crate::wrappers::*;
 use crate::{buffers::*, int_snprintf, slice_to_str};
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
 /// the FITS array is not the same as the array being written).
@@ -34,14 +38,23 @@ use crate::{buffers::*, int_snprintf, slice_to_str};
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to write(1 = 1st group)
+/// * `firstelem` — (I) first vector element to write(1 = 1st)
+/// * `nelem`     — (I) number of values to write
+/// * `array`     — (I) array of values that are written
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffpprsb(
-    fptr: *mut fitsfile, /* I - FITS file pointer                      */
-    group: c_long,       /* I - group to write(1 = 1st group)           */
-    firstelem: LONGLONG, /* I - first vector element to write(1 = 1st)  */
-    nelem: LONGLONG,     /* I - number of values to write               */
-    array: *const i8,    /* I - array of values that are written     */
-    status: *mut c_int,  /* IO - error status                           */
+    fptr: *mut fitsfile,
+    group: c_long,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: *const i8,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -54,7 +67,6 @@ pub unsafe extern "C" fn ffpprsb(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
 /// the FITS array is not the same as the array being written).
@@ -63,13 +75,22 @@ pub unsafe extern "C" fn ffpprsb(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to write(1 = 1st group)
+/// * `firstelem` — (I) first vector element to write(1 = 1st)
+/// * `nelem`     — (I) number of values to write
+/// * `array`     — (I) array of values that are written
+/// * `status`    — (IO) error status
 pub fn ffpprsb_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                      */
-    group: c_long,       /* I - group to write(1 = 1st group)           */
-    firstelem: LONGLONG, /* I - first vector element to write(1 = 1st)  */
-    nelem: LONGLONG,     /* I - number of values to write               */
-    array: &[i8],        /* I - array of values that are written     */
-    status: &mut c_int,  /* IO - error status                           */
+    fptr: &mut fitsfile,
+    group: c_long,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: &[i8],
+    status: &mut c_int,
 ) -> c_int {
     let nullvalue: i8 = 0;
 
@@ -102,7 +123,6 @@ pub fn ffpprsb_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of the
 /// FITS array is not the same as the array being written).  Any array values
@@ -113,15 +133,25 @@ pub fn ffpprsb_safe(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to write(1 = 1st group)
+/// * `firstelem` — (I) first vector element to write(1 = 1st)
+/// * `nelem`     — (I) number of values to write
+/// * `array`     — (I) array of values that are written
+/// * `nulval`    — (I) undefined pixel value
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffppnsb(
-    fptr: *mut fitsfile, /* I - FITS file pointer                       */
-    group: c_long,       /* I - group to write(1 = 1st group)           */
-    firstelem: LONGLONG, /* I - first vector element to write(1 = 1st)  */
-    nelem: LONGLONG,     /* I - number of values to write               */
-    array: *const i8,    /* I - array of values that are written   */
-    nulval: i8,          /* I - undefined pixel value              */
-    status: *mut c_int,  /* IO - error status                           */
+    fptr: *mut fitsfile,
+    group: c_long,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: *const i8,
+    nulval: i8,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -133,7 +163,6 @@ pub unsafe extern "C" fn ffppnsb(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of the
 /// FITS array is not the same as the array being written).  Any array values
@@ -144,14 +173,24 @@ pub unsafe extern "C" fn ffppnsb(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to write(1 = 1st group)
+/// * `firstelem` — (I) first vector element to write(1 = 1st)
+/// * `nelem`     — (I) number of values to write
+/// * `array`     — (I) array of values that are written
+/// * `nulval`    — (I) undefined pixel value
+/// * `status`    — (IO) error status
 pub fn ffppnsb_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                       */
-    group: c_long,       /* I - group to write(1 = 1st group)           */
-    firstelem: LONGLONG, /* I - first vector element to write(1 = 1st)  */
-    nelem: LONGLONG,     /* I - number of values to write               */
-    array: &[i8],        /* I - array of values that are written   */
-    nulval: i8,          /* I - undefined pixel value              */
-    status: &mut c_int,  /* IO - error status                           */
+    fptr: &mut fitsfile,
+    group: c_long,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: &[i8],
+    nulval: i8,
+    status: &mut c_int,
 ) -> c_int {
     let mut nullvalue: i8 = 0;
 
@@ -188,19 +227,28 @@ pub fn ffppnsb_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an entire 2-D array of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of the
 /// FITS array is not the same as the array being written).
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `group`  — (I) group to write(1 = 1st group)
+/// * `ncols`  — (I) number of pixels in each row of array
+/// * `naxis1` — (I) FITS image NAXIS1 value
+/// * `naxis2` — (I) FITS image NAXIS2 value
+/// * `array`  — (I) array to be written
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffp2dsb(
-    fptr: *mut fitsfile, /* I - FITS file pointer                     */
-    group: c_long,       /* I - group to write(1 = 1st group)         */
-    ncols: LONGLONG,     /* I - number of pixels in each row of array */
-    naxis1: LONGLONG,    /* I - FITS image NAXIS1 value               */
-    naxis2: LONGLONG,    /* I - FITS image NAXIS2 value               */
-    array: *const i8,    /* I - array to be written               */
-    status: *mut c_int,  /* IO - error status                         */
+    fptr: *mut fitsfile,
+    group: c_long,
+    ncols: LONGLONG,
+    naxis1: LONGLONG,
+    naxis2: LONGLONG,
+    array: *const i8,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -212,18 +260,27 @@ pub unsafe extern "C" fn ffp2dsb(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an entire 2-D array of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of the
 /// FITS array is not the same as the array being written).
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `group`  — (I) group to write(1 = 1st group)
+/// * `ncols`  — (I) number of pixels in each row of array
+/// * `naxis1` — (I) FITS image NAXIS1 value
+/// * `naxis2` — (I) FITS image NAXIS2 value
+/// * `array`  — (I) array to be written
+/// * `status` — (IO) error status
 pub fn ffp2dsb_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                     */
-    group: c_long,       /* I - group to write(1 = 1st group)         */
-    ncols: LONGLONG,     /* I - number of pixels in each row of array */
-    naxis1: LONGLONG,    /* I - FITS image NAXIS1 value               */
-    naxis2: LONGLONG,    /* I - FITS image NAXIS2 value               */
-    array: &[i8],        /* I - array to be written               */
-    status: &mut c_int,  /* IO - error status                         */
+    fptr: &mut fitsfile,
+    group: c_long,
+    ncols: LONGLONG,
+    naxis1: LONGLONG,
+    naxis2: LONGLONG,
+    array: &[i8],
+    status: &mut c_int,
 ) -> c_int {
     /* call the 3D writing routine, with the 3rd dimension = 1 */
     ffp3dsb_safe(fptr, group, ncols, naxis2, naxis1, naxis2, 1, array, status);
@@ -231,7 +288,6 @@ pub fn ffp2dsb_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an entire 3-D cube of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of the
 /// FITS array is not the same as the array being written).
@@ -240,17 +296,29 @@ pub fn ffp2dsb_safe(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `group`  — (I) group to write(1 = 1st group)
+/// * `ncols`  — (I) number of pixels in each row of array
+/// * `nrows`  — (I) number of rows in each plane of array
+/// * `naxis1` — (I) FITS image NAXIS1 value
+/// * `naxis2` — (I) FITS image NAXIS2 value
+/// * `naxis3` — (I) FITS image NAXIS3 value
+/// * `array`  — (I) array to be written
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffp3dsb(
-    fptr: *mut fitsfile, /* I - FITS file pointer                     */
-    group: c_long,       /* I - group to write(1 = 1st group)         */
-    ncols: LONGLONG,     /* I - number of pixels in each row of array */
-    nrows: LONGLONG,     /* I - number of rows in each plane of array */
-    naxis1: LONGLONG,    /* I - FITS image NAXIS1 value               */
-    naxis2: LONGLONG,    /* I - FITS image NAXIS2 value               */
-    naxis3: LONGLONG,    /* I - FITS image NAXIS3 value               */
-    array: *const i8,    /* I - array to be written               */
-    status: *mut c_int,  /* IO - error status                         */
+    fptr: *mut fitsfile,
+    group: c_long,
+    ncols: LONGLONG,
+    nrows: LONGLONG,
+    naxis1: LONGLONG,
+    naxis2: LONGLONG,
+    naxis3: LONGLONG,
+    array: *const i8,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -265,7 +333,6 @@ pub unsafe extern "C" fn ffp3dsb(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an entire 3-D cube of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of the
 /// FITS array is not the same as the array being written).
@@ -274,16 +341,28 @@ pub unsafe extern "C" fn ffp3dsb(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `group`  — (I) group to write(1 = 1st group)
+/// * `ncols`  — (I) number of pixels in each row of array
+/// * `nrows`  — (I) number of rows in each plane of array
+/// * `naxis1` — (I) FITS image NAXIS1 value
+/// * `naxis2` — (I) FITS image NAXIS2 value
+/// * `naxis3` — (I) FITS image NAXIS3 value
+/// * `array`  — (I) array to be written
+/// * `status` — (IO) error status
 pub fn ffp3dsb_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                     */
-    group: c_long,       /* I - group to write(1 = 1st group)         */
-    ncols: LONGLONG,     /* I - number of pixels in each row of array */
-    nrows: LONGLONG,     /* I - number of rows in each plane of array */
-    naxis1: LONGLONG,    /* I - FITS image NAXIS1 value               */
-    naxis2: LONGLONG,    /* I - FITS image NAXIS2 value               */
-    naxis3: LONGLONG,    /* I - FITS image NAXIS3 value               */
-    array: &[i8],        /* I - array to be written               */
-    status: &mut c_int,  /* IO - error status                         */
+    fptr: &mut fitsfile,
+    group: c_long,
+    ncols: LONGLONG,
+    nrows: LONGLONG,
+    naxis1: LONGLONG,
+    naxis2: LONGLONG,
+    naxis3: LONGLONG,
+    array: &[i8],
+    status: &mut c_int,
 ) -> c_int {
     let fpixel: [c_long; 3] = [1; 3];
     let mut lpixel: [c_long; 3] = [0; 3];
@@ -361,7 +440,6 @@ pub fn ffp3dsb_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write a subsection of pixels to the primary array or image.
 ///
 /// A subsection is defined to be any contiguous rectangular
@@ -369,16 +447,27 @@ pub fn ffp3dsb_safe(
 /// Data conversion and scaling will be performed if necessary
 /// (e.g, if the datatype of the FITS array is not the same as
 /// the array being written).
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `group`  — (I) group to write(1 = 1st group)
+/// * `naxis`  — (I) number of data axes in array
+/// * `naxes`  — (I) size of each FITS axis
+/// * `fpixel` — (I) 1st pixel in each axis to write (1=1st)
+/// * `lpixel` — (I) last pixel in each axis to write
+/// * `array`  — (I) array to be written
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffpsssb(
-    fptr: *mut fitsfile,   /* I - FITS file pointer                       */
-    group: c_long,         /* I - group to write(1 = 1st group)           */
-    naxis: c_long,         /* I - number of data axes in array            */
-    naxes: *const c_long,  /* I - size of each FITS axis                  */
-    fpixel: *const c_long, /* I - 1st pixel in each axis to write (1=1st) */
-    lpixel: *const c_long, /* I - last pixel in each axis to write        */
-    array: *const i8,      /* I - array to be written                 */
-    status: *mut c_int,    /* IO - error status                           */
+    fptr: *mut fitsfile,
+    group: c_long,
+    naxis: c_long,
+    naxes: *const c_long,
+    fpixel: *const c_long,
+    lpixel: *const c_long,
+    array: *const i8,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -400,7 +489,6 @@ pub unsafe extern "C" fn ffpsssb(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write a subsection of pixels to the primary array or image.
 ///
 /// A subsection is defined to be any contiguous rectangular
@@ -408,15 +496,26 @@ pub unsafe extern "C" fn ffpsssb(
 /// Data conversion and scaling will be performed if necessary
 /// (e.g, if the datatype of the FITS array is not the same as
 /// the array being written).
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `group`  — (I) group to write(1 = 1st group)
+/// * `naxis`  — (I) number of data axes in array
+/// * `naxes`  — (I) size of each FITS axis
+/// * `fpixel` — (I) 1st pixel in each axis to write (1=1st)
+/// * `lpixel` — (I) last pixel in each axis to write
+/// * `array`  — (I) array to be written
+/// * `status` — (IO) error status
 pub fn ffpsssb_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                       */
-    group: c_long,       /* I - group to write(1 = 1st group)           */
-    naxis: c_long,       /* I - number of data axes in array            */
-    naxes: &[c_long],    /* I - size of each FITS axis                  */
-    fpixel: &[c_long],   /* I - 1st pixel in each axis to write (1=1st) */
-    lpixel: &[c_long],   /* I - last pixel in each axis to write        */
-    array: &[i8],        /* I - array to be written                 */
-    status: &mut c_int,  /* IO - error status                           */
+    fptr: &mut fitsfile,
+    group: c_long,
+    naxis: c_long,
+    naxes: &[c_long],
+    fpixel: &[c_long],
+    lpixel: &[c_long],
+    array: &[i8],
+    status: &mut c_int,
 ) -> c_int {
     let mut fpix: [LONGLONG; 7] = [0; 7];
     let mut dimen: [LONGLONG; 7] = [0; 7];
@@ -544,7 +643,6 @@ pub fn ffpsssb_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of group parameters to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
 /// the FITS array is not the same as the array being written).
@@ -553,14 +651,23 @@ pub fn ffpsssb_safe(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to write(1 = 1st group)
+/// * `firstelem` — (I) first vector element to write(1 = 1st)
+/// * `nelem`     — (I) number of values to write
+/// * `array`     — (I) array of values that are written
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffpgpsb(
-    fptr: *mut fitsfile, /* I - FITS file pointer                      */
-    group: c_long,       /* I - group to write(1 = 1st group)          */
-    firstelem: c_long,   /* I - first vector element to write(1 = 1st) */
-    nelem: c_long,       /* I - number of values to write              */
-    array: *const i8,    /* I - array of values that are written   */
-    status: *mut c_int,  /* IO - error status                          */
+    fptr: *mut fitsfile,
+    group: c_long,
+    firstelem: c_long,
+    nelem: c_long,
+    array: *const i8,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -572,7 +679,6 @@ pub unsafe extern "C" fn ffpgpsb(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of group parameters to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
 /// the FITS array is not the same as the array being written).
@@ -581,13 +687,22 @@ pub unsafe extern "C" fn ffpgpsb(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to write(1 = 1st group)
+/// * `firstelem` — (I) first vector element to write(1 = 1st)
+/// * `nelem`     — (I) number of values to write
+/// * `array`     — (I) array of values that are written
+/// * `status`    — (IO) error status
 pub fn ffpgpsb_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                      */
-    group: c_long,       /* I - group to write(1 = 1st group)          */
-    firstelem: c_long,   /* I - first vector element to write(1 = 1st) */
-    nelem: c_long,       /* I - number of values to write              */
-    array: &[i8],        /* I - array of values that are written   */
-    status: &mut c_int,  /* IO - error status                          */
+    fptr: &mut fitsfile,
+    group: c_long,
+    firstelem: c_long,
+    nelem: c_long,
+    array: &[i8],
+    status: &mut c_int,
 ) -> c_int {
     let row = cmp::max(1, group);
 
@@ -603,7 +718,6 @@ pub fn ffpgpsb_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of values to a column in the current FITS HDU.
 ///
 /// The column number may refer to a real column in an ASCII or binary table,
@@ -616,15 +730,25 @@ pub fn ffpgpsb_safe(
 ///
 /// The input array of values will be converted to the datatype of the column
 /// and will be inverse-scaled by the FITS TSCALn and TZEROn values if necessary.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to write (1 = 1st col)
+/// * `firstrow`  — (I) first row to write (1 = 1st row)
+/// * `firstelem` — (I) first vector element to write (1 = 1st)
+/// * `nelem`     — (I) number of values to write
+/// * `array`     — (I) array of values to write
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffpclsb(
-    fptr: *mut fitsfile, /* I - FITS file pointer                       */
-    colnum: c_int,       /* I - number of column to write (1 = 1st col) */
-    firstrow: LONGLONG,  /* I - first row to write (1 = 1st row)        */
-    firstelem: LONGLONG, /* I - first vector element to write (1 = 1st) */
-    nelem: LONGLONG,     /* I - number of values to write               */
-    array: *const i8,    /* I - array of values to write           */
-    status: *mut c_int,  /* IO - error status                           */
+    fptr: *mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: *const i8,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -645,7 +769,6 @@ pub unsafe extern "C" fn ffpclsb(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of values to a column in the current FITS HDU.
 ///
 /// The column number may refer to a real column in an ASCII or binary table,
@@ -658,14 +781,24 @@ pub unsafe extern "C" fn ffpclsb(
 ///
 /// The input array of values will be converted to the datatype of the column
 /// and will be inverse-scaled by the FITS TSCALn and TZEROn values if necessary.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to write (1 = 1st col)
+/// * `firstrow`  — (I) first row to write (1 = 1st row)
+/// * `firstelem` — (I) first vector element to write (1 = 1st)
+/// * `nelem`     — (I) number of values to write
+/// * `array`     — (I) array of values to write
+/// * `status`    — (IO) error status
 pub fn ffpclsb_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                       */
-    colnum: c_int,       /* I - number of column to write (1 = 1st col) */
-    firstrow: LONGLONG,  /* I - first row to write (1 = 1st row)        */
-    firstelem: LONGLONG, /* I - first vector element to write (1 = 1st) */
-    nelem: LONGLONG,     /* I - number of values to write               */
-    array: &[i8],        /* I - array of values to write           */
-    status: &mut c_int,  /* IO - error status                           */
+    fptr: &mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: &[i8],
+    status: &mut c_int,
 ) -> c_int {
     let mut writemode: c_int = 0;
     let mut tcode: c_int = 0;
@@ -698,9 +831,7 @@ pub fn ffpclsb_safe(
         return *status;
     }
 
-    /*---------------------------------------------------*/
     /*  Check input and get parameters about the column: */
-    /*---------------------------------------------------*/
 
     /* IMPORTANT NOTE: that the special case of using this subroutine
     to write bytes to a character column are handled internally
@@ -742,12 +873,10 @@ pub fn ffpclsb_safe(
         ffcfmt(&tform, &mut cform); /* derive C format for writing strings */
     }
 
-    /*---------------------------------------------------------------------*/
     /*  Now write the pixels to the FITS column.                           */
     /*  First call the ffXXfYY routine to  (1) convert the datatype        */
     /*  if necessary, and (2) scale the values by the FITS TSCALn and      */
     /*  TZEROn linear scaling parameters into a temporary buffer.          */
-    /*---------------------------------------------------------------------*/
     remain = nelem; /* remaining number of values to write  */
     next = 0; /* next element in array to be written  */
     rownum = 0; /* row number, relative to firstrow     */
@@ -928,9 +1057,7 @@ pub fn ffpclsb_safe(
             }
         } /* End of switch block */
 
-        /*-------------------------*/
         /*  Check for fatal error  */
-        /*-------------------------*/
         if *status > 0 {
             /* test for error during previous write operation */
 
@@ -945,9 +1072,7 @@ pub fn ffpclsb_safe(
             return *status;
         }
 
-        /*--------------------------------------------*/
         /*  increment the counters for the next loop  */
-        /*--------------------------------------------*/
         remain -= ntodo as LONGLONG;
         if remain > 0 {
             next += ntodo as LONGLONG;
@@ -961,9 +1086,7 @@ pub fn ffpclsb_safe(
         }
     } /*  End of main while Loop  */
 
-    /*--------------------------------*/
     /*  check for numerical overflow  */
-    /*--------------------------------*/
     if *status == OVERFLOW_ERR {
         ffpmsg_str("Numerical overflow during type conversion while writing FITS data.");
         *status = NUM_OVERFLOW;
@@ -972,23 +1095,33 @@ pub fn ffpclsb_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of elements to the specified column of a table.  Any input
 /// pixels equal to the value of nulvalue will be replaced by the appropriate
 /// null value in the output FITS file.
 ///
 /// The input array of values will be converted to the datatype of the column
 /// and will be inverse-scaled by the FITS TSCALn and TZEROn values if necessary
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to write (1 = 1st col)
+/// * `firstrow`  — (I) first row to write (1 = 1st row)
+/// * `firstelem` — (I) first vector element to write (1 = 1st)
+/// * `nelem`     — (I) number of values to write
+/// * `array`     — (I) array of values to write
+/// * `nulvalue`  — (I) flag for undefined pixels
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffpcnsb(
-    fptr: *mut fitsfile, /* I - FITS file pointer                       */
-    colnum: c_int,       /* I - number of column to write (1 = 1st col) */
-    firstrow: LONGLONG,  /* I - first row to write (1 = 1st row)        */
-    firstelem: LONGLONG, /* I - first vector element to write (1 = 1st) */
-    nelem: LONGLONG,     /* I - number of values to write               */
-    array: *const i8,    /* I - array of values to write         */
-    nulvalue: i8,        /* I - flag for undefined pixels        */
-    status: *mut c_int,  /* IO - error status                           */
+    fptr: *mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: *const i8,
+    nulvalue: i8,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -1010,22 +1143,32 @@ pub unsafe extern "C" fn ffpcnsb(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of elements to the specified column of a table.  Any input
 /// pixels equal to the value of nulvalue will be replaced by the appropriate
 /// null value in the output FITS file.
 ///
 /// The input array of values will be converted to the datatype of the column
 /// and will be inverse-scaled by the FITS TSCALn and TZEROn values if necessary
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to write (1 = 1st col)
+/// * `firstrow`  — (I) first row to write (1 = 1st row)
+/// * `firstelem` — (I) first vector element to write (1 = 1st)
+/// * `nelem`     — (I) number of values to write
+/// * `array`     — (I) array of values to write
+/// * `nulvalue`  — (I) flag for undefined pixels
+/// * `status`    — (IO) error status
 pub fn ffpcnsb_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                       */
-    colnum: c_int,       /* I - number of column to write (1 = 1st col) */
-    firstrow: LONGLONG,  /* I - first row to write (1 = 1st row)        */
-    firstelem: LONGLONG, /* I - first vector element to write (1 = 1st) */
-    nelem: LONGLONG,     /* I - number of values to write               */
-    array: &[i8],        /* I - array of values to write         */
-    nulvalue: i8,        /* I - flag for undefined pixels        */
-    status: &mut c_int,  /* IO - error status                           */
+    fptr: &mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: &[i8],
+    nulvalue: i8,
+    status: &mut c_int,
 ) -> c_int {
     let mut ngood: LONGLONG = 0;
     let mut nbad: LONGLONG = 0;
@@ -1179,16 +1322,24 @@ pub fn ffpcnsb_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output prior to writing output to a FITS file.
 /// Do datatype conversion and scaling if required
+///
+/// # Parameters
+///
+/// * `input`  — (I) array of values to be converted
+/// * `ntodo`  — (I) number of elements in the array
+/// * `scale`  — (I) FITS TSCALn or BSCALE value
+/// * `zero`   — (I) FITS TZEROn or BZERO value
+/// * `output` — (O) output array of converted values
+/// * `status` — (IO) error status
 pub(crate) fn ffs1fi1(
-    input: &[i8],       /* I - array of values to be converted  */
-    ntodo: c_long,      /* I - number of elements in the array  */
-    scale: f64,         /* I - FITS TSCALn or BSCALE value      */
-    zero: f64,          /* I - FITS TZEROn or BZERO  value      */
-    output: &mut [u8],  /* O - output array of converted values */
-    status: &mut c_int, /* IO - error status                    */
+    input: &[i8],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    output: &mut [u8],
+    status: &mut c_int,
 ) -> c_int {
     if scale == 1.0 && zero == -128. {
         /* Instead of adding 128, it is more efficient */
@@ -1224,16 +1375,24 @@ pub(crate) fn ffs1fi1(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output prior to writing output to a FITS file.
 /// Do datatype conversion and scaling if required
+///
+/// # Parameters
+///
+/// * `input`  — (I) array of values to be converted
+/// * `ntodo`  — (I) number of elements in the array
+/// * `scale`  — (I) FITS TSCALn or BSCALE value
+/// * `zero`   — (I) FITS TZEROn or BZERO value
+/// * `output` — (O) output array of converted values
+/// * `status` — (IO) error status
 pub(crate) fn ffs1fi2(
-    input: &[i8],           /* I - array of values to be converted  */
-    ntodo: c_long,          /* I - number of elements in the array  */
-    scale: f64,             /* I - FITS TSCALn or BSCALE value      */
-    zero: f64,              /* I - FITS TZEROn or BZERO  value      */
-    output: &mut [c_short], /* O - output array of converted values */
-    status: &mut c_int,     /* IO - error status                    */
+    input: &[i8],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    output: &mut [c_short],
+    status: &mut c_int,
 ) -> c_int {
     if scale == 1.0 && zero == 0.0 {
         for ii in 0..(ntodo as usize) {
@@ -1259,16 +1418,24 @@ pub(crate) fn ffs1fi2(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output prior to writing output to a FITS file.
 /// Do datatype conversion and scaling if required
+///
+/// # Parameters
+///
+/// * `input`  — (I) array of values to be converted
+/// * `ntodo`  — (I) number of elements in the array
+/// * `scale`  — (I) FITS TSCALn or BSCALE value
+/// * `zero`   — (I) FITS TZEROn or BZERO value
+/// * `output` — (O) output array of converted values
+/// * `status` — (IO) error status
 pub(crate) fn ffs1fi4(
-    input: &[i8],            /* I - array of values to be converted  */
-    ntodo: c_long,           /* I - number of elements in the array  */
-    scale: f64,              /* I - FITS TSCALn or BSCALE value      */
-    zero: f64,               /* I - FITS TZEROn or BZERO  value      */
-    output: &mut [INT32BIT], /* O - output array of converted values */
-    status: &mut c_int,      /* IO - error status                    */
+    input: &[i8],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    output: &mut [INT32BIT],
+    status: &mut c_int,
 ) -> c_int {
     if scale == 1.0 && zero == 0.0 {
         for ii in 0..(ntodo as usize) {
@@ -1294,16 +1461,24 @@ pub(crate) fn ffs1fi4(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output prior to writing output to a FITS file.
 /// Do datatype conversion and scaling if required
+///
+/// # Parameters
+///
+/// * `input`  — (I) array of values to be converted
+/// * `ntodo`  — (I) number of elements in the array
+/// * `scale`  — (I) FITS TSCALn or BSCALE value
+/// * `zero`   — (I) FITS TZEROn or BZERO value
+/// * `output` — (O) output array of converted values
+/// * `status` — (IO) error status
 pub(crate) fn ffs1fi8(
-    input: &[i8],            /* I - array of values to be converted  */
-    ntodo: c_long,           /* I - number of elements in the array  */
-    scale: f64,              /* I - FITS TSCALn or BSCALE value      */
-    zero: f64,               /* I - FITS TZEROn or BZERO  value      */
-    output: &mut [LONGLONG], /* O - output array of converted values */
-    status: &mut c_int,      /* IO - error status                    */
+    input: &[i8],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    output: &mut [LONGLONG],
+    status: &mut c_int,
 ) -> c_int {
     if scale == 1.0 && zero == 9223372036854775808. {
         /* Writing to unsigned long long column. */
@@ -1345,16 +1520,24 @@ pub(crate) fn ffs1fi8(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output prior to writing output to a FITS file.
 /// Do datatype conversion and scaling if required.
+///
+/// # Parameters
+///
+/// * `input`  — (I) array of values to be converted
+/// * `ntodo`  — (I) number of elements in the array
+/// * `scale`  — (I) FITS TSCALn or BSCALE value
+/// * `zero`   — (I) FITS TZEROn or BZERO value
+/// * `output` — (O) output array of converted values
+/// * `status` — (IO) error status
 pub(crate) fn ffs1fr4(
-    input: &[i8],       /* I - array of values to be converted  */
-    ntodo: c_long,      /* I - number of elements in the array  */
-    scale: f64,         /* I - FITS TSCALn or BSCALE value      */
-    zero: f64,          /* I - FITS TZEROn or BZERO  value      */
-    output: &mut [f32], /* O - output array of converted values */
-    status: &mut c_int, /* IO - error status                    */
+    input: &[i8],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    output: &mut [f32],
+    status: &mut c_int,
 ) -> c_int {
     if scale == 1.0 && zero == 0.0 {
         for ii in 0..(ntodo as usize) {
@@ -1368,16 +1551,24 @@ pub(crate) fn ffs1fr4(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output prior to writing output to a FITS file.
 /// Do datatype conversion and scaling if required.
+///
+/// # Parameters
+///
+/// * `input`  — (I) array of values to be converted
+/// * `ntodo`  — (I) number of elements in the array
+/// * `scale`  — (I) FITS TSCALn or BSCALE value
+/// * `zero`   — (I) FITS TZEROn or BZERO value
+/// * `output` — (O) output array of converted values
+/// * `status` — (IO) error status
 pub(crate) fn ffs1fr8(
-    input: &[i8],       /* I - array of values to be converted  */
-    ntodo: c_long,      /* I - number of elements in the array  */
-    scale: f64,         /* I - FITS TSCALn or BSCALE value      */
-    zero: f64,          /* I - FITS TZEROn or BZERO  value      */
-    output: &mut [f64], /* O - output array of converted values */
-    status: &mut c_int, /* IO - error status                    */
+    input: &[i8],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    output: &mut [f64],
+    status: &mut c_int,
 ) -> c_int {
     if scale == 1.0 && zero == 0.0 {
         for ii in 0..(ntodo as usize) {
@@ -1391,18 +1582,28 @@ pub(crate) fn ffs1fr8(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output prior to writing output to a FITS file.
 /// Do scaling if required.
+///
+/// # Parameters
+///
+/// * `input`  — (I) array of values to be converted
+/// * `ntodo`  — (I) number of elements in the array
+/// * `scale`  — (I) FITS TSCALn or BSCALE value
+/// * `zero`   — (I) FITS TZEROn or BZERO value
+/// * `cform`  — (I) format for output string values
+/// * `twidth` — (I) width of each field, in chars
+/// * `output` — (O) output array of converted values
+/// * `status` — (IO) error status
 pub(crate) fn ffs1fstr(
-    input: &[i8],          /* I - array of values to be converted  */
-    ntodo: c_long,         /* I - number of elements in the array  */
-    scale: f64,            /* I - FITS TSCALn or BSCALE value      */
-    zero: f64,             /* I - FITS TZEROn or BZERO  value      */
-    cform: &[c_char],      /* I - format for output string values  */
-    twidth: c_long,        /* I - width of each field, in chars    */
-    output: &mut [c_char], /* O - output array of converted values */
-    status: &mut c_int,    /* IO - error status                    */
+    input: &[i8],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    cform: &[c_char],
+    twidth: c_long,
+    output: &mut [c_char],
+    status: &mut c_int,
 ) -> c_int {
     let mut ci = 0;
 

--- a/src/putcolu.rs
+++ b/src/putcolu.rs
@@ -1,9 +1,14 @@
-/*  This file, putcolu.rs, contains routines that write data elements to    */
-/*  a FITS image or table.  Writes null values.                            */
-
-/*  The FITSIO software was written by William Pence at the High Energy    */
-/*  Astrophysic Science Archive Research Center (HEASARC) at the NASA      */
-/*  Goddard Space Flight Center.                                           */
+//! Routines that write null values to a FITS image or table.
+//!
+//! Unlike the rest of the typed column I/O family, these write no data of their
+//! own: they mark elements as undefined. How that is done depends on the
+//! column: an integer column stores its `TNULLn` value, a floating point column
+//! stores an IEEE NaN, and an ASCII table column stores its null string.
+//!
+//! Ported from CFITSIO's `putcolu.c`, written by William Pence at the High
+//! Energy Astrophysics Science Archive Research Center (HEASARC), NASA Goddard
+//! Space Flight Center.
+#![warn(missing_docs)]
 
 use core::cmp;
 
@@ -20,20 +25,27 @@ use crate::fitsio2::*;
 use crate::wrappers::*;
 use crate::{buffers::*, int_snprintf, slice_to_str};
 
-/*--------------------------------------------------------------------------*/
 /// Write null values to the primary array.
 ///
 /// The primary array is represented as a binary table:
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to write(1 = 1st group)
+/// * `firstelem` — (I) first vector element to write(1 = 1st)
+/// * `nelem`     — (I) number of values to write
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffppru(
-    fptr: *mut fitsfile, /* I - FITS file pointer                       */
-    group: c_long,       /* I - group to write(1 = 1st group)          */
-    firstelem: LONGLONG, /* I - first vector element to write(1 = 1st) */
-    nelem: LONGLONG,     /* I - number of values to write              */
-    status: *mut c_int,  /* IO - error status                          */
+    fptr: *mut fitsfile,
+    group: c_long,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -44,19 +56,26 @@ pub unsafe extern "C" fn ffppru(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write null values to the primary array.
 ///
 /// The primary array is represented as a binary table:
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to write(1 = 1st group)
+/// * `firstelem` — (I) first vector element to write(1 = 1st)
+/// * `nelem`     — (I) number of values to write
+/// * `status`    — (IO) error status
 pub fn ffppru_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                       */
-    group: c_long,       /* I - group to write(1 = 1st group)          */
-    firstelem: LONGLONG, /* I - first vector element to write(1 = 1st) */
-    nelem: LONGLONG,     /* I - number of values to write              */
-    status: &mut c_int,  /* IO - error status                          */
+    fptr: &mut fitsfile,
+    group: c_long,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    status: &mut c_int,
 ) -> c_int {
     if fits_is_compressed_image_safe(fptr, status) > 0 {
         /* this is a compressed image in a binary table */
@@ -79,19 +98,25 @@ pub fn ffppru_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write null values to the primary array. (Doesn't support groups).
 ///
 /// The primary array is represented as a binary table:
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `firstelem` — (I) first vector element to write(1 = 1st)
+/// * `nelem`     — (I) number of values to write
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffpprn(
-    fptr: *mut fitsfile, /* I - FITS file pointer                       */
-    firstelem: LONGLONG, /* I - first vector element to write(1 = 1st) */
-    nelem: LONGLONG,     /* I - number of values to write              */
-    status: *mut c_int,  /* IO - error status                          */
+    fptr: *mut fitsfile,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -102,18 +127,24 @@ pub unsafe extern "C" fn ffpprn(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write null values to the primary array. (Doesn't support groups).
 ///
 /// The primary array is represented as a binary table:
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `firstelem` — (I) first vector element to write(1 = 1st)
+/// * `nelem`     — (I) number of values to write
+/// * `status`    — (IO) error status
 pub fn ffpprn_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                       */
-    firstelem: LONGLONG, /* I - first vector element to write(1 = 1st) */
-    nelem: LONGLONG,     /* I - number of values to write              */
-    status: &mut c_int,  /* IO - error status                          */
+    fptr: &mut fitsfile,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    status: &mut c_int,
 ) -> c_int {
     let row: c_long = 1;
 
@@ -137,7 +168,6 @@ pub fn ffpprn_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Set elements of a table column to the appropriate null value for the column
 /// The column number may refer to a real column in an ASCII or binary table,
 /// or it may refer to a virtual column in a 1 or more grouped FITS primary
@@ -149,14 +179,23 @@ pub fn ffpprn_safe(
 ///
 /// This routine support COMPLEX and DOUBLE COMPLEX binary table columns, and
 /// sets both the real and imaginary components of the element to a NaN.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to write (1 = 1st col)
+/// * `firstrow`  — (I) first row to write (1 = 1st row)
+/// * `firstelem` — (I) first vector element to write (1 = 1st)
+/// * `nelempar`  — (I) number of values to write
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffpclu(
-    fptr: *mut fitsfile, /* I - FITS file pointer                       */
-    colnum: c_int,       /* I - number of column to write (1 = 1st col) */
-    firstrow: LONGLONG,  /* I - first row to write (1 = 1st row)        */
-    firstelem: LONGLONG, /* I - first vector element to write (1 = 1st) */
-    nelempar: LONGLONG,  /* I - number of values to write               */
-    status: *mut c_int,  /* IO - error status                           */
+    fptr: *mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelempar: LONGLONG,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -167,7 +206,6 @@ pub unsafe extern "C" fn ffpclu(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Set elements of a table column to the appropriate null value for the column
 /// The column number may refer to a real column in an ASCII or binary table,
 /// or it may refer to a virtual column in a 1 or more grouped FITS primary
@@ -179,13 +217,22 @@ pub unsafe extern "C" fn ffpclu(
 ///
 /// This routine support COMPLEX and DOUBLE COMPLEX binary table columns, and
 /// sets both the real and imaginary components of the element to a NaN.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to write (1 = 1st col)
+/// * `firstrow`  — (I) first row to write (1 = 1st row)
+/// * `firstelem` — (I) first vector element to write (1 = 1st)
+/// * `nelempar`  — (I) number of values to write
+/// * `status`    — (IO) error status
 pub fn ffpclu_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                       */
-    colnum: c_int,       /* I - number of column to write (1 = 1st col) */
-    firstrow: LONGLONG,  /* I - first row to write (1 = 1st row)        */
-    firstelem: LONGLONG, /* I - first vector element to write (1 = 1st) */
-    nelempar: LONGLONG,  /* I - number of values to write               */
-    status: &mut c_int,  /* IO - error status                           */
+    fptr: &mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelempar: LONGLONG,
+    status: &mut c_int,
 ) -> c_int {
     let mut tcode: c_int = 0;
     let mut maxelem: c_int = 0;
@@ -230,9 +277,7 @@ pub fn ffpclu_safe(
 
     largeelem = firstelem;
 
-    /*---------------------------------------------------*/
     /*  Check input and get parameters about the column: */
-    /*---------------------------------------------------*/
 
     /* note that writemode = 2 by default (not 1), so that the returned */
     /* repeat and incre values will be the actual values for this column. */
@@ -326,9 +371,7 @@ pub fn ffpclu_safe(
         }
     }
 
-    /*---------------------------------------------------------------------*/
     /*  Now write the pixels to the FITS column.                           */
-    /*---------------------------------------------------------------------*/
     remain = nelem; /* remaining number of values to write  */
     next = 0; /* next element in array to be written  */
     rownum = 0; /* row number, relative to firstrow     */
@@ -399,9 +442,7 @@ pub fn ffpclu_safe(
             }
         } /* End of switch block */
 
-        /*-------------------------*/
         /*  Check for fatal error  */
-        /*-------------------------*/
         if *status > 0 {
             /* test for error during previous write operation */
 
@@ -417,9 +458,7 @@ pub fn ffpclu_safe(
             return *status;
         }
 
-        /*--------------------------------------------*/
         /*  increment the counters for the next loop  */
-        /*--------------------------------------------*/
         remain -= ntodo as LONGLONG;
         if remain > 0 {
             next += ntodo as LONGLONG;
@@ -437,7 +476,6 @@ pub fn ffpclu_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Set elements of a table column to the appropriate null value for the column
 /// The column number may refer to a real column in an ASCII or binary table,
 /// or it may refer to a virtual column in a 1 or more grouped FITS primary
@@ -451,13 +489,22 @@ pub fn ffpclu_safe(
 /// (unlike the similar ffpclu routine).  This routine is mainly for use by
 /// ffpcne which already compensates for the effective doubling of the number of
 /// elements in a complex column.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to write (1 = 1st col)
+/// * `firstrow`  — (I) first row to write (1 = 1st row)
+/// * `firstelem` — (I) first vector element to write (1 = 1st)
+/// * `nelem`     — (I) number of values to write
+/// * `status`    — (IO) error status
 pub(crate) fn ffpcluc(
-    fptr: &mut fitsfile, /* I - FITS file pointer                       */
-    colnum: c_int,       /* I - number of column to write (1 = 1st col) */
-    firstrow: LONGLONG,  /* I - first row to write (1 = 1st row)        */
-    firstelem: LONGLONG, /* I - first vector element to write (1 = 1st) */
-    nelem: LONGLONG,     /* I - number of values to write               */
-    status: &mut c_int,  /* IO - error status                           */
+    fptr: &mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    status: &mut c_int,
 ) -> c_int {
     let mut tcode: c_int = 0;
     let mut maxelem: c_int = 0;
@@ -497,9 +544,7 @@ pub(crate) fn ffpcluc(
         return *status;
     }
 
-    /*---------------------------------------------------*/
     /*  Check input and get parameters about the column: */
-    /*---------------------------------------------------*/
 
     /* note that writemode = 2 by default (not 1), so that the returned */
     /* repeat and incre values will be the actual values for this column. */
@@ -589,9 +634,7 @@ pub(crate) fn ffpcluc(
         }
     }
 
-    /*---------------------------------------------------------------------*/
     /*  Now write the pixels to the FITS column.                           */
-    /*---------------------------------------------------------------------*/
     remain = nelem; /* remaining number of values to write  */
     next = 0; /* next element in array to be written  */
     rownum = 0; /* row number, relative to firstrow     */
@@ -667,9 +710,7 @@ pub(crate) fn ffpcluc(
             }
         } /* End of switch block */
 
-        /*-------------------------*/
         /*  Check for fatal error  */
-        /*-------------------------*/
         if *status > 0 {
             /* test for error during previous write operation */
 
@@ -685,9 +726,7 @@ pub(crate) fn ffpcluc(
             return *status;
         }
 
-        /*--------------------------------------------*/
         /*  increment the counters for the next loop  */
-        /*--------------------------------------------*/
         remain -= ntodo as LONGLONG;
         if remain > 0 {
             next += ntodo as LONGLONG;
@@ -705,8 +744,7 @@ pub(crate) fn ffpcluc(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
-/// fits_write_nullrows / ffprwu - write TNULLs to all columns in one or more rows
+/// Fits_write_nullrows / ffprwu - write TNULLs to all columns in one or more rows
 ///
 /// fitsfile *fptr - pointer to FITS HDU opened for read/write
 /// long int firstrow - first table row to set to null. (firstrow >= 1)
@@ -732,8 +770,7 @@ pub unsafe extern "C" fn ffprwu(
     }
 }
 
-/*--------------------------------------------------------------------------*/
-/// fits_write_nullrows / ffprwu - write TNULLs to all columns in one or more rows
+/// Fits_write_nullrows / ffprwu - write TNULLs to all columns in one or more rows
 ///
 /// fitsfile *fptr - pointer to FITS HDU opened for read/write
 /// long int firstrow - first table row to set to null. (firstrow >= 1)

--- a/src/putcolui.rs
+++ b/src/putcolui.rs
@@ -1,9 +1,14 @@
-/*  This file, putcolui.rs, contains routines that write data elements to   */
-/*  a FITS image or table, with unsigned short datatype.                   */
-
-/*  The FITSIO software was written by William Pence at the High Energy    */
-/*  Astrophysic Science Archive Research Center (HEASARC) at the NASA      */
-/*  Goddard Space Flight Center.                                           */
+//! Routines that write data elements to a FITS image or table, with
+//! unsigned short datatype.
+//!
+//! The [`TUSHORT`] arm of the typed column I/O family. [`crate::putcol`]
+//! dispatches here when a caller asks for this datatype at run time; the
+//! write-side counterpart is [`crate::getcolui`].
+//!
+//! Ported from CFITSIO's `putcolui.c`, written by William Pence at the High
+//! Energy Astrophysics Science Archive Research Center (HEASARC), NASA Goddard
+//! Space Flight Center.
+#![warn(missing_docs)]
 
 use core::slice;
 use core::{cmp, mem};
@@ -25,7 +30,6 @@ use crate::relibc::header::stdio::snprintf_f64;
 use crate::wrappers::strlen_safe;
 use crate::{buffers::*, int_snprintf, slice_to_str};
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
 /// the FITS array is not the same as the array being written).
@@ -34,14 +38,23 @@ use crate::{buffers::*, int_snprintf, slice_to_str};
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to write (1 = 1st group)
+/// * `firstelem` — (I) first vector element to write (1 = 1st)
+/// * `nelem`     — (I) number of values to write
+/// * `array`     — (I) array of values that are written
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffpprui(
-    fptr: *mut fitsfile,    /* I - FITS file pointer                       */
-    group: c_long,          /* I - group to write (1 = 1st group)          */
-    firstelem: LONGLONG,    /* I - first vector element to write (1 = 1st) */
-    nelem: LONGLONG,        /* I - number of values to write               */
-    array: *const c_ushort, /* I - array of values that are written        */
-    status: *mut c_int,     /* IO - error status                           */
+    fptr: *mut fitsfile,
+    group: c_long,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: *const c_ushort,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -53,7 +66,6 @@ pub unsafe extern "C" fn ffpprui(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
 /// the FITS array is not the same as the array being written).
@@ -62,13 +74,22 @@ pub unsafe extern "C" fn ffpprui(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to write (1 = 1st group)
+/// * `firstelem` — (I) first vector element to write (1 = 1st)
+/// * `nelem`     — (I) number of values to write
+/// * `array`     — (I) array of values that are written
+/// * `status`    — (IO) error status
 pub fn ffpprui_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                       */
-    group: c_long,       /* I - group to write (1 = 1st group)          */
-    firstelem: LONGLONG, /* I - first vector element to write (1 = 1st) */
-    nelem: LONGLONG,     /* I - number of values to write               */
-    array: &[c_ushort],  /* I - array of values that are written        */
-    status: &mut c_int,  /* IO - error status                           */
+    fptr: &mut fitsfile,
+    group: c_long,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: &[c_ushort],
+    status: &mut c_int,
 ) -> c_int {
     let nullvalue: c_ushort = 0;
 
@@ -102,7 +123,6 @@ pub fn ffpprui_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of the
 /// FITS array is not the same as the array being written).  Any array values
@@ -113,15 +133,25 @@ pub fn ffpprui_safe(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to write(1 = 1st group)
+/// * `firstelem` — (I) first vector element to write(1 = 1st)
+/// * `nelem`     — (I) number of values to write
+/// * `array`     — (I) array of values that are written
+/// * `nulval`    — (I) undefined pixel value
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffppnui(
-    fptr: *mut fitsfile,    /* I - FITS file pointer                       */
-    group: c_long,          /* I - group to write(1 = 1st group)           */
-    firstelem: LONGLONG,    /* I - first vector element to write(1 = 1st)  */
-    nelem: LONGLONG,        /* I - number of values to write               */
-    array: *const c_ushort, /* I - array of values that are written        */
-    nulval: c_ushort,       /* I - undefined pixel value                   */
-    status: *mut c_int,     /* IO - error status                           */
+    fptr: *mut fitsfile,
+    group: c_long,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: *const c_ushort,
+    nulval: c_ushort,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -134,7 +164,6 @@ pub unsafe extern "C" fn ffppnui(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of the
 /// FITS array is not the same as the array being written).  Any array values
@@ -145,14 +174,24 @@ pub unsafe extern "C" fn ffppnui(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to write(1 = 1st group)
+/// * `firstelem` — (I) first vector element to write(1 = 1st)
+/// * `nelem`     — (I) number of values to write
+/// * `array`     — (I) array of values that are written
+/// * `nulval`    — (I) undefined pixel value
+/// * `status`    — (IO) error status
 pub fn ffppnui_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                       */
-    group: c_long,       /* I - group to write(1 = 1st group)           */
-    firstelem: LONGLONG, /* I - first vector element to write(1 = 1st)  */
-    nelem: LONGLONG,     /* I - number of values to write               */
-    array: &[c_ushort],  /* I - array of values that are written        */
-    nulval: c_ushort,    /* I - undefined pixel value                   */
-    status: &mut c_int,  /* IO - error status                           */
+    fptr: &mut fitsfile,
+    group: c_long,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: &[c_ushort],
+    nulval: c_ushort,
+    status: &mut c_int,
 ) -> c_int {
     let mut nullvalue: c_ushort = 0;
 
@@ -188,19 +227,28 @@ pub fn ffppnui_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an entire 2-D array of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of the
 /// FITS array is not the same as the array being written).
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `group`  — (I) group to write(1 = 1st group)
+/// * `ncols`  — (I) number of pixels in each row of array
+/// * `naxis1` — (I) FITS image NAXIS1 value
+/// * `naxis2` — (I) FITS image NAXIS2 value
+/// * `array`  — (I) array to be written
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffp2dui(
-    fptr: *mut fitsfile,    /* I - FITS file pointer                     */
-    group: c_long,          /* I - group to write(1 = 1st group)         */
-    ncols: LONGLONG,        /* I - number of pixels in each row of array */
-    naxis1: LONGLONG,       /* I - FITS image NAXIS1 value               */
-    naxis2: LONGLONG,       /* I - FITS image NAXIS2 value               */
-    array: *const c_ushort, /* I - array to be written                   */
-    status: *mut c_int,     /* IO - error status                         */
+    fptr: *mut fitsfile,
+    group: c_long,
+    ncols: LONGLONG,
+    naxis1: LONGLONG,
+    naxis2: LONGLONG,
+    array: *const c_ushort,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -213,18 +261,27 @@ pub unsafe extern "C" fn ffp2dui(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an entire 2-D array of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of the
 /// FITS array is not the same as the array being written).
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `group`  — (I) group to write(1 = 1st group)
+/// * `ncols`  — (I) number of pixels in each row of array
+/// * `naxis1` — (I) FITS image NAXIS1 value
+/// * `naxis2` — (I) FITS image NAXIS2 value
+/// * `array`  — (I) array to be written
+/// * `status` — (IO) error status
 pub fn ffp2dui_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                     */
-    group: c_long,       /* I - group to write(1 = 1st group)         */
-    ncols: LONGLONG,     /* I - number of pixels in each row of array */
-    naxis1: LONGLONG,    /* I - FITS image NAXIS1 value               */
-    naxis2: LONGLONG,    /* I - FITS image NAXIS2 value               */
-    array: &[c_ushort],  /* I - array to be written                   */
-    status: &mut c_int,  /* IO - error status                         */
+    fptr: &mut fitsfile,
+    group: c_long,
+    ncols: LONGLONG,
+    naxis1: LONGLONG,
+    naxis2: LONGLONG,
+    array: &[c_ushort],
+    status: &mut c_int,
 ) -> c_int {
     /* call the 3D writing routine, with the 3rd dimension = 1 */
     ffp3dui_safe(fptr, group, ncols, naxis2, naxis1, naxis2, 1, array, status);
@@ -232,7 +289,6 @@ pub fn ffp2dui_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an entire 3-D cube of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of the
 /// FITS array is not the same as the array being written).
@@ -241,17 +297,29 @@ pub fn ffp2dui_safe(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `group`  — (I) group to write(1 = 1st group)
+/// * `ncols`  — (I) number of pixels in each row of array
+/// * `nrows`  — (I) number of rows in each plane of array
+/// * `naxis1` — (I) FITS image NAXIS1 value
+/// * `naxis2` — (I) FITS image NAXIS2 value
+/// * `naxis3` — (I) FITS image NAXIS3 value
+/// * `array`  — (I) array to be written
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffp3dui(
-    fptr: *mut fitsfile,    /* I - FITS file pointer                     */
-    group: c_long,          /* I - group to write(1 = 1st group)         */
-    ncols: LONGLONG,        /* I - number of pixels in each row of array */
-    nrows: LONGLONG,        /* I - number of rows in each plane of array */
-    naxis1: LONGLONG,       /* I - FITS image NAXIS1 value               */
-    naxis2: LONGLONG,       /* I - FITS image NAXIS2 value               */
-    naxis3: LONGLONG,       /* I - FITS image NAXIS3 value               */
-    array: *const c_ushort, /* I - array to be written                   */
-    status: *mut c_int,     /* IO - error status                         */
+    fptr: *mut fitsfile,
+    group: c_long,
+    ncols: LONGLONG,
+    nrows: LONGLONG,
+    naxis1: LONGLONG,
+    naxis2: LONGLONG,
+    naxis3: LONGLONG,
+    array: *const c_ushort,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -266,7 +334,6 @@ pub unsafe extern "C" fn ffp3dui(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an entire 3-D cube of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of the
 /// FITS array is not the same as the array being written).
@@ -275,16 +342,28 @@ pub unsafe extern "C" fn ffp3dui(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `group`  — (I) group to write(1 = 1st group)
+/// * `ncols`  — (I) number of pixels in each row of array
+/// * `nrows`  — (I) number of rows in each plane of array
+/// * `naxis1` — (I) FITS image NAXIS1 value
+/// * `naxis2` — (I) FITS image NAXIS2 value
+/// * `naxis3` — (I) FITS image NAXIS3 value
+/// * `array`  — (I) array to be written
+/// * `status` — (IO) error status
 pub fn ffp3dui_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                     */
-    group: c_long,       /* I - group to write(1 = 1st group)         */
-    ncols: LONGLONG,     /* I - number of pixels in each row of array */
-    nrows: LONGLONG,     /* I - number of rows in each plane of array */
-    naxis1: LONGLONG,    /* I - FITS image NAXIS1 value               */
-    naxis2: LONGLONG,    /* I - FITS image NAXIS2 value               */
-    naxis3: LONGLONG,    /* I - FITS image NAXIS3 value               */
-    array: &[c_ushort],  /* I - array to be written                   */
-    status: &mut c_int,  /* IO - error status                         */
+    fptr: &mut fitsfile,
+    group: c_long,
+    ncols: LONGLONG,
+    nrows: LONGLONG,
+    naxis1: LONGLONG,
+    naxis2: LONGLONG,
+    naxis3: LONGLONG,
+    array: &[c_ushort],
+    status: &mut c_int,
 ) -> c_int {
     let fpixel: [c_long; 3] = [1; 3];
     let mut lpixel: [c_long; 3] = [0; 3];
@@ -361,7 +440,6 @@ pub fn ffp3dui_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write a subsection of pixels to the primary array or image.
 ///
 /// A subsection is defined to be any contiguous rectangular
@@ -369,16 +447,27 @@ pub fn ffp3dui_safe(
 /// Data conversion and scaling will be performed if necessary
 /// (e.g, if the datatype of the FITS array is not the same as
 /// the array being written).
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `group`  — (I) group to write(1 = 1st group)
+/// * `naxis`  — (I) number of data axes in array
+/// * `naxes`  — (I) size of each FITS axis
+/// * `fpixel` — (I) 1st pixel in each axis to write (1=1st)
+/// * `lpixel` — (I) last pixel in each axis to write
+/// * `array`  — (I) array to be written
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffpssui(
-    fptr: *mut fitsfile,    /* I - FITS file pointer                       */
-    group: c_long,          /* I - group to write(1 = 1st group)           */
-    naxis: c_long,          /* I - number of data axes in array            */
-    naxes: *const c_long,   /* I - size of each FITS axis                  */
-    fpixel: *const c_long,  /* I - 1st pixel in each axis to write (1=1st) */
-    lpixel: *const c_long,  /* I - last pixel in each axis to write        */
-    array: *const c_ushort, /* I - array to be written                     */
-    status: *mut c_int,     /* IO - error status                           */
+    fptr: *mut fitsfile,
+    group: c_long,
+    naxis: c_long,
+    naxes: *const c_long,
+    fpixel: *const c_long,
+    lpixel: *const c_long,
+    array: *const c_ushort,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -400,7 +489,6 @@ pub unsafe extern "C" fn ffpssui(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write a subsection of pixels to the primary array or image.
 ///
 /// A subsection is defined to be any contiguous rectangular
@@ -408,15 +496,26 @@ pub unsafe extern "C" fn ffpssui(
 /// Data conversion and scaling will be performed if necessary
 /// (e.g, if the datatype of the FITS array is not the same as
 /// the array being written).
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `group`  — (I) group to write(1 = 1st group)
+/// * `naxis`  — (I) number of data axes in array
+/// * `naxes`  — (I) size of each FITS axis
+/// * `fpixel` — (I) 1st pixel in each axis to write (1=1st)
+/// * `lpixel` — (I) last pixel in each axis to write
+/// * `array`  — (I) array to be written
+/// * `status` — (IO) error status
 pub fn ffpssui_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                       */
-    group: c_long,       /* I - group to write(1 = 1st group)           */
-    naxis: c_long,       /* I - number of data axes in array            */
-    naxes: &[c_long],    /* I - size of each FITS axis                  */
-    fpixel: &[c_long],   /* I - 1st pixel in each axis to write (1=1st) */
-    lpixel: &[c_long],   /* I - last pixel in each axis to write        */
-    array: &[c_ushort],  /* I - array to be written                     */
-    status: &mut c_int,  /* IO - error status                           */
+    fptr: &mut fitsfile,
+    group: c_long,
+    naxis: c_long,
+    naxes: &[c_long],
+    fpixel: &[c_long],
+    lpixel: &[c_long],
+    array: &[c_ushort],
+    status: &mut c_int,
 ) -> c_int {
     let mut fpix: [LONGLONG; 7] = [0; 7];
     let mut dimen: [LONGLONG; 7] = [0; 7];
@@ -543,7 +642,6 @@ pub fn ffpssui_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of group parameters to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
 /// the FITS array is not the same as the array being written).
@@ -552,14 +650,23 @@ pub fn ffpssui_safe(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to write(1 = 1st group)
+/// * `firstelem` — (I) first vector element to write(1 = 1st)
+/// * `nelem`     — (I) number of values to write
+/// * `array`     — (I) array of values that are written
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffpgpui(
-    fptr: *mut fitsfile,    /* I - FITS file pointer                      */
-    group: c_long,          /* I - group to write(1 = 1st group)          */
-    firstelem: c_long,      /* I - first vector element to write(1 = 1st) */
-    nelem: c_long,          /* I - number of values to write              */
-    array: *const c_ushort, /* I - array of values that are written       */
-    status: *mut c_int,     /* IO - error status                          */
+    fptr: *mut fitsfile,
+    group: c_long,
+    firstelem: c_long,
+    nelem: c_long,
+    array: *const c_ushort,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -572,7 +679,6 @@ pub unsafe extern "C" fn ffpgpui(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of group parameters to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
 /// the FITS array is not the same as the array being written).
@@ -581,13 +687,22 @@ pub unsafe extern "C" fn ffpgpui(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to write(1 = 1st group)
+/// * `firstelem` — (I) first vector element to write(1 = 1st)
+/// * `nelem`     — (I) number of values to write
+/// * `array`     — (I) array of values that are written
+/// * `status`    — (IO) error status
 pub fn ffpgpui_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                      */
-    group: c_long,       /* I - group to write(1 = 1st group)          */
-    firstelem: c_long,   /* I - first vector element to write(1 = 1st) */
-    nelem: c_long,       /* I - number of values to write              */
-    array: &[c_ushort],  /* I - array of values that are written       */
-    status: &mut c_int,  /* IO - error status                          */
+    fptr: &mut fitsfile,
+    group: c_long,
+    firstelem: c_long,
+    nelem: c_long,
+    array: &[c_ushort],
+    status: &mut c_int,
 ) -> c_int {
     let row = cmp::max(1, group);
 
@@ -603,7 +718,6 @@ pub fn ffpgpui_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of values to a column in the current FITS HDU.
 ///
 /// The column number may refer to a real column in an ASCII or binary table,
@@ -616,15 +730,25 @@ pub fn ffpgpui_safe(
 ///
 /// The input array of values will be converted to the datatype of the column
 /// and will be inverse-scaled by the FITS TSCALn and TZEROn values if necessary.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to write (1 = 1st col)
+/// * `firstrow`  — (I) first row to write (1 = 1st row)
+/// * `firstelem` — (I) first vector element to write (1 = 1st)
+/// * `nelem`     — (I) number of values to write
+/// * `array`     — (I) array of values to write
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffpclui(
-    fptr: *mut fitsfile,    /* I - FITS file pointer                       */
-    colnum: c_int,          /* I - number of column to write (1 = 1st col) */
-    firstrow: LONGLONG,     /* I - first row to write (1 = 1st row)        */
-    firstelem: LONGLONG,    /* I - first vector element to write (1 = 1st) */
-    nelem: LONGLONG,        /* I - number of values to write               */
-    array: *const c_ushort, /* I - array of values to write                */
-    status: *mut c_int,     /* IO - error status                           */
+    fptr: *mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: *const c_ushort,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -645,7 +769,6 @@ pub unsafe extern "C" fn ffpclui(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of values to a column in the current FITS HDU.
 ///
 /// The column number may refer to a real column in an ASCII or binary table,
@@ -658,14 +781,24 @@ pub unsafe extern "C" fn ffpclui(
 ///
 /// The input array of values will be converted to the datatype of the column
 /// and will be inverse-scaled by the FITS TSCALn and TZEROn values if necessary.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to write (1 = 1st col)
+/// * `firstrow`  — (I) first row to write (1 = 1st row)
+/// * `firstelem` — (I) first vector element to write (1 = 1st)
+/// * `nelem`     — (I) number of values to write
+/// * `array`     — (I) array of values to write
+/// * `status`    — (IO) error status
 pub fn ffpclui_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                       */
-    colnum: c_int,       /* I - number of column to write (1 = 1st col) */
-    firstrow: LONGLONG,  /* I - first row to write (1 = 1st row)        */
-    firstelem: LONGLONG, /* I - first vector element to write (1 = 1st) */
-    nelem: LONGLONG,     /* I - number of values to write               */
-    array: &[c_ushort],  /* I - array of values to write                */
-    status: &mut c_int,  /* IO - error status                           */
+    fptr: &mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: &[c_ushort],
+    status: &mut c_int,
 ) -> c_int {
     let mut tcode: c_int = 0;
     let mut maxelem: c_int = 0;
@@ -696,9 +829,7 @@ pub fn ffpclui_safe(
         return *status;
     }
 
-    /*---------------------------------------------------*/
     /*  Check input and get parameters about the column: */
-    /*---------------------------------------------------*/
     if ffgcprll(
         fptr,
         colnum,
@@ -730,12 +861,10 @@ pub fn ffpclui_safe(
         ffcfmt(&tform, &mut cform); /* derive C format for writing strings */
     }
 
-    /*---------------------------------------------------------------------*/
     /*  Now write the pixels to the FITS column.                           */
     /*  First call the ffXXfYY routine to  (1) convert the datatype        */
     /*  if necessary, and (2) scale the values by the FITS TSCALn and      */
     /*  TZEROn linear scaling parameters into a temporary buffer.          */
-    /*---------------------------------------------------------------------*/
     remain = nelem; /* remaining number of values to write  */
     next = 0; /* next element in array to be written  */
     rownum = 0; /* row number, relative to firstrow     */
@@ -902,9 +1031,7 @@ pub fn ffpclui_safe(
             }
         } /* End of switch block */
 
-        /*-------------------------*/
         /*  Check for fatal error  */
-        /*-------------------------*/
         if *status > 0 {
             /* test for error during previous write operation */
 
@@ -919,9 +1046,7 @@ pub fn ffpclui_safe(
             return *status;
         }
 
-        /*--------------------------------------------*/
         /*  increment the counters for the next loop  */
-        /*--------------------------------------------*/
         remain -= ntodo as LONGLONG;
         if remain > 0 {
             next += ntodo as LONGLONG;
@@ -935,9 +1060,7 @@ pub fn ffpclui_safe(
         }
     } /*  End of main while Loop  */
 
-    /*--------------------------------*/
     /*  check for numerical overflow  */
-    /*--------------------------------*/
     if *status == OVERFLOW_ERR {
         ffpmsg_str("Numerical overflow during type conversion while writing FITS data.");
         *status = NUM_OVERFLOW;
@@ -946,23 +1069,33 @@ pub fn ffpclui_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of elements to the specified column of a table.  Any input
 /// pixels equal to the value of nulvalue will be replaced by the appropriate
 /// null value in the output FITS file.
 ///
 /// The input array of values will be converted to the datatype of the column
 /// and will be inverse-scaled by the FITS TSCALn and TZEROn values if necessary
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to write (1 = 1st col)
+/// * `firstrow`  — (I) first row to write (1 = 1st row)
+/// * `firstelem` — (I) first vector element to write (1 = 1st)
+/// * `nelem`     — (I) number of values to write
+/// * `array`     — (I) array of values to write
+/// * `nulvalue`  — (I) value used to flag undefined pixels
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffpcnui(
-    fptr: *mut fitsfile,    /* I - FITS file pointer                       */
-    colnum: c_int,          /* I - number of column to write (1 = 1st col) */
-    firstrow: LONGLONG,     /* I - first row to write (1 = 1st row)        */
-    firstelem: LONGLONG,    /* I - first vector element to write (1 = 1st) */
-    nelem: LONGLONG,        /* I - number of values to write               */
-    array: *const c_ushort, /* I - array of values to write                */
-    nulvalue: c_ushort,     /* I - value used to flag undefined pixels     */
-    status: *mut c_int,     /* IO - error status                           */
+    fptr: *mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: *const c_ushort,
+    nulvalue: c_ushort,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -984,22 +1117,32 @@ pub unsafe extern "C" fn ffpcnui(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of elements to the specified column of a table.  Any input
 /// pixels equal to the value of nulvalue will be replaced by the appropriate
 /// null value in the output FITS file.
 ///
 /// The input array of values will be converted to the datatype of the column
 /// and will be inverse-scaled by the FITS TSCALn and TZEROn values if necessary
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to write (1 = 1st col)
+/// * `firstrow`  — (I) first row to write (1 = 1st row)
+/// * `firstelem` — (I) first vector element to write (1 = 1st)
+/// * `nelem`     — (I) number of values to write
+/// * `array`     — (I) array of values to write
+/// * `nulvalue`  — (I) value used to flag undefined pixels
+/// * `status`    — (IO) error status
 pub fn ffpcnui_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                       */
-    colnum: c_int,       /* I - number of column to write (1 = 1st col) */
-    firstrow: LONGLONG,  /* I - first row to write (1 = 1st row)        */
-    firstelem: LONGLONG, /* I - first vector element to write (1 = 1st) */
-    nelem: LONGLONG,     /* I - number of values to write               */
-    array: &[c_ushort],  /* I - array of values to write                */
-    nulvalue: c_ushort,  /* I - value used to flag undefined pixels     */
-    status: &mut c_int,  /* IO - error status                           */
+    fptr: &mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: &[c_ushort],
+    nulvalue: c_ushort,
+    status: &mut c_int,
 ) -> c_int {
     let mut ngood: LONGLONG = 0;
     let mut nbad: LONGLONG = 0;
@@ -1153,16 +1296,24 @@ pub fn ffpcnui_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output prior to writing output to a FITS file.
 /// Do datatype conversion and scaling if required
+///
+/// # Parameters
+///
+/// * `input`  — (I) array of values to be converted
+/// * `ntodo`  — (I) number of elements in the array
+/// * `scale`  — (I) FITS TSCALn or BSCALE value
+/// * `zero`   — (I) FITS TZEROn or BZERO value
+/// * `output` — (O) output array of converted values
+/// * `status` — (IO) error status
 pub(crate) fn ffu2fi1(
-    input: &[c_ushort], /* I - array of values to be converted  */
-    ntodo: c_long,      /* I - number of elements in the array  */
-    scale: f64,         /* I - FITS TSCALn or BSCALE value      */
-    zero: f64,          /* I - FITS TZEROn or BZERO  value      */
-    output: &mut [u8],  /* O - output array of converted values */
-    status: &mut c_int, /* IO - error status                    */
+    input: &[c_ushort],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    output: &mut [u8],
+    status: &mut c_int,
 ) -> c_int {
     if scale == 1.0 && zero == 0.0 {
         for ii in 0..(ntodo as usize) {
@@ -1191,19 +1342,27 @@ pub(crate) fn ffu2fi1(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output prior to writing output to a FITS file.
 /// Do datatype conversion and scaling if required
+///
+/// # Parameters
+///
+/// * `input`  — (I) array of values to be converted
+/// * `ntodo`  — (I) number of elements in the array
+/// * `scale`  — (I) FITS TSCALn or BSCALE value
+/// * `zero`   — (I) FITS TZEROn or BZERO value
+/// * `output` — (O) output array of converted values
+/// * `status` — (IO) error status
 pub(crate) fn ffu2fi2(
-    input: &[c_ushort],     /* I - array of values to be converted  */
-    ntodo: c_long,          /* I - number of elements in the array  */
-    scale: f64,             /* I - FITS TSCALn or BSCALE value      */
-    zero: f64,              /* I - FITS TZEROn or BZERO  value      */
-    output: &mut [c_short], /* O - output array of converted values */
-    status: &mut c_int,     /* IO - error status                    */
-                            /*
+    input: &[c_ushort],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    output: &mut [c_short],
+    status: &mut c_int,
+    /*
 
-                            */
+    */
 ) -> c_int {
     if scale == 1.0 && zero == 32768. {
         /* Instead of subtracting 32768, it is more efficient */
@@ -1241,18 +1400,25 @@ pub(crate) fn ffu2fi2(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
+/// # Parameters
+///
+/// * `input`  — (I) array of values to be converted
+/// * `ntodo`  — (I) number of elements in the array
+/// * `scale`  — (I) FITS TSCALn or BSCALE value
+/// * `zero`   — (I) FITS TZEROn or BZERO value
+/// * `output` — (O) output array of converted values
+/// * `status` — (IO) error status
 pub(crate) fn ffu2fi4(
-    input: &[c_ushort],      /* I - array of values to be converted  */
-    ntodo: c_long,           /* I - number of elements in the array  */
-    scale: f64,              /* I - FITS TSCALn or BSCALE value      */
-    zero: f64,               /* I - FITS TZEROn or BZERO  value      */
-    output: &mut [INT32BIT], /* O - output array of converted values */
-    status: &mut c_int,      /* IO - error status                    */
-                             /*
-                             Copy input to output prior to writing output to a FITS file.
-                             Do datatype conversion and scaling if required
-                             */
+    input: &[c_ushort],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    output: &mut [INT32BIT],
+    status: &mut c_int,
+    /*
+    Copy input to output prior to writing output to a FITS file.
+    Do datatype conversion and scaling if required
+    */
 ) -> c_int {
     if scale == 1.0 && zero == 0.0 {
         for ii in 0..(ntodo as usize) {
@@ -1278,18 +1444,25 @@ pub(crate) fn ffu2fi4(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
+/// # Parameters
+///
+/// * `input`  — (I) array of values to be converted
+/// * `ntodo`  — (I) number of elements in the array
+/// * `scale`  — (I) FITS TSCALn or BSCALE value
+/// * `zero`   — (I) FITS TZEROn or BZERO value
+/// * `output` — (O) output array of converted values
+/// * `status` — (IO) error status
 pub(crate) fn ffu2fi8(
-    input: &[c_ushort],      /* I - array of values to be converted  */
-    ntodo: c_long,           /* I - number of elements in the array  */
-    scale: f64,              /* I - FITS TSCALn or BSCALE value      */
-    zero: f64,               /* I - FITS TZEROn or BZERO  value      */
-    output: &mut [LONGLONG], /* O - output array of converted values */
-    status: &mut c_int,      /* IO - error status                    */
-                             /*
-                             Copy input to output prior to writing output to a FITS file.
-                             Do datatype conversion and scaling if required
-                             */
+    input: &[c_ushort],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    output: &mut [LONGLONG],
+    status: &mut c_int,
+    /*
+    Copy input to output prior to writing output to a FITS file.
+    Do datatype conversion and scaling if required
+    */
 ) -> c_int {
     if scale == 1.0 && zero == 9223372036854775808. {
         /* Writing to unsigned long long column. Input values must not be negative */
@@ -1326,16 +1499,24 @@ pub(crate) fn ffu2fi8(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output prior to writing output to a FITS file.
 /// Do datatype conversion and scaling if required.
+///
+/// # Parameters
+///
+/// * `input`  — (I) array of values to be converted
+/// * `ntodo`  — (I) number of elements in the array
+/// * `scale`  — (I) FITS TSCALn or BSCALE value
+/// * `zero`   — (I) FITS TZEROn or BZERO value
+/// * `output` — (O) output array of converted values
+/// * `status` — (IO) error status
 pub(crate) fn ffu2fr4(
-    input: &[c_ushort], /* I - array of values to be converted  */
-    ntodo: c_long,      /* I - number of elements in the array  */
-    scale: f64,         /* I - FITS TSCALn or BSCALE value      */
-    zero: f64,          /* I - FITS TZEROn or BZERO  value      */
-    output: &mut [f32], /* O - output array of converted values */
-    status: &mut c_int, /* IO - error status                    */
+    input: &[c_ushort],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    output: &mut [f32],
+    status: &mut c_int,
 ) -> c_int {
     if scale == 1.0 && zero == 0.0 {
         for ii in 0..(ntodo as usize) {
@@ -1349,16 +1530,24 @@ pub(crate) fn ffu2fr4(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output prior to writing output to a FITS file.
 /// Do datatype conversion and scaling if required.
+///
+/// # Parameters
+///
+/// * `input`  — (I) array of values to be converted
+/// * `ntodo`  — (I) number of elements in the array
+/// * `scale`  — (I) FITS TSCALn or BSCALE value
+/// * `zero`   — (I) FITS TZEROn or BZERO value
+/// * `output` — (O) output array of converted values
+/// * `status` — (IO) error status
 pub(crate) fn ffu2fr8(
-    input: &[c_ushort], /* I - array of values to be converted  */
-    ntodo: c_long,      /* I - number of elements in the array  */
-    scale: f64,         /* I - FITS TSCALn or BSCALE value      */
-    zero: f64,          /* I - FITS TZEROn or BZERO  value      */
-    output: &mut [f64], /* O - output array of converted values */
-    status: &mut c_int, /* IO - error status                    */
+    input: &[c_ushort],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    output: &mut [f64],
+    status: &mut c_int,
 ) -> c_int {
     if scale == 1.0 && zero == 0.0 {
         for ii in 0..(ntodo as usize) {
@@ -1372,18 +1561,28 @@ pub(crate) fn ffu2fr8(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output prior to writing output to a FITS file.
 /// Do scaling if required.
+///
+/// # Parameters
+///
+/// * `input`  — (I) array of values to be converted
+/// * `ntodo`  — (I) number of elements in the array
+/// * `scale`  — (I) FITS TSCALn or BSCALE value
+/// * `zero`   — (I) FITS TZEROn or BZERO value
+/// * `cform`  — (I) format for output string values
+/// * `twidth` — (I) width of each field, in chars
+/// * `output` — (O) output array of converted values
+/// * `status` — (IO) error status
 pub(crate) fn ffu2fstr(
-    input: &[c_ushort],    /* I - array of values to be converted  */
-    ntodo: c_long,         /* I - number of elements in the array  */
-    scale: f64,            /* I - FITS TSCALn or BSCALE value      */
-    zero: f64,             /* I - FITS TZEROn or BZERO  value      */
-    cform: &[c_char],      /* I - format for output string values  */
-    twidth: c_long,        /* I - width of each field, in chars    */
-    output: &mut [c_char], /* O - output array of converted values */
-    status: &mut c_int,    /* IO - error status                    */
+    input: &[c_ushort],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    cform: &[c_char],
+    twidth: c_long,
+    output: &mut [c_char],
+    status: &mut c_int,
 ) -> c_int {
     let mut oi = 0;
 

--- a/src/putcoluj.rs
+++ b/src/putcoluj.rs
@@ -1,9 +1,14 @@
-/*  This file, putcoluj.rs, contains routines that write data elements to   */
-/*  a FITS image or table, with unsigned long datatype.                    */
-
-/*  The FITSIO software was written by William Pence at the High Energy    */
-/*  Astrophysic Science Archive Research Center (HEASARC) at the NASA      */
-/*  Goddard Space Flight Center.                                           */
+//! Routines that write data elements to a FITS image or table, with
+//! unsigned long datatype.
+//!
+//! The [`TULONG`] arm of the typed column I/O family. [`crate::putcol`]
+//! dispatches here when a caller asks for this datatype at run time; the
+//! write-side counterpart is [`crate::getcoluj`].
+//!
+//! Ported from CFITSIO's `putcoluj.c`, written by William Pence at the High
+//! Energy Astrophysics Science Archive Research Center (HEASARC), NASA Goddard
+//! Space Flight Center.
+#![warn(missing_docs)]
 
 use core::slice;
 use core::{cmp, mem};
@@ -25,7 +30,6 @@ use crate::relibc::header::stdio::{snprintf_f64, sprintf_f64};
 use crate::wrappers::strlen_safe;
 use crate::{buffers::*, int_snprintf, slice_to_str};
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
 /// the FITS array is not the same as the array being written).
@@ -34,14 +38,23 @@ use crate::{buffers::*, int_snprintf, slice_to_str};
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to write(1 = 1st group)
+/// * `firstelem` — (I) first vector element to write(1 = 1st)
+/// * `nelem`     — (I) number of values to write
+/// * `array`     — (I) array of values that are written
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffppruj(
-    fptr: *mut fitsfile,   /* I - FITS file pointer                       */
-    group: c_long,         /* I - group to write(1 = 1st group)           */
-    firstelem: LONGLONG,   /* I - first vector element to write(1 = 1st)  */
-    nelem: LONGLONG,       /* I - number of values to write               */
-    array: *const c_ulong, /* I - array of values that are written        */
-    status: *mut c_int,    /* IO - error status                           */
+    fptr: *mut fitsfile,
+    group: c_long,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: *const c_ulong,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -53,7 +66,6 @@ pub unsafe extern "C" fn ffppruj(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
 /// the FITS array is not the same as the array being written).
@@ -62,13 +74,22 @@ pub unsafe extern "C" fn ffppruj(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to write(1 = 1st group)
+/// * `firstelem` — (I) first vector element to write(1 = 1st)
+/// * `nelem`     — (I) number of values to write
+/// * `array`     — (I) array of values that are written
+/// * `status`    — (IO) error status
 pub fn ffppruj_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                       */
-    group: c_long,       /* I - group to write(1 = 1st group)           */
-    firstelem: LONGLONG, /* I - first vector element to write(1 = 1st)  */
-    nelem: LONGLONG,     /* I - number of values to write               */
-    array: &[c_ulong],   /* I - array of values that are written        */
-    status: &mut c_int,  /* IO - error status                           */
+    fptr: &mut fitsfile,
+    group: c_long,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: &[c_ulong],
+    status: &mut c_int,
 ) -> c_int {
     let nullvalue: c_ulong = 0;
 
@@ -101,7 +122,6 @@ pub fn ffppruj_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of the
 /// FITS array is not the same as the array being written).  Any array values
@@ -112,15 +132,25 @@ pub fn ffppruj_safe(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to write(1 = 1st group)
+/// * `firstelem` — (I) first vector element to write(1 = 1st)
+/// * `nelem`     — (I) number of values to write
+/// * `array`     — (I) array of values that are written
+/// * `nulval`    — (I) undefined pixel value
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffppnuj(
-    fptr: *mut fitsfile,   /* I - FITS file pointer                       */
-    group: c_long,         /* I - group to write(1 = 1st group)           */
-    firstelem: LONGLONG,   /* I - first vector element to write(1 = 1st)  */
-    nelem: LONGLONG,       /* I - number of values to write               */
-    array: *const c_ulong, /* I - array of values that are written        */
-    nulval: c_ulong,       /* I - undefined pixel value                   */
-    status: *mut c_int,    /* IO - error status                           */
+    fptr: *mut fitsfile,
+    group: c_long,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: *const c_ulong,
+    nulval: c_ulong,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -132,7 +162,6 @@ pub unsafe extern "C" fn ffppnuj(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of the
 /// FITS array is not the same as the array being written).  Any array values
@@ -143,14 +172,24 @@ pub unsafe extern "C" fn ffppnuj(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to write(1 = 1st group)
+/// * `firstelem` — (I) first vector element to write(1 = 1st)
+/// * `nelem`     — (I) number of values to write
+/// * `array`     — (I) array of values that are written
+/// * `nulval`    — (I) undefined pixel value
+/// * `status`    — (IO) error status
 pub fn ffppnuj_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                       */
-    group: c_long,       /* I - group to write(1 = 1st group)           */
-    firstelem: LONGLONG, /* I - first vector element to write(1 = 1st)  */
-    nelem: LONGLONG,     /* I - number of values to write               */
-    array: &[c_ulong],   /* I - array of values that are written        */
-    nulval: c_ulong,     /* I - undefined pixel value                   */
-    status: &mut c_int,  /* IO - error status                           */
+    fptr: &mut fitsfile,
+    group: c_long,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: &[c_ulong],
+    nulval: c_ulong,
+    status: &mut c_int,
 ) -> c_int {
     let nullvalue: c_ulong;
 
@@ -186,19 +225,28 @@ pub fn ffppnuj_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an entire 2-D array of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of the
 /// FITS array is not the same as the array being written).
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `group`  — (I) group to write(1 = 1st group)
+/// * `ncols`  — (I) number of pixels in each row of array
+/// * `naxis1` — (I) FITS image NAXIS1 value
+/// * `naxis2` — (I) FITS image NAXIS2 value
+/// * `array`  — (I) array to be written
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffp2duj(
-    fptr: *mut fitsfile,   /* I - FITS file pointer                     */
-    group: c_long,         /* I - group to write(1 = 1st group)         */
-    ncols: LONGLONG,       /* I - number of pixels in each row of array */
-    naxis1: LONGLONG,      /* I - FITS image NAXIS1 value               */
-    naxis2: LONGLONG,      /* I - FITS image NAXIS2 value               */
-    array: *const c_ulong, /* I - array to be written                   */
-    status: *mut c_int,    /* IO - error status                         */
+    fptr: *mut fitsfile,
+    group: c_long,
+    ncols: LONGLONG,
+    naxis1: LONGLONG,
+    naxis2: LONGLONG,
+    array: *const c_ulong,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -210,18 +258,27 @@ pub unsafe extern "C" fn ffp2duj(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an entire 2-D array of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of the
 /// FITS array is not the same as the array being written).
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `group`  — (I) group to write(1 = 1st group)
+/// * `ncols`  — (I) number of pixels in each row of array
+/// * `naxis1` — (I) FITS image NAXIS1 value
+/// * `naxis2` — (I) FITS image NAXIS2 value
+/// * `array`  — (I) array to be written
+/// * `status` — (IO) error status
 pub fn ffp2duj_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                     */
-    group: c_long,       /* I - group to write(1 = 1st group)         */
-    ncols: LONGLONG,     /* I - number of pixels in each row of array */
-    naxis1: LONGLONG,    /* I - FITS image NAXIS1 value               */
-    naxis2: LONGLONG,    /* I - FITS image NAXIS2 value               */
-    array: &[c_ulong],   /* I - array to be written                   */
-    status: &mut c_int,  /* IO - error status                         */
+    fptr: &mut fitsfile,
+    group: c_long,
+    ncols: LONGLONG,
+    naxis1: LONGLONG,
+    naxis2: LONGLONG,
+    array: &[c_ulong],
+    status: &mut c_int,
 ) -> c_int {
     /* call the 3D writing routine, with the 3rd dimension = 1 */
     ffp3duj_safe(fptr, group, ncols, naxis2, naxis1, naxis2, 1, array, status);
@@ -229,7 +286,6 @@ pub fn ffp2duj_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an entire 3-D cube of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of the
 /// FITS array is not the same as the array being written).
@@ -238,17 +294,29 @@ pub fn ffp2duj_safe(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `group`  — (I) group to write(1 = 1st group)
+/// * `ncols`  — (I) number of pixels in each row of array
+/// * `nrows`  — (I) number of rows in each plane of array
+/// * `naxis1` — (I) FITS image NAXIS1 value
+/// * `naxis2` — (I) FITS image NAXIS2 value
+/// * `naxis3` — (I) FITS image NAXIS3 value
+/// * `array`  — (I) array to be written
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffp3duj(
-    fptr: *mut fitsfile,   /* I - FITS file pointer                     */
-    group: c_long,         /* I - group to write(1 = 1st group)         */
-    ncols: LONGLONG,       /* I - number of pixels in each row of array */
-    nrows: LONGLONG,       /* I - number of rows in each plane of array */
-    naxis1: LONGLONG,      /* I - FITS image NAXIS1 value               */
-    naxis2: LONGLONG,      /* I - FITS image NAXIS2 value               */
-    naxis3: LONGLONG,      /* I - FITS image NAXIS3 value               */
-    array: *const c_ulong, /* I - array to be written                   */
-    status: *mut c_int,    /* IO - error status                         */
+    fptr: *mut fitsfile,
+    group: c_long,
+    ncols: LONGLONG,
+    nrows: LONGLONG,
+    naxis1: LONGLONG,
+    naxis2: LONGLONG,
+    naxis3: LONGLONG,
+    array: *const c_ulong,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -263,7 +331,6 @@ pub unsafe extern "C" fn ffp3duj(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an entire 3-D cube of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of the
 /// FITS array is not the same as the array being written).
@@ -272,16 +339,28 @@ pub unsafe extern "C" fn ffp3duj(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `group`  — (I) group to write(1 = 1st group)
+/// * `ncols`  — (I) number of pixels in each row of array
+/// * `nrows`  — (I) number of rows in each plane of array
+/// * `naxis1` — (I) FITS image NAXIS1 value
+/// * `naxis2` — (I) FITS image NAXIS2 value
+/// * `naxis3` — (I) FITS image NAXIS3 value
+/// * `array`  — (I) array to be written
+/// * `status` — (IO) error status
 pub fn ffp3duj_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                     */
-    group: c_long,       /* I - group to write(1 = 1st group)         */
-    ncols: LONGLONG,     /* I - number of pixels in each row of array */
-    nrows: LONGLONG,     /* I - number of rows in each plane of array */
-    naxis1: LONGLONG,    /* I - FITS image NAXIS1 value               */
-    naxis2: LONGLONG,    /* I - FITS image NAXIS2 value               */
-    naxis3: LONGLONG,    /* I - FITS image NAXIS3 value               */
-    array: &[c_ulong],   /* I - array to be written                   */
-    status: &mut c_int,  /* IO - error status                         */
+    fptr: &mut fitsfile,
+    group: c_long,
+    ncols: LONGLONG,
+    nrows: LONGLONG,
+    naxis1: LONGLONG,
+    naxis2: LONGLONG,
+    naxis3: LONGLONG,
+    array: &[c_ulong],
+    status: &mut c_int,
 ) -> c_int {
     let fpixel: [c_long; 3] = [1; 3];
     let mut lpixel: [c_long; 3] = [0; 3];
@@ -359,7 +438,6 @@ pub fn ffp3duj_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write a subsection of pixels to the primary array or image.
 ///
 /// A subsection is defined to be any contiguous rectangular
@@ -367,16 +445,27 @@ pub fn ffp3duj_safe(
 /// Data conversion and scaling will be performed if necessary
 /// (e.g, if the datatype of the FITS array is not the same as
 /// the array being written).
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `group`  — (I) group to write(1 = 1st group)
+/// * `naxis`  — (I) number of data axes in array
+/// * `naxes`  — (I) size of each FITS axis
+/// * `fpixel` — (I) 1st pixel in each axis to write (1=1st)
+/// * `lpixel` — (I) last pixel in each axis to write
+/// * `array`  — (I) array to be written
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffpssuj(
-    fptr: *mut fitsfile,   /* I - FITS file pointer                       */
-    group: c_long,         /* I - group to write(1 = 1st group)           */
-    naxis: c_long,         /* I - number of data axes in array            */
-    naxes: *const c_long,  /* I - size of each FITS axis                  */
-    fpixel: *const c_long, /* I - 1st pixel in each axis to write (1=1st) */
-    lpixel: *const c_long, /* I - last pixel in each axis to write        */
-    array: *const c_ulong, /* I - array to be written                     */
-    status: *mut c_int,    /* IO - error status                           */
+    fptr: *mut fitsfile,
+    group: c_long,
+    naxis: c_long,
+    naxes: *const c_long,
+    fpixel: *const c_long,
+    lpixel: *const c_long,
+    array: *const c_ulong,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -398,7 +487,6 @@ pub unsafe extern "C" fn ffpssuj(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write a subsection of pixels to the primary array or image.
 ///
 /// A subsection is defined to be any contiguous rectangular
@@ -406,15 +494,26 @@ pub unsafe extern "C" fn ffpssuj(
 /// Data conversion and scaling will be performed if necessary
 /// (e.g, if the datatype of the FITS array is not the same as
 /// the array being written).
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `group`  — (I) group to write(1 = 1st group)
+/// * `naxis`  — (I) number of data axes in array
+/// * `naxes`  — (I) size of each FITS axis
+/// * `fpixel` — (I) 1st pixel in each axis to write (1=1st)
+/// * `lpixel` — (I) last pixel in each axis to write
+/// * `array`  — (I) array to be written
+/// * `status` — (IO) error status
 pub fn ffpssuj_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                       */
-    group: c_long,       /* I - group to write(1 = 1st group)           */
-    naxis: c_long,       /* I - number of data axes in array            */
-    naxes: &[c_long],    /* I - size of each FITS axis                  */
-    fpixel: &[c_long],   /* I - 1st pixel in each axis to write (1=1st) */
-    lpixel: &[c_long],   /* I - last pixel in each axis to write        */
-    array: &[c_ulong],   /* I - array to be written                     */
-    status: &mut c_int,  /* IO - error status                           */
+    fptr: &mut fitsfile,
+    group: c_long,
+    naxis: c_long,
+    naxes: &[c_long],
+    fpixel: &[c_long],
+    lpixel: &[c_long],
+    array: &[c_ulong],
+    status: &mut c_int,
 ) -> c_int {
     let mut fpix: [LONGLONG; 7] = [0; 7];
     let mut dimen: [LONGLONG; 7] = [0; 7];
@@ -541,7 +640,6 @@ pub fn ffpssuj_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of group parameters to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
 /// the FITS array is not the same as the array being written).
@@ -550,14 +648,23 @@ pub fn ffpssuj_safe(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to write(1 = 1st group)
+/// * `firstelem` — (I) first vector element to write(1 = 1st)
+/// * `nelem`     — (I) number of values to write
+/// * `array`     — (I) array of values that are written
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffpgpuj(
-    fptr: *mut fitsfile,   /* I - FITS file pointer                      */
-    group: c_long,         /* I - group to write(1 = 1st group)          */
-    firstelem: c_long,     /* I - first vector element to write(1 = 1st) */
-    nelem: c_long,         /* I - number of values to write              */
-    array: *const c_ulong, /* I - array of values that are written       */
-    status: *mut c_int,    /* IO - error status                          */
+    fptr: *mut fitsfile,
+    group: c_long,
+    firstelem: c_long,
+    nelem: c_long,
+    array: *const c_ulong,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -569,7 +676,6 @@ pub unsafe extern "C" fn ffpgpuj(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of group parameters to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
 /// the FITS array is not the same as the array being written).
@@ -578,13 +684,22 @@ pub unsafe extern "C" fn ffpgpuj(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to write(1 = 1st group)
+/// * `firstelem` — (I) first vector element to write(1 = 1st)
+/// * `nelem`     — (I) number of values to write
+/// * `array`     — (I) array of values that are written
+/// * `status`    — (IO) error status
 pub fn ffpgpuj_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                      */
-    group: c_long,       /* I - group to write(1 = 1st group)          */
-    firstelem: c_long,   /* I - first vector element to write(1 = 1st) */
-    nelem: c_long,       /* I - number of values to write              */
-    array: &[c_ulong],   /* I - array of values that are written       */
-    status: &mut c_int,  /* IO - error status                          */
+    fptr: &mut fitsfile,
+    group: c_long,
+    firstelem: c_long,
+    nelem: c_long,
+    array: &[c_ulong],
+    status: &mut c_int,
 ) -> c_int {
     let row = cmp::max(1, group);
 
@@ -600,7 +715,6 @@ pub fn ffpgpuj_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of values to a column in the current FITS HDU.
 ///
 /// The column number may refer to a real column in an ASCII or binary table,
@@ -613,15 +727,25 @@ pub fn ffpgpuj_safe(
 ///
 /// The input array of values will be converted to the datatype of the column
 /// and will be inverse-scaled by the FITS TSCALn and TZEROn values if necessary.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to write (1 = 1st col)
+/// * `firstrow`  — (I) first row to write (1 = 1st row)
+/// * `firstelem` — (I) first vector element to write (1 = 1st)
+/// * `nelem`     — (I) number of values to write
+/// * `array`     — (I) array of values to write
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffpcluj(
-    fptr: *mut fitsfile,   /* I - FITS file pointer                       */
-    colnum: c_int,         /* I - number of column to write (1 = 1st col) */
-    firstrow: LONGLONG,    /* I - first row to write (1 = 1st row)        */
-    firstelem: LONGLONG,   /* I - first vector element to write (1 = 1st) */
-    nelem: LONGLONG,       /* I - number of values to write               */
-    array: *const c_ulong, /* I - array of values to write                */
-    status: *mut c_int,    /* IO - error status                           */
+    fptr: *mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: *const c_ulong,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -642,7 +766,6 @@ pub unsafe extern "C" fn ffpcluj(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of values to a column in the current FITS HDU.
 ///
 /// The column number may refer to a real column in an ASCII or binary table,
@@ -655,14 +778,24 @@ pub unsafe extern "C" fn ffpcluj(
 ///
 /// The input array of values will be converted to the datatype of the column
 /// and will be inverse-scaled by the FITS TSCALn and TZEROn values if necessary.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to write (1 = 1st col)
+/// * `firstrow`  — (I) first row to write (1 = 1st row)
+/// * `firstelem` — (I) first vector element to write (1 = 1st)
+/// * `nelem`     — (I) number of values to write
+/// * `array`     — (I) array of values to write
+/// * `status`    — (IO) error status
 pub fn ffpcluj_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                       */
-    colnum: c_int,       /* I - number of column to write (1 = 1st col) */
-    firstrow: LONGLONG,  /* I - first row to write (1 = 1st row)        */
-    firstelem: LONGLONG, /* I - first vector element to write (1 = 1st) */
-    nelem: LONGLONG,     /* I - number of values to write               */
-    array: &[c_ulong],   /* I - array of values to write                */
-    status: &mut c_int,  /* IO - error status                           */
+    fptr: &mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: &[c_ulong],
+    status: &mut c_int,
 ) -> c_int {
     let mut tcode: c_int = 0;
     let mut hdutype: c_int = 0;
@@ -693,9 +826,7 @@ pub fn ffpcluj_safe(
         return *status;
     }
 
-    /*---------------------------------------------------*/
     /*  Check input and get parameters about the column: */
-    /*---------------------------------------------------*/
     if ffgcprll(
         fptr,
         colnum,
@@ -727,12 +858,10 @@ pub fn ffpcluj_safe(
         ffcfmt(&tform, &mut cform); /* derive C format for writing strings */
     }
 
-    /*---------------------------------------------------------------------*/
     /*  Now write the pixels to the FITS column.                           */
     /*  First call the ffXXfYY routine to  (1) convert the datatype        */
     /*  if necessary, and (2) scale the values by the FITS TSCALn and      */
     /*  TZEROn linear scaling parameters into a temporary buffer.          */
-    /*---------------------------------------------------------------------*/
     remain = nelem; /* remaining number of values to write  */
     next = 0; /* next element in array to be written  */
     rownum = 0; /* row number, relative to firstrow     */
@@ -900,9 +1029,7 @@ pub fn ffpcluj_safe(
             }
         } /* End of switch block */
 
-        /*-------------------------*/
         /*  Check for fatal error  */
-        /*-------------------------*/
         if *status > 0 {
             /* test for error during previous write operation */
 
@@ -917,9 +1044,7 @@ pub fn ffpcluj_safe(
             return *status;
         }
 
-        /*--------------------------------------------*/
         /*  increment the counters for the next loop  */
-        /*--------------------------------------------*/
         remain -= ntodo as LONGLONG;
         if remain > 0 {
             next += ntodo as LONGLONG;
@@ -933,9 +1058,7 @@ pub fn ffpcluj_safe(
         }
     } /*  End of main while Loop  */
 
-    /*--------------------------------*/
     /*  check for numerical overflow  */
-    /*--------------------------------*/
     if *status == OVERFLOW_ERR {
         ffpmsg_str("Numerical overflow during type conversion while writing FITS data.");
         *status = NUM_OVERFLOW;
@@ -944,23 +1067,33 @@ pub fn ffpcluj_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of elements to the specified column of a table.  Any input
 /// pixels equal to the value of nulvalue will be replaced by the appropriate
 /// null value in the output FITS file.
 ///
 /// The input array of values will be converted to the datatype of the column
 /// and will be inverse-scaled by the FITS TSCALn and TZEROn values if necessary
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to write (1 = 1st col)
+/// * `firstrow`  — (I) first row to write (1 = 1st row)
+/// * `firstelem` — (I) first vector element to write (1 = 1st)
+/// * `nelem`     — (I) number of values to write
+/// * `array`     — (I) array of values to write
+/// * `nulvalue`  — (I) value used to flag undefined pixels
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffpcnuj(
-    fptr: *mut fitsfile,   /* I - FITS file pointer                       */
-    colnum: c_int,         /* I - number of column to write (1 = 1st col) */
-    firstrow: LONGLONG,    /* I - first row to write (1 = 1st row)        */
-    firstelem: LONGLONG,   /* I - first vector element to write (1 = 1st) */
-    nelem: LONGLONG,       /* I - number of values to write               */
-    array: *const c_ulong, /* I - array of values to write                */
-    nulvalue: c_ulong,     /* I - value used to flag undefined pixels     */
-    status: *mut c_int,    /* IO - error status                           */
+    fptr: *mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: *const c_ulong,
+    nulvalue: c_ulong,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -982,22 +1115,32 @@ pub unsafe extern "C" fn ffpcnuj(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of elements to the specified column of a table.  Any input
 /// pixels equal to the value of nulvalue will be replaced by the appropriate
 /// null value in the output FITS file.
 ///
 /// The input array of values will be converted to the datatype of the column
 /// and will be inverse-scaled by the FITS TSCALn and TZEROn values if necessary
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to write (1 = 1st col)
+/// * `firstrow`  — (I) first row to write (1 = 1st row)
+/// * `firstelem` — (I) first vector element to write (1 = 1st)
+/// * `nelem`     — (I) number of values to write
+/// * `array`     — (I) array of values to write
+/// * `nulvalue`  — (I) value used to flag undefined pixels
+/// * `status`    — (IO) error status
 pub fn ffpcnuj_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                       */
-    colnum: c_int,       /* I - number of column to write (1 = 1st col) */
-    firstrow: LONGLONG,  /* I - first row to write (1 = 1st row)        */
-    firstelem: LONGLONG, /* I - first vector element to write (1 = 1st) */
-    nelem: LONGLONG,     /* I - number of values to write               */
-    array: &[c_ulong],   /* I - array of values to write                */
-    nulvalue: c_ulong,   /* I - value used to flag undefined pixels     */
-    status: &mut c_int,  /* IO - error status                           */
+    fptr: &mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: &[c_ulong],
+    nulvalue: c_ulong,
+    status: &mut c_int,
 ) -> c_int {
     let mut ngood: LONGLONG = 0;
     let mut nbad: LONGLONG = 0;
@@ -1151,16 +1294,24 @@ pub fn ffpcnuj_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output prior to writing output to a FITS file.
 /// Do datatype conversion and scaling if required.
+///
+/// # Parameters
+///
+/// * `input`  — (I) array of values to be converted
+/// * `ntodo`  — (I) number of elements in the array
+/// * `scale`  — (I) FITS TSCALn or BSCALE value
+/// * `zero`   — (I) FITS TZEROn or BZERO value
+/// * `output` — (O) output array of converted values
+/// * `status` — (IO) error status
 pub(crate) fn ffu4fi1(
-    input: &[c_ulong],  /* I - array of values to be converted  */
-    ntodo: c_long,      /* I - number of elements in the array  */
-    scale: f64,         /* I - FITS TSCALn or BSCALE value      */
-    zero: f64,          /* I - FITS TZEROn or BZERO  value      */
-    output: &mut [u8],  /* O - output array of converted values */
-    status: &mut c_int, /* IO - error status                    */
+    input: &[c_ulong],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    output: &mut [u8],
+    status: &mut c_int,
 ) -> c_int {
     if scale == 1.0 && zero == 0.0 {
         for ii in 0..(ntodo as usize) {
@@ -1189,18 +1340,25 @@ pub(crate) fn ffu4fi1(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
+/// # Parameters
+///
+/// * `input`  — (I) array of values to be converted
+/// * `ntodo`  — (I) number of elements in the array
+/// * `scale`  — (I) FITS TSCALn or BSCALE value
+/// * `zero`   — (I) FITS TZEROn or BZERO value
+/// * `output` — (O) output array of converted values
+/// * `status` — (IO) error status
 pub(crate) fn ffu4fi2(
-    input: &[c_ulong],      /* I - array of values to be converted  */
-    ntodo: c_long,          /* I - number of elements in the array  */
-    scale: f64,             /* I - FITS TSCALn or BSCALE value      */
-    zero: f64,              /* I - FITS TZEROn or BZERO  value      */
-    output: &mut [c_short], /* O - output array of converted values */
-    status: &mut c_int,     /* IO - error status                    */
-                            /*
-                            Copy input to output prior to writing output to a FITS file.
-                            Do datatype conversion and scaling if required.
-                            */
+    input: &[c_ulong],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    output: &mut [c_short],
+    status: &mut c_int,
+    /*
+    Copy input to output prior to writing output to a FITS file.
+    Do datatype conversion and scaling if required.
+    */
 ) -> c_int {
     if scale == 1.0 && zero == 0.0 {
         for ii in 0..(ntodo as usize) {
@@ -1231,16 +1389,24 @@ pub(crate) fn ffu4fi2(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output prior to writing output to a FITS file.
 /// Do datatype conversion and scaling if required
+///
+/// # Parameters
+///
+/// * `input`  — (I) array of values to be converted
+/// * `ntodo`  — (I) number of elements in the array
+/// * `scale`  — (I) FITS TSCALn or BSCALE value
+/// * `zero`   — (I) FITS TZEROn or BZERO value
+/// * `output` — (O) output array of converted values
+/// * `status` — (IO) error status
 pub(crate) fn ffu4fi4(
-    input: &[c_ulong],       /* I - array of values to be converted  */
-    ntodo: c_long,           /* I - number of elements in the array  */
-    scale: f64,              /* I - FITS TSCALn or BSCALE value      */
-    zero: f64,               /* I - FITS TZEROn or BZERO  value      */
-    output: &mut [INT32BIT], /* O - output array of converted values */
-    status: &mut c_int,      /* IO - error status                    */
+    input: &[c_ulong],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    output: &mut [INT32BIT],
+    status: &mut c_int,
 ) -> c_int {
     if scale == 1.0 && zero == 2147483648.0 && c_long::BITS / 8 == 4 {
         /* Instead of subtracting 2147483648, it is more efficient */
@@ -1278,16 +1444,24 @@ pub(crate) fn ffu4fi4(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output prior to writing output to a FITS file.
 /// Do datatype conversion and scaling if required
+///
+/// # Parameters
+///
+/// * `input`  — (I) array of values to be converted
+/// * `ntodo`  — (I) number of elements in the array
+/// * `scale`  — (I) FITS TSCALn or BSCALE value
+/// * `zero`   — (I) FITS TZEROn or BZERO value
+/// * `output` — (O) output array of converted values
+/// * `status` — (IO) error status
 pub(crate) fn ffu4fi8(
-    input: &[c_ulong],       /* I - array of values to be converted  */
-    ntodo: c_long,           /* I - number of elements in the array  */
-    scale: f64,              /* I - FITS TSCALn or BSCALE value      */
-    zero: f64,               /* I - FITS TZEROn or BZERO  value      */
-    output: &mut [LONGLONG], /* O - output array of converted values */
-    status: &mut c_int,      /* IO - error status                    */
+    input: &[c_ulong],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    output: &mut [LONGLONG],
+    status: &mut c_int,
 ) -> c_int {
     if scale == 1.0 && zero == 9223372036854775808. {
         /* Writing to unsigned long long column. Input values must not be negative */
@@ -1324,16 +1498,24 @@ pub(crate) fn ffu4fi8(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output prior to writing output to a FITS file.
 /// Do datatype conversion and scaling if required.
+///
+/// # Parameters
+///
+/// * `input`  — (I) array of values to be converted
+/// * `ntodo`  — (I) number of elements in the array
+/// * `scale`  — (I) FITS TSCALn or BSCALE value
+/// * `zero`   — (I) FITS TZEROn or BZERO value
+/// * `output` — (O) output array of converted values
+/// * `status` — (IO) error status
 pub(crate) fn ffu4fr4(
-    input: &[c_ulong],  /* I - array of values to be converted  */
-    ntodo: c_long,      /* I - number of elements in the array  */
-    scale: f64,         /* I - FITS TSCALn or BSCALE value      */
-    zero: f64,          /* I - FITS TZEROn or BZERO  value      */
-    output: &mut [f32], /* O - output array of converted values */
-    status: &mut c_int, /* IO - error status                    */
+    input: &[c_ulong],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    output: &mut [f32],
+    status: &mut c_int,
 ) -> c_int {
     if scale == 1.0 && zero == 0.0 {
         for ii in 0..(ntodo as usize) {
@@ -1347,16 +1529,24 @@ pub(crate) fn ffu4fr4(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output prior to writing output to a FITS file.
 /// Do datatype conversion and scaling if required.
+///
+/// # Parameters
+///
+/// * `input`  — (I) array of values to be converted
+/// * `ntodo`  — (I) number of elements in the array
+/// * `scale`  — (I) FITS TSCALn or BSCALE value
+/// * `zero`   — (I) FITS TZEROn or BZERO value
+/// * `output` — (O) output array of converted values
+/// * `status` — (IO) error status
 pub(crate) fn ffu4fr8(
-    input: &[c_ulong],  /* I - array of values to be converted  */
-    ntodo: c_long,      /* I - number of elements in the array  */
-    scale: f64,         /* I - FITS TSCALn or BSCALE value      */
-    zero: f64,          /* I - FITS TZEROn or BZERO  value      */
-    output: &mut [f64], /* O - output array of converted values */
-    status: &mut c_int, /* IO - error status                    */
+    input: &[c_ulong],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    output: &mut [f64],
+    status: &mut c_int,
 ) -> c_int {
     if scale == 1.0 && zero == 0.0 {
         for ii in 0..(ntodo as usize) {
@@ -1370,18 +1560,28 @@ pub(crate) fn ffu4fr8(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output prior to writing output to a FITS file.
 /// Do scaling if required.
+///
+/// # Parameters
+///
+/// * `input`  — (I) array of values to be converted
+/// * `ntodo`  — (I) number of elements in the array
+/// * `scale`  — (I) FITS TSCALn or BSCALE value
+/// * `zero`   — (I) FITS TZEROn or BZERO value
+/// * `cform`  — (I) format for output string values
+/// * `twidth` — (I) width of each field, in chars
+/// * `output` — (O) output array of converted values
+/// * `status` — (IO) error status
 pub(crate) fn ffu4fstr(
-    input: &[c_ulong],     /* I - array of values to be converted  */
-    ntodo: c_long,         /* I - number of elements in the array  */
-    scale: f64,            /* I - FITS TSCALn or BSCALE value      */
-    zero: f64,             /* I - FITS TZEROn or BZERO  value      */
-    cform: &[c_char],      /* I - format for output string values  */
-    twidth: c_long,        /* I - width of each field, in chars    */
-    output: &mut [c_char], /* O - output array of converted values */
-    status: &mut c_int,    /* IO - error status                    */
+    input: &[c_ulong],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    cform: &[c_char],
+    twidth: c_long,
+    output: &mut [c_char],
+    status: &mut c_int,
 ) -> c_int {
     let mut oi = 0;
 
@@ -1422,7 +1622,6 @@ pub(crate) fn ffu4fstr(
 /*      the following routines support the 'long long' data type            */
 /* ======================================================================== */
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
 /// the FITS array is not the same as the array being written).
@@ -1431,14 +1630,23 @@ pub(crate) fn ffu4fstr(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to write(1 = 1st group)
+/// * `firstelem` — (I) first vector element to write(1 = 1st)
+/// * `nelem`     — (I) number of values to write
+/// * `array`     — (I) array of values that are written
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffpprujj(
-    fptr: *mut fitsfile,     /* I - FITS file pointer                       */
-    group: c_long,           /* I - group to write(1 = 1st group)           */
-    firstelem: LONGLONG,     /* I - first vector element to write(1 = 1st)  */
-    nelem: LONGLONG,         /* I - number of values to write               */
-    array: *const ULONGLONG, /* I - array of values that are written       */
-    status: *mut c_int,      /* IO - error status                           */
+    fptr: *mut fitsfile,
+    group: c_long,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: *const ULONGLONG,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -1450,7 +1658,6 @@ pub unsafe extern "C" fn ffpprujj(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
 /// the FITS array is not the same as the array being written).
@@ -1459,13 +1666,22 @@ pub unsafe extern "C" fn ffpprujj(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to write(1 = 1st group)
+/// * `firstelem` — (I) first vector element to write(1 = 1st)
+/// * `nelem`     — (I) number of values to write
+/// * `array`     — (I) array of values that are written
+/// * `status`    — (IO) error status
 pub fn ffpprujj_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                       */
-    group: c_long,       /* I - group to write(1 = 1st group)           */
-    firstelem: LONGLONG, /* I - first vector element to write(1 = 1st)  */
-    nelem: LONGLONG,     /* I - number of values to write               */
-    array: &[ULONGLONG], /* I - array of values that are written       */
-    status: &mut c_int,  /* IO - error status                           */
+    fptr: &mut fitsfile,
+    group: c_long,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: &[ULONGLONG],
+    status: &mut c_int,
 ) -> c_int {
     if fits_is_compressed_image_safe(fptr, status) > 0 {
         /* this is a compressed image in a binary table */
@@ -1490,7 +1706,6 @@ pub fn ffpprujj_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of the
 /// FITS array is not the same as the array being written).  Any array values
@@ -1501,15 +1716,25 @@ pub fn ffpprujj_safe(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to write(1 = 1st group)
+/// * `firstelem` — (I) first vector element to write(1 = 1st)
+/// * `nelem`     — (I) number of values to write
+/// * `array`     — (I) array of values that are written
+/// * `nulval`    — (I) undefined pixel value
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffppnujj(
-    fptr: *mut fitsfile,     /* I - FITS file pointer                       */
-    group: c_long,           /* I - group to write(1 = 1st group)           */
-    firstelem: LONGLONG,     /* I - first vector element to write(1 = 1st)  */
-    nelem: LONGLONG,         /* I - number of values to write               */
-    array: *const ULONGLONG, /* I - array of values that are written       */
-    nulval: ULONGLONG,       /* I - undefined pixel value                   */
-    status: *mut c_int,      /* IO - error status                           */
+    fptr: *mut fitsfile,
+    group: c_long,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: *const ULONGLONG,
+    nulval: ULONGLONG,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -1521,7 +1746,6 @@ pub unsafe extern "C" fn ffppnujj(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of the
 /// FITS array is not the same as the array being written).  Any array values
@@ -1532,14 +1756,24 @@ pub unsafe extern "C" fn ffppnujj(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to write(1 = 1st group)
+/// * `firstelem` — (I) first vector element to write(1 = 1st)
+/// * `nelem`     — (I) number of values to write
+/// * `array`     — (I) array of values that are written
+/// * `nulval`    — (I) undefined pixel value
+/// * `status`    — (IO) error status
 pub fn ffppnujj_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                       */
-    group: c_long,       /* I - group to write(1 = 1st group)           */
-    firstelem: LONGLONG, /* I - first vector element to write(1 = 1st)  */
-    nelem: LONGLONG,     /* I - number of values to write               */
-    array: &[ULONGLONG], /* I - array of values that are written       */
-    nulval: ULONGLONG,   /* I - undefined pixel value                   */
-    status: &mut c_int,  /* IO - error status                           */
+    fptr: &mut fitsfile,
+    group: c_long,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: &[ULONGLONG],
+    nulval: ULONGLONG,
+    status: &mut c_int,
 ) -> c_int {
     if fits_is_compressed_image_safe(fptr, status) > 0 {
         /* this is a compressed image in a binary table */
@@ -1565,19 +1799,28 @@ pub fn ffppnujj_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an entire 2-D array of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of the
 /// FITS array is not the same as the array being written).
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `group`  — (I) group to write(1 = 1st group)
+/// * `ncols`  — (I) number of pixels in each row of array
+/// * `naxis1` — (I) FITS image NAXIS1 value
+/// * `naxis2` — (I) FITS image NAXIS2 value
+/// * `array`  — (I) array to be written
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffp2dujj(
-    fptr: *mut fitsfile,     /* I - FITS file pointer                     */
-    group: c_long,           /* I - group to write(1 = 1st group)         */
-    ncols: LONGLONG,         /* I - number of pixels in each row of array */
-    naxis1: LONGLONG,        /* I - FITS image NAXIS1 value               */
-    naxis2: LONGLONG,        /* I - FITS image NAXIS2 value               */
-    array: *const ULONGLONG, /* I - array to be written                   */
-    status: *mut c_int,      /* IO - error status                         */
+    fptr: *mut fitsfile,
+    group: c_long,
+    ncols: LONGLONG,
+    naxis1: LONGLONG,
+    naxis2: LONGLONG,
+    array: *const ULONGLONG,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -1590,18 +1833,27 @@ pub unsafe extern "C" fn ffp2dujj(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an entire 2-D array of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of the
 /// FITS array is not the same as the array being written).
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `group`  — (I) group to write(1 = 1st group)
+/// * `ncols`  — (I) number of pixels in each row of array
+/// * `naxis1` — (I) FITS image NAXIS1 value
+/// * `naxis2` — (I) FITS image NAXIS2 value
+/// * `array`  — (I) array to be written
+/// * `status` — (IO) error status
 pub fn ffp2dujj_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                     */
-    group: c_long,       /* I - group to write(1 = 1st group)         */
-    ncols: LONGLONG,     /* I - number of pixels in each row of array */
-    naxis1: LONGLONG,    /* I - FITS image NAXIS1 value               */
-    naxis2: LONGLONG,    /* I - FITS image NAXIS2 value               */
-    array: &[ULONGLONG], /* I - array to be written                   */
-    status: &mut c_int,  /* IO - error status                         */
+    fptr: &mut fitsfile,
+    group: c_long,
+    ncols: LONGLONG,
+    naxis1: LONGLONG,
+    naxis2: LONGLONG,
+    array: &[ULONGLONG],
+    status: &mut c_int,
 ) -> c_int {
     /* call the 3D writing routine, with the 3rd dimension = 1 */
     ffp3dujj_safe(fptr, group, ncols, naxis2, naxis1, naxis2, 1, array, status);
@@ -1609,7 +1861,6 @@ pub fn ffp2dujj_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an entire 3-D cube of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of the
 /// FITS array is not the same as the array being written).
@@ -1618,17 +1869,29 @@ pub fn ffp2dujj_safe(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `group`  — (I) group to write(1 = 1st group)
+/// * `ncols`  — (I) number of pixels in each row of array
+/// * `nrows`  — (I) number of rows in each plane of array
+/// * `naxis1` — (I) FITS image NAXIS1 value
+/// * `naxis2` — (I) FITS image NAXIS2 value
+/// * `naxis3` — (I) FITS image NAXIS3 value
+/// * `array`  — (I) array to be written
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffp3dujj(
-    fptr: *mut fitsfile,     /* I - FITS file pointer                     */
-    group: c_long,           /* I - group to write(1 = 1st group)         */
-    ncols: LONGLONG,         /* I - number of pixels in each row of array */
-    nrows: LONGLONG,         /* I - number of rows in each plane of array */
-    naxis1: LONGLONG,        /* I - FITS image NAXIS1 value               */
-    naxis2: LONGLONG,        /* I - FITS image NAXIS2 value               */
-    naxis3: LONGLONG,        /* I - FITS image NAXIS3 value               */
-    array: *const ULONGLONG, /* I - array to be written                   */
-    status: *mut c_int,      /* IO - error status                         */
+    fptr: *mut fitsfile,
+    group: c_long,
+    ncols: LONGLONG,
+    nrows: LONGLONG,
+    naxis1: LONGLONG,
+    naxis2: LONGLONG,
+    naxis3: LONGLONG,
+    array: *const ULONGLONG,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -1643,7 +1906,6 @@ pub unsafe extern "C" fn ffp3dujj(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an entire 3-D cube of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of the
 /// FITS array is not the same as the array being written).
@@ -1652,16 +1914,28 @@ pub unsafe extern "C" fn ffp3dujj(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `group`  — (I) group to write(1 = 1st group)
+/// * `ncols`  — (I) number of pixels in each row of array
+/// * `nrows`  — (I) number of rows in each plane of array
+/// * `naxis1` — (I) FITS image NAXIS1 value
+/// * `naxis2` — (I) FITS image NAXIS2 value
+/// * `naxis3` — (I) FITS image NAXIS3 value
+/// * `array`  — (I) array to be written
+/// * `status` — (IO) error status
 pub fn ffp3dujj_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                     */
-    group: c_long,       /* I - group to write(1 = 1st group)         */
-    ncols: LONGLONG,     /* I - number of pixels in each row of array */
-    nrows: LONGLONG,     /* I - number of rows in each plane of array */
-    naxis1: LONGLONG,    /* I - FITS image NAXIS1 value               */
-    naxis2: LONGLONG,    /* I - FITS image NAXIS2 value               */
-    naxis3: LONGLONG,    /* I - FITS image NAXIS3 value               */
-    array: &[ULONGLONG], /* I - array to be written                   */
-    status: &mut c_int,  /* IO - error status                         */
+    fptr: &mut fitsfile,
+    group: c_long,
+    ncols: LONGLONG,
+    nrows: LONGLONG,
+    naxis1: LONGLONG,
+    naxis2: LONGLONG,
+    naxis3: LONGLONG,
+    array: &[ULONGLONG],
+    status: &mut c_int,
 ) -> c_int {
     if fits_is_compressed_image_safe(fptr, status) > 0 {
         /* this is a compressed image in a binary table */
@@ -1725,7 +1999,6 @@ pub fn ffp3dujj_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write a subsection of pixels to the primary array or image.
 ///
 /// A subsection is defined to be any contiguous rectangular
@@ -1733,16 +2006,27 @@ pub fn ffp3dujj_safe(
 /// Data conversion and scaling will be performed if necessary
 /// (e.g, if the datatype of the FITS array is not the same as
 /// the array being written).
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `group`  — (I) group to write(1 = 1st group)
+/// * `naxis`  — (I) number of data axes in array
+/// * `naxes`  — (I) size of each FITS axis
+/// * `fpixel` — (I) 1st pixel in each axis to write (1=1st)
+/// * `lpixel` — (I) last pixel in each axis to write
+/// * `array`  — (I) array to be written
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffpssujj(
-    fptr: *mut fitsfile,     /* I - FITS file pointer                       */
-    group: c_long,           /* I - group to write(1 = 1st group)           */
-    naxis: c_long,           /* I - number of data axes in array            */
-    naxes: *const c_long,    /* I - size of each FITS axis                  */
-    fpixel: *const c_long,   /* I - 1st pixel in each axis to write (1=1st) */
-    lpixel: *const c_long,   /* I - last pixel in each axis to write        */
-    array: *const ULONGLONG, /* I - array to be written                     */
-    status: *mut c_int,      /* IO - error status                           */
+    fptr: *mut fitsfile,
+    group: c_long,
+    naxis: c_long,
+    naxes: *const c_long,
+    fpixel: *const c_long,
+    lpixel: *const c_long,
+    array: *const ULONGLONG,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -1764,7 +2048,6 @@ pub unsafe extern "C" fn ffpssujj(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write a subsection of pixels to the primary array or image.
 ///
 /// A subsection is defined to be any contiguous rectangular
@@ -1772,15 +2055,26 @@ pub unsafe extern "C" fn ffpssujj(
 /// Data conversion and scaling will be performed if necessary
 /// (e.g, if the datatype of the FITS array is not the same as
 /// the array being written).
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `group`  — (I) group to write(1 = 1st group)
+/// * `naxis`  — (I) number of data axes in array
+/// * `naxes`  — (I) size of each FITS axis
+/// * `fpixel` — (I) 1st pixel in each axis to write (1=1st)
+/// * `lpixel` — (I) last pixel in each axis to write
+/// * `array`  — (I) array to be written
+/// * `status` — (IO) error status
 pub fn ffpssujj_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                       */
-    group: c_long,       /* I - group to write(1 = 1st group)           */
-    naxis: c_long,       /* I - number of data axes in array            */
-    naxes: &[c_long],    /* I - size of each FITS axis                  */
-    fpixel: &[c_long],   /* I - 1st pixel in each axis to write (1=1st) */
-    lpixel: &[c_long],   /* I - last pixel in each axis to write        */
-    array: &[ULONGLONG], /* I - array to be written                     */
-    status: &mut c_int,  /* IO - error status                           */
+    fptr: &mut fitsfile,
+    group: c_long,
+    naxis: c_long,
+    naxes: &[c_long],
+    fpixel: &[c_long],
+    lpixel: &[c_long],
+    array: &[ULONGLONG],
+    status: &mut c_int,
 ) -> c_int {
     let mut fpix: [LONGLONG; 7] = [0; 7];
     let mut dimen: [LONGLONG; 7] = [0; 7];
@@ -1900,7 +2194,6 @@ pub fn ffpssujj_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of group parameters to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
 /// the FITS array is not the same as the array being written).
@@ -1909,14 +2202,23 @@ pub fn ffpssujj_safe(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to write(1 = 1st group)
+/// * `firstelem` — (I) first vector element to write(1 = 1st)
+/// * `nelem`     — (I) number of values to write
+/// * `array`     — (I) array of values that are written
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffpgpujj(
-    fptr: *mut fitsfile,     /* I - FITS file pointer                      */
-    group: c_long,           /* I - group to write(1 = 1st group)          */
-    firstelem: c_long,       /* I - first vector element to write(1 = 1st) */
-    nelem: c_long,           /* I - number of values to write              */
-    array: *const ULONGLONG, /* I - array of values that are written       */
-    status: *mut c_int,      /* IO - error status                          */
+    fptr: *mut fitsfile,
+    group: c_long,
+    firstelem: c_long,
+    nelem: c_long,
+    array: *const ULONGLONG,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -1928,7 +2230,6 @@ pub unsafe extern "C" fn ffpgpujj(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of group parameters to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
 /// the FITS array is not the same as the array being written).
@@ -1937,13 +2238,22 @@ pub unsafe extern "C" fn ffpgpujj(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to write(1 = 1st group)
+/// * `firstelem` — (I) first vector element to write(1 = 1st)
+/// * `nelem`     — (I) number of values to write
+/// * `array`     — (I) array of values that are written
+/// * `status`    — (IO) error status
 pub fn ffpgpujj_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                      */
-    group: c_long,       /* I - group to write(1 = 1st group)          */
-    firstelem: c_long,   /* I - first vector element to write(1 = 1st) */
-    nelem: c_long,       /* I - number of values to write              */
-    array: &[ULONGLONG], /* I - array of values that are written       */
-    status: &mut c_int,  /* IO - error status                          */
+    fptr: &mut fitsfile,
+    group: c_long,
+    firstelem: c_long,
+    nelem: c_long,
+    array: &[ULONGLONG],
+    status: &mut c_int,
 ) -> c_int {
     let row = cmp::max(1, group);
 
@@ -1959,7 +2269,6 @@ pub fn ffpgpujj_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of values to a column in the current FITS HDU.
 ///
 /// The column number may refer to a real column in an ASCII or binary table,
@@ -1972,15 +2281,25 @@ pub fn ffpgpujj_safe(
 ///
 /// The input array of values will be converted to the datatype of the column
 /// and will be inverse-scaled by the FITS TSCALn and TZEROn values if necessary.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to write (1 = 1st col)
+/// * `firstrow`  — (I) first row to write (1 = 1st row)
+/// * `firstelem` — (I) first vector element to write (1 = 1st)
+/// * `nelem`     — (I) number of values to write
+/// * `array`     — (I) array of values to write
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffpclujj(
-    fptr: *mut fitsfile,     /* I - FITS file pointer                       */
-    colnum: c_int,           /* I - number of column to write (1 = 1st col) */
-    firstrow: LONGLONG,      /* I - first row to write (1 = 1st row)        */
-    firstelem: LONGLONG,     /* I - first vector element to write (1 = 1st) */
-    nelem: LONGLONG,         /* I - number of values to write               */
-    array: *const ULONGLONG, /* I - array of values to write               */
-    status: *mut c_int,      /* IO - error status                           */
+    fptr: *mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: *const ULONGLONG,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -2001,7 +2320,6 @@ pub unsafe extern "C" fn ffpclujj(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of values to a column in the current FITS HDU.
 ///
 /// The column number may refer to a real column in an ASCII or binary table,
@@ -2014,14 +2332,24 @@ pub unsafe extern "C" fn ffpclujj(
 ///
 /// The input array of values will be converted to the datatype of the column
 /// and will be inverse-scaled by the FITS TSCALn and TZEROn values if necessary.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to write (1 = 1st col)
+/// * `firstrow`  — (I) first row to write (1 = 1st row)
+/// * `firstelem` — (I) first vector element to write (1 = 1st)
+/// * `nelem`     — (I) number of values to write
+/// * `array`     — (I) array of values to write
+/// * `status`    — (IO) error status
 pub fn ffpclujj_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                       */
-    colnum: c_int,       /* I - number of column to write (1 = 1st col) */
-    firstrow: LONGLONG,  /* I - first row to write (1 = 1st row)        */
-    firstelem: LONGLONG, /* I - first vector element to write (1 = 1st) */
-    nelem: LONGLONG,     /* I - number of values to write               */
-    array: &[ULONGLONG], /* I - array of values to write               */
-    status: &mut c_int,  /* IO - error status                           */
+    fptr: &mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: &[ULONGLONG],
+    status: &mut c_int,
 ) -> c_int {
     let mut tcode: c_int = 0;
     let mut hdutype: c_int = 0;
@@ -2052,9 +2380,7 @@ pub fn ffpclujj_safe(
         return *status;
     }
 
-    /*---------------------------------------------------*/
     /*  Check input and get parameters about the column: */
-    /*---------------------------------------------------*/
     if ffgcprll(
         fptr,
         colnum,
@@ -2086,12 +2412,10 @@ pub fn ffpclujj_safe(
         ffcfmt(&tform, &mut cform); /* derive C format for writing strings */
     }
 
-    /*---------------------------------------------------------------------*/
     /*  Now write the pixels to the FITS column.                           */
     /*  First call the ffXXfYY routine to  (1) convert the datatype        */
     /*  if necessary, and (2) scale the values by the FITS TSCALn and      */
     /*  TZEROn linear scaling parameters into a temporary buffer.          */
-    /*---------------------------------------------------------------------*/
     remain = nelem; /* remaining number of values to write  */
     next = 0; /* next element in array to be written  */
     rownum = 0; /* row number, relative to firstrow     */
@@ -2258,9 +2582,7 @@ pub fn ffpclujj_safe(
             }
         } /* End of switch block */
 
-        /*-------------------------*/
         /*  Check for fatal error  */
-        /*-------------------------*/
         if *status > 0 {
             /* test for error during previous write operation */
 
@@ -2275,9 +2597,7 @@ pub fn ffpclujj_safe(
             return *status;
         }
 
-        /*--------------------------------------------*/
         /*  increment the counters for the next loop  */
-        /*--------------------------------------------*/
         remain -= ntodo as LONGLONG;
         if remain > 0 {
             next += ntodo as LONGLONG;
@@ -2291,9 +2611,7 @@ pub fn ffpclujj_safe(
         }
     } /*  End of main while Loop  */
 
-    /*--------------------------------*/
     /*  check for numerical overflow  */
-    /*--------------------------------*/
     if *status == OVERFLOW_ERR {
         ffpmsg_str("Numerical overflow during type conversion while writing FITS data.");
         *status = NUM_OVERFLOW;
@@ -2302,23 +2620,33 @@ pub fn ffpclujj_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of elements to the specified column of a table.  Any input
 /// pixels equal to the value of nulvalue will be replaced by the appropriate
 /// null value in the output FITS file.
 ///
 /// The input array of values will be converted to the datatype of the column
 /// and will be inverse-scaled by the FITS TSCALn and TZEROn values if necessary
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to write (1 = 1st col)
+/// * `firstrow`  — (I) first row to write (1 = 1st row)
+/// * `firstelem` — (I) first vector element to write (1 = 1st)
+/// * `nelem`     — (I) number of values to write
+/// * `array`     — (I) array of values to write
+/// * `nulvalue`  — (I) value used to flag undefined pixels
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffpcnujj(
-    fptr: *mut fitsfile,     /* I - FITS file pointer                       */
-    colnum: c_int,           /* I - number of column to write (1 = 1st col) */
-    firstrow: LONGLONG,      /* I - first row to write (1 = 1st row)        */
-    firstelem: LONGLONG,     /* I - first vector element to write (1 = 1st) */
-    nelem: LONGLONG,         /* I - number of values to write               */
-    array: *const ULONGLONG, /* I - array of values to write                */
-    nulvalue: ULONGLONG,     /* I - value used to flag undefined pixels   */
-    status: *mut c_int,      /* IO - error status                           */
+    fptr: *mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: *const ULONGLONG,
+    nulvalue: ULONGLONG,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -2340,22 +2668,32 @@ pub unsafe extern "C" fn ffpcnujj(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of elements to the specified column of a table.  Any input
 /// pixels equal to the value of nulvalue will be replaced by the appropriate
 /// null value in the output FITS file.
 ///
 /// The input array of values will be converted to the datatype of the column
 /// and will be inverse-scaled by the FITS TSCALn and TZEROn values if necessary
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to write (1 = 1st col)
+/// * `firstrow`  — (I) first row to write (1 = 1st row)
+/// * `firstelem` — (I) first vector element to write (1 = 1st)
+/// * `nelem`     — (I) number of values to write
+/// * `array`     — (I) array of values to write
+/// * `nulvalue`  — (I) value used to flag undefined pixels
+/// * `status`    — (IO) error status
 pub fn ffpcnujj_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                       */
-    colnum: c_int,       /* I - number of column to write (1 = 1st col) */
-    firstrow: LONGLONG,  /* I - first row to write (1 = 1st row)        */
-    firstelem: LONGLONG, /* I - first vector element to write (1 = 1st) */
-    nelem: LONGLONG,     /* I - number of values to write               */
-    array: &[ULONGLONG], /* I - array of values to write                */
-    nulvalue: ULONGLONG, /* I - value used to flag undefined pixels   */
-    status: &mut c_int,  /* IO - error status                           */
+    fptr: &mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: &[ULONGLONG],
+    nulvalue: ULONGLONG,
+    status: &mut c_int,
 ) -> c_int {
     let mut ngood: LONGLONG = 0;
     let mut nbad: LONGLONG = 0;
@@ -2508,16 +2846,24 @@ pub fn ffpcnujj_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output prior to writing output to a FITS file.
 /// Do datatype conversion and scaling if required.
+///
+/// # Parameters
+///
+/// * `input`  — (I) array of values to be converted
+/// * `ntodo`  — (I) number of elements in the array
+/// * `scale`  — (I) FITS TSCALn or BSCALE value
+/// * `zero`   — (I) FITS TZEROn or BZERO value
+/// * `output` — (O) output array of converted values
+/// * `status` — (IO) error status
 pub(crate) fn ffu8fi1(
-    input: &[ULONGLONG], /* I - array of values to be converted  */
-    ntodo: c_long,       /* I - number of elements in the array  */
-    scale: f64,          /* I - FITS TSCALn or BSCALE value      */
-    zero: f64,           /* I - FITS TZEROn or BZERO  value      */
-    output: &mut [u8],   /* O - output array of converted values */
-    status: &mut c_int,  /* IO - error status                    */
+    input: &[ULONGLONG],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    output: &mut [u8],
+    status: &mut c_int,
 ) -> c_int {
     if scale == 1.0 && zero == 0.0 {
         for ii in 0..(ntodo as usize) {
@@ -2546,16 +2892,24 @@ pub(crate) fn ffu8fi1(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output prior to writing output to a FITS file.
 /// Do datatype conversion and scaling if required.
+///
+/// # Parameters
+///
+/// * `input`  — (I) array of values to be converted
+/// * `ntodo`  — (I) number of elements in the array
+/// * `scale`  — (I) FITS TSCALn or BSCALE value
+/// * `zero`   — (I) FITS TZEROn or BZERO value
+/// * `output` — (O) output array of converted values
+/// * `status` — (IO) error status
 pub(crate) fn ffu8fi2(
-    input: &[ULONGLONG],    /* I - array of values to be converted  */
-    ntodo: c_long,          /* I - number of elements in the array  */
-    scale: f64,             /* I - FITS TSCALn or BSCALE value      */
-    zero: f64,              /* I - FITS TZEROn or BZERO  value      */
-    output: &mut [c_short], /* O - output array of converted values */
-    status: &mut c_int,     /* IO - error status                    */
+    input: &[ULONGLONG],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    output: &mut [c_short],
+    status: &mut c_int,
 ) -> c_int {
     if scale == 1.0 && zero == 0.0 {
         for ii in 0..(ntodo as usize) {
@@ -2586,16 +2940,24 @@ pub(crate) fn ffu8fi2(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output prior to writing output to a FITS file.
 /// Do datatype conversion and scaling if required
+///
+/// # Parameters
+///
+/// * `input`  — (I) array of values to be converted
+/// * `ntodo`  — (I) number of elements in the array
+/// * `scale`  — (I) FITS TSCALn or BSCALE value
+/// * `zero`   — (I) FITS TZEROn or BZERO value
+/// * `output` — (O) output array of converted values
+/// * `status` — (IO) error status
 pub(crate) fn ffu8fi4(
-    input: &[ULONGLONG],     /* I - array of values to be converted  */
-    ntodo: c_long,           /* I - number of elements in the array  */
-    scale: f64,              /* I - FITS TSCALn or BSCALE value      */
-    zero: f64,               /* I - FITS TZEROn or BZERO  value      */
-    output: &mut [INT32BIT], /* O - output array of converted values */
-    status: &mut c_int,      /* IO - error status                    */
+    input: &[ULONGLONG],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    output: &mut [INT32BIT],
+    status: &mut c_int,
 ) -> c_int {
     if scale == 1.0 && zero == 0.0 {
         for ii in 0..(ntodo as usize) {
@@ -2626,16 +2988,24 @@ pub(crate) fn ffu8fi4(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output prior to writing output to a FITS file.
 /// Do datatype conversion and scaling if required
+///
+/// # Parameters
+///
+/// * `input`  — (I) array of values to be converted
+/// * `ntodo`  — (I) number of elements in the array
+/// * `scale`  — (I) FITS TSCALn or BSCALE value
+/// * `zero`   — (I) FITS TZEROn or BZERO value
+/// * `output` — (O) output array of converted values
+/// * `status` — (IO) error status
 pub(crate) fn ffu8fi8(
-    input: &[ULONGLONG],     /* I - array of values to be converted  */
-    ntodo: c_long,           /* I - number of elements in the array  */
-    scale: f64,              /* I - FITS TSCALn or BSCALE value      */
-    zero: f64,               /* I - FITS TZEROn or BZERO  value      */
-    output: &mut [LONGLONG], /* O - output array of converted values */
-    status: &mut c_int,      /* IO - error status                    */
+    input: &[ULONGLONG],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    output: &mut [LONGLONG],
+    status: &mut c_int,
 ) -> c_int {
     if scale == 1.0 && zero == 9223372036854775808. {
         /* Writing to unsigned long long column. Input values must not be negative */
@@ -2677,16 +3047,24 @@ pub(crate) fn ffu8fi8(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output prior to writing output to a FITS file.
 /// Do datatype conversion and scaling if required.
+///
+/// # Parameters
+///
+/// * `input`  — (I) array of values to be converted
+/// * `ntodo`  — (I) number of elements in the array
+/// * `scale`  — (I) FITS TSCALn or BSCALE value
+/// * `zero`   — (I) FITS TZEROn or BZERO value
+/// * `output` — (O) output array of converted values
+/// * `status` — (IO) error status
 pub(crate) fn ffu8fr4(
-    input: &[ULONGLONG], /* I - array of values to be converted  */
-    ntodo: c_long,       /* I - number of elements in the array  */
-    scale: f64,          /* I - FITS TSCALn or BSCALE value      */
-    zero: f64,           /* I - FITS TZEROn or BZERO  value      */
-    output: &mut [f32],  /* O - output array of converted values */
-    status: &mut c_int,  /* IO - error status                    */
+    input: &[ULONGLONG],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    output: &mut [f32],
+    status: &mut c_int,
 ) -> c_int {
     if scale == 1.0 && zero == 0.0 {
         for ii in 0..(ntodo as usize) {
@@ -2700,16 +3078,24 @@ pub(crate) fn ffu8fr4(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output prior to writing output to a FITS file.
 /// Do datatype conversion and scaling if required.
+///
+/// # Parameters
+///
+/// * `input`  — (I) array of values to be converted
+/// * `ntodo`  — (I) number of elements in the array
+/// * `scale`  — (I) FITS TSCALn or BSCALE value
+/// * `zero`   — (I) FITS TZEROn or BZERO value
+/// * `output` — (O) output array of converted values
+/// * `status` — (IO) error status
 pub(crate) fn ffu8fr8(
-    input: &[ULONGLONG], /* I - array of values to be converted  */
-    ntodo: c_long,       /* I - number of elements in the array  */
-    scale: f64,          /* I - FITS TSCALn or BSCALE value      */
-    zero: f64,           /* I - FITS TZEROn or BZERO  value      */
-    output: &mut [f64],  /* O - output array of converted values */
-    status: &mut c_int,  /* IO - error status                    */
+    input: &[ULONGLONG],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    output: &mut [f64],
+    status: &mut c_int,
 ) -> c_int {
     if scale == 1.0 && zero == 0.0 {
         for ii in 0..(ntodo as usize) {
@@ -2723,18 +3109,28 @@ pub(crate) fn ffu8fr8(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output prior to writing output to a FITS file.
 /// Do scaling if required.
+///
+/// # Parameters
+///
+/// * `input`  — (I) array of values to be converted
+/// * `ntodo`  — (I) number of elements in the array
+/// * `scale`  — (I) FITS TSCALn or BSCALE value
+/// * `zero`   — (I) FITS TZEROn or BZERO value
+/// * `cform`  — (I) format for output string values
+/// * `twidth` — (I) width of each field, in chars
+/// * `output` — (O) output array of converted values
+/// * `status` — (IO) error status
 pub(crate) fn ffu8fstr(
-    input: &[ULONGLONG],   /* I - array of values to be converted  */
-    ntodo: c_long,         /* I - number of elements in the array  */
-    scale: f64,            /* I - FITS TSCALn or BSCALE value      */
-    zero: f64,             /* I - FITS TZEROn or BZERO  value      */
-    cform: &[c_char],      /* I - format for output string values  */
-    twidth: c_long,        /* I - width of each field, in chars    */
-    output: &mut [c_char], /* O - output array of converted values */
-    status: &mut c_int,    /* IO - error status                    */
+    input: &[ULONGLONG],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    cform: &[c_char],
+    twidth: c_long,
+    output: &mut [c_char],
+    status: &mut c_int,
 ) -> c_int {
     let mut oi = 0;
 

--- a/src/putcoluk.rs
+++ b/src/putcoluk.rs
@@ -1,9 +1,14 @@
-/*  This file, putcolk.rs, contains routines that write data elements to    */
-/*  a FITS image or table, with 'c_uint' datatype.                   */
-
-/*  The FITSIO software was written by William Pence at the High Energy    */
-/*  Astrophysic Science Archive Research Center (HEASARC) at the NASA      */
-/*  Goddard Space Flight Center.                                           */
+//! Routines that write data elements to a FITS image or table, with
+//! `unsigned int` datatype.
+//!
+//! The [`TUINT`] arm of the typed column I/O family. [`crate::putcol`]
+//! dispatches here when a caller asks for this datatype at run time; the
+//! write-side counterpart is [`crate::getcoluk`].
+//!
+//! Ported from CFITSIO's `putcoluk.c`, written by William Pence at the High
+//! Energy Astrophysics Science Archive Research Center (HEASARC), NASA Goddard
+//! Space Flight Center.
+#![warn(missing_docs)]
 
 use core::slice;
 use core::{cmp, mem};
@@ -27,7 +32,6 @@ use crate::relibc::header::stdio::snprintf_f64;
 use crate::wrappers::strlen_safe;
 use crate::{buffers::*, int_snprintf, slice_to_str};
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
 /// the FITS array is not the same as the array being written).
@@ -36,14 +40,23 @@ use crate::{buffers::*, int_snprintf, slice_to_str};
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to write(1 = 1st group)
+/// * `firstelem` — (I) first vector element to write(1 = 1st)
+/// * `nelem`     — (I) number of values to write
+/// * `array`     — (I) array of values that are written
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffppruk(
-    fptr: *mut fitsfile,  /* I - FITS file pointer                       */
-    group: c_long,        /* I - group to write(1 = 1st group)           */
-    firstelem: LONGLONG,  /* I - first vector element to write(1 = 1st)  */
-    nelem: LONGLONG,      /* I - number of values to write               */
-    array: *const c_uint, /* I - array of values that are written        */
-    status: *mut c_int,   /* IO - error status                           */
+    fptr: *mut fitsfile,
+    group: c_long,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: *const c_uint,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -56,7 +69,6 @@ pub unsafe extern "C" fn ffppruk(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
 /// the FITS array is not the same as the array being written).
@@ -65,13 +77,22 @@ pub unsafe extern "C" fn ffppruk(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to write(1 = 1st group)
+/// * `firstelem` — (I) first vector element to write(1 = 1st)
+/// * `nelem`     — (I) number of values to write
+/// * `array`     — (I) array of values that are written
+/// * `status`    — (IO) error status
 pub fn ffppruk_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                       */
-    group: c_long,       /* I - group to write(1 = 1st group)           */
-    firstelem: LONGLONG, /* I - first vector element to write(1 = 1st)  */
-    nelem: LONGLONG,     /* I - number of values to write               */
-    array: &[c_uint],    /* I - array of values that are written        */
-    status: &mut c_int,  /* IO - error status                           */
+    fptr: &mut fitsfile,
+    group: c_long,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: &[c_uint],
+    status: &mut c_int,
 ) -> c_int {
     let nullvalue: c_uint = 0;
 
@@ -96,7 +117,6 @@ pub fn ffppruk_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of the
 /// FITS array is not the same as the array being written).  Any array values
@@ -107,15 +127,25 @@ pub fn ffppruk_safe(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to write(1 = 1st group)
+/// * `firstelem` — (I) first vector element to write(1 = 1st)
+/// * `nelem`     — (I) number of values to write
+/// * `array`     — (I) array of values that are written
+/// * `nulval`    — (I) undefined pixel value
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffppnuk(
-    fptr: *mut fitsfile,  /* I - FITS file pointer                       */
-    group: c_long,        /* I - group to write(1 = 1st group)           */
-    firstelem: LONGLONG,  /* I - first vector element to write(1 = 1st)  */
-    nelem: LONGLONG,      /* I - number of values to write               */
-    array: *const c_uint, /* I - array of values that are written        */
-    nulval: c_uint,       /* I - undefined pixel value                   */
-    status: *mut c_int,   /* IO - error status                           */
+    fptr: *mut fitsfile,
+    group: c_long,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: *const c_uint,
+    nulval: c_uint,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -127,7 +157,6 @@ pub unsafe extern "C" fn ffppnuk(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of the
 /// FITS array is not the same as the array being written).  Any array values
@@ -138,14 +167,24 @@ pub unsafe extern "C" fn ffppnuk(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to write(1 = 1st group)
+/// * `firstelem` — (I) first vector element to write(1 = 1st)
+/// * `nelem`     — (I) number of values to write
+/// * `array`     — (I) array of values that are written
+/// * `nulval`    — (I) undefined pixel value
+/// * `status`    — (IO) error status
 pub fn ffppnuk_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                       */
-    group: c_long,       /* I - group to write(1 = 1st group)           */
-    firstelem: LONGLONG, /* I - first vector element to write(1 = 1st)  */
-    nelem: LONGLONG,     /* I - number of values to write               */
-    array: &[c_uint],    /* I - array of values that are written        */
-    nulval: c_uint,      /* I - undefined pixel value                   */
-    status: &mut c_int,  /* IO - error status                           */
+    fptr: &mut fitsfile,
+    group: c_long,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: &[c_uint],
+    nulval: c_uint,
+    status: &mut c_int,
 ) -> c_int {
     let mut nullvalue: c_uint = 0;
 
@@ -182,19 +221,28 @@ pub fn ffppnuk_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an entire 2-D array of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of the
 /// FITS array is not the same as the array being written).
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `group`  — (I) group to write(1 = 1st group)
+/// * `ncols`  — (I) number of pixels in each row of array
+/// * `naxis1` — (I) FITS image NAXIS1 value
+/// * `naxis2` — (I) FITS image NAXIS2 value
+/// * `array`  — (I) array to be written
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffp2duk(
-    fptr: *mut fitsfile,  /* I - FITS file pointer                     */
-    group: c_long,        /* I - group to write(1 = 1st group)         */
-    ncols: LONGLONG,      /* I - number of pixels in each row of array */
-    naxis1: LONGLONG,     /* I - FITS image NAXIS1 value               */
-    naxis2: LONGLONG,     /* I - FITS image NAXIS2 value               */
-    array: *const c_uint, /* I - array to be written                   */
-    status: *mut c_int,   /* IO - error status                         */
+    fptr: *mut fitsfile,
+    group: c_long,
+    ncols: LONGLONG,
+    naxis1: LONGLONG,
+    naxis2: LONGLONG,
+    array: *const c_uint,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -206,18 +254,27 @@ pub unsafe extern "C" fn ffp2duk(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an entire 2-D array of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of the
 /// FITS array is not the same as the array being written).
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `group`  — (I) group to write(1 = 1st group)
+/// * `ncols`  — (I) number of pixels in each row of array
+/// * `naxis1` — (I) FITS image NAXIS1 value
+/// * `naxis2` — (I) FITS image NAXIS2 value
+/// * `array`  — (I) array to be written
+/// * `status` — (IO) error status
 pub fn ffp2duk_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                     */
-    group: c_long,       /* I - group to write(1 = 1st group)         */
-    ncols: LONGLONG,     /* I - number of pixels in each row of array */
-    naxis1: LONGLONG,    /* I - FITS image NAXIS1 value               */
-    naxis2: LONGLONG,    /* I - FITS image NAXIS2 value               */
-    array: &[c_uint],    /* I - array to be written                   */
-    status: &mut c_int,  /* IO - error status                         */
+    fptr: &mut fitsfile,
+    group: c_long,
+    ncols: LONGLONG,
+    naxis1: LONGLONG,
+    naxis2: LONGLONG,
+    array: &[c_uint],
+    status: &mut c_int,
 ) -> c_int {
     /* call the 3D writing routine, with the 3rd dimension = 1 */
     ffp3duk_safe(fptr, group, ncols, naxis2, naxis1, naxis2, 1, array, status);
@@ -225,7 +282,6 @@ pub fn ffp2duk_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an entire 3-D cube of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of the
 /// FITS array is not the same as the array being written).
@@ -234,17 +290,29 @@ pub fn ffp2duk_safe(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `group`  — (I) group to write(1 = 1st group)
+/// * `ncols`  — (I) number of pixels in each row of array
+/// * `nrows`  — (I) number of rows in each plane of array
+/// * `naxis1` — (I) FITS image NAXIS1 value
+/// * `naxis2` — (I) FITS image NAXIS2 value
+/// * `naxis3` — (I) FITS image NAXIS3 value
+/// * `array`  — (I) array to be written
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffp3duk(
-    fptr: *mut fitsfile,  /* I - FITS file pointer                     */
-    group: c_long,        /* I - group to write(1 = 1st group)         */
-    ncols: LONGLONG,      /* I - number of pixels in each row of array */
-    nrows: LONGLONG,      /* I - number of rows in each plane of array */
-    naxis1: LONGLONG,     /* I - FITS image NAXIS1 value               */
-    naxis2: LONGLONG,     /* I - FITS image NAXIS2 value               */
-    naxis3: LONGLONG,     /* I - FITS image NAXIS3 value               */
-    array: *const c_uint, /* I - array to be written                   */
-    status: *mut c_int,   /* IO - error status                         */
+    fptr: *mut fitsfile,
+    group: c_long,
+    ncols: LONGLONG,
+    nrows: LONGLONG,
+    naxis1: LONGLONG,
+    naxis2: LONGLONG,
+    naxis3: LONGLONG,
+    array: *const c_uint,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -259,7 +327,6 @@ pub unsafe extern "C" fn ffp3duk(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an entire 3-D cube of values to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of the
 /// FITS array is not the same as the array being written).
@@ -268,16 +335,28 @@ pub unsafe extern "C" fn ffp3duk(
 /// each group of the primary array is a row in the table,
 /// where the first column contains the group parameters
 /// and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `group`  — (I) group to write(1 = 1st group)
+/// * `ncols`  — (I) number of pixels in each row of array
+/// * `nrows`  — (I) number of rows in each plane of array
+/// * `naxis1` — (I) FITS image NAXIS1 value
+/// * `naxis2` — (I) FITS image NAXIS2 value
+/// * `naxis3` — (I) FITS image NAXIS3 value
+/// * `array`  — (I) array to be written
+/// * `status` — (IO) error status
 pub fn ffp3duk_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                     */
-    group: c_long,       /* I - group to write(1 = 1st group)         */
-    ncols: LONGLONG,     /* I - number of pixels in each row of array */
-    nrows: LONGLONG,     /* I - number of rows in each plane of array */
-    naxis1: LONGLONG,    /* I - FITS image NAXIS1 value               */
-    naxis2: LONGLONG,    /* I - FITS image NAXIS2 value               */
-    naxis3: LONGLONG,    /* I - FITS image NAXIS3 value               */
-    array: &[c_uint],    /* I - array to be written                   */
-    status: &mut c_int,  /* IO - error status                         */
+    fptr: &mut fitsfile,
+    group: c_long,
+    ncols: LONGLONG,
+    nrows: LONGLONG,
+    naxis1: LONGLONG,
+    naxis2: LONGLONG,
+    naxis3: LONGLONG,
+    array: &[c_uint],
+    status: &mut c_int,
 ) -> c_int {
     let mut tablerow: c_long = 0;
     let fpixel: [c_long; 3] = [1, 1, 1];
@@ -357,7 +436,6 @@ pub fn ffp3duk_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write a subsection of pixels to the primary array or image.
 ///
 /// A subsection is defined to be any contiguous rectangular
@@ -365,16 +443,27 @@ pub fn ffp3duk_safe(
 /// Data conversion and scaling will be performed if necessary
 /// (e.g, if the datatype of the FITS array is not the same as
 /// the array being written).
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `group`  — (I) group to write(1 = 1st group)
+/// * `naxis`  — (I) number of data axes in array
+/// * `naxes`  — (I) size of each FITS axis
+/// * `fpixel` — (I) 1st pixel in each axis to write (1=1st)
+/// * `lpixel` — (I) last pixel in each axis to write
+/// * `array`  — (I) array to be written
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffpssuk(
-    fptr: *mut fitsfile,   /* I - FITS file pointer                       */
-    group: c_long,         /* I - group to write(1 = 1st group)           */
-    naxis: c_long,         /* I - number of data axes in array            */
-    naxes: *const c_long,  /* I - size of each FITS axis                  */
-    fpixel: *const c_long, /* I - 1st pixel in each axis to write (1=1st) */
-    lpixel: *const c_long, /* I - last pixel in each axis to write        */
-    array: *const c_uint,  /* I - array to be written                     */
-    status: *mut c_int,    /* IO - error status                           */
+    fptr: *mut fitsfile,
+    group: c_long,
+    naxis: c_long,
+    naxes: *const c_long,
+    fpixel: *const c_long,
+    lpixel: *const c_long,
+    array: *const c_uint,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -396,7 +485,6 @@ pub unsafe extern "C" fn ffpssuk(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write a subsection of pixels to the primary array or image.
 ///
 /// A subsection is defined to be any contiguous rectangular
@@ -404,15 +492,26 @@ pub unsafe extern "C" fn ffpssuk(
 /// Data conversion and scaling will be performed if necessary
 /// (e.g, if the datatype of the FITS array is not the same as
 /// the array being written).
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `group`  — (I) group to write(1 = 1st group)
+/// * `naxis`  — (I) number of data axes in array
+/// * `naxes`  — (I) size of each FITS axis
+/// * `fpixel` — (I) 1st pixel in each axis to write (1=1st)
+/// * `lpixel` — (I) last pixel in each axis to write
+/// * `array`  — (I) array to be written
+/// * `status` — (IO) error status
 pub fn ffpssuk_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                       */
-    group: c_long,       /* I - group to write(1 = 1st group)           */
-    naxis: c_long,       /* I - number of data axes in array            */
-    naxes: &[c_long],    /* I - size of each FITS axis                  */
-    fpixel: &[c_long],   /* I - 1st pixel in each axis to write (1=1st) */
-    lpixel: &[c_long],   /* I - last pixel in each axis to write        */
-    array: &[c_uint],    /* I - array to be written                     */
-    status: &mut c_int,  /* IO - error status                           */
+    fptr: &mut fitsfile,
+    group: c_long,
+    naxis: c_long,
+    naxes: &[c_long],
+    fpixel: &[c_long],
+    lpixel: &[c_long],
+    array: &[c_uint],
+    status: &mut c_int,
 ) -> c_int {
     let mut fpix: [LONGLONG; 7] = [0; 7];
     let mut dimen: [LONGLONG; 7] = [0; 7];
@@ -552,7 +651,6 @@ pub fn ffpssuk_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of group parameters to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
 /// the FITS array is not the same as the array being written).
@@ -561,14 +659,23 @@ pub fn ffpssuk_safe(
 ///each group of the primary array is a row in the table,
 ///where the first column contains the group parameters
 ///and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to write(1 = 1st group)
+/// * `firstelem` — (I) first vector element to write(1 = 1st)
+/// * `nelem`     — (I) number of values to write
+/// * `array`     — (I) array of values that are written
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffpgpuk(
-    fptr: *mut fitsfile,  /* I - FITS file pointer                      */
-    group: c_long,        /* I - group to write(1 = 1st group)          */
-    firstelem: c_long,    /* I - first vector element to write(1 = 1st) */
-    nelem: c_long,        /* I - number of values to write              */
-    array: *const c_uint, /* I - array of values that are written       */
-    status: *mut c_int,   /* IO - error status                          */
+    fptr: *mut fitsfile,
+    group: c_long,
+    firstelem: c_long,
+    nelem: c_long,
+    array: *const c_uint,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -580,7 +687,6 @@ pub unsafe extern "C" fn ffpgpuk(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of group parameters to the primary array. Data conversion
 /// and scaling will be performed if necessary (e.g, if the datatype of
 /// the FITS array is not the same as the array being written).
@@ -589,13 +695,22 @@ pub unsafe extern "C" fn ffpgpuk(
 ///each group of the primary array is a row in the table,
 ///where the first column contains the group parameters
 ///and the second column contains the image itself.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `group`     — (I) group to write(1 = 1st group)
+/// * `firstelem` — (I) first vector element to write(1 = 1st)
+/// * `nelem`     — (I) number of values to write
+/// * `array`     — (I) array of values that are written
+/// * `status`    — (IO) error status
 pub fn ffpgpuk_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                      */
-    group: c_long,       /* I - group to write(1 = 1st group)          */
-    firstelem: c_long,   /* I - first vector element to write(1 = 1st) */
-    nelem: c_long,       /* I - number of values to write              */
-    array: &[c_uint],    /* I - array of values that are written       */
-    status: &mut c_int,  /* IO - error status                          */
+    fptr: &mut fitsfile,
+    group: c_long,
+    firstelem: c_long,
+    nelem: c_long,
+    array: &[c_uint],
+    status: &mut c_int,
 ) -> c_int {
     let row = cmp::max(1, group);
 
@@ -611,7 +726,6 @@ pub fn ffpgpuk_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of values to a column in the current FITS HDU.
 ///
 /// The column number may refer to a real column in an ASCII or binary table,
@@ -624,15 +738,25 @@ pub fn ffpgpuk_safe(
 ///
 /// The input array of values will be converted to the datatype of the column
 /// and will be inverse-scaled by the FITS TSCALn and TZEROn values if necessary.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to write (1 = 1st col)
+/// * `firstrow`  — (I) first row to write (1 = 1st row)
+/// * `firstelem` — (I) first vector element to write (1 = 1st)
+/// * `nelem`     — (I) number of values to write
+/// * `array`     — (I) array of values to write
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffpcluk(
-    fptr: *mut fitsfile,  /* I - FITS file pointer                       */
-    colnum: c_int,        /* I - number of column to write (1 = 1st col) */
-    firstrow: LONGLONG,   /* I - first row to write (1 = 1st row)        */
-    firstelem: LONGLONG,  /* I - first vector element to write (1 = 1st) */
-    nelem: LONGLONG,      /* I - number of values to write               */
-    array: *const c_uint, /* I - array of values to write                */
-    status: *mut c_int,   /* IO - error status                           */
+    fptr: *mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: *const c_uint,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -653,7 +777,6 @@ pub unsafe extern "C" fn ffpcluk(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of values to a column in the current FITS HDU.
 ///
 /// The column number may refer to a real column in an ASCII or binary table,
@@ -666,14 +789,24 @@ pub unsafe extern "C" fn ffpcluk(
 ///
 /// The input array of values will be converted to the datatype of the column
 /// and will be inverse-scaled by the FITS TSCALn and TZEROn values if necessary.
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to write (1 = 1st col)
+/// * `firstrow`  — (I) first row to write (1 = 1st row)
+/// * `firstelem` — (I) first vector element to write (1 = 1st)
+/// * `nelem`     — (I) number of values to write
+/// * `array`     — (I) array of values to write
+/// * `status`    — (IO) error status
 pub fn ffpcluk_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                       */
-    colnum: c_int,       /* I - number of column to write (1 = 1st col) */
-    firstrow: LONGLONG,  /* I - first row to write (1 = 1st row)        */
-    firstelem: LONGLONG, /* I - first vector element to write (1 = 1st) */
-    nelem: LONGLONG,     /* I - number of values to write               */
-    array: &[c_uint],    /* I - array of values to write                */
-    status: &mut c_int,  /* IO - error status                           */
+    fptr: &mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: &[c_uint],
+    status: &mut c_int,
 ) -> c_int {
     let mut tcode: c_int = 0;
     let mut maxelem: c_int = 0;
@@ -732,9 +865,7 @@ pub fn ffpcluk_safe(
         int = 4 bytes, and long = 8 bytes.
         */
 
-        /*---------------------------------------------------*/
         /*  Check input and get parameters about the column: */
-        /*---------------------------------------------------*/
         if ffgcprll(
             fptr,
             colnum,
@@ -766,12 +897,10 @@ pub fn ffpcluk_safe(
             ffcfmt(&tform, &mut cform); /* derive C format for writing strings */
         }
 
-        /*---------------------------------------------------------------------*/
         /*  Now write the pixels to the FITS column.                           */
         /*  First call the ffXXfYY routine to  (1) convert the datatype        */
         /*  if necessary, and (2) scale the values by the FITS TSCALn and      */
         /*  TZEROn linear scaling parameters into a temporary buffer.          */
-        /*---------------------------------------------------------------------*/
         remain = nelem; /* remaining number of values to write  */
         next = 0; /* next element in array to be written  */
         rownum = 0; /* row number, relative to firstrow     */
@@ -933,9 +1062,7 @@ pub fn ffpcluk_safe(
                 }
             } /* End of switch block */
 
-            /*-------------------------*/
             /*  Check for fatal error  */
-            /*-------------------------*/
             if *status > 0 {
                 /* test for error during previous write operation */
 
@@ -950,9 +1077,7 @@ pub fn ffpcluk_safe(
                 return *status;
             }
 
-            /*--------------------------------------------*/
             /*  increment the counters for the next loop  */
-            /*--------------------------------------------*/
             remain -= ntodo as LONGLONG;
             if remain > 0 {
                 next += ntodo as LONGLONG;
@@ -966,9 +1091,7 @@ pub fn ffpcluk_safe(
             }
         } /*  End of main while Loop  */
 
-        /*--------------------------------*/
         /*  check for numerical overflow  */
-        /*--------------------------------*/
         if *status == OVERFLOW_ERR {
             ffpmsg_str("Numerical overflow during type conversion while writing FITS data.");
             *status = NUM_OVERFLOW;
@@ -978,23 +1101,33 @@ pub fn ffpcluk_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of elements to the specified column of a table.  Any input
 /// pixels equal to the value of nulvalue will be replaced by the appropriate
 /// null value in the output FITS file.
 ///
 /// The input array of values will be converted to the datatype of the column
 /// and will be inverse-scaled by the FITS TSCALn and TZEROn values if necessary
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to write (1 = 1st col)
+/// * `firstrow`  — (I) first row to write (1 = 1st row)
+/// * `firstelem` — (I) first vector element to write (1 = 1st)
+/// * `nelem`     — (I) number of values to write
+/// * `array`     — (I) array of values to write
+/// * `nulvalue`  — (I) value used to flag undefined pixels
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffpcnuk(
-    fptr: *mut fitsfile,  /* I - FITS file pointer                       */
-    colnum: c_int,        /* I - number of column to write (1 = 1st col) */
-    firstrow: LONGLONG,   /* I - first row to write (1 = 1st row)        */
-    firstelem: LONGLONG,  /* I - first vector element to write (1 = 1st) */
-    nelem: LONGLONG,      /* I - number of values to write               */
-    array: *const c_uint, /* I - array of values to write                */
-    nulvalue: c_uint,     /* I - value used to flag undefined pixels     */
-    status: *mut c_int,   /* IO - error status                           */
+    fptr: *mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: *const c_uint,
+    nulvalue: c_uint,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -1016,22 +1149,32 @@ pub unsafe extern "C" fn ffpcnuk(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write an array of elements to the specified column of a table.  Any input
 /// pixels equal to the value of nulvalue will be replaced by the appropriate
 /// null value in the output FITS file.
 ///
 /// The input array of values will be converted to the datatype of the column
 /// and will be inverse-scaled by the FITS TSCALn and TZEROn values if necessary
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) number of column to write (1 = 1st col)
+/// * `firstrow`  — (I) first row to write (1 = 1st row)
+/// * `firstelem` — (I) first vector element to write (1 = 1st)
+/// * `nelem`     — (I) number of values to write
+/// * `array`     — (I) array of values to write
+/// * `nulvalue`  — (I) value used to flag undefined pixels
+/// * `status`    — (IO) error status
 pub fn ffpcnuk_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                       */
-    colnum: c_int,       /* I - number of column to write (1 = 1st col) */
-    firstrow: LONGLONG,  /* I - first row to write (1 = 1st row)        */
-    firstelem: LONGLONG, /* I - first vector element to write (1 = 1st) */
-    nelem: LONGLONG,     /* I - number of values to write               */
-    array: &[c_uint],    /* I - array of values to write                */
-    nulvalue: c_uint,    /* I - value used to flag undefined pixels     */
-    status: &mut c_int,  /* IO - error status                           */
+    fptr: &mut fitsfile,
+    colnum: c_int,
+    firstrow: LONGLONG,
+    firstelem: LONGLONG,
+    nelem: LONGLONG,
+    array: &[c_uint],
+    nulvalue: c_uint,
+    status: &mut c_int,
 ) -> c_int {
     let mut ngood: LONGLONG = 0;
     let mut nbad: LONGLONG = 0;
@@ -1185,16 +1328,24 @@ pub fn ffpcnuk_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output prior to writing output to a FITS file.
 /// Do datatype conversion and scaling if required.
+///
+/// # Parameters
+///
+/// * `input`  — (I) array of values to be converted
+/// * `ntodo`  — (I) number of elements in the array
+/// * `scale`  — (I) FITS TSCALn or BSCALE value
+/// * `zero`   — (I) FITS TZEROn or BZERO value
+/// * `output` — (O) output array of converted values
+/// * `status` — (IO) error status
 pub(crate) fn ffuintfi1(
-    input: &[c_uint],   /* I - array of values to be converted  */
-    ntodo: c_long,      /* I - number of elements in the array  */
-    scale: f64,         /* I - FITS TSCALn or BSCALE value      */
-    zero: f64,          /* I - FITS TZEROn or BZERO  value      */
-    output: &mut [u8],  /* O - output array of converted values */
-    status: &mut c_int, /* IO - error status                    */
+    input: &[c_uint],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    output: &mut [u8],
+    status: &mut c_int,
 ) -> c_int {
     if scale == 1.0 && zero == 0.0 {
         for ii in 0..(ntodo as usize) {
@@ -1223,16 +1374,24 @@ pub(crate) fn ffuintfi1(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output prior to writing output to a FITS file.
 /// Do datatype conversion and scaling if required.
+///
+/// # Parameters
+///
+/// * `input`  — (I) array of values to be converted
+/// * `ntodo`  — (I) number of elements in the array
+/// * `scale`  — (I) FITS TSCALn or BSCALE value
+/// * `zero`   — (I) FITS TZEROn or BZERO value
+/// * `output` — (O) output array of converted values
+/// * `status` — (IO) error status
 pub(crate) fn ffuintfi2(
-    input: &[c_uint],       /* I - array of values to be converted  */
-    ntodo: c_long,          /* I - number of elements in the array  */
-    scale: f64,             /* I - FITS TSCALn or BSCALE value      */
-    zero: f64,              /* I - FITS TZEROn or BZERO  value      */
-    output: &mut [c_short], /* O - output array of converted values */
-    status: &mut c_int,     /* IO - error status                    */
+    input: &[c_uint],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    output: &mut [c_short],
+    status: &mut c_int,
 ) -> c_int {
     if scale == 1.0 && zero == 0.0 {
         for ii in 0..(ntodo as usize) {
@@ -1263,16 +1422,24 @@ pub(crate) fn ffuintfi2(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output prior to writing output to a FITS file.
 /// Do datatype conversion and scaling if required
+///
+/// # Parameters
+///
+/// * `input`  — (I) array of values to be converted
+/// * `ntodo`  — (I) number of elements in the array
+/// * `scale`  — (I) FITS TSCALn or BSCALE value
+/// * `zero`   — (I) FITS TZEROn or BZERO value
+/// * `output` — (O) output array of converted values
+/// * `status` — (IO) error status
 pub(crate) fn ffuintfi4(
-    input: &[c_uint],        /* I - array of values to be converted  */
-    ntodo: c_long,           /* I - number of elements in the array  */
-    scale: f64,              /* I - FITS TSCALn or BSCALE value      */
-    zero: f64,               /* I - FITS TZEROn or BZERO  value      */
-    output: &mut [INT32BIT], /* O - output array of converted values */
-    status: &mut c_int,      /* IO - error status                    */
+    input: &[c_uint],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    output: &mut [INT32BIT],
+    status: &mut c_int,
 ) -> c_int {
     if scale == 1.0 && zero == 2147483648. {
         /* Instead of subtracting 2147483648, it is more efficient */
@@ -1310,16 +1477,24 @@ pub(crate) fn ffuintfi4(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output prior to writing output to a FITS file.
 /// Do datatype conversion and scaling if required
+///
+/// # Parameters
+///
+/// * `input`  — (I) array of values to be converted
+/// * `ntodo`  — (I) number of elements in the array
+/// * `scale`  — (I) FITS TSCALn or BSCALE value
+/// * `zero`   — (I) FITS TZEROn or BZERO value
+/// * `output` — (O) output array of converted values
+/// * `status` — (IO) error status
 pub(crate) fn ffuintfi8(
-    input: &[c_uint],        /* I - array of values to be converted  */
-    ntodo: c_long,           /* I - number of elements in the array  */
-    scale: f64,              /* I - FITS TSCALn or BSCALE value      */
-    zero: f64,               /* I - FITS TZEROn or BZERO  value      */
-    output: &mut [LONGLONG], /* O - output array of converted values */
-    status: &mut c_int,      /* IO - error status                    */
+    input: &[c_uint],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    output: &mut [LONGLONG],
+    status: &mut c_int,
 ) -> c_int {
     if scale == 1.0 && zero == 9223372036854775808.0 {
         /* Writing to unsigned long long column. */
@@ -1356,16 +1531,24 @@ pub(crate) fn ffuintfi8(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output prior to writing output to a FITS file.
 /// Do datatype conversion and scaling if required.
+///
+/// # Parameters
+///
+/// * `input`  — (I) array of values to be converted
+/// * `ntodo`  — (I) number of elements in the array
+/// * `scale`  — (I) FITS TSCALn or BSCALE value
+/// * `zero`   — (I) FITS TZEROn or BZERO value
+/// * `output` — (O) output array of converted values
+/// * `status` — (IO) error status
 pub(crate) fn ffuintfr4(
-    input: &[c_uint],   /* I - array of values to be converted  */
-    ntodo: c_long,      /* I - number of elements in the array  */
-    scale: f64,         /* I - FITS TSCALn or BSCALE value      */
-    zero: f64,          /* I - FITS TZEROn or BZERO  value      */
-    output: &mut [f32], /* O - output array of converted values */
-    status: &mut c_int, /* IO - error status                    */
+    input: &[c_uint],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    output: &mut [f32],
+    status: &mut c_int,
 ) -> c_int {
     if scale == 1.0 && zero == 0.0 {
         for ii in 0..(ntodo as usize) {
@@ -1379,16 +1562,24 @@ pub(crate) fn ffuintfr4(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output prior to writing output to a FITS file.
 /// Do datatype conversion and scaling if required.
+///
+/// # Parameters
+///
+/// * `input`  — (I) array of values to be converted
+/// * `ntodo`  — (I) number of elements in the array
+/// * `scale`  — (I) FITS TSCALn or BSCALE value
+/// * `zero`   — (I) FITS TZEROn or BZERO value
+/// * `output` — (O) output array of converted values
+/// * `status` — (IO) error status
 pub(crate) fn ffuintfr8(
-    input: &[c_uint],   /* I - array of values to be converted  */
-    ntodo: c_long,      /* I - number of elements in the array  */
-    scale: f64,         /* I - FITS TSCALn or BSCALE value      */
-    zero: f64,          /* I - FITS TZEROn or BZERO  value      */
-    output: &mut [f64], /* O - output array of converted values */
-    status: &mut c_int, /* IO - error status                    */
+    input: &[c_uint],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    output: &mut [f64],
+    status: &mut c_int,
 ) -> c_int {
     if scale == 1.0 && zero == 0.0 {
         for ii in 0..(ntodo as usize) {
@@ -1402,18 +1593,28 @@ pub(crate) fn ffuintfr8(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Copy input to output prior to writing output to a FITS file.
 /// Do scaling if required.
+///
+/// # Parameters
+///
+/// * `input`  — (I) array of values to be converted
+/// * `ntodo`  — (I) number of elements in the array
+/// * `scale`  — (I) FITS TSCALn or BSCALE value
+/// * `zero`   — (I) FITS TZEROn or BZERO value
+/// * `cform`  — (I) format for output string values
+/// * `twidth` — (I) width of each field, in chars
+/// * `output` — (O) output array of converted values
+/// * `status` — (IO) error status
 pub(crate) fn ffuintfstr(
-    input: &[c_uint],      /* I - array of values to be converted  */
-    ntodo: c_long,         /* I - number of elements in the array  */
-    scale: f64,            /* I - FITS TSCALn or BSCALE value      */
-    zero: f64,             /* I - FITS TZEROn or BZERO  value      */
-    cform: &[c_char],      /* I - format for output string values  */
-    twidth: c_long,        /* I - width of each field, in chars    */
-    output: &mut [c_char], /* O - output array of converted values */
-    status: &mut c_int,    /* IO - error status                    */
+    input: &[c_uint],
+    ntodo: c_long,
+    scale: f64,
+    zero: f64,
+    cform: &[c_char],
+    twidth: c_long,
+    output: &mut [c_char],
+    status: &mut c_int,
 ) -> c_int {
     let mut oi = 0;
 

--- a/src/putkey.rs
+++ b/src/putkey.rs
@@ -1,9 +1,22 @@
-/*  This file, putkey.rs, contains routines that write keywords to          */
-/*  a FITS header.                                                         */
-
-/*  The FITSIO software was written by William Pence at the High Energy    */
-/*  Astrophysic Science Archive Research Center (HEASARC) at the NASA      */
-/*  Goddard Space Flight Center.                                           */
+//! Routines that write keywords to a FITS header.
+//!
+//! The `ffpky*` family appends a keyword of a given datatype, formatting the
+//! value into the card's value field; the `ffpkn*` family writes an indexed set
+//! such as `TTYPEn`. Writing a value too long for one card uses the long-string
+//! convention, continuing it over `CONTINUE` keywords.
+//!
+//! Also here are the routines that write the required keywords for each HDU
+//! type (`ffphps`, `ffphbn`, `ffphtb`), which is how a newly created HDU gets
+//! its mandatory structure, and the number-to-string formatters the whole
+//! family is built on.
+//!
+//! Appending a keyword may need more room than the current header has, in which
+//! case a FITS block is inserted and the data that follows is moved.
+//!
+//! Ported from CFITSIO's `putkey.c`, written by William Pence at the High
+//! Energy Astrophysics Science Archive Research Center (HEASARC), NASA Goddard
+//! Space Flight Center.
+#![warn(missing_docs)]
 
 use alloc::ffi::CString;
 use core::ffi::CStr;
@@ -35,18 +48,25 @@ use crate::{bb, cs, parse_c_int};
 use crate::{buffers::*, nullable_slice_cstr, raw_to_slice};
 use crate::{fitsio::*, fmt_f64};
 
-/*--------------------------------------------------------------------------*/
-/// create an IMAGE extension following the current HDU. If the
+/// Create an IMAGE extension following the current HDU. If the
 /// current HDU is empty (contains no header keywords), then simply
 /// write the required image (or primary array) keywords to the current
 /// HDU.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `bitpix` — (I) bits per pixel
+/// * `naxis`  — (I) number of axes in the array
+/// * `naxes`  — (I) size of each axis
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffcrim(
-    fptr: *mut fitsfile,  /* I - FITS file pointer           */
-    bitpix: c_int,        /* I - bits per pixel              */
-    naxis: c_int,         /* I - number of axes in the array */
-    naxes: *const c_long, /* I - size of each axis           */
-    status: *mut c_int,   /* IO - error status               */
+    fptr: *mut fitsfile,
+    bitpix: c_int,
+    naxis: c_int,
+    naxes: *const c_long,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -62,17 +82,24 @@ pub unsafe extern "C" fn ffcrim(
     }
 }
 
-/*--------------------------------------------------------------------------*/
-/// create an IMAGE extension following the current HDU. If the
+/// Create an IMAGE extension following the current HDU. If the
 /// current HDU is empty (contains no header keywords), then simply
 /// write the required image (or primary array) keywords to the current
 /// HDU.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `bitpix` — (I) bits per pixel
+/// * `naxis`  — (I) number of axes in the array
+/// * `naxes`  — (I) size of each axis
+/// * `status` — (IO) error status
 pub fn ffcrim_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer           */
-    bitpix: c_int,       /* I - bits per pixel              */
-    naxis: c_int,        /* I - number of axes in the array */
-    naxes: &[c_long],    /* I - size of each axis           */
-    status: &mut c_int,  /* IO - error status               */
+    fptr: &mut fitsfile,
+    bitpix: c_int,
+    naxis: c_int,
+    naxes: &[c_long],
+    status: &mut c_int,
 ) -> c_int {
     if *status > 0 {
         return *status;
@@ -104,18 +131,25 @@ pub fn ffcrim_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
-/// create an IMAGE extension following the current HDU. If the
+/// Create an IMAGE extension following the current HDU. If the
 /// current HDU is empty (contains no header keywords), then simply
 /// write the required image (or primary array) keywords to the current
 /// HDU.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `bitpix` — (I) bits per pixel
+/// * `naxis`  — (I) number of axes in the array
+/// * `naxes`  — (I) size of each axis
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffcrimll(
-    fptr: *mut fitsfile,    /* I - FITS file pointer           */
-    bitpix: c_int,          /* I - bits per pixel              */
-    naxis: c_int,           /* I - number of axes in the array */
-    naxes: *const LONGLONG, /* I - size of each axis           */
-    status: *mut c_int,     /* IO - error status               */
+    fptr: *mut fitsfile,
+    bitpix: c_int,
+    naxis: c_int,
+    naxes: *const LONGLONG,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -128,17 +162,24 @@ pub unsafe extern "C" fn ffcrimll(
     }
 }
 
-/*--------------------------------------------------------------------------*/
-/// create an IMAGE extension following the current HDU. If the
+/// Create an IMAGE extension following the current HDU. If the
 /// current HDU is empty (contains no header keywords), then simply
 /// write the required image (or primary array) keywords to the current
 /// HDU.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `bitpix` — (I) bits per pixel
+/// * `naxis`  — (I) number of axes in the array
+/// * `naxes`  — (I) size of each axis
+/// * `status` — (IO) error status
 pub fn ffcrimll_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer           */
-    bitpix: c_int,       /* I - bits per pixel              */
-    naxis: c_int,        /* I - number of axes in the array */
-    naxes: &[LONGLONG],  /* I - size of each axis           */
-    status: &mut c_int,  /* IO - error status               */
+    fptr: &mut fitsfile,
+    bitpix: c_int,
+    naxis: c_int,
+    naxes: &[LONGLONG],
+    status: &mut c_int,
 ) -> c_int {
     if *status > 0 {
         return *status;
@@ -170,19 +211,30 @@ pub fn ffcrimll_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Create a table extension in a FITS file.
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `tbltype` — (I) type of table to create
+/// * `naxis2`  — (I) number of rows in the table
+/// * `tfields` — (I) number of columns in the table
+/// * `ttype`   — (I) name of each column
+/// * `tform`   — (I) value of TFORMn keyword for each column
+/// * `tunit`   — (I) value of TUNITn keyword for each column
+/// * `extnm`   — (I) value of EXTNAME keyword, if any
+/// * `status`  — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffcrtb(
-    fptr: *mut fitsfile,         /* I - FITS file pointer                        */
-    tbltype: c_int,              /* I - type of table to create                  */
-    naxis2: LONGLONG,            /* I - number of rows in the table              */
-    tfields: c_int,              /* I - number of columns in the table           */
-    ttype: *const *const c_char, /* I - name of each column                      */
-    tform: *const *const c_char, /* I - value of TFORMn keyword for each column  */
-    tunit: *const *const c_char, /* I - value of TUNITn keyword for each column  */
-    extnm: *const c_char,        /* I - value of EXTNAME keyword, if any         */
-    status: *mut c_int,          /* IO - error status                            */
+    fptr: *mut fitsfile,
+    tbltype: c_int,
+    naxis2: LONGLONG,
+    tfields: c_int,
+    ttype: *const *const c_char,
+    tform: *const *const c_char,
+    tunit: *const *const c_char,
+    extnm: *const c_char,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -208,18 +260,29 @@ pub unsafe extern "C" fn ffcrtb(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Create a table extension in a FITS file.
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `tbltype` — (I) type of table to create
+/// * `naxis2`  — (I) number of rows in the table
+/// * `tfields` — (I) number of columns in the table
+/// * `ttype`   — (I) name of each column
+/// * `tform`   — (I) value of TFORMn keyword for each column
+/// * `tunit`   — (I) value of TUNITn keyword for each column
+/// * `extnm`   — (I) value of EXTNAME keyword, if any
+/// * `status`  — (IO) error status
 pub fn ffcrtb_safe(
-    fptr: &mut fitsfile,         /* I - FITS file pointer                        */
-    tbltype: c_int,              /* I - type of table to create                  */
-    naxis2: LONGLONG,            /* I - number of rows in the table              */
-    tfields: c_int,              /* I - number of columns in the table           */
-    ttype: &[Option<&[c_char]>], /* I - name of each column                      */
-    tform: &[&[c_char]],         /* I - value of TFORMn keyword for each column  */
-    tunit: Option<&[Option<&[c_char]>]>, /* I - value of TUNITn keyword for each column  */
-    extnm: Option<&[c_char]>,    /* I - value of EXTNAME keyword, if any         */
-    status: &mut c_int,          /* IO - error status                            */
+    fptr: &mut fitsfile,
+    tbltype: c_int,
+    naxis2: LONGLONG,
+    tfields: c_int,
+    ttype: &[Option<&[c_char]>],
+    tform: &[&[c_char]],
+    tunit: Option<&[Option<&[c_char]>]>,
+    extnm: Option<&[c_char]>,
+    status: &mut c_int,
 ) -> c_int {
     let naxis1: LONGLONG = 0;
 
@@ -258,15 +321,22 @@ pub fn ffcrtb_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
-/// write STANDARD set of required primary header keywords
+/// Write STANDARD set of required primary header keywords
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `bitpix` — (I) number of bits per data value pixel
+/// * `naxis`  — (I) number of axes in the data array
+/// * `naxes`  — (I) length of each data axis
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffphps(
-    fptr: *mut fitsfile,  /* I - FITS file pointer                        */
-    bitpix: c_int,        /* I - number of bits per data value pixel      */
-    naxis: c_int,         /* I - number of axes in the data array         */
-    naxes: *const c_long, /* I - length of each data axis                 */
-    status: *mut c_int,   /* IO - error status                            */
+    fptr: *mut fitsfile,
+    bitpix: c_int,
+    naxis: c_int,
+    naxes: *const c_long,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -283,14 +353,21 @@ pub unsafe extern "C" fn ffphps(
     }
 }
 
-/*--------------------------------------------------------------------------*/
-/// write STANDARD set of required primary header keywords
+/// Write STANDARD set of required primary header keywords
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `bitpix` — (I) number of bits per data value pixel
+/// * `naxis`  — (I) number of axes in the data array
+/// * `naxes`  — (I) length of each data axis
+/// * `status` — (IO) error status
 pub fn ffphps_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                        */
-    bitpix: c_int,       /* I - number of bits per data value pixel      */
-    naxis: c_int,        /* I - number of axes in the data array         */
-    naxes: &[c_long],    /* I - length of each data axis                 */
-    status: &mut c_int,  /* IO - error status                            */
+    fptr: &mut fitsfile,
+    bitpix: c_int,
+    naxis: c_int,
+    naxes: &[c_long],
+    status: &mut c_int,
 ) -> c_int {
     let simple: c_int = 1; /* does file conform to FITS standard? 1/0  */
     let pcount: LONGLONG = 0; /* number of group parameters (usually 0)   */
@@ -304,15 +381,22 @@ pub fn ffphps_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write STANDARD set of required primary header keywords
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `bitpix` — (I) number of bits per data value pixel
+/// * `naxis`  — (I) number of axes in the data array
+/// * `naxes`  — (I) length of each data axis
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffphpsll(
-    fptr: *mut fitsfile,    /* I - FITS file pointer                        */
-    bitpix: c_int,          /* I - number of bits per data value pixel      */
-    naxis: c_int,           /* I - number of axes in the data array         */
-    naxes: *const LONGLONG, /* I - length of each data axis                 */
-    status: *mut c_int,     /* IO - error status                            */
+    fptr: *mut fitsfile,
+    bitpix: c_int,
+    naxis: c_int,
+    naxes: *const LONGLONG,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -325,14 +409,21 @@ pub unsafe extern "C" fn ffphpsll(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write STANDARD set of required primary header keywords
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `bitpix` — (I) number of bits per data value pixel
+/// * `naxis`  — (I) number of axes in the data array
+/// * `naxes`  — (I) length of each data axis
+/// * `status` — (IO) error status
 pub fn ffphpsll_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                        */
-    bitpix: c_int,       /* I - number of bits per data value pixel      */
-    naxis: c_int,        /* I - number of axes in the data array         */
-    naxes: &[LONGLONG],  /* I - length of each data axis                 */
-    status: &mut c_int,  /* IO - error status                            */
+    fptr: &mut fitsfile,
+    bitpix: c_int,
+    naxis: c_int,
+    naxes: &[LONGLONG],
+    status: &mut c_int,
 ) -> c_int {
     let simple: c_int = 1; /* does file conform to FITS standard? 1/0  */
     let pcount: LONGLONG = 0; /* number of group parameters (usually 0)   */
@@ -345,19 +436,30 @@ pub fn ffphpsll_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
-/// write required primary header keywords
+/// Write required primary header keywords
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `simple` — (I) does file conform to FITS standard? 1/0
+/// * `bitpix` — (I) number of bits per data value pixel
+/// * `naxis`  — (I) number of axes in the data array
+/// * `naxes`  — (I) length of each data axis
+/// * `pcount` — (I) number of group parameters (usually 0)
+/// * `gcount` — (I) number of random groups (usually 1 or 0)
+/// * `extend` — (I) may FITS file have extensions?
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffphpr(
-    fptr: *mut fitsfile,  /* I - FITS file pointer                        */
-    simple: c_int,        /* I - does file conform to FITS standard? 1/0  */
-    bitpix: c_int,        /* I - number of bits per data value pixel      */
-    naxis: c_int,         /* I - number of axes in the data array         */
-    naxes: *const c_long, /* I - length of each data axis                 */
-    pcount: LONGLONG,     /* I - number of group parameters (usually 0)   */
-    gcount: LONGLONG,     /* I - number of random groups (usually 1 or 0) */
-    extend: c_int,        /* I - may FITS file have extensions?           */
-    status: *mut c_int,   /* IO - error status                            */
+    fptr: *mut fitsfile,
+    simple: c_int,
+    bitpix: c_int,
+    naxis: c_int,
+    naxes: *const c_long,
+    pcount: LONGLONG,
+    gcount: LONGLONG,
+    extend: c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -376,18 +478,29 @@ pub unsafe extern "C" fn ffphpr(
     }
 }
 
-/*--------------------------------------------------------------------------*/
-/// write required primary header keywords
+/// Write required primary header keywords
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `simple` — (I) does file conform to FITS standard? 1/0
+/// * `bitpix` — (I) number of bits per data value pixel
+/// * `naxis`  — (I) number of axes in the data array
+/// * `naxes`  — (I) length of each data axis
+/// * `pcount` — (I) number of group parameters (usually 0)
+/// * `gcount` — (I) number of random groups (usually 1 or 0)
+/// * `extend` — (I) may FITS file have extensions?
+/// * `status` — (IO) error status
 pub fn ffphpr_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                        */
-    simple: c_int,       /* I - does file conform to FITS standard? 1/0  */
-    bitpix: c_int,       /* I - number of bits per data value pixel      */
-    naxis: c_int,        /* I - number of axes in the data array         */
-    naxes: &[c_long],    /* I - length of each data axis                 */
-    pcount: LONGLONG,    /* I - number of group parameters (usually 0)   */
-    gcount: LONGLONG,    /* I - number of random groups (usually 1 or 0) */
-    extend: c_int,       /* I - may FITS file have extensions?           */
-    status: &mut c_int,  /* IO - error status                            */
+    fptr: &mut fitsfile,
+    simple: c_int,
+    bitpix: c_int,
+    naxis: c_int,
+    naxes: &[c_long],
+    pcount: LONGLONG,
+    gcount: LONGLONG,
+    extend: c_int,
+    status: &mut c_int,
 ) -> c_int {
     let mut ii: usize = 0;
     let mut naxesll = [0 as LONGLONG; 20];
@@ -406,19 +519,30 @@ pub fn ffphpr_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
-/// write required primary header keywords
+/// Write required primary header keywords
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `simple` — (I) does file conform to FITS standard? 1/0
+/// * `bitpix` — (I) number of bits per data value pixel
+/// * `naxis`  — (I) number of axes in the data array
+/// * `naxes`  — (I) length of each data axis
+/// * `pcount` — (I) number of group parameters (usually 0)
+/// * `gcount` — (I) number of random groups (usually 1 or 0)
+/// * `extend` — (I) may FITS file have extensions?
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffphprll(
-    fptr: *mut fitsfile,    /* I - FITS file pointer                        */
-    simple: c_int,          /* I - does file conform to FITS standard? 1/0  */
-    bitpix: c_int,          /* I - number of bits per data value pixel      */
-    naxis: c_int,           /* I - number of axes in the data array         */
-    naxes: *const LONGLONG, /* I - length of each data axis                 */
-    pcount: LONGLONG,       /* I - number of group parameters (usually 0)   */
-    gcount: LONGLONG,       /* I - number of random groups (usually 1 or 0) */
-    extend: c_int,          /* I - may FITS file have extensions?           */
-    status: *mut c_int,     /* IO - error status                            */
+    fptr: *mut fitsfile,
+    simple: c_int,
+    bitpix: c_int,
+    naxis: c_int,
+    naxes: *const LONGLONG,
+    pcount: LONGLONG,
+    gcount: LONGLONG,
+    extend: c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -436,18 +560,29 @@ pub unsafe extern "C" fn ffphprll(
     }
 }
 
-/*--------------------------------------------------------------------------*/
-/// write required primary header keywords
+/// Write required primary header keywords
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `simple` — (I) does file conform to FITS standard? 1/0
+/// * `bitpix` — (I) number of bits per data value pixel
+/// * `naxis`  — (I) number of axes in the data array
+/// * `naxes`  — (I) length of each data axis
+/// * `pcount` — (I) number of group parameters (usually 0)
+/// * `gcount` — (I) number of random groups (usually 1 or 0)
+/// * `extend` — (I) may FITS file have extensions?
+/// * `status` — (IO) error status
 pub fn ffphprll_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                        */
-    simple: c_int,       /* I - does file conform to FITS standard? 1/0  */
-    bitpix: c_int,       /* I - number of bits per data value pixel      */
-    naxis: c_int,        /* I - number of axes in the data array         */
-    naxes: &[LONGLONG],  /* I - length of each data axis                 */
-    pcount: LONGLONG,    /* I - number of group parameters (usually 0)   */
-    gcount: LONGLONG,    /* I - number of random groups (usually 1 or 0) */
-    extend: c_int,       /* I - may FITS file have extensions?           */
-    status: &mut c_int,  /* IO - error status                            */
+    fptr: &mut fitsfile,
+    simple: c_int,
+    bitpix: c_int,
+    naxis: c_int,
+    naxes: &[LONGLONG],
+    pcount: LONGLONG,
+    gcount: LONGLONG,
+    extend: c_int,
+    status: &mut c_int,
 ) -> c_int {
     let mut ii: usize = 0;
     let mut tnaxes: [c_long; 20] = [0; 20];
@@ -682,20 +817,32 @@ pub fn ffphprll_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Put required Header keywords into the ASCII TaBle:
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `naxis1`  — (I) width of row in the table
+/// * `naxis2`  — (I) number of rows in the table
+/// * `tfields` — (I) number of columns in the table
+/// * `ttype`   — (I) name of each column
+/// * `tbcol`   — (I) byte offset in row to each column
+/// * `tform`   — (I) value of TFORMn keyword for each column
+/// * `tunit`   — (I) value of TUNITn keyword for each column
+/// * `extnmx`  — (I) value of EXTNAME keyword, if any
+/// * `status`  — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffphtb(
-    fptr: *mut fitsfile,         /* I - FITS file pointer                        */
-    naxis1: LONGLONG,            /* I - width of row in the table                */
-    naxis2: LONGLONG,            /* I - number of rows in the table              */
-    tfields: c_int,              /* I - number of columns in the table           */
-    ttype: *const *const c_char, /* I - name of each column                      */
-    tbcol: *const c_long,        /* I - byte offset in row to each column        */
-    tform: *const *const c_char, /* I - value of TFORMn keyword for each column  */
-    tunit: *const *const c_char, /* I - value of TUNITn keyword for each column  */
-    extnmx: *const c_char,       /* I - value of EXTNAME keyword, if any         */
-    status: *mut c_int,          /* IO - error status                            */
+    fptr: *mut fitsfile,
+    naxis1: LONGLONG,
+    naxis2: LONGLONG,
+    tfields: c_int,
+    ttype: *const *const c_char,
+    tbcol: *const c_long,
+    tform: *const *const c_char,
+    tunit: *const *const c_char,
+    extnmx: *const c_char,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -728,19 +875,31 @@ pub unsafe extern "C" fn ffphtb(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Put required Header keywords into the ASCII TaBle:
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `naxis1`  — (I) width of row in the table
+/// * `naxis2`  — (I) number of rows in the table
+/// * `tfields` — (I) number of columns in the table
+/// * `ttype`   — (I) name of each column
+/// * `tbcol`   — (I) byte offset in row to each column
+/// * `tform`   — (I) value of TFORMn keyword for each column
+/// * `tunit`   — (I) value of TUNITn keyword for each column
+/// * `extnmx`  — (I) value of EXTNAME keyword, if any
+/// * `status`  — (IO) error status
 pub fn ffphtb_safe(
-    fptr: &mut fitsfile,         /* I - FITS file pointer                        */
-    naxis1: LONGLONG,            /* I - width of row in the table                */
-    naxis2: LONGLONG,            /* I - number of rows in the table              */
-    tfields: c_int,              /* I - number of columns in the table           */
-    ttype: &[Option<&[c_char]>], /* I - name of each column                      */
-    tbcol: Option<&[c_long]>,    /* I - byte offset in row to each column        */
-    tform: &[&[c_char]],         /* I - value of TFORMn keyword for each column  */
-    tunit: Option<&[Option<&[c_char]>]>, /* I - value of TUNITn keyword for each column  */
-    extnmx: Option<&[c_char]>,   /* I - value of EXTNAME keyword, if any         */
-    status: &mut c_int,          /* IO - error status                            */
+    fptr: &mut fitsfile,
+    naxis1: LONGLONG,
+    naxis2: LONGLONG,
+    tfields: c_int,
+    ttype: &[Option<&[c_char]>],
+    tbcol: Option<&[c_long]>,
+    tform: &[&[c_char]],
+    tunit: Option<&[Option<&[c_char]>]>,
+    extnmx: Option<&[c_char]>,
+    status: &mut c_int,
 ) -> c_int {
     let mut ncols: c_int = 0;
 
@@ -968,19 +1127,30 @@ pub fn ffphtb_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Put required Header keywords into the Binary Table:
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `naxis2`  — (I) number of rows in the table
+/// * `tfields` — (I) number of columns in the table
+/// * `ttype`   — (I) name of each column
+/// * `tform`   — (I) value of TFORMn keyword for each column
+/// * `tunit`   — (I) value of TUNITn keyword for each column
+/// * `extnmx`  — (I) value of EXTNAME keyword, if any
+/// * `pcount`  — (I) size of the variable length heap area
+/// * `status`  — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffphbn(
-    fptr: *mut fitsfile,         /* I - FITS file pointer                        */
-    naxis2: LONGLONG,            /* I - number of rows in the table              */
-    tfields: c_int,              /* I - number of columns in the table           */
-    ttype: *const *const c_char, /* I - name of each column                      */
-    tform: *const *const c_char, /* I - value of TFORMn keyword for each column  */
-    tunit: *const *const c_char, /* I - value of TUNITn keyword for each column  */
-    extnmx: *const c_char,       /* I - value of EXTNAME keyword, if any         */
-    pcount: LONGLONG,            /* I - size of the variable length heap area    */
-    status: *mut c_int,          /* IO - error status                            */
+    fptr: *mut fitsfile,
+    naxis2: LONGLONG,
+    tfields: c_int,
+    ttype: *const *const c_char,
+    tform: *const *const c_char,
+    tunit: *const *const c_char,
+    extnmx: *const c_char,
+    pcount: LONGLONG,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -1006,20 +1176,30 @@ pub unsafe extern "C" fn ffphbn(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Put required Header keywords into the Binary Table:
 #[allow(clippy::if_same_then_else)]
 // C dispatch chain: distinct conditions deliberately share an action.
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `naxis2`  — (I) number of rows in the table
+/// * `tfields` — (I) number of columns in the table
+/// * `ttype`   — (I) name of each column
+/// * `tform`   — (I) value of TFORMn keyword for each column
+/// * `tunit`   — (I) value of TUNITn keyword for each column
+/// * `extnmx`  — (I) value of EXTNAME keyword, if any
+/// * `pcount`  — (I) size of the variable length heap area
+/// * `status`  — (IO) error status
 pub fn ffphbn_safe(
-    fptr: &mut fitsfile,         /* I - FITS file pointer                        */
-    naxis2: LONGLONG,            /* I - number of rows in the table              */
-    tfields: c_int,              /* I - number of columns in the table           */
-    ttype: &[Option<&[c_char]>], /* I - name of each column                      */
-    tform: &[&[c_char]],         /* I - value of TFORMn keyword for each column  */
-    tunit: Option<&[Option<&[c_char]>]>, /* I - value of TUNITn keyword for each column  */
-    extnmx: Option<&[c_char]>,   /* I - value of EXTNAME keyword, if any         */
-    pcount: LONGLONG,            /* I - size of the variable length heap area    */
-    status: &mut c_int,          /* IO - error status                            */
+    fptr: &mut fitsfile,
+    naxis2: LONGLONG,
+    tfields: c_int,
+    ttype: &[Option<&[c_char]>],
+    tform: &[&[c_char]],
+    tunit: Option<&[Option<&[c_char]>]>,
+    extnmx: Option<&[c_char]>,
+    pcount: LONGLONG,
+    status: &mut c_int,
 ) -> c_int {
     let mut datatype: c_int = 0;
     let mut iread: c_int = 0;
@@ -1376,18 +1556,28 @@ pub fn ffphbn_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Put required Header keywords into a conforming extension:
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `xtensionx` — (I) value for the XTENSION keyword
+/// * `bitpix`    — (I) value for the BIXPIX keyword
+/// * `naxis`     — (I) value for the NAXIS keyword
+/// * `naxes`     — (I) value for the NAXISn keywords
+/// * `pcount`    — (I) value for the PCOUNT keyword
+/// * `gcount`    — (I) value for the GCOUNT keyword
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffphext(
-    fptr: *mut fitsfile,      /* I - FITS file pointer                       */
-    xtensionx: *const c_char, /* I - value for the XTENSION keyword          */
-    bitpix: c_int,            /* I - value for the BIXPIX keyword            */
-    naxis: c_int,             /* I - value for the NAXIS keyword             */
-    naxes: *const c_long,     /* I - value for the NAXISn keywords           */
-    pcount: LONGLONG,         /* I - value for the PCOUNT keyword            */
-    gcount: LONGLONG,         /* I - value for the GCOUNT keyword            */
-    status: *mut c_int,       /* IO - error status                           */
+    fptr: *mut fitsfile,
+    xtensionx: *const c_char,
+    bitpix: c_int,
+    naxis: c_int,
+    naxes: *const c_long,
+    pcount: LONGLONG,
+    gcount: LONGLONG,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -1403,17 +1593,27 @@ pub unsafe extern "C" fn ffphext(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Put required Header keywords into a conforming extension:
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `xtensionx` — (I) value for the XTENSION keyword
+/// * `bitpix`    — (I) value for the BIXPIX keyword
+/// * `naxis`     — (I) value for the NAXIS keyword
+/// * `naxes`     — (I) value for the NAXISn keywords
+/// * `pcount`    — (I) value for the PCOUNT keyword
+/// * `gcount`    — (I) value for the GCOUNT keyword
+/// * `status`    — (IO) error status
 pub fn ffphext_safe(
-    fptr: &mut fitsfile,  /* I - FITS file pointer                       */
-    xtensionx: &[c_char], /* I - value for the XTENSION keyword          */
-    bitpix: c_int,        /* I - value for the BIXPIX keyword            */
-    naxis: c_int,         /* I - value for the NAXIS keyword             */
-    naxes: &[c_long],     /* I - value for the NAXISn keywords           */
-    pcount: LONGLONG,     /* I - value for the PCOUNT keyword            */
-    gcount: LONGLONG,     /* I - value for the GCOUNT keyword            */
-    status: &mut c_int,   /* IO - error status                           */
+    fptr: &mut fitsfile,
+    xtensionx: &[c_char],
+    bitpix: c_int,
+    naxis: c_int,
+    naxes: &[c_long],
+    pcount: LONGLONG,
+    gcount: LONGLONG,
+    status: &mut c_int,
 ) -> c_int {
     let mut message: [c_char; FLEN_ERRMSG] = [0; FLEN_ERRMSG];
     let mut comm: [c_char; 81] = [0; 81];
@@ -1501,13 +1701,18 @@ pub fn ffphext_safe(
     *status
 }
 
-/*-------------------------------------------------------------------------*/
-/// write a keyword record (80 bytes long) to the end of the header
+/// Write a keyword record (80 bytes long) to the end of the header
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `card`   — (I) string to be written
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffprec(
-    fptr: *mut fitsfile, /* I - FITS file pointer        */
-    card: *const c_char, /* I - string to be written     */
-    status: *mut c_int,  /* IO - error status            */
+    fptr: *mut fitsfile,
+    card: *const c_char,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -1520,13 +1725,14 @@ pub unsafe extern "C" fn ffprec(
     }
 }
 
-/*-------------------------------------------------------------------------*/
-/// write a keyword record (80 bytes long) to the end of the header
-pub fn ffprec_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer        */
-    card: &[c_char],     /* I - string to be written     */
-    status: &mut c_int,  /* IO - error status            */
-) -> c_int {
+/// Write a keyword record (80 bytes long) to the end of the header
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `card`   — (I) string to be written
+/// * `status` — (IO) error status
+pub fn ffprec_safe(fptr: &mut fitsfile, card: &[c_char], status: &mut c_int) -> c_int {
     let mut tcard: [c_char; FLEN_CARD] = [0; FLEN_CARD];
 
     let mut ii: usize;
@@ -1605,14 +1811,20 @@ pub fn ffprec_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write (put) a null-valued keyword and comment into the FITS header.  
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) name of keyword to write
+/// * `comm`    — (I) keyword comment
+/// * `status`  — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffpkyu(
-    fptr: *mut fitsfile,    /* I - FITS file pointer        */
-    keyname: *const c_char, /* I - name of keyword to write */
-    comm: *const c_char,    /* I - keyword comment          */
-    status: *mut c_int,     /* IO - error status            */
+    fptr: *mut fitsfile,
+    keyname: *const c_char,
+    comm: *const c_char,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -1626,13 +1838,19 @@ pub unsafe extern "C" fn ffpkyu(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write (put) a null-valued keyword and comment into the FITS header.  
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) name of keyword to write
+/// * `comm`    — (I) keyword comment
+/// * `status`  — (IO) error status
 pub fn ffpkyu_safe(
-    fptr: &mut fitsfile,     /* I - FITS file pointer        */
-    keyname: &[c_char],      /* I - name of keyword to write */
-    comm: Option<&[c_char]>, /* I - keyword comment          */
-    status: &mut c_int,      /* IO - error status            */
+    fptr: &mut fitsfile,
+    keyname: &[c_char],
+    comm: Option<&[c_char]>,
+    status: &mut c_int,
 ) -> c_int {
     let mut valstring: [c_char; FLEN_VALUE] = [0; FLEN_VALUE];
     let mut card: [c_char; FLEN_CARD] = [0; FLEN_CARD];
@@ -1649,17 +1867,24 @@ pub fn ffpkyu_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write (put) the keyword, value and comment into the FITS header.
 /// The value string will be truncated at 68 characters which is the
 /// maximum length that will fit on a single FITS keyword.
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) name of keyword to write
+/// * `value`   — (I) keyword value
+/// * `comm`    — (I) keyword comment
+/// * `status`  — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffpkys(
-    fptr: *mut fitsfile,    /* I - FITS file pointer        */
-    keyname: *const c_char, /* I - name of keyword to write */
-    value: *const c_char,   /* I - keyword value            */
-    comm: *const c_char,    /* I - keyword comment          */
-    status: *mut c_int,     /* IO - error status            */
+    fptr: *mut fitsfile,
+    keyname: *const c_char,
+    value: *const c_char,
+    comm: *const c_char,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -1677,16 +1902,23 @@ pub unsafe extern "C" fn ffpkys(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write (put) the keyword, value and comment into the FITS header.
 /// The value string will be truncated at 68 characters which is the
 /// maximum length that will fit on a single FITS keyword.
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) name of keyword to write
+/// * `value`   — (I) keyword value
+/// * `comm`    — (I) keyword comment
+/// * `status`  — (IO) error status
 pub fn ffpkys_safe(
-    fptr: &mut fitsfile,     /* I - FITS file pointer        */
-    keyname: &[c_char],      /* I - name of keyword to write */
-    value: &[c_char],        /* I - keyword value            */
-    comm: Option<&[c_char]>, /* I - keyword comment          */
-    status: &mut c_int,      /* IO - error status            */
+    fptr: &mut fitsfile,
+    keyname: &[c_char],
+    value: &[c_char],
+    comm: Option<&[c_char]>,
+    status: &mut c_int,
 ) -> c_int {
     let mut valstring: [c_char; FLEN_VALUE] = [0; FLEN_VALUE];
     let mut card: [c_char; FLEN_CARD] = [0; FLEN_CARD];
@@ -1704,16 +1936,23 @@ pub fn ffpkys_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write (put) the keyword, value and comment into the FITS header.
 /// Writes an integer keyword value.
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) name of keyword to write
+/// * `value`   — (I) keyword value
+/// * `comm`    — (I) keyword comment
+/// * `status`  — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffpkyuj(
-    fptr: *mut fitsfile,    /* I - FITS file pointer        */
-    keyname: *const c_char, /* I - name of keyword to write */
-    value: ULONGLONG,       /* I - keyword value            */
-    comm: *const c_char,    /* I - keyword comment          */
-    status: *mut c_int,     /* IO - error status            */
+    fptr: *mut fitsfile,
+    keyname: *const c_char,
+    value: ULONGLONG,
+    comm: *const c_char,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -1727,15 +1966,22 @@ pub unsafe extern "C" fn ffpkyuj(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write (put) the keyword, value and comment into the FITS header.
 /// Writes an integer keyword value.
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) name of keyword to write
+/// * `value`   — (I) keyword value
+/// * `comm`    — (I) keyword comment
+/// * `status`  — (IO) error status
 pub fn ffpkyuj_safe(
-    fptr: &mut fitsfile,     /* I - FITS file pointer        */
-    keyname: &[c_char],      /* I - name of keyword to write */
-    value: ULONGLONG,        /* I - keyword value            */
-    comm: Option<&[c_char]>, /* I - keyword comment          */
-    status: &mut c_int,      /* IO - error status            */
+    fptr: &mut fitsfile,
+    keyname: &[c_char],
+    value: ULONGLONG,
+    comm: Option<&[c_char]>,
+    status: &mut c_int,
 ) -> c_int {
     let mut valstring: [c_char; FLEN_VALUE] = [0; FLEN_VALUE];
     let mut card: [c_char; FLEN_CARD] = [0; FLEN_CARD];
@@ -1752,17 +1998,25 @@ pub fn ffpkyuj_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write (put) the keyword, value and comment into the FITS header.
 /// Writes a fixed float keyword value.
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) name of keyword to write
+/// * `value`   — (I) keyword value
+/// * `decim`   — (I) number of decimal places to display
+/// * `comm`    — (I) keyword comment
+/// * `status`  — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffpkyf(
-    fptr: *mut fitsfile,    /* I - FITS file pointer                   */
-    keyname: *const c_char, /* I - name of keyword to write            */
-    value: f32,             /* I - keyword value                       */
-    decim: c_int,           /* I - number of decimal places to display */
-    comm: *const c_char,    /* I - keyword comment                     */
-    status: *mut c_int,     /* IO - error status                       */
+    fptr: *mut fitsfile,
+    keyname: *const c_char,
+    value: f32,
+    decim: c_int,
+    comm: *const c_char,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -1776,16 +2030,24 @@ pub unsafe extern "C" fn ffpkyf(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write (put) the keyword, value and comment into the FITS header.
 /// Writes a fixed float keyword value.
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) name of keyword to write
+/// * `value`   — (I) keyword value
+/// * `decim`   — (I) number of decimal places to display
+/// * `comm`    — (I) keyword comment
+/// * `status`  — (IO) error status
 pub fn ffpkyf_safe(
-    fptr: &mut fitsfile,     /* I - FITS file pointer                   */
-    keyname: &[c_char],      /* I - name of keyword to write            */
-    value: f32,              /* I - keyword value                       */
-    decim: c_int,            /* I - number of decimal places to display */
-    comm: Option<&[c_char]>, /* I - keyword comment                     */
-    status: &mut c_int,      /* IO - error status                       */
+    fptr: &mut fitsfile,
+    keyname: &[c_char],
+    value: f32,
+    decim: c_int,
+    comm: Option<&[c_char]>,
+    status: &mut c_int,
 ) -> c_int {
     let mut valstring: [c_char; FLEN_VALUE] = [0; FLEN_VALUE];
     let mut card: [c_char; FLEN_CARD] = [0; FLEN_CARD];
@@ -1802,17 +2064,25 @@ pub fn ffpkyf_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write (put) the keyword, value and comment into the FITS header.
 /// Writes an exponential float keyword value.
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) name of keyword to write
+/// * `value`   — (I) keyword value
+/// * `decim`   — (I) number of decimal places to display
+/// * `comm`    — (I) keyword comment
+/// * `status`  — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffpkye(
-    fptr: *mut fitsfile,    /* I - FITS file pointer                   */
-    keyname: *const c_char, /* I - name of keyword to write            */
-    value: f32,             /* I - keyword value                       */
-    decim: c_int,           /* I - number of decimal places to display */
-    comm: *const c_char,    /* I - keyword comment                     */
-    status: *mut c_int,     /* IO - error status                       */
+    fptr: *mut fitsfile,
+    keyname: *const c_char,
+    value: f32,
+    decim: c_int,
+    comm: *const c_char,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -1826,16 +2096,24 @@ pub unsafe extern "C" fn ffpkye(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write (put) the keyword, value and comment into the FITS header.
 /// Writes an exponential float keyword value.
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) name of keyword to write
+/// * `value`   — (I) keyword value
+/// * `decim`   — (I) number of decimal places to display
+/// * `comm`    — (I) keyword comment
+/// * `status`  — (IO) error status
 pub fn ffpkye_safe(
-    fptr: &mut fitsfile,     /* I - FITS file pointer                   */
-    keyname: &[c_char],      /* I - name of keyword to write            */
-    value: f32,              /* I - keyword value                       */
-    decim: c_int,            /* I - number of decimal places to display */
-    comm: Option<&[c_char]>, /* I - keyword comment                     */
-    status: &mut c_int,      /* IO - error status                       */
+    fptr: &mut fitsfile,
+    keyname: &[c_char],
+    value: f32,
+    decim: c_int,
+    comm: Option<&[c_char]>,
+    status: &mut c_int,
 ) -> c_int {
     let mut valstring: [c_char; FLEN_VALUE] = [0; FLEN_VALUE];
     let mut card: [c_char; FLEN_CARD] = [0; FLEN_CARD];
@@ -1852,17 +2130,25 @@ pub fn ffpkye_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write (put) the keyword, value and comment into the FITS header.
 /// Writes a fixed double keyword value.
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) name of keyword to write
+/// * `value`   — (I) keyword value
+/// * `decim`   — (I) number of decimal places to display
+/// * `comm`    — (I) keyword comment
+/// * `status`  — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffpkyg(
-    fptr: *mut fitsfile,    /* I - FITS file pointer                   */
-    keyname: *const c_char, /* I - name of keyword to write            */
-    value: f64,             /* I - keyword value                       */
-    decim: c_int,           /* I - number of decimal places to display */
-    comm: *const c_char,    /* I - keyword comment                     */
-    status: *mut c_int,     /* IO - error status                       */
+    fptr: *mut fitsfile,
+    keyname: *const c_char,
+    value: f64,
+    decim: c_int,
+    comm: *const c_char,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -1876,16 +2162,24 @@ pub unsafe extern "C" fn ffpkyg(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write (put) the keyword, value and comment into the FITS header.
 /// Writes a fixed double keyword value.
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) name of keyword to write
+/// * `value`   — (I) keyword value
+/// * `decim`   — (I) number of decimal places to display
+/// * `comm`    — (I) keyword comment
+/// * `status`  — (IO) error status
 pub fn ffpkyg_safe(
-    fptr: &mut fitsfile,     /* I - FITS file pointer                   */
-    keyname: &[c_char],      /* I - name of keyword to write            */
-    value: f64,              /* I - keyword value                       */
-    decim: c_int,            /* I - number of decimal places to display */
-    comm: Option<&[c_char]>, /* I - keyword comment                     */
-    status: &mut c_int,      /* IO - error status                       */
+    fptr: &mut fitsfile,
+    keyname: &[c_char],
+    value: f64,
+    decim: c_int,
+    comm: Option<&[c_char]>,
+    status: &mut c_int,
 ) -> c_int {
     let mut valstring: [c_char; FLEN_VALUE] = [0; FLEN_VALUE];
     let mut card: [c_char; FLEN_CARD] = [0; FLEN_CARD];
@@ -1902,17 +2196,25 @@ pub fn ffpkyg_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write (put) the keyword, value and comment into the FITS header.
 /// Writes an exponential double keyword value.*/
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) name of keyword to write
+/// * `value`   — (I) keyword value
+/// * `decim`   — (I) number of decimal places to display
+/// * `comm`    — (I) keyword comment
+/// * `status`  — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffpkyd(
-    fptr: *mut fitsfile,    /* I - FITS file pointer                   */
-    keyname: *const c_char, /* I - name of keyword to write            */
-    value: f64,             /* I - keyword value                       */
-    decim: c_int,           /* I - number of decimal places to display */
-    comm: *const c_char,    /* I - keyword comment                     */
-    status: *mut c_int,     /* IO - error status                       */
+    fptr: *mut fitsfile,
+    keyname: *const c_char,
+    value: f64,
+    decim: c_int,
+    comm: *const c_char,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -1926,16 +2228,24 @@ pub unsafe extern "C" fn ffpkyd(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write (put) the keyword, value and comment into the FITS header.
 /// Writes an exponential double keyword value.*/
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) name of keyword to write
+/// * `value`   — (I) keyword value
+/// * `decim`   — (I) number of decimal places to display
+/// * `comm`    — (I) keyword comment
+/// * `status`  — (IO) error status
 pub fn ffpkyd_safe(
-    fptr: &mut fitsfile,     /* I - FITS file pointer                   */
-    keyname: &[c_char],      /* I - name of keyword to write            */
-    value: f64,              /* I - keyword value                       */
-    decim: c_int,            /* I - number of decimal places to display */
-    comm: Option<&[c_char]>, /* I - keyword comment                     */
-    status: &mut c_int,      /* IO - error status                       */
+    fptr: &mut fitsfile,
+    keyname: &[c_char],
+    value: f64,
+    decim: c_int,
+    comm: Option<&[c_char]>,
+    status: &mut c_int,
 ) -> c_int {
     let mut valstring: [c_char; FLEN_VALUE] = [0; FLEN_VALUE];
     let mut card: [c_char; FLEN_CARD] = [0; FLEN_CARD];
@@ -1952,17 +2262,25 @@ pub fn ffpkyd_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write (put) the keyword, value and comment into the FITS header.
 /// Writes an complex float keyword value. Format = (realvalue, imagvalue)
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) name of keyword to write
+/// * `value`   — (I) keyword value (real, imaginary)
+/// * `decim`   — (I) number of decimal places to display
+/// * `comm`    — (I) keyword comment
+/// * `status`  — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffpkyc(
-    fptr: *mut fitsfile,    /* I - FITS file pointer                   */
-    keyname: *const c_char, /* I - name of keyword to write            */
-    value: *const [f32; 2], /* I - keyword value (real, imaginary)     */
-    decim: c_int,           /* I - number of decimal places to display */
-    comm: *const c_char,    /* I - keyword comment                     */
-    status: *mut c_int,     /* IO - error status                       */
+    fptr: *mut fitsfile,
+    keyname: *const c_char,
+    value: *const [f32; 2],
+    decim: c_int,
+    comm: *const c_char,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -1977,16 +2295,24 @@ pub unsafe extern "C" fn ffpkyc(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write (put) the keyword, value and comment into the FITS header.
 /// Writes an complex float keyword value. Format = (realvalue, imagvalue)
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) name of keyword to write
+/// * `value`   — (I) keyword value (real, imaginary)
+/// * `decim`   — (I) number of decimal places to display
+/// * `comm`    — (I) keyword comment
+/// * `status`  — (IO) error status
 pub fn ffpkyc_safe(
-    fptr: &mut fitsfile,     /* I - FITS file pointer                   */
-    keyname: &[c_char],      /* I - name of keyword to write            */
-    value: &[f32; 2],        /* I - keyword value (real, imaginary)     */
-    decim: c_int,            /* I - number of decimal places to display */
-    comm: Option<&[c_char]>, /* I - keyword comment                     */
-    status: &mut c_int,      /* IO - error status                       */
+    fptr: &mut fitsfile,
+    keyname: &[c_char],
+    value: &[f32; 2],
+    decim: c_int,
+    comm: Option<&[c_char]>,
+    status: &mut c_int,
 ) -> c_int {
     let mut valstring: [c_char; FLEN_VALUE] = [0; FLEN_VALUE];
     let mut tmpstring: [c_char; FLEN_VALUE] = [0; FLEN_VALUE];
@@ -2024,17 +2350,25 @@ pub fn ffpkyc_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write (put) the keyword, value and comment into the FITS header.
 /// Writes an complex double keyword value. Format = (realvalue, imagvalue)
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) name of keyword to write
+/// * `value`   — (I) keyword value (real, imaginary)
+/// * `decim`   — (I) number of decimal places to display
+/// * `comm`    — (I) keyword comment
+/// * `status`  — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffpkym(
-    fptr: *mut fitsfile,    /* I - FITS file pointer                   */
-    keyname: *const c_char, /* I - name of keyword to write            */
-    value: *const [f64; 2], /* I - keyword value (real, imaginary)     */
-    decim: c_int,           /* I - number of decimal places to display */
-    comm: *const c_char,    /* I - keyword comment                     */
-    status: *mut c_int,     /* IO - error status                       */
+    fptr: *mut fitsfile,
+    keyname: *const c_char,
+    value: *const [f64; 2],
+    decim: c_int,
+    comm: *const c_char,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -2049,16 +2383,24 @@ pub unsafe extern "C" fn ffpkym(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write (put) the keyword, value and comment into the FITS header.
 /// Writes an complex double keyword value. Format = (realvalue, imagvalue)
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) name of keyword to write
+/// * `value`   — (I) keyword value (real, imaginary)
+/// * `decim`   — (I) number of decimal places to display
+/// * `comm`    — (I) keyword comment
+/// * `status`  — (IO) error status
 pub fn ffpkym_safe(
-    fptr: &mut fitsfile,     /* I - FITS file pointer                   */
-    keyname: &[c_char],      /* I - name of keyword to write            */
-    value: &[f64; 2],        /* I - keyword value (real, imaginary)     */
-    decim: c_int,            /* I - number of decimal places to display */
-    comm: Option<&[c_char]>, /* I - keyword comment                     */
-    status: &mut c_int,      /* IO - error status                       */
+    fptr: &mut fitsfile,
+    keyname: &[c_char],
+    value: &[f64; 2],
+    decim: c_int,
+    comm: Option<&[c_char]>,
+    status: &mut c_int,
 ) -> c_int {
     let mut valstring: [c_char; FLEN_VALUE] = [0; FLEN_VALUE];
     let mut tmpstring: [c_char; FLEN_VALUE] = [0; FLEN_VALUE];
@@ -2096,17 +2438,25 @@ pub fn ffpkym_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write (put) the keyword, value and comment into the FITS header.
 /// Writes an complex float keyword value. Format = (realvalue, imagvalue)
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) name of keyword to write
+/// * `value`   — (I) keyword value (real, imaginary)
+/// * `decim`   — (I) number of decimal places to display
+/// * `comm`    — (I) keyword comment
+/// * `status`  — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffpkfc(
-    fptr: *mut fitsfile,    /* I - FITS file pointer                   */
-    keyname: *const c_char, /* I - name of keyword to write            */
-    value: *const [f32; 2], /* I - keyword value (real, imaginary)     */
-    decim: c_int,           /* I - number of decimal places to display */
-    comm: *const c_char,    /* I - keyword comment                     */
-    status: *mut c_int,     /* IO - error status                       */
+    fptr: *mut fitsfile,
+    keyname: *const c_char,
+    value: *const [f32; 2],
+    decim: c_int,
+    comm: *const c_char,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -2121,16 +2471,24 @@ pub unsafe extern "C" fn ffpkfc(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write (put) the keyword, value and comment into the FITS header.
 /// Writes an complex float keyword value. Format = (realvalue, imagvalue)
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) name of keyword to write
+/// * `value`   — (I) keyword value (real, imaginary)
+/// * `decim`   — (I) number of decimal places to display
+/// * `comm`    — (I) keyword comment
+/// * `status`  — (IO) error status
 pub fn ffpkfc_safe(
-    fptr: &mut fitsfile,     /* I - FITS file pointer                   */
-    keyname: &[c_char],      /* I - name of keyword to write            */
-    value: &[f32; 2],        /* I - keyword value (real, imaginary)     */
-    decim: c_int,            /* I - number of decimal places to display */
-    comm: Option<&[c_char]>, /* I - keyword comment                     */
-    status: &mut c_int,      /* IO - error status                       */
+    fptr: &mut fitsfile,
+    keyname: &[c_char],
+    value: &[f32; 2],
+    decim: c_int,
+    comm: Option<&[c_char]>,
+    status: &mut c_int,
 ) -> c_int {
     let mut valstring: [c_char; FLEN_VALUE] = [0; FLEN_VALUE];
     let mut tmpstring: [c_char; FLEN_VALUE] = [0; FLEN_VALUE];
@@ -2167,17 +2525,25 @@ pub fn ffpkfc_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write (put) the keyword, value and comment into the FITS header.
 /// Writes an complex double keyword value. Format = (realvalue, imagvalue)
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) name of keyword to write
+/// * `value`   — (I) keyword value (real, imaginary)
+/// * `decim`   — (I) number of decimal places to display
+/// * `comm`    — (I) keyword comment
+/// * `status`  — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffpkfm(
-    fptr: *mut fitsfile,    /* I - FITS file pointer                   */
-    keyname: *const c_char, /* I - name of keyword to write            */
-    value: *const [f64; 2], /* I - keyword value (real, imaginary)     */
-    decim: c_int,           /* I - number of decimal places to display */
-    comm: *const c_char,    /* I - keyword comment                     */
-    status: *mut c_int,     /* IO - error status                       */
+    fptr: *mut fitsfile,
+    keyname: *const c_char,
+    value: *const [f64; 2],
+    decim: c_int,
+    comm: *const c_char,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -2192,16 +2558,24 @@ pub unsafe extern "C" fn ffpkfm(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write (put) the keyword, value and comment into the FITS header.
 /// Writes an complex double keyword value. Format = (realvalue, imagvalue)
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) name of keyword to write
+/// * `value`   — (I) keyword value (real, imaginary)
+/// * `decim`   — (I) number of decimal places to display
+/// * `comm`    — (I) keyword comment
+/// * `status`  — (IO) error status
 pub fn ffpkfm_safe(
-    fptr: &mut fitsfile,     /* I - FITS file pointer                   */
-    keyname: &[c_char],      /* I - name of keyword to write            */
-    value: &[f64; 2],        /* I - keyword value (real, imaginary)     */
-    decim: c_int,            /* I - number of decimal places to display */
-    comm: Option<&[c_char]>, /* I - keyword comment                     */
-    status: &mut c_int,      /* IO - error status                       */
+    fptr: &mut fitsfile,
+    keyname: &[c_char],
+    value: &[f64; 2],
+    decim: c_int,
+    comm: Option<&[c_char]>,
+    status: &mut c_int,
 ) -> c_int {
     let mut valstring: [c_char; FLEN_VALUE] = [0; FLEN_VALUE];
     let mut tmpstring: [c_char; FLEN_VALUE] = [0; FLEN_VALUE];
@@ -2238,7 +2612,6 @@ pub fn ffpkfm_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write (put) the keyword, value and comment into the FITS header.
 ///
 /// This routine is a modified version of ffpkys which supports the
@@ -2247,13 +2620,21 @@ pub fn ffpkfm_safe(
 /// have the name CONTINUE without an equal sign in column 9 of the card.
 /// This routine also supports simple string keywords which are less than
 /// 75 characters in length.
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) name of keyword to write
+/// * `value`   — (I) keyword value
+/// * `comm`    — (I) keyword comment
+/// * `status`  — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffpkls(
-    fptr: *mut fitsfile,    /* I - FITS file pointer        */
-    keyname: *const c_char, /* I - name of keyword to write */
-    value: *const c_char,   /* I - keyword value            */
-    comm: *const c_char,    /* I - keyword comment          */
-    status: *mut c_int,     /* IO - error status            */
+    fptr: *mut fitsfile,
+    keyname: *const c_char,
+    value: *const c_char,
+    comm: *const c_char,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -2272,7 +2653,6 @@ pub unsafe extern "C" fn ffpkls(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write (put) the keyword, value and comment into the FITS header.
 ///
 /// This routine is a modified version of ffpkys which supports the
@@ -2281,12 +2661,20 @@ pub unsafe extern "C" fn ffpkls(
 /// have the name CONTINUE without an equal sign in column 9 of the card.
 /// This routine also supports simple string keywords which are less than
 /// 75 characters in length.
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) name of keyword to write
+/// * `value`   — (I) keyword value
+/// * `comm`    — (I) keyword comment
+/// * `status`  — (IO) error status
 pub fn ffpkls_safe(
-    fptr: &mut fitsfile,     /* I - FITS file pointer        */
-    keyname: &[c_char],      /* I - name of keyword to write */
-    value: &[c_char],        /* I - keyword value            */
-    comm: Option<&[c_char]>, /* I - keyword comment          */
-    status: &mut c_int,      /* IO - error status            */
+    fptr: &mut fitsfile,
+    keyname: &[c_char],
+    value: &[c_char],
+    comm: Option<&[c_char]>,
+    status: &mut c_int,
 ) -> c_int {
     if *status > 0 {
         return *status;
@@ -2297,7 +2685,6 @@ pub fn ffpkls_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write (put) the keyword, value and comment into the FITS header.
 ///
 /// This routine is a modified version of ffpkys which supports the
@@ -2306,13 +2693,22 @@ pub fn ffpkls_safe(
 /// have the name CONTINUE without an equal sign in column 9 of the card.
 /// This routine also supports simple string keywords which are less than
 /// 75 characters in length.
+///
+/// # Parameters
+///
+/// * `fptr`     — (I) FITS file pointer
+/// * `keyname`  — (I) name of keyword to write
+/// * `value`    — (I) keyword value
+/// * `comm`     — (I) keyword comment
+/// * `position` — (I) position to insert (-1 for end)
+/// * `status`   — (IO) error status
 pub fn fits_make_longstr_key_util(
-    fptr: &mut fitsfile,     /* I - FITS file pointer        */
-    keyname: &[c_char],      /* I - name of keyword to write */
-    value: &[c_char],        /* I - keyword value            */
-    comm: Option<&[c_char]>, /* I - keyword comment          */
-    mut position: c_int,     /* I - position to insert (-1 for end) */
-    status: &mut c_int,      /* IO - error status            */
+    fptr: &mut fitsfile,
+    keyname: &[c_char],
+    value: &[c_char],
+    comm: Option<&[c_char]>,
+    mut position: c_int,
+    status: &mut c_int,
 ) -> c_int {
     let mut valstring: [c_char; FLEN_CARD] = [0; FLEN_CARD];
     let mut commstring: [c_char; FLEN_COMMENT] = [0; FLEN_COMMENT];
@@ -2586,17 +2982,18 @@ pub fn fits_make_longstr_key_util(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write the LONGSTRN keyword and a series of related COMMENT keywords
 /// which document that this FITS header may contain long string keyword
 /// values which are continued over multiple keywords using the HEASARC
 /// long string keyword convention.  If the LONGSTRN keyword already exists
 /// then this routine simple returns without doing anything.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
-pub unsafe extern "C" fn ffplsw(
-    fptr: *mut fitsfile, /* I - FITS file pointer  */
-    status: *mut c_int,  /* IO - error status       */
-) -> c_int {
+pub unsafe extern "C" fn ffplsw(fptr: *mut fitsfile, status: *mut c_int) -> c_int {
     // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
@@ -2606,16 +3003,17 @@ pub unsafe extern "C" fn ffplsw(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write the LONGSTRN keyword and a series of related COMMENT keywords
 /// which document that this FITS header may contain long string keyword
 /// values which are continued over multiple keywords using the HEASARC
 /// long string keyword convention.  If the LONGSTRN keyword already exists
 /// then this routine simple returns without doing anything.
-pub fn ffplsw_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer  */
-    status: &mut c_int,  /* IO - error status       */
-) -> c_int {
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `status` — (IO) error status
+pub fn ffplsw_safe(fptr: &mut fitsfile, status: &mut c_int) -> c_int {
     let mut valstring: [c_char; FLEN_CARD] = [0; FLEN_CARD];
     let mut comm: [c_char; FLEN_COMMENT] = [0; FLEN_COMMENT];
     let mut tstatus = 0;
@@ -2672,17 +3070,24 @@ pub fn ffplsw_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write (put) the keyword, value and comment into the FITS header.
 /// Values equal to 0 will result in a False FITS keyword; any other
 /// non-zero value will result in a True FITS keyword.
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) name of keyword to write
+/// * `value`   — (I) keyword value
+/// * `comm`    — (I) keyword comment
+/// * `status`  — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffpkyl(
-    fptr: *mut fitsfile,    /* I - FITS file pointer        */
-    keyname: *const c_char, /* I - name of keyword to write */
-    value: c_int,           /* I - keyword value            */
-    comm: *const c_char,    /* I - keyword comment          */
-    status: *mut c_int,     /* IO - error status            */
+    fptr: *mut fitsfile,
+    keyname: *const c_char,
+    value: c_int,
+    comm: *const c_char,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -2696,16 +3101,23 @@ pub unsafe extern "C" fn ffpkyl(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write (put) the keyword, value and comment into the FITS header.
 /// Values equal to 0 will result in a False FITS keyword; any other
 /// non-zero value will result in a True FITS keyword.
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) name of keyword to write
+/// * `value`   — (I) keyword value
+/// * `comm`    — (I) keyword comment
+/// * `status`  — (IO) error status
 pub fn ffpkyl_safe(
-    fptr: &mut fitsfile,     /* I - FITS file pointer        */
-    keyname: &[c_char],      /* I - name of keyword to write */
-    value: c_int,            /* I - keyword value            */
-    comm: Option<&[c_char]>, /* I - keyword comment          */
-    status: &mut c_int,      /* IO - error status            */
+    fptr: &mut fitsfile,
+    keyname: &[c_char],
+    value: c_int,
+    comm: Option<&[c_char]>,
+    status: &mut c_int,
 ) -> c_int {
     let mut valstring: [c_char; FLEN_VALUE] = [0; FLEN_VALUE];
     let mut card: [c_char; FLEN_CARD] = [0; FLEN_CARD];
@@ -2721,16 +3133,23 @@ pub fn ffpkyl_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write (put) the keyword, value and comment into the FITS header.
 /// Writes an integer keyword value.
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) name of keyword to write
+/// * `value`   — (I) keyword value
+/// * `comm`    — (I) keyword comment
+/// * `status`  — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffpkyj(
-    fptr: *mut fitsfile,    /* I - FITS file pointer        */
-    keyname: *const c_char, /* I - name of keyword to write */
-    value: LONGLONG,        /* I - keyword value            */
-    comm: *const c_char,    /* I - keyword comment          */
-    status: *mut c_int,     /* IO - error status            */
+    fptr: *mut fitsfile,
+    keyname: *const c_char,
+    value: LONGLONG,
+    comm: *const c_char,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -2744,15 +3163,22 @@ pub unsafe extern "C" fn ffpkyj(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write (put) the keyword, value and comment into the FITS header.
 /// Writes an integer keyword value.
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyname` — (I) name of keyword to write
+/// * `value`   — (I) keyword value
+/// * `comm`    — (I) keyword comment
+/// * `status`  — (IO) error status
 pub fn ffpkyj_safe(
-    fptr: &mut fitsfile,     /* I - FITS file pointer        */
-    keyname: &[c_char],      /* I - name of keyword to write */
-    value: LONGLONG,         /* I - keyword value            */
-    comm: Option<&[c_char]>, /* I - keyword comment          */
-    status: &mut c_int,      /* IO - error status            */
+    fptr: &mut fitsfile,
+    keyname: &[c_char],
+    value: LONGLONG,
+    comm: Option<&[c_char]>,
+    status: &mut c_int,
 ) -> c_int {
     let mut valstring: [c_char; FLEN_VALUE] = [0; FLEN_VALUE];
     let mut card: [c_char; FLEN_CARD] = [0; FLEN_CARD];
@@ -2769,18 +3195,26 @@ pub fn ffpkyj_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write (put) a 'triple' precision keyword where the integer and
 /// fractional parts of the value are passed in separate parameters to
 /// increase the total amount of numerical precision.
+///
+/// # Parameters
+///
+/// * `fptr`     — (I) FITS file pointer
+/// * `keyname`  — (I) name of keyword to write
+/// * `intval`   — (I) integer part of value
+/// * `fraction` — (I) fractional part of value
+/// * `comm`     — (I) keyword comment
+/// * `status`   — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffpkyt(
-    fptr: *mut fitsfile,    /* I - FITS file pointer        */
-    keyname: *const c_char, /* I - name of keyword to write */
-    intval: c_long,         /* I - integer part of value    */
-    fraction: f64,          /* I - fractional part of value */
-    comm: *const c_char,    /* I - keyword comment          */
-    status: *mut c_int,     /* IO - error status            */
+    fptr: *mut fitsfile,
+    keyname: *const c_char,
+    intval: c_long,
+    fraction: f64,
+    comm: *const c_char,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -2793,17 +3227,25 @@ pub unsafe extern "C" fn ffpkyt(
         ffpkyt_safe(fptr, keyname, intval, fraction, comm, status)
     }
 }
-/*--------------------------------------------------------------------------*/
 /// Write (put) a 'triple' precision keyword where the integer and
 /// fractional parts of the value are passed in separate parameters to
 /// increase the total amount of numerical precision.
+///
+/// # Parameters
+///
+/// * `fptr`     — (I) FITS file pointer
+/// * `keyname`  — (I) name of keyword to write
+/// * `intval`   — (I) integer part of value
+/// * `fraction` — (I) fractional part of value
+/// * `comm`     — (I) keyword comment
+/// * `status`   — (IO) error status
 pub fn ffpkyt_safe(
-    fptr: &mut fitsfile,     /* I - FITS file pointer        */
-    keyname: &[c_char],      /* I - name of keyword to write */
-    intval: c_long,          /* I - integer part of value    */
-    fraction: f64,           /* I - fractional part of value */
-    comm: Option<&[c_char]>, /* I - keyword comment          */
-    status: &mut c_int,      /* IO - error status            */
+    fptr: &mut fitsfile,
+    keyname: &[c_char],
+    intval: c_long,
+    fraction: f64,
+    comm: Option<&[c_char]>,
+    status: &mut c_int,
 ) -> c_int {
     let mut valstring: [c_char; FLEN_CARD] = [0; FLEN_CARD];
     let mut card: [c_char; FLEN_CARD] = [0; FLEN_CARD];
@@ -2838,15 +3280,20 @@ pub fn ffpkyt_safe(
     *status
 }
 
-/*-----------------------------------------------------------------*/
 /// Write 1 or more COMMENT keywords.  If the comment string is too
 /// long to fit on a single keyword (72 chars) then it will automatically
 /// be continued on multiple CONTINUE keywords.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `comm`   — (I) comment string
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffpcom(
-    fptr: *mut fitsfile, /* I - FITS file pointer   */
-    comm: *const c_char, /* I - comment string      */
-    status: *mut c_int,  /* IO - error status       */
+    fptr: *mut fitsfile,
+    comm: *const c_char,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -2858,15 +3305,16 @@ pub unsafe extern "C" fn ffpcom(
     }
 }
 
-/*-----------------------------------------------------------------*/
 /// Write 1 or more COMMENT keywords.  If the comment string is too
 /// long to fit on a single keyword (72 chars) then it will automatically
 /// be continued on multiple CONTINUE keywords.
-pub fn ffpcom_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer   */
-    comm: &[c_char],     /* I - comment string      */
-    status: &mut c_int,  /* IO - error status       */
-) -> c_int {
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `comm`   — (I) comment string
+/// * `status` — (IO) error status
+pub fn ffpcom_safe(fptr: &mut fitsfile, comm: &[c_char], status: &mut c_int) -> c_int {
     let mut card: [c_char; FLEN_CARD] = [0; FLEN_CARD];
 
     if *status > 0 {
@@ -2888,15 +3336,20 @@ pub fn ffpcom_safe(
     *status
 }
 
-/*-----------------------------------------------------------------*/
 /// Write 1 or more HISTORY keywords.  If the history string is too
 /// long to fit on a single keyword (72 chars) then it will automatically
 /// be continued on multiple HISTORY keywords.
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `history` — (I) history string
+/// * `status`  — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffphis(
-    fptr: *mut fitsfile,    /* I - FITS file pointer  */
-    history: *const c_char, /* I - history string     */
-    status: *mut c_int,     /* IO - error status      */
+    fptr: *mut fitsfile,
+    history: *const c_char,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -2908,15 +3361,16 @@ pub unsafe extern "C" fn ffphis(
     }
 }
 
-/*-----------------------------------------------------------------*/
 /// Write 1 or more HISTORY keywords.  If the history string is too
 /// long to fit on a single keyword (72 chars) then it will automatically
 /// be continued on multiple HISTORY keywords.
-pub fn ffphis_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer  */
-    history: &[c_char],  /* I - history string     */
-    status: &mut c_int,  /* IO - error status      */
-) -> c_int {
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `history` — (I) history string
+/// * `status`  — (IO) error status
+pub fn ffphis_safe(fptr: &mut fitsfile, history: &[c_char], status: &mut c_int) -> c_int {
     let mut card: [c_char; FLEN_CARD] = [0; FLEN_CARD];
 
     if *status > 0 {
@@ -2938,14 +3392,15 @@ pub fn ffphis_safe(
     *status
 }
 
-/*-----------------------------------------------------------------*/
 /// Write the DATE keyword into the FITS header.  If the keyword already
 /// exists then the date will simply be updated in the existing keyword.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
-pub unsafe extern "C" fn ffpdat(
-    fptr: *mut fitsfile, /* I - FITS file pointer  */
-    status: *mut c_int,  /* IO - error status      */
-) -> c_int {
+pub unsafe extern "C" fn ffpdat(fptr: *mut fitsfile, status: *mut c_int) -> c_int {
     // FFI WRAPPER
     unsafe {
         let status = status.as_mut().expect(NULL_MSG);
@@ -2955,13 +3410,14 @@ pub unsafe extern "C" fn ffpdat(
     }
 }
 
-/*-----------------------------------------------------------------*/
 /// Write the DATE keyword into the FITS header.  If the keyword already
 /// exists then the date will simply be updated in the existing keyword.
-pub fn ffpdat_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer  */
-    status: &mut c_int,  /* IO - error status      */
-) -> c_int {
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `status` — (IO) error status
+pub fn ffpdat_safe(fptr: &mut fitsfile, status: &mut c_int) -> c_int {
     let mut timeref = 0;
     let mut date: [c_char; 20] = [0; 20];
     let mut tmzone: [c_char; 10] = [0; 10];
@@ -2995,20 +3451,29 @@ pub fn ffpdat_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write (put) an indexed array of keywords with index numbers between
 /// NSTART and (NSTART + NKEY -1) inclusive.  Writes string keywords.
 /// The value strings will be truncated at 68 characters, and the HEASARC
 /// long string keyword convention is not supported by this routine.
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyroot` — (I) root name of keywords to write
+/// * `nstart`  — (I) starting index number
+/// * `nkey`    — (I) number of keywords to write
+/// * `value`   — (I) array of pointers to keyword values
+/// * `comm`    — (I) array of pointers to keyword comment
+/// * `status`  — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffpkns(
-    fptr: *mut fitsfile,         /* I - FITS file pointer                    */
-    keyroot: *const c_char,      /* I - root name of keywords to write       */
-    nstart: c_int,               /* I - starting index number                */
-    nkey: c_int,                 /* I - number of keywords to write          */
-    value: *const *const c_char, /* I - array of pointers to keyword values  */
-    comm: *const *const c_char,  /* I - array of pointers to keyword comment */
-    status: *mut c_int,          /* IO - error status                        */
+    fptr: *mut fitsfile,
+    keyroot: *const c_char,
+    nstart: c_int,
+    nkey: c_int,
+    value: *const *const c_char,
+    comm: *const *const c_char,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -3029,19 +3494,28 @@ pub unsafe extern "C" fn ffpkns(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write (put) an indexed array of keywords with index numbers between
 /// NSTART and (NSTART + NKEY -1) inclusive.  Writes string keywords.
 /// The value strings will be truncated at 68 characters, and the HEASARC
 /// long string keyword convention is not supported by this routine.
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyroot` — (I) root name of keywords to write
+/// * `nstart`  — (I) starting index number
+/// * `nkey`    — (I) number of keywords to write
+/// * `value`   — (I) array of pointers to keyword values
+/// * `comm`    — (I) array of pointers to keyword comment
+/// * `status`  — (IO) error status
 pub fn ffpkns_safe(
-    fptr: &mut fitsfile,     /* I - FITS file pointer                    */
-    keyroot: &[c_char],      /* I - root name of keywords to write       */
-    nstart: c_int,           /* I - starting index number                */
-    nkey: c_int,             /* I - number of keywords to write          */
-    value: &[*const c_char], /* I - array of pointers to keyword values  */
-    comm: &[*const c_char],  /* I - array of pointers to keyword comment */
-    status: &mut c_int,      /* IO - error status                        */
+    fptr: &mut fitsfile,
+    keyroot: &[c_char],
+    nstart: c_int,
+    nkey: c_int,
+    value: &[*const c_char],
+    comm: &[*const c_char],
+    status: &mut c_int,
 ) -> c_int {
     let mut keyname: [c_char; FLEN_KEYWORD] = [0; FLEN_KEYWORD];
     let mut tcomment: [c_char; FLEN_COMMENT] = [0; FLEN_COMMENT];
@@ -3104,20 +3578,29 @@ pub fn ffpkns_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write (put) an indexed array of keywords with index numbers between
 /// NSTART and (NSTART + NKEY -1) inclusive.  Writes logical keywords
 /// Values equal to zero will be written as a False FITS keyword value; any
 /// other non-zero value will result in a True FITS keyword.
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyroot` — (I) root name of keywords to write
+/// * `nstart`  — (I) starting index number
+/// * `nkey`    — (I) number of keywords to write
+/// * `value`   — (I) array of keyword values
+/// * `comm`    — (I) array of pointers to keyword comment
+/// * `status`  — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffpknl(
-    fptr: *mut fitsfile,        /* I - FITS file pointer                    */
-    keyroot: *const c_char,     /* I - root name of keywords to write       */
-    nstart: c_int,              /* I - starting index number                */
-    nkey: c_int,                /* I - number of keywords to write          */
-    value: *const c_int,        /* I - array of keyword values              */
-    comm: *const *const c_char, /* I - array of pointers to keyword comment */
-    status: *mut c_int,         /* IO - error status                        */
+    fptr: *mut fitsfile,
+    keyroot: *const c_char,
+    nstart: c_int,
+    nkey: c_int,
+    value: *const c_int,
+    comm: *const *const c_char,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -3138,19 +3621,28 @@ pub unsafe extern "C" fn ffpknl(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write (put) an indexed array of keywords with index numbers between
 /// NSTART and (NSTART + NKEY -1) inclusive.  Writes logical keywords
 /// Values equal to zero will be written as a False FITS keyword value; any
 /// other non-zero value will result in a True FITS keyword.
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyroot` — (I) root name of keywords to write
+/// * `nstart`  — (I) starting index number
+/// * `nkey`    — (I) number of keywords to write
+/// * `value`   — (I) array of keyword values
+/// * `comm`    — (I) array of pointers to keyword comment
+/// * `status`  — (IO) error status
 pub fn ffpknl_safe(
-    fptr: &mut fitsfile,    /* I - FITS file pointer                    */
-    keyroot: &[c_char],     /* I - root name of keywords to write       */
-    nstart: c_int,          /* I - starting index number                */
-    nkey: c_int,            /* I - number of keywords to write          */
-    value: &[c_int],        /* I - array of keyword values              */
-    comm: &[*const c_char], /* I - array of pointers to keyword comment */
-    status: &mut c_int,     /* IO - error status                        */
+    fptr: &mut fitsfile,
+    keyroot: &[c_char],
+    nstart: c_int,
+    nkey: c_int,
+    value: &[c_int],
+    comm: &[*const c_char],
+    status: &mut c_int,
 ) -> c_int {
     let mut keyname: [c_char; FLEN_KEYWORD] = [0; FLEN_KEYWORD];
     let mut tcomment: [c_char; FLEN_COMMENT] = [0; FLEN_COMMENT];
@@ -3210,18 +3702,27 @@ pub fn ffpknl_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write (put) an indexed array of keywords with index numbers between
 /// NSTART and (NSTART + NKEY -1) inclusive.  Write integer keywords
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyroot` — (I) root name of keywords to write
+/// * `nstart`  — (I) starting index number
+/// * `nkey`    — (I) number of keywords to write
+/// * `value`   — (I) array of keyword values
+/// * `comm`    — (I) array of pointers to keyword comment
+/// * `status`  — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffpknj(
-    fptr: *mut fitsfile,        /* I - FITS file pointer                    */
-    keyroot: *const c_char,     /* I - root name of keywords to write       */
-    nstart: c_int,              /* I - starting index number                */
-    nkey: c_int,                /* I - number of keywords to write          */
-    value: *const c_long,       /* I - array of keyword values              */
-    comm: *const *const c_char, /* I - array of pointers to keyword comment */
-    status: *mut c_int,         /* IO - error status                        */
+    fptr: *mut fitsfile,
+    keyroot: *const c_char,
+    nstart: c_int,
+    nkey: c_int,
+    value: *const c_long,
+    comm: *const *const c_char,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -3242,17 +3743,26 @@ pub unsafe extern "C" fn ffpknj(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write (put) an indexed array of keywords with index numbers between
 /// NSTART and (NSTART + NKEY -1) inclusive.  Write integer keywords
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyroot` — (I) root name of keywords to write
+/// * `nstart`  — (I) starting index number
+/// * `nkey`    — (I) number of keywords to write
+/// * `value`   — (I) array of keyword values
+/// * `comm`    — (I) array of pointers to keyword comment
+/// * `status`  — (IO) error status
 pub fn ffpknj_safe(
-    fptr: &mut fitsfile,    /* I - FITS file pointer                    */
-    keyroot: &[c_char],     /* I - root name of keywords to write       */
-    nstart: c_int,          /* I - starting index number                */
-    nkey: c_int,            /* I - number of keywords to write          */
-    value: &[c_long],       /* I - array of keyword values              */
-    comm: &[*const c_char], /* I - array of pointers to keyword comment */
-    status: &mut c_int,     /* IO - error status                        */
+    fptr: &mut fitsfile,
+    keyroot: &[c_char],
+    nstart: c_int,
+    nkey: c_int,
+    value: &[c_long],
+    comm: &[*const c_char],
+    status: &mut c_int,
 ) -> c_int {
     let mut keyname: [c_char; FLEN_KEYWORD] = [0; FLEN_KEYWORD];
     let mut tcomment: [c_char; FLEN_COMMENT] = [0; FLEN_COMMENT];
@@ -3318,19 +3828,29 @@ pub fn ffpknj_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write (put) an indexed array of keywords with index numbers between
 /// NSTART and (NSTART + NKEY -1) inclusive.  Writes fixed float values.
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyroot` — (I) root name of keywords to write
+/// * `nstart`  — (I) starting index number
+/// * `nkey`    — (I) number of keywords to write
+/// * `value`   — (I) array of keyword values
+/// * `decim`   — (I) number of decimals to display
+/// * `comm`    — (I) array of pointers to keyword comment
+/// * `status`  — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffpknf(
-    fptr: *mut fitsfile,        /* I - FITS file pointer                    */
-    keyroot: *const c_char,     /* I - root name of keywords to write       */
-    nstart: c_int,              /* I - starting index number                */
-    nkey: c_int,                /* I - number of keywords to write          */
-    value: *const f32,          /* I - array of keyword values              */
-    decim: c_int,               /* I - number of decimals to display        */
-    comm: *const *const c_char, /* I - array of pointers to keyword comment */
-    status: *mut c_int,         /* IO - error status                        */
+    fptr: *mut fitsfile,
+    keyroot: *const c_char,
+    nstart: c_int,
+    nkey: c_int,
+    value: *const f32,
+    decim: c_int,
+    comm: *const *const c_char,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -3351,18 +3871,28 @@ pub unsafe extern "C" fn ffpknf(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write (put) an indexed array of keywords with index numbers between
 /// NSTART and (NSTART + NKEY -1) inclusive.  Writes fixed float values.
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyroot` — (I) root name of keywords to write
+/// * `nstart`  — (I) starting index number
+/// * `nkey`    — (I) number of keywords to write
+/// * `value`   — (I) array of keyword values
+/// * `decim`   — (I) number of decimals to display
+/// * `comm`    — (I) array of pointers to keyword comment
+/// * `status`  — (IO) error status
 pub fn ffpknf_safe(
-    fptr: &mut fitsfile,    /* I - FITS file pointer                    */
-    keyroot: &[c_char],     /* I - root name of keywords to write       */
-    nstart: c_int,          /* I - starting index number                */
-    nkey: c_int,            /* I - number of keywords to write          */
-    value: &[f32],          /* I - array of keyword values              */
-    decim: c_int,           /* I - number of decimals to display        */
-    comm: &[*const c_char], /* I - array of pointers to keyword comment */
-    status: &mut c_int,     /* IO - error status                        */
+    fptr: &mut fitsfile,
+    keyroot: &[c_char],
+    nstart: c_int,
+    nkey: c_int,
+    value: &[f32],
+    decim: c_int,
+    comm: &[*const c_char],
+    status: &mut c_int,
 ) -> c_int {
     let mut keyname: [c_char; FLEN_KEYWORD] = [0; FLEN_KEYWORD];
     let mut tcomment: [c_char; FLEN_COMMENT] = [0; FLEN_COMMENT];
@@ -3422,19 +3952,29 @@ pub fn ffpknf_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write (put) an indexed array of keywords with index numbers between
 /// NSTART and (NSTART + NKEY -1) inclusive.  Writes exponential float values.
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyroot` — (I) root name of keywords to write
+/// * `nstart`  — (I) starting index number
+/// * `nkey`    — (I) number of keywords to write
+/// * `value`   — (I) array of keyword values
+/// * `decim`   — (I) number of decimals to display
+/// * `comm`    — (I) array of pointers to keyword comment
+/// * `status`  — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffpkne(
-    fptr: *mut fitsfile,        /* I - FITS file pointer                    */
-    keyroot: *const c_char,     /* I - root name of keywords to write       */
-    nstart: c_int,              /* I - starting index number                */
-    nkey: c_int,                /* I - number of keywords to write          */
-    value: *const f32,          /* I - array of keyword values              */
-    decim: c_int,               /* I - number of decimals to display        */
-    comm: *const *const c_char, /* I - array of pointers to keyword comment */
-    status: *mut c_int,         /* IO - error status                        */
+    fptr: *mut fitsfile,
+    keyroot: *const c_char,
+    nstart: c_int,
+    nkey: c_int,
+    value: *const f32,
+    decim: c_int,
+    comm: *const *const c_char,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -3455,18 +3995,28 @@ pub unsafe extern "C" fn ffpkne(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write (put) an indexed array of keywords with index numbers between
 /// NSTART and (NSTART + NKEY -1) inclusive.  Writes exponential float values.
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyroot` — (I) root name of keywords to write
+/// * `nstart`  — (I) starting index number
+/// * `nkey`    — (I) number of keywords to write
+/// * `value`   — (I) array of keyword values
+/// * `decim`   — (I) number of decimals to display
+/// * `comm`    — (I) array of pointers to keyword comment
+/// * `status`  — (IO) error status
 pub fn ffpkne_safe(
-    fptr: &mut fitsfile,    /* I - FITS file pointer                    */
-    keyroot: &[c_char],     /* I - root name of keywords to write       */
-    nstart: c_int,          /* I - starting index number                */
-    nkey: c_int,            /* I - number of keywords to write          */
-    value: &[f32],          /* I - array of keyword values              */
-    decim: c_int,           /* I - number of decimals to display        */
-    comm: &[*const c_char], /* I - array of pointers to keyword comment */
-    status: &mut c_int,     /* IO - error status                        */
+    fptr: &mut fitsfile,
+    keyroot: &[c_char],
+    nstart: c_int,
+    nkey: c_int,
+    value: &[f32],
+    decim: c_int,
+    comm: &[*const c_char],
+    status: &mut c_int,
 ) -> c_int {
     let mut keyname: [c_char; FLEN_KEYWORD] = [0; FLEN_KEYWORD];
     let mut tcomment: [c_char; FLEN_COMMENT] = [0; FLEN_COMMENT];
@@ -3526,19 +4076,29 @@ pub fn ffpkne_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write (put) an indexed array of keywords with index numbers between
 /// NSTART and (NSTART + NKEY -1) inclusive.  Writes fixed double values.
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyroot` — (I) root name of keywords to write
+/// * `nstart`  — (I) starting index number
+/// * `nkey`    — (I) number of keywords to write
+/// * `value`   — (I) array of keyword values
+/// * `decim`   — (I) number of decimals to display
+/// * `comm`    — (I) array of pointers to keyword comment
+/// * `status`  — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffpkng(
-    fptr: *mut fitsfile,        /* I - FITS file pointer                    */
-    keyroot: *const c_char,     /* I - root name of keywords to write       */
-    nstart: c_int,              /* I - starting index number                */
-    nkey: c_int,                /* I - number of keywords to write          */
-    value: *const f64,          /* I - array of keyword values              */
-    decim: c_int,               /* I - number of decimals to display        */
-    comm: *const *const c_char, /* I - array of pointers to keyword comment */
-    status: *mut c_int,         /* IO - error status                        */
+    fptr: *mut fitsfile,
+    keyroot: *const c_char,
+    nstart: c_int,
+    nkey: c_int,
+    value: *const f64,
+    decim: c_int,
+    comm: *const *const c_char,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -3559,18 +4119,28 @@ pub unsafe extern "C" fn ffpkng(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write (put) an indexed array of keywords with index numbers between
 /// NSTART and (NSTART + NKEY -1) inclusive.  Writes fixed double values.
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyroot` — (I) root name of keywords to write
+/// * `nstart`  — (I) starting index number
+/// * `nkey`    — (I) number of keywords to write
+/// * `value`   — (I) array of keyword values
+/// * `decim`   — (I) number of decimals to display
+/// * `comm`    — (I) array of pointers to keyword comment
+/// * `status`  — (IO) error status
 pub fn ffpkng_safe(
-    fptr: &mut fitsfile,    /* I - FITS file pointer                    */
-    keyroot: &[c_char],     /* I - root name of keywords to write       */
-    nstart: c_int,          /* I - starting index number                */
-    nkey: c_int,            /* I - number of keywords to write          */
-    value: &[f64],          /* I - array of keyword values              */
-    decim: c_int,           /* I - number of decimals to display        */
-    comm: &[*const c_char], /* I - array of pointers to keyword comment */
-    status: &mut c_int,     /* IO - error status                        */
+    fptr: &mut fitsfile,
+    keyroot: &[c_char],
+    nstart: c_int,
+    nkey: c_int,
+    value: &[f64],
+    decim: c_int,
+    comm: &[*const c_char],
+    status: &mut c_int,
 ) -> c_int {
     let mut keyname: [c_char; FLEN_KEYWORD] = [0; FLEN_KEYWORD];
     let mut tcomment: [c_char; FLEN_COMMENT] = [0; FLEN_COMMENT];
@@ -3630,19 +4200,29 @@ pub fn ffpkng_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write (put) an indexed array of keywords with index numbers between
 /// NSTART and (NSTART + NKEY -1) inclusive.  Writes exponential double values.
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyroot` — (I) root name of keywords to write
+/// * `nstart`  — (I) starting index number
+/// * `nkey`    — (I) number of keywords to write
+/// * `value`   — (I) array of keyword values
+/// * `decim`   — (I) number of decimals to display
+/// * `comm`    — (I) array of pointers to keyword comment
+/// * `status`  — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffpknd(
-    fptr: *mut fitsfile,        /* I - FITS file pointer                    */
-    keyroot: *const c_char,     /* I - root name of keywords to write       */
-    nstart: c_int,              /* I - starting index number                */
-    nkey: c_int,                /* I - number of keywords to write          */
-    value: *const f64,          /* I - array of keyword values              */
-    decim: c_int,               /* I - number of decimals to display        */
-    comm: *const *const c_char, /* I - array of pointers to keyword comment */
-    status: *mut c_int,         /* IO - error status                        */
+    fptr: *mut fitsfile,
+    keyroot: *const c_char,
+    nstart: c_int,
+    nkey: c_int,
+    value: *const f64,
+    decim: c_int,
+    comm: *const *const c_char,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -3663,18 +4243,28 @@ pub unsafe extern "C" fn ffpknd(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write (put) an indexed array of keywords with index numbers between
 /// NSTART and (NSTART + NKEY -1) inclusive.  Writes exponential double values.
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyroot` — (I) root name of keywords to write
+/// * `nstart`  — (I) starting index number
+/// * `nkey`    — (I) number of keywords to write
+/// * `value`   — (I) array of keyword values
+/// * `decim`   — (I) number of decimals to display
+/// * `comm`    — (I) array of pointers to keyword comment
+/// * `status`  — (IO) error status
 pub fn ffpknd_safe(
-    fptr: &mut fitsfile,    /* I - FITS file pointer                    */
-    keyroot: &[c_char],     /* I - root name of keywords to write       */
-    nstart: c_int,          /* I - starting index number                */
-    nkey: c_int,            /* I - number of keywords to write          */
-    value: &[f64],          /* I - array of keyword values              */
-    decim: c_int,           /* I - number of decimals to display        */
-    comm: &[*const c_char], /* I - array of pointers to keyword comment */
-    status: &mut c_int,     /* IO - error status                        */
+    fptr: &mut fitsfile,
+    keyroot: &[c_char],
+    nstart: c_int,
+    nkey: c_int,
+    value: &[f64],
+    decim: c_int,
+    comm: &[*const c_char],
+    status: &mut c_int,
 ) -> c_int {
     let mut keyname: [c_char; FLEN_KEYWORD] = [0; FLEN_KEYWORD];
     let mut tcomment: [c_char; FLEN_COMMENT] = [0; FLEN_COMMENT];
@@ -3735,17 +4325,24 @@ pub fn ffpknd_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 // Write (put) the keyword, value and comment into the FITS header.
 // Writes a keyword value with the datatype specified by the 2nd argument.
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
+/// # Parameters
+///
+/// * `fptr`     — (I) FITS file pointer
+/// * `datatype` — (I) datatype of the value
+/// * `keyname`  — (I) name of keyword to write
+/// * `value`    — (I) keyword value
+/// * `comm`     — (I) keyword comment
+/// * `status`   — (IO) error status
 pub unsafe extern "C" fn ffpky(
-    fptr: *mut fitsfile,    /* I - FITS file pointer        */
-    datatype: c_int,        /* I - datatype of the value    */
-    keyname: *const c_char, /* I - name of keyword to write */
-    value: *const c_void,   /* I - keyword value            */
-    comm: *const c_char,    /* I - keyword comment          */
-    status: *mut c_int,     /* IO - error status            */
+    fptr: *mut fitsfile,
+    datatype: c_int,
+    keyname: *const c_char,
+    value: *const c_void,
+    comm: *const c_char,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -3761,17 +4358,24 @@ pub unsafe extern "C" fn ffpky(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write (put) the keyword, value and comment into the FITS header.
 /// Writes a keyword value with the datatype specified by the 2nd argument.
 ///
 /// Heavily modified to use safe Rust types and idioms.
+///
+/// # Parameters
+///
+/// * `fptr`     — (I) FITS file pointer
+/// * `datatype` — (I) datatype of the value
+/// * `keyname`  — (I) name of keyword to write
+/// * `comm`     — (I) keyword comment
+/// * `status`   — (IO) error status
 pub fn ffpky_safe(
-    fptr: &mut fitsfile,       /* I - FITS file pointer        */
-    datatype: KeywordDatatype, /* I - datatype of the value    */
-    keyname: &[c_char],        /* I - name of keyword to write */
-    comm: Option<&[c_char]>,   /* I - keyword comment          */
-    status: &mut c_int,        /* IO - error status            */
+    fptr: &mut fitsfile,
+    datatype: KeywordDatatype,
+    keyname: &[c_char],
+    comm: Option<&[c_char]>,
+    status: &mut c_int,
 ) -> c_int {
     let mut errmsg: [c_char; FLEN_ERRMSG] = [0; FLEN_ERRMSG];
 
@@ -3844,13 +4448,18 @@ pub fn ffpky_safe(
     *status
 }
 
-/*-------------------------------------------------------------------------*/
-/// read keywords from template file and append to the FITS file
+/// Read keywords from template file and append to the FITS file
+///
+/// # Parameters
+///
+/// * `fptr`     — (I) FITS file pointer
+/// * `filename` — (I) name of template file
+/// * `status`   — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffpktp(
-    fptr: *mut fitsfile,     /* I - FITS file pointer       */
-    filename: *const c_char, /* I - name of template file   */
-    status: *mut c_int,      /* IO - error status           */
+    fptr: *mut fitsfile,
+    filename: *const c_char,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -3862,13 +4471,14 @@ pub unsafe extern "C" fn ffpktp(
     }
 }
 
-/*-------------------------------------------------------------------------*/
-/// read keywords from template file and append to the FITS file
-pub fn ffpktp_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer       */
-    filename: &[c_char], /* I - name of template file   */
-    status: &mut c_int,  /* IO - error status           */
-) -> c_int {
+/// Read keywords from template file and append to the FITS file
+///
+/// # Parameters
+///
+/// * `fptr`     — (I) FITS file pointer
+/// * `filename` — (I) name of template file
+/// * `status`   — (IO) error status
+pub fn ffpktp_safe(fptr: &mut fitsfile, filename: &[c_char], status: &mut c_int) -> c_int {
     let mut card: [c_char; FLEN_CARD] = [0; FLEN_CARD];
     let mut template: [c_char; 161] = [0; 161];
     let mut keyname: [c_char; FLEN_KEYWORD] = [0; FLEN_KEYWORD];
@@ -3945,15 +4555,22 @@ pub fn ffpktp_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
-/// write the TDIMnnn keyword describing the dimensionality of a column
+/// Write the TDIMnnn keyword describing the dimensionality of a column
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `colnum` — (I) column number
+/// * `naxis`  — (I) number of axes in the data array
+/// * `naxes`  — (I) length of each data axis
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffptdm(
-    fptr: *mut fitsfile,  /* I - FITS file pointer                        */
-    colnum: c_int,        /* I - column number                            */
-    naxis: c_int,         /* I - number of axes in the data array         */
-    naxes: *const c_long, /* I - length of each data axis                 */
-    status: *mut c_int,   /* IO - error status                            */
+    fptr: *mut fitsfile,
+    colnum: c_int,
+    naxis: c_int,
+    naxes: *const c_long,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -3965,14 +4582,21 @@ pub unsafe extern "C" fn ffptdm(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write the TDIMnnn keyword describing the dimensionality of a column
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `colnum` — (I) column number
+/// * `naxis`  — (I) number of axes in the data array
+/// * `naxes`  — (I) length of each data axis
+/// * `status` — (IO) error status
 pub fn ffptdm_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                        */
-    colnum: c_int,       /* I - column number                            */
-    naxis: c_int,        /* I - number of axes in the data array         */
-    naxes: &[c_long],    /* I - length of each data axis                 */
-    status: &mut c_int,  /* IO - error status                            */
+    fptr: &mut fitsfile,
+    colnum: c_int,
+    naxis: c_int,
+    naxes: &[c_long],
+    status: &mut c_int,
 ) -> c_int {
     let mut keyname: [c_char; FLEN_KEYWORD] = [0; FLEN_KEYWORD];
     let mut tdimstr: [c_char; FLEN_VALUE] = [0; FLEN_VALUE];
@@ -4072,15 +4696,22 @@ pub fn ffptdm_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write the TDIMnnn keyword describing the dimensionality of a column
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `colnum` — (I) column number
+/// * `naxis`  — (I) number of axes in the data array
+/// * `naxes`  — (I) length of each data axis
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffptdmll(
-    fptr: *mut fitsfile,    /* I - FITS file pointer                      */
-    colnum: c_int,          /* I - column number                            */
-    naxis: c_int,           /* I - number of axes in the data array         */
-    naxes: *const LONGLONG, /* I - length of each data axis               */
-    status: *mut c_int,     /* IO - error status                            */
+    fptr: *mut fitsfile,
+    colnum: c_int,
+    naxis: c_int,
+    naxes: *const LONGLONG,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -4093,14 +4724,21 @@ pub unsafe extern "C" fn ffptdmll(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write the TDIMnnn keyword describing the dimensionality of a column
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `colnum` — (I) column number
+/// * `naxis`  — (I) number of axes in the data array
+/// * `naxes`  — (I) length of each data axis
+/// * `status` — (IO) error status
 pub fn ffptdmll_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                      */
-    colnum: c_int,       /* I - column number                            */
-    naxis: c_int,        /* I - number of axes in the data array         */
-    naxes: &[LONGLONG],  /* I - length of each data axis                 */
-    status: &mut c_int,  /* IO - error status                            */
+    fptr: &mut fitsfile,
+    colnum: c_int,
+    naxis: c_int,
+    naxes: &[LONGLONG],
+    status: &mut c_int,
 ) -> c_int {
     let mut keyname: [c_char; FLEN_KEYWORD] = [0; FLEN_KEYWORD];
     let mut tdimstr: [c_char; FLEN_VALUE] = [0; FLEN_VALUE];
@@ -4203,13 +4841,18 @@ pub fn ffptdmll_safe(
     *status
 }
 
-/*-----------------------------------------------------------------*/
 /// Returns the current date and time in format 'yyyy-mm-ddThh:mm:ss'.
+///
+/// # Parameters
+///
+/// * `timestr` — (O) returned system date and time string
+/// * `timeref` — (O) GMT = 0, Local time = 1
+/// * `status`  — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgstm(
-    timestr: *mut c_char, /* O  - returned system date and time string  */
-    timeref: *mut c_int,  /* O - GMT = 0, Local time = 1  */
-    status: *mut c_int,   /* IO - error status      */
+    timestr: *mut c_char,
+    timeref: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -4223,12 +4866,17 @@ pub unsafe extern "C" fn ffgstm(
     }
 }
 
-/*-----------------------------------------------------------------*/
 /// Returns the current date and time in format 'yyyy-mm-ddThh:mm:ss'.
+///
+/// # Parameters
+///
+/// * `timestr` — (O) returned system date and time string
+/// * `timeref` — (O) GMT = 0, Local time = 1
+/// * `status`  — (IO) error status
 pub fn ffgstm_safe(
-    timestr: &mut [c_char; 20], /* O  - returned system date and time string  */
-    timeref: Option<&mut c_int>, /* O - GMT = 0, Local time = 1  */
-    status: &mut c_int,         /* IO - error status      */
+    timestr: &mut [c_char; 20],
+    timeref: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     if *status > 0 {
         /* inherit input status value if > 0 */
@@ -4249,15 +4897,22 @@ pub fn ffgstm_safe(
     *status
 }
 
-/*-----------------------------------------------------------------*/
 /// Construct a date character string
+///
+/// # Parameters
+///
+/// * `year`    — (I) year (0 - 9999)
+/// * `month`   — (I) month (1 - 12)
+/// * `day`     — (I) day (1 - 31)
+/// * `datestr` — (O) date string: "YYYY-MM-DD"
+/// * `status`  — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffdt2s(
-    year: c_int,          /* I - year (0 - 9999)           */
-    month: c_int,         /* I - month (1 - 12)            */
-    day: c_int,           /* I - day (1 - 31)              */
-    datestr: *mut c_char, /* O - date string: "YYYY-MM-DD" */
-    status: *mut c_int,   /* IO - error status             */
+    year: c_int,
+    month: c_int,
+    day: c_int,
+    datestr: *mut c_char,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -4269,14 +4924,21 @@ pub unsafe extern "C" fn ffdt2s(
     }
 }
 
-/*-----------------------------------------------------------------*/
 /// Construct a date character string
+///
+/// # Parameters
+///
+/// * `year`    — (I) year (0 - 9999)
+/// * `month`   — (I) month (1 - 12)
+/// * `day`     — (I) day (1 - 31)
+/// * `datestr` — (O) date string: "YYYY-MM-DD"
+/// * `status`  — (IO) error status
 pub fn ffdt2s_safe(
-    year: c_int,                /* I - year (0 - 9999)           */
-    month: c_int,               /* I - month (1 - 12)            */
-    day: c_int,                 /* I - day (1 - 31)              */
-    datestr: &mut [c_char; 11], /* O - date string: "YYYY-MM-DD" */
-    status: &mut c_int,         /* IO - error status             */
+    year: c_int,
+    month: c_int,
+    day: c_int,
+    datestr: &mut [c_char; 11],
+    status: &mut c_int,
 ) -> c_int {
     if *status > 0 {
         /* inherit input status value if > 0 */
@@ -4301,15 +4963,22 @@ pub fn ffdt2s_safe(
     *status
 }
 
-/*-----------------------------------------------------------------*/
 /// Parse a date character string into year, month, and day values
+///
+/// # Parameters
+///
+/// * `datestr` — (I) date string: "YYYY-MM-DD" or "dd/mm/yy"
+/// * `year`    — (O) year (0 - 9999)
+/// * `month`   — (O) month (1 - 12)
+/// * `day`     — (O) day (1 - 31)
+/// * `status`  — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffs2dt(
-    datestr: *const c_char, /* I - date string: "YYYY-MM-DD" or "dd/mm/yy" */
-    year: *mut c_int,       /* O - year (0 - 9999)                         */
-    month: *mut c_int,      /* O - month (1 - 12)                          */
-    day: *mut c_int,        /* O - day (1 - 31)                            */
-    status: *mut c_int,     /* IO - error status                           */
+    datestr: *const c_char,
+    year: *mut c_int,
+    month: *mut c_int,
+    day: *mut c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -4323,14 +4992,21 @@ pub unsafe extern "C" fn ffs2dt(
     }
 }
 
-/*-----------------------------------------------------------------*/
 /// Parse a date character string into year, month, and day values
+///
+/// # Parameters
+///
+/// * `datestr` — (I) date string: "YYYY-MM-DD" or "dd/mm/yy"
+/// * `year`    — (O) year (0 - 9999)
+/// * `month`   — (O) month (1 - 12)
+/// * `day`     — (O) day (1 - 31)
+/// * `status`  — (IO) error status
 pub fn ffs2dt_safe(
-    datestr: Option<&[c_char]>, /* I - date string: "YYYY-MM-DD" or "dd/mm/yy" */
-    mut year: Option<&mut c_int>, /* O - year (0 - 9999)                         */
-    mut month: Option<&mut c_int>, /* O - month (1 - 12)                          */
-    mut day: Option<&mut c_int>, /* O - day (1 - 31)                            */
-    status: &mut c_int,         /* IO - error status                           */
+    datestr: Option<&[c_char]>,
+    mut year: Option<&mut c_int>,
+    mut month: Option<&mut c_int>,
+    mut day: Option<&mut c_int>,
+    status: &mut c_int,
 ) -> c_int {
     let lyear: c_int;
     let lmonth: c_int;
@@ -4441,19 +5117,30 @@ pub fn ffs2dt_safe(
     *status
 }
 
-/*-----------------------------------------------------------------*/
 /// Construct a date and time character string
+///
+/// # Parameters
+///
+/// * `year`     — (I) year (0 - 9999)
+/// * `month`    — (I) month (1 - 12)
+/// * `day`      — (I) day (1 - 31)
+/// * `hour`     — (I) hour (0 - 23)
+/// * `minute`   — (I) minute (0 - 59)
+/// * `second`   — (I) second (0. - 60.9999999)
+/// * `decimals` — (I) number of decimal points to write
+/// * `datestr`  — (O) date string: "YYYY-MM-DDThh:mm:ss.ddd" or "hh:mm:ss.ddd" if year, month day = 0
+/// * `status`   — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn fftm2s(
-    year: c_int,          /* I - year (0 - 9999)           */
-    month: c_int,         /* I - month (1 - 12)            */
-    day: c_int,           /* I - day (1 - 31)              */
-    hour: c_int,          /* I - hour (0 - 23)             */
-    minute: c_int,        /* I - minute (0 - 59)           */
-    second: c_double,     /* I - second (0. - 60.9999999)  */
-    decimals: c_int,      /* I - number of decimal points to write      */
-    datestr: *mut c_char, /* O - date string: "YYYY-MM-DDThh:mm:ss.ddd" or "hh:mm:ss.ddd" if year, month day = 0 */
-    status: *mut c_int,   /* IO - error status             */
+    year: c_int,
+    month: c_int,
+    day: c_int,
+    hour: c_int,
+    minute: c_int,
+    second: c_double,
+    decimals: c_int,
+    datestr: *mut c_char,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -4468,18 +5155,29 @@ pub unsafe extern "C" fn fftm2s(
     }
 }
 
-/*-----------------------------------------------------------------*/
 /// Construct a date and time character string
+///
+/// # Parameters
+///
+/// * `year`     — (I) year (0 - 9999)
+/// * `month`    — (I) month (1 - 12)
+/// * `day`      — (I) day (1 - 31)
+/// * `hour`     — (I) hour (0 - 23)
+/// * `minute`   — (I) minute (0 - 59)
+/// * `second`   — (I) second (0. - 60.9999999)
+/// * `decimals` — (I) number of decimal points to write
+/// * `datestr`  — (O) date string: "YYYY-MM-DDThh:mm:ss.ddd" or "hh:mm:ss.ddd" if year, month day = 0
+/// * `status`   — (IO) error status
 pub fn fftm2s_safe(
-    year: c_int,            /* I - year (0 - 9999)           */
-    month: c_int,           /* I - month (1 - 12)            */
-    day: c_int,             /* I - day (1 - 31)              */
-    hour: c_int,            /* I - hour (0 - 23)             */
-    minute: c_int,          /* I - minute (0 - 59)           */
-    second: c_double,       /* I - second (0. - 60.9999999)  */
-    decimals: c_int,        /* I - number of decimal points to write      */
-    datestr: &mut [c_char], /* O - date string: "YYYY-MM-DDThh:mm:ss.ddd" or "hh:mm:ss.ddd" if year, month day = 0 */
-    status: &mut c_int,     /* IO - error status             */
+    year: c_int,
+    month: c_int,
+    day: c_int,
+    hour: c_int,
+    minute: c_int,
+    second: c_double,
+    decimals: c_int,
+    datestr: &mut [c_char],
+    status: &mut c_int,
 ) -> c_int {
     let width: c_int;
     let mut errmsg: [c_char; FLEN_ERRMSG] = [0; FLEN_ERRMSG];
@@ -4586,20 +5284,30 @@ pub fn fftm2s_safe(
     *status
 }
 
-/*-----------------------------------------------------------------*/
 /// Parse a date character string into date and time values
+///
+/// # Parameters
+///
+/// * `datestr` — (I) date string: "YYYY-MM-DD"
+/// * `year`    — (O) year (0 - 9999)
+/// * `month`   — (O) month (1 - 12)
+/// * `day`     — (O) day (1 - 31)
+/// * `hour`    — (O) hour (0 - 23)
+/// * `minute`  — (O) minute (0 - 59)
+/// * `second`  — (O) second (0. - 60.9999999)
+/// * `status`  — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffs2tm(
-    datestr: *const c_char, /* I - date string: "YYYY-MM-DD"    */
+    datestr: *const c_char,
     /*     or "YYYY-MM-DDThh:mm:ss.ddd" */
     /*     or "dd/mm/yy"                */
-    year: *mut c_int,      /* O - year (0 - 9999)              */
-    month: *mut c_int,     /* O - month (1 - 12)               */
-    day: *mut c_int,       /* O - day (1 - 31)                 */
-    hour: *mut c_int,      /* O - hour (0 - 23)                */
-    minute: *mut c_int,    /* O - minute (0 - 59)              */
-    second: *mut c_double, /* O - second (0. - 60.9999999)     */
-    status: *mut c_int,    /* IO - error status                */
+    year: *mut c_int,
+    month: *mut c_int,
+    day: *mut c_int,
+    hour: *mut c_int,
+    minute: *mut c_int,
+    second: *mut c_double,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -4626,19 +5334,29 @@ pub unsafe extern "C" fn ffs2tm(
     }
 }
 
-/*-----------------------------------------------------------------*/
 /// Parse a date character string into date and time values
+///
+/// # Parameters
+///
+/// * `datestr` — (I) date string: "YYYY-MM-DD"
+/// * `year`    — (O) year (0 - 9999)
+/// * `month`   — (O) month (1 - 12)
+/// * `day`     — (O) day (1 - 31)
+/// * `hour`    — (O) hour (0 - 23)
+/// * `minute`  — (O) minute (0 - 59)
+/// * `second`  — (O) second (0. - 60.9999999)
+/// * `status`  — (IO) error status
 pub fn ffs2tm_safe(
-    datestr: Option<&[c_char]>, /* I - date string: "YYYY-MM-DD"    */
+    datestr: Option<&[c_char]>,
     /*     or "YYYY-MM-DDThh:mm:ss.ddd" */
     /*     or "dd/mm/yy"                */
-    mut year: Option<&mut c_int>,  /* O - year (0 - 9999)              */
-    mut month: Option<&mut c_int>, /* O - month (1 - 12)               */
-    mut day: Option<&mut c_int>,   /* O - day (1 - 31)                 */
-    mut hour: Option<&mut c_int>,  /* O - hour (0 - 23)                */
-    mut minute: Option<&mut c_int>, /* O - minute (0 - 59)              */
-    mut second: Option<&mut c_double>, /* O - second (0. - 60.9999999)     */
-    status: &mut c_int,            /* IO - error status                */
+    mut year: Option<&mut c_int>,
+    mut month: Option<&mut c_int>,
+    mut day: Option<&mut c_int>,
+    mut hour: Option<&mut c_int>,
+    mut minute: Option<&mut c_int>,
+    mut second: Option<&mut c_double>,
+    status: &mut c_int,
 ) -> c_int {
     let slen: usize;
     let mut errmsg: [c_char; FLEN_ERRMSG] = [0; FLEN_ERRMSG];
@@ -4812,8 +5530,7 @@ pub fn ffs2tm_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
-/// his routine is included for backward compatibility with the Fortran FITSIO library.
+/// His routine is included for backward compatibility with the Fortran FITSIO library.
 /// Get current System DaTe (GMT if available)
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgsdt(
@@ -4833,7 +5550,6 @@ pub unsafe extern "C" fn ffgsdt(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// This routine is included for backward compatibility with the Fortran FITSIO library.
 /// Get current System DaTe (GMT if available)
 pub fn ffgsdt_safe(
@@ -4852,13 +5568,14 @@ pub fn ffgsdt_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
-/// convert value to a null-terminated formatted string.
-pub(crate) fn ffi2c(
-    ival: LONGLONG,      /* I - value to be converted to a string */
-    cval: &mut [c_char], /* O - character string representation of the value */
-    status: &mut c_int,  /* IO - error status */
-) -> c_int {
+/// Convert value to a null-terminated formatted string.
+///
+/// # Parameters
+///
+/// * `ival`   — (I) value to be converted to a string
+/// * `cval`   — (O) character string representation of the value
+/// * `status` — (IO) error status
+pub(crate) fn ffi2c(ival: LONGLONG, cval: &mut [c_char], status: &mut c_int) -> c_int {
     if *status > 0 {
         /* inherit input status value if > 0 */
         return *status;
@@ -4872,13 +5589,14 @@ pub(crate) fn ffi2c(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
-/// convert  value to a null-terminated formatted string.
-pub(crate) fn ffu2c(
-    ival: ULONGLONG,     /* I - value to be converted to a string */
-    cval: &mut [c_char], /* O - character string representation of the value */
-    status: &mut c_int,  /* IO - error status */
-) -> c_int {
+/// Convert  value to a null-terminated formatted string.
+///
+/// # Parameters
+///
+/// * `ival`   — (I) value to be converted to a string
+/// * `cval`   — (O) character string representation of the value
+/// * `status` — (IO) error status
+pub(crate) fn ffu2c(ival: ULONGLONG, cval: &mut [c_char], status: &mut c_int) -> c_int {
     if *status > 0 {
         /* inherit input status value if > 0 */
         return *status;
@@ -4894,15 +5612,16 @@ pub(crate) fn ffu2c(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Convert logical value to a null-terminated formatted string.  If the
 /// input value == 0, then the output character is the letter F, else
 /// the output character is the letter T.  The output string is null terminated.
-pub(crate) fn ffl2c(
-    lval: c_int,         /* I - value to be converted to a string */
-    cval: &mut [c_char], /* O - character string representation of the value */
-    status: &mut c_int,  /* IO - error status ) */
-) -> c_int {
+///
+/// # Parameters
+///
+/// * `lval`   — (I) value to be converted to a string
+/// * `cval`   — (O) character string representation of the value
+/// * `status` — (IO) error status )
+pub(crate) fn ffl2c(lval: c_int, cval: &mut [c_char], status: &mut c_int) -> c_int {
     if *status > 0 {
         /* inherit input status value if > 0 */
         return *status;
@@ -4916,8 +5635,7 @@ pub(crate) fn ffl2c(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
-/// convert an input string to a quoted string. Leading spaces
+/// Convert an input string to a quoted string. Leading spaces
 /// are significant.  FITS string keyword values must be at least
 /// 8 chars long so pad out string with spaces if necessary.
 /// (*** This 8 char requirement is now obsolete.  See ffs2c_nopad
@@ -4925,11 +5643,13 @@ pub(crate) fn ffl2c(
 /// Example:   km/s ==> 'km/s    '
 /// Single quote characters in the input string will be replace by
 /// two single quote characters. e.g., o'brian ==> 'o''brian'
-pub(crate) fn ffs2c(
-    instr: &[c_char],      /* I - null terminated input string  */
-    outstr: &mut [c_char], /* O - null terminated quoted output string */
-    status: &mut c_int,    /* IO - error status */
-) -> c_int {
+///
+/// # Parameters
+///
+/// * `instr`  — (I) null terminated input string
+/// * `outstr` — (O) null terminated quoted output string
+/// * `status` — (IO) error status
+pub(crate) fn ffs2c(instr: &[c_char], outstr: &mut [c_char], status: &mut c_int) -> c_int {
     let mut len = 0;
 
     if *status > 0 {
@@ -4977,7 +5697,6 @@ pub(crate) fn ffs2c(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// This performs identically to ffs2c except that it won't pad output
 /// strings to make them a minimum of 8 chars long.  The requirement
 /// that FITS keyword string values be 8 characters is now obsolete
@@ -4985,11 +5704,13 @@ pub(crate) fn ffs2c(
 /// keep ffs2c the way it is.  A better solution would be to add another
 /// argument to ffs2c for 'pad' or 'nopad', but it is called from many other
 /// places in Heasoft outside of CFITSIO.  
-pub(crate) fn ffs2c_nopad(
-    instr: &[c_char],      /* I - null terminated input string  */
-    outstr: &mut [c_char], /* O - null terminated quoted output string */
-    status: &mut c_int,    /* IO - error status */
-) -> c_int {
+///
+/// # Parameters
+///
+/// * `instr`  — (I) null terminated input string
+/// * `outstr` — (O) null terminated quoted output string
+/// * `status` — (IO) error status
+pub(crate) fn ffs2c_nopad(instr: &[c_char], outstr: &mut [c_char], status: &mut c_int) -> c_int {
     //size_t len, ii, jj;
 
     if *status > 0 {
@@ -5033,14 +5754,15 @@ pub(crate) fn ffs2c_nopad(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
-/// convert float value to a null-terminated F format string
-pub(crate) fn ffr2f(
-    fval: f32,           /* I - value to be converted to a string */
-    decim: c_int,        /* I - number of decimal places to display */
-    cval: &mut [c_char], /* O - character string representation of the value */
-    status: &mut c_int,  /* IO - error status */
-) -> c_int {
+/// Convert float value to a null-terminated F format string
+///
+/// # Parameters
+///
+/// * `fval`   — (I) value to be converted to a string
+/// * `decim`  — (I) number of decimal places to display
+/// * `cval`   — (O) character string representation of the value
+/// * `status` — (IO) error status
+pub(crate) fn ffr2f(fval: f32, decim: c_int, cval: &mut [c_char], status: &mut c_int) -> c_int {
     if *status > 0 {
         /* inherit input status value if > 0 */
         return *status;
@@ -5074,14 +5796,15 @@ pub(crate) fn ffr2f(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
-/// convert float value to a null-terminated exponential format string
-pub(crate) fn ffr2e(
-    fval: f32,           /* I - value to be converted to a string */
-    decim: c_int,        /* I - number of decimal places to display */
-    cval: &mut [c_char], /* O - character string representation of the value */
-    status: &mut c_int,  /* IO - error status */
-) -> c_int {
+/// Convert float value to a null-terminated exponential format string
+///
+/// # Parameters
+///
+/// * `fval`   — (I) value to be converted to a string
+/// * `decim`  — (I) number of decimal places to display
+/// * `cval`   — (O) character string representation of the value
+/// * `status` — (IO) error status
+pub(crate) fn ffr2e(fval: f32, decim: c_int, cval: &mut [c_char], status: &mut c_int) -> c_int {
     if *status > 0 {
         /* inherit input status value if > 0 */
         return *status;
@@ -5163,14 +5886,15 @@ pub(crate) fn ffr2e(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
-/// convert double value to a null-terminated F format string
-pub(crate) fn ffd2f(
-    dval: f64,           /* I - value to be converted to a string */
-    decim: c_int,        /* I - number of decimal places to display */
-    cval: &mut [c_char], /* O - character string representation of the value */
-    status: &mut c_int,  /* IO - error status */
-) -> c_int {
+/// Convert double value to a null-terminated F format string
+///
+/// # Parameters
+///
+/// * `dval`   — (I) value to be converted to a string
+/// * `decim`  — (I) number of decimal places to display
+/// * `cval`   — (O) character string representation of the value
+/// * `status` — (IO) error status
+pub(crate) fn ffd2f(dval: f64, decim: c_int, cval: &mut [c_char], status: &mut c_int) -> c_int {
     if *status > 0 {
         /* inherit input status value if > 0 */
         return *status;
@@ -5203,14 +5927,15 @@ pub(crate) fn ffd2f(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
-/// convert double value to a null-terminated exponential format string.
-pub(crate) fn ffd2e(
-    dval: f64,           /* I - value to be converted to a string */
-    decim: c_int,        /* I - number of decimal places to display */
-    cval: &mut [c_char], /* O - character string representation of the value */
-    status: &mut c_int,  /* IO - error status */
-) -> c_int {
+/// Convert double value to a null-terminated exponential format string.
+///
+/// # Parameters
+///
+/// * `dval`   — (I) value to be converted to a string
+/// * `decim`  — (I) number of decimal places to display
+/// * `cval`   — (O) character string representation of the value
+/// * `status` — (IO) error status
+pub(crate) fn ffd2e(dval: f64, decim: c_int, cval: &mut [c_char], status: &mut c_int) -> c_int {
     if *status > 0 {
         /* inherit input status value if > 0 */
         return *status;
@@ -5280,14 +6005,20 @@ pub(crate) fn ffd2e(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Verify that the specified date is valid
+///
+/// # Parameters
+///
+/// * `year`   — (I) year
+/// * `month`  — (I) month (1-12)
+/// * `day`    — (I) day (1-31)
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffverifydate(
-    year: c_int,        /* I - year */
-    month: c_int,       /* I - month (1-12) */
-    day: c_int,         /* I - day (1-31) */
-    status: *mut c_int, /* IO - error status */
+    year: c_int,
+    month: c_int,
+    day: c_int,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -5297,12 +6028,14 @@ pub unsafe extern "C" fn ffverifydate(
 }
 
 /// Verify that the specified date is valid (safe version)
-pub fn ffverifydate_safe(
-    year: c_int,        /* I - year */
-    month: c_int,       /* I - month (1-12) */
-    day: c_int,         /* I - day (1-31) */
-    status: &mut c_int, /* IO - error status */
-) -> c_int {
+///
+/// # Parameters
+///
+/// * `year`   — (I) year
+/// * `month`  — (I) month (1-12)
+/// * `day`    — (I) day (1-31)
+/// * `status` — (IO) error status
+pub fn ffverifydate_safe(year: c_int, month: c_int, day: c_int, status: &mut c_int) -> c_int {
     const NDAYS: [c_int; 13] = [0, 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
     let mut errmsg: [c_char; FLEN_ERRMSG] = [0; FLEN_ERRMSG];
 
@@ -5387,18 +6120,27 @@ pub fn ffverifydate_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write (put) an indexed array of keywords with index numbers between
 /// NSTART and (NSTART + NKEY -1) inclusive.  Write integer keywords
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyroot` — (I) root name of keywords
+/// * `nstart`  — (I) starting index number
+/// * `nkey`    — (I) number of keywords to write
+/// * `value`   — (I) array of keyword values
+/// * `comm`    — (I) array of keyword comments
+/// * `status`  — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffpknjj(
-    fptr: *mut fitsfile,        /* I - FITS file pointer */
-    keyroot: *const c_char,     /* I - root name of keywords */
-    nstart: c_int,              /* I - starting index number */
-    nkey: c_int,                /* I - number of keywords to write */
-    value: *const LONGLONG,     /* I - array of keyword values */
-    comm: *const *const c_char, /* I - array of keyword comments */
-    status: *mut c_int,         /* IO - error status */
+    fptr: *mut fitsfile,
+    keyroot: *const c_char,
+    nstart: c_int,
+    nkey: c_int,
+    value: *const LONGLONG,
+    comm: *const *const c_char,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -5434,17 +6176,26 @@ pub unsafe extern "C" fn ffpknjj(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Write (put) an indexed array of keywords with index numbers between
 /// NSTART and (NSTART + NKEY -1) inclusive.  Write integer keywords
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `keyroot` — (I) root name of keywords
+/// * `nstart`  — (I) starting index number
+/// * `nkey`    — (I) number of keywords to write
+/// * `value`   — (I) array of keyword values
+/// * `comm`    — (I) array of keyword comments
+/// * `status`  — (IO) error status
 pub fn ffpknjj_safe(
-    fptr: &mut fitsfile,        /* I - FITS file pointer */
-    keyroot: &[c_char],         /* I - root name of keywords */
-    nstart: c_int,              /* I - starting index number */
-    nkey: c_int,                /* I - number of keywords to write */
-    value: &[LONGLONG],         /* I - array of keyword values */
-    comm: Option<&[&[c_char]]>, /* I - array of keyword comments */
-    status: &mut c_int,         /* IO - error status */
+    fptr: &mut fitsfile,
+    keyroot: &[c_char],
+    nstart: c_int,
+    nkey: c_int,
+    value: &[LONGLONG],
+    comm: Option<&[&[c_char]]>,
+    status: &mut c_int,
 ) -> c_int {
     let mut keyname: [c_char; FLEN_KEYWORD] = [0; FLEN_KEYWORD];
     let mut tcomment: [c_char; FLEN_COMMENT] = [0; FLEN_COMMENT];

--- a/src/quantize.rs
+++ b/src/quantize.rs
@@ -1,8 +1,20 @@
-/*
-  The following code is based on algorithms written by Richard White at STScI and made
-  available for use in CFITSIO in July 1999 and updated in January 2008.
-
-*/
+//! Quantization of floating point images for lossy compression.
+//!
+//! The tile compressors work on integers, so a `float` or `double` image is
+//! first quantized: each tile's values are divided by a scale factor and
+//! rounded, and the scale and zero point are recorded in the `ZSCALE` and
+//! `ZZERO` columns so the values can be reconstructed. The scale is chosen from
+//! an estimate of the tile's noise, so that the quantization error stays below
+//! the noise already present -- which is what makes the loss acceptable.
+//!
+//! Rounding alone leaves the reconstructed values visibly striped at low signal
+//! levels, so a dither may be added before rounding and subtracted after; see
+//! `DitherType`, which is crate-private. `SubtractiveDither2` additionally
+//! preserves exact zeros, which would otherwise be perturbed.
+//!
+//! Based on algorithms written by Richard White at STScI, made available for
+//! use in CFITSIO in July 1999 and updated in January 2008.
+#![warn(missing_docs)]
 
 use core::slice;
 
@@ -17,9 +29,14 @@ use crate::{
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// Which dithering scheme to apply when quantizing a floating point tile.
 pub(crate) enum DitherType {
+    /// Round without dithering.
     NoDither = -1,
+    /// Add a pseudo-random dither before rounding and subtract it after.
     SubtractiveDither1 = 1,
+    /// As [`DitherType::SubtractiveDither1`], but a value of exactly zero is
+    /// preserved rather than dithered.
     SubtractiveDither2 = 2,
 }
 
@@ -58,11 +75,20 @@ so we must reserve a little more space */
 const N_RESERVED_VALUES: i32 = 10;
 
 /* more than this many standard deviations from the mean is an outlier */
+/// Values further than this many sigma from the mean are clipped when
+/// estimating a tile's noise.
 const SIGMA_CLIP: f64 = 5.0;
 
-const NITER: i32 = 3; /* number of sigma-clipping iterations */
+/// Number of sigma-clipping iterations used when estimating a tile's noise.
+const NITER: i32 = 3;
 
+/// Writes through an optional output reference, doing nothing when the caller
+/// passed `None`.
+///
+/// The C writes to an output parameter only after testing the pointer against
+/// NULL; this is that idiom, as a method.
 pub trait SomeSet<T> {
+    /// Store `v` if there is somewhere to store it.
     fn set_if_some(self, v: T);
 }
 
@@ -75,7 +101,6 @@ impl<T> SomeSet<T> for Option<&mut T> {
     }
 }
 
-/*---------------------------------------------------------------------------*/
 /// The function value will be one if the input fdata were copied to idata;
 /// in this case the parameters bscale and bzero can be used to convert back to
 /// nearly the original floating point values:  fdata ~= idata * bscale + bzero.
@@ -311,7 +336,6 @@ pub(crate) fn fits_quantize_float_inplace(
     1
 }
 
-/*---------------------------------------------------------------------------*/
 /// The function value will be one if the input fdata were copied to idata;
 /// in this case the parameters bscale and bzero can be used to convert back to
 /// nearly the original floating point values:  fdata ~= idata * bscale + bzero.
@@ -546,29 +570,46 @@ pub(crate) fn fits_quantize_double_inplace(
     1
 }
 
-/*--------------------------------------------------------------------------*/
 /// Compute statistics of the input short integer image.
+///
+/// # Parameters
+///
+/// * `array`     — 2 dimensional array of image pixels
+/// * `nx`        — number of pixels in each row of the image
+/// * `ny`        — number of rows in the image
+/// * `nullcheck` — check for null values, if true
+/// * `nullvalue` — value of null pixels, if nullcheck is true
+/// * `ngoodpix`  — number of non-null pixels in the image
+/// * `minvalue`  — returned minimum non-null value in the array
+/// * `maxvalue`  — returned maximum non-null value in the array
+/// * `mean`      — returned mean value of all non-null pixels
+/// * `sigma`     — returned R.M.S. value of all non-null pixels
+/// * `noise1`    — 1st order estimate of noise in image background level
+/// * `noise2`    — 2nd order estimate of noise in image background level
+/// * `noise3`    — 3rd order estimate of noise in image background level
+/// * `noise5`    — 5th order estimate of noise in image background level
+/// * `status`    — error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn fits_img_stats_short(
-    array: *const c_short, /*  2 dimensional array of image pixels */
-    nx: c_long,            /* number of pixels in each row of the image */
-    ny: c_long,            /* number of rows in the image */
+    array: *const c_short,
+    nx: c_long,
+    ny: c_long,
     /* (if this is a 3D image, then ny should be the */
     /* product of the no. of rows times the no. of planes) */
-    nullcheck: c_int,   /* check for null values, if true */
-    nullvalue: c_short, /* value of null pixels, if nullcheck is true */
+    nullcheck: c_int,
+    nullvalue: c_short,
 
     /* returned parameters (if the pointer is not null)  */
-    ngoodpix: *mut c_long,  /* number of non-null pixels in the image */
-    minvalue: *mut c_short, /* returned minimum non-null value in the array */
-    maxvalue: *mut c_short, /* returned maximum non-null value in the array */
-    mean: *mut f64,         /* returned mean value of all non-null pixels */
-    sigma: *mut f64,        /* returned R.M.S. value of all non-null pixels */
-    noise1: *mut f64,       /* 1st order estimate of noise in image background level */
-    noise2: *mut f64,       /* 2nd order estimate of noise in image background level */
-    noise3: *mut f64,       /* 3rd order estimate of noise in image background level */
-    noise5: *mut f64,       /* 5th order estimate of noise in image background level */
-    status: *mut c_int,     /* error status */
+    ngoodpix: *mut c_long,
+    minvalue: *mut c_short,
+    maxvalue: *mut c_short,
+    mean: *mut f64,
+    sigma: *mut f64,
+    noise1: *mut f64,
+    noise2: *mut f64,
+    noise3: *mut f64,
+    noise5: *mut f64,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -594,28 +635,45 @@ pub unsafe extern "C" fn fits_img_stats_short(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Compute statistics of the input short integer image.
+///
+/// # Parameters
+///
+/// * `array`     — 2 dimensional array of image pixels
+/// * `nx`        — number of pixels in each row of the image
+/// * `ny`        — number of rows in the image
+/// * `nullcheck` — check for null values, if true
+/// * `nullvalue` — value of null pixels, if nullcheck is true
+/// * `ngoodpix`  — number of non-null pixels in the image
+/// * `minvalue`  — returned minimum non-null value in the array
+/// * `maxvalue`  — returned maximum non-null value in the array
+/// * `mean`      — returned mean value of all non-null pixels
+/// * `sigma`     — returned R.M.S. value of all non-null pixels
+/// * `noise1`    — 1st order estimate of noise in image background level
+/// * `noise2`    — 2nd order estimate of noise in image background level
+/// * `noise3`    — 3rd order estimate of noise in image background level
+/// * `noise5`    — 5th order estimate of noise in image background level
+/// * `status`    — error status
 pub fn fits_img_stats_short_safe(
-    array: &[c_short], /*  2 dimensional array of image pixels */
-    nx: c_long,        /* number of pixels in each row of the image */
-    ny: c_long,        /* number of rows in the image */
+    array: &[c_short],
+    nx: c_long,
+    ny: c_long,
     /* (if this is a 3D image, then ny should be the */
     /* product of the no. of rows times the no. of planes) */
-    nullcheck: bool,    /* check for null values, if true */
-    nullvalue: c_short, /* value of null pixels, if nullcheck is true */
+    nullcheck: bool,
+    nullvalue: c_short,
 
     /* returned parameters (if the pointer is not null)  */
-    mut ngoodpix: Option<&mut c_long>, /* number of non-null pixels in the image */
-    minvalue: Option<&mut c_short>,    /* returned minimum non-null value in the array */
-    maxvalue: Option<&mut c_short>,    /* returned maximum non-null value in the array */
-    mean: Option<&mut f64>,            /* returned mean value of all non-null pixels */
-    sigma: Option<&mut f64>,           /* returned R.M.S. value of all non-null pixels */
-    noise1: Option<&mut f64>,          /* 1st order estimate of noise in image background level */
-    noise2: Option<&mut f64>,          /* 2nd order estimate of noise in image background level */
-    noise3: Option<&mut f64>,          /* 3rd order estimate of noise in image background level */
-    noise5: Option<&mut f64>,          /* 5th order estimate of noise in image background level */
-    status: &mut c_int,                /* error status */
+    mut ngoodpix: Option<&mut c_long>,
+    minvalue: Option<&mut c_short>,
+    maxvalue: Option<&mut c_short>,
+    mean: Option<&mut f64>,
+    sigma: Option<&mut f64>,
+    noise1: Option<&mut f64>,
+    noise2: Option<&mut f64>,
+    noise3: Option<&mut f64>,
+    noise5: Option<&mut f64>,
+    status: &mut c_int,
 ) -> c_int {
     let mut ngood: usize = 0;
     let mut minval: c_short = 0;
@@ -705,29 +763,46 @@ pub fn fits_img_stats_short_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Compute statistics of the input integer image.
+///
+/// # Parameters
+///
+/// * `array`     — 2 dimensional array of image pixels
+/// * `nx`        — number of pixels in each row of the image
+/// * `ny`        — number of rows in the image
+/// * `nullcheck` — check for null values, if true
+/// * `nullvalue` — value of null pixels, if nullcheck is true
+/// * `ngoodpix`  — number of non-null pixels in the image
+/// * `minvalue`  — returned minimum non-null value in the array
+/// * `maxvalue`  — returned maximum non-null value in the array
+/// * `mean`      — returned mean value of all non-null pixels
+/// * `sigma`     — returned R.M.S. value of all non-null pixels
+/// * `noise1`    — 1st order estimate of noise in image background level
+/// * `noise2`    — 2nd order estimate of noise in image background level
+/// * `noise3`    — 3rd order estimate of noise in image background level
+/// * `noise5`    — 5th order estimate of noise in image background level
+/// * `status`    — error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn fits_img_stats_int(
-    array: *const c_int, /*  2 dimensional array of image pixels */
-    nx: c_long,          /* number of pixels in each row of the image */
-    ny: c_long,          /* number of rows in the image */
+    array: *const c_int,
+    nx: c_long,
+    ny: c_long,
     /* (if this is a 3D image, then ny should be the */
     /* product of the no. of rows times the no. of planes) */
-    nullcheck: c_int, /* check for null values, if true */
-    nullvalue: c_int, /* value of null pixels, if nullcheck is true */
+    nullcheck: c_int,
+    nullvalue: c_int,
 
     /* returned parameters (if the pointer is not null)  */
-    ngoodpix: *mut c_long, /* number of non-null pixels in the image */
-    minvalue: *mut c_int,  /* returned minimum non-null value in the array */
-    maxvalue: *mut c_int,  /* returned maximum non-null value in the array */
-    mean: *mut f64,        /* returned mean value of all non-null pixels */
-    sigma: *mut f64,       /* returned R.M.S. value of all non-null pixels */
-    noise1: *mut f64,      /* 1st order estimate of noise in image background level */
-    noise2: *mut f64,      /* 2nd order estimate of noise in image background level */
-    noise3: *mut f64,      /* 3rd order estimate of noise in image background level */
-    noise5: *mut f64,      /* 5th order estimate of noise in image background level */
-    status: *mut c_int,    /* error status */
+    ngoodpix: *mut c_long,
+    minvalue: *mut c_int,
+    maxvalue: *mut c_int,
+    mean: *mut f64,
+    sigma: *mut f64,
+    noise1: *mut f64,
+    noise2: *mut f64,
+    noise3: *mut f64,
+    noise5: *mut f64,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -753,28 +828,45 @@ pub unsafe extern "C" fn fits_img_stats_int(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Compute statistics of the input integer image.
+///
+/// # Parameters
+///
+/// * `array`     — 2 dimensional array of image pixels
+/// * `nx`        — number of pixels in each row of the image
+/// * `ny`        — number of rows in the image
+/// * `nullcheck` — check for null values, if true
+/// * `nullvalue` — value of null pixels, if nullcheck is true
+/// * `ngoodpix`  — number of non-null pixels in the image
+/// * `minvalue`  — returned minimum non-null value in the array
+/// * `maxvalue`  — returned maximum non-null value in the array
+/// * `mean`      — returned mean value of all non-null pixels
+/// * `sigma`     — returned R.M.S. value of all non-null pixels
+/// * `noise1`    — 1st order estimate of noise in image background level
+/// * `noise2`    — 2nd order estimate of noise in image background level
+/// * `noise3`    — 3rd order estimate of noise in image background level
+/// * `noise5`    — 5th order estimate of noise in image background level
+/// * `status`    — error status
 pub fn fits_img_stats_int_safe(
-    array: &[c_int], /*  2 dimensional array of image pixels */
-    nx: c_long,      /* number of pixels in each row of the image */
-    ny: c_long,      /* number of rows in the image */
+    array: &[c_int],
+    nx: c_long,
+    ny: c_long,
     /* (if this is a 3D image, then ny should be the */
     /* product of the no. of rows times the no. of planes) */
-    nullcheck: bool,  /* check for null values, if true */
-    nullvalue: c_int, /* value of null pixels, if nullcheck is true */
+    nullcheck: bool,
+    nullvalue: c_int,
 
     /* returned parameters (if the pointer is not null)  */
-    mut ngoodpix: Option<&mut c_long>, /* number of non-null pixels in the image */
-    minvalue: Option<&mut c_int>,      /* returned minimum non-null value in the array */
-    maxvalue: Option<&mut c_int>,      /* returned maximum non-null value in the array */
-    mean: Option<&mut f64>,            /* returned mean value of all non-null pixels */
-    sigma: Option<&mut f64>,           /* returned R.M.S. value of all non-null pixels */
-    noise1: Option<&mut f64>,          /* 1st order estimate of noise in image background level */
-    noise2: Option<&mut f64>,          /* 2nd order estimate of noise in image background level */
-    noise3: Option<&mut f64>,          /* 3rd order estimate of noise in image background level */
-    noise5: Option<&mut f64>,          /* 5th order estimate of noise in image background level */
-    status: &mut c_int,                /* error status */
+    mut ngoodpix: Option<&mut c_long>,
+    minvalue: Option<&mut c_int>,
+    maxvalue: Option<&mut c_int>,
+    mean: Option<&mut f64>,
+    sigma: Option<&mut f64>,
+    noise1: Option<&mut f64>,
+    noise2: Option<&mut f64>,
+    noise3: Option<&mut f64>,
+    noise5: Option<&mut f64>,
+    status: &mut c_int,
 ) -> c_int {
     let mut ngood: usize = 0;
     let mut minval: c_int = 0;
@@ -862,29 +954,46 @@ pub fn fits_img_stats_int_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Compute statistics of the input float image.
+///
+/// # Parameters
+///
+/// * `array`     — 2 dimensional array of image pixels
+/// * `nx`        — number of pixels in each row of the image
+/// * `ny`        — number of rows in the image
+/// * `nullcheck` — check for null values, if true
+/// * `nullvalue` — value of null pixels, if nullcheck is true
+/// * `ngoodpix`  — number of non-null pixels in the image
+/// * `minvalue`  — returned minimum non-null value in the array
+/// * `maxvalue`  — returned maximum non-null value in the array
+/// * `mean`      — returned mean value of all non-null pixels
+/// * `sigma`     — returned R.M.S. value of all non-null pixels
+/// * `noise1`    — 1st order estimate of noise in image background level
+/// * `noise2`    — 2nd order estimate of noise in image background level
+/// * `noise3`    — 3rd order estimate of noise in image background level
+/// * `noise5`    — 5th order estimate of noise in image background level
+/// * `status`    — error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn fits_img_stats_float(
-    array: *const f32, /*  2 dimensional array of image pixels */
-    nx: c_long,        /* number of pixels in each row of the image */
-    ny: c_long,        /* number of rows in the image */
+    array: *const f32,
+    nx: c_long,
+    ny: c_long,
     /* (if this is a 3D image, then ny should be the */
     /* product of the no. of rows times the no. of planes) */
-    nullcheck: c_int, /* check for null values, if true */
-    nullvalue: f32,   /* value of null pixels, if nullcheck is true */
+    nullcheck: c_int,
+    nullvalue: f32,
 
     /* returned parameters (if the pointer is not null)  */
-    ngoodpix: *mut c_long, /* number of non-null pixels in the image */
-    minvalue: *mut f32,    /* returned minimum non-null value in the array */
-    maxvalue: *mut f32,    /* returned maximum non-null value in the array */
-    mean: *mut f64,        /* returned mean value of all non-null pixels */
-    sigma: *mut f64,       /* returned R.M.S. value of all non-null pixels */
-    noise1: *mut f64,      /* 1st order estimate of noise in image background level */
-    noise2: *mut f64,      /* 2nd order estimate of noise in image background level */
-    noise3: *mut f64,      /* 3rd order estimate of noise in image background level */
-    noise5: *mut f64,      /* 5th order estimate of noise in image background level */
-    status: *mut c_int,    /* error status */
+    ngoodpix: *mut c_long,
+    minvalue: *mut f32,
+    maxvalue: *mut f32,
+    mean: *mut f64,
+    sigma: *mut f64,
+    noise1: *mut f64,
+    noise2: *mut f64,
+    noise3: *mut f64,
+    noise5: *mut f64,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -910,28 +1019,45 @@ pub unsafe extern "C" fn fits_img_stats_float(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Compute statistics of the input float image.
+///
+/// # Parameters
+///
+/// * `array`     — 2 dimensional array of image pixels
+/// * `nx`        — number of pixels in each row of the image
+/// * `ny`        — number of rows in the image
+/// * `nullcheck` — check for null values, if true
+/// * `nullvalue` — value of null pixels, if nullcheck is true
+/// * `ngoodpix`  — number of non-null pixels in the image
+/// * `minvalue`  — returned minimum non-null value in the array
+/// * `maxvalue`  — returned maximum non-null value in the array
+/// * `mean`      — returned mean value of all non-null pixels
+/// * `sigma`     — returned R.M.S. value of all non-null pixels
+/// * `noise1`    — 1st order estimate of noise in image background level
+/// * `noise2`    — 2nd order estimate of noise in image background level
+/// * `noise3`    — 3rd order estimate of noise in image background level
+/// * `noise5`    — 5th order estimate of noise in image background level
+/// * `status`    — error status
 pub fn fits_img_stats_float_safe(
-    array: &[f32], /*  2 dimensional array of image pixels */
-    nx: c_long,    /* number of pixels in each row of the image */
-    ny: c_long,    /* number of rows in the image */
+    array: &[f32],
+    nx: c_long,
+    ny: c_long,
     /* (if this is a 3D image, then ny should be the */
     /* product of the no. of rows times the no. of planes) */
-    nullcheck: bool, /* check for null values, if true */
-    nullvalue: f32,  /* value of null pixels, if nullcheck is true */
+    nullcheck: bool,
+    nullvalue: f32,
 
     /* returned parameters (if the pointer is not null)  */
-    mut ngoodpix: Option<&mut c_long>, /* number of non-null pixels in the image */
-    minvalue: Option<&mut f32>,        /* returned minimum non-null value in the array */
-    maxvalue: Option<&mut f32>,        /* returned maximum non-null value in the array */
-    mean: Option<&mut f64>,            /* returned mean value of all non-null pixels */
-    sigma: Option<&mut f64>,           /* returned R.M.S. value of all non-null pixels */
-    noise1: Option<&mut f64>,          /* 1st order estimate of noise in image background level */
-    noise2: Option<&mut f64>,          /* 2nd order estimate of noise in image background level */
-    noise3: Option<&mut f64>,          /* 3rd order estimate of noise in image background level */
-    noise5: Option<&mut f64>,          /* 5th order estimate of noise in image background level */
-    status: &mut c_int,                /* error status */
+    mut ngoodpix: Option<&mut c_long>,
+    minvalue: Option<&mut f32>,
+    maxvalue: Option<&mut f32>,
+    mean: Option<&mut f64>,
+    sigma: Option<&mut f64>,
+    noise1: Option<&mut f64>,
+    noise2: Option<&mut f64>,
+    noise3: Option<&mut f64>,
+    noise5: Option<&mut f64>,
+    status: &mut c_int,
 ) -> c_int {
     let mut ngood: usize = 0;
     let mut minval: f32 = 0.0;
@@ -1019,17 +1145,27 @@ pub fn fits_img_stats_float_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Compute mean and RMS sigma of the non-null pixels in the input array.
+///
+/// # Parameters
+///
+/// * `array`     — 2 dimensional array of image pixels
+/// * `npix`      — number of pixels in the image
+/// * `nullcheck` — check for null values, if true
+/// * `nullvalue` — value of null pixels, if nullcheck is true
+/// * `ngoodpix`  — number of non-null pixels in the image
+/// * `mean`      — returned mean value of all non-null pixels
+/// * `sigma`     — returned R.M.S. value of all non-null pixels
+/// * `status`    — error status
 fn FnMeanSigma_short(
-    array: &[c_short],    /*  2 dimensional array of image pixels */
-    npix: usize,          /* number of pixels in the image */
-    nullcheck: bool,      /* check for null values, if true */
-    nullvalue: c_short,   /* value of null pixels, if nullcheck is true */
-    ngoodpix: &mut usize, /* number of non-null pixels in the image */
-    mean: &mut f64,       /* returned mean value of all non-null pixels */
-    sigma: &mut f64,      /* returned R.M.S. value of all non-null pixels */
-    status: &mut c_int,   /* error status */
+    array: &[c_short],
+    npix: usize,
+    nullcheck: bool,
+    nullvalue: c_short,
+    ngoodpix: &mut usize,
+    mean: &mut f64,
+    sigma: &mut f64,
+    status: &mut c_int,
 ) -> c_int {
     let mut ngood: usize = 0;
 
@@ -1079,17 +1215,27 @@ fn FnMeanSigma_short(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Compute mean and RMS sigma of the non-null pixels in the input array.
+///
+/// # Parameters
+///
+/// * `array`     — 2 dimensional array of image pixels
+/// * `npix`      — number of pixels in the image
+/// * `nullcheck` — check for null values, if true
+/// * `nullvalue` — value of null pixels, if nullcheck is true
+/// * `ngoodpix`  — number of non-null pixels in the image
+/// * `mean`      — returned mean value of all non-null pixels
+/// * `sigma`     — returned R.M.S. value of all non-null pixels
+/// * `status`    — error status
 fn FnMeanSigma_int(
-    array: &[c_int],      /*  2 dimensional array of image pixels */
-    npix: usize,          /* number of pixels in the image */
-    nullcheck: bool,      /* check for null values, if true */
-    nullvalue: c_int,     /* value of null pixels, if nullcheck is true */
-    ngoodpix: &mut usize, /* number of non-null pixels in the image */
-    mean: &mut f64,       /* returned mean value of all non-null pixels */
-    sigma: &mut f64,      /* returned R.M.S. value of all non-null pixels */
-    status: &mut c_int,   /* error status */
+    array: &[c_int],
+    npix: usize,
+    nullcheck: bool,
+    nullvalue: c_int,
+    ngoodpix: &mut usize,
+    mean: &mut f64,
+    sigma: &mut f64,
+    status: &mut c_int,
 ) -> c_int {
     let mut ngood: usize = 0;
 
@@ -1139,17 +1285,27 @@ fn FnMeanSigma_int(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Compute mean and RMS sigma of the non-null pixels in the input array.
+///
+/// # Parameters
+///
+/// * `array`     — 2 dimensional array of image pixels
+/// * `npix`      — number of pixels in the image
+/// * `nullcheck` — check for null values, if true
+/// * `nullvalue` — value of null pixels, if nullcheck is true
+/// * `ngoodpix`  — number of non-null pixels in the image
+/// * `mean`      — returned mean value of all non-null pixels
+/// * `sigma`     — returned R.M.S. value of all non-null pixels
+/// * `status`    — error status
 fn FnMeanSigma_float(
-    array: &[f32],        /*  2 dimensional array of image pixels */
-    npix: usize,          /* number of pixels in the image */
-    nullcheck: bool,      /* check for null values, if true */
-    nullvalue: f32,       /* value of null pixels, if nullcheck is true */
-    ngoodpix: &mut usize, /* number of non-null pixels in the image */
-    mean: &mut f64,       /* returned mean value of all non-null pixels */
-    sigma: &mut f64,      /* returned R.M.S. value of all non-null pixels */
-    status: &mut c_int,   /* error status */
+    array: &[f32],
+    npix: usize,
+    nullcheck: bool,
+    nullvalue: f32,
+    ngoodpix: &mut usize,
+    mean: &mut f64,
+    sigma: &mut f64,
+    status: &mut c_int,
 ) -> c_int {
     let mut ngood: usize = 0;
 
@@ -1199,17 +1355,27 @@ fn FnMeanSigma_float(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Compute mean and RMS sigma of the non-null pixels in the input array.
+///
+/// # Parameters
+///
+/// * `array`     — 2 dimensional array of image pixels
+/// * `npix`      — number of pixels in the image
+/// * `nullcheck` — check for null values, if true
+/// * `nullvalue` — value of null pixels, if nullcheck is true
+/// * `ngoodpix`  — number of non-null pixels in the image
+/// * `mean`      — returned mean value of all non-null pixels
+/// * `sigma`     — returned R.M.S. value of all non-null pixels
+/// * `status`    — error status
 fn FnMeanSigma_double(
-    array: &[f64],        /*  2 dimensional array of image pixels */
-    npix: usize,          /* number of pixels in the image */
-    nullcheck: bool,      /* check for null values, if true */
-    nullvalue: f64,       /* value of null pixels, if nullcheck is true */
-    ngoodpix: &mut usize, /* number of non-null pixels in the image */
-    mean: &mut f64,       /* returned mean value of all non-null pixels */
-    sigma: &mut f64,      /* returned R.M.S. value of all non-null pixels */
-    status: &mut c_int,   /* error status */
+    array: &[f64],
+    npix: usize,
+    nullcheck: bool,
+    nullvalue: f64,
+    ngoodpix: &mut usize,
+    mean: &mut f64,
+    sigma: &mut f64,
+    status: &mut c_int,
 ) -> c_int {
     let mut ngood: usize = 0;
 
@@ -1259,30 +1425,44 @@ fn FnMeanSigma_double(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Estimate the median and background noise in the input image using 2nd, 3rd and 5th order Median Absolute Differences.
 ///
 /// The noise in the background of the image is calculated using the MAD algorithms
 /// developed for deriving the signal to noise ratio in spectra
-/// (see issue #42 of the ST-ECF newsletter, http://www.stecf.org/documents/newsletter/)
+/// (see issue #42 of the ST-ECF newsletter, <http://www.stecf.org/documents/newsletter/>)
 ///
 /// 3rd order:  noise = 1.482602 / sqrt(6) * median (abs(2*flux(i) - flux(i-2) - flux(i+2)))
 ///
 /// The returned estimates are the median of the values that are computed for each
 /// row of the image.
+///
+/// # Parameters
+///
+/// * `array`     — 2 dimensional array of image pixels
+/// * `nx`        — number of pixels in each row of the image
+/// * `ny`        — number of rows in the image
+/// * `nullcheck` — check for null values, if true
+/// * `nullvalue` — value of null pixels, if nullcheck is true
+/// * `ngood`     — number of good, non-null pixels?
+/// * `minval`    — minimum non-null value
+/// * `maxval`    — maximum non-null value
+/// * `noise2`    — returned 2nd order MAD of all non-null pixels
+/// * `noise3`    — returned 3rd order MAD of all non-null pixels
+/// * `noise5`    — returned 5th order MAD of all non-null pixels
+/// * `status`    — error status
 fn FnNoise5_short(
-    array: &[c_short],            /*  2 dimensional array of image pixels */
-    nx: usize,                    /* number of pixels in each row of the image */
-    ny: usize,                    /* number of rows in the image */
-    nullcheck: bool,              /* check for null values, if true */
-    nullvalue: c_short,           /* value of null pixels, if nullcheck is true */
-    ngood: Option<&mut usize>,    /* number of good, non-null pixels? */
-    minval: Option<&mut c_short>, /* minimum non-null value */
-    maxval: Option<&mut c_short>, /* maximum non-null value */
-    noise2: Option<&mut f64>,     /* returned 2nd order MAD of all non-null pixels */
-    noise3: Option<&mut f64>,     /* returned 3rd order MAD of all non-null pixels */
-    noise5: Option<&mut f64>,     /* returned 5th order MAD of all non-null pixels */
-    status: &mut c_int,           /* error status */
+    array: &[c_short],
+    nx: usize,
+    ny: usize,
+    nullcheck: bool,
+    nullvalue: c_short,
+    ngood: Option<&mut usize>,
+    minval: Option<&mut c_short>,
+    maxval: Option<&mut c_short>,
+    noise2: Option<&mut f64>,
+    noise3: Option<&mut f64>,
+    noise5: Option<&mut f64>,
+    status: &mut c_int,
 ) -> c_int {
     let mut ii: usize;
     let mut _jj: usize;
@@ -1408,7 +1588,6 @@ fn FnNoise5_short(
 
         rowpix = &array[(jj * nx)..]; /* point to first pixel in the row */
 
-        /***** find the first valid pixel in row */
         ii = 0;
         if nullcheck {
             while ii < nx && rowpix[ii] == nullvalue {
@@ -1432,7 +1611,6 @@ fn FnNoise5_short(
             }
         }
 
-        /***** find the 2nd valid pixel in row (which we will skip over) */
         ii += 1;
         if nullcheck {
             while ii < nx && rowpix[ii] == nullvalue {
@@ -1456,7 +1634,6 @@ fn FnNoise5_short(
             }
         }
 
-        /***** find the 3rd valid pixel in row */
         ii += 1;
         if nullcheck {
             while ii < nx && rowpix[ii] == nullvalue {
@@ -1725,30 +1902,44 @@ fn FnNoise5_short(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Estimate the median and background noise in the input image using 2nd, 3rd and 5th order Median Absolute Differences.
 ///
 /// The noise in the background of the image is calculated using the MAD algorithms
 /// developed for deriving the signal to noise ratio in spectra
-/// (see issue #42 of the ST-ECF newsletter, http://www.stecf.org/documents/newsletter/)
+/// (see issue #42 of the ST-ECF newsletter, <http://www.stecf.org/documents/newsletter/>)
 ///
 /// 3rd order:  noise = 1.482602 / sqrt(6) * median (abs(2*flux(i) - flux(i-2) - flux(i+2)))
 ///
 /// The returned estimates are the median of the values that are computed for each
 /// row of the image.
+///
+/// # Parameters
+///
+/// * `array`     — 2 dimensional array of image pixels
+/// * `nx`        — number of pixels in each row of the image
+/// * `ny`        — number of rows in the image
+/// * `nullcheck` — check for null values, if true
+/// * `nullvalue` — value of null pixels, if nullcheck is true
+/// * `ngood`     — number of good, non-null pixels?
+/// * `minval`    — minimum non-null value
+/// * `maxval`    — maximum non-null value
+/// * `noise2`    — returned 2nd order MAD of all non-null pixels
+/// * `noise3`    — returned 3rd order MAD of all non-null pixels
+/// * `noise5`    — returned 5th order MAD of all non-null pixels
+/// * `status`    — error status
 fn FnNoise5_int(
-    array: &[c_int],            /*  2 dimensional array of image pixels */
-    nx: usize,                  /* number of pixels in each row of the image */
-    ny: usize,                  /* number of rows in the image */
-    nullcheck: bool,            /* check for null values, if true */
-    nullvalue: c_int,           /* value of null pixels, if nullcheck is true */
-    ngood: Option<&mut usize>,  /* number of good, non-null pixels? */
-    minval: Option<&mut c_int>, /* minimum non-null value */
-    maxval: Option<&mut c_int>, /* maximum non-null value */
-    noise2: Option<&mut f64>,   /* returned 2nd order MAD of all non-null pixels */
-    noise3: Option<&mut f64>,   /* returned 3rd order MAD of all non-null pixels */
-    noise5: Option<&mut f64>,   /* returned 5th order MAD of all non-null pixels */
-    status: &mut c_int,         /* error status */
+    array: &[c_int],
+    nx: usize,
+    ny: usize,
+    nullcheck: bool,
+    nullvalue: c_int,
+    ngood: Option<&mut usize>,
+    minval: Option<&mut c_int>,
+    maxval: Option<&mut c_int>,
+    noise2: Option<&mut f64>,
+    noise3: Option<&mut f64>,
+    noise5: Option<&mut f64>,
+    status: &mut c_int,
 ) -> c_int {
     let mut ii: usize;
     let mut _jj: usize;
@@ -1874,7 +2065,6 @@ fn FnNoise5_int(
 
         rowpix = &array[(jj * nx)..]; /* point to first pixel in the row */
 
-        /***** find the first valid pixel in row */
         ii = 0;
         if nullcheck {
             while ii < nx && rowpix[ii] == nullvalue {
@@ -1897,7 +2087,6 @@ fn FnNoise5_int(
             }
         }
 
-        /***** find the 2nd valid pixel in row (which we will skip over) */
         ii += 1;
         if nullcheck {
             while ii < nx && rowpix[ii] == nullvalue {
@@ -1920,7 +2109,6 @@ fn FnNoise5_int(
             }
         }
 
-        /***** find the 3rd valid pixel in row */
         ii += 1;
         if nullcheck {
             while ii < nx && rowpix[ii] == nullvalue {
@@ -2196,30 +2384,44 @@ fn FnNoise5_int(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Estimate the median and background noise in the input image using 2nd, 3rd and 5th order Median Absolute Differences.
 ///
 /// The noise in the background of the image is calculated using the MAD algorithms
 /// developed for deriving the signal to noise ratio in spectra
-/// (see issue #42 of the ST-ECF newsletter, http://www.stecf.org/documents/newsletter/)
+/// (see issue #42 of the ST-ECF newsletter, <http://www.stecf.org/documents/newsletter/>)
 ///
 /// 3rd order:  noise = 1.482602 / sqrt(6) * median (abs(2*flux(i) - flux(i-2) - flux(i+2)))
 ///
 /// The returned estimates are the median of the values that are computed for each
 /// row of the image.
+///
+/// # Parameters
+///
+/// * `array`     — 2 dimensional array of image pixels
+/// * `nx`        — number of pixels in each row of the image
+/// * `ny`        — number of rows in the image
+/// * `nullcheck` — check for null values, if true
+/// * `nullvalue` — value of null pixels, if nullcheck is true
+/// * `ngood`     — number of good, non-null pixels?
+/// * `minval`    — minimum non-null value
+/// * `maxval`    — maximum non-null value
+/// * `noise2`    — returned 2nd order MAD of all non-null pixels
+/// * `noise3`    — returned 3rd order MAD of all non-null pixels
+/// * `noise5`    — returned 5th order MAD of all non-null pixels
+/// * `status`    — error status
 fn FnNoise5_float(
-    array: &[f32],             /*  2 dimensional array of image pixels */
-    nx: usize,                 /* number of pixels in each row of the image */
-    ny: usize,                 /* number of rows in the image */
-    nullcheck: bool,           /* check for null values, if true */
-    nullvalue: f32,            /* value of null pixels, if nullcheck is true */
-    ngood: Option<&mut usize>, /* number of good, non-null pixels? */
-    minval: Option<&mut f32>,  /* minimum non-null value */
-    maxval: Option<&mut f32>,  /* maximum non-null value */
-    noise2: Option<&mut f64>,  /* returned 2nd order MAD of all non-null pixels */
-    noise3: Option<&mut f64>,  /* returned 3rd order MAD of all non-null pixels */
-    noise5: Option<&mut f64>,  /* returned 5th order MAD of all non-null pixels */
-    status: &mut c_int,        /* error status */
+    array: &[f32],
+    nx: usize,
+    ny: usize,
+    nullcheck: bool,
+    nullvalue: f32,
+    ngood: Option<&mut usize>,
+    minval: Option<&mut f32>,
+    maxval: Option<&mut f32>,
+    noise2: Option<&mut f64>,
+    noise3: Option<&mut f64>,
+    noise5: Option<&mut f64>,
+    status: &mut c_int,
 ) -> c_int {
     let mut ii: usize;
     let mut _jj: usize;
@@ -2345,7 +2547,6 @@ fn FnNoise5_float(
 
         rowpix = &array[(jj * nx)..]; /* point to first pixel in the row */
 
-        /***** find the first valid pixel in row */
         ii = 0;
         if nullcheck {
             while ii < nx && rowpix[ii] == nullvalue {
@@ -2368,7 +2569,6 @@ fn FnNoise5_float(
             }
         }
 
-        /***** find the 2nd valid pixel in row (which we will skip over) */
         ii += 1;
         if nullcheck {
             while ii < nx && rowpix[ii] == nullvalue {
@@ -2391,7 +2591,6 @@ fn FnNoise5_float(
             }
         }
 
-        /***** find the 3rd valid pixel in row */
         ii += 1;
         if nullcheck {
             while ii < nx && rowpix[ii] == nullvalue {
@@ -2646,30 +2845,44 @@ fn FnNoise5_float(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Estimate the median and background noise in the input image using 2nd, 3rd and 5th order Median Absolute Differences.
 ///
 /// The noise in the background of the image is calculated using the MAD algorithms
 /// developed for deriving the signal to noise ratio in spectra
-/// (see issue #42 of the ST-ECF newsletter, http://www.stecf.org/documents/newsletter/)
+/// (see issue #42 of the ST-ECF newsletter, <http://www.stecf.org/documents/newsletter/>)
 ///
 /// 3rd order:  noise = 1.482602 / sqrt(6) * median (abs(2*flux(i) - flux(i-2) - flux(i+2)))
 ///
 /// The returned estimates are the median of the values that are computed for each
 /// row of the image.
+///
+/// # Parameters
+///
+/// * `array`     — 2 dimensional array of image pixels
+/// * `nx`        — number of pixels in each row of the image
+/// * `ny`        — number of rows in the image
+/// * `nullcheck` — check for null values, if true
+/// * `nullvalue` — value of null pixels, if nullcheck is true
+/// * `ngood`     — number of good, non-null pixels?
+/// * `minval`    — minimum non-null value
+/// * `maxval`    — maximum non-null value
+/// * `noise2`    — returned 2nd order MAD of all non-null pixels
+/// * `noise3`    — returned 3rd order MAD of all non-null pixels
+/// * `noise5`    — returned 5th order MAD of all non-null pixels
+/// * `status`    — error status
 fn FnNoise5_double(
-    array: &[f64],             /*  2 dimensional array of image pixels */
-    nx: usize,                 /* number of pixels in each row of the image */
-    ny: usize,                 /* number of rows in the image */
-    nullcheck: bool,           /* check for null values, if true */
-    nullvalue: f64,            /* value of null pixels, if nullcheck is true */
-    ngood: Option<&mut usize>, /* number of good, non-null pixels? */
-    minval: Option<&mut f64>,  /* minimum non-null value */
-    maxval: Option<&mut f64>,  /* maximum non-null value */
-    noise2: Option<&mut f64>,  /* returned 2nd order MAD of all non-null pixels */
-    noise3: Option<&mut f64>,  /* returned 3rd order MAD of all non-null pixels */
-    noise5: Option<&mut f64>,  /* returned 5th order MAD of all non-null pixels */
-    status: &mut c_int,        /* error status */
+    array: &[f64],
+    nx: usize,
+    ny: usize,
+    nullcheck: bool,
+    nullvalue: f64,
+    ngood: Option<&mut usize>,
+    minval: Option<&mut f64>,
+    maxval: Option<&mut f64>,
+    noise2: Option<&mut f64>,
+    noise3: Option<&mut f64>,
+    noise5: Option<&mut f64>,
+    status: &mut c_int,
 ) -> c_int {
     let mut ii: usize;
     let mut _jj: usize;
@@ -2795,7 +3008,6 @@ fn FnNoise5_double(
 
         rowpix = &array[(jj * nx)..]; /* point to first pixel in the row */
 
-        /***** find the first valid pixel in row */
         ii = 0;
         if nullcheck {
             while ii < nx && rowpix[ii] == nullvalue {
@@ -2818,7 +3030,6 @@ fn FnNoise5_double(
             }
         }
 
-        /***** find the 2nd valid pixel in row (which we will skip over) */
         ii += 1;
         if nullcheck {
             while ii < nx && rowpix[ii] == nullvalue {
@@ -2841,7 +3052,6 @@ fn FnNoise5_double(
             }
         }
 
-        /***** find the 3rd valid pixel in row */
         ii += 1;
         if nullcheck {
             while ii < nx && rowpix[ii] == nullvalue {
@@ -3096,28 +3306,40 @@ fn FnNoise5_double(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Estimate the median and background noise in the input image using 3rd order differences.
 ///
 /// The noise in the background of the image is calculated using the 3rd order algorithm
 /// developed for deriving the signal to noise ratio in spectra
-/// (see issue #42 of the ST-ECF newsletter, http://www.stecf.org/documents/newsletter/)
+/// (see issue #42 of the ST-ECF newsletter, <http://www.stecf.org/documents/newsletter/>)
 ///
 ///   noise = 1.482602 / sqrt(6) * median (abs(2*flux(i) - flux(i-2) - flux(i+2)))
 ///
 /// The returned estimates are the median of the values that are computed for each
 /// row of the image.
+///
+/// # Parameters
+///
+/// * `array`     — 2 dimensional array of image pixels
+/// * `nx`        — number of pixels in each row of the image
+/// * `ny`        — number of rows in the image
+/// * `nullcheck` — check for null values, if true
+/// * `nullvalue` — value of null pixels, if nullcheck is true
+/// * `ngood`     — number of good, non-null pixels?
+/// * `minval`    — minimum non-null value
+/// * `maxval`    — maximum non-null value
+/// * `noise`     — returned R.M.S. value of all non-null pixels
+/// * `status`    — error status
 fn FnNoise3_short(
-    array: &[c_short],            /*  2 dimensional array of image pixels */
-    nx: usize,                    /* number of pixels in each row of the image */
-    ny: usize,                    /* number of rows in the image */
-    nullcheck: bool,              /* check for null values, if true */
-    nullvalue: c_short,           /* value of null pixels, if nullcheck is true */
-    ngood: Option<&mut usize>,    /* number of good, non-null pixels? */
-    minval: Option<&mut c_short>, /* minimum non-null value */
-    maxval: Option<&mut c_short>, /* maximum non-null value */
-    noise: Option<&mut f64>,      /* returned R.M.S. value of all non-null pixels */
-    status: &mut c_int,           /* error status */
+    array: &[c_short],
+    nx: usize,
+    ny: usize,
+    nullcheck: bool,
+    nullvalue: c_short,
+    ngood: Option<&mut usize>,
+    minval: Option<&mut c_short>,
+    maxval: Option<&mut c_short>,
+    noise: Option<&mut f64>,
+    status: &mut c_int,
 ) -> c_int {
     let mut ii: usize;
     let mut _jj: usize;
@@ -3199,7 +3421,6 @@ fn FnNoise3_short(
 
         rowpix = &array[(jj * nx)..]; /* point to first pixel in the row */
 
-        /***** find the first valid pixel in row */
         ii = 0;
         if nullcheck {
             while ii < nx && rowpix[ii] == nullvalue {
@@ -3221,7 +3442,6 @@ fn FnNoise3_short(
             }
         }
 
-        /***** find the 2nd valid pixel in row (which we will skip over) */
         ii += 1;
         if nullcheck {
             while ii < nx && rowpix[ii] == nullvalue {
@@ -3243,7 +3463,6 @@ fn FnNoise3_short(
             }
         }
 
-        /***** find the 3rd valid pixel in row */
         ii += 1;
         if nullcheck {
             while ii < nx && rowpix[ii] == nullvalue {
@@ -3400,28 +3619,40 @@ fn FnNoise3_short(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Estimate the median and background noise in the input image using 3rd order differences.
 ///
 /// The noise in the background of the image is calculated using the 3rd order algorithm
 /// developed for deriving the signal to noise ratio in spectra
-/// (see issue #42 of the ST-ECF newsletter, http://www.stecf.org/documents/newsletter/)
+/// (see issue #42 of the ST-ECF newsletter, <http://www.stecf.org/documents/newsletter/>)
 ///
 ///   noise = 1.482602 / sqrt(6) * median (abs(2*flux(i) - flux(i-2) - flux(i+2)))
 ///
 /// The returned estimates are the median of the values that are computed for each
 /// row of the image.
+///
+/// # Parameters
+///
+/// * `array`     — 2 dimensional array of image pixels
+/// * `nx`        — number of pixels in each row of the image
+/// * `ny`        — number of rows in the image
+/// * `nullcheck` — check for null values, if true
+/// * `nullvalue` — value of null pixels, if nullcheck is true
+/// * `ngood`     — number of good, non-null pixels?
+/// * `minval`    — minimum non-null value
+/// * `maxval`    — maximum non-null value
+/// * `noise`     — returned R.M.S. value of all non-null pixels
+/// * `status`    — error status
 fn FnNoise3_int(
-    array: &[c_int],            /*  2 dimensional array of image pixels */
-    nx: usize,                  /* number of pixels in each row of the image */
-    ny: usize,                  /* number of rows in the image */
-    nullcheck: bool,            /* check for null values, if true */
-    nullvalue: c_int,           /* value of null pixels, if nullcheck is true */
-    ngood: Option<&mut usize>,  /* number of good, non-null pixels? */
-    minval: Option<&mut c_int>, /* minimum non-null value */
-    maxval: Option<&mut c_int>, /* maximum non-null value */
-    noise: Option<&mut f64>,    /* returned R.M.S. value of all non-null pixels */
-    status: &mut c_int,         /* error status */
+    array: &[c_int],
+    nx: usize,
+    ny: usize,
+    nullcheck: bool,
+    nullvalue: c_int,
+    ngood: Option<&mut usize>,
+    minval: Option<&mut c_int>,
+    maxval: Option<&mut c_int>,
+    noise: Option<&mut f64>,
+    status: &mut c_int,
 ) -> c_int {
     let mut ii: usize;
     let mut _jj: usize;
@@ -3503,7 +3734,6 @@ fn FnNoise3_int(
 
         rowpix = &array[(jj * nx)..]; /* point to first pixel in the row */
 
-        /***** find the first valid pixel in row */
         ii = 0;
         if nullcheck {
             while ii < nx && rowpix[ii] == nullvalue {
@@ -3525,7 +3755,6 @@ fn FnNoise3_int(
             }
         }
 
-        /***** find the 2nd valid pixel in row (which we will skip over) */
         ii += 1;
         if nullcheck {
             while ii < nx && rowpix[ii] == nullvalue {
@@ -3547,7 +3776,6 @@ fn FnNoise3_int(
             }
         }
 
-        /***** find the 3rd valid pixel in row */
         ii += 1;
         if nullcheck {
             while ii < nx && rowpix[ii] == nullvalue {
@@ -3705,28 +3933,40 @@ fn FnNoise3_int(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Estimate the median and background noise in the input image using 3rd order differences.
 ///
 /// The noise in the background of the image is calculated using the 3rd order algorithm
 /// developed for deriving the signal to noise ratio in spectra
-/// (see issue #42 of the ST-ECF newsletter, http://www.stecf.org/documents/newsletter/)
+/// (see issue #42 of the ST-ECF newsletter, <http://www.stecf.org/documents/newsletter/>)
 ///
 ///   noise = 1.482602 / sqrt(6) * median (abs(2*flux(i) - flux(i-2) - flux(i+2)))
 ///
 /// The returned estimates are the median of the values that are computed for each
 /// row of the image.
+///
+/// # Parameters
+///
+/// * `array`     — 2 dimensional array of image pixels
+/// * `nx`        — number of pixels in each row of the image
+/// * `ny`        — number of rows in the image
+/// * `nullcheck` — check for null values, if true
+/// * `nullvalue` — value of null pixels, if nullcheck is true
+/// * `ngood`     — number of good, non-null pixels?
+/// * `minval`    — minimum non-null value
+/// * `maxval`    — maximum non-null value
+/// * `noise`     — returned R.M.S. value of all non-null pixels
+/// * `status`    — error status
 fn FnNoise3_float(
-    array: &[f32],             /*  2 dimensional array of image pixels */
-    nx: usize,                 /* number of pixels in each row of the image */
-    ny: usize,                 /* number of rows in the image */
-    nullcheck: bool,           /* check for null values, if true */
-    nullvalue: f32,            /* value of null pixels, if nullcheck is true */
-    ngood: Option<&mut usize>, /* number of good, non-null pixels? */
-    minval: Option<&mut f32>,  /* minimum non-null value */
-    maxval: Option<&mut f32>,  /* maximum non-null value */
-    noise: Option<&mut f64>,   /* returned R.M.S. value of all non-null pixels */
-    status: &mut c_int,        /* error status */
+    array: &[f32],
+    nx: usize,
+    ny: usize,
+    nullcheck: bool,
+    nullvalue: f32,
+    ngood: Option<&mut usize>,
+    minval: Option<&mut f32>,
+    maxval: Option<&mut f32>,
+    noise: Option<&mut f64>,
+    status: &mut c_int,
 ) -> c_int {
     let mut ii: usize;
     let mut _jj: usize;
@@ -3809,7 +4049,6 @@ fn FnNoise3_float(
 
         rowpix = &array[(jj * nx)..]; /* point to first pixel in the row */
 
-        /***** find the first valid pixel in row */
         ii = 0;
         if nullcheck {
             while ii < nx && rowpix[ii] == nullvalue {
@@ -3831,7 +4070,6 @@ fn FnNoise3_float(
             }
         }
 
-        /***** find the 2nd valid pixel in row (which we will skip over) */
         ii += 1;
         if nullcheck {
             while ii < nx && rowpix[ii] == nullvalue {
@@ -3853,7 +4091,6 @@ fn FnNoise3_float(
             }
         }
 
-        /***** find the 3rd valid pixel in row */
         ii += 1;
         if nullcheck {
             while ii < nx && rowpix[ii] == nullvalue {
@@ -3981,28 +4218,40 @@ fn FnNoise3_float(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Estimate the median and background noise in the input image using 3rd order differences.
 ///
 ///The noise in the background of the image is calculated using the 3rd order algorithm
 ///developed for deriving the signal to noise ratio in spectra
-///(see issue #42 of the ST-ECF newsletter, http://www.stecf.org/documents/newsletter/)
+///(see issue #42 of the ST-ECF newsletter, <http://www.stecf.org/documents/newsletter/>)
 ///
 ///  noise = 1.482602 / sqrt(6) * median (abs(2*flux(i) - flux(i-2) - flux(i+2)))
 ///
 ///The returned estimates are the median of the values that are computed for each
 ///row of the image.
+///
+/// # Parameters
+///
+/// * `array`     — 2 dimensional array of image pixels
+/// * `nx`        — number of pixels in each row of the image
+/// * `ny`        — number of rows in the image
+/// * `nullcheck` — check for null values, if true
+/// * `nullvalue` — value of null pixels, if nullcheck is true
+/// * `ngood`     — number of good, non-null pixels?
+/// * `minval`    — minimum non-null value
+/// * `maxval`    — maximum non-null value
+/// * `noise`     — returned R.M.S. value of all non-null pixels
+/// * `status`    — error status
 fn FnNoise3_double(
-    array: &[f64],             /*  2 dimensional array of image pixels */
-    nx: usize,                 /* number of pixels in each row of the image */
-    ny: usize,                 /* number of rows in the image */
-    nullcheck: bool,           /* check for null values, if true */
-    nullvalue: f64,            /* value of null pixels, if nullcheck is true */
-    ngood: Option<&mut usize>, /* number of good, non-null pixels? */
-    minval: Option<&mut f64>,  /* minimum non-null value */
-    maxval: Option<&mut f64>,  /* maximum non-null value */
-    noise: Option<&mut f64>,   /* returned R.M.S. value of all non-null pixels */
-    status: &mut c_int,        /* error status */
+    array: &[f64],
+    nx: usize,
+    ny: usize,
+    nullcheck: bool,
+    nullvalue: f64,
+    ngood: Option<&mut usize>,
+    minval: Option<&mut f64>,
+    maxval: Option<&mut f64>,
+    noise: Option<&mut f64>,
+    status: &mut c_int,
 ) -> c_int {
     let mut ii: usize;
     let mut _jj: usize;
@@ -4085,7 +4334,6 @@ fn FnNoise3_double(
 
         rowpix = &array[(jj * nx)..]; /* point to first pixel in the row */
 
-        /***** find the first valid pixel in row */
         ii = 0;
         if nullcheck {
             while ii < nx && rowpix[ii] == nullvalue {
@@ -4107,7 +4355,6 @@ fn FnNoise3_double(
             }
         }
 
-        /***** find the 2nd valid pixel in row (which we will skip over) */
         ii += 1;
         if nullcheck {
             while ii < nx && rowpix[ii] == nullvalue {
@@ -4129,7 +4376,6 @@ fn FnNoise3_double(
             }
         }
 
-        /***** find the 3rd valid pixel in row */
         ii += 1;
         if nullcheck {
             while ii < nx && rowpix[ii] == nullvalue {
@@ -4257,21 +4503,30 @@ fn FnNoise3_double(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Estimate the background noise in the input image using sigma of 1st order differences.
 ///
-///   noise = 1.0 / sqrt(2) * rms of (flux[i] - flux[i-1])
+///   noise = 1.0 / sqrt(2) * rms of (`flux[i]` - `flux[i-1]`)
 ///
 /// The returned estimate is the median of the values that are computed for each
 /// row of the image.
+///
+/// # Parameters
+///
+/// * `array`     — 2 dimensional array of image pixels
+/// * `nx`        — number of pixels in each row of the image
+/// * `ny`        — number of rows in the image
+/// * `nullcheck` — check for null values, if true
+/// * `nullvalue` — value of null pixels, if nullcheck is true
+/// * `noise`     — returned R.M.S. value of all non-null pixels
+/// * `status`    — error status
 fn FnNoise1_short(
-    array: &[c_short],  /*  2 dimensional array of image pixels */
-    nx: usize,          /* number of pixels in each row of the image */
-    ny: usize,          /* number of rows in the image */
-    nullcheck: bool,    /* check for null values, if true */
-    nullvalue: c_short, /* value of null pixels, if nullcheck is true */
-    noise: &mut f64,    /* returned R.M.S. value of all non-null pixels */
-    status: &mut c_int, /* error status */
+    array: &[c_short],
+    nx: usize,
+    ny: usize,
+    nullcheck: bool,
+    nullvalue: c_short,
+    noise: &mut f64,
+    status: &mut c_int,
 ) -> c_int {
     let mut ii: usize;
     let mut _jj: usize;
@@ -4316,7 +4571,6 @@ fn FnNoise1_short(
 
         rowpix = &array[(jj * nx)..]; /* point to first pixel in the row */
 
-        /***** find the first valid pixel in row */
         ii = 0;
         if nullcheck {
             while ii < nx && rowpix[ii] == nullvalue {
@@ -4420,21 +4674,30 @@ fn FnNoise1_short(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Estimate the background noise in the input image using sigma of 1st order differences.
 ///
-///   noise = 1.0 / sqrt(2) * rms of (flux[i] - flux[i-1])
+///   noise = 1.0 / sqrt(2) * rms of (`flux[i]` - `flux[i-1]`)
 ///
 /// The returned estimate is the median of the values that are computed for each
 /// row of the image.
+///
+/// # Parameters
+///
+/// * `array`     — 2 dimensional array of image pixels
+/// * `nx`        — number of pixels in each row of the image
+/// * `ny`        — number of rows in the image
+/// * `nullcheck` — check for null values, if true
+/// * `nullvalue` — value of null pixels, if nullcheck is true
+/// * `noise`     — returned R.M.S. value of all non-null pixels
+/// * `status`    — error status
 fn FnNoise1_int(
-    array: &[c_int],    /*  2 dimensional array of image pixels */
-    nx: usize,          /* number of pixels in each row of the image */
-    ny: usize,          /* number of rows in the image */
-    nullcheck: bool,    /* check for null values, if true */
-    nullvalue: c_int,   /* value of null pixels, if nullcheck is true */
-    noise: &mut f64,    /* returned R.M.S. value of all non-null pixels */
-    status: &mut c_int, /* error status */
+    array: &[c_int],
+    nx: usize,
+    ny: usize,
+    nullcheck: bool,
+    nullvalue: c_int,
+    noise: &mut f64,
+    status: &mut c_int,
 ) -> c_int {
     let mut ii: usize;
     let mut _jj: usize;
@@ -4479,7 +4742,6 @@ fn FnNoise1_int(
 
         rowpix = &array[(jj * nx)..]; /* point to first pixel in the row */
 
-        /***** find the first valid pixel in row */
         ii = 0;
         if nullcheck {
             while ii < nx && rowpix[ii] == nullvalue {
@@ -4583,21 +4845,30 @@ fn FnNoise1_int(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Estimate the background noise in the input image using sigma of 1st order differences.
 ///
-///   noise = 1.0 / sqrt(2) * rms of (flux[i] - flux[i-1])
+///   noise = 1.0 / sqrt(2) * rms of (`flux[i]` - `flux[i-1]`)
 ///
 /// The returned estimate is the median of the values that are computed for each
 /// row of the image.
+///
+/// # Parameters
+///
+/// * `array`     — 2 dimensional array of image pixels
+/// * `nx`        — number of pixels in each row of the image
+/// * `ny`        — number of rows in the image
+/// * `nullcheck` — check for null values, if true
+/// * `nullvalue` — value of null pixels, if nullcheck is true
+/// * `noise`     — returned R.M.S. value of all non-null pixels
+/// * `status`    — error status
 fn FnNoise1_float(
-    array: &[f32],      /*  2 dimensional array of image pixels */
-    nx: usize,          /* number of pixels in each row of the image */
-    ny: usize,          /* number of rows in the image */
-    nullcheck: bool,    /* check for null values, if true */
-    nullvalue: f32,     /* value of null pixels, if nullcheck is true */
-    noise: &mut f64,    /* returned R.M.S. value of all non-null pixels */
-    status: &mut c_int, /* error status */
+    array: &[f32],
+    nx: usize,
+    ny: usize,
+    nullcheck: bool,
+    nullvalue: f32,
+    noise: &mut f64,
+    status: &mut c_int,
 ) -> c_int {
     let mut ii: usize;
     let mut _jj: usize;
@@ -4642,7 +4913,6 @@ fn FnNoise1_float(
 
         rowpix = &array[(jj * nx)..]; /* point to first pixel in the row */
 
-        /***** find the first valid pixel in row */
         ii = 0;
         if nullcheck {
             while ii < nx && rowpix[ii] == nullvalue {
@@ -4746,21 +5016,30 @@ fn FnNoise1_float(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Estimate the background noise in the input image using sigma of 1st order differences.
 ///
-///   noise = 1.0 / sqrt(2) * rms of (flux[i] - flux[i-1])
+///   noise = 1.0 / sqrt(2) * rms of (`flux[i]` - `flux[i-1]`)
 ///
 /// The returned estimate is the median of the values that are computed for each
 /// row of the image.
+///
+/// # Parameters
+///
+/// * `array`     — 2 dimensional array of image pixels
+/// * `nx`        — number of pixels in each row of the image
+/// * `ny`        — number of rows in the image
+/// * `nullcheck` — check for null values, if true
+/// * `nullvalue` — value of null pixels, if nullcheck is true
+/// * `noise`     — returned R.M.S. value of all non-null pixels
+/// * `status`    — error status
 fn FnNoise1_double(
-    array: &[f64],      /*  2 dimensional array of image pixels */
-    nx: usize,          /* number of pixels in each row of the image */
-    ny: usize,          /* number of rows in the image */
-    nullcheck: bool,    /* check for null values, if true */
-    nullvalue: f64,     /* value of null pixels, if nullcheck is true */
-    noise: &mut f64,    /* returned R.M.S. value of all non-null pixels */
-    status: &mut c_int, /* error status */
+    array: &[f64],
+    nx: usize,
+    ny: usize,
+    nullcheck: bool,
+    nullvalue: f64,
+    noise: &mut f64,
+    status: &mut c_int,
 ) -> c_int {
     let mut ii: usize;
     let mut _jj: usize;
@@ -4805,7 +5084,6 @@ fn FnNoise1_double(
 
         rowpix = &array[(jj * nx)..]; /* point to first pixel in the row */
 
-        /***** find the first valid pixel in row */
         ii = 0;
         if nullcheck {
             while ii < nx && rowpix[ii] == nullvalue {
@@ -4909,17 +5187,11 @@ fn FnNoise1_double(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
-
-/*
- *  These Quickselect routines are based on the algorithm described in
- *  "Numerical recipes in C", Second Edition,
- *  Cambridge University Press, 1992, Section 8.5, ISBN 0-521-43108-5
- *  This code by Nicolas Devillard - 1998. Public domain.
- */
-
-/*--------------------------------------------------------------------------*/
-
+/// Selects the `n`th smallest element of `arr`, reordering it in the process.
+///
+/// Based on the Quickselect algorithm described in *Numerical Recipes in C*,
+/// Second Edition, Cambridge University Press, 1992, Section 8.5, ISBN
+/// 0-521-43108-5. This code by Nicolas Devillard, 1998, public domain.
 pub fn quick_select_float(arr: &mut [f32], n: usize) -> f32 {
     let mut middle: usize;
     let mut ll: usize;
@@ -4995,7 +5267,11 @@ pub fn quick_select_float(arr: &mut [f32], n: usize) -> f32 {
     }
 }
 
-/*--------------------------------------------------------------------------*/
+/// Selects the `n`th smallest element of `arr`, reordering it in the process.
+///
+/// Based on the Quickselect algorithm described in *Numerical Recipes in C*,
+/// Second Edition, Cambridge University Press, 1992, Section 8.5, ISBN
+/// 0-521-43108-5. This code by Nicolas Devillard, 1998, public domain.
 pub fn quick_select_short(arr: &mut [i16], n: usize) -> i16 {
     let mut middle: usize;
     let mut ll: usize;
@@ -5071,7 +5347,11 @@ pub fn quick_select_short(arr: &mut [i16], n: usize) -> i16 {
     }
 }
 
-/*--------------------------------------------------------------------------*/
+/// Selects the `n`th smallest element of `arr`, reordering it in the process.
+///
+/// Based on the Quickselect algorithm described in *Numerical Recipes in C*,
+/// Second Edition, Cambridge University Press, 1992, Section 8.5, ISBN
+/// 0-521-43108-5. This code by Nicolas Devillard, 1998, public domain.
 pub fn quick_select_int(arr: &mut [i32], n: usize) -> i32 {
     let mut middle: usize;
     let mut ll: usize;
@@ -5147,7 +5427,11 @@ pub fn quick_select_int(arr: &mut [i32], n: usize) -> i32 {
     }
 }
 
-/*--------------------------------------------------------------------------*/
+/// Selects the `n`th smallest element of `arr`, reordering it in the process.
+///
+/// Based on the Quickselect algorithm described in *Numerical Recipes in C*,
+/// Second Edition, Cambridge University Press, 1992, Section 8.5, ISBN
+/// 0-521-43108-5. This code by Nicolas Devillard, 1998, public domain.
 pub fn quick_select_longlong(arr: &mut [i64], n: usize) -> i64 {
     let mut middle: usize;
     let mut ll: usize;
@@ -5224,7 +5508,11 @@ pub fn quick_select_longlong(arr: &mut [i64], n: usize) -> i64 {
     }
 }
 
-/*--------------------------------------------------------------------------*/
+/// Selects the `n`th smallest element of `arr`, reordering it in the process.
+///
+/// Based on the Quickselect algorithm described in *Numerical Recipes in C*,
+/// Second Edition, Cambridge University Press, 1992, Section 8.5, ISBN
+/// 0-521-43108-5. This code by Nicolas Devillard, 1998, public domain.
 pub fn quick_select_double(arr: &mut [f64], n: usize) -> f64 {
     let mut middle: usize;
     let mut ll: usize;

--- a/src/region.rs
+++ b/src/region.rs
@@ -1,3 +1,15 @@
+//! Spatial region filtering.
+//!
+//! Parses a region file -- the format DS9 and funtools write -- into a set of
+//! shapes, and tests whether a position falls inside it. This backs the
+//! `regfilter()` function of the row filtering syntax, so a table can be
+//! filtered down to the rows whose coordinates land in a region drawn on an
+//! image.
+//!
+//! Shapes may be given in pixel, degree or sexagesimal coordinates, and may be
+//! combined with an include or exclude sense.
+#![warn(missing_docs)]
+
 use core::ffi::CStr;
 use std::fs::File;
 
@@ -71,39 +83,56 @@ enum CoordFmt {
 }
 
 #[derive(Default, Debug, Clone, PartialEq)]
+/// One shape in a region: what it is, where it is, and whether it includes or
+/// excludes the area it covers.
 pub(crate) struct RgnShape {
-    sign: c_char,     /*  Include or exclude?        */
-    shape: ShapeType, /*  Shape of this region       */
-    comp: c_int,      /*  Component number for this region */
+    /// Include or exclude?
+    sign: c_char,
+    /// Shape of this region.
+    shape: ShapeType,
+    /// Component number for this region.
+    comp: c_int,
 
-    /*  bounding box    */
+    /// Left edge of the bounding box.
     xmin: f64,
+    /// Right edge of the bounding box.
     xmax: f64,
+    /// Bottom edge of the bounding box.
     ymin: f64,
+    /// Top edge of the bounding box.
     ymax: f64,
 
-    /*  Parameters - In pixels     */
+    /// Shape parameters, in pixels, for every shape but a polygon.
     genericParams: RgnShapeGeneric,
+    /// Shape parameters, in pixels, for a polygon.
     polyParams: RgnShapePolygon,
 }
 
 #[derive(Default, Debug, Clone, Copy, PartialEq)]
+/// Shape parameters for every shape but a polygon; which slots of `p` are
+/// used depends on the [`ShapeType`].
 pub(crate) struct RgnShapeGeneric {
-    p: [f64; 11], /*  Region parameters       */
+    /// Region parameters.
+    p: [f64; 11],
 
-    /*  For rotated shapes      */
+    /// Sine of the rotation angle, for a rotated shape.
     sinT: f64,
+    /// Cosine of the rotation angle, for a rotated shape.
     cosT: f64,
 
-    /*  Extra scratch area      */
+    /// Scratch area, used differently by each shape.
     a: f64,
+    /// Scratch area, used differently by each shape.
     b: f64,
 }
 
 #[derive(Default, Debug, Clone, PartialEq)]
+/// Shape parameters for a polygon.
 struct RgnShapePolygon {
-    nPts: c_int,   /*  Number of Polygon pts   */
-    Pts: Vec<f64>, /*  Polygon points          */
+    /// Number of polygon points.
+    nPts: c_int,
+    /// The polygon points, as alternating x and y.
+    Pts: Vec<f64>,
 }
 
 #[derive(Clone, Default, Debug, PartialEq)]
@@ -113,7 +142,6 @@ pub(crate) struct SAORegion {
     wcs: WCSdata,
 }
 
-/*---------------------------------------------------------------------------*/
 /// Read regions from either a FITS or ASCII region file and return the information
 /// in the "SAORegion" structure.  If it is nonNULL, use wcs to convert the  
 /// region coordinates to pixels.  Return an error if region is in degrees   
@@ -147,7 +175,6 @@ pub(crate) fn fits_read_rgnfile(
     *status
 }
 
-/*---------------------------------------------------------------------------*/
 /// Read regions from a SAO-style region file and return the information     
 /// in the "SAORegion" structure.  If it is nonNULL, use wcs to convert the  
 /// region coordinates to pixels.  Return an error if region is in degrees   
@@ -456,9 +483,7 @@ pub(crate) fn fits_read_ascii_region(
                     return *status;
                 }
 
-                /**************************************************/
                 /*  We've apparently found a region... Set it up  */
-                /**************************************************/
 
                 if (aRgn.nShapes % 10) == 0 {
                     let len = aRgn.Shapes.len();
@@ -922,7 +947,6 @@ pub(crate) fn fits_read_ascii_region(
     *status
 }
 
-/*---------------------------------------------------------------------------*/
 /// Test if the given point is within the region described by Rgn.  X and
 /// Y are in pixel coordinates.                                          
 pub(crate) fn fits_in_region(X: f64, Y: f64, Rgn: &SAORegion) -> c_int {
@@ -1257,7 +1281,6 @@ pub(crate) fn fits_in_region(X: f64, Y: f64, Rgn: &SAORegion) -> c_int {
     if result { 1 } else { 0 }
 }
 
-/*---------------------------------------------------------------------------*/
 ///  Free up memory allocated to hold the region data.
 ///  This is more complicated for the case of polygons, which may be sharing
 ///  points arrays due to shallow copying (in fits_set_region_components) of
@@ -1309,7 +1332,6 @@ pub(crate) fn fits_free_region(Rgn: Box<SAORegion>) {
     drop(Rgn);
 }
 
-/*---------------------------------------------------------------------------*/
 /// Internal routine for testing whether the coordinate x,y is within the
 /// polygon region traced out by the array Pts.
 fn Pt_in_Poly(x: f64, y: f64, nPts: c_int, Pts: &[f64]) -> c_int {
@@ -1388,7 +1410,6 @@ fn Pt_in_Poly(x: f64, y: f64, nPts: c_int, Pts: &[f64]) -> c_int {
     flag
 }
 
-/*---------------------------------------------------------------------------*/
 /// Internal routine to turn a collection of regions read from an ascii file into
 /// the more complex structure that is allowed by the FITS REGION extension with
 /// multiple components. Regions are anded within components and ored between them
@@ -1473,7 +1494,6 @@ pub(crate) fn fits_set_region_components(aRgn: &mut SAORegion) {
     }
 }
 
-/*---------------------------------------------------------------------------*/
 pub(crate) fn fits_setup_shape(newShape: &mut RgnShape) {
     /* Perform some useful calculations now to speed up filter later             */
 
@@ -1740,7 +1760,6 @@ pub(crate) fn fits_setup_shape(newShape: &mut RgnShape) {
     }
 }
 
-/*---------------------------------------------------------------------------*/
 /// Read regions from a FITS region extension and return the information
 /// in the "SAORegion" structure.  If it is nonNULL, use wcs to convert the
 /// region coordinates to pixels.  Return an error if region is in degrees

--- a/src/relibc/header/errno.rs
+++ b/src/relibc/header/errno.rs
@@ -1,3 +1,7 @@
+//! `errno` values used by the vendored code.
+// Vendored code, documented in upstream's style.
+#![allow(missing_docs)]
+
 use crate::c_types::c_int;
 
 pub const EILSEQ: c_int = 84; /* Illegal byte sequence */

--- a/src/relibc/header/mod.rs
+++ b/src/relibc/header/mod.rs
@@ -1,2 +1,8 @@
+//! The C headers this port needs, as Rust modules.
+//!
+//! Vendored from relibc; see [`crate::relibc`].
+// Vendored code, documented in upstream's style.
+#![allow(missing_docs)]
+
 pub mod errno;
 pub mod stdio;

--- a/src/relibc/header/stdio/lookaheadreader.rs
+++ b/src/relibc/header/stdio/lookaheadreader.rs
@@ -1,3 +1,9 @@
+//! A one-character-lookahead reader, used by the `scanf` implementation.
+//!
+//! Vendored from relibc; see [`crate::relibc`].
+// Vendored code, documented in upstream's style.
+#![allow(missing_docs)]
+
 struct LookAheadBuffer {
     buf: *const u8,
     pos: isize,

--- a/src/relibc/header/stdio/mod.rs
+++ b/src/relibc/header/stdio/mod.rs
@@ -1,3 +1,10 @@
+//! The `stdio` formatting routines: `printf`, `scanf` and their variants.
+//!
+//! Vendored from relibc; see [`crate::relibc`]. These are what
+//! `int_snprintf!` and the file drivers use instead of calling libc.
+// Vendored code, documented in upstream's style.
+#![allow(missing_docs)]
+
 use crate::c_types::{c_char, c_double, c_int, c_long, c_uint, size_t};
 use bytemuck::cast_slice;
 use core::ffi::{CStr, c_void};

--- a/src/relibc/header/stdio/printf.rs
+++ b/src/relibc/header/stdio/printf.rs
@@ -1,3 +1,9 @@
+//! `printf`-family formatting.
+//!
+//! Vendored from relibc; see [`crate::relibc`].
+// Vendored code, documented in upstream's style.
+#![allow(missing_docs)]
+
 use crate::c_types::{
     c_char, c_double, c_int, c_long, c_longlong, c_short, c_uchar, c_uint, c_ulong, c_ulonglong,
     c_ushort, intmax_t, ptrdiff_t, size_t, ssize_t, uintmax_t,
@@ -1443,12 +1449,11 @@ unsafe fn inner_printf<W: Write>(w: W, format: &CStr, mut ap: CustomVaList) -> i
 /// [`unsigned ptrdiff_t`]: ptrdiff_t
 /// [`wchar_t`]: wchar_t
 /// [`char`]: c_char
-/// [`signed char`]: c_schar
+/// [`signed char`]: crate::c_types::c_schar
 /// [`short`]: c_short
 /// [`long`]: c_long
 /// [`long long`]: c_longlong
 /// [`double`]: c_double
-/// [`long double`]: c_longdouble
 /// [`void`]: c_void
 ///
 /// # Safety

--- a/src/relibc/header/stdio/printf_tests.rs
+++ b/src/relibc/header/stdio/printf_tests.rs
@@ -1,3 +1,7 @@
+//! Tests for the vendored `printf` implementation.
+// Vendored code, documented in upstream's style.
+#![allow(missing_docs)]
+
 #[cfg(test)]
 mod tests {
 

--- a/src/relibc/header/stdio/scanf.rs
+++ b/src/relibc/header/stdio/scanf.rs
@@ -1,3 +1,9 @@
+//! `scanf`-family parsing.
+//!
+//! Vendored from relibc; see [`crate::relibc`].
+// Vendored code, documented in upstream's style.
+#![allow(missing_docs)]
+
 use super::lookaheadreader::LookAheadReader;
 use super::printf::{CustomVaList, VaArg};
 use crate::c_types::{

--- a/src/relibc/header/stdio/sscanf_tests.rs
+++ b/src/relibc/header/stdio/sscanf_tests.rs
@@ -1,3 +1,7 @@
+//! Tests for the vendored `sscanf` implementation.
+// Vendored code, documented in upstream's style.
+#![allow(missing_docs)]
+
 #[cfg(test)]
 mod tests {
 

--- a/src/relibc/io/buffered.rs
+++ b/src/relibc/io/buffered.rs
@@ -9,6 +9,8 @@
 // except according to those terms.
 
 //! Buffering wrappers for I/O traits
+// Vendored from the Rust project's std::io; documented in upstream's style.
+#![allow(missing_docs)]
 
 use core::{cmp, fmt};
 
@@ -204,7 +206,8 @@ impl<R: Seek> Seek for BufReader<R> {
     /// `.into_inner()` immediately after a seek yields the underlying reader
     /// at the same position.
     ///
-    /// To seek without discarding the internal buffer, use [`Seek::seek_relative`].
+    /// To seek without discarding the internal buffer, use
+    /// [`Seek::seek_relative`](std::io::Seek::seek_relative).
     ///
     /// See [`std::io::Seek`] for more details.
     ///

--- a/src/relibc/io/cursor.rs
+++ b/src/relibc/io/cursor.rs
@@ -1,3 +1,10 @@
+//! The `io::Cursor` adapter, vendored from the Rust project's `std::io`.
+//!
+//! See [`crate::relibc`]. Copyright notices, where present, are in the file
+//! below.
+// Vendored code, documented in upstream's style.
+#![allow(missing_docs)]
+
 // Copyright 2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.

--- a/src/relibc/io/error.rs
+++ b/src/relibc/io/error.rs
@@ -1,3 +1,10 @@
+//! The `io::Error` type, vendored from the Rust project's `std::io`.
+//!
+//! See [`crate::relibc`]. Copyright notices, where present, are in the file
+//! below.
+// Vendored code, documented in upstream's style.
+#![allow(missing_docs)]
+
 // Copyright 2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.

--- a/src/relibc/io/impls.rs
+++ b/src/relibc/io/impls.rs
@@ -1,3 +1,10 @@
+//! Trait implementations for the standard types, vendored from the Rust project's `std::io`.
+//!
+//! See [`crate::relibc`]. Copyright notices, where present, are in the file
+//! below.
+// Vendored code, documented in upstream's style.
+#![allow(missing_docs)]
+
 // Copyright 2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.

--- a/src/relibc/io/mod.rs
+++ b/src/relibc/io/mod.rs
@@ -266,6 +266,8 @@
 //! [`Read::read`]: trait.Read.html#tymethod.read
 //! [`Result`]: ../result/enum.Result.html
 //! [`.unwrap()`]: ../result/enum.Result.html#method.unwrap
+// Vendored from the Rust project's std::io; documented in upstream's style.
+#![allow(missing_docs)]
 
 pub mod buffered;
 pub mod cursor;

--- a/src/relibc/io/prelude.rs
+++ b/src/relibc/io/prelude.rs
@@ -1,3 +1,9 @@
+//! The I/O prelude, vendored from the Rust project's `std::io`.
+//!
+//! See [`crate::relibc`]. Copyright notices, where present, are in the file
+//! below.
+// Vendored code, documented in upstream's style.
+#![allow(missing_docs)]
 // Copyright 2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.

--- a/src/relibc/mod.rs
+++ b/src/relibc/mod.rs
@@ -1,3 +1,17 @@
+//! Vendored pieces of a C standard library, and of Rust's own `std::io`.
+//!
+//! The port needs `printf`/`scanf` formatting and buffered stream I/O without
+//! calling libc for them. Rather than write those from scratch, this module
+//! carries the relevant parts of the Redox project's relibc
+//! (<https://gitlab.redox-os.org/redox-os/relibc>) and of the Rust project's
+//! `std::io`.
+//!
+//! **Vendored code.** It is kept close to upstream so it can be re-synced, so
+//! it is documented in upstream's style rather than converted to this crate's;
+//! see the plan's decision on vendored code. Copyright notices are preserved in
+//! the files that carry them.
+#![warn(missing_docs)]
+
 pub mod header;
 // Vendored from the Rust project's std::io (see the copyright headers in
 // io/mod.rs and io/buffered.rs). Kept byte-identical to upstream so it can be

--- a/src/relibc/platform/mod.rs
+++ b/src/relibc/platform/mod.rs
@@ -1,3 +1,9 @@
+//! Platform glue for the vendored relibc code.
+//!
+//! Vendored from relibc; see [`crate::relibc`].
+// Vendored code, documented in upstream's style.
+#![allow(missing_docs)]
+
 use core::fmt;
 use core::{cell::Cell, ptr};
 

--- a/src/relibc/platform/types.rs
+++ b/src/relibc/platform/types.rs
@@ -1,2 +1,6 @@
+//! The scalar type aliases the vendored code is written against.
+// Vendored code, documented in upstream's style.
+#![allow(missing_docs)]
+
 pub type wint_t = u32;
 pub type wchar_t = i32;

--- a/src/scalnull.rs
+++ b/src/scalnull.rs
@@ -1,9 +1,18 @@
-/*  This file, scalnull.rs, contains the FITSIO routines used to define     */
-/*  the starting heap address, the value scaling and the null values.      */
-/*  The FITSIO software was written by William Pence at the High Energy    */
-/*  Astrophysic Science Archive Research Center (HEASARC) at the NASA      */
-/*  Goddard Space Flight Center.                                           */
-/*--------------------------------------------------------------------------*/
+//! Routines that define the starting heap address, the value scaling and the
+//! null values.
+//!
+//! The scaling set here affects only the automatic conversion performed as data
+//! elements are read and written; it does not change the `BSCALE`, `BZERO` or
+//! `TNULLn` keywords. When reading, the value handed back is
+//! `(value in the FITS array) * scale + zero`; the inverse is applied when
+//! writing.
+//!
+//! Ported from CFITSIO's `scalnull.c`, written by William Pence at the High
+//! Energy Astrophysics Science Archive Research Center (HEASARC), NASA Goddard
+//! Space Flight Center. The routine descriptions draw on the "Define Data
+//! Scaling and Undefined Pixel Parameters" section of the CFITSIO User's
+//! Reference Guide.
+#![warn(missing_docs)]
 
 use core::ffi::CStr;
 
@@ -17,19 +26,25 @@ use crate::fitsio::*;
 use crate::modkey::ffukyj_safe;
 use crate::wrappers::*;
 
-/*--------------------------------------------------------------------------*/
 /// Define the starting address for the heap for a binary table.
 ///
 /// The default address is NAXIS1 * NAXIS2.  It is in units of
 /// bytes relative to the beginning of the regular binary table data.
 /// This routine also writes the appropriate THEAP keyword to the
 /// FITS header.
+///
+/// The offset is zero-indexed and measured from the start of the binary table
+/// data. This is only relevant for binary tables that contain variable length
+/// array columns (`TFORMn = 'Pt'`), and must be called after the required
+/// keywords have been written but before any data is written to the table.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `theap`  — (I) starting address for the heap
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
-pub unsafe extern "C" fn ffpthp(
-    fptr: *mut fitsfile, /* I - FITS file pointer */
-    theap: c_long,       /* I - starting addrss for the heap */
-    status: *mut c_int,  /* IO - error status     */
-) -> c_int {
+pub unsafe extern "C" fn ffpthp(fptr: *mut fitsfile, theap: c_long, status: *mut c_int) -> c_int {
     // FFI WRAPPER
     unsafe {
         let fptr = fptr.as_mut().expect(NULL_MSG);
@@ -39,18 +54,24 @@ pub unsafe extern "C" fn ffpthp(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Define the starting address for the heap for a binary table.
 ///
 /// The default address is NAXIS1 * NAXIS2.  It is in units of
 /// bytes relative to the beginning of the regular binary table data.
 /// This routine also writes the appropriate THEAP keyword to the
 /// FITS header.
-pub fn ffpthp_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer */
-    theap: c_long,       /* I - starting addrss for the heap */
-    status: &mut c_int,  /* IO - error status     */
-) -> c_int {
+///
+/// The offset is zero-indexed and measured from the start of the binary table
+/// data. This is only relevant for binary tables that contain variable length
+/// array columns (`TFORMn = 'Pt'`), and must be called after the required
+/// keywords have been written but before any data is written to the table.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `theap`  — (I) starting address for the heap
+/// * `status` — (IO) error status
+pub fn ffpthp_safe(fptr: &mut fitsfile, theap: c_long, status: &mut c_int) -> c_int {
     if *status > 0 || theap < 1 {
         return *status;
     }
@@ -72,7 +93,6 @@ pub fn ffpthp_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Define the linear scaling factor for the primary array or image extension
 /// pixel values. This routine overrides the scaling values given by the
 /// BSCALE and BZERO keywords if present.  Note that this routine does not
@@ -80,12 +100,19 @@ pub fn ffpthp_safe(
 /// the values temporarily in the internal buffer.  Thus, a subsequent call to
 /// the ffrdef routine will reset the scaling back to the BSCALE and BZERO
 /// keyword values (or 1. and 0. respectively if the keywords are not present).
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `scale`  — (I) scaling factor: value of BSCALE
+/// * `zero`   — (I) zero point: value of BZERO
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffpscl(
-    fptr: *mut fitsfile, /* I - FITS file pointer               */
-    scale: f64,          /* I - scaling factor: value of BSCALE */
-    zero: f64,           /* I - zero point: value of BZERO      */
-    status: *mut c_int,  /* IO - error status                   */
+    fptr: *mut fitsfile,
+    scale: f64,
+    zero: f64,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -96,7 +123,6 @@ pub unsafe extern "C" fn ffpscl(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Define the linear scaling factor for the primary array or image extension
 /// pixel values. This routine overrides the scaling values given by the
 /// BSCALE and BZERO keywords if present.  Note that this routine does not
@@ -104,12 +130,14 @@ pub unsafe extern "C" fn ffpscl(
 /// the values temporarily in the internal buffer.  Thus, a subsequent call to
 /// the ffrdef routine will reset the scaling back to the BSCALE and BZERO
 /// keyword values (or 1. and 0. respectively if the keywords are not present).
-pub fn ffpscl_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer               */
-    scale: f64,          /* I - scaling factor: value of BSCALE */
-    zero: f64,           /* I - zero point: value of BZERO      */
-    status: &mut c_int,  /* IO - error status                   */
-) -> c_int {
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `scale`  — (I) scaling factor: value of BSCALE
+/// * `zero`   — (I) zero point: value of BZERO
+/// * `status` — (IO) error status
+pub fn ffpscl_safe(fptr: &mut fitsfile, scale: f64, zero: f64, status: &mut c_int) -> c_int {
     let mut hdutype = 0;
     if *status > 0 {
         return *status;
@@ -148,7 +176,6 @@ pub fn ffpscl_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Define the value used to represent undefined pixels in the primary array or
 /// image extension. This only applies to integer image pixel (i.e. BITPIX > 0).
 /// This routine overrides the null pixel value given by the BLANK keyword
@@ -157,11 +184,17 @@ pub fn ffpscl_safe(
 /// buffer. Thus, a subsequent call to the ffrdef routine will reset the null
 /// value back to the BLANK  keyword value (or not defined if the keyword is not
 /// present).
+///
+/// # Parameters
+///
+/// * `fptr`     — (I) FITS file pointer
+/// * `nulvalue` — (I) null pixel value: value of BLANK
+/// * `status`   — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffpnul(
-    fptr: *mut fitsfile, /* I - FITS file pointer                */
-    nulvalue: LONGLONG,  /* I - null pixel value: value of BLANK */
-    status: *mut c_int,  /* IO - error status                    */
+    fptr: *mut fitsfile,
+    nulvalue: LONGLONG,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -172,7 +205,6 @@ pub unsafe extern "C" fn ffpnul(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Define the value used to represent undefined pixels in the primary array or
 /// image extension. This only applies to integer image pixel (i.e. BITPIX > 0).
 /// This routine overrides the null pixel value given by the BLANK keyword
@@ -181,11 +213,13 @@ pub unsafe extern "C" fn ffpnul(
 /// buffer. Thus, a subsequent call to the ffrdef routine will reset the null
 /// value back to the BLANK  keyword value (or not defined if the keyword is not
 /// present).
-pub fn ffpnul_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                */
-    nulvalue: LONGLONG,  /* I - null pixel value: value of BLANK */
-    status: &mut c_int,  /* IO - error status                    */
-) -> c_int {
+///
+/// # Parameters
+///
+/// * `fptr`     — (I) FITS file pointer
+/// * `nulvalue` — (I) null pixel value: value of BLANK
+/// * `status`   — (IO) error status
+pub fn ffpnul_safe(fptr: &mut fitsfile, nulvalue: LONGLONG, status: &mut c_int) -> c_int {
     let mut hdutype = 0;
 
     if *status > 0 {
@@ -215,7 +249,6 @@ pub fn ffpnul_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Define the linear scaling factor for the TABLE or BINTABLE extension
 /// column values. This routine overrides the scaling values given by the
 /// TSCALn and TZEROn keywords if present.  Note that this routine does not
@@ -223,13 +256,21 @@ pub fn ffpnul_safe(
 /// the values temporarily in the internal buffer.  Thus, a subsequent call to
 /// the ffrdef routine will reset the scaling back to the TSCALn and TZEROn
 /// keyword values (or 1. and 0. respectively if the keywords are not present).
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `colnum` — (I) column number to apply scaling to
+/// * `scale`  — (I) scaling factor: value of TSCALn
+/// * `zero`   — (I) zero point: value of TZEROn
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn fftscl(
-    fptr: *mut fitsfile, /* I - FITS file pointer                 */
-    colnum: c_int,       /* I - column number to apply scaling to */
-    scale: f64,          /* I - scaling factor: value of TSCALn   */
-    zero: f64,           /* I - zero point: value of TZEROn       */
-    status: *mut c_int,  /* IO - error status                     */
+    fptr: *mut fitsfile,
+    colnum: c_int,
+    scale: f64,
+    zero: f64,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -240,7 +281,6 @@ pub unsafe extern "C" fn fftscl(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Define the linear scaling factor for the TABLE or BINTABLE extension
 /// column values. This routine overrides the scaling values given by the
 /// TSCALn and TZEROn keywords if present.  Note that this routine does not
@@ -248,12 +288,20 @@ pub unsafe extern "C" fn fftscl(
 /// the values temporarily in the internal buffer.  Thus, a subsequent call to
 /// the ffrdef routine will reset the scaling back to the TSCALn and TZEROn
 /// keyword values (or 1. and 0. respectively if the keywords are not present).
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `colnum` — (I) column number to apply scaling to
+/// * `scale`  — (I) scaling factor: value of TSCALn
+/// * `zero`   — (I) zero point: value of TZEROn
+/// * `status` — (IO) error status
 pub fn fftscl_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                 */
-    colnum: c_int,       /* I - column number to apply scaling to */
-    scale: f64,          /* I - scaling factor: value of TSCALn   */
-    zero: f64,           /* I - zero point: value of TZEROn       */
-    status: &mut c_int,  /* IO - error status                     */
+    fptr: &mut fitsfile,
+    colnum: c_int,
+    scale: f64,
+    zero: f64,
+    status: &mut c_int,
 ) -> c_int {
     let mut hdutype = 0;
 
@@ -286,7 +334,6 @@ pub fn fftscl_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Define the value used to represent undefined pixels in the BINTABLE column.
 ///
 /// This only applies to integer datatype columns (TFORM = B, I, or J).
@@ -296,12 +343,19 @@ pub fn fftscl_safe(
 /// buffer. Thus, a subsequent call to the ffrdef routine will reset the null
 /// value back to the TNULLn  keyword value (or not defined if the keyword is not
 /// present).
+///
+/// # Parameters
+///
+/// * `fptr`     — (I) FITS file pointer
+/// * `colnum`   — (I) column number to apply nulvalue to
+/// * `nulvalue` — (I) null pixel value: value of TNULLn
+/// * `status`   — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn fftnul(
-    fptr: *mut fitsfile, /* I - FITS file pointer                  */
-    colnum: c_int,       /* I - column number to apply nulvalue to */
-    nulvalue: LONGLONG,  /* I - null pixel value: value of TNULLn  */
-    status: *mut c_int,  /* IO - error status                      */
+    fptr: *mut fitsfile,
+    colnum: c_int,
+    nulvalue: LONGLONG,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -312,7 +366,6 @@ pub unsafe extern "C" fn fftnul(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Define the value used to represent undefined pixels in the BINTABLE column.
 ///
 /// This only applies to integer datatype columns (TFORM = B, I, or J).
@@ -322,11 +375,18 @@ pub unsafe extern "C" fn fftnul(
 /// buffer. Thus, a subsequent call to the ffrdef routine will reset the null
 /// value back to the TNULLn  keyword value (or not defined if the keyword is not
 /// present).
+///
+/// # Parameters
+///
+/// * `fptr`     — (I) FITS file pointer
+/// * `colnum`   — (I) column number to apply nulvalue to
+/// * `nulvalue` — (I) null pixel value: value of TNULLn
+/// * `status`   — (IO) error status
 pub fn fftnul_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer                  */
-    colnum: c_int,       /* I - column number to apply nulvalue to */
-    nulvalue: LONGLONG,  /* I - null pixel value: value of TNULLn  */
-    status: &mut c_int,  /* IO - error status                      */
+    fptr: &mut fitsfile,
+    colnum: c_int,
+    nulvalue: LONGLONG,
+    status: &mut c_int,
 ) -> c_int {
     let mut hdutype = 0;
     if *status > 0 {
@@ -351,7 +411,6 @@ pub fn fftnul_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Define the string used to represent undefined pixels in the ASCII TABLE
 /// column. This routine overrides the null  value given by the TNULLn keyword
 /// if present.  Note that this routine does not write or modify the TNULLn
@@ -359,12 +418,19 @@ pub fn fftnul_safe(
 /// buffer. Thus, a subsequent call to the ffrdef routine will reset the null
 /// value back to the TNULLn keyword value (or not defined if the keyword is not
 /// present).
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) column number to apply nulvalue to
+/// * `nulstring` — (I) null pixel value: value of TNULLn
+/// * `status`    — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffsnul(
-    fptr: *mut fitsfile,      /* I - FITS file pointer                  */
-    colnum: c_int,            /* I - column number to apply nulvalue to */
-    nulstring: *const c_char, /* I - null pixel value: value of TNULLn  */
-    status: *mut c_int,       /* IO - error status                      */
+    fptr: *mut fitsfile,
+    colnum: c_int,
+    nulstring: *const c_char,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -377,7 +443,6 @@ pub unsafe extern "C" fn ffsnul(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Define the string used to represent undefined pixels in the ASCII TABLE
 /// column. This routine overrides the null  value given by the TNULLn keyword
 /// if present.  Note that this routine does not write or modify the TNULLn
@@ -385,11 +450,18 @@ pub unsafe extern "C" fn ffsnul(
 /// buffer. Thus, a subsequent call to the ffrdef routine will reset the null
 /// value back to the TNULLn keyword value (or not defined if the keyword is not
 /// present).
+///
+/// # Parameters
+///
+/// * `fptr`      — (I) FITS file pointer
+/// * `colnum`    — (I) column number to apply nulvalue to
+/// * `nulstring` — (I) null pixel value: value of TNULLn
+/// * `status`    — (IO) error status
 pub fn ffsnul_safe(
-    fptr: &mut fitsfile,  /* I - FITS file pointer                  */
-    colnum: c_int,        /* I - column number to apply nulvalue to */
-    nulstring: &[c_char], /* I - null pixel value: value of TNULLn  */
-    status: &mut c_int,   /* IO - error status                      */
+    fptr: &mut fitsfile,
+    colnum: c_int,
+    nulstring: &[c_char],
+    status: &mut c_int,
 ) -> c_int {
     let mut hdutype = 0;
     if *status > 0 {

--- a/src/simplerng.rs
+++ b/src/simplerng.rs
@@ -1,3 +1,12 @@
+//! A small, reproducible random number generator.
+//!
+//! Used by the tile compression code to generate the dither pattern in
+//! [`crate::quantize`]. It must be reproducible across platforms and runs: a
+//! dithered image can only be reconstructed by subtracting exactly the values
+//! that were added, so this generator's sequence is part of the file format
+//! rather than an implementation detail.
+#![warn(missing_docs)]
+
 use std::sync::Mutex;
 
 use crate::c_types::{c_int, c_uint};
@@ -41,7 +50,7 @@ fn simplerng_getstate(u: &mut c_uint, v: &mut c_uint) {
     *v = *M_V.lock().unwrap();
 }
 
-/// srand() equivalent to seed the two state variables
+/// Srand() equivalent to seed the two state variables
 pub(crate) fn simplerng_srand(seed: c_uint) {
     fastrand::seed(u64::from(seed));
 }
@@ -64,7 +73,7 @@ fn simplerng_getuint_pr(u: &mut c_uint, v: &mut c_uint) -> c_uint {
     (*v).wrapping_shl(16).wrapping_add(*u)
 }
 
-/// Get uniform deviate [0,1]
+/// Get uniform deviate in `[0,1]`
 pub(crate) fn simplerng_getuniform() -> f64 {
     let r = fastrand::u64(..);
 

--- a/src/swapproc.rs
+++ b/src/swapproc.rs
@@ -1,14 +1,19 @@
-/*  This file, swapproc.rs, contains general utility routines that are      */
-/*  used by other FITSIO routines to swap bytes.                           */
-
-/*  The FITSIO software was written by William Pence at the High Energy    */
-/*  Astrophysic Science Archive Research Center (HEASARC) at the NASA      */
-/*  Goddard Space Flight Center.                                           */
+//! Byte-swapping utilities used by the other FITSIO routines.
+//!
+//! FITS stores numbers most significant byte first, so on a little-endian
+//! machine ([`BYTESWAPPED`](crate::fitsio2::BYTESWAPPED)) every numeric value
+//! is swapped on the way in and out.
+//!
+//! Ported from CFITSIO's `swapproc.c`, written by William Pence at the High
+//! Energy Astrophysics Science Archive Research Center (HEASARC), NASA Goddard
+//! Space Flight Center.
+#![warn(missing_docs)]
 
 use crate::c_types::c_long;
 
 use crate::fitsio::INT32BIT;
 
+/// Swaps the bytes of `nvals` shorts, one at a time.
 fn ffswap2_slow(svalues: &mut [i16], nvals: c_long) {
     svalues
         .iter_mut()
@@ -17,13 +22,16 @@ fn ffswap2_slow(svalues: &mut [i16], nvals: c_long) {
 }
 
 /// Swap the bytes in the input short integers: ( 0 1 -> 1 0 )
-pub(crate) fn ffswap2(
-    svalues: &mut [i16], /* IO - pointer to shorts to be swapped    */
-    nvals: c_long,       /* I  - number of shorts to be swapped     */
-) {
+///
+/// # Parameters
+///
+/// * `svalues` — (IO) pointer to shorts to be swapped
+/// * `nvals`   — (I) number of shorts to be swapped
+pub(crate) fn ffswap2(svalues: &mut [i16], nvals: c_long) {
     ffswap2_slow(svalues, nvals);
 }
 
+/// Swaps the bytes of `nvals` 4-byte integers, one at a time.
 fn ffswap4_slow(svalues: &mut [INT32BIT], nvals: c_long) {
     //let mut v = std::slice::from_raw_parts_mut(svalues, nvals as usize);
     svalues
@@ -32,14 +40,17 @@ fn ffswap4_slow(svalues: &mut [INT32BIT], nvals: c_long) {
         .for_each(|x| *x = (*x).swap_bytes());
 }
 
-/// swap the bytes in the input 4-byte integer: ( 0 1 2 3 -> 3 2 1 0 )
-pub(crate) fn ffswap4(
-    ivalues: &mut [INT32BIT], /* IO - pointer to INT*4 to be swapped    */
-    nvals: c_long,            /* I  - number of floats to be swapped     */
-) {
+/// Swap the bytes in the input 4-byte integers: ( 0 1 2 3 -> 3 2 1 0 )
+///
+/// # Parameters
+///
+/// * `ivalues` — (IO) pointer to INT*4 to be swapped
+/// * `nvals`   — (I) number of floats to be swapped
+pub(crate) fn ffswap4(ivalues: &mut [INT32BIT], nvals: c_long) {
     ffswap4_slow(ivalues, nvals);
 }
 
+/// Swaps the bytes of `nvals` 8-byte values, one at a time.
 fn ffswap8_slow(svalues: &mut [i64], nvals: c_long) {
     svalues
         .iter_mut()
@@ -48,9 +59,11 @@ fn ffswap8_slow(svalues: &mut [i64], nvals: c_long) {
 }
 
 /// Swap the bytes in the input doubles: ( 01234567  -> 76543210 )
-pub(crate) fn ffswap8(
-    ivalues: &mut [i64], /* IO - pointer to doubles to be swapped     */
-    nvals: c_long,       /* I  - number of doubles to be swapped      */
-) {
+///
+/// # Parameters
+///
+/// * `ivalues` — (IO) pointer to doubles to be swapped
+/// * `nvals`   — (I) number of doubles to be swapped
+pub(crate) fn ffswap8(ivalues: &mut [i64], nvals: c_long) {
     ffswap8_slow(ivalues, nvals);
 }

--- a/src/wcssub.rs
+++ b/src/wcssub.rs
@@ -1,3 +1,16 @@
+//! Reading and subsetting World Coordinate System keywords.
+//!
+//! Extracts the WCS keywords describing a coordinate axis from a header, and
+//! copies them across when an image is subsetted, so that the new image's
+//! coordinates still describe the same sky.
+//!
+//! `fits_read_wcstab` here is the interface to Mark Calabretta's WCSLIB, via
+//! the [`wtbarr`] struct.
+//!
+//! See the "World Coordinate System Routines" chapter of the CFITSIO User's
+//! Reference Guide.
+#![warn(missing_docs)]
+
 use core::ptr;
 use core::slice;
 
@@ -21,23 +34,26 @@ use crate::putkey::{ffcrim_safe, ffi2c};
 use crate::wrappers::*;
 use crate::{bb, cs};
 
-/*--------------------------------------------------------------------------*/
 ///  Author: Mark Calabretta, Australia Telescope National Facility
-///  http://www.atnf.csiro.au/~mcalabre/index.html
+///  <http://www.atnf.csiro.au/~mcalabre/index.html>
 ///
 ///  fits_read_wcstab() extracts arrays from a binary table required in
 ///  constructing -TAB coordinates.  This helper routine is intended for
 ///  use by routines in the WCSLIB library when dealing with the -TAB table
 ///  look up WCS convention.
+///
+/// # Parameters
+///
+/// * `fptr` — (I) FITS file pointer
+/// * `nwtb` — Number of arrays to be read from the binary table(s)
+/// * `wtb`  — Address of the first element of an array of wtbarr typedefs. This wtbarr
+///           typedef is defined below to match the wtbarr struct defined in WCSLIB. An
+///           array of such structs returned by the WCSLIB function wcstab().
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn fits_read_wcstab(
-    fptr: *mut fitsfile, /* I - FITS file pointer           */
-    nwtb: c_int,         /* Number of arrays to be read from the binary table(s) */
-    wtb: *const wtbarr,  /* Address of the first element of an array of wtbarr
-                         typedefs.  This wtbarr typedef is defined below to
-                         match the wtbarr struct defined in WCSLIB.  An array
-                         of such structs returned by the WCSLIB function
-                         wcstab(). */
+    fptr: *mut fitsfile,
+    nwtb: c_int,
+    wtb: *const wtbarr,
     status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
@@ -68,17 +84,21 @@ pub unsafe extern "C" fn fits_read_wcstab(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 ///  Author: Mark Calabretta, Australia Telescope National Facility
-///  http://www.atnf.csiro.au/~mcalabre/index.html
+///  <http://www.atnf.csiro.au/~mcalabre/index.html>
 ///
 ///  fits_read_wcstab() extracts arrays from a binary table required in
 ///  constructing -TAB coordinates.  This helper routine is intended for
 ///  use by routines in the WCSLIB library when dealing with the -TAB table
 ///  look up WCS convention.
+///
+/// # Parameters
+///
+/// * `fptr` — (I) FITS file pointer
+/// * `nwtb` — Number of arrays to be read from the binary table(s)
 pub fn fits_read_wcstab_safer(
-    fptr: &mut fitsfile, /* I - FITS file pointer           */
-    nwtb: c_int,         /* Number of arrays to be read from the binary table(s) */
+    fptr: &mut fitsfile,
+    nwtb: c_int,
     wtb: &[wtbarr],
     status: &mut c_int,
 ) -> c_int {
@@ -265,17 +285,22 @@ pub fn fits_read_wcstab_safer(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
-/// int fits_get_image_wcs_keys
+/// Int fits_get_image_wcs_keys
 /// return a string containing all the image WCS header keywords.
 /// This string is then used as input to the wcsinit WCSlib routine.
 ///
 /// THIS ROUTINE IS DEPRECATED. USE fits_hdr2str INSTEAD
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `header` — (O) pointer to the WCS related keywords
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgiwcs(
-    fptr: *mut fitsfile,      /* I - FITS file pointer                    */
-    header: *mut *mut c_char, /* O - pointer to the WCS related keywords  */
-    status: *mut c_int,       /* IO - error status                        */
+    fptr: *mut fitsfile,
+    header: *mut *mut c_char,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -291,17 +316,18 @@ pub unsafe extern "C" fn ffgiwcs(
     }
 }
 
-/*--------------------------------------------------------------------------*/
-/// int fits_get_image_wcs_keys
+/// Int fits_get_image_wcs_keys
 /// return a string containing all the image WCS header keywords.
 /// This string is then used as input to the wcsinit WCSlib routine.
 ///
 /// THIS ROUTINE IS DEPRECATED. USE fits_hdr2str INSTEAD
-pub fn ffgiwcs_safe(
-    fptr: &mut fitsfile,      /* I - FITS file pointer                    */
-    header: &mut *mut c_char, /* O - pointer to the WCS related keywords  */
-    status: &mut c_int,       /* IO - error status                        */
-) -> c_int {
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `header` — (O) pointer to the WCS related keywords
+/// * `status` — (IO) error status
+pub fn ffgiwcs_safe(fptr: &mut fitsfile, header: &mut *mut c_char, status: &mut c_int) -> c_int {
     let mut hdutype = 0;
 
     if *status > 0 {
@@ -324,8 +350,7 @@ pub fn ffgiwcs_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
-/// read the values of the celestial coordinate system keywords.
+/// Read the values of the celestial coordinate system keywords.
 /// These values may be used as input to the subroutines that
 /// calculate celestial coordinates. (ffxypx, ffwldp)
 ///
@@ -333,18 +358,31 @@ pub fn ffgiwcs_safe(
 /// to the old CDELTn form, and to swap the axes if the dec-like
 /// axis is given first, and to assume default values if any of the
 /// keywords are not present.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `xrval`  — (O) X reference value
+/// * `yrval`  — (O) Y reference value
+/// * `xrpix`  — (O) X reference pixel
+/// * `yrpix`  — (O) Y reference pixel
+/// * `xinc`   — (O) X increment per pixel
+/// * `yinc`   — (O) Y increment per pixel
+/// * `rot`    — (O) rotation angle (degrees)
+/// * `ptype`  — (O) type of projection ('-tan')
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgics(
-    fptr: *mut fitsfile,     /* I - FITS file pointer           */
-    xrval: *mut f64,         /* O - X reference value           */
-    yrval: *mut f64,         /* O - Y reference value           */
-    xrpix: *mut f64,         /* O - X reference pixel           */
-    yrpix: *mut f64,         /* O - Y reference pixel           */
-    xinc: *mut f64,          /* O - X increment per pixel       */
-    yinc: *mut f64,          /* O - Y increment per pixel       */
-    rot: *mut f64,           /* O - rotation angle (degrees)    */
-    ptype: *mut [c_char; 5], /* O - type of projection ('-tan') */
-    status: *mut c_int,      /* IO - error status               */
+    fptr: *mut fitsfile,
+    xrval: *mut f64,
+    yrval: *mut f64,
+    xrpix: *mut f64,
+    yrpix: *mut f64,
+    xinc: *mut f64,
+    yinc: *mut f64,
+    rot: *mut f64,
+    ptype: *mut [c_char; 5],
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -365,8 +403,7 @@ pub unsafe extern "C" fn ffgics(
     }
 }
 
-/*--------------------------------------------------------------------------*/
-/// read the values of the celestial coordinate system keywords.
+/// Read the values of the celestial coordinate system keywords.
 /// These values may be used as input to the subroutines that
 /// calculate celestial coordinates. (ffxypx, ffwldp)
 ///
@@ -374,17 +411,30 @@ pub unsafe extern "C" fn ffgics(
 /// to the old CDELTn form, and to swap the axes if the dec-like
 /// axis is given first, and to assume default values if any of the
 /// keywords are not present.
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `xrval`  — (O) X reference value
+/// * `yrval`  — (O) Y reference value
+/// * `xrpix`  — (O) X reference pixel
+/// * `yrpix`  — (O) Y reference pixel
+/// * `xinc`   — (O) X increment per pixel
+/// * `yinc`   — (O) Y increment per pixel
+/// * `rot`    — (O) rotation angle (degrees)
+/// * `ptype`  — (O) type of projection ('-tan')
+/// * `status` — (IO) error status
 pub fn ffgics_safe(
-    fptr: &mut fitsfile,     /* I - FITS file pointer           */
-    xrval: &mut f64,         /* O - X reference value           */
-    yrval: &mut f64,         /* O - Y reference value           */
-    xrpix: &mut f64,         /* O - X reference pixel           */
-    yrpix: &mut f64,         /* O - Y reference pixel           */
-    xinc: &mut f64,          /* O - X increment per pixel       */
-    yinc: &mut f64,          /* O - Y increment per pixel       */
-    rot: &mut f64,           /* O - rotation angle (degrees)    */
-    ptype: &mut [c_char; 5], /* O - type of projection ('-tan') */
-    status: &mut c_int,      /* IO - error status               */
+    fptr: &mut fitsfile,
+    xrval: &mut f64,
+    yrval: &mut f64,
+    xrpix: &mut f64,
+    yrpix: &mut f64,
+    xinc: &mut f64,
+    yinc: &mut f64,
+    rot: &mut f64,
+    ptype: &mut [c_char; 5],
+    status: &mut c_int,
 ) -> c_int {
     let mut tstat: c_int = 0;
     let mut cd_exists: bool = false;
@@ -623,7 +673,6 @@ pub fn ffgics_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read the values of the celestial coordinate system keywords.
 /// These values may be used as input to the subroutines that
 /// calculate celestial coordinates. (ffxypx, ffwldp)
@@ -632,20 +681,34 @@ pub fn ffgics_safe(
 /// to the old CDELTn form, and to swap the axes if the dec-like
 /// axis is given first, and to assume default values if any of the
 /// keywords are not present.
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `version` — (I) character code of desired version
+/// * `xrval`   — (O) X reference value
+/// * `yrval`   — (O) Y reference value
+/// * `xrpix`   — (O) X reference pixel
+/// * `yrpix`   — (O) Y reference pixel
+/// * `xinc`    — (O) X increment per pixel
+/// * `yinc`    — (O) Y increment per pixel
+/// * `rot`     — (O) rotation angle (degrees)
+/// * `ptype`   — (O) type of projection ('-tan')
+/// * `status`  — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgicsa(
-    fptr: *mut fitsfile, /* I - FITS file pointer           */
-    version: c_char,     /* I - character code of desired version */
+    fptr: *mut fitsfile,
+    version: c_char,
     /*     A - Z or blank */
-    xrval: *mut f64,         /* O - X reference value           */
-    yrval: *mut f64,         /* O - Y reference value           */
-    xrpix: *mut f64,         /* O - X reference pixel           */
-    yrpix: *mut f64,         /* O - Y reference pixel           */
-    xinc: *mut f64,          /* O - X increment per pixel       */
-    yinc: *mut f64,          /* O - Y increment per pixel       */
-    rot: *mut f64,           /* O - rotation angle (degrees)    */
-    ptype: *mut [c_char; 5], /* O - type of projection ('-tan') */
-    status: *mut c_int,      /* IO - error status               */
+    xrval: *mut f64,
+    yrval: *mut f64,
+    xrpix: *mut f64,
+    yrpix: *mut f64,
+    xinc: *mut f64,
+    yinc: *mut f64,
+    rot: *mut f64,
+    ptype: *mut [c_char; 5],
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -666,7 +729,6 @@ pub unsafe extern "C" fn ffgicsa(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read the values of the celestial coordinate system keywords.
 /// These values may be used as input to the subroutines that
 /// calculate celestial coordinates. (ffxypx, ffwldp)
@@ -675,19 +737,33 @@ pub unsafe extern "C" fn ffgicsa(
 /// to the old CDELTn form, and to swap the axes if the dec-like
 /// axis is given first, and to assume default values if any of the
 /// keywords are not present.
+///
+/// # Parameters
+///
+/// * `fptr`    — (I) FITS file pointer
+/// * `version` — (I) character code of desired version
+/// * `xrval`   — (O) X reference value
+/// * `yrval`   — (O) Y reference value
+/// * `xrpix`   — (O) X reference pixel
+/// * `yrpix`   — (O) Y reference pixel
+/// * `xinc`    — (O) X increment per pixel
+/// * `yinc`    — (O) Y increment per pixel
+/// * `rot`     — (O) rotation angle (degrees)
+/// * `ptype`   — (O) type of projection ('-tan')
+/// * `status`  — (IO) error status
 pub fn ffgicsa_safe(
-    fptr: &mut fitsfile, /* I - FITS file pointer           */
-    version: c_char,     /* I - character code of desired version */
+    fptr: &mut fitsfile,
+    version: c_char,
     /*     A - Z or blank */
-    xrval: &mut f64,         /* O - X reference value           */
-    yrval: &mut f64,         /* O - Y reference value           */
-    xrpix: &mut f64,         /* O - X reference pixel           */
-    yrpix: &mut f64,         /* O - Y reference pixel           */
-    xinc: &mut f64,          /* O - X increment per pixel       */
-    yinc: &mut f64,          /* O - Y increment per pixel       */
-    rot: &mut f64,           /* O - rotation angle (degrees)    */
-    ptype: &mut [c_char; 5], /* O - type of projection ('-tan') */
-    status: &mut c_int,      /* IO - error status               */
+    xrval: &mut f64,
+    yrval: &mut f64,
+    xrpix: &mut f64,
+    yrpix: &mut f64,
+    xinc: &mut f64,
+    yinc: &mut f64,
+    rot: &mut f64,
+    ptype: &mut [c_char; 5],
+    status: &mut c_int,
 ) -> c_int {
     let mut tstat: c_int = 0;
     let mut cd_exists: bool = false;
@@ -975,7 +1051,6 @@ pub fn ffgicsa_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read the values of the celestial coordinate system keywords
 /// from a FITS table where the X and Y or RA and DEC coordinates
 /// are stored in separate column.  Do this by converting the
@@ -983,20 +1058,35 @@ pub fn ffgicsa_safe(
 /// from the image file.
 /// These values may be used as input to the subroutines that
 /// calculate celestial coordinates. (ffxypx, ffwldp)
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `xcol`   — (I) column containing the RA coordinate
+/// * `ycol`   — (I) column containing the DEC coordinate
+/// * `xrval`  — (O) X reference value
+/// * `yrval`  — (O) Y reference value
+/// * `xrpix`  — (O) X reference pixel
+/// * `yrpix`  — (O) Y reference pixel
+/// * `xinc`   — (O) X increment per pixel
+/// * `yinc`   — (O) Y increment per pixel
+/// * `rot`    — (O) rotation angle (degrees)
+/// * `ptype`  — (O) type of projection ('-sin')
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgtcs(
-    fptr: *mut fitsfile,     /* I - FITS file pointer           */
-    xcol: c_int,             /* I - column containing the RA coordinate  */
-    ycol: c_int,             /* I - column containing the DEC coordinate */
-    xrval: *mut f64,         /* O - X reference value           */
-    yrval: *mut f64,         /* O - Y reference value           */
-    xrpix: *mut f64,         /* O - X reference pixel           */
-    yrpix: *mut f64,         /* O - Y reference pixel           */
-    xinc: *mut f64,          /* O - X increment per pixel       */
-    yinc: *mut f64,          /* O - Y increment per pixel       */
-    rot: *mut f64,           /* O - rotation angle (degrees)    */
-    ptype: *mut [c_char; 5], /* O - type of projection ('-sin') */
-    status: *mut c_int,      /* IO - error status               */
+    fptr: *mut fitsfile,
+    xcol: c_int,
+    ycol: c_int,
+    xrval: *mut f64,
+    yrval: *mut f64,
+    xrpix: *mut f64,
+    yrpix: *mut f64,
+    xinc: *mut f64,
+    yinc: *mut f64,
+    rot: *mut f64,
+    ptype: *mut [c_char; 5],
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -1016,7 +1106,6 @@ pub unsafe extern "C" fn ffgtcs(
         )
     }
 }
-/*--------------------------------------------------------------------------*/
 /// Read the values of the celestial coordinate system keywords
 /// from a FITS table where the X and Y or RA and DEC coordinates
 /// are stored in separate column.  Do this by converting the
@@ -1024,19 +1113,34 @@ pub unsafe extern "C" fn ffgtcs(
 /// from the image file.
 /// These values may be used as input to the subroutines that
 /// calculate celestial coordinates. (ffxypx, ffwldp)
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `xcol`   — (I) column containing the RA coordinate
+/// * `ycol`   — (I) column containing the DEC coordinate
+/// * `xrval`  — (O) X reference value
+/// * `yrval`  — (O) Y reference value
+/// * `xrpix`  — (O) X reference pixel
+/// * `yrpix`  — (O) Y reference pixel
+/// * `xinc`   — (O) X increment per pixel
+/// * `yinc`   — (O) Y increment per pixel
+/// * `rot`    — (O) rotation angle (degrees)
+/// * `ptype`  — (O) type of projection ('-sin')
+/// * `status` — (IO) error status
 pub fn ffgtcs_safe(
-    fptr: &mut fitsfile,     /* I - FITS file pointer           */
-    xcol: c_int,             /* I - column containing the RA coordinate  */
-    ycol: c_int,             /* I - column containing the DEC coordinate */
-    xrval: &mut f64,         /* O - X reference value           */
-    yrval: &mut f64,         /* O - Y reference value           */
-    xrpix: &mut f64,         /* O - X reference pixel           */
-    yrpix: &mut f64,         /* O - Y reference pixel           */
-    xinc: &mut f64,          /* O - X increment per pixel       */
-    yinc: &mut f64,          /* O - Y increment per pixel       */
-    rot: &mut f64,           /* O - rotation angle (degrees)    */
-    ptype: &mut [c_char; 5], /* O - type of projection ('-sin') */
-    status: &mut c_int,      /* IO - error status               */
+    fptr: &mut fitsfile,
+    xcol: c_int,
+    ycol: c_int,
+    xrval: &mut f64,
+    yrval: &mut f64,
+    xrpix: &mut f64,
+    yrpix: &mut f64,
+    xinc: &mut f64,
+    yinc: &mut f64,
+    rot: &mut f64,
+    ptype: &mut [c_char; 5],
+    status: &mut c_int,
 ) -> c_int {
     let mut colnum: [c_int; 2] = [0; 2];
     let mut naxes: [c_long; 2] = [0; 2];
@@ -1087,7 +1191,6 @@ pub fn ffgtcs_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Return string containing all the WCS keywords appropriate for the
 /// pair of X and Y columns containing the coordinate
 /// of each event in an event list table.  This string may then be passed
@@ -1096,13 +1199,21 @@ pub fn ffgtcs_safe(
 /// when it is no longer needed.
 ///
 /// THIS ROUTINE IS DEPRECATED. USE fits_hdr2str INSTEAD
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `xcol`   — (I) column number for the X column
+/// * `ycol`   — (I) column number for the Y column
+/// * `header` — (O) string of all the WCS keywords
+/// * `status` — (IO) error status
 #[cfg_attr(not(test), unsafe(no_mangle), deprecated)]
 pub unsafe extern "C" fn ffgtwcs(
-    fptr: *mut fitsfile,      /* I - FITS file pointer              */
-    xcol: c_int,              /* I - column number for the X column  */
-    ycol: c_int,              /* I - column number for the Y column  */
-    header: *mut *mut c_char, /* O - string of all the WCS keywords  */
-    status: *mut c_int,       /* IO - error status                   */
+    fptr: *mut fitsfile,
+    xcol: c_int,
+    ycol: c_int,
+    header: *mut *mut c_char,
+    status: *mut c_int,
 ) -> c_int {
     // FFI WRAPPER
     unsafe {
@@ -1114,7 +1225,6 @@ pub unsafe extern "C" fn ffgtwcs(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Return string containing all the WCS keywords appropriate for the
 /// pair of X and Y columns containing the coordinate
 /// of each event in an event list table.  This string may then be passed
@@ -1123,12 +1233,20 @@ pub unsafe extern "C" fn ffgtwcs(
 /// when it is no longer needed.
 ///
 /// THIS ROUTINE IS DEPRECATED. USE fits_hdr2str INSTEAD
+///
+/// # Parameters
+///
+/// * `fptr`   — (I) FITS file pointer
+/// * `xcol`   — (I) column number for the X column
+/// * `ycol`   — (I) column number for the Y column
+/// * `header` — (O) string of all the WCS keywords
+/// * `status` — (IO) error status
 pub fn ffgtwcs_safe(
-    fptr: &mut fitsfile,      /* I - FITS file pointer              */
-    xcol: c_int,              /* I - column number for the X column  */
-    ycol: c_int,              /* I - column number for the Y column  */
-    header: &mut *mut c_char, /* O - string of all the WCS keywords  */
-    status: &mut c_int,       /* IO - error status                   */
+    fptr: &mut fitsfile,
+    xcol: c_int,
+    ycol: c_int,
+    header: &mut *mut c_char,
+    status: &mut c_int,
 ) -> c_int {
     let mut hdutype: c_int = 0;
     let mut ncols: c_int = 0;

--- a/src/wcsutil.rs
+++ b/src/wcsutil.rs
@@ -1,3 +1,14 @@
+//! Self-contained world coordinate transformations.
+//!
+//! Converts between pixel positions and celestial coordinates for nine
+//! projections -- `-CAR`, `-SIN`, `-TAN`, `-ARC`, `-NCP`, `-GLS`, `-MER`,
+//! `-AIT` and `-STG`. Self-contained in the sense that they need no external
+//! WCS library; for anything beyond these, use WCSLIB through
+//! [`crate::wcssub`].
+//!
+//! Based on the classic AIPS WCS routines.
+#![warn(missing_docs)]
+
 use crate::c_types::*;
 
 use crate::bb;
@@ -8,7 +19,6 @@ const D2R: f64 = 0.01745329252;
 #[allow(clippy::approx_constant)]
 const TWOPI: f64 = 6.28318530717959; // Could use f64::consts::TAU
 
-/*--------------------------------------------------------------------------*/
 ///This routine is based on the classic AIPS WCS routine.
 ///
 /// It converts from pixel location to RA,Dec for 9 projective geometries:
@@ -62,7 +72,6 @@ pub unsafe extern "C" fn ffwldp(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 ///This routine is based on the classic AIPS WCS routine.
 ///
 /// It converts from pixel location to RA,Dec for 9 projective geometries:
@@ -425,7 +434,6 @@ pub fn ffwldp_safe(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// This routine is based on the classic AIPS WCS routine.
 ///
 /// It converts from RA,Dec to pixel location to for 9 projective geometries:
@@ -480,7 +488,6 @@ pub unsafe extern "C" fn ffxypx(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// This routine is based on the classic AIPS WCS routine.
 ///
 /// It converts from RA,Dec to pixel location to for 9 projective geometries:

--- a/src/wrappers.rs
+++ b/src/wrappers.rs
@@ -1,3 +1,19 @@
+//! Safe replacements for the C string and number-parsing functions.
+//!
+//! The port calls these instead of `libc`. Each takes a `&[c_char]` slice and
+//! returns an index or a value rather than an interior pointer, so the whole
+//! `strcpy` / `strcmp` / `strlen` family is expressible without `unsafe`. The
+//! `_safe` suffix marks them as the safe counterpart of the C function of the
+//! same name.
+//!
+//! The slices are still C strings: they are expected to hold a NUL, and the
+//! routines stop there rather than at the end of the buffer, so trailing
+//! padding in a fixed-size FITS buffer is ignored.
+//!
+//! Several of these were taken from the Redox relibc project,
+//! <https://gitlab.redox-os.org/redox-os/relibc>.
+#![warn(missing_docs)]
+
 use core::{cmp, ffi::CStr, str::FromStr};
 
 use bytemuck::cast_slice;
@@ -6,10 +22,13 @@ use crate::c_types::{c_char, c_int, c_long};
 
 use crate::bb;
 
-// Several wrappers in this file were taken from the Redoc Relibc
-// project. The original source code can be found at:
-// https://gitlab.redox-os.org/redox-os/relibc
-
+/// Copies at most `n` characters of the NUL-terminated `src` into `dst`,
+/// padding the remainder of the `n` with NULs. The safe counterpart of C
+/// `strncpy`.
+///
+/// # Panics
+///
+/// Panics if `n` exceeds the length of `dst`.
 pub fn strncpy_safe(dst: &mut [c_char], src: &[c_char], n: usize) {
     let mut i = 0;
 
@@ -25,10 +44,14 @@ pub fn strncpy_safe(dst: &mut [c_char], src: &[c_char], n: usize) {
     }
 }
 
+/// Length of the initial run of `cs` made up of characters *not* in the set
+/// `ct`. The safe counterpart of C `strcspn`.
 pub fn strcspn_safe(cs: &[c_char], ct: &[c_char]) -> usize {
     strcspn_inner(cs, ct, false)
 }
 
+/// Shared implementation of [`strcspn_safe`] and [`strspn_safe`]: counts the
+/// leading characters of `cs` whose membership of `ct` equals `cmp`.
 fn strcspn_inner(cs: &[c_char], ct: &[c_char], cmp: bool) -> usize {
     let mut it = 0;
     while ct[it] != 0 {
@@ -46,10 +69,14 @@ fn strcspn_inner(cs: &[c_char], ct: &[c_char], cmp: bool) -> usize {
     is
 }
 
+/// Length of the initial run of `cs` made up entirely of characters in the set
+/// `ct`. The safe counterpart of C `strspn`.
 pub fn strspn_safe(cs: &[c_char], ct: &[c_char]) -> usize {
     strcspn_inner(cs, ct, true)
 }
 
+/// Copies the NUL-terminated `src` into `dst`, including the terminator. The
+/// safe counterpart of C `strcpy`.
 pub fn strcpy_safe(dst: &mut [c_char], src: &[c_char]) {
     let mut i = 0;
     loop {
@@ -61,10 +88,21 @@ pub fn strcpy_safe(dst: &mut [c_char], src: &[c_char]) {
     }
 }
 
+/// Compares two NUL-terminated strings. The safe counterpart of C `strcmp`.
+///
+/// # Returns
+///
+/// Negative, zero or positive as `cs` sorts before, equal to, or after `ct`.
 pub fn strcmp_safe(cs: &[c_char], ct: &[c_char]) -> c_int {
     strncmp_safe(cs, ct, cmp::max(cs.len(), ct.len()))
 }
 
+/// Compares at most `n` characters of two NUL-terminated strings. The safe
+/// counterpart of C `strncmp`.
+///
+/// # Returns
+///
+/// Negative, zero or positive as `cs` sorts before, equal to, or after `ct`.
 pub fn strncmp_safe(cs: &[c_char], ct: &[c_char], n: usize) -> c_int {
     let min_len = cmp::min(cs.len(), ct.len());
     let min_n = cmp::min(n, min_len);
@@ -94,6 +132,8 @@ pub fn strncmp_safe(cs: &[c_char], ct: &[c_char], n: usize) -> c_int {
     0
 }
 
+/// Length of a `CStr`, not counting the NUL terminator. The `CStr` form of
+/// [`strlen_safe`].
 pub(crate) fn strlen_safe_cstr(str: &CStr) -> usize {
     str.to_bytes().len()
 }
@@ -117,6 +157,12 @@ pub fn strnlen_safe(cs: &[c_char], n: usize) -> usize {
     cs[..limit].iter().position(|&c| c == 0).unwrap_or(limit)
 }
 
+/// Parses a leading integer out of `input`, skipping leading whitespace and any
+/// non-numeric prefix. The safe counterpart of C `strtol`.
+///
+/// # Returns
+///
+/// The parsed value and the index one past its last digit, or the parse error.
 pub(crate) fn strtol_safe<F: FromStr>(input: &[c_char]) -> Result<(F, usize), <F as FromStr>::Err> {
     let strlen = input.len() - 1;
     let input: &[u8] = cast_slice(input);
@@ -150,10 +196,23 @@ pub(crate) fn strtol_safe<F: FromStr>(input: &[c_char]) -> Result<(F, usize), <F
     Ok((res, end))
 }
 
+/// Parses a leading floating point number out of `s`. The safe counterpart of C
+/// `strtod`.
+///
+/// # Parameters
+///
+/// * `s`    — (I) the string to parse
+/// * `endp` — (O) index one past the last character consumed
 pub fn strtod_safe(s: &[c_char], endp: &mut usize) -> f64 {
     strto_float_impl(s, endp)
 }
 
+/// Index of the first occurrence of `c` in `cs`, or `None` if not found. The
+/// safe counterpart of C `strchr`, returning an index rather than an interior
+/// pointer.
+///
+/// Unlike [`strrchr_safe`], the search covers the whole slice rather than
+/// stopping at the NUL, so passing `0` for `c` finds the terminator.
 pub fn strchr_safe(cs: &[c_char], c: c_char) -> Option<usize> {
     cs.iter().position(|&x| x == c)
 }
@@ -184,12 +243,17 @@ pub fn strstr_safe(cs: &[c_char], ct: &[c_char]) -> Option<usize> {
     hay.windows(needle.len()).position(|w| w == needle)
 }
 
+/// Appends the NUL-terminated `ct` to the NUL-terminated `s`. The safe
+/// counterpart of C `strcat`.
 pub fn strcat_safe(s: &mut [c_char], ct: &[c_char]) {
     let ct_len = strlen_safe(ct);
 
     strncat_safe(s, ct, ct_len);
 }
 
+/// Appends at most `n` characters of the NUL-terminated `ct` to the
+/// NUL-terminated `s`, adding a terminator. The safe counterpart of C
+/// `strncat`.
 pub fn strncat_safe(s: &mut [c_char], ct: &[c_char], n: usize) {
     let s_len = strlen_safe(s);
     let ct_len = strlen_safe(ct);
@@ -208,6 +272,8 @@ pub fn strncat_safe(s: &mut [c_char], ct: &[c_char], n: usize) {
     s[s_len + i] = 0;
 }
 
+/// Maps an ASCII lower-case letter to upper case, leaving anything else
+/// unchanged. The safe counterpart of C `toupper`.
 pub(crate) fn toupper(c: c_char) -> c_char {
     if islower(c) {
         return c & 0x5f;
@@ -215,6 +281,8 @@ pub(crate) fn toupper(c: c_char) -> c_char {
     c
 }
 
+/// Maps an ASCII upper-case letter to lower case, leaving anything else
+/// unchanged. The safe counterpart of C `tolower`.
 pub(crate) fn tolower(c: c_char) -> c_char {
     if isupper(c) {
         return c | 0x20;
@@ -222,20 +290,27 @@ pub(crate) fn tolower(c: c_char) -> c_char {
     c
 }
 
+/// Whether `c` is an ASCII lower-case letter. The safe counterpart of C
+/// `islower`.
 pub(crate) fn islower(c: c_char) -> bool {
     (c >= 97) && (c <= 122)
 }
 
+/// Whether `c` is an ASCII upper-case letter. The safe counterpart of C
+/// `isupper`.
 pub(crate) fn isupper(c: c_char) -> bool {
     (c >= 65) && (c <= 90)
 }
 
+/// Whether `c` is ASCII whitespace. The safe counterpart of C `isspace`.
 pub(crate) fn isspace(c: c_char) -> bool {
     let c = c as c_char;
     c == bb(b' ') || c == bb(b'\t') || c == bb(b'\n') || c == bb(b'\r') || c == 0x0b || c == 0x0c
 }
 
 /// C `atol`: leading optional whitespace and sign, then decimal digits.
+///
+/// Parses `cs` as a `long`. The safe counterpart of C `atol`.
 ///
 /// Matches the C on the two edge cases Rust's `parse` gets differently:
 /// a value that does not fit saturates to `c_long::MIN`/`MAX` rather than
@@ -287,11 +362,14 @@ pub fn atol_safe(cs: &[c_char]) -> c_long {
     }
 }
 
+/// Parses `cs` as a `double`, yielding 0.0 rather than an error on anything
+/// unparseable. The safe counterpart of C `atof`.
 pub fn atof_safe(cs: &[c_char]) -> f64 {
     let mut dummy = 0;
     strtod_safe(cs, &mut dummy)
 }
 
+/// Whether `c` is an ASCII decimal digit. The safe counterpart of C `isdigit`.
 pub fn isdigit_safe(c: c_char) -> bool {
     (b'0' as c_char) <= c && c <= (b'9' as c_char)
 }
@@ -304,7 +382,11 @@ pub fn strpbrk_safe(cs: &[c_char], ct: &[c_char]) -> Option<usize> {
     (cs[i] != 0).then_some(i)
 }
 
-// Copied and modified from Redox's Relibc: https://gitlab.redox-os.org/redox-os/relibc/-/blob/master/src/macros.rs
+/// Parses a leading floating point number, the shared implementation behind
+/// [`strtod_safe`].
+///
+/// Copied and modified from Redox's relibc,
+/// <https://gitlab.redox-os.org/redox-os/relibc/-/blob/master/src/macros.rs>.
 fn strto_float_impl(s: &[c_char], endptr: &mut usize) -> f64 {
     let mut s = s;
 
@@ -452,7 +534,6 @@ fn strto_float_impl(s: &[c_char], endptr: &mut usize) -> f64 {
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Read into `buf` until it is full or end-of-file is reached, returning the
 /// total number of bytes read.
 ///

--- a/src/zcompress.rs
+++ b/src/zcompress.rs
@@ -1,3 +1,9 @@
+//! GZIP compression of a byte stream, over `libz-rs-sys`.
+//!
+//! Used when a FITS file is written to a `.gz` name, and by the `GZIP_1` and
+//! `GZIP_2` tile compressors in [`crate::imcompress`].
+#![warn(missing_docs)]
+
 use core::ptr;
 use std::io::{Read, Write};
 
@@ -47,18 +53,27 @@ pub(crate) unsafe fn deflateInit2(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Uncompress the disk file into memory.  Fill whatever amount of memory has
 /// already been allocated, then realloc more memory, using the supplied
 /// input function, if necessary.
+///
+/// # Parameters
+///
+/// * `_filename`   — name of input file
+/// * `diskfile`    — (I) file pointer
+/// * `buffptr`     — (IO) memory pointer
+/// * `buffsize`    — (IO) size of buffer, in bytes
+/// * `mem_realloc` — function
+/// * `filesize`    — (O) size of file, in bytes
+/// * `status`      — (IO) error status
 pub(crate) unsafe fn uncompress2mem<T: Read>(
-    _filename: &[c_char],  /* name of input file                 */
-    diskfile: &mut T,      /* I - file pointer                        */
-    buffptr: *mut *mut u8, /* IO - memory pointer                     */
-    buffsize: &mut usize,  /* IO - size of buffer, in bytes           */
-    mem_realloc: Option<unsafe extern "C" fn(p: *mut c_void, newsize: usize) -> *mut c_void>, /* function     */
-    filesize: &mut usize, /* O - size of file, in bytes              */
-    status: &mut c_int,   /* IO - error status                       */
+    _filename: &[c_char],
+    diskfile: &mut T,
+    buffptr: *mut *mut u8,
+    buffsize: &mut usize,
+    mem_realloc: Option<unsafe extern "C" fn(p: *mut c_void, newsize: usize) -> *mut c_void>,
+    filesize: &mut usize,
+    status: &mut c_int,
 ) -> c_int {
     unsafe {
         let mut err: c_int = 0;
@@ -218,18 +233,27 @@ pub(crate) unsafe fn uncompress2mem<T: Read>(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Uncompress the file in memory into memory.  Fill whatever amount of memory has
 /// already been allocated, then realloc more memory, using the supplied
 /// input function, if necessary.
+///
+/// # Parameters
+///
+/// * `inmemptr`    — (I) memory pointer to compressed bytes
+/// * `inmemsize`   — (I) size of input compressed file
+/// * `buffptr`     — (IO) memory pointer
+/// * `buffsize`    — (IO) size of buffer, in bytes
+/// * `mem_realloc` — function
+/// * `filesize`    — (O) size of file, in bytes
+/// * `status`      — (IO) error status
 pub(crate) unsafe fn uncompress2mem_from_mem(
-    inmemptr: &[c_char],   /* I - memory pointer to compressed bytes */
-    inmemsize: usize,      /* I - size of input compressed file      */
-    buffptr: *mut *mut u8, /* IO - memory pointer                      */
-    buffsize: &mut usize,  /* IO - size of buffer, in bytes           */
-    mem_realloc: Option<unsafe extern "C" fn(p: *mut c_void, newsize: usize) -> *mut c_void>, /* function     */
-    filesize: Option<&mut usize>, /* O - size of file, in bytes              */
-    status: &mut c_int,           /* IO - error status                       */
+    inmemptr: &[c_char],
+    inmemsize: usize,
+    buffptr: *mut *mut u8,
+    buffsize: &mut usize,
+    mem_realloc: Option<unsafe extern "C" fn(p: *mut c_void, newsize: usize) -> *mut c_void>,
+    filesize: Option<&mut usize>,
+    status: &mut c_int,
 ) -> c_int {
     unsafe {
         let mut err: c_int = 0;
@@ -326,18 +350,24 @@ pub(crate) unsafe fn uncompress2mem_from_mem(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Uncompress the file into another file.
 ///
 /// The body is one `unsafe` block because it is zlib stream manipulation throughout:
 /// every call reads and writes through `z_stream`'s `next_in`/`next_out` raw
 /// pointers.  The function itself is safe: it owns both buffers and is the only
 /// thing that sets those pointers, so no caller can influence them.
+///
+/// # Parameters
+///
+/// * `_filename`   — name of input file
+/// * `indiskfile`  — (I) input file pointer
+/// * `outdiskfile` — (I) output file pointer
+/// * `status`      — (IO) error status
 pub(crate) fn uncompress2file<R: Read, W: Write>(
-    _filename: &[c_char], /* name of input file                  */
-    indiskfile: &mut R,   /* I - input file pointer                */
-    outdiskfile: &mut W,  /* I - output file pointer               */
-    status: &mut c_int,   /* IO - error status                       */
+    _filename: &[c_char],
+    indiskfile: &mut R,
+    outdiskfile: &mut W,
+    status: &mut c_int,
 ) -> c_int {
     unsafe {
         let mut err: c_int = 0;
@@ -491,16 +521,23 @@ pub(crate) fn uncompress2file<R: Read, W: Write>(
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Compress the file into memory.  Fill whatever amount of memory has
 /// already been allocated, then realloc more memory, using the supplied
 /// input function, if necessary.
+///
+/// # Parameters
+///
+/// * `inmemptr`  — (I) memory pointer to uncompressed bytes
+/// * `inmemsize` — (I) size of input uncompressed file
+/// * `outbuf`    — (IO) buffer for compressed file; grown as needed
+/// * `filesize`  — (O) size of compressed file, in bytes
+/// * `status`    — (IO) error status
 pub(crate) fn compress2mem_from_mem(
-    inmemptr: &[c_char],          /* I - memory pointer to uncompressed bytes */
-    inmemsize: usize,             /* I - size of input uncompressed file      */
-    outbuf: &mut Vec<u8>,         /* IO - buffer for compressed file; grown as needed */
-    filesize: Option<&mut usize>, /* O - size of compressed file, in bytes    */
-    status: &mut c_int,           /* IO - error status                        */
+    inmemptr: &[c_char],
+    inmemsize: usize,
+    outbuf: &mut Vec<u8>,
+    filesize: Option<&mut usize>,
+    status: &mut c_int,
 ) -> c_int {
     let mut err: c_int;
     let mut c_stream: z_stream; /* compression stream */
@@ -604,18 +641,22 @@ pub(crate) fn compress2mem_from_mem(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Compress the memory file into disk file.
 ///
 /// The body is one `unsafe` block because it is zlib stream manipulation throughout:
 /// every call reads and writes through `z_stream`'s `next_in`/`next_out` raw
 /// pointers.  The function itself is safe: it owns both buffers and is the only
 /// thing that sets those pointers, so no caller can influence them.
+///
+/// # Parameters
+///
+/// * `inmemptr`  — (I) memory pointer to uncompressed bytes
+/// * `inmemsize` — (I) size of input uncompressed file
 pub(crate) fn compress2file_from_mem<W: Write>(
-    inmemptr: &[c_char], /* I - memory pointer to uncompressed bytes */
-    inmemsize: usize,    /* I - size of input uncompressed file      */
+    inmemptr: &[c_char],
+    inmemsize: usize,
     outdiskfile: &mut W,
-    filesize: Option<&mut usize>, /* O - size of file, in bytes              */
+    filesize: Option<&mut usize>,
     status: &mut c_int,
 ) -> c_int {
     unsafe {

--- a/src/zuncompress.rs
+++ b/src/zuncompress.rs
@@ -1,5 +1,10 @@
-//! This is an old implementation of the LZW decompression algorithm from the
-//! Unix compress utility.
+//! LZW decompression, for reading files compressed by the Unix `compress`
+//! utility.
+//!
+//! An old implementation of the algorithm, carried over from CFITSIO so that a
+//! `.Z` file can still be read. The compression side is not provided; new files
+//! are written with GZIP by [`crate::zcompress`].
+#![warn(missing_docs)]
 
 use bytemuck::{cast_slice, cast_slice_mut};
 
@@ -51,27 +56,53 @@ macro_rules! MAXCODE {
     };
 }
 
+/// The decompressor's working state: the buffers, the LZW code table and the
+/// input and output streams.
+///
+/// The C keeps all of this in file-scope globals; gathering it into one struct
+/// is what lets the routines below be safe methods rather than functions
+/// reaching for mutable statics.
 struct LZW_Compress<'a> {
+    /// Input buffer.
     inbuf: [c_uchar; INBUFSIZ + INBUF_EXTRA],
+    /// Output buffer.
     outbuf: [c_uchar; OUTBUFSIZ + OUTBUF_EXTRA],
+    /// Distance buffer.
     d_buf: [c_ushort; DIST_BUFSIZE],
+    /// Sliding window of already-decompressed output.
     window: [c_uchar; 2 * WSIZE],
-    tab_prefix: [c_ushort; 1 << BITS], /* prefix code for each entry */
-    maxbits: c_int,                    /* max bits per code for LZW */
-    method: c_int,                     /* compression method */
-    exit_code: c_int,                  /* program exit code */
-    last_member: c_int,                /* set for .zip and .Z files */
-    bytes_in: usize,                   /* number of input bytes */
-    bytes_out: usize,                  /* number of output bytes */
-    ifname: [c_char; 128],             /* input file name */
-    ifd: *mut FILE,                    /* input file descriptor */
-    ofd: *mut FILE,                    /* output file descriptor */
-    memptr: *mut *mut c_void,          /* memory location for uncompressed file */
-    memsize: &'a mut usize,            /* size (bytes) of memory allocated for file */
-    realloc_fn: Option<unsafe extern "C" fn(*mut c_void, usize) -> *mut c_void>, /* reallocation function */
-    insize: usize,     /* valid bytes in inbuf */
-    inptr: usize,      /* index of next byte to be processed in inbuf */
-    block_mode: c_int, /* block compress mode -C compatible with 2.0 */
+    /// Prefix code for each entry of the LZW table.
+    tab_prefix: [c_ushort; 1 << BITS],
+    /// Maximum bits per code for LZW.
+    maxbits: c_int,
+    /// Compression method.
+    method: c_int,
+    /// Program exit code.
+    exit_code: c_int,
+    /// Set for `.zip` and `.Z` files.
+    last_member: c_int,
+    /// Number of input bytes.
+    bytes_in: usize,
+    /// Number of output bytes.
+    bytes_out: usize,
+    /// Input file name.
+    ifname: [c_char; 128],
+    /// Input file descriptor.
+    ifd: *mut FILE,
+    /// Output file descriptor.
+    ofd: *mut FILE,
+    /// Memory location for the uncompressed file.
+    memptr: *mut *mut c_void,
+    /// Size in bytes of the memory allocated for the file.
+    memsize: &'a mut usize,
+    /// Reallocation function used to grow that memory.
+    realloc_fn: Option<unsafe extern "C" fn(*mut c_void, usize) -> *mut c_void>,
+    /// Valid bytes in `inbuf`.
+    insize: usize,
+    /// Index of the next byte to be processed in `inbuf`.
+    inptr: usize,
+    /// Block compress mode; `-C` compatible with 2.0.
+    block_mode: c_int,
 }
 
 impl<'a> LZW_Compress<'a> {
@@ -170,18 +201,27 @@ impl<'a> LZW_Compress<'a> {
     }
 }
 
-/*--------------------------------------------------------------------------*/
 /// Uncompress the file into memory.  Fill whatever amount of memory has
 /// already been allocated, then realloc more memory, using the supplied
 /// input function, if necessary.
+///
+/// # Parameters
+///
+/// * `filename`    — name of input file
+/// * `indiskfile`  — (I) file pointer
+/// * `buffptr`     — (IO) memory pointer
+/// * `buffsize`    — (IO) size of buffer, in bytes
+/// * `mem_realloc` — function
+/// * `filesize`    — (O) size of file, in bytes
+/// * `status`      — (IO) error status
 pub(crate) fn zuncompress2mem(
-    filename: &[c_char],   /* name of input file                 */
-    indiskfile: *mut FILE, /* I - file pointer                        */
-    buffptr: *mut *mut u8, /* IO - memory pointer                     */
-    buffsize: &mut usize,  /* IO - size of buffer, in bytes           */
-    mem_realloc: Option<unsafe extern "C" fn(p: *mut c_void, newsize: usize) -> *mut c_void>, /* function     */
-    filesize: &mut usize, /* O - size of file, in bytes              */
-    status: &mut c_int,   /* IO - error status                       */
+    filename: &[c_char],
+    indiskfile: *mut FILE,
+    buffptr: *mut *mut u8,
+    buffsize: &mut usize,
+    mem_realloc: Option<unsafe extern "C" fn(p: *mut c_void, newsize: usize) -> *mut c_void>,
+    filesize: &mut usize,
+    status: &mut c_int,
 ) -> c_int {
     let mut magic: [c_char; 2] = [0; 2]; /* magic header */
 
@@ -233,7 +273,6 @@ pub(crate) fn zuncompress2mem(
     *status
 }
 
-/*--------------------------------------------------------------------------*/
 /// Decompress in to out.  This routine adapts to the codes in the
 /// file building the "string" table on-the-fly; requiring no table to
 /// be stored in the compressed file.


### PR DESCRIPTION
Converts the inherited CFITSIO C comment style to rustdoc across all 109 files
in `src/`. Documentation only: no code changes.

| | before | after |
|---|---:|---:|
| C banner headers | 59 | 0 |
| `/*-----*/` separators | 2,372 | 0 |
| trailing `/* I - ... */` parameter comments | 10,589 | 0 |
| `cargo doc` warnings | 29 | 0 |

## What changed

- File banners become `//!` module docs, rewritten to say what the module does
  and, where it helps, why — what a tile-compressed image actually is, the
  difference between modify/update/insert in `modkey.rs`, why `simplerng.rs`
  has to be reproducible across platforms.
- Trailing `/* I - ... */` parameter comments move into `# Parameters`
  sections, keeping their `I`/`O`/`IO` direction markers.
- Struct fields and constants get `///` above them rather than a `/* ... */`
  after.
- `# Returns` / `# Errors` / `# Safety` / `# Panics` sections and intra-doc
  links where they apply.
- Comments **inside** function bodies are untouched, so the code still reads
  side by side with the original C.

Descriptions are enriched from the CFITSIO User's Reference Guide where the C
comments were thin — the 141 error status constants in `fitsio.rs` come from
its appendix, and `ffpthp`, `ffcpht`, `ffcdfl` and the checksum routines gain
detail the C omits. Where the existing comment was already fuller than the
guide, it stands.

## Keeping it converted

`#![warn(missing_docs)]` is on at the crate root and in every module, so the
state cannot regress. The flex/bison output (`eval_l`, `eval_y`, `eval_tab`)
and the vendored relibc carry a commented `#![allow(missing_docs)]` instead:
those are generated or upstream code, documented in their own style.

CI gains a job running `cargo doc --no-deps` with `RUSTDOCFLAGS: -D warnings`.
Not `--lib` — that covers only the library and leaves the utility binaries
unchecked.

## Verification

Every commit was checked to change comments only, by comparing the token stream
of the code with comments stripped. Zero warnings for `cargo doc --no-deps` and
`--document-private-items`, under both the default features and
`--all-features`. `cargo build` clean, `cargo test` 35/35, and
`testprog_check.sh` still byte-identical to the C reference.

Four upstream slips fixed along the way: `putcoluk.c`'s banner naming itself
`putcolk.c`, `NAXSI2` in `edithdu.rs`, `addrss` in `scalnull.rs`, and
`ffgkls_safe` documented as "a safe wrapper handling null pointer checks",
which describes the other half of the pair.

One commit per file, so it can be reviewed a file at a time.
