### PR TITLE
Record the clean miri run

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -96,16 +96,16 @@
         PixelFilter is a C struct of raw pointers, so narrowing it means changing
         that struct. Documented in place.
 - [X] Fix broken testprog.out comparison
-- [ ] Re-run miri end to end and confirm the findings below are gone. Use
+- [X] Miri is clean. The confirming end-to-end run reported 2780 passed, 0
+      failed, 59 skipped in 5h12m: no UB, no leaks, no unsupported operations.
+      Re-run it after any change to the aliasing-sensitive code below. Use
       `MIRIFLAGS="-Zmiri-disable-isolation" cargo +nightly miri nextest run
       --no-fail-fast -j 8` (cap the threads: the default fans out to one miri
       process per core at ~1.1GB each and thrashes swap). A full run takes
-      ~3.8h. Do not run any other cargo command while one is in flight -- it
+      ~5h. Do not run any other cargo command while one is in flight -- it
       corrupts the run.
-      The last full run reported 2287 passed / 485 failed. Every finding from
-      it has since been fixed, but no full run has been done since, so the
-      confirming run is what is outstanding here. What that run found, and
-      where it went:
+      The run before the fixes reported 485 failures. What it found, and where
+      each part went:
       * 435 UB, all Stacked Borrows violations -- real aliasing UB that LLVM's
         `noalias` is entitled to miscompile, not miri pedantry. The dominant
         shape, five times over, was a struct holding a pointer to something


### PR DESCRIPTION
The confirming end-to-end miri run, against a tree identical to current main (verified with `git diff`):

```
Summary [18698.601s] 2780 tests run: 2780 passed (110 slow), 59 skipped
```

**0 UB, 0 leaks, 0 unsupported operations** — down from 485 failures (435 UB, 19 leaks, 42 unsupported, 8 alignment panics) when this started.

The skip count reconciles exactly against the previous run, so nothing was hidden by the gating in #132:

| | before | change | after |
|---|---|---|---|
| total | 2882 | −44 (whole `test_fpack_cli` file: 42 + 2 already-ignored) +1 (new regression test) | 2839 |
| run | 2822 | −42 −1 (edithdu) +1 | 2780 |
| skipped | 60 | −2 +1 | 59 |

TODO.md now records the result and keeps the invocation, with the runtime corrected to ~5h.