### PR TITLE
Remove the remaining libc allocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,41 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+- Allocation ownership put on one ladder. `ffiter_internal` owns its per-column work
+  arrays instead of `calloc`ing seventeen of them, so they are released on every path
+  and a failed reservation reports `MEMORY_ALLOCATION` rather than a null pointer that
+  only a later check would notice. The allocation registry moved behind
+  `helpers::raw_owned`, which records the element size and alignment alongside the
+  length and capacity and refuses to release a pointer it never handed out.
+- No `libc` allocation is left in the library. The expression engine's node buffers
+  come from the Rust allocator, and `NodeValue::Buffer` carries the `Layout` to
+  release them with plus whether the node owns the block at all -- so a column node
+  pointing into `varData` can no longer be freed through, and both of
+  `Allocate_Ptrs`' allocations go together instead of the character block having to
+  be released by hand at each call site.
+- The decompression routines' `mem_realloc` callback is no longer `libc::realloc`
+  where the buffer being grown is a Rust `Vec`.
+
+### Fixed
+- Compressed files were not recognised at all. Two independent defects in the same
+  path: the two-byte magic numbers for GZIP, PACK, LZW and LZH were transpiled from the
+  C's octal escapes as if they were decimal, so `file_is_compressed` and
+  `mem_compress_open` rejected every `.gz`, `.Z` and `.bz2` file; and
+  `file_is_compressed` read those two bytes with a bare `read()`, which is allowed to
+  come back short, and treated a short read as "not compressed".
+- Memory-file buffers allocated by `mem_createmem` (a `Vec`, i.e. the Rust allocator)
+  were resized with the C `realloc` by `stdin2mem`, both compressed-open paths and the
+  decompression grow callback -- a cross-allocator free. They route through
+  `owned_realloc` now, and `stdin2mem` publishes the new address as it grows instead of
+  leaving a stale one behind for its own error path to free.
+- Two frees on a guessed layout: `fits_read_wcstab` released an `nelem`-element `f64`
+  array as if it held `ndim` elements, and `FITSfile::drop` freed the six `tile*`
+  pointers that `TILE_STRUCTS` owns. The latter is the double free that had
+  `test_copy_within_same_file` ignored.
+
 ## [0.470.1] - 2026.08.16
 
 ### Changed

--- a/TODO.md
+++ b/TODO.md
@@ -10,7 +10,38 @@
 - [ ] Refactor the NullCheckType and NullValue. NullValue isn't Copy and these concepts are intrinsicly linked.
 - [ ] Investigate all code with 'WARNING'
 - [ ] Investigate all code with 'TODO'
-- [ ] Remove use a malloc and free
+- [X] Remove use of malloc and free. No `libc` allocation is left in `src/`
+      outside two `#[cfg(test)]` uses in cfileio.rs, where the test acts as a
+      C caller supplying its own allocator through `fits_create_memfile` and so
+      must free with the same one.
+      `ffiter_internal` owns its per-column work arrays in an
+      `AlignedBytes`/`Vec` arena instead of calloc'ing 17 of them (which also
+      makes the 16 unchecked allocations fallible and stops the early returns
+      leaking), and drvrmem no longer resizes a Vec-allocated memory-file
+      buffer with the C `realloc` -- `stdin2mem`, `mem_compress_open`,
+      `mem_compress_stdin_open` and the decompression grow callback all route
+      through `owned_realloc` now, which was a real cross-allocator free.
+      The global `ALLOCATIONS` map has moved behind
+      `src/helpers/raw_owned.rs`: it records the element size and alignment as
+      well as the length and capacity, and there is no "assume the length"
+      fallback any more -- an unregistered pointer is reported in debug builds
+      and leaked rather than freed on a guessed `Layout`. That removed two
+      wrong-layout frees (`fits_read_wcstab` released an `nelem`-element f64
+      array as `ndim` elements; `FITSfile::drop` freed the six tile* pointers
+      that `TILE_STRUCTS` owns) and un-ignored `test_copy_within_same_file`.
+      See the ladder at the top of `raw_owned.rs` for which mechanism to reach
+      for.
+      The expression engine went last. `NodeValue::Buffer` carries an `Owned`
+      describing how its block is released -- `None` for a column node's
+      borrowed view into `varData`, `Block(Layout)` for a numeric row buffer,
+      `BlockAndText` for the row-pointer array plus the character block behind
+      it -- so `free_buffer` hands the right `Layout` back to the Rust
+      allocator, releases both of `Allocate_Ptrs`' allocations, and cannot free
+      a buffer the node only borrows. The `FREE!` macro is gone. The Bits
+      column arrays in `Setup_DataArrays` are `DataInfo::bit_rows`/`bit_block`
+      Vecs rather than mallocs freed in `ffcprs`.
+      Still raw pointers, though: the deeper rework that would make the node
+      buffers `Vec`s and drop the `unsafe` around them is the entry below.
 - [X] Remove use of libc unsafe functions. Every raw C string function is gone:
       the whole `strcpy`/`strncpy`/`strcmp`/`strncmp`/`strlen`/`strnlen`/
       `strchr`/`strstr`/`strcat`/`strncat`/`strtok_r`/`strpbrk`/`strspn`/
@@ -19,11 +50,16 @@
       per-row string buffers through `lval::str_row`/`str_row_mut` instead of a
       `char **` row-pointer array, and `bitand`/`bitor`/`bitnot`/`bitcmp`/
       `bitlgte`/`cstrmid` are now safe functions taking slices.
-      Remaining follow-up, none of it string-related: stage 3 of
-      `notes/EVAL_STRING_STORAGE.md` (own the row buffers in `ParseData` so the
-      two `str_row` accessors stop being `unsafe`), then stage 4 (the numeric
-      buffers and `value.undef`, ~660 sites, which would remove the last
-      `malloc`/`free` and raw pointer from `NodeValue`).
+      Remaining follow-up, none of it string-related (the `notes/` directory
+      this used to point at is gone): own the row buffers in `ParseData` so the
+      two `str_row` accessors stop being `unsafe`, then the numeric buffers and
+      `value.undef` (~660 sites), which would remove the last `malloc`/`free`
+      and raw pointer from `NodeValue`. Two structural obstacles:
+      `NodeValue::Buffer` needs an owning arm *and* a borrowed sibling, because
+      `Evaluate_Parser` re-points column nodes at `varData[col].data` on every
+      evaluation; and `Allocate_Ptrs` packs the data array and the `undef`
+      flags into one allocation with `undef` pointing into its tail, so each
+      becomes two `Vec`s and `lval.undef` changes with them.
 - [X] Fix the Stacked Borrows violation in the lexer's buffer stack
       (`yy_buffer_stack`). yyrestart held a reference to the stack slot across
       yy_create_buffer, which re-enters the scanner; yy_init_buffer and

--- a/src/cfileio.rs
+++ b/src/cfileio.rs
@@ -30,7 +30,7 @@ use crate::drvrnet::{fits_dwnld_prog_bar, fits_net_timeout, https_set_verbose};
 use crate::grparser::fits_execute_template_safe;
 use crate::helpers::boxed::box_try_new;
 use crate::helpers::cfile::{CFile, fgets};
-use crate::helpers::vec_raw_parts::vec_into_raw_parts;
+use crate::helpers::raw_owned::into_raw_registered;
 use bytemuck::{cast_mut, cast_slice, cast_slice_mut};
 use errno::errno;
 use libc::ERANGE;
@@ -65,7 +65,7 @@ use crate::eval_f::{
     fits_pixel_filter_safer,
 };
 use crate::fitscore::{
-    ALLOCATIONS, ffchdu, ffcmrk_safe, ffcmsg_safe, ffgcnn_safe, ffgcno_safe, ffgcprll, ffgerr_safe,
+    ffchdu, ffcmrk_safe, ffcmsg_safe, ffgcnn_safe, ffgcno_safe, ffgcprll, ffgerr_safe,
     ffghadll_safe, ffghdn_safe, ffghdt_safe, ffgidm_safe, ffgidt_safe, ffgiprll_safe, ffgkcl_safe,
     ffgmsg_safe, ffgncl_safe, ffgnrw_safe, ffgtclll_safe, ffkeyn_safe, ffmahd_safe, ffmnhd_safe,
     ffmrhd_safe, ffpmrk_safe, ffpmsg_slice, ffpmsg_str, ffrdef_safe, ffrhdu_safe, ffupch_safe,
@@ -8906,10 +8906,7 @@ pub unsafe extern "C" fn ffimport_file(
 
         if let Some(safe_contents) = safe_contents {
             // HEAP ALLOCATION
-            let (p, l, c) = vec_into_raw_parts(safe_contents);
-            ALLOCATIONS.lock().unwrap().insert(p as usize, (l, c));
-
-            *contents = p;
+            *contents = into_raw_registered(safe_contents);
         }
 
         result

--- a/src/drvrfile.rs
+++ b/src/drvrfile.rs
@@ -798,7 +798,11 @@ pub(crate) fn file_is_compressed(filename: &mut [c_char; FLEN_FILENAME]) -> c_in
     }
 
     /* read the first 2 bytes of the file */
-    if diskfile.unwrap().read(&mut buffer).unwrap() != 2 {
+    /* read_fill, not a bare read(): a single read() is allowed to come back
+    short, and treating that as end-of-file reported every compressed file as
+    uncompressed.  Miri, which does return short reads where Linux does not,
+    is what surfaced it. */
+    if read_fill(&mut diskfile.unwrap(), &mut buffer).unwrap() != 2 {
         /* read 2 bytes */
         return 0;
     }
@@ -808,13 +812,18 @@ pub(crate) fn file_is_compressed(filename: &mut [c_char; FLEN_FILENAME]) -> c_in
     1 = this is a compressed file
     0 = not a compressed file
     */
+    /* The C spells these as octal escapes -- "\037\213" and friends -- so the
+    decimal values below are 0o37 = 31, 0o213 = 139, and so on.  Reading the
+    escapes as decimal digits is what made every one of these but PKZIP and
+    BZip2 unmatchable, which in turn made the whole compress:// driver
+    unreachable. */
     match buffer[..2] {
-        [37, 13] => 1,     /* GZIP  */
-        [b'P', b'K'] => 1, /* PKZIP */
-        [37, 36] => 1,     /* PACK  */
-        [37, 35] => 1,     /* LZW   */
-        [b'B', b'Z'] => 1, /* BZip2 */
-        [37, 40] => 1,     /* LZH   */
+        [0o037, 0o213] => 1, /* GZIP  */
+        [b'P', b'K'] => 1,   /* PKZIP, i.e. "\120\113" */
+        [0o037, 0o036] => 1, /* PACK  */
+        [0o037, 0o235] => 1, /* LZW   */
+        [b'B', b'Z'] => 1,   /* BZip2 */
+        [0o037, 0o240] => 1, /* LZH   */
         _ => 0,
     }
 }

--- a/src/drvrmem.rs
+++ b/src/drvrmem.rs
@@ -25,16 +25,18 @@ use std::sync::Mutex;
 
 use crate::c_types::{FILE, c_char, c_int, c_long, c_uchar, c_uint, c_ushort, c_void};
 use crate::helpers::cfile::CFile;
-use crate::helpers::vec_raw_parts::vec_into_raw_parts;
+use crate::helpers::raw_owned::{
+    free_registered, into_raw_registered, reregister, take_registered,
+};
 use crate::zuncompress::zuncompress2mem;
-use libc::{EOF, fclose, fgetc, fopen, fread, memcmp, memcpy, memset, realloc, ungetc};
+use libc::{EOF, fclose, fgetc, fopen, fread, memcmp, memcpy, memset, ungetc};
 
 use bytemuck::{cast_slice, cast_slice_mut};
 
 use crate::cfileio::ffclos_safe;
 use crate::cfileio::{MAX_PREFIX_LEN, ffimem_safer};
 use crate::drvrfile::{file_close, file_create, file_open, file_openfile, file_write};
-use crate::fitscore::{ALLOCATIONS, ffpmsg_slice, ffpmsg_str};
+use crate::fitscore::{ffpmsg_slice, ffpmsg_str};
 use crate::fitsio::*;
 use crate::fitsio2::*;
 use crate::iraffits::iraf2mem;
@@ -149,28 +151,66 @@ fn release_owned_cell(d: &mut memdriver) {
 /// calling realloc.
 unsafe fn owned_realloc(ptr: *mut c_char, newsize: usize) -> *mut c_char {
     unsafe {
-        let mut allocations = ALLOCATIONS.lock().unwrap();
-
-        let Some((len, capacity)) = allocations.remove(&(ptr as usize)) else {
+        let Some(mut v) = take_registered(ptr) else {
             /* Not one of ours; refuse rather than free it with the wrong
             allocator. */
             return ptr::null_mut();
         };
 
-        let mut v = Vec::from_raw_parts(ptr, len, capacity);
-
         if newsize > v.len() && v.try_reserve_exact(newsize - v.len()).is_err() {
             /* Put it back so the close path can still release it. */
-            let (p, l, c) = vec_into_raw_parts(v);
-            allocations.insert(p as usize, (l, c));
+            reregister(ptr, v);
             return ptr::null_mut();
         }
         v.resize(newsize, 0);
         v.shrink_to(newsize);
 
-        let (p, l, c) = vec_into_raw_parts(v);
-        allocations.insert(p as usize, (l, c));
-        p
+        reregister(ptr, v)
+    }
+}
+
+/// [`owned_realloc`] in the shape of CFITSIO's `mem_realloc` callback.
+///
+/// The decompression entry points take a C-style grow function and apply it to
+/// the memory file's buffer.  The C passed `realloc` there; that buffer comes
+/// from `mem_createmem`, i.e. a `Vec`, so the callback has to go through the
+/// Rust allocator instead.  Returns null for any pointer this driver did not
+/// allocate, which is what `owned_realloc` does.
+unsafe extern "C" fn owned_realloc_c(p: *mut c_void, newsize: usize) -> *mut c_void {
+    unsafe { owned_realloc(p.cast::<c_char>(), newsize).cast::<c_void>() }
+}
+
+/// Resize a memory-file buffer down to `fitsfilesize`, through whichever
+/// allocator owns it.
+///
+/// Both compressed-open paths trim an over-allocated decompression buffer.  The
+/// C did that with a bare `realloc()`, which is wrong for a buffer that
+/// `mem_createmem` allocated as a `Vec` -- the same distinction
+/// [`owned_realloc`] documents.  Returns the new address, or null on failure
+/// (leaving the old buffer intact and still recorded).
+///
+/// # Safety
+/// `d` must be a live table slot whose `memaddrptr`/`memsizeptr` are set.
+unsafe fn shrink_mem_buffer(d: &mut memdriver) -> *mut c_char {
+    unsafe {
+        let newsize = d.fitsfilesize as usize;
+
+        let ptr = if d.owned_cell.is_null() {
+            /* caller's buffer, so the caller's realloc -- and nothing to do if
+            the caller did not supply one */
+            match d.mem_realloc {
+                Some(f) => f((*(d.memaddrptr)).cast::<c_void>(), newsize).cast::<c_char>(),
+                None => ptr::null_mut(),
+            }
+        } else {
+            owned_realloc(*(d.memaddrptr), newsize)
+        };
+
+        if !ptr.is_null() {
+            *(d.memaddrptr) = ptr;
+            *(d.memsizeptr) = newsize;
+        }
+        ptr
     }
 }
 
@@ -363,9 +403,7 @@ pub(crate) fn mem_createmem(msize: usize, handle: &mut c_int) -> c_int {
             return FILE_NOT_OPENED;
         } else {
             v.resize(msize, 0);
-            let (p, l, c) = vec_into_raw_parts(v);
-            ALLOCATIONS.lock().unwrap().insert(p as usize, (l, c));
-            unsafe { *m[ii].memaddrptr = p };
+            unsafe { *m[ii].memaddrptr = into_raw_registered(v) };
         }
     }
 
@@ -374,7 +412,11 @@ pub(crate) fn mem_createmem(msize: usize, handle: &mut c_int) -> c_int {
     m[ii].deltasize = BL!();
     m[ii].fitsfilesize = 0;
     m[ii].currentpos = 0;
-    m[ii].mem_realloc = Some(realloc);
+    /* The C set this to realloc().  This buffer is a Vec, so it is resized
+    through owned_realloc instead -- selected by owned_cell, which is always
+    set here.  Leaving the C realloc() in the slot would be a live
+    cross-allocator hazard for no gain, so the slot advertises no realloc. */
+    m[ii].mem_realloc = None;
     0
 }
 
@@ -582,13 +624,33 @@ pub(crate) unsafe fn stdin2mem(hd: c_int) -> c_int {
 
         loop {
             /* allocate memory for another FITS block */
-            memptr = realloc(memptr.cast::<c_void>(), memsize + delta).cast::<c_char>();
+            /* The C called realloc() directly.  mem_createmem allocates this
+            buffer with a Vec, so it has to be resized through the Rust
+            allocator; see owned_realloc.  Only a caller-supplied buffer goes
+            through the caller's realloc. */
+            let newptr = if m[hd as usize].owned_cell.is_null() {
+                match m[hd as usize].mem_realloc {
+                    Some(f) => f(memptr.cast::<c_void>(), memsize + delta).cast::<c_char>(),
+                    None => ptr::null_mut(),
+                }
+            } else {
+                owned_realloc(memptr, memsize + delta)
+            };
 
-            if memptr.is_null() {
+            if newptr.is_null() {
                 ffpmsg_str("realloc failed while copying stdin (stdin2mem)");
                 return MEMORY_ALLOCATION;
             }
+            memptr = newptr;
             memsize += delta;
+
+            /* Publish the new address immediately.  The C left the caller's
+            *memaddrptr holding the pre-realloc pointer until the function
+            returned, so the MEMORY_ALLOCATION path above -- and the
+            Vec::from_raw_parts cleanup in mem_stdin_open that follows it --
+            would have worked from a stale address. */
+            *m[hd as usize].memaddrptr = memptr;
+            *m[hd as usize].memsizeptr = memsize;
 
             /* read another FITS block */
             nread = fread(memptr.add(filesize).cast::<c_void>(), 1, delta, STDIN!());
@@ -758,7 +820,11 @@ pub(crate) fn mem_compress_open(filename: &mut [c_char], rwmode: c_int, hdl: &mu
             return READ_ERROR;
         }
 
-        if buffer[..2] == [37, 213] {
+        /* The C writes these magic numbers as octal escapes ("\037\213" and
+        friends), so they are spelled in octal here too; reading the escapes as
+        decimal is what made this function reject every compressed file it was
+        handed.  See file_is_compressed for the same fix. */
+        if buffer[..2] == [0o037, 0o213] {
             /* GZIP */
 
             /* the uncompressed file size is give at the end */
@@ -812,7 +878,7 @@ pub(crate) fn mem_compress_open(filename: &mut [c_char], rwmode: c_int, hdl: &mu
             }
 
             estimated = 0; /* file size is known, not estimated */
-        } else if buffer[..2] == [120, 113] {
+        } else if buffer[..2] == [0o120, 0o113] {
             /* PKZIP */
 
             /* the uncompressed file size is give at byte 22 the file */
@@ -830,13 +896,13 @@ pub(crate) fn mem_compress_open(filename: &mut [c_char], rwmode: c_int, hdl: &mu
             finalsize = modulosize as usize;
 
             estimated = 0; /* file size is known, not estimated */
-        } else if buffer[..2] == [37, 36] {
+        } else if buffer[..2] == [0o037, 0o036] {
             /* PACK */
             finalsize = 0; /* for most methods we can't determine final size */
-        } else if buffer[..2] == [37, 235] {
+        } else if buffer[..2] == [0o037, 0o235] {
             /* LZW */
             finalsize = 0; /* for most methods we can't determine final size */
-        } else if buffer[..2] == [37, 240] {
+        } else if buffer[..2] == [0o037, 0o240] {
             /* LZH */
             finalsize = 0; /* for most methods we can't determine final size */
         } else if memcmp(
@@ -888,18 +954,13 @@ pub(crate) fn mem_compress_open(filename: &mut [c_char], rwmode: c_int, hdl: &mu
 
         /* if we allocated too much memory initially, then free it */
         if *(m[*hdl as usize].memsizeptr) > ((m[*hdl as usize].fitsfilesize as usize) + 256) {
-            let ptr = realloc(
-                (*(m[*hdl as usize].memaddrptr)).cast(),
-                m[*hdl as usize].fitsfilesize as usize,
-            )
-            .cast::<c_char>();
+            /* the C shrank this with realloc(); mem_createmem allocated it
+            with a Vec, so it has to go back through the Rust allocator */
+            let ptr = shrink_mem_buffer(&mut m[*hdl as usize]);
             if ptr.is_null() {
                 ffpmsg_str("Failed to reduce size of allocated memory (compress_open)");
                 return MEMORY_ALLOCATION;
             }
-
-            *(m[*hdl as usize].memaddrptr) = ptr;
-            *(m[*hdl as usize].memsizeptr) = (m[*hdl as usize].fitsfilesize) as usize;
         }
 
         0
@@ -946,18 +1007,13 @@ pub(crate) unsafe fn mem_compress_stdin_open(
 
         /* if we allocated too much memory initially, then free it */
         if *(m[*hdl as usize].memsizeptr) > ((m[*hdl as usize].fitsfilesize as usize) + 256) {
-            let ptr = realloc(
-                (*(m[*hdl as usize].memaddrptr)).cast::<c_void>(),
-                m[*hdl as usize].fitsfilesize as usize,
-            )
-            .cast::<c_char>();
+            /* the C shrank this with realloc(); mem_createmem allocated it
+            with a Vec, so it has to go back through the Rust allocator */
+            let ptr = shrink_mem_buffer(&mut m[*hdl as usize]);
             if ptr.is_null() {
                 ffpmsg_str("Failed to reduce size of allocated memory (compress_stdin_open)");
                 return MEMORY_ALLOCATION;
             }
-
-            *(m[*hdl as usize].memaddrptr) = ptr;
-            *(m[*hdl as usize].memsizeptr) = (m[*hdl as usize].fitsfilesize) as usize;
         }
 
         0
@@ -1288,7 +1344,7 @@ pub(crate) unsafe fn mem_uncompress2mem<T: Read + AsRawFd>(
                 raw_file_handle,
                 m[hdl as usize].memaddrptr.cast::<*mut u8>(), /* pointer to memory address */
                 m[hdl as usize].memsizeptr.as_mut().unwrap(), /* pointer to size of memory */
-                Some(realloc),                                /* reallocation function */
+                Some(owned_realloc_c),                        /* reallocation function */
                 &mut finalsize,
                 &mut status, /* returned file size and status*/
             );
@@ -1316,7 +1372,7 @@ pub(crate) unsafe fn mem_uncompress2mem<T: Read + AsRawFd>(
                 diskfile,
                 m[hdl as usize].memaddrptr.cast::<*mut u8>(), /* pointer to memory address */
                 m[hdl as usize].memsizeptr.as_mut().expect(NULL_MSG), /* pointer to size of memory */
-                Some(realloc),                                        /* reallocation function */
+                Some(owned_realloc_c),                                /* reallocation function */
                 &mut finalsize,
                 &mut status,
             ); /* returned file size nd status*/
@@ -1357,7 +1413,7 @@ pub(crate) unsafe fn mem_uncompress2mem<T: Read + AsRawHandle>(
                 raw_file_handle,
                 m[hdl as usize].memaddrptr as *mut *mut u8, /* pointer to memory address */
                 m[hdl as usize].memsizeptr.as_mut().unwrap(), /* pointer to size of memory */
-                Some(realloc),                              /* reallocation function */
+                Some(owned_realloc_c),                      /* reallocation function */
                 &mut finalsize,
                 &mut status, /* returned file size and status*/
             );
@@ -1380,7 +1436,7 @@ pub(crate) unsafe fn mem_uncompress2mem<T: Read + AsRawHandle>(
                 diskfile,
                 m[hdl as usize].memaddrptr as *mut *mut u8, /* pointer to memory address */
                 m[hdl as usize].memsizeptr.as_mut().expect(NULL_MSG), /* pointer to size of memory */
-                Some(realloc),                                        /* reallocation function */
+                Some(owned_realloc_c),                                /* reallocation function */
                 &mut finalsize,
                 &mut status,
             ); /* returned file size nd status*/
@@ -1415,14 +1471,11 @@ pub(crate) fn mem_close_free_unsafe(handle: c_int) -> c_int {
         /* free( *(m[handle].memaddrptr) );  - C free() tolerates a NULL pointer, so
         guard against it here (the buffer may never have been allocated, e.g. when
         an IRAF conversion failed before writing the buffer pointer). */
-        let dataptr = *(m[handle].memaddrptr);
-        if !dataptr.is_null() {
-            if let Some((l, c)) = ALLOCATIONS.lock().unwrap().remove(&(dataptr as usize)) {
-                _ = Vec::from_raw_parts(dataptr, l, c);
-            } else {
-                _ = Vec::from_raw_parts(dataptr, memsize, memsize);
-            }
-        }
+        /* A buffer supplied through mem_openmem belongs to the caller and was
+        never registered; free_registered leaves it alone, where the old
+        `else` branch would have released it on a guessed layout with the
+        wrong allocator. */
+        free_registered(*(m[handle].memaddrptr));
         // free( *(m[handle].memaddrptr) );
 
         release_owned_cell(&mut m[handle]);
@@ -1695,5 +1748,148 @@ pub(crate) unsafe fn bzip2uncompress2mem(
             return;
         }
         *filesize = total_read;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs::File;
+
+    use flate2::Compression;
+    use flate2::write::GzEncoder;
+
+    use super::*;
+    use crate::cfileio::{ffinit_safe, ffopen_safe};
+    use crate::getcolj::ffgpvj_safe;
+    use crate::helpers::testhelpers::{to_buf, with_temp_file};
+    use crate::putcolj::ffpprj_safe;
+    use crate::putkey::ffphps_safe;
+
+    /// Write a 1-D LONG_IMG of `npix` values to `path` and return them.
+    ///
+    /// `compressible` picks a ramp (which bzip2 crushes) or a deterministic LCG
+    /// sequence (which it cannot), because the bz2 path's buffer estimate is
+    /// three times the *compressed* size -- only incompressible data makes that
+    /// estimate overshoot the real file.
+    fn write_fits_data(path: &str, npix: usize, compressible: bool) -> Vec<c_long> {
+        let data: Vec<c_long> = if compressible {
+            (0..npix as c_long).collect()
+        } else {
+            let mut x: u64 = 0x2545_F491_4F6C_DD1D;
+            (0..npix)
+                .map(|_| {
+                    x = x
+                        .wrapping_mul(6364136223846793005)
+                        .wrapping_add(1442695040888963407);
+                    /* LONG_IMG is BITPIX 32, so keep the values in i32 */
+                    ((x >> 32) as u32 as i32) as c_long
+                })
+                .collect()
+        };
+
+        let mut status: c_int = 0;
+        let mut fptr: Option<Box<fitsfile>> = None;
+        ffinit_safe(&mut fptr, &to_buf(path), &mut status);
+        assert_eq!(status, 0, "ffinit failed");
+        {
+            let f = fptr.as_deref_mut().unwrap();
+            let naxes: [c_long; 1] = [npix as c_long];
+            ffphps_safe(f, LONG_IMG, 1, &naxes, &mut status);
+            ffpprj_safe(f, 1, 1, npix as LONGLONG, &data, &mut status);
+            assert_eq!(status, 0, "write failed");
+        }
+        ffclos_safe(fptr.take().unwrap(), &mut status);
+        assert_eq!(status, 0, "ffclos failed");
+
+        data
+    }
+
+    /// Open a compressed FITS file and return its `npix` pixels.
+    fn read_back(path: &str, npix: usize) -> Vec<c_long> {
+        let mut status: c_int = 0;
+        let mut fptr: Option<Box<fitsfile>> = None;
+        ffopen_safe(&mut fptr, &to_buf(path), READONLY, &mut status);
+        assert_eq!(status, 0, "ffopen of the compressed file failed");
+
+        let mut got: Vec<c_long> = vec![-1; npix];
+        {
+            let f = fptr.as_deref_mut().unwrap();
+            ffgpvj_safe(f, 1, 1, npix as LONGLONG, 0, &mut got, None, &mut status);
+            assert_eq!(status, 0, "ffgpv failed");
+        }
+        ffclos_safe(fptr.take().unwrap(), &mut status);
+        assert_eq!(status, 0, "ffclos failed");
+        got
+    }
+
+    /// Write a ramp, gzip it, reopen it through the compress:// driver and
+    /// check the pixels came back unchanged.
+    fn roundtrip_gz(npix: usize) {
+        with_temp_file(|filename| {
+            let expected = write_fits_data(filename, npix, true);
+
+            let plain = std::fs::read(filename).unwrap();
+            let gz = File::create(format!("{filename}.gz")).unwrap();
+            let mut enc = GzEncoder::new(gz, Compression::default());
+            enc.write_all(&plain).unwrap();
+            enc.finish().unwrap();
+
+            assert_eq!(read_back(&format!("{filename}.gz"), npix), expected);
+        });
+    }
+
+    /// Opening a gzipped file end to end through the compress:// driver.
+    ///
+    /// gzip records the uncompressed size in its trailer, so mem_compress_open
+    /// sizes the memory file exactly and neither grows nor shrinks it; what
+    /// this pins is that a compressed file is recognised as one at all.
+    #[test]
+    fn test_gz_open_reads_back_through_the_compress_driver() {
+        roundtrip_gz(64);
+    }
+
+    /// bzip2 does not record the uncompressed size, so mem_compress_open
+    /// guesses 3x the compressed size and mem_compress_open trims the result.
+    ///
+    /// That trim is the regression test for the allocator mismatch: the buffer
+    /// comes from mem_createmem, i.e. a Vec, and the C shrank it with a bare
+    /// realloc().  It now goes through shrink_mem_buffer -> owned_realloc.
+    #[cfg(feature = "bzip2")]
+    #[test]
+    // mem_uncompress2mem hands the bzip2 reader a C `FILE *` built with
+    // `fdopen`, which miri cannot call.
+    #[cfg_attr(miri, ignore)]
+    fn test_bz2_open_shrinks_driver_owned_buffer() {
+        use libbz2_rs_sys::BZ2_bzBuffToBuffCompress;
+
+        with_temp_file(|filename| {
+            /* enough incompressible pixels that 3x the compressed size
+            overshoots the real file by well over the 256-byte slack, so
+            mem_compress_open takes its trim branch */
+            let npix = 2000;
+            let expected = write_fits_data(filename, npix, false);
+
+            let mut plain = std::fs::read(filename).unwrap();
+            let mut dest = vec![0u8; plain.len() * 2 + 1024];
+            let mut destlen = dest.len() as c_uint;
+            // SAFETY: both buffers are live and `destlen` is dest's length.
+            let rc = unsafe {
+                BZ2_bzBuffToBuffCompress(
+                    dest.as_mut_ptr().cast::<c_char>(),
+                    &raw mut destlen,
+                    plain.as_mut_ptr().cast::<c_char>(),
+                    plain.len() as c_uint,
+                    9,
+                    0,
+                    30,
+                )
+            };
+            assert_eq!(rc, 0, "bzip2 compression failed");
+            dest.truncate(destlen as usize);
+            std::fs::write(format!("{filename}.bz2"), &dest).unwrap();
+
+            let got = read_back(&format!("{filename}.bz2"), npix);
+            assert_eq!(got, expected);
+        });
     }
 }

--- a/src/edithdu.rs
+++ b/src/edithdu.rs
@@ -2498,18 +2498,17 @@ mod tests {
         });
     }
 
+    /// Copying between two fitsfile handles that share one FITSfile -- the same
+    /// file opened twice -- used to abort with `double free detected` and was
+    /// ignored for it.
+    ///
+    /// The second free came from `FITSfile::drop`'s guessed-length fallbacks:
+    /// once the registry entry had been consumed, the `else` branch rebuilt a
+    /// `Vec` from an assumed length and freed the block again. `free_registered`
+    /// has no such fallback -- an unregistered pointer is left alone -- and the
+    /// six tile* pointers, which `TILE_STRUCTS` owns, are no longer freed there
+    /// at all.
     #[test]
-    #[ignore = "REAL IMPL BUG: copying between two fitsfile handles that share the same \
-                underlying FITSfile (same file opened twice) double-frees an inner buffer \
-                (headstart/tableptr) during the copy. CFITSIO shares Fptr via a raw pointer \
-                with an open_count, but rsfitsio's reopen path wraps the same FITSfile in a \
-                second Box (cfileio.rs ~line 2064 `Box::from_raw(oldFptr)`); growing the \
-                shared header arrays during the copy then trips the global ALLOCATIONS \
-                registry on close, aborting with `double free detected`. A minimal repro \
-                (open same path twice + ffcopy_hdu + close both) reproduces it without any \
-                edithdu-specific code, so the defect lives in the core open/close/realloc \
-                lifecycle, not in edithdu. Fixing it safely requires reworking the \
-                shared-Fptr ownership model and is out of scope for this port."]
     fn test_copy_within_same_file() {
         // Test copying HDU data within the same file.
         // Open the file twice with different fitsfile pointers.

--- a/src/eval_defs.rs
+++ b/src/eval_defs.rs
@@ -8,7 +8,9 @@
 //! See [`crate::eval_f`] for how the three files fit together.
 #![warn(missing_docs)]
 
+use alloc::alloc::{alloc_zeroed, dealloc};
 use alloc::rc::Rc;
+use core::alloc::Layout;
 use core::ffi::c_void;
 
 use crate::c_types::{c_char, c_int, c_long};
@@ -89,6 +91,15 @@ pub(crate) struct DataInfo {
     pub naxes: [c_long; MAXDIMS as usize],
     pub undef: Option<Vec<c_char>>,
     pub data: *mut c_void,
+    /// `Bits` columns only: the row-pointer array `data` points at, and the
+    /// single character block those pointers index into.
+    ///
+    /// `Setup_DataArrays` malloc'd both and `ffcprs` freed them. They are owned
+    /// here instead, so they go when the `ParseData` does; `data` is still the
+    /// raw `*mut c_void` the nodes read, taken from `bit_rows`.
+    pub bit_rows: Vec<*mut c_char>,
+    /// The character block `bit_rows` indexes into. See [`DataInfo::bit_rows`].
+    pub bit_block: Vec<c_char>,
 }
 
 impl Default for DataInfo {
@@ -101,6 +112,8 @@ impl Default for DataInfo {
             naxes: [0; MAXDIMS as usize],
             undef: None,
             data: core::ptr::null_mut(),
+            bit_rows: Vec::new(),
+            bit_block: Vec::new(),
         }
     }
 }
@@ -113,6 +126,55 @@ pub(crate) enum BufferKind {
     Logical,
     /// An array of row pointers into one contiguous character block.
     Text,
+}
+
+impl BufferKind {
+    /// The alignment a buffer of this kind must have.
+    ///
+    /// `Allocate_Ptrs` sizes its blocks in bytes -- the numeric one packs the
+    /// data and the trailing `undef` flags into a single allocation -- so the
+    /// alignment cannot come from a `Layout::array::<T>` and has to be stated.
+    const fn align(self) -> usize {
+        match self {
+            BufferKind::Long => align_of::<c_long>(),
+            BufferKind::Double => align_of::<f64>(),
+            BufferKind::Logical => align_of::<c_char>(),
+            BufferKind::Text => align_of::<*mut c_char>(),
+        }
+    }
+}
+
+/// Allocate `bytes` zeroed bytes aligned for `kind`, returning the block and
+/// the [`Layout`] it must be released with.
+///
+/// This is the C's `malloc`/`calloc` for the expression engine's row buffers.
+/// It is `alloc_zeroed` rather than `libc::calloc` so the blocks come from
+/// whatever global allocator the program installed, and the layout travels with
+/// the pointer because Rust's `dealloc` needs it back -- C's `free` did not.
+///
+/// A zero-length request is rounded up to one byte, matching the C, where
+/// `malloc(0)` returns a non-null pointer that the callers treat as success.
+/// Returns `None` on allocation failure, which is the null the C checked for.
+pub(crate) fn alloc_row_bytes(kind: BufferKind, bytes: usize) -> Option<(*mut c_void, Layout)> {
+    let layout = Layout::from_size_align(bytes.max(1), kind.align()).ok()?;
+    // SAFETY: the layout has a non-zero size.
+    let p = unsafe { alloc_zeroed(layout) };
+    if p.is_null() {
+        None
+    } else {
+        Some((p.cast::<c_void>(), layout))
+    }
+}
+
+/// Release a block from [`alloc_row_bytes`].
+///
+/// # Safety
+/// `ptr` must have come from [`alloc_row_bytes`] with this exact `layout`, and
+/// must not be used again.
+pub(crate) unsafe fn free_row_bytes(ptr: *mut c_void, layout: Layout) {
+    if !ptr.is_null() {
+        unsafe { dealloc(ptr.cast::<u8>(), layout) };
+    }
 }
 
 /// The value carried by a [`Node`].
@@ -136,7 +198,13 @@ pub(crate) enum BufferKind {
 ///   *column* node at `varData[column].data` before each evaluation, and for a
 ///   String column that is the iterator's own array, laid out by `ffiter`. An
 ///   owning arm would need a borrowed one beside it, and the ownership question
-///   moves to `ffiter`. See `notes/EVAL_STRING_STORAGE.md`.
+///   moves to `ffiter`.
+///
+/// What the allocation *is* no longer depends on the C runtime: the block comes
+/// from [`alloc_row_bytes`], i.e. the global Rust allocator, and the variant
+/// carries the [`Layout`] to release it with. `Owned::None` is how a column
+/// node's borrowed view into `varData` is distinguished from a buffer the node
+/// must free, which the callers used to have to know out of band.
 ///
 /// The `Text` arm makes this 264 bytes where the others need 16. That is the
 /// union's own footprint, so it is not a regression.
@@ -157,6 +225,9 @@ pub(crate) enum NodeValue {
     Buffer {
         kind: BufferKind,
         ptr: *mut c_void,
+        /// How `ptr` (and, for `Text`, the character block behind it) is
+        /// released.
+        own: Owned,
     },
     /// A region, by index into [`ParseData::regions`].
     ///
@@ -175,7 +246,9 @@ impl core::fmt::Debug for NodeValue {
             NodeValue::Double(v) => write!(f, "Double({v})"),
             NodeValue::Logical(v) => write!(f, "Logical({v})"),
             NodeValue::Text(_) => write!(f, "Text(..)"),
-            NodeValue::Buffer { kind, ptr } => write!(f, "Buffer({kind:?}, {ptr:?})"),
+            NodeValue::Buffer { kind, ptr, own } => {
+                write!(f, "Buffer({kind:?}, {ptr:?}, {own:?})")
+            }
             NodeValue::Region(i) => write!(f, "Region({i})"),
         }
     }
@@ -238,7 +311,7 @@ impl NodeValue {
 
     fn buffer(&self, want: BufferKind) -> *mut c_void {
         match self {
-            NodeValue::Buffer { kind, ptr } if *kind == want => *ptr,
+            NodeValue::Buffer { kind, ptr, .. } if *kind == want => *ptr,
             /* an unallocated node reads as a null buffer, as the union did */
             NodeValue::Empty => core::ptr::null_mut(),
             other => wrong_arm(&format!("Buffer({want:?})"), other),
@@ -275,8 +348,50 @@ impl NodeValue {
         }
     }
 
-    pub(crate) fn set_buffer(&mut self, kind: BufferKind, ptr: *mut c_void) {
-        *self = NodeValue::Buffer { kind, ptr };
+    /// Point the node at a buffer somebody else owns.
+    ///
+    /// `Evaluate_Parser` uses this for column nodes, whose data lives in
+    /// `varData` (and, for a String column, in the iterator's own array).
+    /// Nothing is freed through such a node.
+    pub(crate) fn set_borrowed_buffer(&mut self, kind: BufferKind, ptr: *mut c_void) {
+        *self = NodeValue::Buffer {
+            kind,
+            ptr,
+            own: Owned::None,
+        };
+    }
+
+    /// Give the node a buffer from [`alloc_row_bytes`] to own.
+    pub(crate) fn set_owned_buffer(&mut self, kind: BufferKind, ptr: *mut c_void, layout: Layout) {
+        *self = NodeValue::Buffer {
+            kind,
+            ptr,
+            own: Owned::Block(layout),
+        };
+    }
+
+    /// Record the single character block a `Text` buffer's row pointers index
+    /// into, which `Allocate_Ptrs` stores at `ptr[0]`.
+    ///
+    /// # Panics
+    /// If the node does not hold an owned buffer.
+    pub(crate) fn set_text_block(&mut self, block: *mut c_char, block_layout: Layout) {
+        match self {
+            NodeValue::Buffer {
+                own: own @ Owned::Block(_),
+                ..
+            } => {
+                let Owned::Block(rows) = *own else {
+                    unreachable!()
+                };
+                *own = Owned::BlockAndText {
+                    rows,
+                    block,
+                    block_layout,
+                };
+            }
+            other => wrong_arm("an owned Buffer", other),
+        }
     }
 
     /// A pointer to the scalar payload, for the conversion helpers that take a
@@ -296,19 +411,52 @@ impl NodeValue {
         }
     }
 
-    /// Release a row buffer and mark the node empty.
+    /// Release whatever this node owns and mark it empty.
+    ///
+    /// A borrowed buffer (`Owned::None`) is left alone; that is what makes it
+    /// safe to call on a column node, which points into `varData`. For a
+    /// `Text` buffer both allocations go -- the character block first, then the
+    /// row-pointer array -- so callers no longer have to free the block by hand
+    /// before calling this.
     ///
     /// # Safety
-    /// The buffer must have come from `malloc`/`calloc` and must not be
-    /// referenced elsewhere.
+    /// Nothing else may still refer to the buffer.
     pub(crate) unsafe fn free_buffer(&mut self) {
-        if let NodeValue::Buffer { ptr, .. } = *self
-            && !ptr.is_null()
-        {
-            unsafe { libc::free(ptr) };
+        if let NodeValue::Buffer { ptr, own, .. } = *self {
+            match own {
+                Owned::None => {}
+                Owned::Block(layout) => unsafe { free_row_bytes(ptr, layout) },
+                Owned::BlockAndText {
+                    rows,
+                    block,
+                    block_layout,
+                } => unsafe {
+                    /* the row pointers all index one block, allocated at [0] */
+                    free_row_bytes(block.cast::<c_void>(), block_layout);
+                    free_row_bytes(ptr, rows);
+                },
+            }
         }
         *self = NodeValue::Empty;
     }
+}
+
+/// How a [`NodeValue::Buffer`]'s storage is released.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub(crate) enum Owned {
+    /// The node only borrows the block; something else frees it. This is a
+    /// column node pointing into `varData`.
+    #[default]
+    None,
+    /// The node owns one block, allocated with this layout.
+    Block(Layout),
+    /// A `Text` buffer: a row-pointer array with the `rows` layout, plus the
+    /// single character block at `ptr[0]` that every row pointer indexes into.
+    BlockAndText {
+        rows: Layout,
+        block: *mut c_char,
+        block_layout: Layout,
+    },
 }
 
 #[cold]

--- a/src/eval_f.rs
+++ b/src/eval_f.rs
@@ -72,7 +72,6 @@ use crate::wrappers::{strcat_safe, strcpy_safe, strlen_safe, strncpy_safe};
 use crate::{BL, NullCheckType, cs, fitsio::*, int_snprintf, raw_to_slice};
 use bytemuck::{cast_slice, cast_slice_mut};
 use core::ffi::CStr;
-use libc::{free, malloc};
 
 // Constants needed for the function
 const UCHAR_MAX: LONGLONG = 255;
@@ -90,21 +89,6 @@ pub(crate) struct ffffrw_workdata {
 static DEBUG_PIXFILTER: c_int = 0;
 
 // Free macro for raw pointers
-macro_rules! FREE {
-    ($x:expr) => {
-        if !$x.is_null() {
-            // Every current expansion sits inside an unsafe fn or block, but
-            // keep the block so the macro stays usable from safe code.
-            #[allow(unused_unsafe)]
-            unsafe {
-                libc::free($x.cast::<libc::c_void>());
-            }
-            $x = core::ptr::null_mut();
-        } else {
-            println!("invalid free at {}:{}", file!(), line!());
-        }
-    };
-}
 
 /// Evaluate a boolean expression using the indicated rows, returning an
 /// array of flags indicating which rows evaluated to TRUE/FALSE
@@ -2439,13 +2423,9 @@ pub(crate) fn ffcprs(lParse: &mut ParseData) {
                     Bits column has no undef array -- see "No need for UNDEF
                     array" in Setup_DataArrays -- so the skip fired every time
                     and the free below it was unreachable. */
-                    let mut data_ptr = lParse.varData[col as usize].data.cast::<*mut c_char>();
-                    if !data_ptr.is_null() {
-                        let mut first_ptr = *data_ptr;
-                        FREE!(first_ptr);
-                        FREE!(data_ptr);
-                        lParse.varData[col as usize].data = ptr::null_mut();
-                    }
+                    lParse.varData[col as usize].bit_rows = Vec::new();
+                    lParse.varData[col as usize].bit_block = Vec::new();
+                    lParse.varData[col as usize].data = ptr::null_mut();
                 }
 
                 lParse.varData[col as usize].undef = None;
@@ -3085,9 +3065,9 @@ pub(crate) fn fits_parser_workfn_safe(
                         }
                     }
                     if result.is_computed() {
-                        /* the row pointers all index one block, allocated at [0] */
-                        let mut block = *(result.value.data.str_buf());
-                        FREE!(block);
+                        /* free_buffer releases the character block at [0] as
+                        well as the row-pointer array, so the block no longer
+                        has to be freed by hand here */
                         result.value.data.free_buffer();
                     }
                 }
@@ -3130,9 +3110,9 @@ pub(crate) fn fits_parser_workfn_safe(
                         lParse.status = PARSE_BAD_TYPE;
                     }
                     if result.is_computed() {
-                        /* the row pointers all index one block, allocated at [0] */
-                        let mut block = *(result.value.data.str_buf());
-                        FREE!(block);
+                        /* free_buffer releases the character block at [0] as
+                        well as the row-pointer array, so the block no longer
+                        has to be freed by hand here */
                         result.value.data.free_buffer();
                     }
                 }
@@ -3270,7 +3250,6 @@ fn Setup_DataArrays(
         let mut row: c_long = 0;
         let mut idx: c_long = 0;
 
-        let mut bitStrs: *mut *mut c_char = core::ptr::null_mut();
         let mut sptr: *mut *mut c_char = core::ptr::null_mut();
         let mut barray: *mut c_char = core::ptr::null_mut();
         let mut iarray: *mut c_long = core::ptr::null_mut();
@@ -3304,33 +3283,28 @@ fn Setup_DataArrays(
                 ValueSort::Bits => {
                     /* No need for UNDEF array, but must make string DATA array */
                     len = (nelem + 1) * nRows; /* Count '\0' */
-                    bitStrs = varData.data.cast::<*mut c_char>();
+                    /* The C free()d and malloc()ed the row-pointer array and
+                    the character block on every resize.  DataInfo owns both as
+                    Vecs now, so they are resized in place and released with
+                    ParseData; `data` is still the raw pointer the nodes read,
+                    taken from the row-pointer Vec. */
                     if do_realloc != 0 {
-                        if !bitStrs.is_null() {
-                            FREE!(*bitStrs);
-                        }
-                        free(bitStrs.cast::<c_void>());
-                        bitStrs =
-                            malloc(nRows as usize * size_of::<*mut c_char>()).cast::<*mut c_char>();
-                        if bitStrs.is_null() {
+                        varData.bit_rows.clear();
+                        varData.bit_block.clear();
+                        if varData.bit_rows.try_reserve_exact(nRows as usize).is_err()
+                            || varData.bit_block.try_reserve_exact(len as usize).is_err()
+                        {
                             varData.undef = None;
                             varData.data = ptr::null_mut();
                             lParse.status = MEMORY_ALLOCATION;
                             break;
                         }
-                        *bitStrs = malloc(len as usize * size_of::<c_char>()).cast::<c_char>();
-                        if (*bitStrs).is_null() {
-                            free(bitStrs.cast::<c_void>());
-                            varData.undef = None;
-                            varData.data = ptr::null_mut();
-                            lParse.status = MEMORY_ALLOCATION;
-                            break;
-                        }
+                        varData.bit_rows.resize(nRows as usize, ptr::null_mut());
+                        varData.bit_block.resize(len as usize, 0);
                     }
 
                     for row in 0..nRows as usize {
-                        *bitStrs.add(row) =
-                            (*bitStrs.add(0)).add((row as c_long * (nelem + 1)) as usize);
+                        let base = row * (nelem + 1) as usize;
                         idx = (row as c_long) * ((nelem + 7) / 8) + 1;
 
                         for len in 0..nelem as usize {
@@ -3338,20 +3312,28 @@ fn Setup_DataArrays(
                                 & (1 << (7 - (len % 8))))
                                 != 0
                             {
-                                *(*bitStrs.add(row)).add(len) = b'1' as c_char;
+                                varData.bit_block[base + len] = b'1' as c_char;
                             } else {
-                                *(*bitStrs.add(row)).add(len) = b'0' as c_char;
+                                varData.bit_block[base + len] = b'0' as c_char;
                             }
                             if len % 8 == 7 {
                                 idx += 1;
                             }
                         }
-                        *(*bitStrs.add(row)).add(nelem as usize) = 0;
+                        varData.bit_block[base + nelem as usize] = 0;
+                    }
+
+                    /* The C built each row pointer inside the fill loop; they
+                    are taken here instead, after the block is written, so no
+                    `&mut` to the Vec is live while the pointers into it are. */
+                    let block = varData.bit_block.as_mut_ptr();
+                    for row in 0..nRows as usize {
+                        varData.bit_rows[row] = block.add(row * (nelem + 1) as usize);
                     }
 
                     // WARNING: THIS SHOULD NOT BE COMMENTED OUT, BUT IT CAUSES A
                     // varData.undef = bitStrs.cast::<c_char>();
-                    varData.data = bitStrs.cast::<c_void>();
+                    varData.data = varData.bit_rows.as_mut_ptr().cast::<c_void>();
                 }
 
                 ValueSort::String => {
@@ -3485,13 +3467,11 @@ fn Setup_DataArrays(
                     j -= 1;
                     let varData = &mut lParse.varData[j];
                     if varData.dtype == ValueSort::Bits {
-                        /* The array as well as the block; see ffcprs. */
-                        let mut data_ptr = varData.data.cast::<*mut c_char>();
-                        if !data_ptr.is_null() {
-                            FREE!(*data_ptr);
-                            FREE!(data_ptr);
-                            varData.data = ptr::null_mut();
-                        }
+                        /* Both blocks are Vecs on DataInfo; releasing them is
+                        dropping them.  See ffcprs. */
+                        varData.bit_rows = Vec::new();
+                        varData.bit_block = Vec::new();
+                        varData.data = ptr::null_mut();
                     }
                     varData.undef = None;
                 }

--- a/src/eval_y.rs
+++ b/src/eval_y.rs
@@ -19,7 +19,7 @@ use core::ffi::CStr;
 use core::{cmp, ptr};
 
 use bytemuck::{cast_slice, cast_slice_mut};
-use libc::{calloc, free, malloc, memcpy};
+use libc::memcpy;
 
 const APPROX: f64 = 1.0e-7;
 
@@ -85,7 +85,7 @@ use crate::c_types::{
 use crate::cfileio::{ffclos_safe, ffexts_safe, ffopen_safe};
 use crate::eval_defs::{
     BufferKind, CONST_OP, MAX_STRLEN, MAXDIMS, MAXSUBS, Node, NodeValue, ParseData, ValueSort,
-    lval, yyscan_t,
+    alloc_row_bytes, lval, yyscan_t,
 };
 use crate::eval_l::{fits_parser_yyGetVariable, fits_parser_yylex, yyguts_t};
 use crate::eval_tab::{FITS_PARSER_YYSTYPE, fits_parser_yytokentype};
@@ -8182,25 +8182,24 @@ fn New_GTI(
                 the starts, then the stops. The node's buffer is still a raw
                 allocation, so this is a copy out of the Vec rather than
                 giving it away. */
-                let gtibuf = malloc(
-                    ((2 as c_long * nrows) as c_ulong)
-                        .wrapping_mul(::core::mem::size_of::<c_double>() as c_ulong)
-                        .try_into()
-                        .unwrap(),
-                );
-                if gtibuf.is_null() {
+                let Some((gtibuf, gtilayout)) = alloc_row_bytes(
+                    BufferKind::Double,
+                    ((2 as c_long * nrows) as usize)
+                        .wrapping_mul(::core::mem::size_of::<c_double>()),
+                ) else {
                     lParse.status = MEMORY_ALLOCATION;
                     return -(1);
-                }
+                };
                 core::ptr::copy_nonoverlapping(
                     times.as_ptr(),
                     gtibuf.cast::<c_double>(),
                     times.len(),
                 );
-                (lParse.Nodes[that0_idx])
-                    .value
-                    .data
-                    .set_buffer(BufferKind::Double, gtibuf);
+                (lParse.Nodes[that0_idx]).value.data.set_owned_buffer(
+                    BufferKind::Double,
+                    gtibuf,
+                    gtilayout,
+                );
             }
 
             /* If Node1 is constant (gtifilt_fct) or
@@ -8800,26 +8799,30 @@ pub(crate) fn Evaluate_Parser(lParse: &mut ParseData, firstRow: c_long, nRows: c
 
                 match ((lParse.Nodes)[i as usize]).ntype {
                     ValueSort::Bits => {
-                        (((lParse.Nodes)[i as usize]).value).data.set_buffer(
-                            BufferKind::Text,
-                            ((lParse.varData)[column as usize])
-                                .data
-                                .cast::<*mut c_char>()
-                                .offset(rowOffset as isize)
-                                .cast(),
-                        );
+                        (((lParse.Nodes)[i as usize]).value)
+                            .data
+                            .set_borrowed_buffer(
+                                BufferKind::Text,
+                                ((lParse.varData)[column as usize])
+                                    .data
+                                    .cast::<*mut c_char>()
+                                    .offset(rowOffset as isize)
+                                    .cast(),
+                            );
                         let fresh13 = &mut (((lParse.Nodes)[i as usize]).value).undef;
                         *fresh13 = ptr::null_mut();
                     }
                     ValueSort::String => {
-                        (((lParse.Nodes)[i as usize]).value).data.set_buffer(
-                            BufferKind::Text,
-                            ((lParse.varData)[column as usize])
-                                .data
-                                .cast::<*mut c_char>()
-                                .offset(rowOffset as isize)
-                                .cast(),
-                        );
+                        (((lParse.Nodes)[i as usize]).value)
+                            .data
+                            .set_borrowed_buffer(
+                                BufferKind::Text,
+                                ((lParse.varData)[column as usize])
+                                    .data
+                                    .cast::<*mut c_char>()
+                                    .offset(rowOffset as isize)
+                                    .cast(),
+                            );
                         /* Vec::as_mut_ptr, as in the other arm: the node keeps
                         this pointer, so a reference to the contents would be a
                         child of this borrow of lParse and die with it. */
@@ -8836,29 +8839,37 @@ pub(crate) fn Evaluate_Parser(lParse: &mut ParseData, firstRow: c_long, nRows: c
                         (((lParse.Nodes)[i as usize]).value).undef = undef_ptr;
                     }
                     ValueSort::Boolean => {
-                        (((lParse.Nodes)[i as usize]).value).data.set_buffer(
-                            BufferKind::Logical,
-                            (((lParse.varData)[column as usize]).data.cast_const() as *mut c_char)
-                                .offset(offset as isize)
-                                .cast(),
-                        );
+                        (((lParse.Nodes)[i as usize]).value)
+                            .data
+                            .set_borrowed_buffer(
+                                BufferKind::Logical,
+                                (((lParse.varData)[column as usize]).data.cast_const()
+                                    as *mut c_char)
+                                    .offset(offset as isize)
+                                    .cast(),
+                            );
                     }
                     ValueSort::Long => {
-                        (((lParse.Nodes)[i as usize]).value).data.set_buffer(
-                            BufferKind::Long,
-                            (((lParse.varData)[column as usize]).data.cast_const() as *mut c_long)
-                                .offset(offset as isize)
-                                .cast(),
-                        );
+                        (((lParse.Nodes)[i as usize]).value)
+                            .data
+                            .set_borrowed_buffer(
+                                BufferKind::Long,
+                                (((lParse.varData)[column as usize]).data.cast_const()
+                                    as *mut c_long)
+                                    .offset(offset as isize)
+                                    .cast(),
+                            );
                     }
                     ValueSort::Double => {
-                        (((lParse.Nodes)[i as usize]).value).data.set_buffer(
-                            BufferKind::Double,
-                            (((lParse.varData)[column as usize]).data.cast_const()
-                                as *mut c_double)
-                                .offset(offset as isize)
-                                .cast(),
-                        );
+                        (((lParse.Nodes)[i as usize]).value)
+                            .data
+                            .set_borrowed_buffer(
+                                BufferKind::Double,
+                                (((lParse.varData)[column as usize]).data.cast_const()
+                                    as *mut c_double)
+                                    .offset(offset as isize)
+                                    .cast(),
+                            );
                     }
                 }
             }
@@ -8912,60 +8923,66 @@ fn Allocate_Ptrs(lParse: &mut ParseData, this_node_idx: usize) {
         if (lParse.Nodes[this_node_idx]).ntype == ValueSort::Bits
             || (lParse.Nodes[this_node_idx]).ntype == ValueSort::String
         {
-            (lParse.Nodes[this_node_idx]).value.data.set_buffer(
+            /* The C's two mallocs: the row-pointer array, then the single
+            character block every row points into.  Both now come from the Rust
+            allocator, and the node carries the layouts so free_node_buffer can
+            hand them back. */
+            let rows = alloc_row_bytes(
                 BufferKind::Text,
-                malloc(
-                    (lParse.nRows as c_ulong)
-                        .wrapping_mul(::core::mem::size_of::<*mut c_char>() as c_ulong)
-                        .try_into()
-                        .unwrap(),
-                ),
+                (lParse.nRows as usize).wrapping_mul(::core::mem::size_of::<*mut c_char>()),
             );
-            if !((lParse.Nodes[this_node_idx]).value.data.str_buf()).is_null() {
-                let fresh20 = &mut *((lParse.Nodes[this_node_idx]).value.data.str_buf()).offset(0);
-                *fresh20 = malloc(
-                    ((lParse.nRows * ((lParse.Nodes[this_node_idx]).value.nelem + 2 as c_long))
-                        as c_ulong)
-                        .wrapping_mul(::core::mem::size_of::<c_char>() as c_ulong)
-                        .try_into()
-                        .unwrap(),
-                )
-                .cast::<c_char>();
-                if !(*((lParse.Nodes[this_node_idx]).value.data.str_buf()).offset(0)).is_null() {
-                    row = 0;
-                    loop {
-                        row += 1;
-                        if row >= lParse.nRows {
-                            break;
-                        }
-                        let fresh21 = &mut *((lParse.Nodes[this_node_idx]).value.data.str_buf())
-                            .offset(row as isize);
-                        *fresh21 = (*((lParse.Nodes[this_node_idx]).value.data.str_buf())
-                            .offset((row - 1) as isize))
-                        .offset((lParse.Nodes[this_node_idx]).value.nelem as isize)
-                        .offset(1);
-                    }
-                    if (lParse.Nodes[this_node_idx]).ntype == ValueSort::String {
-                        (lParse.Nodes[this_node_idx]).value.undef =
-                            (*((lParse.Nodes[this_node_idx]).value.data.str_buf())
-                                .offset((row - 1) as isize))
-                            .offset((lParse.Nodes[this_node_idx]).value.nelem as isize)
-                            .offset(1);
-                    } else {
-                        (lParse.Nodes[this_node_idx]).value.undef = ptr::null_mut(); /* BITSTRs don't use undef array */
-                    }
-                } else {
-                    lParse.status = MEMORY_ALLOCATION;
-                    free(
-                        (lParse.Nodes[this_node_idx])
-                            .value
-                            .data
-                            .str_buf()
-                            .cast::<c_void>(),
-                    );
-                }
-            } else {
+            let Some((rows_ptr, rows_layout)) = rows else {
                 lParse.status = MEMORY_ALLOCATION;
+                return;
+            };
+            (lParse.Nodes[this_node_idx]).value.data.set_owned_buffer(
+                BufferKind::Text,
+                rows_ptr,
+                rows_layout,
+            );
+
+            let block = alloc_row_bytes(
+                /* a character block, so byte alignment */
+                BufferKind::Logical,
+                ((lParse.nRows * ((lParse.Nodes[this_node_idx]).value.nelem + 2 as c_long))
+                    as usize)
+                    .wrapping_mul(::core::mem::size_of::<c_char>()),
+            );
+            let Some((block_ptr, block_layout)) = block else {
+                lParse.status = MEMORY_ALLOCATION;
+                (lParse.Nodes[this_node_idx]).value.data.free_buffer();
+                return;
+            };
+            let block_ptr = block_ptr.cast::<c_char>();
+            (lParse.Nodes[this_node_idx])
+                .value
+                .data
+                .set_text_block(block_ptr, block_layout);
+
+            let fresh20 = &mut *((lParse.Nodes[this_node_idx]).value.data.str_buf()).offset(0);
+            *fresh20 = block_ptr;
+
+            row = 0;
+            loop {
+                row += 1;
+                if row >= lParse.nRows {
+                    break;
+                }
+                let fresh21 =
+                    &mut *((lParse.Nodes[this_node_idx]).value.data.str_buf()).offset(row as isize);
+                *fresh21 = (*((lParse.Nodes[this_node_idx]).value.data.str_buf())
+                    .offset((row - 1) as isize))
+                .offset((lParse.Nodes[this_node_idx]).value.nelem as isize)
+                .offset(1);
+            }
+            if (lParse.Nodes[this_node_idx]).ntype == ValueSort::String {
+                (lParse.Nodes[this_node_idx]).value.undef =
+                    (*((lParse.Nodes[this_node_idx]).value.data.str_buf())
+                        .offset((row - 1) as isize))
+                    .offset((lParse.Nodes[this_node_idx]).value.nelem as isize)
+                    .offset(1);
+            } else {
+                (lParse.Nodes[this_node_idx]).value.undef = ptr::null_mut(); /* BITSTRs don't use undef array */
             }
         } else {
             elem = (lParse.Nodes[this_node_idx]).value.nelem * lParse.nRows;
@@ -8990,22 +9007,22 @@ fn Allocate_Ptrs(lParse: &mut ParseData, this_node_idx: usize) {
                     kind = BufferKind::Logical;
                 }
             }
-            (lParse.Nodes[this_node_idx]).value.data.set_buffer(
-                kind,
-                calloc(
-                    ((size + 1) as c_ulong).try_into().unwrap(),
-                    (elem as c_ulong).try_into().unwrap(),
-                ),
-            );
-            if ((lParse.Nodes[this_node_idx]).value.data.raw()).is_null() {
-                lParse.status = MEMORY_ALLOCATION;
-            } else {
-                (lParse.Nodes[this_node_idx]).value.undef = (lParse.Nodes[this_node_idx])
-                    .value
-                    .data
-                    .raw()
-                    .cast::<c_char>()
-                    .offset((elem * size) as isize);
+            /* the C's calloc(size + 1, elem): `elem` values of `size` bytes,
+            with the `elem`-byte undef array packed on the end */
+            match alloc_row_bytes(kind, ((size + 1) as usize) * (elem as usize)) {
+                None => {
+                    lParse.status = MEMORY_ALLOCATION;
+                    /* leave the node empty, so `raw()` still reads as null */
+                    (lParse.Nodes[this_node_idx]).value.data = NodeValue::Empty;
+                }
+                Some((p, layout)) => {
+                    (lParse.Nodes[this_node_idx])
+                        .value
+                        .data
+                        .set_owned_buffer(kind, p, layout);
+                    (lParse.Nodes[this_node_idx]).value.undef =
+                        p.cast::<c_char>().offset((elem * size) as isize);
+                }
             }
         };
     }
@@ -9019,17 +9036,11 @@ pub(crate) unsafe fn free_node_buffer(node: &mut Node) {
         if !matches!(node.value.data, NodeValue::Buffer { .. }) {
             return;
         }
-        if node.ntype == ValueSort::Bits || node.ntype == ValueSort::String {
-            if !node.value.data.str_buf().is_null() {
-                /* the row pointers all point into one block, allocated at [0] */
-                if !(*node.value.data.str_buf()).is_null() {
-                    free((*node.value.data.str_buf()).cast::<c_void>());
-                }
-                node.value.data.free_buffer();
-            }
-        } else {
-            node.value.data.free_buffer();
-        }
+        /* The Bits/String special case is gone: the node records both of
+        Allocate_Ptrs' allocations, so free_buffer releases the character block
+        as well as the row-pointer array, and does nothing at all for a column
+        node that only borrows varData's. */
+        node.value.data.free_buffer();
 
         node.value.undef = ptr::null_mut();
     }
@@ -14386,13 +14397,14 @@ fn Do_Func(lParse: &mut ParseData, this_node_idx: usize) {
     }
 }
 
-/* NOTE: the error paths below release the result node with free_node_buffer,
-not value.data.free_buffer().  For a Bits or String node Allocate_Ptrs makes
-two allocations -- the row-pointer array in `data`, and the single block every
-row points into, at data[0] -- and free_buffer releases only the array.  It
-also leaves the value Empty, so the teardown in ffcprs then skipped the node
-and the block at data[0] leaked.  BITS[9] is the smallest case: an out-of-range
-index on an 8X column. */
+/* NOTE: the error paths below release the result node with free_node_buffer.
+For a Bits or String node Allocate_Ptrs makes two allocations -- the row-pointer
+array in `data`, and the single block every row points into, at data[0] -- and
+free_buffer used to release only the array, leaving the value Empty so that the
+teardown in ffcprs skipped the node and the block at data[0] leaked.  BITS[9] is
+the smallest case: an out-of-range index on an 8X column.  The node now records
+both allocations, so free_buffer releases both and either call is correct;
+free_node_buffer stays because it also clears `undef`. */
 fn Do_Deref(lParse: &mut ParseData, this_node_idx: usize) {
     unsafe {
         let mut theVar: &mut Node;
@@ -14787,8 +14799,8 @@ fn Do_Deref(lParse: &mut ParseData, this_node_idx: usize) {
             }
         }
         if (lParse.Nodes[theVar]).is_computed() {
-            /* free_node_buffer covers both shapes; the String/Bits arm here
-            used to free only the backing block and leak the pointer array. */
+            /* free_node_buffer covers both shapes: the node records the
+            row-pointer array and the block behind it, so neither leaks. */
             free_node_buffer(&mut (lParse.Nodes[theVar]));
         }
         i = 0;

--- a/src/fitscore.rs
+++ b/src/fitscore.rs
@@ -48,11 +48,12 @@ use core::ffi::CStr;
 use core::num::{ParseFloatError, ParseIntError};
 use core::{cmp, ptr};
 use core::{slice, str};
-use std::collections::HashMap;
 use std::sync::{LazyLock, Mutex};
 
 use crate::c_types::{c_char, c_int, c_long, c_short, c_uint, c_ulong, c_ushort, off_t};
-use crate::helpers::vec_raw_parts::vec_into_raw_parts;
+use crate::helpers::raw_owned::{
+    free_registered, into_raw_registered, reregister, take_registered,
+};
 use crate::wrappers::strcpy_safe;
 
 use bytemuck::{cast_slice, cast_slice_mut};
@@ -95,10 +96,6 @@ pub const GET_MESG: c_int = 4;
 pub const PUT_MESG: c_int = 5;
 /// `ffxmsg` action: add a marker to the stack.
 pub const PUT_MARK: c_int = 6;
-
-// Use this to keep track of allocations so we can deallocate with the same `Layout` used for allocation.
-pub(crate) static ALLOCATIONS: LazyLock<Mutex<HashMap<usize, (usize, usize)>>> =
-    LazyLock::new(Default::default);
 
 static ERROR_STACK: LazyLock<Mutex<ErrorStack>> = LazyLock::new(|| Mutex::new(ErrorStack::new()));
 
@@ -6451,18 +6448,7 @@ pub(crate) fn ffpinit(fptr: &mut fitsfile, status: &mut c_int) -> c_int {
                 /* free memory for the old CHDU */
 
                 // HEAP DEALLOCATION
-                let mut alloc_lock = ALLOCATIONS.lock().unwrap();
-                let alloc = alloc_lock.remove(&(fptr.Fptr.tableptr as usize));
-                if let Some((l, c)) = alloc {
-                    // HEAP DEALLOCATION
-                    let _ = Vec::from_raw_parts(fptr.Fptr.tableptr, l, c);
-                } else {
-                    let _ = Vec::from_raw_parts(
-                        fptr.Fptr.tableptr,
-                        fptr.Fptr.tfield as usize,
-                        fptr.Fptr.tfield as usize,
-                    );
-                }
+                free_registered(fptr.Fptr.tableptr);
             }
 
             fptr.Fptr.tableptr = ptr::null_mut(); /* set a null table structure pointer */
@@ -6501,18 +6487,7 @@ pub(crate) fn ffpinit(fptr: &mut fitsfile, status: &mut c_int) -> c_int {
             if !fptr.Fptr.tableptr.is_null() {
                 /* free memory for the old CHDU */
                 // HEAP DEALLOCATION
-                let mut alloc_lock = ALLOCATIONS.lock().unwrap();
-                let alloc = alloc_lock.remove(&(fptr.Fptr.tableptr as usize));
-                if let Some((l, c)) = alloc {
-                    // HEAP DEALLOCATION
-                    let _ = Vec::from_raw_parts(fptr.Fptr.tableptr, l, c);
-                } else {
-                    let _ = Vec::from_raw_parts(
-                        fptr.Fptr.tableptr,
-                        fptr.Fptr.tfield as usize,
-                        fptr.Fptr.tfield as usize,
-                    );
-                }
+                free_registered(fptr.Fptr.tableptr);
             }
 
             // HEAP ALLOCATION
@@ -6546,9 +6521,7 @@ pub(crate) fn ffpinit(fptr: &mut fitsfile, status: &mut c_int) -> c_int {
 
             /* copy the table structure address to the fitsfile structure */
 
-            let (p, l, c) = vec_into_raw_parts(colptr);
-            ALLOCATIONS.lock().unwrap().insert(p as usize, (l, c));
-            fptr.Fptr.tableptr = p;
+            fptr.Fptr.tableptr = into_raw_registered(colptr);
         }
 
         let headstart = fptr.Fptr.get_headstart_as_slice();
@@ -6633,18 +6606,7 @@ pub(crate) fn ffainit(fptr: &mut fitsfile, status: &mut c_int) -> c_int {
         if !fptr.Fptr.tableptr.is_null() {
             /* free memory for the old CHDU */
             // HEAP DEALLOCATION
-            let mut alloc_lock = ALLOCATIONS.lock().unwrap();
-            let alloc = alloc_lock.remove(&(fptr.Fptr.tableptr as usize));
-            if let Some((l, c)) = alloc {
-                // HEAP DEALLOCATION
-                let _ = Vec::from_raw_parts(fptr.Fptr.tableptr, l, c);
-            } else {
-                let _ = Vec::from_raw_parts(
-                    fptr.Fptr.tableptr,
-                    fptr.Fptr.tfield as usize,
-                    fptr.Fptr.tfield as usize,
-                );
-            }
+            free_registered(fptr.Fptr.tableptr);
         }
         /* mem for column structures ; space is initialized = 0 */
         if tfield > 0 {
@@ -6658,9 +6620,7 @@ pub(crate) fn ffainit(fptr: &mut fitsfile, status: &mut c_int) -> c_int {
                 tmp.resize(tfield as usize, tcolumn::default());
             }
 
-            let (p, l, c) = vec_into_raw_parts(tmp);
-            ALLOCATIONS.lock().unwrap().insert(p as usize, (l, c));
-            colptr = p;
+            colptr = into_raw_registered(tmp);
         }
 
         /* copy the table structure address to the fitsfile structure */
@@ -6896,18 +6856,7 @@ pub(crate) fn ffbinit(fptr: &mut fitsfile, status: &mut c_int) -> c_int {
         if !fptr.Fptr.tableptr.is_null() {
             /* free memory for the old CHDU */
             // HEAP DEALLOCATION
-            let mut alloc_lock = ALLOCATIONS.lock().unwrap();
-            let alloc = alloc_lock.remove(&(fptr.Fptr.tableptr as usize));
-            if let Some((l, c)) = alloc {
-                // HEAP DEALLOCATION
-                let _ = Vec::from_raw_parts(fptr.Fptr.tableptr, l, c);
-            } else {
-                let _ = Vec::from_raw_parts(
-                    fptr.Fptr.tableptr,
-                    fptr.Fptr.tfield as usize,
-                    fptr.Fptr.tfield as usize,
-                );
-            }
+            free_registered(fptr.Fptr.tableptr);
         }
 
         /* mem for column structures ; space is initialized = 0  */
@@ -6922,9 +6871,7 @@ pub(crate) fn ffbinit(fptr: &mut fitsfile, status: &mut c_int) -> c_int {
                 tmp.resize(tfield as usize, tcolumn::default());
             }
 
-            let (p, l, c) = vec_into_raw_parts(tmp);
-            ALLOCATIONS.lock().unwrap().insert(p as usize, (l, c));
-            colptr = p;
+            colptr = into_raw_registered(tmp);
         }
 
         /* copy the table structure address to the fitsfile structure */
@@ -9280,20 +9227,7 @@ pub(crate) fn ffchdu(fptr: &mut fitsfile, status: &mut c_int) -> c_int {
         /* free memory for the CHDU structure only if no other files are using it */
         if !fptr.Fptr.tableptr.is_null() {
             // HEAP DEALLOCATION
-            let mut alloc_lock = ALLOCATIONS.lock().unwrap();
-            let alloc = alloc_lock.remove(&(fptr.Fptr.tableptr as usize));
-            if let Some((l, c)) = alloc {
-                // HEAP DEALLOCATION
-                let _ = unsafe { Vec::from_raw_parts(fptr.Fptr.tableptr, l, c) };
-            } else {
-                let _ = unsafe {
-                    Vec::from_raw_parts(
-                        fptr.Fptr.tableptr,
-                        fptr.Fptr.tfield as usize,
-                        fptr.Fptr.tfield as usize,
-                    )
-                };
-            }
+            unsafe { free_registered(fptr.Fptr.tableptr) };
 
             fptr.Fptr.tableptr = ptr::null_mut();
 
@@ -9988,16 +9922,17 @@ pub fn ffcdfl_safe(fptr: &mut fitsfile, status: &mut c_int) -> c_int {
 /// not be dropped here, otherwise `fptr.Fptr.headstart` would be left dangling
 /// and freed a second time by `FITSfile::drop`.
 ///
-/// The array is always kept fully initialized with `MAXHDU + 1` elements
-/// (length == capacity), which is the invariant `get_headstart_as_slice` and
-/// the `ALLOCATIONS` bookkeeping rely on.
+/// The array is always kept fully initialized with `MAXHDU + 1` elements, which
+/// is the invariant `get_headstart_as_slice` relies on; the recorded length in
+/// [`crate::helpers::raw_owned`] is what `FITSfile::drop` releases it against.
 fn grow_headstart(fptr: &mut fitsfile) -> Result<(), c_int> {
     let old_ptr = fptr.Fptr.headstart;
     let l = fptr.Fptr.MAXHDU as usize + 1;
 
-    // SAFETY: headstart was registered in ALLOCATIONS as a Vec<LONGLONG> of
-    // exactly `l` elements, with length == capacity, and is not aliased here.
-    let mut vo = unsafe { Vec::from_raw_parts(old_ptr, l, l) };
+    // SAFETY: headstart was registered as a Vec<LONGLONG> of exactly `l`
+    // elements, with length == capacity, and is not aliased here.
+    let mut vo =
+        unsafe { take_registered(old_ptr) }.expect("headstart was registered by FITSfile::new");
 
     let res = vo.try_reserve_exact(1000);
     if res.is_ok() {
@@ -10009,12 +9944,7 @@ fn grow_headstart(fptr: &mut fitsfile) -> Result<(), c_int> {
     // Hand the allocation back to `fptr` before reporting anything: on the
     // error path the pointer is unchanged, on the success path it may have
     // moved.  Either way `fptr` must own it again.
-    let (p, len, cap) = vec_into_raw_parts(vo);
-    let mut allocations = ALLOCATIONS.lock().unwrap();
-    allocations.remove(&(old_ptr as usize));
-    allocations.insert(p as usize, (len, cap));
-    drop(allocations);
-    fptr.Fptr.headstart = p;
+    fptr.Fptr.headstart = reregister(old_ptr, vo);
 
     if res.is_err() {
         return Err(MEMORY_ALLOCATION);

--- a/src/fitsio.rs
+++ b/src/fitsio.rs
@@ -13,7 +13,10 @@
 
 use crate::{
     c_types::c_ulonglong,
-    helpers::{boxed::box_try_new, vec_raw_parts::vec_into_raw_parts},
+    helpers::{
+        boxed::box_try_new,
+        raw_owned::{free_registered, into_raw_registered, registered_len},
+    },
 };
 use bytemuck::{cast_slice, cast_slice_mut};
 use core::{
@@ -24,11 +27,7 @@ use core::{
 };
 use std::os::raw::c_void;
 
-use crate::{
-    fitscore::{ALLOCATIONS, ffpmsg_slice},
-    int_snprintf, slice_to_str,
-    wrappers::strlen_safe,
-};
+use crate::{fitscore::ffpmsg_slice, int_snprintf, slice_to_str, wrappers::strlen_safe};
 
 use crate::cfileio::fitsdriver;
 
@@ -1084,17 +1083,8 @@ impl FITSfile {
         let f_iobuffer: Box<[c_char; NIOBUF as usize * IOBUFLEN as usize]> =
             f_iobuffer.into_boxed_slice().try_into().unwrap();
 
-        let (f_headstart, l, c) = vec_into_raw_parts(f_headstart);
-        ALLOCATIONS
-            .lock()
-            .unwrap()
-            .insert(f_headstart as usize, (l, c));
-
-        let (f_filename, l, c) = vec_into_raw_parts(f_filename);
-        ALLOCATIONS
-            .lock()
-            .unwrap()
-            .insert(f_filename as usize, (l, c));
+        let f_headstart = into_raw_registered(f_headstart);
+        let f_filename = into_raw_registered(f_filename);
 
         // HEAP ALLOCATION
         /* allocate FITSfile structure and initialize = 0 */
@@ -1284,16 +1274,15 @@ impl FITSfile {
     /// The heap-allocated filename buffer as a writable slice, so callers can
     /// use `strcpy_safe` instead of a raw `strcpy` into `self.filename`.
     ///
-    /// The allocation's length is the one recorded in `ALLOCATIONS` when
-    /// `FITSfile::new` reserved it -- the same entry `Drop` frees against. 32
-    /// is the minimum `new` reserves, and the size `Drop` falls back to when
-    /// the entry is missing.
+    /// The allocation's length is the one recorded when `FITSfile::new`
+    /// reserved it -- the same entry `Drop` frees against.
+    ///
+    /// # Panics
+    /// If `filename` was not handed out by `FITSfile::new`. Guessing a length
+    /// here would hand `strcpy_safe` a slice longer than the allocation.
     pub(crate) fn get_filename_as_mut_slice(&mut self) -> &mut [c_char] {
-        let len = ALLOCATIONS
-            .lock()
-            .unwrap()
-            .get(&(self.filename as usize))
-            .map_or(32, |&(l, _)| l);
+        let len = registered_len(self.filename.cast_const())
+            .expect("filename was registered by FITSfile::new");
 
         // SAFETY: filename points at a `len`-element allocation owned by self.
         unsafe { core::slice::from_raw_parts_mut(self.filename, len) }
@@ -1302,138 +1291,22 @@ impl FITSfile {
 
 impl Drop for FITSfile {
     fn drop(&mut self) {
+        // HEAP DEALLOCATION
+        //
+        // Only three of these pointers are ours. `filename`, `headstart` and
+        // `tableptr` were handed out by `into_raw_registered`, so the registry
+        // knows the layout to release them against.
+        //
+        // The six tile* pointers are *not*: `imcomp_decompress_tile` points
+        // them at the Vecs inside a `TileStruct` that `TILE_STRUCTS` owns
+        // (src/imcompress.rs), and that entry frees them. This used to free
+        // them here too, on a `get_tile_alloc_len()` guess, which only escaped
+        // being a double free because every path that drops the TILE_STRUCTS
+        // entry also nulls the fields first.
         unsafe {
-            if !self.filename.is_null() {
-                // HEAP DEALLOCATION
-                let mut alloc_lock = ALLOCATIONS.lock().unwrap();
-                let alloc = alloc_lock.remove(&(self.filename as usize));
-                if let Some((l, c)) = alloc {
-                    // HEAP DEALLOCATION
-                    let _ = Vec::from_raw_parts(self.filename, l, c);
-                } else {
-                    let _ = Vec::from_raw_parts(self.filename, 32, 32);
-                }
-            }
-
-            if !self.headstart.is_null() {
-                let mut alloc_lock = ALLOCATIONS.lock().unwrap();
-                let alloc = alloc_lock.remove(&(self.headstart as usize));
-                if let Some((l, c)) = alloc {
-                    // HEAP DEALLOCATION
-                    let _ = Vec::from_raw_parts(self.headstart, l, c);
-                } else {
-                    let _ = Vec::from_raw_parts(
-                        self.headstart,
-                        (self.MAXHDU as usize) + 1,
-                        (self.MAXHDU as usize) + 1,
-                    );
-                }
-            }
-
-            if !self.tableptr.is_null() {
-                let mut alloc_lock = ALLOCATIONS.lock().unwrap();
-                let alloc = alloc_lock.remove(&(self.tableptr as usize));
-                if let Some((l, c)) = alloc {
-                    // HEAP DEALLOCATION
-                    let _ = Vec::from_raw_parts(self.tableptr, l, c);
-                } else {
-                    let _ = Vec::from_raw_parts(
-                        self.tableptr,
-                        self.tfield as usize,
-                        self.tfield as usize,
-                    );
-                }
-            }
-
-            if !self.tilerow.is_null() {
-                let mut alloc_lock = ALLOCATIONS.lock().unwrap();
-                let alloc = alloc_lock.remove(&(self.tilerow as usize));
-                if let Some((l, c)) = alloc {
-                    // HEAP DEALLOCATION
-                    let _ = Vec::from_raw_parts(self.tilerow, l, c);
-                } else {
-                    let _ = Vec::from_raw_parts(
-                        self.tilerow,
-                        self.get_tile_alloc_len(),
-                        self.get_tile_alloc_len(),
-                    );
-                }
-            }
-
-            if !self.tiledatasize.is_null() {
-                let mut alloc_lock = ALLOCATIONS.lock().unwrap();
-                let alloc = alloc_lock.remove(&(self.tiledatasize as usize));
-                if let Some((l, c)) = alloc {
-                    // HEAP DEALLOCATION
-                    let _ = Vec::from_raw_parts(self.tiledatasize, l, c);
-                } else {
-                    let _ = Vec::from_raw_parts(
-                        self.tiledatasize,
-                        self.get_tile_alloc_len(),
-                        self.get_tile_alloc_len(),
-                    );
-                }
-            }
-
-            if !self.tiletype.is_null() {
-                let mut alloc_lock = ALLOCATIONS.lock().unwrap();
-                let alloc = alloc_lock.remove(&(self.tiletype as usize));
-                if let Some((l, c)) = alloc {
-                    // HEAP DEALLOCATION
-                    let _ = Vec::from_raw_parts(self.tiletype, l, c);
-                } else {
-                    let _ = Vec::from_raw_parts(
-                        self.tiletype,
-                        self.get_tile_alloc_len(),
-                        self.get_tile_alloc_len(),
-                    );
-                }
-            }
-
-            if !self.tiledata.is_null() {
-                let mut alloc_lock = ALLOCATIONS.lock().unwrap();
-                let alloc = alloc_lock.remove(&(self.tiledata as usize));
-                if let Some((l, c)) = alloc {
-                    // HEAP DEALLOCATION
-                    let _ = Vec::from_raw_parts(self.tiledata, l, c);
-                } else {
-                    let _ = Vec::from_raw_parts(
-                        self.tiledata,
-                        self.get_tile_alloc_len(),
-                        self.get_tile_alloc_len(),
-                    );
-                }
-            }
-
-            if !self.tilenullarray.is_null() {
-                let mut alloc_lock = ALLOCATIONS.lock().unwrap();
-                let alloc = alloc_lock.remove(&(self.tilenullarray as usize));
-                if let Some((l, c)) = alloc {
-                    // HEAP DEALLOCATION
-                    let _ = Vec::from_raw_parts(self.tilenullarray, l, c);
-                } else {
-                    let _ = Vec::from_raw_parts(
-                        self.tilenullarray,
-                        self.get_tile_alloc_len(),
-                        self.get_tile_alloc_len(),
-                    );
-                }
-            }
-
-            if !self.tileanynull.is_null() {
-                let mut alloc_lock = ALLOCATIONS.lock().unwrap();
-                let alloc = alloc_lock.remove(&(self.tileanynull as usize));
-                if let Some((l, c)) = alloc {
-                    // HEAP DEALLOCATION
-                    let _ = Vec::from_raw_parts(self.tileanynull, l, c);
-                } else {
-                    let _ = Vec::from_raw_parts(
-                        self.tileanynull,
-                        self.get_tile_alloc_len(),
-                        self.get_tile_alloc_len(),
-                    );
-                }
-            }
+            free_registered(self.filename);
+            free_registered(self.headstart);
+            free_registered(self.tableptr);
         }
     }
 }

--- a/src/getkey.rs
+++ b/src/getkey.rs
@@ -21,8 +21,7 @@ use core::slice;
 use core::{cmp, ptr};
 
 use crate::c_types::{c_char, c_int, c_long, c_short, c_uint, c_ulong, c_ushort, c_void};
-use crate::fitscore::ALLOCATIONS;
-use crate::helpers::vec_raw_parts::vec_into_raw_parts;
+use crate::helpers::raw_owned::{free_registered, into_raw_registered};
 use crate::imcompress::fits_img_decompress_header_safe;
 
 use bytemuck::{cast_slice, cast_slice_mut};
@@ -1655,9 +1654,7 @@ pub fn ffgkls_safe(
         let mut v: Vec<c_char> = vec![0; 1];
         v[0] = 0;
 
-        let (p, l, c) = vec_into_raw_parts(v);
-        ALLOCATIONS.lock().unwrap().insert(p as usize, (l, c));
-        *value = p;
+        *value = into_raw_registered(v);
     } else {
         /* allocate space,  plus 1 for null */
         // HEAP ALLOCATION
@@ -1716,9 +1713,7 @@ pub fn ffgkls_safe(
             }
         }
 
-        let (p, l, c) = vec_into_raw_parts(v);
-        ALLOCATIONS.lock().unwrap().insert(p as usize, (l, c));
-        *value = p;
+        *value = into_raw_registered(v);
     }
     *status
 }
@@ -2258,17 +2253,14 @@ pub unsafe fn fffree_safe(value: *mut c_void, status: &mut c_int) -> c_int {
         return *status;
     }
 
-    if !value.is_null() {
-        // HEAP DEALLOCATION
-        let mut alloc_lock = ALLOCATIONS.lock().unwrap();
-        let alloc = alloc_lock.remove(&(value as usize));
-        if let Some((l, c)) = alloc {
-            // HEAP DEALLOCATION
-            let _ = unsafe { Vec::from_raw_parts(value, l, c) };
-        } else {
-            let _ = unsafe { Vec::from_raw_parts(value, 1, 1) };
-        }
-    }
+    // HEAP DEALLOCATION
+    //
+    // Every block this routine is documented to release -- ffgkls, fits_hdr2str,
+    // fits_convert_hdr2str, ffimport_file -- is a `Vec<c_char>`, so that is the
+    // element type the registry is asked for. A pointer registered as anything
+    // else, or never registered at all, is left alone rather than freed on a
+    // guessed layout; the C's `free()` had no such distinction to make.
+    unsafe { free_registered(value.cast::<c_char>()) };
     *status
 }
 
@@ -6728,13 +6720,7 @@ pub fn ffh2st_safe(fptr: &mut fitsfile, header: &mut *mut c_char, status: &mut c
     ); /* copy header */
     hdr[(nrec as LONGLONG * IOBUFLEN) as usize] = 0;
 
-    let (header_ptr, l, c) = vec_into_raw_parts(hdr);
-    ALLOCATIONS
-        .lock()
-        .unwrap()
-        .insert(header_ptr as usize, (l, c));
-
-    *header = header_ptr;
+    *header = into_raw_registered(hdr);
 
     *status
 }
@@ -6903,13 +6889,7 @@ pub fn ffhdr2str_safe(
     hdr.resize(((*nkeys * 80) + 1) as usize, 0);
     hdr.shrink_to_fit();
 
-    let (header_ptr, l, c) = vec_into_raw_parts(hdr);
-    ALLOCATIONS
-        .lock()
-        .unwrap()
-        .insert(header_ptr as usize, (l, c));
-
-    *header = header_ptr;
+    *header = into_raw_registered(hdr);
 
     *status
 }

--- a/src/group.rs
+++ b/src/group.rs
@@ -29,6 +29,7 @@ use alloc::collections::VecDeque;
 
 use crate::aliases::rust_api::*;
 use crate::c_types::{c_char, c_int, c_long, c_uchar};
+use crate::helpers::raw_owned::free_registered;
 use bytemuck::{cast_slice, cast_slice_mut};
 
 use core::ffi::CStr;
@@ -1581,9 +1582,9 @@ pub fn ffgtop_safe(
 
             int_snprintf!(&mut keyword, FLEN_KEYWORD, "GRPLC{}", grpid);
             /* SPR 1738 */
-            // SAFETY: ffgkls_safe sets tkeyvalue to a heap-allocated C string tracked in
-            // the ALLOCATIONS table (it is not yet ported to an owned String); copy it out
-            // and release it through the same mechanism.
+            // SAFETY: ffgkls_safe sets tkeyvalue to a heap-allocated C string
+            // tracked by helpers::raw_owned (it is not yet ported to an owned
+            // String); copy it out and release it the same way.
             let mut tkeyvalue: *mut c_char = core::ptr::null_mut();
             *status =
                 fits_read_key_longstr(mfptr, &keyword, &mut tkeyvalue, Some(&mut comment), status);
@@ -1593,10 +1594,7 @@ pub fn ffgtop_safe(
                         cast_slice::<u8, c_char>(CStr::from_ptr(tkeyvalue).to_bytes_with_nul());
                     let n = bytes.len().min(FLEN_FILENAME);
                     keyvalue[..n].copy_from_slice(&bytes[..n]);
-                    if let Some((l, c)) = ALLOCATIONS.lock().unwrap().remove(&(tkeyvalue as usize))
-                    {
-                        let _ = Vec::from_raw_parts(tkeyvalue, l, c);
-                    }
+                    free_registered(tkeyvalue);
                 }
             }
 
@@ -2492,7 +2490,7 @@ pub fn ffgtam_safe(
                         int_snprintf!(&mut keyword, FLEN_KEYWORD, "GRPLC{}", ngroups as c_int);
                         /* SPR 1738 */
                         /* fits_read_key_longstr (ffgkls_safe) outputs a raw heap C
-                        string tracked in ALLOCATIONS. The C reads from `mfptr`
+                        string tracked by helpers::raw_owned. The C reads from `mfptr`
                         here; when supplied by pointer that is the same as
                         tmpfptr, and the hdupos path does not reach this
                         negative-GRPID branch (it implies a different file). */
@@ -2506,7 +2504,7 @@ pub fn ffgtam_safe(
                         );
                         if 0 == *status {
                             // SAFETY: tgrplc is the heap C string from ffgkls_safe,
-                            // tracked in ALLOCATIONS; copy it out then release it.
+                            // tracked by helpers::raw_owned; copy it out then release it.
                             unsafe {
                                 let cs = CStr::from_ptr(tgrplc);
                                 let too_long = cs.to_bytes().len() > FLEN_FILENAME - 1;
@@ -2514,11 +2512,7 @@ pub fn ffgtam_safe(
                                     let val = cast_slice::<u8, c_char>(cs.to_bytes_with_nul());
                                     strcpy_safe(&mut grplc, val);
                                 }
-                                if let Some((l, c)) =
-                                    ALLOCATIONS.lock().unwrap().remove(&(tgrplc as usize))
-                                {
-                                    let _ = Vec::from_raw_parts(tgrplc, l, c);
-                                }
+                                free_registered(tgrplc);
                                 if too_long {
                                     ffpmsg_str("GRPLCn string is too long (ffgtam)");
                                     *status = URL_PARSE_ERROR;
@@ -2929,17 +2923,13 @@ pub fn ffgmng_safe(mfptr: &mut fitsfile, ngroups: &mut c_long, status: &mut c_in
                 if 0 == *status {
                     fits_delete_key(mfptr, &keyword, status);
                     // SAFETY: tkeyvalue is the heap C string allocated by ffgkls_safe and
-                    // tracked in ALLOCATIONS; use it then release it via that table.
+                    // tracked by helpers::raw_owned; use it then release it that way.
                     unsafe {
                         let val =
                             cast_slice::<u8, c_char>(CStr::from_ptr(tkeyvalue).to_bytes_with_nul());
                         fits_insert_key_longstr(mfptr, &newKeyword, val, Some(&comment), status);
                         fits_write_key_longwarn(mfptr, status);
-                        if let Some((l, c)) =
-                            ALLOCATIONS.lock().unwrap().remove(&(tkeyvalue as usize))
-                        {
-                            let _ = Vec::from_raw_parts(tkeyvalue, l, c);
-                        }
+                        free_registered(tkeyvalue);
                     }
                 }
 
@@ -4446,18 +4436,14 @@ pub fn ffgmrm_safe(
                         );
                         if 0 == *status {
                             // SAFETY: tgrplc is the heap C string from ffgkls_safe,
-                            // tracked in ALLOCATIONS; copy it out then release it.
+                            // tracked by helpers::raw_owned; copy it out then release it.
                             let too_long = unsafe {
                                 let cs = CStr::from_ptr(tgrplc);
                                 let too_long = cs.to_bytes().len() > FLEN_FILENAME - 1;
                                 if !too_long {
                                     strcpy_safe(&mut grplc, cast_slice(cs.to_bytes_with_nul()));
                                 }
-                                if let Some((l, c)) =
-                                    ALLOCATIONS.lock().unwrap().remove(&(tgrplc as usize))
-                                {
-                                    let _ = Vec::from_raw_parts(tgrplc, l, c);
-                                }
+                                free_registered(tgrplc);
                                 too_long
                             };
 
@@ -6275,17 +6261,13 @@ pub(crate) fn ffgtcpr(
                 );
                 if 0 == *status {
                     // SAFETY: tkeyvalue is the heap C string from ffgkls_safe,
-                    // tracked in ALLOCATIONS; copy it out, use it, then release it.
+                    // tracked by helpers::raw_owned; copy it out, use it, then release it.
                     unsafe {
                         let val =
                             cast_slice::<u8, c_char>(CStr::from_ptr(tkeyvalue).to_bytes_with_nul());
                         fits_insert_key_longstr(outfptr, &card, val, Some(&comment), status);
                         fits_write_key_longwarn(outfptr, status);
-                        if let Some((l, c)) =
-                            ALLOCATIONS.lock().unwrap().remove(&(tkeyvalue as usize))
-                        {
-                            let _ = Vec::from_raw_parts(tkeyvalue, l, c);
-                        }
+                        free_registered(tkeyvalue);
                     }
                 }
             }

--- a/src/helpers/aligned.rs
+++ b/src/helpers/aligned.rs
@@ -37,6 +37,10 @@ impl AlignedBytes {
     pub(crate) fn try_resize_zeroed(&mut self, len: usize) -> Result<(), TryReserveError> {
         let words = len.div_ceil(size_of::<u64>());
         self.buf.clear();
+        /* clear() left `buf` empty; drop `len` with it so that a failed
+        reservation leaves a consistent (empty) buffer rather than a length
+        that outruns it. */
+        self.len = 0;
         self.buf.try_reserve_exact(words)?;
         self.buf.resize(words, 0);
         self.len = len;

--- a/src/helpers/mod.rs
+++ b/src/helpers/mod.rs
@@ -1,13 +1,15 @@
 //! Small Rust-side helpers with no CFITSIO counterpart.
 //!
 //! These exist to express in safe Rust what the C did with raw allocation and
-//! `FILE*` I/O: fallible boxing, an over-aligned byte buffer, a `Read`/`Write`
-//! adapter over a C stream, and the test fixtures.
+//! `FILE*` I/O: fallible boxing, an over-aligned byte buffer, the registry that
+//! carries a `Vec`'s layout across a C-ABI boundary, a `Read`/`Write` adapter
+//! over a C stream, and the test fixtures.
 #![warn(missing_docs)]
 
 pub mod aligned;
 pub mod boxed;
 pub mod cfile;
+pub mod raw_owned;
 #[cfg(test)]
 pub mod testhelpers;
 pub mod vec_raw_parts;

--- a/src/helpers/raw_owned.rs
+++ b/src/helpers/raw_owned.rs
@@ -1,0 +1,210 @@
+//! Handing a `Vec`'s storage out as a raw pointer, and reclaiming it later.
+//!
+//! CFITSIO's structs and its API traffic in bare pointers: `FITSfile` stores a
+//! `char *filename` and a `tcolumn *tableptr`, and routines like `ffgkls` and
+//! `fits_hdr2str` hand the caller a heap block to release with `fffree`. In C
+//! that costs nothing, because `free` needs only the address.
+//!
+//! Rust's allocator needs more: [`alloc::alloc::dealloc`] must be given the same
+//! [`Layout`](core::alloc::Layout) the block was allocated with, and
+//! `Vec::from_raw_parts` needs the capacity, neither of which can be recovered
+//! from the pointer. This module is the side channel that carries them from the
+//! hand-out site to the reclaim site.
+//!
+//! Reach for it only when nothing simpler fits. In order of preference:
+//!
+//! 1. The block never escapes: use a plain `Vec<T>` or `Box<[T]>` and let RAII
+//!    free it.
+//! 2. A raw pointer has to be visible, but something we own can hold the
+//!    storage: keep the `Vec<T>` in a local or a struct field and take
+//!    `as_mut_ptr()` at the point of use.
+//! 3. The pointer really is the handle, and the length is recoverable at the
+//!    free site (from a sibling field, or from a NUL terminator): use
+//!    `Box::into_raw(v.into_boxed_slice())` and
+//!    `Box::from_raw(ptr::slice_from_raw_parts_mut(p, len))`. A `Box<[T]>` has
+//!    no spare capacity, so its layout is exactly `Layout::array::<T>(len)`.
+//! 4. Otherwise, this module.
+//!
+//! There is deliberately no "assume the length" fallback. Every reclaim site
+//! used to end in `else { Vec::from_raw_parts(p, <guess>, <guess>) }`, and a
+//! guess that is wrong is a wrong `Layout` handed to the allocator. An
+//! unregistered pointer is a bug, so it is reported in debug builds and leaked
+//! rather than freed.
+#![warn(missing_docs)]
+
+use std::collections::HashMap;
+use std::sync::{LazyLock, Mutex};
+
+use crate::helpers::vec_raw_parts::vec_into_raw_parts;
+
+/// What was recorded about one handed-out allocation.
+///
+/// `len` and `capacity` are in elements. The element type is not part of the
+/// key, so `elem_size`/`elem_align` are kept to catch a pointer registered as
+/// one type and reclaimed as another -- a mismatch the address alone cannot
+/// reveal, and which would deallocate with the wrong `Layout`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct Record {
+    len: usize,
+    capacity: usize,
+    elem_size: usize,
+    elem_align: usize,
+}
+
+impl Record {
+    fn of<T>(len: usize, capacity: usize) -> Self {
+        Record {
+            len,
+            capacity,
+            elem_size: size_of::<T>(),
+            elem_align: align_of::<T>(),
+        }
+    }
+
+    fn matches<T>(&self) -> bool {
+        self.elem_size == size_of::<T>() && self.elem_align == align_of::<T>()
+    }
+}
+
+/// Address -> layout, for every allocation this crate has handed out as a raw
+/// pointer.
+static ALLOCATIONS: LazyLock<Mutex<HashMap<usize, Record>>> = LazyLock::new(Default::default);
+
+/// Hand `v`'s storage out as a raw pointer, recording its layout.
+///
+/// The returned pointer must eventually reach [`take_registered`] or
+/// [`free_registered`]; until then the allocation is owned by nothing and will
+/// leak.
+pub(crate) fn into_raw_registered<T>(v: Vec<T>) -> *mut T {
+    let (p, len, capacity) = vec_into_raw_parts(v);
+    ALLOCATIONS
+        .lock()
+        .unwrap()
+        .insert(p as usize, Record::of::<T>(len, capacity));
+    p
+}
+
+/// Reclaim a pointer handed out by [`into_raw_registered`], as the `Vec` it
+/// came from.
+///
+/// Returns `None` -- leaking the block rather than freeing it with a layout
+/// that may be wrong -- for a null pointer, one that was never registered, and
+/// one whose element type does not match `T`. The last two are bugs and are
+/// reported by a debug assertion.
+///
+/// # Safety
+/// `p` must not be used again after this returns `Some`, and no other live
+/// reference may point into the block.
+pub(crate) unsafe fn take_registered<T>(p: *mut T) -> Option<Vec<T>> {
+    if p.is_null() {
+        return None;
+    }
+
+    let Some(record) = ALLOCATIONS.lock().unwrap().remove(&(p as usize)) else {
+        debug_assert!(false, "{p:p} was never registered with into_raw_registered");
+        return None;
+    };
+
+    if !record.matches::<T>() {
+        debug_assert!(
+            false,
+            "{p:p} was registered as {}-byte elements but is being reclaimed as {}",
+            record.elem_size,
+            core::any::type_name::<T>()
+        );
+        return None;
+    }
+
+    // SAFETY: the record is the (len, capacity) the Vec was taken apart with,
+    // and the element size and alignment have just been checked to match.
+    Some(unsafe { Vec::from_raw_parts(p, record.len, record.capacity) })
+}
+
+/// Reclaim and drop a pointer handed out by [`into_raw_registered`].
+///
+/// The counterpart of C's `free`. A null pointer is ignored, as `free(NULL)` is.
+///
+/// # Safety
+/// As [`take_registered`].
+pub(crate) unsafe fn free_registered<T>(p: *mut T) {
+    drop(unsafe { take_registered::<T>(p) });
+}
+
+/// Move the registration from `old` to `v`'s storage, returning the new
+/// pointer.
+///
+/// This is the `realloc` shape: the caller has already reclaimed `old` (or is
+/// replacing it wholesale) and wants the map to describe the replacement. `old`
+/// is used only as a key, so passing a stale address is harmless.
+pub(crate) fn reregister<T>(old: *mut T, v: Vec<T>) -> *mut T {
+    let (p, len, capacity) = vec_into_raw_parts(v);
+    let mut map = ALLOCATIONS.lock().unwrap();
+    map.remove(&(old as usize));
+    map.insert(p as usize, Record::of::<T>(len, capacity));
+    p
+}
+
+/// The recorded element count of a handed-out allocation, for the callers that
+/// need to view it as a slice without giving up ownership.
+pub(crate) fn registered_len<T>(p: *const T) -> Option<usize> {
+    ALLOCATIONS
+        .lock()
+        .unwrap()
+        .get(&(p as usize))
+        .map(|r| r.len)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_round_trip_preserves_contents_and_capacity() {
+        let mut v: Vec<u32> = Vec::with_capacity(16);
+        v.extend([1, 2, 3]);
+
+        let p = into_raw_registered(v);
+        assert_eq!(registered_len(p.cast_const()), Some(3));
+
+        let back = unsafe { take_registered::<u32>(p) }.unwrap();
+        assert_eq!(back, vec![1, 2, 3]);
+        assert_eq!(back.capacity(), 16);
+
+        /* the entry is gone, so a second reclaim finds nothing */
+        assert_eq!(registered_len(p.cast_const()), None);
+    }
+
+    #[test]
+    fn test_null_is_ignored() {
+        assert!(unsafe { take_registered::<u8>(core::ptr::null_mut()) }.is_none());
+        unsafe { free_registered::<u8>(core::ptr::null_mut()) };
+    }
+
+    #[test]
+    fn test_reregister_replaces_the_entry() {
+        let old = into_raw_registered(vec![0u8; 4]);
+        /* the caller has taken the old block apart itself */
+        let v = unsafe { Vec::from_raw_parts(old, 4, 4) };
+        let mut v = v;
+        v.resize(9, 7);
+
+        let new = reregister(old, v);
+        assert_eq!(registered_len(new.cast_const()), Some(9));
+
+        let back = unsafe { take_registered::<u8>(new) }.unwrap();
+        assert_eq!(back.len(), 9);
+    }
+
+    /// An unregistered pointer must not be deallocated on a guessed layout.
+    /// The debug assertion fires first in a debug build, so this is the
+    /// release-build behaviour being pinned.
+    #[test]
+    #[cfg_attr(debug_assertions, ignore = "the debug assertion fires first")]
+    fn test_unregistered_pointer_is_leaked_not_freed() {
+        let mut v = vec![1u8, 2, 3];
+        let p = v.as_mut_ptr();
+        assert!(unsafe { take_registered::<u8>(p) }.is_none());
+        /* v still owns its storage and drops normally */
+        assert_eq!(v, vec![1, 2, 3]);
+    }
+}

--- a/src/imcompress.rs
+++ b/src/imcompress.rs
@@ -77,8 +77,6 @@ use crate::putcold::ffpcld_safe;
 use crate::putcoli::ffpcli_safe;
 use crate::scalnull::ffpscl_safe;
 
-use libc::realloc;
-
 use bytemuck::{cast, cast_slice, cast_slice_mut};
 
 use crate::pliocomp::{pl_l2pi, pl_p2li, pl_p2li_max_len};
@@ -100,7 +98,7 @@ use crate::quantize::{
 };
 use crate::swapproc::{ffswap2, ffswap4, ffswap8};
 
-use crate::zcompress::{compress2mem_from_mem, uncompress2mem_from_mem};
+use crate::zcompress::{compress2mem_from_mem, mem_realloc_unsupported, uncompress2mem_from_mem};
 use crate::{FFLOCK, FFUNLOCK, KeywordDatatype, KeywordDatatypeMut};
 
 use crate::fitsio2::*;
@@ -8812,7 +8810,7 @@ fn imcomp_decompress_tile(
                 (nelemll as c_long).try_into().unwrap(),
                 &mut (idata.as_mut_ptr()),
                 &mut idatalen,
-                Some(realloc),
+                Some(mem_realloc_unsupported),
                 Some(&mut tilebytesize),
                 status,
             );
@@ -13331,7 +13329,7 @@ pub fn fits_uncompress_table_safe(
                                             cvlalen.try_into().unwrap(),
                                             &mut uncompressed_vla.as_mut_ptr(),
                                             &mut vlamemlen,
-                                            Some(realloc),
+                                            Some(mem_realloc_unsupported),
                                             Some(&mut filesize),
                                             status,
                                         );

--- a/src/iraffits.rs
+++ b/src/iraffits.rs
@@ -20,7 +20,7 @@
 #![warn(missing_docs)]
 
 use crate::c_types::{c_char, c_int};
-use crate::helpers::vec_raw_parts::vec_into_raw_parts;
+use crate::helpers::raw_owned::into_raw_registered;
 use crate::wrappers::read_fill;
 use bytemuck::{cast_slice, cast_slice_mut};
 
@@ -31,7 +31,7 @@ use std::io::Error;
 use std::io::Seek;
 use std::sync::Mutex;
 
-use crate::fitscore::{ALLOCATIONS, ffpmsg_slice, ffpmsg_str};
+use crate::fitscore::{ffpmsg_slice, ffpmsg_str};
 use crate::fitsio::NULL_MSG;
 use crate::int_snprintf;
 use crate::{
@@ -235,8 +235,7 @@ pub(crate) fn iraf2mem(
     /* append the image data onto the FITS header */
     irafrdimage(&mut b_ptr, buffsize, filesize, status);
 
-    let (raw_ptr, l, c) = vec_into_raw_parts(b_ptr);
-    ALLOCATIONS.lock().unwrap().insert(raw_ptr as usize, (l, c));
+    let raw_ptr = into_raw_registered(b_ptr);
 
     *buffptr = raw_ptr;
 

--- a/src/putcol.rs
+++ b/src/putcol.rs
@@ -14,7 +14,9 @@
 //! Space Flight Center.
 #![warn(missing_docs)]
 
+use alloc::collections::TryReserveError;
 use core::ffi::CStr;
+use core::ptr;
 use core::slice;
 
 use crate::buffers::ffgrsz_safe;
@@ -36,10 +38,11 @@ use crate::getcol::ffgcv_safe;
 use crate::getcol::ffgpv_safe;
 use crate::getkey::ffgkyj_safe;
 use crate::getkey::ffgkys_safe;
+use crate::helpers::aligned::AlignedBytes;
 
 use bytemuck::{cast_slice, cast_slice_mut};
 use core::mem::size_of;
-use libc::{calloc, free, memcmp, memcpy, memset};
+use libc::{memcmp, memcpy, memset};
 use std::os::raw::{c_char, c_int, c_long, c_schar, c_short, c_uchar, c_uint, c_ulong, c_ushort};
 
 use crate::NullValue;
@@ -2891,6 +2894,39 @@ pub(crate) fn ffiter_internal(
     /* Re-borrowed from `cols_ptr` again after every work-function call. */
     let mut cols: &mut [iteratorCol] = unsafe { slice::from_raw_parts_mut(cols_ptr, cols_len) };
 
+    /// Reserve `n` zeroed elements of `T` in `slot` and return the pointer the
+    /// C's `calloc(n, sizeof(T))` would have produced, or null if the
+    /// reservation failed.
+    ///
+    /// The C leaked every one of these work arrays on the early `return`s above
+    /// the cleanup label, and stored the result of all but the TSTRING calloc
+    /// without checking it for null.  Owning the storage in `work` fixes both:
+    /// the buffers are released by RAII on every path, and a failed reservation
+    /// still yields the null pointer the `is_null()` check below looks for.
+    ///
+    /// [`AlignedBytes`] rather than `Vec<u8>` because the caller reinterprets
+    /// these bytes as `f64`, `LONGLONG`, `c_long` and `*mut c_char`; a
+    /// `Vec<u8>` guarantees only 1-byte alignment.
+    fn work_ptr<T>(slot: &mut AlignedBytes, n: usize) -> *mut c_void {
+        match slot.try_resize_zeroed(n * size_of::<T>()) {
+            Ok(()) => slot.as_mut_ptr().cast::<c_void>(),
+            Err(_) => ptr::null_mut(),
+        }
+    }
+
+    /// Reserve `n` zeroed `c_char`s in `slot` and return the pointer, or the
+    /// allocation error the C would have seen as a null `calloc`.
+    ///
+    /// The TSTRING arm's two `char` buffers, unlike the numeric work arrays,
+    /// are read back as `[c_char]` rather than reinterpreted, so a plain `Vec`
+    /// is enough.
+    fn try_zeroed(slot: &mut Vec<c_char>, n: usize) -> Result<*mut c_char, TryReserveError> {
+        slot.clear();
+        slot.try_reserve_exact(n)?;
+        slot.resize(n, 0);
+        Ok(slot.as_mut_ptr())
+    }
+
     // Structure to store the column null value
     #[derive(Default, Clone, Copy)]
     struct ColNulls {
@@ -3411,6 +3447,18 @@ pub(crate) fn ffiter_internal(
 
         col = vec![ColNulls::default(); n_cols as usize]; /* memory for the null values */
 
+        /* The C calloc'd the per-column work arrays and freed them in the
+        cleanup block at the bottom.  They are owned here instead: `cols[jj]
+        .array` still receives a raw pointer, exactly as the C left it, but the
+        storage belongs to these arenas and is released when the function
+        returns -- including on the early `return *status` paths, which the C
+        leaked.  All three are sized once, before any pointer is taken out of
+        them, so the outer Vecs never move. */
+        let mut work: Vec<AlignedBytes> =
+            (0..n_cols as usize).map(|_| AlignedBytes::new()).collect(); /* cols[jj].array */
+        let mut strblock: Vec<Vec<c_char>> = vec![Vec::new(); n_cols as usize]; /* TSTRING values */
+        let mut nullstrs: Vec<Vec<c_char>> = vec![Vec::new(); n_cols as usize]; /* TSTRING TNULLn */
+
         #[allow(clippy::never_loop)]
         'cleanup: loop {
             for jj in 0..n_cols as usize {
@@ -3672,7 +3720,7 @@ pub(crate) fn ffiter_internal(
 
                 match cols[jj].datatype {
                     TBYTE => {
-                        cols[jj].array = calloc((ntodo + 1) as usize, size_of::<c_char>());
+                        cols[jj].array = work_ptr::<c_char>(&mut work[jj], (ntodo + 1) as usize);
                         col[jj].nullsize = size_of::<c_char>(); /* number of bytes per value */
 
                         if typecode.abs() == TBYTE
@@ -3689,7 +3737,7 @@ pub(crate) fn ffiter_internal(
                         }
                     }
                     TSBYTE => {
-                        cols[jj].array = calloc((ntodo + 1) as usize, size_of::<c_char>());
+                        cols[jj].array = work_ptr::<c_char>(&mut work[jj], (ntodo + 1) as usize);
                         col[jj].nullsize = size_of::<c_char>(); /* number of bytes per value */
 
                         if typecode.abs() == TBYTE
@@ -3706,7 +3754,7 @@ pub(crate) fn ffiter_internal(
                         }
                     }
                     TSHORT => {
-                        cols[jj].array = calloc((ntodo + 1) as usize, size_of::<c_short>());
+                        cols[jj].array = work_ptr::<c_short>(&mut work[jj], (ntodo + 1) as usize);
                         col[jj].nullsize = size_of::<c_short>(); /* number of bytes per value */
 
                         if typecode.abs() == TBYTE
@@ -3723,7 +3771,7 @@ pub(crate) fn ffiter_internal(
                         }
                     }
                     TUSHORT => {
-                        cols[jj].array = calloc((ntodo + 1) as usize, size_of::<c_ushort>());
+                        cols[jj].array = work_ptr::<c_ushort>(&mut work[jj], (ntodo + 1) as usize);
                         col[jj].nullsize = size_of::<c_ushort>(); /* bytes per value */
 
                         if typecode.abs() == TBYTE
@@ -3740,7 +3788,7 @@ pub(crate) fn ffiter_internal(
                         }
                     }
                     TINT => {
-                        cols[jj].array = calloc((ntodo + 1) as usize, size_of::<c_int>());
+                        cols[jj].array = work_ptr::<c_int>(&mut work[jj], (ntodo + 1) as usize);
                         col[jj].nullsize = size_of::<c_int>(); /* number of bytes per value */
 
                         if typecode.abs() == TBYTE
@@ -3757,7 +3805,7 @@ pub(crate) fn ffiter_internal(
                         }
                     }
                     TUINT => {
-                        cols[jj].array = calloc((ntodo + 1) as usize, size_of::<c_uint>());
+                        cols[jj].array = work_ptr::<c_uint>(&mut work[jj], (ntodo + 1) as usize);
                         col[jj].nullsize = size_of::<c_uint>(); /* bytes per value */
 
                         if typecode.abs() == TBYTE
@@ -3774,7 +3822,7 @@ pub(crate) fn ffiter_internal(
                         }
                     }
                     TLONG => {
-                        cols[jj].array = calloc((ntodo + 1) as usize, size_of::<c_long>());
+                        cols[jj].array = work_ptr::<c_long>(&mut work[jj], (ntodo + 1) as usize);
                         col[jj].nullsize = size_of::<c_long>(); /* number of bytes per value */
 
                         if typecode.abs() == TBYTE
@@ -3789,7 +3837,7 @@ pub(crate) fn ffiter_internal(
                         }
                     }
                     TULONG => {
-                        cols[jj].array = calloc((ntodo + 1) as usize, size_of::<c_ulong>());
+                        cols[jj].array = work_ptr::<c_ulong>(&mut work[jj], (ntodo + 1) as usize);
                         col[jj].nullsize = size_of::<c_ulong>(); /* bytes per value */
 
                         if typecode.abs() == TBYTE
@@ -3809,7 +3857,7 @@ pub(crate) fn ffiter_internal(
                         }
                     }
                     TFLOAT => {
-                        cols[jj].array = calloc((ntodo + 1) as usize, size_of::<f32>());
+                        cols[jj].array = work_ptr::<f32>(&mut work[jj], (ntodo + 1) as usize);
                         col[jj].nullsize = size_of::<f32>(); /* number of bytes per value */
 
                         if typecode.abs() == TBYTE
@@ -3824,12 +3872,12 @@ pub(crate) fn ffiter_internal(
                         }
                     }
                     TCOMPLEX => {
-                        cols[jj].array = calloc(((ntodo * 2) + 1) as usize, size_of::<f32>());
+                        cols[jj].array = work_ptr::<f32>(&mut work[jj], ((ntodo * 2) + 1) as usize);
                         col[jj].nullsize = size_of::<f32>(); /* number of bytes per value */
                         col[jj].null = ColNullValue::FloatNull(FLOATNULLVALUE); /* special value */
                     }
                     TDOUBLE => {
-                        cols[jj].array = calloc((ntodo + 1) as usize, size_of::<f64>());
+                        cols[jj].array = work_ptr::<f64>(&mut work[jj], (ntodo + 1) as usize);
                         col[jj].nullsize = size_of::<f64>(); /* number of bytes per value */
 
                         if typecode.abs() == TBYTE
@@ -3845,7 +3893,7 @@ pub(crate) fn ffiter_internal(
                     }
 
                     TDBLCOMPLEX => {
-                        cols[jj].array = calloc(((ntodo * 2) + 1) as usize, size_of::<f64>());
+                        cols[jj].array = work_ptr::<f64>(&mut work[jj], ((ntodo * 2) + 1) as usize);
                         col[jj].nullsize = size_of::<f64>(); /* number of bytes per value */
                         col[jj].null = ColNullValue::DoubleNull(DOUBLENULLVALUE); /* special value */
                     }
@@ -3854,7 +3902,7 @@ pub(crate) fn ffiter_internal(
                         if hdutype == ASCII_TBL {
                             rept = width;
                         }
-                        stringptr = calloc((ntodo + 1) as usize, size_of::<*mut c_char>())
+                        stringptr = work_ptr::<*mut c_char>(&mut work[jj], (ntodo + 1) as usize)
                             .cast::<*mut c_char>();
                         cols[jj].array = stringptr.cast::<c_void>();
                         col[jj].nullsize = (rept + 1) as usize; /* number of bytes per value */
@@ -3862,10 +3910,14 @@ pub(crate) fn ffiter_internal(
                         if !stringptr.is_null() {
                             /* allocate string to store the null string value */
                             let stringnull =
-                                calloc((rept + 1) as usize, size_of::<c_char>()).cast::<c_char>();
+                                match try_zeroed(&mut nullstrs[jj], (rept + 1) as usize) {
+                                    Ok(v) => v,
+                                    Err(_) => ptr::null_mut(),
+                                };
                             col[jj].null = ColNullValue::StringNull(stringnull);
                             if rept > 0
                                 && let ColNullValue::StringNull(ptr) = col[jj].null
+                                && !ptr.is_null()
                             {
                                 *ptr.add(1) = 1;
                                 /* to make sure string != 0 */
@@ -3873,11 +3925,15 @@ pub(crate) fn ffiter_internal(
 
                             /* allocate big block for the array of table column strings */
 
-                            (*stringptr) =
-                                calloc(((ntodo + 1) * (rept + 1)) as usize, size_of::<c_char>())
-                                    .cast::<c_char>();
+                            (*stringptr) = match try_zeroed(
+                                &mut strblock[jj],
+                                ((ntodo + 1) * (rept + 1)) as usize,
+                            ) {
+                                Ok(v) => v,
+                                Err(_) => ptr::null_mut(),
+                            };
 
-                            if !(*stringptr).is_null() {
+                            if !(*stringptr).is_null() && !stringnull.is_null() {
                                 for ii in 1..=ntodo as usize {
                                     /* pointer to each string */
 
@@ -3903,8 +3959,8 @@ pub(crate) fn ffiter_internal(
                                 if tstatus == 0
                                     && let ColNullValue::StringNull(ptr) = col[jj].null
                                 {
-                                    // SAFETY: `ptr` is the calloc'd rept+1 byte
-                                    // null-value buffer allocated just above.
+                                    // SAFETY: `ptr` is the rept+1 byte
+                                    // null-value buffer reserved just above.
                                     let nullval =
                                         slice::from_raw_parts_mut(ptr, (rept + 1) as usize);
                                     strncat_safe(nullval, &nullstr, rept as usize);
@@ -3918,14 +3974,14 @@ pub(crate) fn ffiter_internal(
                     }
 
                     TLOGICAL => {
-                        cols[jj].array = calloc((ntodo + 1) as usize, size_of::<c_char>());
+                        cols[jj].array = work_ptr::<c_char>(&mut work[jj], (ntodo + 1) as usize);
                         col[jj].nullsize = size_of::<c_char>(); /* number of bytes per value */
 
                         /* use value = 2 to flag null values in logical columns */
                         col[jj].null = ColNullValue::UCharNull(2);
                     }
                     TLONGLONG => {
-                        cols[jj].array = calloc((ntodo + 1) as usize, size_of::<LONGLONG>());
+                        cols[jj].array = work_ptr::<LONGLONG>(&mut work[jj], (ntodo + 1) as usize);
                         col[jj].nullsize = size_of::<LONGLONG>(); /* number of bytes per value */
 
                         if typecode.abs() == TBYTE
@@ -4296,26 +4352,15 @@ pub(crate) fn ffiter_internal(
 
         /* free work arrays for the columns */
 
-        for jj in 0..n_cols as usize {
-            /* The C guards these on `if (cols[jj].array)`, i.e. non-null.
-            Testing is_null() instead meant the frees only ran for columns
-            that had nothing to free, so every allocated work array leaked. */
-            if cols[jj].datatype == TSTRING && !cols[jj].array.is_null() {
-                stringptr = cols[jj].array.cast::<*mut c_char>();
-
-                free((*stringptr).cast::<c_void>()); /* free the block of strings */
-                if let ColNullValue::StringNull(ptr) = col[jj].null {
-                    free(ptr.cast::<c_void>()); /* free the null string */
-                }
-            }
-            if !cols[jj].array.is_null() {
-                free(cols[jj].array);
-                /* memory for the array of values from the col */
-            }
-        }
+        /* The C's per-column free() loop is gone: `work`, `strblock` and
+        `nullstrs` own every buffer it released -- the value array, the TSTRING
+        character block and the TSTRING null string -- and drop them when this
+        function returns.  The C left the freed addresses behind in
+        `cols[jj].array`; so does this, since the caller's iteratorCol array is
+        not ours to clear. */
     }
 
-    // col is a Vec, so it will be automatically freed
+    // col, work, strblock and nullstrs are Vecs, so they are freed automatically
     *status
 }
 

--- a/src/wcssub.rs
+++ b/src/wcssub.rs
@@ -15,7 +15,7 @@ use core::ptr;
 use core::slice;
 
 use crate::c_types::*;
-use crate::helpers::vec_raw_parts::vec_into_raw_parts;
+use crate::helpers::raw_owned::{free_registered, into_raw_registered};
 
 use bytemuck::cast_slice;
 
@@ -23,8 +23,8 @@ use crate::cfileio::ffdelt_safe;
 use crate::cfileio::ffinit_safe;
 
 use crate::fitscore::{
-    ALLOCATIONS, ffgcno_safe, ffghdn_safe, ffghdt_safe, ffgncl_safe, ffkeyn_safe, ffmahd_safe,
-    ffmkky_safe, ffmnhd_safe, ffpmsg_str, fits_copy_pixlist2image_safe,
+    ffgcno_safe, ffghdn_safe, ffghdt_safe, ffgncl_safe, ffkeyn_safe, ffmahd_safe, ffmkky_safe,
+    ffmnhd_safe, ffpmsg_str, fits_copy_pixlist2image_safe,
 };
 use crate::fitsio::*;
 use crate::getcold::ffgcvd_safe;
@@ -250,8 +250,7 @@ pub fn fits_read_wcstab_safer(
         }
 
         // HEAP ALLOCATION
-        let (ptr, l, c) = vec_into_raw_parts(tmp);
-        ALLOCATIONS.lock().unwrap().insert(ptr as usize, (l, c));
+        let ptr = into_raw_registered(tmp);
 
         // SAFETY: `arrayp` is a valid output pointer supplied by the caller.
         unsafe {
@@ -267,17 +266,15 @@ pub fn fits_read_wcstab_safer(
     if *status != 0 {
         wtbp = wtb;
         for iwtb in 0..(nwtb as usize) {
-            // SAFETY: `arrayp` was either nulled or set to a `vec_into_raw_parts`
-            // allocation above; reconstructing the Vec frees it.
+            // SAFETY: `arrayp` was either nulled or handed out by
+            // into_raw_registered above, and nothing else refers to it.
+            //
+            // This used to rebuild the Vec with `ndim` elements. `ndim` is the
+            // number of axes, not the element count -- the allocation above is
+            // `nelem` f64s -- so the block was released on a layout it was
+            // never allocated with. The registry carries the real length.
             unsafe {
-                if !(*wtbp[iwtb].arrayp).is_null() {
-                    // WARNING: Assuming that the ndim hasn't been changed
-                    let _ = Vec::from_raw_parts(
-                        *wtbp[iwtb].arrayp,
-                        wtbp[iwtb].ndim as usize,
-                        wtbp[iwtb].ndim as usize,
-                    );
-                }
+                free_registered(*wtbp[iwtb].arrayp);
             }
         }
     }
@@ -1640,13 +1637,7 @@ pub fn ffgtwcs_safe(
     strcat_safe(&mut hdr[cptr..], cs!(c"END"));
     strncat_safe(&mut hdr[cptr..], blanks, 77);
 
-    let (header_ptr, l, c) = vec_into_raw_parts(hdr);
-    ALLOCATIONS
-        .lock()
-        .unwrap()
-        .insert(header_ptr as usize, (l, c));
-
-    *header = header_ptr;
+    *header = into_raw_registered(hdr);
 
     *status
 }

--- a/src/zcompress.rs
+++ b/src/zcompress.rs
@@ -20,6 +20,29 @@ use crate::fitsio::{DATA_COMPRESSION_ERR, DATA_DECOMPRESSION_ERR, MEMORY_ALLOCAT
 const GZBUFSIZE: usize = 115200; /* 40 FITS blocks */
 const BUFFINCR: usize = 28800; /* 10 FITS blocks */
 
+/// Stand-in for the `mem_realloc` callback of [`uncompress2mem_from_mem`] and
+/// [`crate::zuncompress::zuncompress2mem`], for the in-crate callers whose
+/// buffer is a Rust `Vec`.
+///
+/// Those routines take a C-style grow function.  The C passed `realloc`, and so
+/// did this port -- but every in-crate caller hands them a `Vec`'s storage, so
+/// actually calling the C reallocator on it would free a Rust allocation with
+/// the wrong allocator.  It is never reached today (the grow branch in
+/// `uncompress2mem_from_mem` is a `panic!("not implemented")`, and the callers
+/// that do reach a live one size their buffer so it cannot grow), and passing
+/// this instead of `realloc` means a future implementation gets a loud failure
+/// rather than a silent cross-allocator free.
+///
+/// A caller that really can grow its buffer must own it -- see
+/// `owned_realloc` in [`crate::drvrmem`], which resizes the `Vec` it is
+/// registered against.
+pub(crate) unsafe extern "C" fn mem_realloc_unsupported(
+    _p: *mut c_void,
+    _newsize: usize,
+) -> *mut c_void {
+    unimplemented!("cannot grow a caller-owned Vec through the C realloc")
+}
+
 pub(crate) unsafe fn inflateInit2(strm: z_streamp, windowBits: c_int) -> c_int {
     unsafe {
         inflateInit2_(

--- a/src/zuncompress.rs
+++ b/src/zuncompress.rs
@@ -542,7 +542,9 @@ mod tests {
 
     use crate::c_types::{c_char, c_int};
     use bytemuck::cast_slice;
-    use libc::{fdopen, realloc};
+    use libc::fdopen;
+
+    use crate::zcompress::mem_realloc_unsupported;
 
     use crate::zuncompress::zuncompress2mem;
 
@@ -593,7 +595,9 @@ mod tests {
             compressed_file_ptr,
             &mut decompressed_buffer.as_mut_ptr(),
             &mut buffer_size,
-            Some(realloc),
+            /* the buffer above is a Vec sized so this is never reached;
+            see mem_realloc_unsupported */
+            Some(mem_realloc_unsupported),
             &mut decompressed_size,
             &mut status,
         );


### PR DESCRIPTION
Closes the `Remove use a malloc and free` TODO. No libc `malloc`/`calloc`/`realloc`/`free`
is left in the library — the only survivors are five lines in cfileio's `#[cfg(test)]`
module, where the test deliberately plays the part of a C caller supplying its own
allocator through `fits_create_memfile`, and so must free with the same one.

### The ladder

`Layout` is the right primitive, but hand-rolling it at thirty call sites is a step
backwards: `Vec<T>` and `Box<[T]>` *are* `Layout::array::<T>(n)` with the bookkeeping
already correct. It ends up used in exactly three places. The reasoning is documented at
the top of the new `src/helpers/raw_owned.rs`, and `TRANSPILING.md` points at it so the
next transpile doesn't have to re-derive it.

| | when | mechanism |
|---|---|---|
| A | the block never escapes | `Vec<T>` / `Box<[T]>`, RAII |
| B | a raw pointer must be visible, but we can own the storage | keep the `Vec`, take `as_mut_ptr()` at the point of use |
| C | the pointer *is* the handle and the length is recoverable | `Box<[T]>` + `slice_from_raw_parts_mut` |
| D | the length is not recoverable at the free site | the registry |

### What changed

- **`ffiter_internal`** owns its per-column work arrays in an `AlignedBytes`/`Vec` arena
  instead of `calloc`ing seventeen of them. `cols[jj].array` still receives a raw pointer,
  so no ABI change, but the buffers are released on every path (the C leaked them on its
  early returns) and the sixteen allocations that stored their result without a null check
  are now fallible and report `MEMORY_ALLOCATION`.
- **The `ALLOCATIONS` map** moved behind `helpers::raw_owned`. It records the element size
  and alignment as well as the length and capacity, and there is no "assume the length"
  fallback any more: an unregistered pointer is reported in debug builds and leaked rather
  than freed on a guessed `Layout`.
- **The expression engine's node buffers** come from the Rust allocator. `NodeValue::Buffer`
  carries an `Owned` describing how the block is released — `None` for a column node's
  borrowed view into `varData`, `Block(Layout)` for a numeric row buffer, `BlockAndText`
  for the row-pointer array plus the character block behind it. So `free_buffer` hands back
  the right `Layout`, releases both of `Allocate_Ptrs`' allocations together (four call
  sites no longer have to free the character block by hand first), and structurally cannot
  free a buffer a column node only borrows — an invariant that was previously maintained by
  every caller remembering to write `if node.is_computed()`. The `FREE!` macro is gone.

`FITSfile`'s `filename`, `headstart` and `tableptr` are untouched. They are public C-ABI
fields; their types and the struct layout are unchanged. Only *how the block is reclaimed*
moved, from an open-coded `remove()`-or-guess to `free_registered`.

### Bugs found on the way

None of these were what I went looking for.

1. **Compressed files were never recognised.** Two independent defects in the same path.
   The two-byte magic numbers for GZIP, PACK, LZW and LZH were transpiled from the C's
   octal escapes (`"\037\213"`) as if they were decimal, so `file_is_compressed` and
   `mem_compress_open` rejected every `.gz`, `.Z` and `.bz2` file — the whole `compress://`
   driver was unreachable. And `file_is_compressed` read those two bytes with a bare
   `read()`, which is allowed to come back short, and treated a short read as "not
   compressed". Miri caught the second one.
2. **Cross-allocator free.** `mem_createmem` allocates the memory-file buffer as a `Vec`,
   but `stdin2mem`, both compressed-open paths and the decompression grow callback resized
   it with raw `libc::realloc` — exactly what `owned_realloc`'s own doc comment says must
   not happen. They route through `owned_realloc` now, and `stdin2mem` publishes the new
   address as it grows instead of leaving a stale one behind for its own error path to free.
3. **`fits_read_wcstab`** released an `nelem`-element `f64` array as if it held `ndim`
   elements — `ndim` is the number of axes, not the element count.
4. **`FITSfile::drop`** freed the six `tile*` pointers that `TILE_STRUCTS` owns. This is
   the double free that had `test_copy_within_same_file` `#[ignore]`d; it is un-ignored and
   passes, including under miri.

New coverage: two tests open a compressed file end to end through the `compress://` driver,
one of them sized so the driver's buffer estimate overshoots and the trim path runs — that
is the regression test for the cross-allocator free.

### Verification

`cargo test` green across all 35 binaries. 32-bit `i686` check clean. No new clippy
warnings (the 82 pre-existing doc-indent ones are unchanged). rustdoc and `check_docs.py`
clean. Miri ran in three scoped passes over everything touched — 105, 218 and 174 tests —
all clean: no UB, no leaks, no unsupported operations. One new test is
`#[cfg_attr(miri, ignore)]` because the bzip2 path goes through `fdopen`, the gap `TODO.md`
already documents.

The full ~5h miri suite has **not** been run; `TODO.md` asks for one after changes to
aliasing-sensitive code, so that is worth doing before release.
